### PR TITLE
FIX: ResourceStatus and clients catch MySQLdb import exceptions

### DIFF
--- a/ResourceStatusSystem/Client/ResourceManagementClient.py
+++ b/ResourceStatusSystem/Client/ResourceManagementClient.py
@@ -47,6 +47,9 @@ class ResourceManagementClient:
       try:
         self.gate = ResourceManagementDB()
       except SystemExit:
+        self.gate = RPCClient( "ResourceStatus/ResourceManagement" )
+      except ImportError:
+        # Pilots will connect here, as MySQLdb is not installed for them        
         self.gate = RPCClient( "ResourceStatus/ResourceManagement" )        
     else:
       self.gate = serviceIn    

--- a/ResourceStatusSystem/Client/ResourceStatus.py
+++ b/ResourceStatusSystem/Client/ResourceStatus.py
@@ -122,13 +122,12 @@ def __getCSStorageElementStatus( elementName, statusType, default ):
   if not isinstance( elementName, list ):
     elementName = [ elementName ]
 
-  rsc      = ResourceStatusClient()
-  statuses = rsc.getValidStatusTypes()
-  
+  statuses = gConfig.getOptionsDict( '/Operations/RSSConfiguration/GeneralConfig/Resources/StorageElement' )
+    
   if statuses[ 'OK' ]:
-    statuses = statuses[ 'Value' ][ 'StorageElement' ][ 'StatusType' ]
+    statuses = statuses[ 'Value' ][ 'StatusType' ]
   else:
-    statuses = []  
+    statuses = [ 'Read', 'Write' ]  
     
   r = {}
   for element in elementName:

--- a/ResourceStatusSystem/Client/ResourceStatusClient.py
+++ b/ResourceStatusSystem/Client/ResourceStatusClient.py
@@ -54,6 +54,9 @@ class ResourceStatusClient:
         self.gate = ResourceStatusDB()
       except SystemExit:
         self.gate = RPCClient( "ResourceStatus/ResourceStatus" )
+      except ImportError:
+        # Pilots will connect here, as MySQLdb is not installed for them
+        self.gate = RPCClient( "ResourceStatus/ResourceStatus" )  
     else:
       self.gate = serviceIn
            


### PR DESCRIPTION
Updated RSS clients to catch ImportErrors ( sould only happen on pilots ).
Updated ResourceStatus helper to not use RSS at all on cs methods.
