### PR TITLE
Stager fix

### DIFF
--- a/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/StorageManagementSystem/DB/StorageManagementDB.py
@@ -998,6 +998,15 @@ class StorageManagementDB( DB ):
       return res
 
     replicaIDs = [ row[0] for row in res['Value'] ]
+    # Look for Failed CacheReplicas which are not associated to any Task. These have no PinExpiryTime in StageRequests
+    # as they were not staged successfully (for various reasons), even though a staging request had been submitted
+    req = "SELECT ReplicaID FROM CacheReplicas WHERE Links = 0 AND Status = 'Failed';"
+    res = self._query( req, connection )    
+    if not res['OK']:
+      gLogger.error( "StorageManagementDB.removeUnlinkedReplicas. Problem selecting entries from CacheReplicas where Links = 0 AND Status=Failed." )
+    else:
+      replicaIDs.extend( [ row[0] for row in res['Value'] ] )
+        
     if replicaIDs:
       # Removed the entries from the StageRequests table that are expired
       reqSelect = "SELECT * FROM StageRequests WHERE ReplicaID IN (%s);" % intListToString( replicaIDs )
@@ -1016,7 +1025,7 @@ class StorageManagementDB( DB ):
 
       gLogger.debug( "StorageManagementDB.removeUnlinkedReplicas: Successfully removed %s StageRequests entries for ReplicaIDs: %s." % ( res['Value'], replicaIDs ) )
 
-    # Second look for CacheReplicas for which there is no entry in CacheReplicas
+    # Second look for CacheReplicas for which there is no entry in StageRequests
     req = 'SELECT ReplicaID FROM CacheReplicas WHERE Links = 0 AND ReplicaID NOT IN ( SELECT DISTINCT( ReplicaID ) FROM StageRequests )'
     res = self._query( req, connection )
     if not res['OK']:


### PR DESCRIPTION
FIX: When removing unlinked replicas, take into account the case where a
staging request had been submitted, but the staging failed for various
reasons (inconsistency between SRM database and actual storage, SE
banned after request was submitted etc).

These unlinked replicas were not cleaned from the DB, only the ones with
expired pin time, or a missing staging request.
