### PR TITLE
FIX: removing LHCb leftovers

### DIFF
--- a/DataManagementSystem/private/RegistrationTask.py
+++ b/DataManagementSystem/private/RegistrationTask.py
@@ -61,17 +61,15 @@ class RegistrationTask( RequestTask ):
     targetSEs = list( set( [ targetSE.strip() for targetSE in  subRequestAttrs["TargetSE"].split(",") 
                              if targetSE.strip() ] ) )
     if not targetSEs:
-      self.warn( "registerFile: no TargetSE specified! will use default 'CERN-FAILOVER'")
-      targetSEs = [ "CERN-FAILOVER" ]
+      self.error( "registerFile: no TargetSE specified!")
+      return S_ERROR( "registerFile: no TargetSE specified!" )
 
     ## dict for failed LFNs
     failed = {}
     failedFiles = 0
 
+    ## get catalogue
     catalogue = subRequestAttrs["Catalogue"] if subRequestAttrs["Catalogue"] else ""
-    if catalogue == "BookkeepingDB":
-      self.warn( "registerFile: catalogue set to 'BookkeepingDB', set it to 'CERN-HIST'")
-      catalogue = "CERN-HIST"
 
     for subRequestFile in subRequestFiles:
       lfn = subRequestFile.get( "LFN", "" ) 


### PR DESCRIPTION
From now on register requests should have TargetSE specified, else they won't be executed. Also removeing special case for LHCb Bookkeeping catalogue (Fede is putting in place a proper failover register request with all required fields).  

This should go to v6r5 and v6r6 branches as well.
