### PR TITLE
FIX: Server authorization using roles instead of groups

### DIFF
--- a/ResourceStatusSystem/ConfigTemplate.cfg
+++ b/ResourceStatusSystem/ConfigTemplate.cfg
@@ -3,7 +3,8 @@ Services {
     Port = 9160
     Authorization
     {
-      Default = authenticated
+      Default = SiteManager
+      get = all
     }
   }
 
@@ -11,7 +12,8 @@ Services {
     Port = 9172
     Authorization
     {
-      Default = authenticated
+      Default = SiteManager
+      get = all
     }
   }
 }

--- a/ResourceStatusSystem/Service/ResourceManagementHandler.py
+++ b/ResourceStatusSystem/Service/ResourceManagementHandler.py
@@ -7,7 +7,7 @@ from DIRAC                                              import S_OK
 from DIRAC.Core.DISET.RequestHandler                    import RequestHandler
 
 from DIRAC.ResourceStatusSystem.DB.ResourceManagementDB import ResourceManagementDB
-from DIRAC.ResourceStatusSystem.Utilities.Decorators    import HandlerDec3, AdminRequired
+from DIRAC.ResourceStatusSystem.Utilities.Decorators    import HandlerDec3
 
 db = False
 
@@ -59,7 +59,6 @@ class ResourceManagementHandler( RequestHandler ):
     db = database
 
   types_insert = [ dict, dict ]
-  @AdminRequired
   @HandlerDec3
   def export_insert( self, params, meta ):
     '''   
@@ -83,7 +82,6 @@ class ResourceManagementHandler( RequestHandler ):
     return db, credentials
 
   types_update = [ dict, dict ]
-  @AdminRequired
   @HandlerDec3
   def export_update( self, params, meta ):
     '''   
@@ -130,7 +128,6 @@ class ResourceManagementHandler( RequestHandler ):
     return db, credentials
 
   types_delete = [ dict, dict ]
-  @AdminRequired
   @HandlerDec3
   def export_delete( self, params, meta ):
     '''   

--- a/ResourceStatusSystem/Service/ResourceStatusHandler.py
+++ b/ResourceStatusSystem/Service/ResourceStatusHandler.py
@@ -7,7 +7,7 @@ from DIRAC                                             import gConfig, S_OK
 from DIRAC.Core.DISET.RequestHandler                   import RequestHandler
 
 from DIRAC.ResourceStatusSystem.DB.ResourceStatusDB    import ResourceStatusDB
-from DIRAC.ResourceStatusSystem.Utilities.Decorators   import HandlerDec3, AdminRequired
+from DIRAC.ResourceStatusSystem.Utilities.Decorators   import HandlerDec3
 from DIRAC.ResourceStatusSystem.Utilities              import Utils
 db = False
 
@@ -75,7 +75,6 @@ class ResourceStatusHandler( RequestHandler ):
 
 
   types_insert = [ dict, dict ]
-  @AdminRequired
   @HandlerDec3
   def export_insert( self, params, meta ):
     '''
@@ -99,7 +98,6 @@ class ResourceStatusHandler( RequestHandler ):
     return db, credentials
 
   types_update = [ dict, dict ]
-  @AdminRequired
   @HandlerDec3
   def export_update( self, params, meta ):
     '''
@@ -146,7 +144,6 @@ class ResourceStatusHandler( RequestHandler ):
     return db, credentials
 
   types_delete = [ dict, dict ]
-  @AdminRequired
   @HandlerDec3
   def export_delete( self, params, meta ):
     '''

--- a/ResourceStatusSystem/Utilities/Decorators.py
+++ b/ResourceStatusSystem/Utilities/Decorators.py
@@ -170,7 +170,7 @@ class AdminRequired( BaseDec ):
     
     self.f.processArgs( *args, **kwargs )
     
-    gLogger.info( dir( args[ 0 ] ) )
+    _system,_handler = args[ 0 ].__module__.rsplit( '.', 2 )[-2:]
     
     okProperties   = set( [ 'SiteAdmin' ] )
     


### PR DESCRIPTION
AdminRequired decorator deprecated, using CS Authentication option. Default is SiteManager, and get methods are all.

Reminder: update CS when this is released.
