### PR TITLE
[rel-v6r4] fix for empty environmentDict (setExecutionEnv)

### DIFF
--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -817,16 +817,17 @@ class Job:
     if not type( environmentDict ) == type( {} ):
       return self._reportError( 'Expected dictionary of environment variables', **kwargs )
 
-    environment = []
-    for var, val in environmentDict.items():
-      try:
-        environment.append( '='.join( [str( var ), str( val )] ) )
-      except Exception:
-        return self._reportError( 'Expected string for environment variable key value pairs', **kwargs )
+    if environmentDict:
+      environment = []
+      for var, val in environmentDict.items():
+        try:
+          environment.append( '='.join( [str( var ), str( val )] ) )
+        except Exception:
+          return self._reportError( 'Expected string for environment variable key value pairs', **kwargs )
 
-    envStr = ';'.join( environment )
-    description = 'Env vars specified by user'
-    self._addParameter( self.workflow, 'ExecutionEnvironment', 'JDL', envStr, description )
+      envStr = ';'.join( environment )
+      description = 'Env vars specified by user'
+      self._addParameter( self.workflow, 'ExecutionEnvironment', 'JDL', envStr, description )
     return S_OK()
 
   #############################################################################


### PR DESCRIPTION
When empty, an exception was spawned in the wrapper (see e.g. job 37384483 in LHCb)
