### PR TITLE
FIX: 9144 -> 9139 port for StorageElementProxy service to avoid clashes with

### DIFF
--- a/DataManagementSystem/ConfigTemplate.cfg
+++ b/DataManagementSystem/ConfigTemplate.cfg
@@ -92,7 +92,7 @@ Services
   StorageElementProxy
   {
     BasePath = storageElement
-    Port = 9144
+    Port = 9139
     Authorization
     {
       Default = all


### PR DESCRIPTION
FIX: DataManagement configTemplate - 9144 -> 9139 port for StorageElementProxy service to avoid clashes with SystemLogging
