### PR TITLE
Fixes related to JobType in the accounting WMSHistory type

### DIFF
--- a/AccountingSystem/Client/Types/WMSHistory.py
+++ b/AccountingSystem/Client/Types/WMSHistory.py
@@ -7,9 +7,9 @@ class WMSHistory( BaseAccountingType ):
 
   def __init__( self ):
     BaseAccountingType.__init__( self )
-    self.definitionKeyFields = [ ( 'Status', "VARCHAR(256)" ),
-                                 ( 'MinorStatus', 'VARCHAR(256)' ),
-                                 ( 'ApplicationStatus', 'VARCHAR(256)' ),
+    self.definitionKeyFields = [ ( 'Status', "VARCHAR(128)" ),
+                                 ( 'MinorStatus', 'VARCHAR(128)' ),
+                                 ( 'ApplicationStatus', 'VARCHAR(128)' ),
                                  ( 'Site', 'VARCHAR(128)' ),
                                  ( 'User', 'VARCHAR(128)' ),
                                  ( 'UserGroup', 'VARCHAR(128)' ),

--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -55,8 +55,14 @@ else:
     print >> sys.stderr, "Can not determine local platform"
     sys.exit(-1)
 DiracPath        = '%s' % ( os.path.join(DiracRoot,DiracPlatform,'bin'), )
-DiracLibraryPath = '%s' % ( os.path.join(DiracRoot,DiracPlatform,'lib'), )
 DiracPythonPath  = '%s' % ( DiracRoot, )
+DiracLibraryPath      = '%s' % ( os.path.join(DiracRoot,DiracPlatform,'lib'), )
+
+baseLibPath = DiracLibraryPath
+for entry in os.listdir( baseLibPath ):
+  if os.path.isdir( entry ):
+    DiracLibraryPath = '%s:%s' % ( DiracLibraryPath, os.path.join( baseLibPath, entry ) ) 
+
 
 os.environ['PATH'] = '%s:%s' % ( DiracPath, os.environ['PATH'] )
 

--- a/FrameworkSystem/Client/SecurityLogClient.py
+++ b/FrameworkSystem/Client/SecurityLogClient.py
@@ -9,7 +9,7 @@ class SecurityLogClient:
 
   __securityLogStore = []
 
-  def __init__(self):
+  def __init__( self ):
     self.__messagesList = []
     self.__maxMessagesInBundle = 1000
     self.__maxMessagesWaiting = 10000
@@ -26,7 +26,7 @@ class SecurityLogClient:
       strMsg = "Time=%s Accept=%s Source=%s:%s SourceID=%s Destination=%s:%s Service=%s Action=%s"
       syslog.syslog( strMsg % msg )
     while len( self.__messagesList ) > self.__maxMessagesWaiting:
-      self.__messagesList.pop(0)
+      self.__messagesList.pop( 0 )
     if not self.__securityLogStore:
       self.__messagesList.append( msg )
     else:
@@ -38,8 +38,8 @@ class SecurityLogClient:
     self.__securityLogStore.append( logStore )
     gThreadScheduler.addPeriodicTask( 10, self.__sendData, executions = 1 )
 
-  def __sendData(self):
-    gLogger.info( "Sending records to security log service...")
+  def __sendData( self ):
+    gLogger.verbose( "Sending records to security log service..." )
     msgList = self.__messagesList
     self.__messagesList = []
     rpcClient = RPCClient( "Framework/SecurityLogging" )
@@ -50,6 +50,6 @@ class SecurityLogClient:
         self.__messagesList.extend( msgList )
         break
       msgList = msgList[ self.__maxMessagesInBundle: ]
-    gLogger.info( "Data sent to security log service" )
+    gLogger.verbose( "Data sent to security log service" )
 
 

--- a/WorkloadManagementSystem/Agent/StatesAccountingAgent.py
+++ b/WorkloadManagementSystem/Agent/StatesAccountingAgent.py
@@ -33,12 +33,13 @@ class StatesAccountingAgent( AgentModule ):
                                 'User',
                                 'UserGroup',
                                 'JobGroup',
-                                'JobSplitType',
+                                'JobType',
                               ]
   __summaryDefinedFields = [ ( 'ApplicationStatus', 'unset' ), ( 'MinorStatus', 'unset' ) ]
   __summaryValueFieldsMapping = [ 'Jobs',
                                   'Reschedules',
                                 ]
+  __renameFieldsMapping = { 'JobType' : 'JobSplitType' }
 
 
   def initialize( self ):
@@ -87,7 +88,7 @@ class StatesAccountingAgent( AgentModule ):
           rD[ fV[0] ] = fV[1]
         for iP in range( len( self.__summaryKeyFieldsMapping ) ):
           fieldName = self.__summaryKeyFieldsMapping[iP]
-          rD[ fieldName ] = record[iP]
+          rD[ self.__renameFieldsMapping.get( fieldName, fieldName ) ] = record[iP]
         record = record[ len( self.__summaryKeyFieldsMapping ): ]
         for iP in range( len( self.__summaryValueFieldsMapping ) ):
           rD[ self.__summaryValueFieldsMapping[iP] ] = int( record[iP] )


### PR DESCRIPTION
CHANGE: For the WMSHistory type, send as JobSplitType the JobType

Not related to WMSHistory but equally useful, comfy and nice

CHANGE: Reduced the size of the max key length to workaround mysql max bytes for index problem
NEW: When setting the lib path in the deploy scripts. Also search for subpaths of the libdir and include them
CHANGE: Security log level to verbose
