### PR TITLE
FIX: TransferAgent - getActiveReplicas

### DIFF
--- a/DataManagementSystem/Agent/TransferAgent.py
+++ b/DataManagementSystem/Agent/TransferAgent.py
@@ -446,7 +446,7 @@ class TransferAgent( RequestAgentBase ):
         waitingFiles.setdefault( fileLFN, subRequestFile["FileID"] )
 
     if waitingFiles:     
-      replicas = self.replicaManager().getCatalogReplicas( waitingFiles.keys() )
+      replicas = self.replicaManager().getActiveReplicas( waitingFiles.keys() )
       if not replicas["OK"]:
         self.log.error( "collectFiles: failed to get replica information", replicas["Message"] )
         return replicas
@@ -519,7 +519,7 @@ class TransferAgent( RequestAgentBase ):
           failback = True
         elif executeFTS["OK"]:
           if executeFTS["Value"]:
-            self.log.info("execute: request %s has been processed in FTS" % requestDict["requestName"] )
+            self.log.debug("execute: request %s has been processed in FTS" % requestDict["requestName"] )
             requestCounter = requestCounter - 1
             self.deleteRequest( requestDict["requestName"] )
             continue 
@@ -587,7 +587,7 @@ class TransferAgent( RequestAgentBase ):
      
     schedule = self.schedule( requestDict )
     if schedule["OK"]:
-      self.log.info("executeFTS: request %s has been processed" % requestDict["requestName"] )
+      self.log.debug("executeFTS: request %s has been processed" % requestDict["requestName"] )
     else:
       self.log.error( schedule["Message"] )
       return schedule 
@@ -668,7 +668,7 @@ class TransferAgent( RequestAgentBase ):
       #execOrder = int(subAttrs["ExecutionOrder"]) if "ExecutionOrder" in subAttrs else 0
       #if execOrder > requestDict["executionOrder"]:
       #  strTup = ( iSubRequest, execOrder, requestDict["executionOrder"] )
-      #  self.info.warn("schedule: skipping %s subrequest, executionOrder %s > request's executionOrder" % strTup )  
+      #  self.log.warn("schedule: skipping %s subrequest, executionOrder %s > request's executionOrder" % strTup )  
       #  continue 
 
       if subRequestStatus != "Waiting" :
@@ -769,7 +769,7 @@ class TransferAgent( RequestAgentBase ):
     :param RequestContainer requestObj: request being processed
     :param dict subAttrs: subrequest's attributes
     """
-    self.log.info( "scheduleFiles: FTS scheduling, processing subrequest %s" % index )
+    self.log.debug( "scheduleFiles: FTS scheduling, processing subrequest %s" % index )
     ## get source SE
     sourceSE = subAttrs["SourceSE"] if subAttrs["SourceSE"] not in ( None, "None", "" ) else None
     ## get target SEs, no matter what's a type we need a list

--- a/DataManagementSystem/Client/FTSRequest.py
+++ b/DataManagementSystem/Client/FTSRequest.py
@@ -1243,7 +1243,6 @@ class FTSRequest(object):
 
     :param self: self reference
     """
-
     missingSourceErrors = [
       'SOURCE error during TRANSFER_PREPARATION phase: \[INVALID_PATH\] Failed',
       'SOURCE error during TRANSFER_PREPARATION phase: \[INVALID_PATH\] No such file or directory',


### PR DESCRIPTION
Change RM call from getCatalogueReplicas to getActiveReplicas. Lowering log printouts here and there.
