### PR TITLE
FIX: Create a different SBPath with the group included

### DIFF
--- a/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -67,7 +67,7 @@ class SandboxStoreHandler( RequestHandler ):
     if Properties.JOB_SHARING in credDict[ 'properties' ]:
       idField = credDict[ 'group' ]
     else:
-      idField = "%s@%s" % ( credDict[ 'username' ], credDict[ 'group' ] )
+      idField = "%s.%s" % ( credDict[ 'username' ], credDict[ 'group' ] )
     pathItems = [ "/", prefix, idField[0], idField ]
     pathItems.extend( [ md5[0:3], md5[3:6], md5 ] )
     return os.path.join( *pathItems )


### PR DESCRIPTION
Solves #33

*Sandbox path now includes the group to avoid collisions
FIX: Create a different SBPath with the group included
