### PR TITLE
NEW: Added functionality to kill all children processes dramatically

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -1,7 +1,7 @@
 import threading
 import types
 from DIRAC import S_OK, S_ERROR
-from DIRAC.Core.Utilities import CFG
+from DIRAC.Core.Utilities import CFG, LockRing
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry, CSGlobals
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 
@@ -9,7 +9,7 @@ class Operations( object ):
 
   __cache = {}
   __cacheVersion = 0
-  __cacheLock = threading.Lock()
+  __cacheLock = LockRing.LockRing().getLock( "CSOperations.cache" )
 
   def __init__( self, vo = False, group = False, setup = False ):
     self.__threadData = threading.local()

--- a/ConfigurationSystem/private/ConfigurationData.py
+++ b/ConfigurationSystem/private/ConfigurationData.py
@@ -10,14 +10,16 @@ import DIRAC
 from DIRAC.Core.Utilities import List, Time
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.Utilities.CFG import CFG
+from DIRAC.Core.Utilities.LockRing import LockRing
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
 class ConfigurationData:
 
   def __init__( self, loadDefaultCFG = True ):
-    self.threadingEvent = threading.Event()
+    lr = LockRing()
+    self.threadingEvent = lr.getEvent( "configdata.dangerZone" )
     self.threadingEvent.set()
-    self.threadingLock = threading.Lock()
+    self.threadingLock = lr.getLock( "configdata.update" )
     self.runningThreadsNumber = 0
     self.compressedConfigurationData = ""
     self.configurationPath = "/DIRAC/Configuration"

--- a/ConfigurationSystem/private/Refresher.py
+++ b/ConfigurationSystem/private/Refresher.py
@@ -7,7 +7,7 @@ import random
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 from DIRAC.ConfigurationSystem.Client.PathFinder import getGatewayURLs
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
-from DIRAC.Core.Utilities import List
+from DIRAC.Core.Utilities import List, LockRing
 from DIRAC.Core.Utilities.EventDispatcher import gEventDispatcher
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 
@@ -38,7 +38,7 @@ class Refresher( threading.Thread ):
     self.__callbacks = { 'newVersion' : [] }
     gEventDispatcher.registerEvent( "CSNewVersion" )
     random.seed()
-    self.__triggeredRefreshLock = threading.Lock()
+    self.__triggeredRefreshLock = LockRing.LockRing().getLock( "Refresher.triggerUpdate" )
 
   def disable( self ):
     self.__refreshEnabled = False

--- a/Core/DISET/TransferClient.py
+++ b/Core/DISET/TransferClient.py
@@ -2,7 +2,6 @@
 __RCSID__ = "$Id$"
 
 import tarfile
-import threading
 import os
 from DIRAC.Core.DISET.private.BaseClient import BaseClient
 from DIRAC.Core.DISET.private.FileHelper import FileHelper

--- a/Core/DISET/private/GatewayService.py
+++ b/Core/DISET/private/GatewayService.py
@@ -1,10 +1,10 @@
 
 import os
-import threading
 import cStringIO
 import DIRAC
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities import List, Time
+from DIRAC.Core.Utilities.LockRing import LockRing
 from DIRAC.Core.Utilities.DictCache import DictCache
 from DIRAC.Core.DISET.private.ServiceConfiguration import ServiceConfiguration
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
@@ -387,7 +387,7 @@ class TransferRelay( TransferClient ):
 class MessageForwarder:
 
   def __init__( self, msgBroker ):
-    self.__inOutLock = threading.Lock()
+    self.__inOutLock = LockRing().getLock( "DISET.MsgFwd.IO" )
     self.__msgBroker = msgBroker
     self.__byClient = {}
     self.__srvToCliTrid = {}

--- a/Core/DISET/private/Transports/SSL/SocketInfo.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfo.py
@@ -4,10 +4,10 @@ __RCSID__ = "$Id$"
 import time
 import copy
 import os.path
-import threading
 import GSI
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK
 from DIRAC.Core.Utilities.Network import checkHostsMatch
+from DIRAC.Core.Utilities.LockRing import LockRing
 from DIRAC.Core.Security import Locations
 from DIRAC.Core.Security.X509Chain import X509Chain
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
@@ -16,7 +16,7 @@ class SocketInfo:
 
   __cachedCAsCRLs = False
   __cachedCAsCRLsLastLoaded = 0
-  __cachedCAsCRLsLoadLock = threading.Lock()
+  __cachedCAsCRLsLoadLock = LockRing().getLock( "DISET.SocketInfo.CAs" )
 
 
   def __init__( self, infoDict, sslContext = False ):

--- a/Core/DISET/private/Transports/SSL/ThreadSafeSSLObject.py
+++ b/Core/DISET/private/Transports/SSL/ThreadSafeSSLObject.py
@@ -2,11 +2,11 @@
 __RCSID__ = "$Id$"
 
 import GSI
-import threading
+from DIRAC.Core.Utilities.LockRing import LockRing
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
 class ThreadSafeSSLObject:
-  cLock = threading.RLock()
+  cLock = LockRing().getLock( "DISET.TSSSLObj" )
   def __init__( self, object ):
     self.cObject = object
   def __getattr__( self, name ):
@@ -25,7 +25,7 @@ class ThreadSafeSSLObject:
 class _MagicMethod:
   # some magic to bind a method to an object
   # supports "nested" methods (e.g. examples.getStateName)
-  def __init__(self, cLock, method, name ):
+  def __init__( self, cLock, method, name ):
     self.sFunctionName = name
     self.cMethod = method
     self.cLock = cLock
@@ -41,7 +41,7 @@ class _MagicMethod:
       self.cLock.release()
     else:
       self.cLock.release()
