### PR TITLE
FIX: TypeError form DIRAC/Core/Utilities/Pfn.py:parsepfn

### DIFF
--- a/Core/Utilities/Pfn.py
+++ b/Core/Utilities/Pfn.py
@@ -65,6 +65,10 @@ def pfnunparse( pfnDict ):
 def pfnparse( pfn ):
 
   pfnDict = {'Protocol':'', 'Host':'', 'Port':'', 'WSUrl':'', 'Path':'', 'FileName':''}
+
+  if not pfn:
+    return S_ERROR("wrong 'pfn' argument value in function call, expected non-empty string, got %s" % str(pfn) )
+
   try:
     #gLogger.debug("Pfn.pfnunparse: Attempting to parse pfn %s." % pfn)
     if not re.search( ':', pfn ):


### PR DESCRIPTION
Hi,

This error has been spotted several times in cert and now in prod:

2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent  WARN: StorageElement.getPfnForProtocol: Requested
protocol not available for SE. DIP for CERN-HIST
2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent EXCEPT: Pfn.pfnparse: Exception while parsing pfn: None 
2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent EXCEPT: == EXCEPTION ==
2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent EXCEPT: <type 'exceptions.TypeError'>:expected string
or buffer
2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent EXCEPT:   File
"/opt/dirac/pro/DIRAC/Core/Utilities/Pfn.py", line 70, in pfnparse
2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent EXCEPT:     if not re.search( ':', pfn ):
2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent EXCEPT: 
2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent EXCEPT:   File
"/opt/dirac/pro/Linux_x86_64_glibc-2.5/lib/python2.6/re.py", line 142, in search
2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent EXCEPT:     return _compile(pattern, flags).search(string)
2011-12-13 10:39:22 UTC DataManagement/RegistrationAgent EXCEPT: ===============

My fix return S_ERROR if pgn arg is wrong.

Cheers,
K.
