### PR TITLE
[v6r8] RequestHandler - added getServiceOption()

### DIFF
--- a/Core/DISET/RequestHandler.py
+++ b/Core/DISET/RequestHandler.py
@@ -12,6 +12,17 @@ from DIRAC.Core.DISET.private.MessageBroker import getGlobalMessageBroker
 from DIRAC.Core.Utilities import Time
 import DIRAC
 
+def getServiceOption( serviceInfo, optionName, defaultValue ):
+  """ Get service option resolving default values from the master service
+  """
+  if optionName[0] == "/":
+    return gConfig.getValue( optionName, defaultValue )
+  for csPath in serviceInfo[ 'csPaths' ]:
+    result = gConfig.getOption( "%s/%s" % ( csPath, optionName, ), defaultValue )
+    if result[ 'OK' ]:
+      return result[ 'Value' ]
+  return defaultValue
+
 class RequestHandler( object ):
 
   class ConnectionError( Exception ):

--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -15,8 +15,8 @@ __RCSID__ = "$Id$"
 import os
 from types import IntType, LongType, DictType, StringTypes, BooleanType, ListType 
 ## from DIRAC
-from DIRAC.Core.DISET.RequestHandler import RequestHandler
-from DIRAC import gLogger, gConfig, S_OK, S_ERROR
+from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
+from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.DataManagementSystem.DB.FileCatalogDB import FileCatalogDB
 from DIRAC.Core.Utilities.List import sortList
 
@@ -27,13 +27,10 @@ def initializeFileCatalogHandler(serviceInfo):
   """ handler initialisation """
 
   global gFileCatalogDB
-  
-  serviceCS = serviceInfo['serviceSectionPath']
-  
-  # Instantiate the requested database
-  dbLocation = gConfig.getValue( '%s/Database' % serviceCS, 'DataManagement/FileCatalogDB' )
+
+  dbLocation = getServiceOption( serviceInfo, 'Database', 'DataManagement/FileCatalogDB' )
   gFileCatalogDB = FileCatalogDB(dbLocation)
-  
+
   databaseConfig = {}
   # Obtain the plugins to be used for DB interaction
   gLogger.info("Initializing with FileCatalog with following managers:")
@@ -46,7 +43,7 @@ def initializeFileCatalogHandler(serviceInfo):
                        'FileMetadata'      : 'FileMetadata'}
   for configKey in sortList(defaultManagers.keys()):
     defaultValue = defaultManagers[configKey]
-    configValue = gConfig.getValue( '%s/%s' % ( serviceCS, configKey), defaultValue )
+    configValue = getServiceOption( serviceInfo, configKey, defaultValue )
     gLogger.info("%-20s : %-20s" % ( str(configKey), str(configValue) ) )
     databaseConfig[configKey] = configValue
 
@@ -60,7 +57,7 @@ def initializeFileCatalogHandler(serviceInfo):
                     'VisibleStatus'     : ['AprioriGood']}
   for configKey in sortList( defaultConfig.keys() ):
     defaultValue = defaultConfig[configKey]
-    configValue = gConfig.getValue( '%s/%s' % ( serviceCS, configKey), defaultValue )
+    configValue = getServiceOption( serviceInfo, configKey, defaultValue )
     gLogger.info("%-20s : %-20s" % ( str(configKey), str(configValue) ) )
     databaseConfig[configKey] = configValue
   res = gFileCatalogDB.setConfig(databaseConfig)

--- a/DataManagementSystem/Service/StorageElementHandler.py
+++ b/DataManagementSystem/Service/StorageElementHandler.py
@@ -35,8 +35,8 @@ import re
 from stat import ST_MODE, ST_SIZE, ST_ATIME, ST_CTIME, ST_MTIME, S_ISDIR, S_IMODE
 from types import StringType, StringTypes, ListType
 ## from DIRAC
-from DIRAC import gLogger, S_OK, S_ERROR, gConfig
-from DIRAC.Core.DISET.RequestHandler import RequestHandler
+from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
 from DIRAC.Core.Utilities.Os import getDirectorySize
 from DIRAC.Core.Utilities.Subprocess import shellCall
 
@@ -51,17 +51,16 @@ def initializeStorageElementHandler( serviceInfo ):
   global BASE_PATH
   global USE_TOKENS
   global MAX_STORAGE_SIZE
-  cfgPath = serviceInfo['serviceSectionPath']
 
-  BASE_PATH = gConfig.getValue( "%s/BasePath" % cfgPath, BASE_PATH )
+  BASE_PATH = getServiceOption( serviceInfo, "BasePath", BASE_PATH )
   if not BASE_PATH:
     gLogger.error( 'Failed to get the base path' )
     return S_ERROR( 'Failed to get the base path' )
   if not os.path.exists( BASE_PATH ):
     os.makedirs( BASE_PATH )
 
-  USE_TOKENS = gConfig.getValue( "%s/UseTokens" % cfgPath, USE_TOKENS )
-  MAX_STORAGE_SIZE = gConfig.getValue( "%s/MaxStorageSize" % cfgPath, MAX_STORAGE_SIZE )
+  USE_TOKENS = getServiceOption( serviceInfo, "%UseTokens", USE_TOKENS )
+  MAX_STORAGE_SIZE = getServiceOption( serviceInfo, "MaxStorageSize", MAX_STORAGE_SIZE )
 
   gLogger.info( 'Starting DIRAC Storage Element' )
   gLogger.info( 'Base Path: %s' % BASE_PATH )


### PR DESCRIPTION
NEW: RequestHandler - getServiceOption() to properly resolve inherited options in the global service handler initialize method
NEW: FileCatalogHandler, StorageElementHandler - use getServiceOption()
