### PR TITLE
Pipe support

### DIFF
--- a/FrameworkSystem/scripts/dirac-sys-sendmail.py
+++ b/FrameworkSystem/scripts/dirac-sys-sendmail.py
@@ -19,8 +19,9 @@
   Options:
     There are no options.
 
-  Example:
+  Examples:
     dirac-sys-sendmail "From: source@email.com\\nTo: destination@email.com\\nSubject: Test\\n\\nMessage body"
+    echo "From: source@email.com\\nSubject: Test\\n\\nMessage body" | dirac-sys-sendmail destination@email.com
 """
 
 __RCSID__ = "$Id$"


### PR DESCRIPTION
mail headers and body can be taken from a system pipe. Recipient's address have to be provided as an argument
