### PR TITLE
[v6r8] StalledJobAgent accounting fix

### DIFF
--- a/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -365,6 +365,11 @@ used to fail jobs due to the optimizer chain.
                'OutputSandBoxSize' : 0.0,
                'ProcessedEvents' : 0
              }
+    
+    # For accidentally stopped jobs ExecTime can be not set
+    if not acData['ExecTime']:
+      acData['ExecTime'] = acData['CPUTime']
+    
     self.log.verbose( 'Accounting Report is:' )
     self.log.verbose( acData )
     accountingReport.setValuesFromDict( acData )


### PR DESCRIPTION
FIX: StalledJobAgent - for accidentally stopped jobs ExecTime can be not set, set to CPUTime for the accounting purpose in this case
