### PR TITLE
NEW: StorageElement getCurrentStatus method

### DIFF
--- a/Resources/Storage/DIPStorage.py
+++ b/Resources/Storage/DIPStorage.py
@@ -603,4 +603,15 @@ class DIPStorage( StorageBase ):
     
     return S_OK( res['Value']['Successful'][url] )
 
-
+  def getCurrentStatus(self):
+    """ Ask the server the current status (disk usage). Needed for RSS
+    """
+    serviceClient = RPCClient( self.url )
+    res = serviceClient.getAdminInfo()
+    if not res['OK']:
+      return res
+    se_status = {}
+    se_status['totalsize'] = res['Value']['AvailableSpace'] + res['Value']['UsedSpace']
+    se_status['unusedsize'] = res['Value']['AvailableSpace']
+    se_status['guaranteedsize'] = res['Value']['MaxCapacity']
+    return S_OK(se_status)

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -1698,6 +1698,23 @@ class SRM2Storage( StorageBase ):
 
     return S_OK( protocolsList )
 
+  def getCurrentStatus(self):
+    """ Get the current status (lcg_stmd), needed for RSS
+    """
+    res = self.__importExternals()
+    if not res['OK']:
+      return S_ERROR("Cannot import externals")
+    if not self.spaceToken:
+      return S_ERROR("Space token not defined for SE")
+    #make the endpoint
+    endpoint = 'httpg://%s:%s%s' % ( self.host, self.port, self.wspath )
+    endpoint = endpoint.replace( '?SFN=', '' )
+    status, resdict, errmessage = self.lcg_util.lcg_stmd(self.spaceToken, endpoint, 1, 10)
+    if status:
+      return S_ERROR("lcg_util.lcg_stmd failed: %s" % errmessage)
+    
+    return S_OK(resdict[0])
+
 #######################################################################
 #
 # These methods wrap the gfal functionality with the accounting. All these are based on __gfal_operation_wrapper()

--- a/Resources/Storage/StorageBase.py
+++ b/Resources/Storage/StorageBase.py
@@ -161,6 +161,15 @@ class StorageBase:
     """
     return S_ERROR( "Storage.getDirectorySize: implement me!" )
 
+  #############################################################
+  #
+  # These are the methods to get the current storage properties
+  #
+
+  def getCurrentStatus(self, *parms, **kws ):
+    """ Get the current properties: available disk, usage (for RSS)
+    """
+    return S_ERROR("Storage.getCurrentStatus: implement me!")
 
   #############################################################
   #


### PR DESCRIPTION
For the RSS, the SpaceTokenOccupency should use the StorageElement
instead of the lcg_util calls (to allow monitoring also DIRAC
StorageElements), therefore I added the method to extract the info from
the corresponding methods. 

In any case, the space token is a bit nasty: all SEs do not provide
dedicated ones for the VOs. Catch the case the space token is not
defined, and return an error.
