### PR TITLE
FIX: wrong import of getTypedDictRootedAtOperations

### DIFF
--- a/ResourceStatusSystem/Utilities/InfoGetter.py
+++ b/ResourceStatusSystem/Utilities/InfoGetter.py
@@ -7,7 +7,7 @@
 
 import copy
 
-from DIRAC.ResourceStatusSystem.Utilities.CS import getTypedDictRootedAt
+from DIRAC.ResourceStatusSystem.Utilities.CS import getTypedDictRootedAtOperations
 from DIRAC.ResourceStatusSystem.Utilities    import Utils
 from DIRAC.ResourceStatusSystem              import views_panels
 


### PR DESCRIPTION
It is already fixed on integration, but not in rel-v6r4.
