### PR TITLE
Add cutDate and condDict parameters to getJobGroup

### DIFF
--- a/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -76,11 +76,12 @@ class JobMonitoringHandler( RequestHandler ):
 
 ##############################################################################
   types_getJobGroups = []
-  def export_getJobGroups( self ):
+  def export_getJobGroups( self, condDict = None, cutDate = None ):
     """
     Return Distict Values of ProductionId job Attribute in WMS
     """
-    return jobDB.getDistinctJobAttributes( 'JobGroup' )
+    return jobDB.getDistinctJobAttributes( 'JobGroup', condDict, 
+                                           newer = cutDate )
 
 ##############################################################################
   types_getSites = []


### PR DESCRIPTION
cutDate will enable the retrieval of JobGroups newer than the
date, and condDict will allow the retrieval of JobGroups to be
limited by specific conditions. Both can significantly reduce query time
for the list of JobGroups if used.

My first DIRAC pull request - comments very welcome :)
