### PR TITLE
BUGFIX: missing [ 'Versions' ]

### DIFF
--- a/Core/scripts/dirac-create-svn-tag.py
+++ b/Core/scripts/dirac-create-svn-tag.py
@@ -136,7 +136,7 @@ for svnPackage in List.fromChar( svnPackages ):
 
     if not svnVersion in buildCFG[ 'Versions' ].listSections():
       gLogger.error( 'Version does not exist:', svnVersion )
-      gLogger.error( 'Available versions:', ', '.join( buildCFG.listSections() ) )
+      gLogger.error( 'Available versions:', ', '.join( buildCFG[ 'Versions' ].listSections() ) )
       continue
 
     versionCFG = buildCFG[ 'Versions' ][svnVersion]


### PR DESCRIPTION
Fixes the bug in #135
$ dirac-create-svn-tag -p LHCbDIRAC -v v6r6
   Version does not exist: v6r6
   Available versions: Versions
