### PR TITLE
Remove explicit timeout on RPC instantiation

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1624,7 +1624,7 @@ class Dirac:
     else:
       return self.__errorReport( 'Expected single string for LFN' )
 
-    dataLogging = RPCClient( 'DataManagement/DataLogging', timeout = 120 )
+    dataLogging = RPCClient( 'DataManagement/DataLogging' )
     result = dataLogging.getFileLoggingInfo( lfn )
     if not result['OK']:
       return self.__errorReport( 'Problem during getFileLoggingInfo call', result['Message'] )
@@ -1959,7 +1959,7 @@ class Dirac:
     elif type( jobID ) == types.IntType:
       jobID = [jobID]
 
-    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
     statusDict = monitoring.getJobsStatus( jobID )
     minorStatusDict = monitoring.getJobsMinorStatus( jobID )
     siteDict = monitoring.getJobsSites( jobID )
@@ -2021,7 +2021,7 @@ class Dirac:
       jobID = [jobID]
 
     summary = {}
-    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
     for job in jobID:
       result = monitoring.getInputData( job )
       if result['OK']:
@@ -2198,7 +2198,7 @@ class Dirac:
 
     self.log.verbose( 'Will select jobs with last update %s and following conditions' % date )
     self.log.verbose( self.pPrint.pformat( conditions ) )
-    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
     result = monitoring.getJobs( conditions, date )
     if not result['OK']:
       self.log.warn( result['Message'] )
@@ -2250,7 +2250,7 @@ class Dirac:
     if type( jobID ) == type( 1 ):
       jobID = [jobID]
 
-    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
     result = monitoring.getJobsSummary( jobID )
     if not result['OK']:
       self.log.warn( result['Message'] )
@@ -2457,7 +2457,7 @@ class Dirac:
 
     summary = {}
     for job in jobID:
-      monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+      monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
       result = monitoring.getJobHeartBeatData( job )
       summary[job] = {}
       if not result['OK']:
@@ -2507,7 +2507,7 @@ class Dirac:
       except Exception, x:
         return self.__errorReport( str( x ), 'Expected integer or string for existing jobID' )
 
-    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
     result = monitoring.getJobAttributes( jobID )
     if not result['OK']:
       return result
@@ -2544,7 +2544,7 @@ class Dirac:
     elif type( jobID ) == type( [] ):
       return self.__errorReport( 'Expected integer or string for jobID' )
 
-    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
     result = monitoring.getJobParameters( jobID )
     if not result['OK']:
       return result
@@ -2583,7 +2583,7 @@ class Dirac:
     elif type( jobID ) == type( [] ):
       return self.__errorReport( 'Expected int or string, not list' )
 
-    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
     result = monitoring.getJobLoggingInfo( jobID )
     if not result['OK']:
       self.log.warn( 'Could not retrieve logging information for job %s' % jobID )
@@ -2631,7 +2631,7 @@ class Dirac:
     elif type( jobID ) == type( [] ):
       return self.__errorReport( 'Expected int or string, not list' )
 
-    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
     result = monitoring.getJobParameter( jobID, 'StandardOutput' )
     if not result['OK']:
       return self.__errorReport( result, 'Could not retrieve job attributes' )
@@ -2676,7 +2676,7 @@ class Dirac:
       self.log.verbose( 'Requested service should have CS path: %s' % ( section ) )
       serviceURL = getServiceURL( '%s/%s' % ( system, service ) )
       self.log.verbose( 'Service URL is: %s' % ( serviceURL ) )
-      client = RPCClient( '%s/%s' % ( system, service ), timeout = 120 )
+      client = RPCClient( '%s/%s' % ( system, service ) )
       result = client.ping()
       if result['OK']:
         result['Value']['service url'] = serviceURL
@@ -2727,7 +2727,7 @@ class Dirac:
       except Exception, x:
         return self.__errorReport( str( x ), 'Expected integer or string for existing jobID' )
 
-    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring', timeout = 120 )
+    monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
     result = monitoring.getJobJDL( jobID )
     if not result['OK']:
       return result

