### PR TITLE
[v6r8] FIX: do not account gfal_ls operations. (missing cases)

### DIFF
--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -1769,7 +1769,7 @@ class SRM2Storage( StorageBase ):
       gfalDict['nbfiles'] = len( urls )
       gfalDict['timeout'] = self.fileTimeout * len( urls )
       res = self.__gfal_operation_wrapper( 'gfal_ls', gfalDict )
-      gDataStoreClient.addRegister( res['AccountingOperation'] )
+      # gDataStoreClient.addRegister( res['AccountingOperation'] )
       if not res['OK']:
         for url in urls:
           failed[url] = res['Message']


### PR DESCRIPTION
There was a second place where gfal_ls records were created.
