### PR TITLE
Missing option in wget for https download: --no-check-certificate

### DIFF
--- a/Core/scripts/install_site.sh
+++ b/Core/scripts/install_site.sh
@@ -51,7 +51,7 @@ fi
 # Get the latest version of dirac-install
 #
 #wget -O dirac-install 'http://svnweb.cern.ch/guest/dirac/DIRAC/trunk/DIRAC/Core/scripts/dirac-install.py' | exit
-wget -O dirac-install 'https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/dirac-install.py' | exit
+wget --no-check-certificate -O dirac-install 'https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/dirac-install.py' | exit
 #
 # define the target Dir
 #


### PR DESCRIPTION
> wget -O dirac-install 'https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/dirac-install.py'
> --2011-06-02 16:11:49--  https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/dirac-install.py
> Resolving github.com... 207.97.227.239
> Connecting to github.com|207.97.227.239|:443... connected.
> ERROR: cannot verify github.com's certificate, issued by `/C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert High Assurance EV CA-1':
>   Unable to locally verify the issuer's authority.
> To connect to github.com insecurely, use`--no-check-certificate'.
> Unable to establish SSL connection.
