### PR TITLE
FIX: TransferAgent TypeError

### DIFF
--- a/DataManagementSystem/Agent/TransferAgent.py
+++ b/DataManagementSystem/Agent/TransferAgent.py
@@ -1012,7 +1012,7 @@ class TransferAgent( RequestAgentBase ):
             return S_ERROR( error )
           elif lfn in registerReplica["Value"]["Successful"]:
             ## no other option, it must be in successfull
-            register = self.transferDB().setRegistrationDone( channelID, fileID )
+            register = self.transferDB().setRegistrationDone( channelID, [ fileID ] )
             if not register["OK"]:
               self.log.error("registerFiles: set status error %s fileID=%s channelID=%s: %s" % ( lfn,
                                                                                                  fileID,


### PR DESCRIPTION
To prevent `TypeError` when executing failover registration: 

```
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT: == EXCEPTION ==
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT: <type 'exceptions.TypeError'>:'long' object is not iterable
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:   File "/opt/dirac/pro/DIRAC/Core/Base/AgentModule.py", line 314, in am_secureCall
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:     result = functor( *args )
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT: 
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:   File "/opt/dirac/pro/DIRAC/DataManagementSystem/Agent/TransferAgent.py", line 516, in execute
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:     executeFTS = self.executeFTS( requestDict )
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT: 
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:   File "/opt/dirac/pro/DIRAC/DataManagementSystem/Agent/TransferAgent.py", line 588, in executeFTS
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:     schedule = self.schedule( requestDict )
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT: 
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:   File "/opt/dirac/pro/DIRAC/DataManagementSystem/Agent/TransferAgent.py", line 688, in schedule
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:     registerFiles = self.registerFiles( requestObj, iSubRequest )
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT: 
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:   File "/opt/dirac/pro/DIRAC/DataManagementSystem/Agent/TransferAgent.py", line 1015, in registerFiles
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:     register = self.transferDB().setRegistrationDone( channelID, fileID )
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT: 
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:   File "/opt/dirac/pro/DIRAC/DataManagementSystem/DB/TransferDB.py", line 1222, in setRegistrationDone
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:     "WHERE FileID IN (%s) AND ChannelID=%s AND Status='Waiting';" % ( intListToString( fileID ), channelID )
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT: 
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:   File "/opt/dirac/pro/DIRAC/Core/Utilities/List.py", line 90, in intListToString
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT:     return ",".join( [str( x ) for x in aList ] )
2013-02-01 17:04:05 UTC DataManagement/TransferAgent EXCEPT: ===============
```
