### PR TITLE
Better performances for large queries to TransformationDB

### DIFF
--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -1,6 +1,3 @@
-########################################################################
-# $HeadURL$
-########################################################################
 """ DIRAC Basic MySQL Class
     It provides access to the basic MySQL methods in a multithread-safe mode
     keeping used connections in a python Queue for further reuse.
@@ -67,7 +64,7 @@
 
 
 
-    Some high level methods have been added to avoid the need to write SQL 
+    Some high level methods have been added to avoid the need to write SQL
     statement in most common cases. They should be used instead of low level
     _insert, _update methods when ever possible.
 
@@ -79,9 +76,9 @@
       a specified time stamp.
       The conditions dictionary specifies for each attribute one or a List of possible
       values
-      greater and smaller are dictionaries in which the keys are the names of the fields, 
+      greater and smaller are dictionaries in which the keys are the names of the fields,
       that are requested to be >= or < than the corresponding value.
-      For compatibility with current usage it uses Exceptions to exit in case of 
+      For compatibility with current usage it uses Exceptions to exit in case of
       invalid arguments
 
 
@@ -135,7 +132,7 @@
       for compatibility with other methods condDict keyed argument is added
 
 
-    getCounters( self, table, attrList, condDict = None, older = None, 
+    getCounters( self, table, attrList, condDict = None, older = None,
                  newer = None, timeStamp = None, connection = False ):
 
       Count the number of records on each distinct combination of AttrList, selected
@@ -155,7 +152,6 @@ __RCSID__ = "$Id$"
 
 from DIRAC                                  import gLogger
 from DIRAC                                  import S_OK, S_ERROR
-from DIRAC                                  import Time
 
 import MySQLdb
 # This is for proper initialization of embeded server, it should only be called once
@@ -192,7 +188,7 @@ def _checkFields( inFields, inValues ):
 
   try:
     assert len( inFields ) == len( inValues )
-  except:
+  except AssertionError:
     return S_ERROR( 'Mismatch between inFields and inValues.' )
 
   return S_OK()
@@ -201,7 +197,7 @@ def _quotedList( fieldList = None ):
   """
     Quote a list of MySQL Field Names with "`"
     Return a comma separated list of quoted Field Names
-    
+
     To be use for Table and Field Names
   """
   if fieldList == None:
@@ -541,13 +537,13 @@ class MySQL:
 
 
   def _transaction( self, cmdList, conn = None ):
-    """ dummy transaction support 
+    """ dummy transaction support
 
     :param self: self reference
     :param list cmdList: list of queries to be executed within the transaction
-    :param MySQLDB.Connection conn: connection 
+    :param MySQLDB.Connection conn: connection
 
-    :return: S_OK( [ ( cmd1, ret1 ), ... ] ) or S_ERROR 
+    :return: S_OK( [ ( cmd1, ret1 ), ... ] ) or S_ERROR
     """
     if type( cmdList ) != ListType:
       return S_ERROR( "_transaction: wrong type (%s) for cmdList" % type( cmdList ) )
@@ -899,7 +895,7 @@ class MySQL:
 ########################################################################################
   def getCounters( self, table, attrList, condDict, older = None, newer = None, timeStamp = None, connection = False,
                    greater = None, smaller = None ):
-    """ 
+    """
       Count the number of records on each distinct combination of AttrList, selected
       with condition defined by condDict and time stamps
     """
@@ -970,14 +966,14 @@ class MySQL:
 #############################################################################
   def buildCondition( self, condDict = None, older = None, newer = None,
                       timeStamp = None, orderAttribute = None, limit = False,
-                      greater = None, smaller = None ):
+                      greater = None, smaller = None, offset = None ):
     """ Build SQL condition statement from provided condDict and other extra check on
         a specified time stamp.
         The conditions dictionary specifies for each attribute one or a List of possible
         values
-        greater and smaller are dictionaries in which the keys are the names of the fields, 
+        greater and smaller are dictionaries in which the keys are the names of the fields,
         that are requested to be >= or < than the corresponding value.
