### PR TITLE
FIX: remove check for opening a session in __init__ as credentials are not yet set :((

### DIFF
--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -194,11 +194,6 @@ class LcgFileCatalogClient( FileCatalogueBase ):
     self.prefix = '/grid'
     self.session = False
     self.transaction = False
-    # Verify if the LFC can be accessed, if not, declare it invalid
-    created = self.__openSession()
-    if created < 0:
-      self.isValid = False
-    self.__closeSession()
 
   ####################################################################
   #


### PR DESCRIPTION
This was just causing the opposite effect to that desired, i.e crashing processes...
