### PR TITLE
BUGFIX: getExt() returns always a string

### DIFF
--- a/ResourceStatusSystem/Utilities/CS.py
+++ b/ResourceStatusSystem/Utilities/CS.py
@@ -113,14 +113,11 @@ def getExtensions():
 #############################################################################
 
 def getExt():
-  VOExtension = ''
-
-  ext = getExtensions()['Value']
-
-  if 'LHCb' in ext:
-    VOExtension = 'LHCb'
-
-  return VOExtension
+  try:
+    if 'LHCb' in getExtensions()['Value']:
+      return 'LHCb'
+  except TypeError:
+    return ""
 
 #############################################################################
 


### PR DESCRIPTION
In RSS’s CS.py, function getExt() crashed when no value was defined for /DIRAC/Extensions in CS. Fix issue #305
