### PR TITLE
v6r4: BUGFIX: Crash in CacheCleanerAgent while getting ClientCache records from DB

### DIFF
--- a/ResourceStatusSystem/Agent/CacheCleanerAgent.py
+++ b/ResourceStatusSystem/Agent/CacheCleanerAgent.py
@@ -82,7 +82,7 @@ class CacheCleanerAgent( AgentModule ):
       kwargs = { 'meta' : {
                    'value'  : 'EndDate',
                    'columns': 'Opt_ID',
-                   'minor'  : { 'Result' : aDayAgo }
+                   'minor'  : { 'Result' : str( aDayAgo ) }
                   } 
                 }
       opt_IDs = self.rmClient.getClientCache( **kwargs )              


### PR DESCRIPTION
Result in ClientCache table is a varchar, but the method was getting a datetime. Converted to string to avoid problems
