### PR TITLE
allow minus character in long script options

### DIFF
--- a/ConfigurationSystem/Client/LocalConfiguration.py
+++ b/ConfigurationSystem/Client/LocalConfiguration.py
@@ -309,7 +309,7 @@ class LocalConfiguration:
     self.unprocessedSwitches = []
 
     for optionName, optionValue in self.parsedOptionList:
-      optionName = optionName.replace( "-", "" )
+      optionName = optionName.lstrip( "-" )
       for definedOptionTuple in self.commandOptionList:
         if optionName == definedOptionTuple[0].replace( ":", "" ) or \
           optionName == definedOptionTuple[1].replace( "=", "" ):


### PR DESCRIPTION
Concerning long options like "--some-long-option"

Original code was swallowing all minus signs inside the option because of the use of `optionName.replace( "-", "" )`.

Making use of lstrip instead should not harm, I think.