-        For compatibility with current usage it uses Exceptions to exit in case of 
+        For compatibility with current usage it uses Exceptions to exit in case of
         invalid arguments
     """
     condition = ''
@@ -1121,7 +1117,10 @@ class MySQL:
       condition = "%s ORDER BY %s" % ( condition, ', '.join( orderList ) )
 
     if limit:
-      condition = "%s LIMIT %d" % ( condition, limit )
+      if offset:
+        condition = "%s LIMIT %d OFFSET %d" % ( condition, limit, offset )
+      else:
+        condition = "%s LIMIT %d" % ( condition, limit )
 
     return condition
 

--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -10,17 +10,17 @@ from DIRAC.Core.Base.Client                         import Client
 from DIRAC.Core.Utilities.List                      import breakListIntoChunks
 from DIRAC.Resources.Catalog.FileCatalogueBase      import FileCatalogueBase
 import types
-    
+
 rpc = None
-url = None    
-    
-class TransformationClient(Client,FileCatalogueBase):
-  
+url = None
+
+class TransformationClient( Client, FileCatalogueBase ):
+
   """ Exposes the functionality available in the DIRAC/TransformationHandler
 
       This inherits the DIRAC base Client for direct execution of server functionality.
       The following methods are available (although not visible here).
-      
+
       Transformation (table) manipulation
 
           deleteTransformation(transName)
@@ -31,225 +31,283 @@ class TransformationClient(Client,FileCatalogueBase):
           deleteTransformationParameter(transName,paramName)
 
       TransformationFiles table manipulation
-      
+
           addFilesToTransformation(transName,lfns)
           addTaskForTransformation(transName,lfns=[],se='Unknown')
           setFileStatusForTransformation(transName,status,lfns)
-          setFileUsedSEForTransformation(transName,usedSE,lfns)  
+          setFileUsedSEForTransformation(transName,usedSE,lfns)
           getTransformationStats(transName)
-          
-      TransformationTasks table manipulation 
-          
-          setTaskStatus(transName, taskID, status) 
-          setTaskStatusAndWmsID(transName, taskID, status, taskWmsID) 
-          getTransformationTaskStats(transName) 
-          deleteTasks(transName, taskMin, taskMax) 
-          extendTransformation( transName, nTasks) 
-          getTasksToSubmit(transName,numTasks,site='') 
-          
+
+      TransformationTasks table manipulation
+
+          setTaskStatus(transName, taskID, status)
+          setTaskStatusAndWmsID(transName, taskID, status, taskWmsID)
+          getTransformationTaskStats(transName)
+          deleteTasks(transName, taskMin, taskMax)
+          extendTransformation( transName, nTasks)
+          getTasksToSubmit(transName,numTasks,site='')
+
       TransformationLogging table manipulation
-          
-          getTransformationLogging(transName) 
-      
+
+          getTransformationLogging(transName)
+
       File/directory manipulation methods (the remainder of the interface can be found below)
-      
+
           getFileSummary(lfns,transName)
