### PR TITLE
Fix invalid information when doing proxy-info without CS

### DIFF
--- a/Core/Security/X509Chain.py
+++ b/Core/Security/X509Chain.py
@@ -581,11 +581,8 @@ class X509Chain:
       credDict[ 'identity'] = self.__certList[ self.__firstProxyStep + 1 ].get_subject().one_line()
       retVal = Registry.getUsernameForDN( credDict[ 'identity' ] )
       if not retVal[ 'OK' ]:
-        # We could not contact the CS most likely, which is possible, e.g. when doing
-        # dirac-proxy-init -x
-        credDict[ 'username' ] = 'unknown'
-      else:  
-        credDict[ 'username' ] = retVal[ 'Value' ]
+        return S_OK( credDict )
+      credDict[ 'username' ] = retVal[ 'Value' ]
       credDict[ 'validDN' ] = True
       retVal = self.getDIRACGroup( ignoreDefault = ignoreDefault )
       if retVal[ 'OK' ]:
@@ -602,7 +599,7 @@ class X509Chain:
         credDict[ 'hostname' ] = retVal[ 'Value' ]
         credDict[ 'validDN' ] = True
         credDict[ 'validGroup' ] = True
-        credDict[ 'groupProperties' ] = Registry.getHostOption( credDict[ 'hostname' ], 'Properties' ) 
+        credDict[ 'groupProperties' ] = Registry.getHostOption( credDict[ 'hostname' ], 'Properties' )
       retVal = Registry.getUsernameForDN( credDict[ 'subject' ] )
       if retVal[ 'OK' ]:
         credDict[ 'username' ] = retVal[ 'Value' ]


### PR DESCRIPTION
Revert "CHNAGE: in getCredentials() - failure to contact CS is not fatal"

This reverts commit 3b0886ee8dcf33023c899891643239f0f5bd7833.
