### PR TITLE
[v6r10] [CHANGE] Set file status for transformation as bulk op, plus logic in the client

### DIFF
--- a/TransformationSystem/Client/FileReport.py
+++ b/TransformationSystem/Client/FileReport.py
@@ -1,6 +1,6 @@
 """ FileReport class encapsulates methods to report file status to the transformation DB """
 
-from DIRAC import S_OK, S_ERROR, gLogger
+from DIRAC import S_OK
 from DIRAC.Core.Utilities                                     import DEncode
 from DIRAC.TransformationSystem.Client.TransformationClient   import TransformationClient
 from DIRAC.RequestManagementSystem.Client.Operation           import Operation
@@ -16,6 +16,7 @@ class FileReport( object ):
     self.transClient.setServer( server )
     self.statusDict = {}
     self.transformation = None
+    self.force = False
 
   def setFileStatus( self, transformation, lfn, status, sendFlag = False ):
     """ Set file status in the context of the given transformation """
@@ -41,32 +42,11 @@ class FileReport( object ):
     if not self.statusDict:
       return S_OK()
 
-    # create intermediate status dictionary
-    sDict = {}
-    for lfn, status in self.statusDict.items():
-      if not sDict.has_key( status ):
-        sDict[status] = []
-      sDict[status].append( lfn )
+    res = self.transClient.setFileStatusForTransformation( self.transformation, self.statusDict, force = self.force )
+    if not res['OK']:
+      return res
 
-    summaryDict = {}
-    failedResults = []
-    for status, lfns in sDict.items():
-      res = self.transClient.setFileStatusForTransformation( self.transformation, status, lfns )
-      if not res['OK']:
-        failedResults.append( res )
-        continue
-      for lfn, error in res['Value']['Failed'].items():
-        gLogger.error( "Failed to update file status", "%s %s" % ( lfn, error ) )
-      if res['Value']['Successful']:
-        summaryDict[status] = len( res['Value']['Successful'] )
-        for lfn in res['Value']['Successful']:
-          self.statusDict.pop( lfn )
-
-    if not self.statusDict:
-      return S_OK( summaryDict )
-    result = S_ERROR( "Failed to update all file statuses" )
-    result['FailedResults'] = failedResults
-    return result
+    return S_OK()
 
   def generateForwardDISET( self ):
     """ Commit the accumulated records and generate request eventually """
@@ -74,11 +54,9 @@ class FileReport( object ):
     forwardDISETOp = None
     if not result['OK']:
       # Generate Request
-      if "FailedResults" in result:
-        for res in result['FailedResults']:
-          if 'rpcStub' in res:
-            forwardDISETOp = Operation()
-            forwardDISETOp.Type = "ForwardDISET"
-            forwardDISETOp.Arguments = DEncode.encode( res['rpcStub'] )
+      if result.has_key( 'rpcStub' ):
+        forwardDISETOp = Operation()
+        forwardDISETOp.Type = "ForwardDISET"
+        forwardDISETOp.Arguments = DEncode.encode( result['rpcStub'] )
 
     return S_OK( forwardDISETOp )

--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -1,10 +1,14 @@
 """ Class that contains client access to the transformation DB handler. """
 
-from DIRAC                                          import S_OK, S_ERROR, gLogger
-from DIRAC.Core.Base.Client                         import Client
-from DIRAC.Core.Utilities.List                      import breakListIntoChunks
-from DIRAC.Resources.Catalog.FileCatalogueBase      import FileCatalogueBase
+__RCSID__ = "$Id$"
+
 import types
+
+from DIRAC                                                  import S_OK, S_ERROR, gLogger
+from DIRAC.Core.Base.Client                                 import Client
+from DIRAC.Core.Utilities.List                              import breakListIntoChunks
+from DIRAC.Resources.Catalog.FileCatalogueBase              import FileCatalogueBase
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations    import Operations
 
 rpc = None
 url = None
@@ -28,7 +32,7 @@ class TransformationClient( Client, FileCatalogueBase ):
 
           addFilesToTransformation(transName,lfns)
           addTaskForTransformation(transName,lfns=[],se='Unknown')
