### PR TITLE
Allow for underscores in the startup link names

### DIFF
--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -417,9 +417,6 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
       system = argss[0]
       del argss[0]
       component = argss[0]
-      if '_' in component:
-        print "ERROR: component name can not contain '_' character"
-        return 
       del argss[0]
       
       specialOptions = {}


### PR DESCRIPTION
FIX: Allow for underscores in the startup link names
