### PR TITLE
X509Chain - return the right structure in getCredentials() in case of failure

### DIFF
--- a/Core/Security/X509Chain.py
+++ b/Core/Security/X509Chain.py
@@ -582,7 +582,7 @@ class X509Chain:
       credDict[ 'identity'] = self.__certList[ self.__firstProxyStep + 1 ].get_subject().one_line()
       retVal = Registry.getUsernameForDN( credDict[ 'identity' ] )
       if not retVal[ 'OK' ]:
-        return credDict
+        return retVal
       credDict[ 'username' ] = retVal[ 'Value' ]
       credDict[ 'validDN' ] = True
       retVal = self.getDIRACGroup( ignoreDefault = ignoreDefault )


### PR DESCRIPTION
BUGFIX: X509Chain - return the right structure in getCredentials() in case of failure
closes #1109 
