### PR TITLE
!!! [v7r0]Changes in the JobLoggingDB.LoggingInfo schema.

### DIFF
--- a/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -21,6 +21,26 @@ MAGIC_EPOC_NUMBER = 1270000000
 #############################################################################
 class JobLoggingDB( DB ):
 
+  _tablesDict = {}
+  # LoggingInfo table
+  _tablesDict[ 'LoggingInfo' ] = {
+                                  'Fields' :
+                                            {
+                                             'JobID'             : 'INTEGER NOT NULL',
+                                             'SeqNum'            : 'INTEGER NOT NULL DEFAULT 0',
+                                             'Status'            : 'VARCHAR(32) NOT NULL DEFAULT ""',
+                                             'MinorStatus'       : 'VARCHAR(128) NOT NULL DEFAULT ""',
+                                             'ApplicationStatus' : 'VARCHAR(256) NOT NULL DEFAULT ""',
+                                             'StatusTime'        : 'DATETIME NOT NULL',
+                                             'StatusTimeOrder'   : 'DOUBLE(12,3) NOT NULL',
+                                             'StatusSource'      : 'VARCHAR(32) NOT NULL DEFAULT "Unknown"',
+                                            },
+                                  'PrimaryKey': ['JobID', 'SeqNum'],
+                                  'Engine': 'InnoDB'
+#                                  'Indexes' : { 'JobID' : [ 'JobID' ] }
+                                 }
+
+
 
   def __init__( self, maxQueueSize = 10 ):
     """ Standard Constructor
@@ -28,6 +48,50 @@ class JobLoggingDB( DB ):
 
     DB.__init__( self, 'JobLoggingDB', 'WorkloadManagement/JobLoggingDB', maxQueueSize )
     self.gLogger = gLogger
+
+
+  def _checkTable( self ):
+    """ _checkTable.
+
+    Method called on the MatcherHandler instead of on the JobLoggingDB constructor
+    to avoid an awful number of unnecessary queries with "show tables".
+    """
+
+    return self.__createTables()
+
+
+  def __createTables( self ):
+    """ __createTables
+
+    Writes the schema in the database. If a table is already in the schema, it is
+    skipped to avoid problems trying to create a table that already exists.
+    """
+
+    # Horrible SQL here !!
+    existingTables = self._query( "show tables" )
+    if not existingTables[ 'OK' ]:
+      return existingTables
+    existingTables = [ existingTable[0] for existingTable in existingTables[ 'Value' ] ]
+
+    # Makes a copy of the dictionary _tablesDict
+    tables = {}
+    tables.update( self._tablesDict )
+
+    for existingTable in existingTables:
+      if existingTable in tables:
+        del tables[ existingTable ]
+
+    res = self._createTables( tables )
+    if not res[ 'OK' ]:
+      return res
+
+    # Human readable S_OK message
+    if res[ 'Value' ] == 0:
+      res[ 'Value' ] = 'No tables created'
+    else:
+      res[ 'Value' ] = 'Tables created: %s' % ( ','.join( tables.keys() ) )
+    return res
+
 
 #############################################################################
   def addLoggingRecord( self,

--- a/WorkloadManagementSystem/DB/JobLoggingDB.sql
+++ b/WorkloadManagementSystem/DB/JobLoggingDB.sql
@@ -7,38 +7,48 @@
 -- -
 -- ------------------------------------------------------------------------------
 
-DROP DATABASE IF EXISTS JobLoggingDB;
+-- DROP DATABASE IF EXISTS JobLoggingDB;
 
-CREATE DATABASE JobLoggingDB;
+-- CREATE DATABASE JobLoggingDB;
 
 -- ------------------------------------------------------------------------------
 -- Database owner definition
 
-USE mysql;
-DELETE FROM user WHERE user='Dirac';
+-- USE mysql;
+-- DELETE FROM user WHERE user='Dirac';
 
 --
 -- Must set passwords for database user by replacing "must_be_set".
 --
 
-GRANT SELECT,INSERT,LOCK TABLES,UPDATE,DELETE,CREATE,DROP,ALTER ON JobLoggingDB.* TO Dirac@localhost IDENTIFIED BY 'must_be_set';
-GRANT SELECT,INSERT,LOCK TABLES,UPDATE,DELETE,CREATE,DROP,ALTER ON JobLoggingDB.* TO Dirac@'%' IDENTIFIED BY 'must_be_set';
+-- GRANT SELECT,INSERT,LOCK TABLES,UPDATE,DELETE,CREATE,DROP,ALTER ON JobLoggingDB.* TO Dirac@localhost IDENTIFIED BY 'must_be_set';
+-- GRANT SELECT,INSERT,LOCK TABLES,UPDATE,DELETE,CREATE,DROP,ALTER ON JobLoggingDB.* TO Dirac@'%' IDENTIFIED BY 'must_be_set';
 
-FLUSH PRIVILEGES;
+-- FLUSH PRIVILEGES;
 
 -- ----------------------------------------------------------------------------- 
 USE JobLoggingDB;
 
--- ------------------------------------------------------------------------------
-DROP TABLE IF EXISTS LoggingInfo;
-CREATE TABLE LoggingInfo (
-    JobID INTEGER NOT NULL,
-    Status VARCHAR(32) NOT NULL DEFAULT '',
-    MinorStatus VARCHAR(128) NOT NULL DEFAULT '',
-    ApplicationStatus varchar(256) NOT NULL DEFAULT '', 
-    StatusTime DATETIME NOT NULL ,
-    StatusTimeOrder DOUBLE(11,3) NOT NULL,  
-    StatusSource VARCHAR(32) NOT NULL DEFAULT 'Unknown',
-    INDEX (JobID)
-) ENGINE = InnoDB;
+-- -----------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS LoggingInfo;
+-- CREATE TABLE LoggingInfo (
+--    JobID INTEGER NOT NULL,
+--	  SeqNum INTEGER NOT NULL DEFAULT 0,
+--    Status VARCHAR(32) NOT NULL DEFAULT '',
+--    MinorStatus VARCHAR(128) NOT NULL DEFAULT '',
+--    ApplicationStatus varchar(256) NOT NULL DEFAULT '', 
+--    StatusTime DATETIME NOT NULL ,
+--    StatusTimeOrder DOUBLE(12,3) NOT NULL,  
+--    StatusSource VARCHAR(32) NOT NULL DEFAULT 'Unknown',
+--    PRIMARY KEY (JobID, SeqNum)
+--) ENGINE = InnoDB;
+-- -----------------------------------------------------------------------------
+
+--
+-- Trigger to manage the new LoggingInfo structure: SeqNum is a sequential number within the same JobID
+--		the trigger generates a proper sequence for each JobID
+--
+
+CREATE TRIGGER SeqNumGenerator BEFORE INSERT ON LoggingInfo
+FOR EACH ROW SET NEW.SeqNum= (SELECT IFNULL(MAX(SeqNum) + 1,1) FROM LoggingInfo WHERE JobID=NEW.JobID);
 


### PR DESCRIPTION
Request to be processed AFTER Ubeda's request #1589

Two reasons for the change:
1. StatusTimeOrder field was in overflow, so it has been changed to
DOUBLE(12,3) instead of (11,3)
2. There was no Primary Key (PK) definition. So, a new field has been
added, SeqNum (INTEGER), which is part of the new PK (JobID, SeqNum).
SeqNum is generated by a trigger at every insert and behave as a counter
within a given JobID.

The trigger definition is:
CREATE TRIGGER SeqNumGenerator BEFORE INSERT ON LoggingInfo FOR EACH ROW
SET NEW.SeqNum= (SELECT IFNULL(MAX(SeqNum) + 1,1) FROM LoggingInfo WHERE
JobID=NEW.JobID)

Code has been changed starting from the Ubeda's pull request files
(#1589)

Note: Table definition modification using python dictionary, trigger
definition still in the sql file.
