### PR TITLE
CHANGE: getTransformationFiles Removed duplicated dictionary key 'LFNs'. 

### DIFF
--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -77,7 +77,7 @@ class TransformationAgent( AgentModule ):
       gLogger.error( "processTransformation: Failed to obtain input data: %s." % res['Message'] )
       return res
     transFiles = res['Value']
-    lfns = res['LFNs']
+    lfns = [f['LFN'] for f in res['Value']]
 
     if not lfns:
       gLogger.info( "processTransformation: No 'Unused' files found for transformation." )

--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -518,7 +518,7 @@ class TransformationDB( DB ):
         webList.append( rList )
         resultList.append( fDict )
     result = S_OK( resultList )
-    result['LFNs'] = originalFileIDs.values()
+    #result['LFNs'] = originalFileIDs.values()#Why needing to add this when it's all already in resultList
     result['Records'] = webList
     result['ParameterNames'] = ['LFN'] + self.TRANSFILEPARAMS
     return result


### PR DESCRIPTION
Made the TransformationAgent not rely on this key as all the info is already provided in resultList. Other clients must check if they use the result['Value'][LFNs] and change it to [f['LFN'] for f in result['Value']]