-          exists(lfns) 
-          
-      Web monitoring tools    
-          
-          getDistinctAttributeValues(attribute, selectDict) 
-          getTransformationStatusCounters() 
-          getTransformationSummary() 
-          getTransformationSummaryWeb(selectDict, sortList, startItem, maxItems) 
+          exists(lfns)
+
+      Web monitoring tools
+
+          getDistinctAttributeValues(attribute, selectDict)
+          getTransformationStatusCounters()
+          getTransformationSummary()
+          getTransformationSummaryWeb(selectDict, sortList, startItem, maxItems)
   """
 
-  def __init__(self,name='TransformationClient'):
-    self.setServer('Transformation/TransformationManager')
+  def __init__( self, name = 'TransformationClient' ):
+    self.setServer( 'Transformation/TransformationManager' )
 
-  def setServer(self,url):
+  def setServer( self, url ):
     self.serverURL = url
 
-  def getCounters(self, table, attrList, condDict, older=None, newer=None, timeStamp=None,rpc='',url='',timeout=120):
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient. getCounters(table,attrList,condDict,older,newer,timeStamp)   
+  def getCounters( self, table, attrList, condDict, older = None, newer = None, timeStamp = None, rpc = '', url = '', timeout = 120 ):
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient. getCounters( table, attrList, condDict, older, newer, timeStamp )
 
-  def addTransformation(self, transName,description,longDescription,type,plugin,agentType,fileMask,
-                            transformationGroup = 'General',
-                            groupSize           = 1,
-                            inheritedFrom       = 0,
-                            body                = '', 
-                            maxTasks            = 0,
-                            eventsPerTask        = 0,
-                            addFiles            = True,
-                            rpc='',url='',timeout=120):
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.addTransformation(transName,description,longDescription,type,plugin,agentType,fileMask,transformationGroup,groupSize,inheritedFrom,body,maxTasks,eventsPerTask,addFiles)    
+  def addTransformation( self, transName, description, longDescription, type, plugin, agentType, fileMask,
+                         transformationGroup = 'General',
+                         groupSize = 1,
+                         inheritedFrom = 0,
+                         body = '',
+                         maxTasks = 0,
+                         eventsPerTask = 0,
+                         addFiles = True,
+                         rpc = '', url = '', timeout = 120 ):
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.addTransformation( transName, description, longDescription, type, plugin, agentType,
+                                        fileMask, transformationGroup, groupSize, inheritedFrom, body,
+                                        maxTasks, eventsPerTask, addFiles )
 
-  def getTransformations(self,condDict={},older=None, newer=None, timeStamp='CreationDate', orderAttribute=None, limit=None, extraParams=False,rpc='',url='',timeout=120):
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.getTransformations(condDict,older,newer,timeStamp,orderAttribute,limit,extraParams)
+  def getTransformations( self, condDict = {}, older = None, newer = None, timeStamp = 'CreationDate',
+                          orderAttribute = None, limit = 5000, extraParams = False, rpc = '', url = '', timeout = 120 ):
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
 
-  def getTransformation(self,transName,extraParams=False,rpc='',url='',timeout=120):
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.getTransformation(transName,extraParams)
+    transformations = []
+    #getting transformations - incrementally
+    offsetToApply = 0
+    while True:
+      res = rpcClient.getTransformations( condDict, older, newer, timeStamp, orderAttribute, limit, extraParams,
+                                          offset = offsetToApply )
+      if not res['OK']:
+        return res
+      else:
+        if res['Value']:
+          transformations.append( res['Value'] )
+          offsetToApply += limit
+        if len( res['Value'] ) < limit:
+          break
 
-  def getTransformationFiles(self,condDict={},older=None, newer=None, timeStamp='LastUpdate', orderAttribute=None, limit=None, rpc='',url='',timeout=120):
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout) 
-    return rpcClient.getTransformationFiles(condDict,older,newer,timeStamp,orderAttribute,limit)
+    return S_OK( transformations )
 
-  def getTransformationTasks(self,condDict={},older=None, newer=None, timeStamp='CreationTime', orderAttribute=None, limit=None, inputVector=False,rpc='',url='',timeout=120):
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout) 
-    return rpcClient.getTransformationTasks(condDict,older, newer, timeStamp, orderAttribute, limit, inputVector)
 
-  def setFileStatusForTransformation(self,transName,status,lfns,force=False,timeout=120):
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout) 
-    return rpcClient.setFileStatusForTransformation(transName,status,lfns,force)
+  def getTransformation( self, transName, extraParams = False, rpc = '', url = '', timeout = 120 ):
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.getTransformation( transName, extraParams )
+
+  def getTransformationFiles( self, condDict = {}, older = None, newer = None, timeStamp = 'LastUpdate',
+                              orderAttribute = None, limit = 5000, rpc = '', url = '', timeout = 120 ):
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+
+    transformationFiles = []
+    #getting transformationFiles - incrementally
+    offsetToApply = 0
+    while True:
+      res = rpcClient.getTransformationFiles( condDict, older, newer, timeStamp, orderAttribute, limit,
+                                              offset = offsetToApply )
+      if not res['OK']:
+        return res
+      else:
+        if res['Value']:
+          transformationFiles.append( res['Value'] )
+          offsetToApply += limit
+        if len( res['Value'] ) < limit:
+          break
+
+    return S_OK( transformationFiles )
+
+  def getTransformationTasks( self, condDict = {}, older = None, newer = None, timeStamp = 'CreationTime',
+                              orderAttribute = None, limit = 5000, inputVector = False,
+                              rpc = '', url = '', timeout = 120 ):
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+
+
+    transformationTasks = []
+    #getting transformationTasks - incrementally
+    offsetToApply = 0
+    while True:
+      res = rpcClient.getTransformationTasks( condDict, older, newer, timeStamp, orderAttribute, limit, inputVector,
+                                              offset = offsetToApply )
+      if not res['OK']:
+        return res
+      else:
+        if res['Value']:
+          transformationTasks.append( res['Value'] )
+          offsetToApply += limit
+        if len( res['Value'] ) < limit:
+          break
+
+    return S_OK( transformationTasks )
+
+
+
+  def setFileStatusForTransformation( self, transName, status, lfns, force = False, timeout = 120 ):
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.setFileStatusForTransformation( transName, status, lfns, force )
 
   #####################################################################
   #
   # These are the file catalog interface methods
   #
 
-  def isOK(self):
+  def isOK( self ):
     return self.valid
 
-  def getName(self,DN=''):
+  def getName( self, DN = '' ):
     """ Get the file catalog type name
     """
     return self.name
 
-  def addDirectory(self,path,force=False,rpc='',url='',timeout=120):
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.addDirectory(path,force)
+  def addDirectory( self, path, force = False, rpc = '', url = '', timeout = 120 ):
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.addDirectory( path, force )
 
-  def getReplicas(self,lfn,rpc='',url='',timeout=120):
-    res = self.__checkArgumentFormat(lfn)
+  def getReplicas( self, lfn, rpc = '', url = '', timeout = 120 ):
+    res = self.__checkArgumentFormat( lfn )
     if not res['OK']:
       return res
     lfns = res['Value'].keys()
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.getReplicas(lfns)
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.getReplicas( lfns )
 
-  def addFile(self,lfn,force=False,rpc='',url='',timeout=120):
-    res = self.__checkArgumentFormat(lfn)
+  def addFile( self, lfn, force = False, rpc = '', url = '', timeout = 120 ):
+    res = self.__checkArgumentFormat( lfn )
     if not res['OK']:
       return res
     tuples = []
-    for lfn,info in res['Value'].items():
-      tuples.append((lfn,info['PFN'],info['Size'],info['SE'],info['GUID'],info['Checksum']))
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.addFile(tuples,force)
+    for lfn, info in res['Value'].items():
+      tuples.append( ( lfn, info['PFN'], info['Size'], info['SE'], info['GUID'], info['Checksum'] ) )
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.addFile( tuples, force )
 
-  def addReplica(self,lfn,force=False,rpc='',url='',timeout=120):
-    res = self.__checkArgumentFormat(lfn)
+  def addReplica( self, lfn, force = False, rpc = '', url = '', timeout = 120 ):
+    res = self.__checkArgumentFormat( lfn )
     if not res['OK']:
       return res
     tuples = []
-    for lfn,info in res['Value'].items():
-      tuples.append((lfn,info['PFN'],info['SE'],False))
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.addReplica(tuples,force)
+    for lfn, info in res['Value'].items():
+      tuples.append( ( lfn, info['PFN'], info['SE'], False ) )
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.addReplica( tuples, force )
 
-  def removeFile(self,lfn,rpc='',url='',timeout=120):
-    res = self.__checkArgumentFormat(lfn)
+  def removeFile( self, lfn, rpc = '', url = '', timeout = 120 ):
+    res = self.__checkArgumentFormat( lfn )
     if not res['OK']:
       return res
     lfns = res['Value'].keys()
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
     successful = {}
     failed = {}
-    listOfLists = breakListIntoChunks(lfns,100)
+    listOfLists = breakListIntoChunks( lfns, 100 )
     for list in listOfLists:
-      res = rpcClient.removeFile(list)
+      res = rpcClient.removeFile( list )
       if not res['OK']:
         return res
-      successful.update(res['Value']['Successful'])
-      failed.update(res['Value']['Failed'])
+      successful.update( res['Value']['Successful'] )
+      failed.update( res['Value']['Failed'] )
     resDict = {'Successful': successful, 'Failed':failed}
-    return S_OK(resDict) 
+    return S_OK( resDict )
 
-  def removeReplica(self,lfn,rpc='',url='',timeout=120):
-    res = self.__checkArgumentFormat(lfn)
+  def removeReplica( self, lfn, rpc = '', url = '', timeout = 120 ):
+    res = self.__checkArgumentFormat( lfn )
     if not res['OK']:
       return res
     tuples = []
-    for lfn,info in res['Value'].items():
-      tuples.append((lfn,info['PFN'],info['SE']))
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
+    for lfn, info in res['Value'].items():
+      tuples.append( ( lfn, info['PFN'], info['SE'] ) )
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
     successful = {}
     failed = {}
-    listOfLists = breakListIntoChunks(tuples,100)
+    listOfLists = breakListIntoChunks( tuples, 100 )
     for list in listOfLists:
-      res = rpcClient.removeReplica(list)
+      res = rpcClient.removeReplica( list )
       if not res['OK']:
         return res
-      successful.update(res['Value']['Successful'])
-      failed.update(res['Value']['Failed'])
+      successful.update( res['Value']['Successful'] )
+      failed.update( res['Value']['Failed'] )
     resDict = {'Successful': successful, 'Failed':failed}
-    return S_OK(resDict)
+    return S_OK( resDict )
 
-  def getReplicaStatus(self,lfn,rpc='',url='',timeout=120):
-    res = self.__checkArgumentFormat(lfn)
+  def getReplicaStatus( self, lfn, rpc = '', url = '', timeout = 120 ):
+    res = self.__checkArgumentFormat( lfn )
     if not res['OK']:
       return res
     tuples = []
-    for lfn,info in res['Value'].items():
-      tuples.append((lfn,info['SE']))
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.getReplicaStatus(tuples)
+    for lfn, info in res['Value'].items():
+      tuples.append( ( lfn, info['SE'] ) )
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.getReplicaStatus( tuples )
 
-  def setReplicaStatus(self,lfn,rpc='',url='',timeout=120):
-    res = self.__checkArgumentFormat(lfn)
+  def setReplicaStatus( self, lfn, rpc = '', url = '', timeout = 120 ):
+    res = self.__checkArgumentFormat( lfn )
     if not res['OK']:
       return res
     tuples = []
-    for lfn,info in res['Value'].items():
-      tuples.append((lfn,info['PFN'],info['SE'],info['Status']))
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.setReplicaStatus(tuples)
+    for lfn, info in res['Value'].items():
+      tuples.append( ( lfn, info['PFN'], info['SE'], info['Status'] ) )
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.setReplicaStatus( tuples )
 
-  def setReplicaHost(self,lfn,rpc='',url='',timeout=120):
-    res = self.__checkArgumentFormat(lfn)
+  def setReplicaHost( self, lfn, rpc = '', url = '', timeout = 120 ):
+    res = self.__checkArgumentFormat( lfn )
     if not res['OK']:
       return res
     tuples = []
-    for lfn,info in res['Value'].items():
-      tuples.append((lfn,info['PFN'],info['SE'],info['NewSE']))
-    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
-    return rpcClient.setReplicaHost(tuples)
+    for lfn, info in res['Value'].items():
+      tuples.append( ( lfn, info['PFN'], info['SE'], info['NewSE'] ) )
+    rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
+    return rpcClient.setReplicaHost( tuples )
 
-  def removeDirectory(self,lfn,rpc='',url='',timeout=120):
-    return self.__returnOK(lfn)
+  def removeDirectory( self, lfn, rpc = '', url = '', timeout = 120 ):
+    return self.__returnOK( lfn )
 
-  def createDirectory(self,lfn,rpc='',url='',timeout=120):
-    return self.__returnOK(lfn)
+  def createDirectory( self, lfn, rpc = '', url = '', timeout = 120 ):
+    return self.__returnOK( lfn )
 
-  def createLink(self,lfn,rpc='',url='',timeout=120):
-    return self.__returnOK(lfn)
+  def createLink( self, lfn, rpc = '', url = '', timeout = 120 ):
+    return self.__returnOK( lfn )
 
-  def removeLink(self,lfn,rpc='',url='',timeout=120):
-    return self.__returnOK(lfn)
+  def removeLink( self, lfn, rpc = '', url = '', timeout = 120 ):
+    return self.__returnOK( lfn )
 
-  def __returnOK(self,lfn):
-    res = self.__checkArgumentFormat(lfn)
+  def __returnOK( self, lfn ):
+    res = self.__checkArgumentFormat( lfn )
     if not res['OK']:
       return res
     successful = {}
     for lfn in res['Value'].keys():
-      successful[lfn] = True     
-    resDict = {'Successful':successful,'Failed':{}}
-    return S_OK(resDict)
+      successful[lfn] = True
+    resDict = {'Successful':successful, 'Failed':{}}
+    return S_OK( resDict )
 
-  def __checkArgumentFormat(self,path):
-    if type(path) in types.StringTypes:
+  def __checkArgumentFormat( self, path ):
+    if type( path ) in types.StringTypes:
       urls = {path:False}
-    elif type(path) == types.ListType:
+    elif type( path ) == types.ListType:
       urls = {}
       for url in path:
         urls[url] = False
-    elif type(path) == types.DictType:
+    elif type( path ) == types.DictType:
       urls = path
     else:
-      return S_ERROR("TransformationClient.__checkArgumentFormat: Supplied path is not of the correct format.")
-    return S_OK(urls)
+      return S_ERROR( "TransformationClient.__checkArgumentFormat: Supplied path is not of the correct format." )
+    return S_OK( urls )

--- a/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/TransformationSystem/Service/TransformationManagerHandler.py
@@ -2,12 +2,12 @@
 # $HeadURL$
 __RCSID__ = "$Id$"
 
-from DIRAC                                               import gLogger, gConfig, S_OK, S_ERROR
+from DIRAC                                               import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler                     import RequestHandler
 from DIRAC.TransformationSystem.DB.TransformationDB      import TransformationDB
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 
-from types import *
+from types import StringTypes, StringType, IntType, LongType, ListType, DictType, TupleType
 
 transTypes = list( StringTypes ) + [IntType, LongType]
 
@@ -95,15 +95,18 @@ class TransformationManagerHandlerBase( RequestHandler ):
     res = database.deleteTransformationParameter( transName, paramName )
     return self._parseRes( res )
 
-  types_getTransformations = []
-  def export_getTransformations( self, condDict = {}, older = None, newer = None, timeStamp = 'CreationDate', orderAttribute = None, limit = None, extraParams = False ):
+  types_getTransformations = [DictType]
+  def export_getTransformations( self, condDict = {}, older = None, newer = None, timeStamp = 'CreationDate',
+                                 orderAttribute = None, limit = None, extraParams = False, offset = None ):
     res = database.getTransformations( condDict = condDict,
-                                  older = older,
-                                  newer = newer,
-                                  timeStamp = timeStamp,
-                                  orderAttribute = orderAttribute,
-                                  limit = limit,
-                                  extraParams = extraParams )
+                                       older = older,
+                                       newer = newer,
+                                       timeStamp = timeStamp,
+                                       orderAttribute = orderAttribute,
+                                       limit = limit,
+                                       extraParams = extraParams,
+                                       offset = offset
+                                       )
     return self._parseRes( res )
 
   types_getTransformation = [transTypes]
@@ -156,9 +159,12 @@ class TransformationManagerHandlerBase( RequestHandler ):
     res = database.getTransformationFilesCount( transName, field, selection = selection )
     return self._parseRes( res )
 
-  types_getTransformationFiles = []
-  def export_getTransformationFiles( self, condDict = {}, older = None, newer = None, timeStamp = 'LastUpdate', orderAttribute = None, limit = None ):
-    res = database.getTransformationFiles( condDict = condDict, older = older, newer = newer, timeStamp = timeStamp, orderAttribute = orderAttribute, limit = limit, connection = False )
+  types_getTransformationFiles = [DictType]
+  def export_getTransformationFiles( self, condDict = {}, older = None, newer = None, timeStamp = 'LastUpdate',
+                                     orderAttribute = None, limit = None, offset = None ):
+    res = database.getTransformationFiles( condDict = condDict, older = older, newer = newer, timeStamp = timeStamp,
+                                           orderAttribute = orderAttribute, limit = limit, offset = offset,
+                                           connection = False )
     return self._parseRes( res )
 
   ####################################################################
@@ -166,9 +172,12 @@ class TransformationManagerHandlerBase( RequestHandler ):
   # These are the methods to manipulate the TransformationTasks table
   #
 
-  types_getTransformationTasks = []
-  def export_getTransformationTasks( self, condDict = {}, older = None, newer = None, timeStamp = 'CreationTime', orderAttribute = None, limit = None, inputVector = False ):
-    res = database.getTransformationTasks( condDict = condDict, older = older, newer = newer, timeStamp = timeStamp, orderAttribute = orderAttribute, limit = limit, inputVector = inputVector )
+  types_getTransformationTasks = [DictType]
+  def export_getTransformationTasks( self, condDict = {}, older = None, newer = None, timeStamp = 'CreationTime',
+                                     orderAttribute = None, limit = None, inputVector = False, offset = None ):
+    res = database.getTransformationTasks( condDict = condDict, older = older, newer = newer, timeStamp = timeStamp,
+                                           orderAttribute = orderAttribute, limit = limit, inputVector = inputVector,
+                                           offset = offset )
     return self._parseRes( res )
 
   types_setTaskStatus = [transTypes, [ListType, IntType, LongType], StringTypes]


### PR DESCRIPTION
When issuing large queries via the service, timeouts happen. This change would make subsequent small queries, summing up the results at the client side.
