### PR TITLE
FIX: TransformationCleaningAgent

### DIFF
--- a/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -346,7 +346,7 @@ class TransformationCleaningAgent( AgentModule ):
           return res
     self.log.info( "Removed directories in the catalog and storage for transformation" )
     # Clean ALL the possible remnants found in the metadata catalog
-    res = self.cleanMetadataCatalogFiles( transID )
+    res = self.cleanMetadataCatalogFiles( transID, directories )
     if not res['OK']:
       return res
     self.log.info( "Successfully removed output of transformation %d" % transID )
@@ -408,7 +408,7 @@ class TransformationCleaningAgent( AgentModule ):
       if not res['OK']:
         return res
     # Clean ALL the possible remnants found in the BK
-    res = self.cleanMetadataCatalogFiles( transID )
+    res = self.cleanMetadataCatalogFiles( transID, directories )
     if not res['OK']:
       return res
     # Clean the transformation DB of the files and job information
@@ -424,7 +424,7 @@ class TransformationCleaningAgent( AgentModule ):
     self.log.info( "Updated status of transformation %s to Deleted" % ( transID ) )
     return S_OK()
 
-  def cleanMetadataCatalogFiles( self, transID ):
+  def cleanMetadataCatalogFiles( self, transID, directories=None ):
     """ wipe out files from catalog """
     res = self.metadataClient.findFilesByMetadata( { self.transfidmeta : transID } )
     if not res['OK']:


### PR DESCRIPTION
Fixing wrong calls to `TCA::cleanMetadataCatalogFiles`:

```
2012-06-05 12:58:16 UTC Transformation/TransformationCleaningAgent ERROR:  Cycle had an error: Exception while calling <bound method TransformationCleaningAgent.execute of <LHCbDIRAC.TransformationSystem.Agent.TransformationCleaningAgent.TransformationCleaningAgent instance at 0x75355f0>> method: cleanMetadataCatalogFiles() takes exactly 3 arguments (2 given)
```
