### PR TITLE
FIX: sanity check for wrong replication tree 

### DIFF
--- a/DataManagementSystem/private/StrategyHandler.py
+++ b/DataManagementSystem/private/StrategyHandler.py
@@ -213,7 +213,14 @@ class StrategyHandler( object ):
           tree = self.__simple( sourceSE, targetSEs )
         elif reStrategy.pattern == "Swarm":
           tree = self.__swarm( targetSEs[0], replicas.keys() )
-      
+   
+    ## sanity check for tree, just checking if all targetSEs are in
+    missing = set( targetSEs ) - set( [ rep["DestSE"] for rep in tree ] )
+    if missing:
+      msg = "wrong replication tree, missing %s targetSEs" % ",".join( [ tSE for tSE in missing ] )
+      self.log.error( "determineReplicationTree: %s" % msg )
+      return S_ERROR( msg )
+   
     # Now update the queues to reflect the chosen strategies
     for channelID in tree:
       self.channels[channelID]["Files"] += 1


### PR DESCRIPTION
If channel site for SE cannot be obtained, replication tree is wrong. This fix adds a sanity check comparing requested TargetSEs set with obtained one. If there is a difference, S_ERROR is returned from `StrategyHandler.determineReplicationTree`.

This should also land in the intergation branch.
