### PR TITLE
CHANGE: Clean the FC_FileAncestors table when removing a file

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
@@ -610,7 +610,7 @@ class FileManagerBase:
         directorySESizeDict[dirID][seID]['Files'] += 1
 
     #Remove files from Ancestor tables
-    res = self._removeFileAncestors(fileIDLfns.keys(), connection)
+    res = self._removeFileAncestors(fileIDLfns.keys(), connection = connection )
     if res['OK'] and res['Value']:
       for fid in res['Value']['Successful'].keys():
         successful[fileIDLfns[fid]] = True


### PR DESCRIPTION
Until of now, when a file was removed from the FC, the ancestor/daughter
relationships where broken. Now simply remove the file also from that
table. Don't change the depths. Needs testing (will do).

Addresses #1190
