### PR TITLE
Restart SysAdmin last

### DIFF
--- a/Core/Utilities/InstallTools.py
+++ b/Core/Utilities/InstallTools.py
@@ -976,6 +976,13 @@ def runsvctrlComponent( system, component, mode ):
     return S_ERROR( 'Unknown runsvctrl mode "%s"' % mode )
 
   startCompDirs = glob.glob( os.path.join( startDir, '%s_%s' % ( system, component ) ) )
+  # Make sure that the Configuration server restarts first and the SystemAdmin restarts last
+  tmpList = list(startCompDirs)
+  for comp in tmpList:
+    if "Framework_SystemAdministrator" in comp:
+      startCompDirs.append(startCompDirs.pop(startCompDirs.index(comp)))
+    if "Configuration_Server" in comp:
+      startCompDirs.insert(0,startCompDirs.pop(startCompDirs.index(comp)))
   startCompList = [ [k] for k in startCompDirs]
   for startComp in startCompList:
     result = execCommand( 0, ['runsvctrl', mode] + startComp )


### PR DESCRIPTION
BUGFIX: when applying runsvctrl to a list of components make sure that the config server is treated first and the sysadmin service - last
