### PR TITLE
DataFiles table (TransformationDB):

### DIFF
--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -132,7 +132,7 @@ class TransformationDB( DB ):
                                          'LFN': 'VARCHAR(255) UNIQUE',
                                          'Status': "VARCHAR(32) DEFAULT 'AprioriGood'"},
                               'Indexes': {'Status': ['Status']},
-                              'PrimaryKey': ['FileID', 'LFN'],
+                              'PrimaryKey': ['FileID'],
                               'Engine': 'InnoDB'
                               }
 


### PR DESCRIPTION
Removed LFN field from the Primary Key
It was already UNIQUE, Primary key is FileID only now.
No need for changes elsewhere...
