### PR TITLE
Transformation: Add support for dictionary in metadata for the InputDataQuery mechanism

### DIFF
--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -976,16 +976,17 @@ class TransformationDB( DB ):
         if type( parameterValue ) in [IntType, LongType]:
           parameterType = 'Integer'
           parameterValue = str( parameterValue )
-      insertTuples.append( "(%d,'%s','%s','%s')" % ( transID, parameterName, parameterValue, parameterType ) )
-    if not insertTuples:
-      return S_ERROR( "No input data query to be inserted" )
-    req = "INSERT INTO TransformationInputDataQuery (TransformationID,ParameterName,ParameterValue,ParameterType) VALUES %s" % ','.join( insertTuples )
-    res = self._update( req, connection )
-    if not res['OK']:
-      message = 'Failed to add input data query'
-      self.deleteTransformationInputDataQuery( transID, connection = connection )
-    else:
-      message = 'Added input data query'
+        if type( parameterValue ) == DictType:
+          parameterType = 'Dict'
+          parameterValue = str( parameterValue )    
+      res = self._insert('TransformationInputDataQuery',['TransformationID','ParameterName','ParameterValue','ParameterType'],
+                         [transID, parameterName, parameterValue, parameterType], connection = connection)
+      if not res['OK']:
+        message = 'Failed to add input data query'
+        self.deleteTransformationInputDataQuery( transID, connection = connection )
+        break
+      else:
+        message = 'Added input data query'      
     self.__updateTransformationLogging( transID, message, author, connection = connection )
     return res
 
@@ -1023,6 +1024,8 @@ class TransformationDB( DB ):
           parameterValue = [int( x ) for x in parameterValue]
       elif parameterType == 'Integer':
         parameterValue = int( parameterValue )
+      elif parameterType == 'Dict':
+        parameterValue = eval( parameterValue )    
       queryDict[parameterName] = parameterValue
     if not queryDict:
       return S_ERROR( "No InputDataQuery found for transformation" )


### PR DESCRIPTION
Until now, if a metadata query for a transformation was defined as
meta={}
meta['EvtType']='gghad'
meta['Datatype'] = 'SIM'
meta['Energy'] = '1.4tev'
meta['ProdID'] = {'>':766}

the last item was not stored properly as it's a dict.  

The proposed change accounts for it. But for proper escape, one needs to use the self._insert method. But as this does not allow for multiple insert in one go, I had to reshuffle a bit the code, and the _insert is called for every metadata object. 
