### PR TITLE
Fix v6r8

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-add-file.py
+++ b/DataManagementSystem/scripts/dirac-dms-add-file.py
@@ -57,7 +57,7 @@ if len( args ) == 1:
     for line in inputFile:
       line = line.rstrip()
       items = line.split()
-      items[0] = item[0].replace( 'LFN:', '' ).replace( 'lfn:', '' )
+      items[0] = items[0].replace( 'LFN:', '' ).replace( 'lfn:', '' )
       lfns.append( getDict( items ) )
     inputFile.close()
 else:


### PR DESCRIPTION
Typo: item -> items

$ dirac-dms-add-file protonlist.txt
Traceback (most recent call last):
  File "/nfs/magic-ifae01/moralejo/myDIRAC/versions/v0r10p4_1373647582/DIRAC/DataManagementSystem/scripts/dirac-dms-add-file.py", line 60, in <module>
    items[0] = item[0].replace('LFN:','').replace('lfn:','')
NameError: name 'item' is not defined
