### PR TITLE
CHANGE: Catalog url default

### DIFF
--- a/Resources/Catalog/FileCatalogFactory.py
+++ b/Resources/Catalog/FileCatalogFactory.py
@@ -1,7 +1,6 @@
 ########################################################################
 # $HeadURL$
 ########################################################################
-from types import ListType
 __RCSID__ = "$Id$"
 """ FileCatalogFactory class to create file catalog client objects according to the 
     configuration description 


### PR DESCRIPTION
Now have a catalogURL default that can use the catalogName to resolve a possible URL if not defined explicitly.
