### PR TITLE
FIX: better handling of pcput

### DIFF
--- a/Core/Utilities/TimeLeft/PBSTimeLeft.py
+++ b/Core/Utilities/TimeLeft/PBSTimeLeft.py
@@ -52,7 +52,7 @@ class PBSTimeLeft:
     lines = result['Value'].split( '\n' )
     for line in lines:
       info = line.split()
-      if re.search( '.*resources_used.pcput.*', line ):
+      if re.search( '.*resources_used.cput.*', line ):
         if len( info ) >= 3:
           cpuList = info[2].split( ':' )
           cpu = ( float( cpuList[0] ) * 60 + float( cpuList[1] ) ) * 60 + float( cpuList[2] )
@@ -64,10 +64,20 @@ class PBSTimeLeft:
           wallClock = ( float( wcList[0] ) * 60 + float( wcList[1] ) ) * 60 + float( wcList[2] )
         else:
           self.log.warn( 'Problem parsing "%s" for elapsed wall clock time' % line )
+      if re.search( '.*Resource_List.cput.*', line ):
+        if len( info ) >= 3:
+          cpuList = info[2].split( ':' )
+          newcpuLimit = ( float( cpuList[0] ) * 60 + float( cpuList[1] ) ) * 60 + float( cpuList[2] )
+          if not cpuLimit or newcpuLimit < cpuLimit:
+            cpuLimit = newcpuLimit
+        else:
+          self.log.warn( 'Problem parsing "%s" for CPU limit' % line )
       if re.search( '.*Resource_List.pcput.*', line ):
         if len( info ) >= 3:
           cpuList = info[2].split( ':' )
-          cpuLimit = ( float( cpuList[0] ) * 60 + float( cpuList[1] ) ) * 60 + float( cpuList[2] )
+          newcpuLimit = ( float( cpuList[0] ) * 60 + float( cpuList[1] ) ) * 60 + float( cpuList[2] )
+          if not cpuLimit or newcpuLimit < cpuLimit:
+            cpuLimit = newcpuLimit
         else:
           self.log.warn( 'Problem parsing "%s" for CPU limit' % line )
       if re.search( '.*Resource_List.walltime.*', line ):


### PR DESCRIPTION
revert to resources_used.cput and take minimum of:
- Resource_List.pcput
- Resource_List.cput
  This assumes we are getting a single core for execution.
