### PR TITLE
PATCH for v6r4 FIX: ResourceStatus was not returning Allowed by default

### DIFF
--- a/ResourceStatusSystem/Client/ResourceStatus.py
+++ b/ResourceStatusSystem/Client/ResourceStatus.py
@@ -146,7 +146,8 @@ class ResourceStatus( object ):
     for element in elementName:
     
       if statusType is not None:
-        res = gConfig.getOption( "%s/%s/%sAccess" % ( cs_path, element, statusType ) )
+        # Added Allowed by default
+        res = gConfig.getOption( "%s/%s/%sAccess" % ( cs_path, element, statusType ), 'Allowed' )
         if res[ 'OK' ] and res[ 'Value' ]:
           r[ element ] = { statusType : res[ 'Value' ] }
         
@@ -158,7 +159,12 @@ class ResourceStatus( object ):
             k = k.replace( 'Access', '' )
             if k in statuses:
               r2[ k ] = v
-              
+          
+          # If there is no status defined in the CS, we add by default Read and 
+          # Write as Allowed.
+          if r2 == {}:
+            r2 = { 'Read' : 'Allowed', 'Write' : 'Allowed' }
+                
           r[ element ] = r2             
     
     if r:


### PR DESCRIPTION
Spotted by Ricardo. When a SE had no defined status in the CS, the ResourceStatus helper was not returning Allowed by default. If queried about all the statuses of a SE and none is defined, it returns Read and Write as Allowed.
