### PR TITLE
InstallType is used in many places, so it has to be supported

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1002,7 +1002,7 @@ def loadConfiguration():
       else:
         logNOTICE( "Loaded %s" % arg )
 
-  for opName in ( 'release', 'externalsType', 'pythonVersion',
+  for opName in ( 'release', 'externalsType', 'installType', 'pythonVersion',
                   'buildExternals', 'noAutoBuild', 'debug' ,
                   'lcgVer', 'useVersionsDir', 'targetPath',
                   'project', 'release', 'extraModules', 'extensions' ):
@@ -1013,6 +1013,8 @@ def loadConfiguration():
     #Also react to Extensions as if they were extra modules
     if opName == 'extensions':
       opName = 'extraModules'
+    if opName == 'installType':
+      opName = 'externalsType'
     if type( getattr( cliParams, opName ) ) == types.StringType:
       setattr( cliParams, opName, opVal )
     elif type( getattr( cliParams, opName ) ) == types.BooleanType:


### PR DESCRIPTION
dirac-install needs to be able to understand /LocalInstallation/InstallType.
 must be in v6ro and this dirac-install must be copied to the download link.
