### PR TITLE
BUGFIX: PilotClient now always returns a dict type

### DIFF
--- a/ResourceStatusSystem/Client/PilotsClient.py
+++ b/ResourceStatusSystem/Client/PilotsClient.py
@@ -142,7 +142,7 @@ class PilotsClient:
         if not siteName[ 'OK' ]:
           raise RSSException, where( self, self.getPilotsSimpleEff ) + " " + res[ 'Message' ]
         if siteName[ 'Value' ] is None or siteName[ 'Value' ] == []:
-          return None
+          return {}
         siteName = siteName['Value']
 
       res = RPC.getPilotSummaryWeb({'ExpandSite':siteName},[],0,50)
@@ -155,7 +155,7 @@ class PilotsClient:
       res = res['Value']['Records']
 
     if len(res) == 0:
-      return None
+      return {}
 
     effRes = {}
 
@@ -183,6 +183,6 @@ class PilotsClient:
       return effRes
 
     except IndexError:
-      return None
+      return {}
 
 #############################################################################


### PR DESCRIPTION
For v6 and v5 series

BUGFIX: Fixed a bug that happen because a function was returning a mix of None and dict types in RSS/Client/PilotClient.py
