### PR TITLE
TransformationDB - missing import of StringType

### DIFF
--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -10,7 +10,7 @@
 """
 
 import re, time, threading, copy
-from types import IntType, LongType, StringTypes, ListType, TupleType, DictType
+from types import IntType, LongType, StringTypes, ListType, TupleType, DictType, StringType
 
 from DIRAC                                                             import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.Core.Base.DB                                                import DB


### PR DESCRIPTION
BUGFIX: StringType must be imported before it can be used

closes #931
