### PR TITLE
JobDB: properly treat Site parameter in the job JDL while rescheduling (closes #11)

### DIFF
--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1669,6 +1669,8 @@ class JobDB( DB ):
     site = classAdJob.getAttributeString( 'Site' )
     if not site:
       site = 'ANY'
+    elif site.find(',') > 0:
+      site = "Multiple"  
     jobAttrNames.append( 'Site' )
     jobAttrValues.append( site )
 


### PR DESCRIPTION
FIX: properly treat Site parameter in the job JDL while rescheduling in the JobDB (closes #11)
