### PR TITLE
[URGENT][v6r7] FIX: Properly set the dirac env for scripts that do not start with 'd' 

### DIFF
--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -123,7 +123,7 @@ if not rootPath:
   sys.exit( 1 )
 
 targetScriptsPath = os.path.join( rootPath, "scripts" )
-pythonScriptRE = re.compile( "(.*/)*([a-z]+-|d[a-zA-Z0-9-]+).py" )
+pythonScriptRE = re.compile( "(.*/)*([a-z]+-[a-zA-Z0-9-]+|d[a-zA-Z0-9-]+).py" )
 logNOTICE( "Scripts will be deployed at %s" % targetScriptsPath )
 
 if not os.path.isdir( targetScriptsPath ):


### PR DESCRIPTION
FIX: Properly set the dirac env for scripts that do not start with 'd'

**This avoids breaking scripts done by extensions with names that do NOT start with 'd'**
