### PR TITLE
BUGFIX: Pfn.pfnunparse() fails to properly concatenate Path and FileName

### DIFF
--- a/Core/Utilities/Pfn.py
+++ b/Core/Utilities/Pfn.py
@@ -79,7 +79,7 @@ def pfnunparse( pfnDict ):
     return S_ERROR("pfnunparse: 'FileName' value is missing in pfnDict")
   ## c
   ## /a/b/c
-  filePath = os.path.normpath( os.path.join( pfnDict["Path"], pfnDict["FileName"] ) ) 
+  filePath = os.path.normpath( '/' + pfnDict["Path"] + '/' + pfnDict["FileName"] ).replace( '//','/' )
     
   ## host
   uri = pfnDict["Host"]


### PR DESCRIPTION
BUGFIX: in pfnunparse() os.path.join if the second argument starts with /, the first one is ignored, replaced by a straight concatenation
