### PR TITLE
CHANGE VOPolicy in TaskManager: OutputDataModule

### DIFF
--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -224,11 +224,6 @@ class WorkflowTasks( TaskBase ):
     else:
       self.jobMonitoringClient = jobMonitoringClient
 
-    if not outputDataModule:
-      self.outputDataModule = gConfig.getValue( "/DIRAC/VOPolicy/OutputDataModule", "" )
-    else:
-      self.outputDataModule = outputDataModule
-
     if not jobClass:
       from DIRAC.Interfaces.API.Job import Job
       self.jobClass = Job
@@ -240,6 +235,11 @@ class WorkflowTasks( TaskBase ):
       self.opsH = Operations()
     else:
       self.opsH = opsH
+
+    if not outputDataModule:
+      self.outputDataModule = self.opsH.getValue( "Transformations/OutputDataModule", "" )
+    else:
+      self.outputDataModule = outputDataModule
 
 
   def prepareTransformationTasks( self, transBody, taskDict, owner = '', ownerGroup = '' ):


### PR DESCRIPTION
Remove usage of that directory in the CS in favor of Operations helper.
Is now under ops().getValue("Transformations/OutputDataModule","")

Needs Agreement from LHCb before merging.
