### PR TITLE
[v7r0]: getFileUserMetadata gets also the Directory metadata

### DIFF
--- a/Resources/Catalog/FileCatalogClient.py
+++ b/Resources/Catalog/FileCatalogClient.py
@@ -66,8 +66,24 @@ class FileCatalogClient(Client):
       result['Value'] = fileList    
       return result
     else:
-      return S_ERROR( 'Illegal return value type %s' % type( result['Value'] ) )    
-     
+      return S_ERROR( 'Illegal return value type %s' % type( result['Value'] ) ) 
+       
+  def getFileUserMetadata(self, path, rpc='', url='', timeout=120):
+    """Get the meta data attached to a file, but also to 
+    the its corresponding directory
+    """
+    directory = "/".join(path.split("/")[:-1])
+    rpcClient = self._getRPC(rpc=rpc,url=url,timeout=timeout)
+    result = rpcClient.getFileUserMetadata(path)
+    if not result['OK']:
+      return result
+    fmeta = result['Value']
+    result = rpcClient.getDirectoryMetadata(directory)
+    if not result['OK']:
+      return result
+    fmeta.update(result['Value'])
+    
+    return S_OK(fmeta)
     
     
   


### PR DESCRIPTION
The meta data of a file is not enough to get that one file back using
meta data queries, it also needs the directory meta data. Now both the
directory meta data and the file meta data are returned.
