### PR TITLE
FIX (v6r8): pass filePath argument when downloading proxy

### DIFF
--- a/Core/Utilities/Shifter.py
+++ b/Core/Utilities/Shifter.py
@@ -39,13 +39,15 @@ def getShifterProxy( shifterType, fileName = False ):
   if vomsAttr:
     gLogger.info( "Getting VOMS [%s] proxy for shifter %s@%s (%s)" % ( vomsAttr, userName,
                                                                        userGroup, userDN ) )
-    result = gProxyManager.downloadVOMSProxyToFile( userDN, userGroup, 
-                                                    requiredTimeLeft = 1200, 
+    result = gProxyManager.downloadVOMSProxyToFile( userDN, userGroup,
+                                                    filePath = fileName,
+                                                    requiredTimeLeft = 1200,
                                                     cacheTime = 4 * 43200 )
   else:
     gLogger.info( "Getting proxy for shifter %s@%s (%s)" % ( userName, userGroup, userDN ) )
-    result = gProxyManager.downloadProxyToFile( userDN, userGroup, 
-                                                requiredTimeLeft = 1200, 
+    result = gProxyManager.downloadProxyToFile( userDN, userGroup,
+                                                filePath = fileName,
+                                                requiredTimeLeft = 1200,
                                                 cacheTime = 4 * 43200 )
   if not result[ 'OK' ]:
     return result


### PR DESCRIPTION
When the filePath argument is not passed, some Agents might remove the proxy from others, since they share the same file.
should also be applied to v6r7 if still is to be maintained.
