### PR TITLE
NEW: Log all policy results ( conficts solved )

### DIFF
--- a/ResourceStatusSystem/Agent/CacheCleanerAgent.py
+++ b/ResourceStatusSystem/Agent/CacheCleanerAgent.py
@@ -64,56 +64,63 @@ class CacheCleanerAgent( AgentModule ):
     
   def execute( self ):
     
-    try:
+#    try:
        
-      # Cleans history tables from entries older than 6 months.
-      now          = datetime.utcnow().replace( microsecond = 0, second = 0 )
-      sixMonthsAgo = now - timedelta( days = 180 )
+    # Cleans history tables from entries older than 6 months.
+    now          = datetime.utcnow().replace( microsecond = 0, second = 0 )
+    sixMonthsAgo = now - timedelta( days = 180 )
       
-      validElements = RssConfiguration.getValidElements()
+    validElements = RssConfiguration.getValidElements()
       
-      for granularity in validElements:
-        #deleter = getattr( self.rsClient, 'delete%sHistory' % g )
-        
-        kwargs = { 'meta' : { 'minor' : { 'DateEnd' : sixMonthsAgo } } }
-        self.log.info( 'Deleting %sHistory older than %s' % ( granularity, sixMonthsAgo ) )
-        res = self.rsClient.deleteElementHistory( granularity, **kwargs )
-        if not res[ 'OK' ]:
-          self.log.error( res[ 'Message' ] )            
+    for granularity in validElements:
+      #deleter = getattr( self.rsClient, 'delete%sHistory' % g )
 
-      # Cleans ClientsCache table from DownTimes older than a day.
-      aDayAgo = now - timedelta( days = 1 )
-      
-      kwargs = { 'meta' : {
-                   'value'  : 'EndDate',
-                   'columns': 'Opt_ID',
-                   'minor'  : { 'Result' : str( aDayAgo ) }
-                  } 
-                }
-      opt_IDs = self.rmClient.getClientCache( **kwargs )              
-      opt_IDs = [ ID[ 0 ] for ID in opt_IDs[ 'Value' ] ]
-      
-      if opt_IDs:
-        self.log.info( 'Found %s ClientCache items to be deleted' % len( opt_IDs) )
-        self.log.debug( opt_IDs )
-      
-      res = self.rmClient.deleteClientCache( opt_ID = opt_IDs )
+      kwargs = { 'meta' : { 'minor' : { 'DateEnd' : sixMonthsAgo } } }
+      self.log.info( 'Deleting %sHistory older than %s' % ( granularity, sixMonthsAgo ) )
+      res = self.rsClient.deleteElementHistory( granularity, **kwargs )
       if not res[ 'OK' ]:
-        self.log.error( res[ 'Message' ] )
-      
-      # Cleans AccountingCache table from plots not updated nor checked in the last 30 mins      
-      anHourAgo = now - timedelta( minutes = 30 )
-      self.log.info( 'Deleting AccountingCache older than %s' % ( anHourAgo ) )
-      res = self.rmClient.deleteAccountingCache( meta = {'minor': { 'LastCheckTime' : anHourAgo }} )
-      if not res[ 'OK' ]:
-        self.log.error( res[ 'Message' ] )
+        self.log.error( res[ 'Message' ] )            
 
-      return S_OK()
+    # Cleans ClientsCache table from DownTimes older than a day.
+    aDayAgo = now - timedelta( days = 1 )
+      
+    kwargs = { 'meta' : {
+                 'value'  : 'EndDate',
+                 'columns': 'Opt_ID',
+                 'minor'  : { 'Result' : str( aDayAgo ) }
+                } 
+              }
+    opt_IDs = self.rmClient.getClientCache( **kwargs )              
+    opt_IDs = [ ID[ 0 ] for ID in opt_IDs[ 'Value' ] ]
+      
+    if opt_IDs:
+      self.log.info( 'Found %s ClientCache items to be deleted' % len( opt_IDs) )
+      self.log.debug( opt_IDs )
+      
+    res = self.rmClient.deleteClientCache( opt_ID = opt_IDs )
+    if not res[ 'OK' ]:
+      self.log.error( res[ 'Message' ] )
+      
+    # Cleans AccountingCache table from plots not updated nor checked in the last 30 mins      
+    anHourAgo = now - timedelta( minutes = 30 )
+    self.log.info( 'Deleting AccountingCache older than %s' % ( anHourAgo ) )
+    res = self.rmClient.deleteAccountingCache( meta = {'minor': { 'LastCheckTime' : anHourAgo }} )
+    if not res[ 'OK' ]:
+      self.log.error( res[ 'Message' ] )
+
+    # Cleans PolicyResultLog
+    twoWeeksAgo = now - timedelta( days = 10 )
+    self.log.info( 'Deleting PolicyResultLog older than %s' % ( twoWeeksAgo ) )
+    res = self.rmClient.deletePolicyResultLog( meta = {'minor': { 'LastCheckTime' : twoWeeksAgo }} )
+    if not res[ 'OK' ]:
+      self.log.error( res[ 'Message' ] )
+
+    return S_OK()
     
