### PR TITLE
ProcessPool: killing stuck workers after timeout

### DIFF
--- a/Core/Utilities/test/ProcessPoolTests.py
+++ b/Core/Utilities/test/ProcessPoolTests.py
@@ -39,16 +39,15 @@ import threading
 
 def ResultCallback( task, taskResult ):
   """ dummy result callback """
-  print "results callback for task %s" % task.getTaskID()
-  print "result is %s" % taskResult
+  print "callback for %s result is %s" % ( task.getTaskID(), taskResult )
 
 def ExceptionCallback( task, exec_info ):
   """ dummy exception callback """
-  print "exception callback for task %s" % task.getTaskID()
-  print "exception is %s" % exec_info
+  print "callback for %s exception is %s" % ( task.getTaskID(), exec_info )
 
 def CallableFunc( timeWait, raiseException = False ):
   """ global function to be executed in task """
+  print "will sleep for %s s" % timeWait
   time.sleep( timeWait )
   if raiseException:
     raise Exception( "testException" )
@@ -64,6 +63,7 @@ class CallableClass( object ):
     self.log = gLogger.getSubLogger( self.__class__.__name__ )
     self.timeWait = timeWait
     self.raiseException = raiseException
+    
   def __call__( self ):
     import time
     self.log.always( "will sleep for %s s" % self.timeWait )
@@ -86,7 +86,7 @@ class LockedCallableClass( object ):
     from DIRAC.FrameworkSystem.Client.Logger import gLogger
     self.log = gLogger.getSubLogger( self.__class__.__name__ )
 
-    self.log.always("Am I locked? %s" % gLock.locked() )
+    self.log.always( "Am I locked!!!" )
     gLock.acquire()
     self.log.always("you can't see that line, object is stuck by gLock" )
     self.timeWait = timeWait 
@@ -94,6 +94,7 @@ class LockedCallableClass( object ):
     gLock.release()
 
   def __call__( self ):
+    self.log.always("If you see this line, miracle had happened!")
     import time
     self.log.always("will sleep for %s" % self.timeWait )
     time.sleep( self.timeWait )
@@ -190,12 +191,10 @@ class ProcessPoolCallbacksTests( unittest.TestCase ):
     self.processPool.daemonize()
 
   def poolCallback( self, taskID, taskResult ):
-    self.log.always( "result callback executed for task %s" % taskID )
-    self.log.always( "result is %s" % taskResult  ) 
+    self.log.always( "callback for %s result is %s" % ( taskID, taskResult ) ) 
   
   def poolExceptionCallback( self, taskID, taskException ):
-    self.log.always( "exception callback executed for task %s" % taskID )
-    self.log.always( "exception is %s" % taskException )
+    self.log.always( "callback for %s exception is %s" % ( taskID, taskException ) )
   
   def testCallableClass( self ):
     """ CallableClass and pool callbacks test """
@@ -238,7 +237,7 @@ class ProcessPoolCallbacksTests( unittest.TestCase ):
                                                       blocking = True )    
         if result["OK"]:
           i += 1
-          self.log.always("CallableClass enqueued to task %s" % i )
+          self.log.always("CallableFunc enqueued to task %s" % i )
         else:
           continue
       if i == 10:
@@ -265,34 +264,32 @@ class TaskTimeOutTests( unittest.TestCase ):
     from DIRAC.FrameworkSystem.Client.Logger import gLogger
     gLogger.showHeaders( True )
     self.log = gLogger.getSubLogger( self.__class__.__name__ )
