### PR TITLE
Sending email directly from service rather from local machine

### DIFF
--- a/FrameworkSystem/scripts/dirac-sys-sendmail.py
+++ b/FrameworkSystem/scripts/dirac-sys-sendmail.py
@@ -67,7 +67,7 @@ if "Subject" in headers:
   subject = headers[ "Subject" ]
 
 ntc = NotificationClient()
-result = ntc.sendMail( to , subject , body , origin , localAttempt = True )
+result = ntc.sendMail( to , subject , body , origin , localAttempt = False )
 if not result[ "OK" ]:
   gLogger.error( result[ "Message" ] )
   DIRACexit( 5 )


### PR DESCRIPTION
Some sites are blocking emails sent from WN, so for dirac-sys-sendmail everything looks okay but mail can not be received.
