### PR TITLE
[v6r8]FIX: typo( elemenDict -> elementDict ) 

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -218,14 +218,14 @@ def checkElementProperties( elementPath, selectDict ):
     return False
   elementDict = result['Value']
   finalResult = True  
-  for property in selectDict:
-    if not property in elementDict:
+  for property_ in selectDict:
+    if not property_ in elementDict:
       return False 
-    if type( selectDict[property] ) == ListType:
-      if not elemenDict[property] in selectDict[property]:
+    if type( selectDict[property_] ) == ListType:
+      if not elementDict[property_] in selectDict[property_]:
         return False
     else:
-      if elemenDict[property] != selectDict[property]:
+      if elementDict[property_] != selectDict[property_]:
         return False     
 
   return finalResult
@@ -323,14 +323,14 @@ class Resources( object ):
         return False
       elementDict = result['Value']
       finalResult = True  
-      for property in selectDict:
-        if not property in elementDict:
+      for property_ in selectDict:
+        if not property_ in elementDict:
           return False 
-        if type( selectDict[property] ) == ListType:
-          if not elemenDict[property] in selectDict[property]:
+        if type( selectDict[property_] ) == ListType:
+          if not elementDict[property_] in selectDict[property_]:
             return False
         else:
-          if elemenDict[property] != selectDict[property]:
+          if elementDict[property_] != selectDict[property_]:
             return False     
 
       return finalResult


### PR DESCRIPTION
and renamed built-in 'property' to 'property_'

on checkElementProperties function
on Resources.__checkElementProperties method