-          setFileUsedSEForTransformation(transName,usedSE,lfns)
+          setFileStatusForTransformation(transName,status,lfns)
           getTransformationStats(transName)
 
       TransformationTasks table manipulation
@@ -60,6 +64,9 @@ class TransformationClient( Client, FileCatalogueBase ):
   def __init__( self, **kwargs ):
 
     Client.__init__( self, **kwargs )
+    opsH = Operations()
+    self.maxResetCounter = opsH.getValue( 'Productions/ProductionFilesMaxResetCounter', 10 )
+
     self.setServer( 'Transformation/TransformationManager' )
 
   def setServer( self, url ):
@@ -161,7 +168,7 @@ class TransformationClient( Client, FileCatalogueBase ):
     return S_OK( transformationTasks )
 
 
-  def cleanTransformation( self, transID, pc = '', url = '', timeout = 120 ):
+  def cleanTransformation( self, transID, rpc = '', url = '', timeout = 120 ):
     """ Clean the transformation, and set the status parameter (doing it here, for easier extensibility)
     """
     # Cleaning
@@ -224,7 +231,7 @@ class TransformationClient( Client, FileCatalogueBase ):
           if not res['OK']:
             gLogger.error( "Error setting status for %s in transformation %d to %s" % ( lfn, prod, status ),
                            res['Message'] )
-            self.setFileStatusForTransformation( parentProd, status , [lfn] )
+            self.setFileStatusForTransformation( parentProd, status, [lfn] )
             continue
           if force:
             status = 'Unused from MaxReset'
@@ -238,9 +245,76 @@ class TransformationClient( Client, FileCatalogueBase ):
 
     return S_OK( ( parentProd, movedFiles ) )
 
-  def setFileStatusForTransformation( self, transName, status, lfns, force = False, timeout = 120 ):
+  def setFileStatusForTransformation( self, transName, newLFNsStatus = {}, lfns = [], force = False,
+                                      rpc = '', url = '', timeout = 120 ):
+    """ sets ths file status for LFNs of a transformation
+
+        For backward compatibility purposes, the status and LFNs can be passed in 2 ways:
+        - newLFNsStatus is a dictionary with the form:
+          {'/this/is/an/lfn1.txt': 'StatusA', '/this/is/an/lfn2.txt': 'StatusB',  ... }
+          and at this point lfns is not considered
+        - newLFNStatus is a string, that applies to all the LFNs in lfns
+    """
     rpcClient = self._getRPC( rpc = rpc, url = url, timeout = timeout )
-    return rpcClient.setFileStatusForTransformation( transName, status, lfns, force )
+
+    # create dictionary in case newLFNsStatus is a string
+    if type( newLFNsStatus ) == type( '' ):
+      newLFNsStatus = dict( [( lfn, newLFNsStatus ) for lfn in lfns ] )
+
+    # gets status as of today
+    tsFiles = self.getTransformationFiles( {'TransformationID':transName, 'LFN': newLFNsStatus.keys()} )
+    if not tsFiles['OK']:
+      return tsFiles
+    tsFiles = tsFiles['Value']
+    if tsFiles:
+      # for convenience, makes a small dictionary out of the tsFiles, with the lfn as key
+      tsFilesAsDict = {}
+      for tsFile in tsFiles:
+        tsFilesAsDict[tsFile['LFN']] = [tsFile['Status'], tsFile['ErrorCount'], tsFile['FileID']]
+
+      # applying the state machine to the proposed status
+      newStatuses = self._applyProductionFilesStateMachine( tsFilesAsDict, newLFNsStatus, force )
+
+      # must do it for the file IDs...
+      newStatusForFileIDs = dict( [( tsFilesAsDict[lfn][2], newStatuses[lfn] ) for lfn in newStatuses.keys()] )
+      return rpcClient.setFileStatusForTransformation( transName, newStatusForFileIDs )
+    else:
+      return S_OK( 'Nothing updated' )
+
+  def _applyProductionFilesStateMachine( self, tsFilesAsDict, dictOfProposedLFNsStatus, force ):
+    """ For easier extension, here we apply the state machine of the production files.
+        VOs might want to replace the standard here with something they prefer.
+
+        tsFiles is a dictionary with the lfn as key and as value a list of [Status, ErrorCount, FileID]
+        dictOfNewLFNsStatus is a dictionary with the proposed status
+        force is a boolean
+
+        It returns a dictionary with the status updates
+    """
+    newStatuses = {}
+
+    for lfn in dictOfProposedLFNsStatus.keys():
+      if lfn not in tsFilesAsDict.keys():
+        continue
+      else:
+        newStatus = dictOfProposedLFNsStatus[lfn]
+        # Apply optional corrections
+        if tsFilesAsDict[lfn][0].lower() == 'processed' and dictOfProposedLFNsStatus[lfn].lower() != 'processed':
+          if not force:
+            newStatus = 'Processed'
+        elif tsFilesAsDict[lfn][0].lower() == 'maxreset':
+          if not force:
+            newStatus = 'MaxReset'
+        elif dictOfProposedLFNsStatus[lfn].lower() == 'unused':
+          errorCount = tsFilesAsDict[lfn][1]
+          # every 10 retries
+          if ( errorCount % self.maxResetCounter ) == 0:
+            if not force:
+              newStatus = 'MaxReset'
+
+        newStatuses[lfn] = newStatus
+
+    return newStatuses
 
   #####################################################################
   #

