### PR TITLE
[v6r9]FIX: do not decrease the retry counter after ping failure

### DIFF
--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -284,7 +284,7 @@ class MySQL:
         except KeyError:
           pass
         if retriesLeft >= 0:
-          return self.__getWithRetry( dbName, totalRetries, retriesLeft - 1 )
+          return self.__getWithRetry( dbName, totalRetries, retriesLeft )
         return S_ERROR( "Could not connect" )
 
       if lastName != dbName:


### PR DESCRIPTION
After a client explicitly closes a connection (many DB classes do it at some point), ping will systematically failed on that connection adding a 5 second delay before trying to open a new connection. 
