### PR TITLE
FIX: RequestClient exceptions in getRequest

### DIFF
--- a/RequestManagementSystem/Client/RequestClient.py
+++ b/RequestManagementSystem/Client/RequestClient.py
@@ -165,7 +165,7 @@ class RequestClient( Client ):
     self.log.info( "getRequest: attempting to get '%s' request." % requestType )
     getRequest = self.requestManager().getRequest( requestType )
     if not getRequest["OK"]:
-      self.log.error("getRequest: unable to get '%s' request: %s" % getRequest["Message"] )
+      self.log.error("getRequest: unable to get '%s' request: %s" % ( requestType, getRequest["Message"] ) )
     return getRequest  
 
   def serveRequest( self, requestType = "" ):


### PR DESCRIPTION
A very small fix for string formatting to prevent this one: 

```
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT: Exception while calling <bound method LogUploadAgent.execute of <LogUploadAgent.LogUploadAgent instance at 0x1bc5a6c8>> method 
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT: == EXCEPTION ==
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT: <type 'exceptions.TypeError'>:not enough arguments for format string
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT:   File "/opt/dirac/versions/v7r11p1_1358159610/DIRAC/Core/Base/AgentModule.py", line 314, in am_secureCall
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT:     result = functor( *args )
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT: 
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT:   File "/opt/dirac/versions/v7r11p1_1358159610/LHCbDIRAC/DataManagementSystem/Agent/LogUploadAgent.py", line 71, in execute
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT:     res = self.requestClient.getRequest( 'logupload' )
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT: 
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT:   File "/opt/dirac/versions/v7r11p1_1358159610/DIRAC/RequestManagementSystem/Client/RequestClient.py", line 168, in getRequest
2013-01-21 08:36:16 UTC DataManagement/LogUploadAgent EXCEPT:     self.log.error("getRequest: unable to get '%s' request: %s" % getRequest["Message"] )
```
