### PR TITLE
BUGFIX: removed 'return True' from DB.__init__

### DIFF
--- a/Core/Base/DB.py
+++ b/Core/Base/DB.py
@@ -89,7 +89,6 @@ class DB( MySQL ):
     self.log.info( "DBName:         " + self.dbName )
     self.log.info( "MaxQueue:       " + str( self.maxQueueSize ) )
     self.log.info( "==================================================" )
-    return True
 
 #############################################################################
   def getCSOption( self, optionName, defaultValue = None ):


### PR DESCRIPTION
Spotted by Federico.

Seems you removed all returns from **init** but then you added one at the end of the method, I guess it is a wrong copy/paste. Why not to do it is explained in the [ Python documentation ](http://docs.python.org/reference/datamodel.html#object.__init__).
