### PR TITLE
FIX: Small fix that prevents ARCHIVE SEs going into Active.

### DIFF
--- a/DataManagementSystem/scripts/dirac-admin-allow-se.py
+++ b/DataManagementSystem/scripts/dirac-admin-allow-se.py
@@ -90,6 +90,10 @@ for se,seOptions in res[ 'Value' ].items():
     if not seOptions[ 'Read' ] in [ "InActive", "Banned", "Probing" ]:
       gLogger.notice( 'Read option for %s is %s, instead of %s' % ( se, seOptions[ 'Read' ], [ "InActive", "Banned", "Probing" ] ) )    
       continue
+    
+    if 'ARCHIVE' in se:
+      gLogger.notice( '%s is not supposed to change status to Acctive' % se )
+      continue
      
     resR = ResourceStatus.setStorageElementStatus( se, 'Read', 'Active', reason, userName )
     if not resR['OK']:


### PR DESCRIPTION
The former dirac-admin-allow-se had a non written convention, only InActive SEs could go into Active, but on the CS the ARCHIVE SEs were aside, with status NotAllowed. With the RSS, this sort of things are not very welcomed. The script nows checks whether is an archive SE or not.