-    self.processPool = ProcessPool( 1,
-                                    4, 
-                                    4,
+    self.processPool = ProcessPool( 2,
+                                    6, 
+                                    6,
                                     poolCallback = self.poolCallback, 
                                     poolExceptionCallback = self.poolExceptionCallback )
     self.processPool.daemonize()
     
   def poolCallback( self, taskID, taskResult ):
-    self.log.always( "result callback executed for task %s" % taskID )
-    self.log.always( "result is %s" % taskResult  ) 
+    self.log.always( "callback result for %s is %s" % ( taskID, taskResult )  ) 
   
-  def poolExceptionCallback( self, taskID, taskException ):
-    self.log.always( "exception callback executed for task %s" % taskID )
-    self.log.always( "exception is %s" % taskException )
+  def poolExceptionCallback( self, taskID, taskException ): 
+    self.log.always( "callback exception for %s is %s" % ( taskID, taskException ) )
   
   def testCallableClass( self ):
     """ CallableClass and task time out test """
     i = 0
     while True:
       if self.processPool.getFreeSlots() > 0:
-        timeWait = random.randint(0, 5)
+        timeWait = random.randint(0, 5) * 10
         raiseException = False
         if not timeWait:
           raiseException = True 
         result = self.processPool.createAndQueueTask( CallableClass,
                                                       taskID = i,
                                                       args = ( timeWait, raiseException ), 
-                                                      timeOut = 1,
+                                                      timeOut = 5,
                                                       usePoolCallbacks = True,
                                                       blocking = True )    
         if result["OK"]:
@@ -310,22 +307,22 @@ class TaskTimeOutTests( unittest.TestCase ):
     i = 0
     while True:
       if self.processPool.getFreeSlots() > 0:
-        timeWait = random.randint(0, 5)
+        timeWait = random.randint(0, 5) * 5
         raiseException = False
         if not timeWait:
           raiseException = True 
         result = self.processPool.createAndQueueTask( CallableFunc,
                                                       taskID = i,
                                                       args = ( timeWait, raiseException ),  
-                                                      timeOut = 1,
+                                                      timeOut = 10,
                                                       usePoolCallbacks = True,
                                                       blocking = True )    
         if result["OK"]:
           i += 1
-          self.log.always("CallableClass enqueued to task %s" % i )
+          self.log.always("CallableFunc enqueued to task %s" % i )
         else:
           continue
-      if i == 10:
+      if i == 100:
         break
     self.processPool.processAllResults() 
     self.processPool.finalize()
@@ -336,27 +333,31 @@ class TaskTimeOutTests( unittest.TestCase ):
     i = 0
     while True:
       if self.processPool.getFreeSlots() > 0:
-        timeWait = random.randint(0, 5)
+        timeWait = random.randint(0, 5)* 5
         raiseException = False
         if not timeWait:
           raiseException = True
         klass = CallableClass
-        if timeWait > 3:
+        if timeWait >= 15:
           klass = LockedCallableClass
 
         result = self.processPool.createAndQueueTask( klass,
                                                       taskID = i,
                                                       args = ( timeWait, raiseException ), 
-                                                      timeOut = 1,
+                                                      timeOut = 10,
                                                       usePoolCallbacks = True,
                                                       blocking = True )    
         if result["OK"]:
           i += 1
-          self.log.always("%s enqueued to task %s" % ( klass, i ) )
+          self.log.always("%s enqueued to task %s" % ( klass.__name__ , i ) )
         else:
           continue
-      if i == 10:
+      if i % 20 == 0:
+        self.log.always("sleeping for 30s...") 
+        time.sleep(30)
+      if i == 100:
         break
+
     self.processPool.processAllResults() 
     self.processPool.finalize()
     ## unlock
@@ -367,9 +368,9 @@ class TaskTimeOutTests( unittest.TestCase ):
 if __name__ == "__main__":
 
   testLoader = unittest.TestLoader()
-  #suitePPCT = testLoader.loadTestsFromTestCase( ProcessPoolCallbacksTests )  
-  #suiteTCT = testLoader.loadTestsFromTestCase( TaskCallbacksTests )
+  suitePPCT = testLoader.loadTestsFromTestCase( ProcessPoolCallbacksTests )  
+  suiteTCT = testLoader.loadTestsFromTestCase( TaskCallbacksTests )
   suiteTTOT = testLoader.loadTestsFromTestCase( TaskTimeOutTests )
-  #suite = unittest.TestSuite( [ suitePPCT, suiteTCT, suiteTTOT ] )
-  unittest.TextTestRunner(verbosity=3).run(suiteTTOT)
+  suite = unittest.TestSuite( [ suitePPCT, suiteTCT, suiteTTOT ] )
+  unittest.TextTestRunner(verbosity=3).run(suite)
 


### PR DESCRIPTION
Finally solved stuck workers: if ProcessTask.process()  is stuck with some locked Lock, it will be killed after timeout seconds. 
