### PR TITLE
ADDED methods to DELETE rows from TransformationFIleTasks table

### DIFF
--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -1645,10 +1645,10 @@ class TransformationDB( DB ):
     res = self.__deleteTransformationFiles( transID, connection = connection )
     if not res['OK']:
       return res
-    res = self.__deleteTransformationTasks( transID, connection = connection )
+    res = self.__deleteTransformationTaskInputs( transID, connection = connection )
     if not res['OK']:
       return res
-    res = self.__deleteTransformationTaskInputs( transID, connection = connection )
+    res = self.__deleteTransformationTasks( transID, connection = connection )
     if not res['OK']:
       return res
     res = self.setTransformationParameter( transID, 'Status', 'Cleaned', author = author, connection = connection )


### PR DESCRIPTION
ADDED methods to DELETE rows from TransformationFIleTasks table
- minor changes in operation order to be ready for FK.

MODIFIED field definition for TaskID in TransformationFiles table (from
VARCHAR to INT, in order to be ready for FK definition: TaskID in
TransformationTasks and TransformationFileTasks is INT)
