### PR TITLE
FIX: in removeReplica of the LFC, consider that the PFN may have been changed

### DIFF
--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -843,7 +843,17 @@ class LcgFileCatalogClient( FileCatalogueBase ):
         if res['OK']:
           successful[lfn] = True
         else:
-          failed[lfn] = res['Message']
+          if res['Message'] == 'No such file or directory':
+            # The PFN didn't exist, but maybe it wsa changed...
+            res1 = self.getReplicas( lfn )
+            if res1['OK']:
+              pfn1 = res1['Value']['Successful'].get( lfn, {} ).get( se )
+              if pfn1 and pfn1 != pfn:
+                res = self.__removeReplica( pfn1 )
+          if res['OK']:
+            successful[lfn] = True
+          else:
+            failed[lfn] = res['Message']
     lfnRemoved = successful.keys()
     if len( lfnRemoved ) > 0:
       res = self.getReplicas( lfnRemoved, True )


### PR DESCRIPTION
With the change of endpoint at GRIDKA, it becomes impossible to remove replicas because the LFC uses the SURL for removing a replica. It fails since the SURL has been changed with the new endpoint.
The fix handles this case and gets back the SURL from the LFC. If it is different from the previous one, it tries and remove it...
