### PR TITLE
enable Storage Element proxy configuration by protocol name

### DIFF
--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -44,10 +44,19 @@ class StorageElement:
         return result
       self.vo = result['Value']
     self.opHelper = Operations( vo = self.vo )
-    useProxy = gConfig.getValue( '/LocalSite/StorageElements/%s/UseProxy' % name, False )
+
+    proxiedProtocols = gConfig.getValue( '/LocalSite/StorageElements/ProxyProtocols', "" ).split( ',' )
+    useProxy = ( gConfig.getValue( "/Resources/StorageElements/%s/AccessProtocol.1/Protocol" % name, "UnknownProtocol" )
+                in proxiedProtocols )
+
+    print "Proxy", name, proxiedProtocols, \
+    gConfig.getValue( "/Resources/StorageElements/%s/AccessProtocol.1/Protocol" % name, "xxx" )
+
+    if not useProxy:
+      useProxy = gConfig.getValue( '/LocalSite/StorageElements/%s/UseProxy' % name, False )
     if not useProxy:
       useProxy = self.opHelper.getValue( '/Services/StorageElements/%s/UseProxy' % name, False )
-    
+
     self.valid = True
     if protocols == None:
       res = StorageFactory( useProxy ).getStorages( name, protocolList = [] )


### PR DESCRIPTION
Enables client configuration for using ProxyStorage based on Storage Element default protocol name.

For example, using a client installation lacking gLite/EMI tools can use the following option to use ProxyStorage on every SRM SE:

/LocalSite/StorageElements/ProxyProtocols=srm
