### PR TITLE
SiteDirector: limit the queue max length 

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -62,6 +62,7 @@ class SiteDirector( AgentModule ):
     self.pilot = DIRAC_PILOT
     self.install = DIRAC_INSTALL
     self.workingDirectory = self.am_getOption( 'WorkDirectory' )
+    self.maxQueueLength = self.am_getOption( 'MaxQueueLength', 86400*3 )
 
     # Flags
     self.updateStatus = self.am_getOption( 'UpdatePilotStatus', True )
@@ -223,6 +224,8 @@ class SiteDirector( AgentModule ):
         queueCPUTime = int( self.queueDict[queue]['ParametersDict']['CPUTime'] )
       else:
         return S_ERROR( 'CPU time limit is not specified for queue %s' % queue )
+      if queueCPUTime > self.maxQueueLength:
+        queueCPUTime = self.maxQueueLength
 
       # Get the working proxy
       cpuTime = queueCPUTime + 86400


### PR DESCRIPTION
FIX: limit the queue max length to the value of MaxQueueLengthOption ( 3 days be default )