--- a/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/TransformationSystem/Service/TransformationManagerHandler.py
@@ -67,7 +67,7 @@ class TransformationManagerHandlerBase( RequestHandler ):
   def export_deleteTransformation( self, transName ):
     credDict = self.getRemoteCredentials()
     authorDN = credDict[ 'DN' ]
-    #authorDN = self._clientTransport.peerCredentials['DN']
+    # authorDN = self._clientTransport.peerCredentials['DN']
     res = database.deleteTransformation( transName, author = authorDN )
     return self._parseRes( res )
 
@@ -75,7 +75,7 @@ class TransformationManagerHandlerBase( RequestHandler ):
   def export_cleanTransformation( self, transName ):
     credDict = self.getRemoteCredentials()
     authorDN = credDict[ 'DN' ]
-    #authorDN = self._clientTransport.peerCredentials['DN']
+    # authorDN = self._clientTransport.peerCredentials['DN']
     res = database.cleanTransformation( transName, author = authorDN )
     return self._parseRes( res )
 
@@ -83,15 +83,15 @@ class TransformationManagerHandlerBase( RequestHandler ):
   def export_setTransformationParameter( self, transName, paramName, paramValue ):
     credDict = self.getRemoteCredentials()
     authorDN = credDict[ 'DN' ]
-    #authorDN = self._clientTransport.peerCredentials['DN']
+    # authorDN = self._clientTransport.peerCredentials['DN']
     res = database.setTransformationParameter( transName, paramName, paramValue, author = authorDN )
     return self._parseRes( res )
 
   types_deleteTransformationParameter = [transTypes, StringTypes]
   def export_deleteTransformationParameter( self, transName, paramName ):
-    #credDict = self.getRemoteCredentials()
-    #authorDN = credDict[ 'DN' ]
-    #authorDN = self._clientTransport.peerCredentials['DN']
+    # credDict = self.getRemoteCredentials()
+    # authorDN = credDict[ 'DN' ]
+    # authorDN = self._clientTransport.peerCredentials['DN']
     res = database.deleteTransformationParameter( transName, paramName )
     return self._parseRes( res )
 
@@ -138,14 +138,21 @@ class TransformationManagerHandlerBase( RequestHandler ):
     res = database.addTaskForTransformation( transName, lfns = lfns, se = se )
     return self._parseRes( res )
 
-  types_setFileStatusForTransformation = [transTypes, StringTypes, ListType]
-  def export_setFileStatusForTransformation( self, transName, status, lfns, force = False ):
-    res = database.setFileStatusForTransformation( transName, status, lfns, force )
-    return self._parseRes( res )
+  types_setFileStatusForTransformation = [transTypes, DictType]
+  def export_setFileStatusForTransformation( self, transName, dictOfNewFilesStatus ):
+    """ Sets the file status for the transformation.
 
-  types_setFileUsedSEForTransformation = [transTypes, StringTypes, ListType]
-  def export_setFileUsedSEForTransformation( self, transName, usedSE, lfns ):
-    res = database.setFileUsedSEForTransformation( transName, usedSE, lfns )
+        The dictOfNewFilesStatus is a dictionary with the form:
+        {12345: 'StatusA', 6789: 'StatusB',  ... }
+    """
+
+    res = database._getConnectionTransID( False, transName )
+    if not res['OK']:
+      return res
+    connection = res['Value']['Connection']
+    transID = res['Value']['TransformationID']
+
+    res = database.setFileStatusForTransformation( transID, dictOfNewFilesStatus, connection = connection )
     return self._parseRes( res )
 
   types_getTransformationStats = [transTypes]
