### PR TITLE
BUGFIX: typo in dict key for TransferAgent

### DIFF
--- a/DataManagementSystem/Agent/TransferAgent.py
+++ b/DataManagementSystem/Agent/TransferAgent.py
@@ -1009,7 +1009,7 @@ class TransferAgent( RequestAgentBase ):
                 error = registerReplica["Value"]["Failed"][lfn]
             self.log.error( "registerFiles: unable to register %s at %s: %s" %  ( lfn, se, error ) )
             return S_ERROR( error )
-          elif lfn in registerReplica["Value"]["Successfull"]:
+          elif lfn in registerReplica["Value"]["Successful"]:
             ## no other option, it must be in successfull
             register = self.transferDB().setRegistrationDone( channelID, fileID )
             if not register["OK"]:


### PR DESCRIPTION
Grrrr.... Small typo when registering files:

```
runit/DataManagement/TransferAgent/log/current:2012-11-30 16:05:16 UTC DataManagement/TransferAgent EXCEPT: == EXCEPTION ==
runit/DataManagement/TransferAgent/log/current:2012-11-30 16:05:16 UTC DataManagement/TransferAgent EXCEPT: <type 'exceptions.KeyError'>:'Successfull'
```
