### PR TITLE
Integration: Add sub command completions in File Catalog Command Line Interface

### DIFF
--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -1583,6 +1583,9 @@ File Catalog Client $Revision: 1.17 $Date:
     """   
    
     argss = args.split()
+    if (len(argss) < 2):
+      print self.do_find.__doc__
+      return
     path = argss[0]
     path = self.getPath(path)
     del argss[0]


### PR DESCRIPTION
Hi, I am a student in IHEP, China. We use DFC to 
query some information. 

I found the DFC command line interface has some bugs,
 such as index out of range. The command line auto completion
 is also another problem.

I add some completions for some _sub_ commands,
so that we can use <TAB>  to get the sub commands.
For an example, when we in DFC:

```
FC:/> meta <TAB>
get      index    metaset  remove   rm       set      show     tag      tags 
```

In the future, I will add some code to keep the cmd more safe,
especially the index out of range errors.
The _LFN_ directory completion is also an interesting work.
