### PR TITLE
Typo fixed in PBSTimeLeft

### DIFF
--- a/Core/Utilities/TimeLeft/PBSTimeLeft.py
+++ b/Core/Utilities/TimeLeft/PBSTimeLeft.py
@@ -52,7 +52,7 @@ class PBSTimeLeft:
     lines = result['Value'].split( '\n' )
     for line in lines:
       info = line.split()
-      if re.search( '.*resources_used.cput.*', line ):
+      if re.search( '.*resources_used.pcput.*', line ):
         if len( info ) >= 3:
           cpuList = info[2].split( ':' )
           cpu = ( float( cpuList[0] ) * 60 + float( cpuList[1] ) ) * 60 + float( cpuList[2] )
@@ -64,7 +64,7 @@ class PBSTimeLeft:
           wallClock = ( float( wcList[0] ) * 60 + float( wcList[1] ) ) * 60 + float( wcList[2] )
         else:
           self.log.warn( 'Problem parsing "%s" for elapsed wall clock time' % line )
-      if re.search( '.*Resource_List.cput.*', line ):
+      if re.search( '.*Resource_List.pcput.*', line ):
         if len( info ) >= 3:
           cpuList = info[2].split( ':' )
           cpuLimit = ( float( cpuList[0] ) * 60 + float( cpuList[1] ) ) * 60 + float( cpuList[2] )


### PR DESCRIPTION
FIX: cput -> pcput in the PBS output parsing
