### PR TITLE
[CS] Updated getOptionsDict in Modificator.py: No need to convert options

### DIFF
--- a/ConfigurationSystem/private/Modificator.py
+++ b/ConfigurationSystem/private/Modificator.py
@@ -57,10 +57,6 @@ class Modificator:
     opts = self.getOptions(sectionPath)
     pathDict = dict( [ ( o, self.getValue( "%s/%s" % ( sectionPath, o
                                                        ) ) ) for o in opts ] )
-    for k in pathDict:
-      if pathDict[k].find( "," ) > -1 :
-        pathDict[k] = List.fromChar( pathDict[k] )
-
     return pathDict
 
   def getDictRootedAt(self, relpath = "", root = ""):


### PR DESCRIPTION
CHANGE: [CS] getOptionsDict in Modificator.py don’t convert (list) CS options into a Python list (not necessary for interacting with the CS).
