### PR TITLE
FIX: SysAdmin CLI error

### DIFF
--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -377,6 +377,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
       result = client.getInfo()
       if not result['OK']:
         print "Error:", result['Message']
+        return 
       hostSetup = result['Value']['Setup']
       result = InstallTools.addDefaultOptionsToCS( gConfig, option, system, component, getCSExtensions(), hostSetup )
       if not result['OK']:


### PR DESCRIPTION
FIX: add return after an error in client.getInfo() call