--- a/Interfaces/API/DiracAdmin.py
+++ b/Interfaces/API/DiracAdmin.py
@@ -130,7 +130,7 @@ class DiracAdmin:
        @return: S_OK,S_ERROR
 
     """
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.getSiteMask()
     if result['OK']:
       sites = result['Value']
@@ -153,7 +153,7 @@ class DiracAdmin:
        @return: S_OK,S_ERROR
 
     """
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     bannedSites = []
     totalList = []
 
@@ -239,7 +239,7 @@ class DiracAdmin:
     if site in siteMask:
       return S_ERROR( 'Site %s already in mask of allowed sites' % site )
 
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.allowSite( site, comment )
     if not result['OK']:
       return result
@@ -264,7 +264,7 @@ class DiracAdmin:
     if not result['OK']:
       return result
 
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.getSiteMaskLogging( site )
     if not result['OK']:
       return result
@@ -312,7 +312,7 @@ class DiracAdmin:
     if not site in siteMask:
       return S_ERROR( 'Site %s is already banned' % site )
 
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.banSite( site, comment )
     if not result['OK']:
       return result
@@ -347,7 +347,7 @@ class DiracAdmin:
        @return: S_OK,S_ERROR
 
     """
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.clearMask()
     return result
 
@@ -483,7 +483,7 @@ class DiracAdmin:
       except Exception, x:
         return self.__errorReport( str( x ), 'Expected integer or convertible integer for existing jobIDs' )
 
-    jobManager = RPCClient( 'WorkloadManagement/JobManager', useCertificates = False, timeout = 120 )
+    jobManager = RPCClient( 'WorkloadManagement/JobManager', useCertificates = False )
     result = jobManager.resetJob( jobID )
     return result
 
@@ -506,7 +506,7 @@ class DiracAdmin:
     if not os.path.exists( directory ):
       return self.__errorReport( 'Directory %s does not exist' % directory )
 
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.getJobPilotOutput( jobID )
     if not result['OK']:
       return result
@@ -562,7 +562,7 @@ class DiracAdmin:
     if not os.path.exists( directory ):
       return self.__errorReport( 'Directory %s does not exist' % directory )
 
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.getPilotOutput( gridReference )
     if not result['OK']:
       return result
@@ -616,7 +616,7 @@ class DiracAdmin:
     if not type( gridReference ) == type( " " ):
       return self.__errorReport( 'Expected string for pilot reference' )
 
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.getPilotInfo( gridReference )
     return result
 
@@ -634,7 +634,7 @@ class DiracAdmin:
     if type( gridReference ) not in types.StringTypes:
       return self.__errorReport( 'Expected string for pilot reference' )
 
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     return wmsAdmin.getPilotLoggingInfo( gridReference )
 
   #############################################################################
@@ -656,7 +656,7 @@ class DiracAdmin:
       except Exception, x:
         return self.__errorReport( str( x ), 'Expected integer or string for existing jobID' )
 
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.getPilots( jobID )
     if result['OK']:
       print self.pPrint.pformat( result['Value'] )
@@ -674,7 +674,7 @@ class DiracAdmin:
        @type job: integer or string
        @return: S_OK,S_ERROR
     """
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator', timeout = 120 )
+    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.getPilotSummary( startDate, endDate )
     if not result['OK']:
       return result
@@ -738,7 +738,7 @@ class DiracAdmin:
 
     self.log.verbose( 'Will select requests with the following conditions' )
     self.log.verbose( self.pPrint.pformat( conditions ) )
-    requestClient = RPCClient( "RequestManagement/centralURL", timeout = 120 )
+    requestClient = RPCClient( "RequestManagement/centralURL" )
     result = requestClient.getRequestSummaryWeb( conditions, [], requestStart, limit )
     if not result['OK']:
       self.log.warn( result['Message'] )


### PR DESCRIPTION
Remove explicit declaration of 120 s timeout when creating RPC clients on Dirac and DiracAdim API. Until the new timeoutless DISET is configured the default 600 s will be applied. This should reduce problems with timeouts in bulk job submission.

To be ported to v6r5 
