### PR TITLE
NEW: JobDB will extract the VO when applying DIRAC/VOPolicy from the prop

### DIFF
--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -56,7 +56,7 @@ from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
 from types                                     import *
 from DIRAC                                     import gLogger, S_OK, S_ERROR, Time
 from DIRAC.ConfigurationSystem.Client.Config   import gConfig
-from DIRAC.ConfigurationSystem.Client.Helpers  import getVO
+from DIRAC.ConfigurationSystem.Client.Helpers  import Registry
 from DIRAC.Core.Base.DB                        import DB
 from DIRAC.Core.Security.CS                    import getUsernameForDN, getDNForUsername
 from DIRAC.WorkloadManagementSystem.Client.JobDescription     import JobDescription
@@ -1419,7 +1419,7 @@ class JobDB( DB ):
     classAdReq.insertAttributeString( 'OwnerGroup', ownerGroup )
 
     setup = gConfig.getValue( '/DIRAC/Setup', '' )
-    vo = getVO()
+    vo = Registry.getVOForGroup( ownerGroup )
     voPolicyDict = gConfig.getOptionsDict( '/DIRAC/VOPolicy/%s/%s' % ( vo, setup ) )
     #voPolicyDict = gConfig.getOptionsDict('/DIRAC/VOPolicy')
     if voPolicyDict['OK']:


### PR DESCRIPTION
NEW: JobDB will extract the VO when applying DIRAC/VOPolicy from the proper VO

That will allow to define a different DIRAC/VOPolicy/<vo>/<setup> based on the /Registry/Groups/<group>/VO for multi-vo installations