-    except Exception:
-      errorStr = "CacheCleanerAgent execution"
-      self.log.exception( errorStr )
-      return S_ERROR( errorStr )
+#    except Exception:
+#      errorStr = "CacheCleanerAgent execution"
+#      self.log.exception( errorStr )
+#      return S_ERROR( errorStr )
 
 ################################################################################
 #EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF      

--- a/ResourceStatusSystem/Client/ResourceManagementClient.py
+++ b/ResourceStatusSystem/Client/ResourceManagementClient.py
@@ -312,7 +312,139 @@ class ResourceManagementClient:
     # Unused argument
     # pylint: disable-msg=W0613
     return self.__query( 'delete', 'PolicyResult', locals() )
-  
+
+################################################################################
+# POLICY RESULT LOG FUNCTIONS
+
+  def insertPolicyResultLog( self, granularity, name, policyName, statusType,
+                             status, reason, lastCheckTime, meta = None ):
+    '''
+    Inserts on PolicyResult a new row with the arguments given.
+    
+    :Parameters:
+      **granularity** - `string`
+        it has to be a valid element ( ValidRes ), any of the defaults: `Site` \
+        | `Service` | `Resource` | `StorageElement`  
+      **name** - `string`
+        name of the element
+      **policyName** - `string`
+        name of the policy
+      **statusType** - `string`
+        it has to be a valid status type for the given granularity
+      **status** - `string`
+        it has to be a valid status, any of the defaults: `Active` | `Bad` | \
+        `Probing` | `Banned`    
+      **reason** - `string`
+        decision that triggered the assigned status
+      **lastCheckTime** - `datetime`
+        time-stamp setting last time the policy result was checked
+      **meta** - `[,dict]`
+        meta-data for the MySQL query. It will be filled automatically with the\
+       `table` key and the proper table name.
+
+    :return: S_OK() || S_ERROR()
+    '''
+    # Unused argument
+    # pylint: disable-msg=W0613
+    return self.__query( 'insert', 'PolicyResultLog', locals() ) 
+  def updatePolicyResultLog( self, granularity, name, policyName, statusType,
+                             status, reason, lastCheckTime, meta = None ):
+    '''
+    Updates PolicyResultLog with the parameters given. By default, `name`, 
+    `policyName`, 'statusType` and `lastCheckTime` will be the parameters used to 
+    select the row.
+    
+    :Parameters:
+      **granularity** - `string`
+        it has to be a valid element ( ValidRes ), any of the defaults: `Site` \
+        | `Service` | `Resource` | `StorageElement`  
+      **name** - `string`
+        name of the element
+      **policyName** - `string`
+        name of the policy
+      **statusType** - `string`
+        it has to be a valid status type for the given granularity
+      **status** - `string`
+        it has to be a valid status, any of the defaults: `Active` | `Bad` | \
+        `Probing` | `Banned`    
+      **reason** - `string`
+        decision that triggered the assigned status
+      **lastCheckTime** - `datetime`
+        time-stamp setting last time the policy result was checked
+      **meta** - `[, dict]`
+        meta-data for the MySQL query. It will be filled automatically with the\
+       `table` key and the proper table name.
+
+    :return: S_OK() || S_ERROR()
+    '''
+    # Unused argument
+    # pylint: disable-msg=W0613
+    return self.__query( 'update', 'PolicyResultLog', locals() )
+  def getPolicyResultLog( self, granularity = None, name = None, 
+                          policyName = None, statusType = None, status = None, 
+                          reason = None, lastCheckTime = None, meta = None ):
+    '''
+    Gets from PolicyResultLog all rows that match the parameters given.
+    
+    :Parameters:
+      **granularity** - `[, string, list]`
+        it has to be a valid element ( ValidRes ), any of the defaults: `Site` \
+        | `Service` | `Resource` | `StorageElement`  
+      **name** - `[, string, list]`
+        name of the element
+      **policyName** - `[, string, list]`
+        name of the policy
+      **statusType** - `[, string, list]`
+        it has to be a valid status type for the given granularity
+      **status** - `[, string, list]`
+        it has to be a valid status, any of the defaults: `Active` | `Bad` | \
+        `Probing` | `Banned`    
+      **reason** - `[, string, list]`
+        decision that triggered the assigned status
+      **lastCheckTime** - `[, datetime, list]`
+        time-stamp setting last time the policy result was checked
+      **meta** - `[, dict]`
+        meta-data for the MySQL query. It will be filled automatically with the\
+       `table` key and the proper table name.
+
+    :return: S_OK() || S_ERROR()
+    '''
+    # Unused argument
+    # pylint: disable-msg=W0613
+    return self.__query( 'get', 'PolicyResultLog', locals() )
+  def deletePolicyResultLog( self, granularity = None, name = None, 
+                             policyName = None, statusType = None, status = None, 
+                             reason = None, lastCheckTime = None, meta = None ):
+    '''
+    Deletes from PolicyResult all rows that match the parameters given.
+    
+    :Parameters:
+      **granularity** - `[, string, list]`
+        it has to be a valid element ( ValidRes ), any of the defaults: `Site` \
+        | `Service` | `Resource` | `StorageElement`  
+      **name** - `[, string, list]`
+        name of the element
+      **policyName** - `[, string, list]`
+        name of the policy
+      **statusType** - `[, string, list]`
+        it has to be a valid status type for the given granularity
+      **status** - `[, string, list]`
+        it has to be a valid status, any of the defaults: `Active` | `Bad` | \
+        `Probing` | `Banned`    
+      **reason** - `[, string, list]`
+        decision that triggered the assigned status
+      **lastCheckTime** - `[, datetime, list]`
+        time-stamp setting last time the policy result was checked
+      **meta** - `[, dict]`
+        meta-data for the MySQL query. It will be filled automatically with the\
+       `table` key and the proper table name.
+
+    :return: S_OK() || S_ERROR()
+    '''
+    # Unused argument
+    # pylint: disable-msg=W0613
+    return self.__query( 'delete', 'PolicyResultLog', locals() )
+    
 ################################################################################
 # CLIENT CACHE FUNCTIONS
 
