### PR TITLE
Proposal for OSG_WN_TMP support

### DIFF
--- a/WorkloadManagementSystem/PilotAgent/dirac-pilot.py
+++ b/WorkloadManagementSystem/PilotAgent/dirac-pilot.py
@@ -122,6 +122,25 @@ rootPath = os.getcwd()
 
 installScriptName = 'dirac-install.py'
 
+rootPath = os.getcwd()
+
+if os.environ.has_key('OSG_WN_TMP'):
+  os.chdir(os.environ['OSG_WN_TMP'])
+  for path in ( pilotRootPath, rootPath ):
+    installScript = os.path.join( path, installScriptName )
+    if os.path.isfile( installScript ):
+      try:
+        shutil.copy(installScript, os.path.join(os.environ['OSG_WN_TMP'],installScriptName))
+      except Exception, x:
+        print sys.executable
+        print sys.version
+        print os.uname()
+        print x
+        raise x
+      break
+
+rootPath = os.getcwd()
+
 for path in ( pilotRootPath, rootPath ):
   installScript = os.path.join( path, installScriptName )
   if os.path.isfile( installScript ):


### PR DESCRIPTION
Basically check if that env variable is set, in which case copy the driac-uinstall there and chdir. I've tested it and it works. There is still something I don't understand:
012-02-23 09:46:45 UTC dirac-pilot [DEBUG] Installing with: /grid/home/ilc/gram_scratch_KYUHdTJDo5/https_3a_2f_2fwmslb01.grid.hep.ph.ic.ac.uk_3a9000_2fMgMp476-o2MEhB5GKJKGZw/dirac-install.py -d -e "ILC" -r "v8r0p4" -V "ILCDIRAC" -g '2011-06-06' -i "26"
2012-02-23 09:46:45 UTC dirac-install [NOTICE]  Processing installation requirements
2012-02-23 09:46:45 UTC dirac-install [DEBUG] Loading global defaults from: http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/globalDefaults.cfg
2012-02-23 09:46:45 UTC dirac-install [DEBUG] Loaded global defaults
2012-02-23 09:46:45 UTC dirac-install [DEBUG] Defaults for Installations/ILCDIRAC are in http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/defaults/ilc.cfg
2012-02-23 09:46:45 UTC dirac-install [NOTICE]  Destination path for installation is /local/stage1/disk5/dir_19016

I'm not sure where the directory https_3a_2f_2fwmslb01.grid.hep.ph.ic.ac.uk_3a9000_2fMgMp476-o2MEhB5GKJKGZw/ comes from... But at least DIRAC is then installed at local/stage1/disk5/dir_19016 that is the OSG_WN_TMP directory. And everything end up there.