-  def __call__(self, *args):
+  def __call__( self, *args ):
     self.lock()
     try:
       try:

--- a/Core/DISET/private/Transports/SSLTransport.py
+++ b/Core/DISET/private/Transports/SSLTransport.py
@@ -4,8 +4,8 @@ __RCSID__ = "$Id$"
 import os
 import types
 import time
-import threading
 import GSI
+from DIRAC.Core.Utilities.LockRing import LockRing
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK
 from DIRAC.Core.DISET.private.Transports.BaseTransport import BaseTransport
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
@@ -18,7 +18,7 @@ GSI.SSL.set_thread_safe()
 
 class SSLTransport( BaseTransport ):
 
-  __readWriteLock = threading.Lock()
+  __readWriteLock = LockRing().getLock( "DISET.SSLTrans.RW" )
 
   def __init__( self, *args, **kwargs ):
     self.__writesDone = 0

--- a/Core/Utilities/LockRing.py
+++ b/Core/Utilities/LockRing.py
@@ -1,0 +1,106 @@
+
+import random
+import time
+import threading
+import thread
+from hashlib import md5
+
+from DIRAC import S_ERROR, S_OK
+from DIRAC.Core.Utilities.DIRACSingleton import DIRACSingleton
+
+class LockRing( object ):
+  __metaclass__ = DIRACSingleton
+
+  def __init__( self ):
+    random.seed()
+    self.__locks = {}
+    self.__events = {}
+
+  def __genName( self, container ):
+    name = md5( str( time.time() + random.random() ) ).hexdump()
+    retries = 10
+    while name in container and retries:
+      name = md5( str( time.time() + random.random() ) ).hexdump()
+      retries -= 1
+    return name
+
+  def getLock( self, lockName = "", recursive = False ):
+    if not lockName:
+      lockName = self.__genName( self.__locks )
+    try:
+      return self.__locks[ lockName ]
+    except KeyError:
+      if recursive:
+        self.__locks[ lockName ] = threading.RLock()
+      else:
+        self.__locks[ lockName ] = threading.Lock()
+    return self.__locks[ lockName ]
+
+  def getEvent( self, evName = "" ):
+    if not evName:
+      evName = self.__genName( self.__events )
+    try:
+      return self.__events[ evName ]
+    except KeyError:
+      self.__events[ evName ] = threading.Event()
+    return self.__events[ evName ]
+
+  def acquire( self, lockName ):
+    try:
+      self.__locks[ lockName ].acquire()
+    except ValueError:
+      return S_ERROR( "No lock named %s" % lockName )
+    return S_OK()
+
+  def release( self, lockName ):
+    try:
+      self.__locks[ lockName ].release()
+    except ValueError:
+      return S_ERROR( "No lock named %s" % lockName )
+    return S_OK()
+
+  def _openAll( self ):
+    """ 
+    WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING 
+    DO NOT USE EXCEPT IN JUST SPAWNED NEW CHILD PROCESSES!!!!!!!!
+    NEVER IN THE PARENT PROCESS!!!!!!
+    WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING 
+    """
+    for lockName in self.__locks.keys():
+      try:
+        self.__locks[ lockName ].release()
+      except ( thread.error, KeyError ):
+        pass
+
+  def _setAllEvents( self ):
+    """ 
+    WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING 
+    DO NOT USE EXCEPT IN JUST SPAWNED NEW CHILD PROCESSES!!!!!!!!
+    NEVER IN THE PARENT PROCESS!!!!!!
+    WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING 
+    """
+    for evName in self.__events.keys():
+      try:
+        self.__events[ evName ].set()
+      except KeyError:
+        pass
+
+if __name__ == "__main__":
+  lr = LockRing()
+  lock = lr.getLock( "test1" )
+  print "ACQUIRING LOCK", lock
+  lock.acquire()
+  print "IS THE SAME LOCK? ", lock == lr.getLock( "test1" )
+  print "OPENING ALL LOCKS"
+  lr._openAll()
+  print "REACQUIRING LOCK", lock
+  lr.acquire( "test1" )
+  print "RELEASING LOCK"
+  lr.release( "test1" )
+  print "IS SINGLETON", lr == LockRing()
+  ev = lr.getEvent( "POT" )
+  ev.set()
+  lr._setAllEvents()
+  print "ALL OK"
+
+

--- a/Core/Utilities/ProcessPool.py
+++ b/Core/Utilities/ProcessPool.py
@@ -85,6 +85,11 @@ except ImportError:
   gLogger = False
 
 try:
+  from DIRAC.Core.Utilities.LockRing import LockRing
+except ImportError:
+  LockRing = False
+
+try:
   from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 except ImportError:
   def S_OK( val = "" ):
@@ -108,6 +113,11 @@ class WorkingProcess( multiprocessing.Process ):
     """
     multiprocessing.Process.__init__( self )
     self.daemon = True
+    if LockRing:
+      #Reset all locks
+      lr = LockRing()
+      lr._openAll()
+      lr._setAllEvents()
     self.__working = multiprocessing.Value( 'i', 0 )
     self.__pendingQueue = pendingQueue
     self.__resultsQueue = resultsQueue
@@ -497,7 +507,7 @@ class ProcessPool:
     """
     while not self.__pendingQueue.empty() or self.getNumWorkingProcesses():
       self.processResults()
-      time.sleep( 1 ) 
+      time.sleep( 1 )
     self.processResults()
 
   def finalize( self, timeout = 10 ):


### PR DESCRIPTION
NEW: Added functionality to kill all children processes dramatically

because some children processes don't respond to SIGTERM and python has no way of setting which signal to use.
