### PR TITLE
BUGFIX: stupid parenthesis

### DIFF
--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -821,7 +821,7 @@ class Job:
       environment = []
       for var, val in environmentDict.items():
         try:
-          environment.append( '='.join( [str( var ), urllib.quote( str( val ) )] ) ) )
+          environment.append( '='.join( [str( var ), urllib.quote( str( val ) )] ) ) 
         except Exception:
           return self._reportError( 'Expected string for environment variable key value pairs', **kwargs )
 


### PR DESCRIPTION
I missed some parenthesis when securing the environment variables
