### PR TITLE
BugFix for getStorageElementStatusWeb, access mode by default is Read.

### DIFF
--- a/ResourceStatusSystem/Service/ResourceStatusHandler.py
+++ b/ResourceStatusSystem/Service/ResourceStatusHandler.py
@@ -1251,7 +1251,7 @@ class ResourceStatusHandler( RequestHandler ):
 #############################################################################
 
   types_getStorageElementsStatusWeb = [ dict, list, int, int, str ]
-  def export_getStorageElementsStatusWeb( self, selectDict, sortList, startItem, maxItems, access ):
+  def export_getStorageElementsStatusWeb( self, selectDict, sortList, startItem, maxItems, access = 'Read' ):
     """ Get present sites status list, for the web
         Calls :meth:`DIRAC.ResourceStatusSystem.DB.ResourceStatusDB.ResourceStatusDB.getMonitoredsStatusWeb`
 


### PR DESCRIPTION
This is a bugfix for the SiteGateway view of the portal.
I've set by default the access type of the SE, this way the web portal should not crash. 
