### PR TITLE
Reverting back InstallTools change

### DIFF
--- a/Core/Utilities/InstallTools.py
+++ b/Core/Utilities/InstallTools.py
@@ -1452,7 +1452,7 @@ exec 2>&1
 #
 [ "%(componentType)s" = "agent" ] && renice 20 -p $$
 #
-exec dirac-%(componentType)s %(system)s/%(component)s %(componentCfg)s < /dev/null
+exec $DIRAC/DIRAC/Core/scripts/dirac-%(componentType)s.py %(system)s/%(component)s %(componentCfg)s < /dev/null
 """ % {'bashrc': os.path.join( instancePath, 'bashrc' ),
        'componentType': componentType,
        'system' : system,


### PR DESCRIPTION
This was a mistake to use dirac-<component> command, runit will leave zombie process when restarting
