### PR TITLE
[v6r9] NEW: allow RSS policies match wildcards on CS

### DIFF
--- a/ResourceStatusSystem/Utilities/Utils.py
+++ b/ResourceStatusSystem/Utilities/Utils.py
@@ -96,10 +96,12 @@ def configMatch( candidateParams, configParams ):
       cParameter = [ cParameter ]
         
     # We allow using UNIX-like regular expression ( wild-cards ) on the CS
-    _matches = []    
+    _matches = False    
     for configItem in configParams[ key ]:
-      _matches.extend( fnmatch.filter( set( cParameter ), configItem ) )
-      
+      if fnmatch.filter( set( cParameter ), configItem ):
+        _matches = True
+        break
+        
     if not _matches:
       return False
     


### PR DESCRIPTION
It makes easier matching a set of elements, e.g. "*-ARCHIVE" StorageElements
