### PR TITLE
TransformationDB - less redundant info returned 

### DIFF
--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -75,7 +75,7 @@ class TransformationAgent( AgentModule ):
       gLogger.error( "%s.processTransformation: Failed to obtain input data." % AGENT_NAME, res['Message'] )
       return res
     transFiles = res['Value']
-    lfns = res['LFNs']
+    lfns = [ f['LFN'] for f in transFiles ]
 
     if not lfns:
       gLogger.info( "%s.processTransformation: No 'Unused' files found for transformation." % AGENT_NAME )

--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -524,7 +524,7 @@ class TransformationDB( DB ):
         webList.append( rList )
         resultList.append( fDict )
     result = S_OK( resultList )
-    result['LFNs'] = originalFileIDs.values()
+    #result['LFNs'] = originalFileIDs.values()
     result['Records'] = webList
     result['ParameterNames'] = ['LFN'] + self.TRANSFILEPARAMS
     return result


### PR DESCRIPTION
FIX: Do not return redundant LFNs in getTransformationFiles()
