### PR TITLE
FIX: FTSSubmitAgent and skipped files

### DIFF
--- a/DataManagementSystem/Agent/FTSSubmitAgent.py
+++ b/DataManagementSystem/Agent/FTSSubmitAgent.py
@@ -184,6 +184,17 @@ class FTSSubmitAgent( AgentModule ):
 """ % ( ftsGUID, ftsServer, str( channelID ), sourceSE, targetSE, str( len( files ) ) )
     self.log.info( infoStr )
 
+    ## filter out skipped files
+    failedFiles = oFTSRequest.getFailed()
+    if not failedFiles["OK"]:
+      self.log.warn("Unable to read skipped LFNs.")
+    failedFiles = failedFiles["Value"] if "Value" in failedFiles else []
+    failedIDs = [ meta["FileID"] for meta in files if meta["LFN"] in failedFiles ]
+    ## only submitted
+    fileIDs = [ fileID for fileID in fileIDs if fileID not in failedIDs ]
+    ## sub failed from total size
+    totalSize -= sum( [ meta["Size"] for meta in files if meta["LFN"] in failedFiles ] )
+
     #########################################################################
     #  Insert the FTS Req details and add the number of files and size
     res = self.transferDB.insertFTSReq( ftsGUID, ftsServer, channelID )

--- a/DataManagementSystem/Client/FTSRequest.py
+++ b/DataManagementSystem/Client/FTSRequest.py
@@ -564,7 +564,7 @@ class FTSRequest(object):
     res = self.__submitFTSTransfer()
     if not res['OK']:
       return res
-    resDict = {'ftsGUID':self.ftsGUID, 'ftsServer':self.ftsServer}
+    resDict = { 'ftsGUID' : self.ftsGUID, 'ftsServer' : self.ftsServer }
     print "Submitted %s @ %s" % ( self.ftsGUID, self.ftsServer )
     if monitor:
       self.monitor( untilTerminal = True, printOutput = printOutput )
@@ -837,7 +837,8 @@ class FTSRequest(object):
       lfnStatus = self.fileDict[lfn].get( 'Status' )
       source = self.fileDict[lfn].get( 'Source' )
       target = self.fileDict[lfn].get( 'Target' )
-      if ( lfnStatus != 'Failed' ) and ( lfnStatus != 'Done' ) and source and target:
+      if ( lfnStatus not in ( 'Failed', 'Done' ) ) and source and target:
+        submitted[lfn] = self.fileDict[lfn]
         cksmStr = ""
         ## add chsmType:cksm only if cksmType is specified, else let FTS decide by itself
         if self.__cksmTest and self.__cksmType:
@@ -973,7 +974,6 @@ class FTSRequest(object):
     :param self: self reference
     :param bool printOutput: print summary to stdout
     """
-
     outStr = ''
     for status in sortList( self.statusSummary.keys() ):
       if self.statusSummary[status]:


### PR DESCRIPTION
If file is for some reason rejected from submission, it should stay as 'Waiting' in TransferDB.Channel table (which is not the case right now). With this  pull files that were skipped from FTS job are filtered out also from db updating procedure in the FTSSubmitAgent.   
