### PR TITLE
FIX:  StorageElementHandler + TransfroamtionCleaningAgent

### DIFF
--- a/DataManagementSystem/Service/StorageElementHandler.py
+++ b/DataManagementSystem/Service/StorageElementHandler.py
@@ -83,10 +83,11 @@ class StorageElementHandler( RequestHandler ):
     port = self.getCSOption('Port','')
     if not port:
       return ''
-    
-    loc = fileID.find( port )
-    if loc >= 0:
-      fileID = fileID[loc + len( port ):]
+
+    if ":%s" % port in fileID:
+      loc = fileID.find( ":%s" % port )
+      if loc >= 0:
+        fileID = fileID[loc + len( ":%s" % port ):]
       
     serviceName = self.serviceInfoDict['serviceName']
     loc = fileID.find( serviceName )
@@ -99,7 +100,7 @@ class StorageElementHandler( RequestHandler ):
       
     if fileID.find( base_path ) == 0:
       return fileID
-    while fileID[0] == '/':
+    while fileID and fileID[0] == '/':
       fileID = fileID[1:]
     return os.path.join( base_path, fileID )
 
@@ -340,6 +341,7 @@ class StorageElementHandler( RequestHandler ):
   def export_removeDirectory( self, fileID, token ):
     """ Remove the given directory from the storage
     """
+
     dir_path = self.__resolveFileID( fileID )
     if not self.__confirmToken( token, fileID, 'x' ):
       return S_ERROR( 'Directory removal %s not authorized' % fileID )

--- a/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -32,6 +32,12 @@ class TransformationCleaningAgent( AgentModule ):
   """
   .. class:: TransformationCleaningAgent
 
+  :param ReplicaManger replicaManager: ReplicaManager instance
+  :param TransfromationClient transClient: TransfromationClient instance
+  :param RequestClient requestClient: RequestClient instance
+  :param FileCatalogClient metadataClient: FileCatalogClient instance
+  :param StorageUsageClient storageUsageClient: StorageUsageClient instance
+
   """
 
   def __init__( self, agentName, baseAgentName = False,	properties = dict() ):
@@ -527,6 +533,11 @@ class TransformationCleaningAgent( AgentModule ):
     if not allRemove:
       return S_ERROR( "Failed to remove all remnants from WMS" )
     self.log.info( "Successfully removed all tasks from the WMS" )
+
+    if not jobIDs:
+      self.log.info("JobIDs not present, unable to remove asociated requests.")
+      return S_OK()
+
     res = self.requestClient.getRequestForJobs( jobIDs )
     if not res['OK']:
       self.log.error( "Failed to get requestID for jobs.", res['Message'] )


### PR DESCRIPTION
FIX: 
- in `StorageElementHandler.__resolveFileID` wrong way of removing port information from `fileID`.
- in `TransformationCleaningAgent.__removeWMSTasks`: skip associated failover request removal if `jobIDs` list is empty.