@@ -917,6 +1049,46 @@ class ResourceManagementClient:
     # Unused argument
     # pylint: disable-msg=W0613
     return self.__addOrModifyElement( 'PolicyResult', locals() )
+
+# THIS METHOD DOES NOT WORK AS EXPECTED 
+# __addOrModifyElement overwrittes the field lastCheckTime.
+# Anyway, this table is a pure insert / get / delete table. No updates foreseen.
+ 
+#  def addOrModifyPolicyResultLog( self, granularity, name, policyName, statusType,
+#                                  status, reason, lastCheckTime ):
+#    '''
+#    Using `name`, `policyName` and `statusType` and `lastCheckTime` to query the 
+#    database, decides whether to insert or update the table.
+#    
+#    BE CAREFUL: lastCheckTime is on the UNIQUE_TOGETHER tuple. On the other hand,
+#    lastCheckTime is overwritten 
+#
+#    :Parameters:
+#      **granularity** - `string`
+#        it has to be a valid element ( ValidRes ), any of the defaults: `Site` \
+#        | `Service` | `Resource` | `StorageElement`  
+#      **name** - `string`
+#        name of the element
+#      **policyName** - `string`
+#        name of the policy
+#      **statusType** - `string`
+#        it has to be a valid status type for the given granularity
+#      **status** - `string`
+#        it has to be a valid status, any of the defaults: `Active` | `Bad` | \
+#        `Probing` | `Banned`    
+#      **reason** - `string`
+#        decision that triggered the assigned status
+#      **lastCheckTime** - `datetime`
+#        time-stamp setting last time the policy result was checked
+#      **meta** - `[, dict]`
+#        meta-data for the MySQL query. It will be filled automatically with the\
+#       `table` key and the proper table name.
+#
+#    :return: S_OK() || S_ERROR()
+#    '''
+#    # Unused argument
+#    # pylint: disable-msg=W0613
+#    return self.__addOrModifyElement( 'PolicyResultLog', locals() )  
   def addOrModifyClientCache( self, name, commandName, opt_ID, value, result,
                               dateEffective, lastCheckTime ):
     '''
@@ -1002,8 +1174,8 @@ class ResourceManagementClient:
     # pylint: disable-msg=W0613
     return self.__addOrModifyElement( 'VOBOXCache', locals() )  
   def addOrModifySpaceTokenOccupancyCache( self, site, token, total, 
-                                                  guaranteed, free, 
-                                                  lastCheckTime, meta = None ):
+                                           guaranteed, free, 
+                                           lastCheckTime, meta = None ):
     '''
     Using `site` and `token` to query the database, decides whether to insert or 
     update the table.

