### PR TITLE
X509Chain.getCredentials() - failure to contact CS is not fatal

### DIFF
--- a/Core/Security/X509Chain.py
+++ b/Core/Security/X509Chain.py
@@ -582,8 +582,11 @@ class X509Chain:
       credDict[ 'identity'] = self.__certList[ self.__firstProxyStep + 1 ].get_subject().one_line()
       retVal = Registry.getUsernameForDN( credDict[ 'identity' ] )
       if not retVal[ 'OK' ]:
-        return retVal
-      credDict[ 'username' ] = retVal[ 'Value' ]
+        # We could not contact the CS most likely, which is possible, e.g. when doing
+        # dirac-proxy-init -x
+        credDict[ 'username' ] = 'unknown'
+      else:  
+        credDict[ 'username' ] = retVal[ 'Value' ]
       credDict[ 'validDN' ] = True
       retVal = self.getDIRACGroup( ignoreDefault = ignoreDefault )
       if retVal[ 'OK' ]:


### PR DESCRIPTION
CHANGE: in getCredentials() - failure to contact CS is not fatal, can happen when calling dirac-proxy-init -x
