### PR TITLE
Fixes in the TimeLeft utilities

### DIFF
--- a/Core/Utilities/TimeLeft/PBSTimeLeft.py
+++ b/Core/Utilities/TimeLeft/PBSTimeLeft.py
@@ -87,6 +87,13 @@ class PBSTimeLeft:
 
     if not failed:
       return S_OK( consumed )
+
+    if cpuLimit and wallClockLimit:
+      # We have got a partial result from PBS, assume that we ran for too short time
+      # This is a temporary dirty solution, real consumption should be rather used, A.T.
+      consumed['CPU'] = 300
+      consumed['WallClock'] = 600
+      return S_OK( consumed )
     else:
       self.log.info( 'Could not determine some parameters, this is the stdout from the batch system call\n%s' % ( result['Value'] ) )
       retVal = S_ERROR( 'Could not determine some parameters' )

--- a/Core/Utilities/TimeLeft/TimeLeft.py
+++ b/Core/Utilities/TimeLeft/TimeLeft.py
@@ -156,10 +156,10 @@ class TimeLeft:
     return S_OK( batchInstance )
 
 #############################################################################
-def runCommand( cmd ):
+def runCommand( cmd, timeout = 120 ):
   """Wrapper around shellCall to return S_OK(stdout) or S_ERROR(message)
   """
-  result = shellCall( 0, cmd )
+  result = shellCall( timeout, cmd )
   if not result['OK']:
     return result
   status = result['Value'][0]


### PR DESCRIPTION
CHANGE: Call batch system commands with the ( default ) timeout 120 sec
CHANGE: PBSTimeLeft uses default CPU/WallClock if not present in the output
