### PR TITLE
FIX: ResourceStatus connecting CS was missing a protection

### DIFF
--- a/ResourceStatusSystem/Client/ResourceStatus.py
+++ b/ResourceStatusSystem/Client/ResourceStatus.py
@@ -246,12 +246,7 @@ class ResourceStatus( object ):
     statuses = self.rssConfig.getConfigStatusType( 'StorageElement' )
     #statuses = self.__opHelper.getOptionsDict( 'RSSConfiguration/GeneralConfig/Resources/StorageElement' )
     #statuses = gConfig.getOptionsDict( '/Operations/RSSConfiguration/GeneralConfig/Resources/StorageElement' )
-    
-    if statuses[ 'OK' ]:
-      statuses = statuses[ 'Value' ][ 'StatusType' ]
-    else:
-      statuses = [ 'ReadAccess', 'WriteAccess' ]  
-    
+       
     result = {}
     for element in elementName:
     
@@ -319,11 +314,15 @@ class ResourceStatus( object ):
     
     return res
 
-  @staticmethod
-  def __setCSStorageElementStatus( elementName, statusType, status ):
+  def __setCSStorageElementStatus( self, elementName, statusType, status ):
     '''
     Sets on the CS the StorageElements status
     '''
+
+    statuses = self.rssConfig.getConfigStatusType( 'StorageElement' )
+    if not statusType in statuses:
+      gLogger.error( "%s is not a valid statusType" % statusType )
+      return S_ERROR( "%s is not a valid statusType: %s" % ( statusType, statuses ) )    
 
     csAPI = CSAPI()
   


### PR DESCRIPTION
While setting a new State ANY statusType was accepted ! and consequently written to the CS. This methods should not be used anyway, as the RSS is going to be active. But just in case.
