### PR TITLE
FIX: if there is no failed files, put an empty dict

### DIFF
--- a/DataManagementSystem/private/StrategyHandler.py
+++ b/DataManagementSystem/private/StrategyHandler.py
@@ -147,7 +147,10 @@ class StrategyHandler( object ):
     :param self: self reference
     :param failedFiles: observed distinct failed files
     """
-    self.failedFiles = failedFiles
+    if not failedFiles:
+      self.failedFiels = {}
+    else:
+      self.failedFiles = failedFiles
 
   def setBandwiths( self, bandwidths ):
     """ set the bandwidths 


### PR DESCRIPTION
In there is no distinct failed files returned from `TransferDB`, `StrategyHandler.failedFiles` should be set to empty dict. 
