### PR TITLE
FIX: use CS to get files statuses not to include in denominator of % processed (for web)

### DIFF
--- a/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/TransformationSystem/Service/TransformationManagerHandler.py
@@ -593,8 +593,10 @@ class TransformationManagerHandlerBase( RequestHandler ):
     statusDict = {}
     extendableTranfs = Operations().getValue( 'Transformations/ExtendableTransfTypes',
                                                 ['Simulation', 'MCsimulation'] )
-    givenUpFileStatus = Operations().getValue( 'Transformations/GivenUpFileSTatus',
+    givenUpFileStatus = Operations().getValue( 'Transformations/GivenUpFileStatus',
                                                ['NotProcessed', 'Removed', 'MissingInFC', 'MissingLFC'] )
+    problematicStatuses = Operations().getValue( 'Transformations/ProblematicStatuses',
+                                               ['Problematic'] )
     # Add specific information for each selected transformation
     for trans in transList:
       transDict = dict( zip( paramNames, trans ) )
@@ -624,11 +626,12 @@ class TransformationManagerHandlerBase( RequestHandler ):
           total = fileDict['Total']
           for stat in givenUpFileStatus:
             total -= fileDict.get( stat, 0 )
-          if total == 0:
-            fileDict['PercentProcessed'] = 0
-          else:
-            processed = fileDict.get( 'Processed', 0 )
-            fileDict['PercentProcessed'] = "%.1f" % ( int( processed * 1000. / total ) / 10. )
+          processed = fileDict.get( 'Processed', 0 )
+          fileDict['PercentProcessed'] = "%.1f" % ( int( processed * 1000. / total ) / 10. ) if total else 0.
+      problematic = 0
+      for stat in problematicStatuses:
+        problematic += fileDict.get( stat, 0 )
+      fileDict ['Problematic'] = problematic
       for state in fileStateNames:
         trans.append( fileDict.get( state, 0 ) )
 


### PR DESCRIPTION
This PR allows to not consider the Removed, MissingInFC, NotProcessed etc… files in the computation of the % of processed files. As users can add statuses, this allows to tune the returned value.
