### PR TITLE
FIX: remove bad index

### DIFF
--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -205,8 +205,7 @@ class TransformationDB( DB ):
                                                    'TargetSE': "char(255) DEFAULT 'Unknown'",
                                                    'TaskID': 'INTEGER NOT NULL AUTO_INCREMENT',
                                                    'TransformationID': 'INTEGER NOT NULL'},
-                                        'Indexes': {'ExternalStatus': ['ExternalStatus'],
-                                                    'TaskID': ['TaskID']},
+                                        'Indexes': {'ExternalStatus': ['ExternalStatus']},
                                         'PrimaryKey': ['TransformationID', 'TaskID'],
                                         'Engine': 'InnoDB'
                                         },


### PR DESCRIPTION
The TaskID must not be an index in the TransformationTasks as it breaks the logic
