### PR TITLE
FIX: ignore files in NotProcessed status to get the % of processed files

### DIFF
--- a/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/TransformationSystem/Service/TransformationManagerHandler.py
@@ -613,18 +613,19 @@ class TransformationManagerHandlerBase( RequestHandler ):
       # Get the statistics for the number of files for the transformation
       fileDict = {}
       transType = transDict['Type']
-      
+
       if transType.lower() in extendableTranfs:
         fileDict['PercentProcessed'] = '-'
       else:
         res = database.getTransformationStats( transID )
         if res['OK']:
           fileDict = res['Value']
-          if fileDict['Total'] == 0:
+          total = fileDict['Total'] - fileDict.get( 'NotProcessed', 0 )
+          if total == 0:
             fileDict['PercentProcessed'] = 0
           else:
             processed = fileDict.get( 'Processed', 0 )
-            fileDict['PercentProcessed'] = "%.1f" % ( int( processed * 1000. / fileDict['Total'] ) / 10. )
+            fileDict['PercentProcessed'] = "%.1f" % ( int( processed * 1000. / total ) / 10. )
       for state in fileStateNames:
         trans.append( fileDict.get( state, 0 ) )
 


### PR DESCRIPTION
As LHCb is not always considering all input files of a transformation for execution, don't take files in NotProcessed status into account to compute the % of processed files
