### PR TITLE
FIX[v6r7]: RSS Agents bugfixes

### DIFF
--- a/ResourceStatusSystem/Agent/ElementInspectorAgent.py
+++ b/ResourceStatusSystem/Agent/ElementInspectorAgent.py
@@ -110,6 +110,14 @@ class ElementInspectorAgent( AgentModule ):
       # of elements returned by mySQL on tuples
       elemDict = dict( zip( elements[ 'Columns' ], element ) )
       
+      # We skip the elements with token different than "rs_svc"
+      if elemDict[ 'TokenOwner' ] != 'rs_svc':
+        self.log.info( 'Skipping %s ( %s ) with token %s' % ( elemDict[ 'Name' ],
+                                                              elemDict[ 'StatusType' ],
+                                                              elemDict[ 'TokenOwner' ]
+                                                             ))
+        continue
+      
       if not elemDict[ 'ElementType' ] in self.checkingFreqs:
         #self.log.warn( '"%s" not in inspectionFreqs, getting default' % elemDict[ 'ElementType' ] )
         timeToNextCheck = self.checkingFreqs[ 'Default' ][ elemDict[ 'Status' ] ]

--- a/ResourceStatusSystem/Agent/TokenAgent.py
+++ b/ResourceStatusSystem/Agent/TokenAgent.py
@@ -11,8 +11,6 @@ from DIRAC.Core.Base.AgentModule                                import AgentModu
 from DIRAC.FrameworkSystem.Client.NotificationClient            import NotificationClient
 from DIRAC.ResourceStatusSystem.Client.ResourceStatusClient     import ResourceStatusClient
 from DIRAC.ResourceStatusSystem.Client.ResourceManagementClient import ResourceManagementClient
-# from DIRAC.ResourceStatusSystem.PolicySystem.PDP                import PDP
-# from DIRAC.ResourceStatusSystem.Utilities                       import RssConfiguration
 
 from DIRAC.Interfaces.API.DiracAdmin import DiracAdmin
 
@@ -56,6 +54,8 @@ class TokenAgent( AgentModule ):
     '''
 
     self.notifyHours = self.am_getOption( 'notifyHours', self.notifyHours )
+    self.adminMail   = self.am_getOption( 'adminMail', self.adminMail )
+
 
     self.rsClient = ResourceStatusClient()
     self.rmClient = ResourceManagementClient()
@@ -187,7 +187,7 @@ class TokenAgent( AgentModule ):
 
       for tokenList in tokenLists:
 
-        if tokenList[ 4 ] < now:
+        if tokenList[ 5 ] < now:
           expired.append( tokenList )
           adminExpired.append( tokenList )
         else:
@@ -198,7 +198,7 @@ class TokenAgent( AgentModule ):
       if not resNotify[ 'OK' ]:
         self.log.error( resNotify[ 'Message' ] )
 
-    if adminExpired or adminExpiring:
+    if ( adminExpired or adminExpiring ) and self.__adminMail:
       return self._notify( self.__adminMail, adminExpired, adminExpiring )
 
     return S_OK()
@@ -214,13 +214,13 @@ class TokenAgent( AgentModule ):
     mail = '\nEXPIRED tokens ( RSS has taken control of them )\n'
     for tokenList in expired:
 
-      mail += ' '.join( tokenList )
+      mail += ' '.join( [ str(x) for x in tokenList ] )
       mail += '\n'
 
-    mail = '\nEXPIRING tokens ( RSS will taken control of them )\n'
+    mail = '\nEXPIRING tokens ( RSS will take control of them )\n'
     for tokenList in expiring:
 
-      mail += ' '.join( tokenList )
+      mail += ' '.join( [ str(x) for x in tokenList ] )
       mail += '\n'
 
     # FIXME: you can re-take control of them using this or that...


### PR DESCRIPTION
ElementInspectorAgent: should only pick elements with rss token  ( rs_svc ). 
TokenAgent: using 4th element instead of the 5th. Added option to set admin email on the CS.

These changes DO NOT affect the BASIC usage of RSS. Are only used on the monitoring part.