@@ -198,7 +205,7 @@ class TransformationManagerHandlerBase( RequestHandler ):
   def export_deleteTasks( self, transName, taskMin, taskMax ):
     credDict = self.getRemoteCredentials()
     authorDN = credDict[ 'DN' ]
-    #authorDN = self._clientTransport.peerCredentials['DN']
+    # authorDN = self._clientTransport.peerCredentials['DN']
     res = database.deleteTasks( transName, taskMin, taskMax, author = authorDN )
     return self._parseRes( res )
 
@@ -206,7 +213,7 @@ class TransformationManagerHandlerBase( RequestHandler ):
   def export_extendTransformation( self, transName, nTasks ):
     credDict = self.getRemoteCredentials()
     authorDN = credDict[ 'DN' ]
-    #authorDN = self._clientTransport.peerCredentials['DN']
+    # authorDN = self._clientTransport.peerCredentials['DN']
     res = database.extendTransformation( transName, nTasks, author = authorDN )
     return self._parseRes( res )
 
@@ -242,7 +249,7 @@ class TransformationManagerHandlerBase( RequestHandler ):
   def export_createTransformationInputDataQuery( self, transName, queryDict ):
     credDict = self.getRemoteCredentials()
     authorDN = credDict[ 'DN' ]
-    #authorDN = self._clientTransport.peerCredentials['DN']
+    # authorDN = self._clientTransport.peerCredentials['DN']
     res = database.createTransformationInputDataQuery( transName, queryDict, author = authorDN )
     return self._parseRes( res )
 
@@ -250,7 +257,7 @@ class TransformationManagerHandlerBase( RequestHandler ):
   def export_deleteTransformationInputDataQuery( self, transName ):
     credDict = self.getRemoteCredentials()
     authorDN = credDict[ 'DN' ]
-    #authorDN = self._clientTransport.peerCredentials['DN']
+    # authorDN = self._clientTransport.peerCredentials['DN']
     res = database.deleteTransformationInputDataQuery( transName, author = authorDN )
     return self._parseRes( res )
 
@@ -349,7 +356,7 @@ class TransformationManagerHandlerBase( RequestHandler ):
   # These are the methods used for web monitoring
   #
 
-  #TODO Get rid of this (talk to Matvey)
+  # TODO Get rid of this (talk to Matvey)
   types_getDistinctAttributeValues = [StringTypes, DictType]
   def export_getDistinctAttributeValues( self, attribute, selectDict ):
     res = database.getTableDistinctAttributeValues( 'Transformations', [attribute], selectDict )
@@ -470,7 +477,7 @@ class TransformationManagerHandlerBase( RequestHandler ):
     fromDate = selectDict.get( 'FromDate', None )
     if fromDate:
       del selectDict['FromDate']
-    #if not fromDate:
+    # if not fromDate:
     #  fromDate = last_update
     toDate = selectDict.get( 'ToDate', None )
     if toDate:


### PR DESCRIPTION
For #1599

Few notes (might go in the "What's new? How to update" for this release, even if should not really affect anyone):

```
the signature of TransformationDB().setFileStatusForTransformation changed a bit
TransformationDB().setFileStatusForTransformation() and TransformationClient().setFileStatusForTransformation() are not returning any more a S_OK({'Failed':[], 'Successful':[]) dictionary. Instead, each operation is bulk, so it is either successful (S_OK()) or failed (S_ERROR())
The ErrorCount for the files will always increase. The check for MaxReset files is done using the module operator
The number of retries before setting a file in MaxReset can be set on the CS
VOs can easily plug their own transformation files state machine
```
