### PR TITLE
[Rel-v6r4] Some improvements for TransformationClient and TransformationAgent

### DIFF
--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -18,6 +18,7 @@ class TransformationAgent( AgentModule ):
     self.pluginLocation = self.am_getOption( 'PluginLocation', 'DIRAC.TransformationSystem.Agent.TransformationPlugin' )
     self.checkCatalog = self.am_getOption( 'CheckCatalog', 'yes' )
     self.maxFiles = self.am_getOption( 'MaxFiles', 5000 )
+    self.transformationTypes = self.am_getOption( 'TransformationTypes', [] )
 
     # This sets the Default Proxy to used as that defined under
     # /Operations/Shifter/ProductionManager
@@ -52,7 +53,10 @@ class TransformationAgent( AgentModule ):
     transName = self.am_getOption( 'Transformation', 'All' )
     if transName == 'All':
       gLogger.info( "%s.getTransformations: Initializing general purpose agent." % AGENT_NAME )
-      res = self.transDB.getTransformations( {'Status':['Active', 'Completing', 'Flush']}, extraParams = True )
+      transfDict = {'Status':['Active', 'Completing', 'Flush'] }
+      if self.transformationTypes:
+        transfDict['Type'] = self.transformationTypes
+      res = self.transDB.getTransformations( transfDict, extraParams = True )
       if not res['OK']:
         gLogger.error( "%s.getTransformations: Failed to get transformations." % AGENT_NAME, res['Message'] )
         return res

--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -86,7 +86,7 @@ class TransformationClient(Client,FileCatalogueBase):
     rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
     return rpcClient.addTransformation(transName,description,longDescription,type,plugin,agentType,fileMask,transformationGroup,groupSize,inheritedFrom,body,maxTasks,eventsPerTask,addFiles)    
 
-  def getTransformations( self, condDict = {}, older = None, newer = None, timeStamp = 'CreationDate', orderAttribute = None, limit = 10000, extraParams = False, rpc = '', url = '', timeout = 120 ):
+  def getTransformations( self, condDict = {}, older = None, newer = None, timeStamp = 'CreationDate', orderAttribute = None, limit = 100, extraParams = False, rpc = '', url = '', timeout = 120 ):
     rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
 
     transformations = []


### PR DESCRIPTION
TransformationClient.getTransformations() has a default limit=100 (was 10000). 

It is also now possible to have multiple TransformationAgents. The changes here will be taken into account when developing for https://github.com/DIRACGrid/DIRAC/issues/120