--- a/ResourceStatusSystem/DB/ResourceManagementDB.sql
+++ b/ResourceStatusSystem/DB/ResourceManagementDB.sql
@@ -33,6 +33,24 @@ CREATE TABLE PolicyResult(
   PRIMARY KEY(PolicyResultID)
 ) Engine=InnoDB;
 
+DROP TABLE IF EXISTS PolicyResultLog;
+CREATE TABLE PolicyResultLog(
+  PolicyResultLogID INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  Granularity VARCHAR(32) NOT NULL,
+  Name VARCHAR(64) NOT NULL,
+  INDEX (Name),
+  PolicyName VARCHAR(64) NOT NULL,
+  INDEX (PolicyName),
+  StatusType VARCHAR(16) NOT NULL DEFAULT '',
+  INDEX (StatusType),
+  Status VARCHAR(8) NOT NULL,
+  Reason VARCHAR(255) NOT NULL DEFAULT 'Unspecified',
+  LastCheckTime DATETIME NOT NULL,
+  INDEX (LastCheckTime),
+  UNIQUE KEY (Name,PolicyName,StatusType,LastCheckTime),
+  PRIMARY KEY(PolicyResultLogID)
+) Engine=InnoDB;
+
 DROP TABLE IF EXISTS ClientCache;
 CREATE TABLE ClientCache(
   ClientCacheID INT UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/ResourceStatusSystem/PolicySystem/PDP.py
+++ b/ResourceStatusSystem/PolicySystem/PDP.py
@@ -7,6 +7,7 @@
 
 import datetime
 
+from DIRAC                                                import gLogger 
 from DIRAC.ResourceStatusSystem.PolicySystem              import Status
 from DIRAC.ResourceStatusSystem.Utilities.InfoGetter      import InfoGetter
 from DIRAC.ResourceStatusSystem.PolicySystem.PolicyCaller import PolicyCaller
@@ -188,7 +189,9 @@ class PDP:
 
       if res[ 'Status' ] not in ( 'Error', 'Unknown' ):
         policyResults.append( res )
-
+      else:
+        gLogger.warn( res )      
+      
     return policyResults
 
 ################################################################################

--- a/ResourceStatusSystem/PolicySystem/PEP.py
+++ b/ResourceStatusSystem/PolicySystem/PEP.py
@@ -135,7 +135,20 @@ class PEP:
 
     resDecisions = self.pdp.takeDecision( knownInfo = knownInfo )
 
-    res          = resDecisions[ 'PolicyCombinedResult' ]
+    ## record all results before doing anything else    
+    for resP in resDecisions[ 'SinglePolicyResults' ]:
+      
+      if not resP.has_key( 'OLD' ):       
+        self.clients[ "rmClient" ].insertPolicyResultLog( granularity, name,
+                                                          resP[ 'PolicyName' ], 
+                                                          statusType,
+                                                          resP[ 'Status' ], 
+                                                          resP[ 'Reason' ], now )
+        
+      else:
+        gLogger.warn( 'OLD: %s' % resP )
+        
+    res          = resDecisions[ 'PolicyCombinedResult' ] 
     actionBaseMod = "DIRAC.ResourceStatusSystem.PolicySystem.Actions"
 
     # Security mechanism in case there is no PolicyType returned


### PR DESCRIPTION
A new table has been added to the ResourceManagementDB schema and the necessary methods in the ResourceManagementClient to access it. Every time the PEP issues PDP.takeDecission, logs every policy result in the PolicyResultLog table. The CacheCleanerAgent takes care of cleaning records older than two weeks.

Closing [ pull 711 ](https://github.com/DIRACGrid/DIRAC/pull/711)
