### PR TITLE
CHANGE: repository in Dirac.py retrieveRepositorySandboxes

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -153,7 +153,7 @@ class Dirac( API ):
       gLogger.warn( "No repository is initialised" )
       return S_OK()
     if requestedStates == None:
-      requestedStates = ['Done', 'Failed']
+      requestedStates = ['Done', 'Failed', 'Completed']#because users dont care about completed
     jobs = self.jobRepo.readRepository()['Value']
     for jobID in sortList( jobs.keys() ):
       jobDict = jobs[jobID]


### PR DESCRIPTION
Users do not really care if a job is completed when getting the output. They just want the files, wherever they are.
