### PR TITLE
Fix change of Mail and Coordinates 

### DIFF
--- a/ConfigurationSystem/Agent/CE2CSAgent.py
+++ b/ConfigurationSystem/Agent/CE2CSAgent.py
@@ -281,7 +281,7 @@ class CE2CSAgent( AgentModule ):
                 if mail == 'Unknown':
                   self.csAPI.setOption( cfgPath( siteSection, 'Mail' ), newmail )
                 else:
-                  self.csAPI.modifyValue( cfgPath( siteSection, 'Coordinates' ), newmail )
+                  self.csAPI.modifyValue( cfgPath( siteSection, 'Mail' ), newmail )
                 changed = True
 
         celist = List.fromChar( opt.get( 'CE', '' ) )


### PR DESCRIPTION
The agent was changing the coordinates for the newEmail when suppose to change Mail Value
