### PR TITLE
FIX: RequestDBMySQL::getRequestForJobs, return S_ERROR if no jobIDs are ...

### DIFF
--- a/RequestManagementSystem/DB/RequestDBMySQL.py
+++ b/RequestManagementSystem/DB/RequestDBMySQL.py
@@ -831,6 +831,9 @@ class RequestDBMySQL( DB ):
   def getRequestForJobs( self, jobIDs ):
     """ Get the request names associated to the jobsIDs
     """
+    if not jobIDs:
+      return S_ERROR("RequestDB: unable to select requests, no jobIDs supplied")
+
     req = "SELECT JobID,RequestName from Requests where JobID IN (%s);" % intListToString( jobIDs )
     res = self._query( req )
     if not res:


### PR DESCRIPTION
Should be merged in rel-v6r4 too.

Fixing this:

```
2012-06-15 14:07:50 UTC RequestManagement/RequestManager/MySQL  WARN: _query: SELECT JobID,RequestName from Requests where JobID IN ();
2012-06-15 14:07:50 UTC RequestManagement/RequestManager EXCEPT: RequestManagerHandler.getRequestForJobs: Exception which getting request names. 
2012-06-15 14:07:50 UTC RequestManagement/RequestManager EXCEPT: == EXCEPTION ==
2012-06-15 14:07:50 UTC RequestManagement/RequestManager EXCEPT: Unknown exception type:Value
2012-06-15 14:07:50 UTC RequestManagement/RequestManager EXCEPT: ===============
```

Will return S_ERROR if no jobIDs are present in args.
