### PR TITLE
[v6r10]FIX: speed up getJobPageSummaryWeb for a large number of jobs in DB

### DIFF
--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -1287,9 +1287,15 @@ class MySQL:
       condDict = {}
 
     try:
+      try:
+        mylimit = limit[0]
+        myoffset = limit[1]
+      except:
+        mylimit = limit
+        myoffset = None
       condition = self.buildCondition( condDict = condDict, older = older, newer = newer,
-                        timeStamp = timeStamp, orderAttribute = orderAttribute, limit = limit,
-                        greater = None, smaller = None )
+                        timeStamp = timeStamp, orderAttribute = orderAttribute, limit = mylimit,
+                        greater = None, smaller = None, offset = myoffset )
     except Exception, x:
       return S_ERROR( x )
 

--- a/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -13,20 +13,19 @@
 
 __RCSID__ = "$Id$"
 
-from types import *
+from types import IntType, LongType, ListType, DictType, StringTypes, StringType
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
-from DIRAC import gLogger, gConfig, S_OK, S_ERROR
+from DIRAC import S_OK, S_ERROR
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 from DIRAC.WorkloadManagementSystem.DB.TaskQueueDB import TaskQueueDB
 from DIRAC.WorkloadManagementSystem.DB.JobLoggingDB import JobLoggingDB
-from DIRAC.WorkloadManagementSystem.Service.JobPolicy import JobPolicy, RIGHT_GET_INFO 
+from DIRAC.WorkloadManagementSystem.Service.JobPolicy import JobPolicy, RIGHT_GET_INFO
 import DIRAC.Core.Utilities.Time as Time
 
 # These are global instances of the DB classes
-jobDB = False
-jobLoggingDB = False
-proxyRepository = False
-taskQueueDB = False
+gJobDB = False
+gJobLoggingDB = False
+gTaskQueueDB = False
 
 SUMMARY = ['JobType', 'Site', 'JobName', 'Owner', 'SubmissionTime',
            'LastUpdateTime', 'Status', 'MinorStatus', 'ApplicationStatus']
@@ -36,97 +35,104 @@ FINAL_STATES = ['Done', 'Completed', 'Stalled', 'Failed', 'Killed']
 
 def initializeJobMonitoringHandler( serviceInfo ):
 
-  global jobDB, jobLoggingDB, taskQueueDB
-  jobDB = JobDB()
-  jobLoggingDB = JobLoggingDB()
-  taskQueueDB = TaskQueueDB()
+  global gJobDB, gJobLoggingDB, gTaskQueueDB
+  gJobDB = JobDB()
+  gJobLoggingDB = JobLoggingDB()
+  gTaskQueueDB = TaskQueueDB()
   return S_OK()
 
 class JobMonitoringHandler( RequestHandler ):
 
   def initialize( self ):
-    
-    global jobDB
-    
+
     credDict = self.getRemoteCredentials()
     self.ownerDN = credDict['DN']
     self.ownerGroup = credDict['group']
     self.userProperties = credDict[ 'properties' ]
     self.jobPolicy = JobPolicy( self.ownerDN, self.ownerGroup, self.userProperties )
-    self.jobPolicy.setJobDB( jobDB )
+    self.jobPolicy.setJobDB( gJobDB )
     return S_OK()
 
 ##############################################################################
   types_getApplicationStates = []
-  def export_getApplicationStates ( self ):
-    """ Return Distict Values of ApplicationStatus job Attribute in WMS
+  @staticmethod
+  def export_getApplicationStates ():
+    """ Return Distinct Values of ApplicationStatus job Attribute in WMS
     """
-    return jobDB.getDistinctJobAttributes( 'ApplicationStatus' )
+    return gJobDB.getDistinctJobAttributes( 'ApplicationStatus' )
 
 ##############################################################################
   types_getJobTypes = []
-  def export_getJobTypes ( self ):
-    """ Return Distict Values of JobType job Attribute in WMS
+  @staticmethod
+  def export_getJobTypes ():
+    """ Return Distinct Values of JobType job Attribute in WMS
     """
-    return jobDB.getDistinctJobAttributes( 'JobType' )
+    return gJobDB.getDistinctJobAttributes( 'JobType' )
 
 ##############################################################################
   types_getOwners = []
-  def export_getOwners ( self ):
+  @staticmethod
+  def export_getOwners ():
     """
-    Return Distict Values of Owner job Attribute in WMS
+    Return Distinct Values of Owner job Attribute in WMS
     """
-    return jobDB.getDistinctJobAttributes( 'Owner' )
+    return gJobDB.getDistinctJobAttributes( 'Owner' )
 
 ##############################################################################
   types_getProductionIds = []
-  def export_getProductionIds ( self ):
+  @staticmethod
+  def export_getProductionIds ():
     """
-    Return Distict Values of ProductionId job Attribute in WMS
+    Return Distinct Values of ProductionId job Attribute in WMS
     """
-    return jobDB.getDistinctJobAttributes( 'JobGroup' )
+    return gJobDB.getDistinctJobAttributes( 'JobGroup' )
 
 ##############################################################################
   types_getJobGroups = []
-  def export_getJobGroups( self, condDict = None, cutDate = None ):
+  @staticmethod
+  def export_getJobGroups( condDict = None, cutDate = None ):
     """
-    Return Distict Values of ProductionId job Attribute in WMS
+    Return Distinct Values of ProductionId job Attribute in WMS
     """
-    return jobDB.getDistinctJobAttributes( 'JobGroup', condDict, 
+    return gJobDB.getDistinctJobAttributes( 'JobGroup', condDict,
                                            newer = cutDate )
 
 ##############################################################################
   types_getSites = []
-  def export_getSites ( self ):
+  @staticmethod
+  def export_getSites ():
     """
-    Return Distict Values of Site job Attribute in WMS
+    Return Distinct Values of Site job Attribute in WMS
     """
-    return jobDB.getDistinctJobAttributes( 'Site' )
+    return gJobDB.getDistinctJobAttributes( 'Site' )
 
 ##############################################################################
   types_getStates = []
-  def export_getStates ( self ):
+  @staticmethod
+  def export_getStates ():
     """
-    Return Distict Values of Status job Attribute in WMS
+    Return Distinct Values of Status job Attribute in WMS
     """
-    return jobDB.getDistinctJobAttributes( 'Status' )
+    return gJobDB.getDistinctJobAttributes( 'Status' )
 
 ##############################################################################
   types_getMinorStates = []
-  def export_getMinorStates ( self ):
+  @staticmethod
+  def export_getMinorStates ():
     """
     Return Distinct Values of Minor Status job Attribute in WMS
     """
-    return jobDB.getDistinctJobAttributes( 'MinorStatus' )
+    return gJobDB.getDistinctJobAttributes( 'MinorStatus' )
 
 ##############################################################################
   types_getJobs = []
-  def export_getJobs ( self, attrDict = None, cutDate = None ):
+  @staticmethod
+  def export_getJobs ( attrDict = None, cutDate = None ):
     """
     Return list of JobIds matching the condition given in attrDict
     """
-    queryDict = {}
-
+    # queryDict = {}
+    #
     #if attrDict:
     #  if type ( attrDict ) != DictType:
     #    return S_ERROR( 'Argument must be of Dict Type' )
@@ -137,11 +143,12 @@ class JobMonitoringHandler( RequestHandler ):
 
     print attrDict
 
-    return jobDB.selectJobs( attrDict, newer = cutDate )
+    return gJobDB.selectJobs( attrDict, newer = cutDate )
 
 ##############################################################################
   types_getCounters = [ ListType ]
-  def export_getCounters( self, attrList, attrDict = {}, cutDate = '' ):
+  @staticmethod
+  def export_getCounters( attrList, attrDict = None, cutDate = '' ):
     """
     Retrieve list of distinct attributes values from attrList
     with attrDict as condition.
@@ -167,21 +174,26 @@ class JobMonitoringHandler( RequestHandler ):
 
 
     cutdate = str( cutDate )
+    if not attrDict:
+      attrDict = {}
 
-    return jobDB.getCounters( 'Jobs', attrList, attrDict, newer = cutDate, timeStamp = 'LastUpdateTime' )
+    return gJobDB.getCounters( 'Jobs', attrList, attrDict, newer = cutdate, timeStamp = 'LastUpdateTime' )
 
 ##############################################################################
   types_getCurrentJobCounters = [ ]
-  def export_getCurrentJobCounters( self, attrDict = {} ):
+  @staticmethod
+  def export_getCurrentJobCounters( attrDict = None ):
     """ Get job counters per Status with attrDict selection. Final statuses are given for
         the last day.
     """
 
-    result = jobDB.getCounters( 'Jobs', ['Status'], attrDict, timeStamp = 'LastUpdateTime' )
+    if not attrDict:
+      attrDict = {}
+    result = gJobDB.getCounters( 'Jobs', ['Status'], attrDict, timeStamp = 'LastUpdateTime' )
     if not result['OK']:
       return result
     last_update = Time.dateTime() - Time.day
-    resultDay = jobDB.getCounters( 'Jobs', ['Status'], attrDict, newer = last_update,
+    resultDay = gJobDB.getCounters( 'Jobs', ['Status'], attrDict, newer = last_update,
                                    timeStamp = 'LastUpdateTime' )
     if not resultDay['OK']:
       return resultDay
@@ -200,86 +212,191 @@ class JobMonitoringHandler( RequestHandler ):
     return S_OK( resultDict )
 
 ##############################################################################
-  types_getJobStatus = [ [StringType, IntType, LongType] ]
-  def export_getJobStatus ( self, jobID ):
+  types_getJobStatus = [ IntType ]
+  @staticmethod
+  def export_getJobStatus ( jobID ):
 
-    return jobDB.getJobAttribute( int( jobID ), 'Status' )
-
-##############################################################################
-  types_getJobOwner = [ [StringType, IntType, LongType] ]
-  def export_getJobOwner ( self, jobID ):
-
-    return jobDB.getJobAttribute( int( jobID ), 'Owner' )
+    return gJobDB.getJobAttribute( jobID, 'Status' )
 
 ##############################################################################
-  types_getJobSite = [ [StringType, IntType, LongType] ]
-  def export_getJobSite ( self, jobID ):
+  types_getJobOwner = [ IntType ]
+  @staticmethod
+  def export_getJobOwner ( jobID ):
 
-    return jobDB.getJobAttribute( int( jobID ), 'Site' )
-
-##############################################################################
-  types_getJobJDL = [ [StringType, IntType, LongType] ]
-  def export_getJobJDL ( self, jobID ):
-
-    result = jobDB.getJobJDL( int( jobID ) )
-    return result
+    return gJobDB.getJobAttribute( jobID, 'Owner' )
 
 ##############################################################################
-  types_getJobLoggingInfo = [ [StringType, IntType, LongType] ]
-  def export_getJobLoggingInfo( self, jobID ):
+  types_getJobSite = [ IntType ]
+  @staticmethod
+  def export_getJobSite ( jobID ):
 
-    return jobLoggingDB.getJobLoggingInfo( int( jobID ) )
+    return gJobDB.getJobAttribute( jobID, 'Site' )
+
+##############################################################################
+  types_getJobJDL = [ IntType ]
+  @staticmethod
+  def export_getJobJDL ( jobID ):
+
+    return gJobDB.getJobJDL( jobID )
+
+##############################################################################
+  types_getJobLoggingInfo = [ IntType ]
+  @staticmethod
+  def export_getJobLoggingInfo( jobID ):
+
+    return gJobLoggingDB.getJobLoggingInfo( jobID )
 
 ##############################################################################
   types_getJobsStatus = [ ListType ]
-  def export_getJobsStatus ( self, jobIDs ):
+  @staticmethod
+  def export_getJobsStatus ( jobIDs ):
     if not jobIDs:
       return S_OK( {} )
-    return jobDB.getAttributesForJobList( jobIDs, ['Status'] )
+    return gJobDB.getAttributesForJobList( jobIDs, ['Status'] )
 
 ##############################################################################
   types_getJobsMinorStatus = [ ListType ]
-  def export_getJobsMinorStatus ( self, jobIDs ):
+  @staticmethod
+  def export_getJobsMinorStatus ( jobIDs ):
 
-    return jobDB.getAttributesForJobList( jobIDs, ['MinorStatus'] )
+    return gJobDB.getAttributesForJobList( jobIDs, ['MinorStatus'] )
 
 ##############################################################################
   types_getJobsApplicationStatus = [ ListType ]
-  def export_getJobsApplicationStatus ( self, jobIDs ):
+  @staticmethod
+  def export_getJobsApplicationStatus ( jobIDs ):
 
-    return jobDB.getAttributesForJobList( jobIDs, ['ApplicationStatus'] )
+    return gJobDB.getAttributesForJobList( jobIDs, ['ApplicationStatus'] )
 
 ##############################################################################
   types_getJobsSites = [ ListType ]
-  def export_getJobsSites ( self, jobIDs ):
+  @staticmethod
+  def export_getJobsSites ( jobIDs ):
 
-    return jobDB.getAttributesForJobList( jobIDs, ['Site'] )
-
-##############################################################################
-  types_getJobSummary = [ [StringType, IntType, LongType] ]
-  def export_getJobSummary( self, jobID ):
-    return jobDB.getJobAttributes( int( jobID ), SUMMARY )
+    return gJobDB.getAttributesForJobList( jobIDs, ['Site'] )
 
 ##############################################################################
-  types_getJobPrimarySummary = [ [StringType, IntType, LongType] ]
-  def export_getJobPrimarySummary( self, jobID ):
-    return jobDB.getJobAttributes( int( jobID ), PRIMARY_SUMMARY )
+  types_getJobSummary = [ IntType ]
+  @staticmethod
+  def export_getJobSummary( jobID ):
+    return gJobDB.getJobAttributes( jobID, SUMMARY )
+
+##############################################################################
+  types_getJobPrimarySummary = [ IntType ]
+  @staticmethod
+  def export_getJobPrimarySummary( jobID ):
+    return gJobDB.getJobAttributes( jobID, PRIMARY_SUMMARY )
 
 ##############################################################################
   types_getJobsSummary = [ ListType ]
-  def export_getJobsSummary( self, jobIDs ):
+  @staticmethod
+  def export_getJobsSummary( jobIDs ):
 
     if not jobIDs:
       return S_ERROR( 'JobMonitoring.getJobsSummary: Received empty job list' )
 
-    result = jobDB.getAttributesForJobList( jobIDs, SUMMARY )
+    result = gJobDB.getAttributesForJobList( jobIDs, SUMMARY )
     #return result
     restring = str( result['Value'] )
     return S_OK( restring )
 
 ##############################################################################
   types_getJobPageSummaryWeb = [DictType, ListType, IntType, IntType]
-  def export_getJobPageSummaryWeb( self, selectDict, sortList, startItem, maxItems, selectJobs = True ):
+  @staticmethod
+  def export_getJobPageSummaryWeb( selectDict, sortList, startItem, maxItems, selectJobs = True ):
+    """ Get the summary of the job information for a given page in the
+        job monitor in a generic format
+    """
+    resultDict = {}
+    startDate = selectDict.get( 'FromDate', None )
+    if startDate:
+      del selectDict['FromDate']
+    # For backward compatibility
+    if startDate is None:
+      startDate = selectDict.get( 'LastUpdate', None )
+      if startDate:
+        del selectDict['LastUpdate']
+    endDate = selectDict.get( 'ToDate', None )
+    if endDate:
+      del selectDict['ToDate']
+
+    # Sorting instructions. Only one for the moment.
+    if sortList:
+      orderAttribute = sortList[0][0] + ":" + sortList[0][1]
+    else:
+      orderAttribute = None
+
+    statusDict = {}
+    result = gJobDB.getCounters( 'Jobs', ['Status'], selectDict,
+                               newer = startDate,
+                               older = endDate,
+                               timeStamp = 'LastUpdateTime' )
+
+    nJobs = 0
+    if result['OK']:
+      for stDict, count in result['Value']:
+        nJobs += count
+        statusDict[stDict['Status']] = count
+
+    resultDict['TotalRecords'] = nJobs
+    if nJobs == 0:
+      return S_OK( resultDict )
+
+    resultDict['Extras'] = statusDict
+
+    if selectJobs:
+      iniJob = startItem
+      if iniJob >= nJobs:
+        return S_ERROR( 'Item number out of range' )
+
+      result = gJobDB.selectJobs( selectDict, orderAttribute = orderAttribute,
+                                newer = startDate, older = endDate, limit = ( maxItems, iniJob ) )
+      if not result['OK']:
+        return S_ERROR( 'Failed to select jobs: ' + result['Message'] )
+
+      summaryJobList = result['Value']
+      result = gJobDB.getAttributesForJobList( summaryJobList, SUMMARY )
+      if not result['OK']:
+        return S_ERROR( 'Failed to get job summary: ' + result['Message'] )
+
+      summaryDict = result['Value']
+
+      # Evaluate last sign of life time
+      for jobID, jobDict in summaryDict.items():
+        if jobDict['HeartBeatTime'] == 'None':
+          jobDict['LastSignOfLife'] = jobDict['LastUpdateTime']
+        else:
+          lastTime = Time.fromString( jobDict['LastUpdateTime'] )
+          hbTime = Time.fromString( jobDict['HeartBeatTime'] )
+          if ( hbTime - lastTime ) > ( lastTime - lastTime ) or jobDict['Status'] == "Stalled":
+            jobDict['LastSignOfLife'] = jobDict['HeartBeatTime']
+          else:
+            jobDict['LastSignOfLife'] = jobDict['LastUpdateTime']
+
+      tqDict = {}
+      result = gTaskQueueDB.getTaskQueueForJobs( summaryJobList )
+      if result['OK']:
+        tqDict = result['Value']
+
+      # prepare the standard structure now
+      key = summaryDict.keys()[0]
+      paramNames = summaryDict[key].keys()
+
+      records = []
+      for jobID, jobDict in summaryDict.items():
+        jParList = []
+        for pname in paramNames:
+          jParList.append( jobDict[pname] )
+        jParList.append( tqDict.get( jobID, 0 ) )
+        records.append( jParList )
+
+      resultDict['ParameterNames'] = paramNames + ['TaskQueueID']
+      resultDict['Records'] = records
+
+    return S_OK( resultDict )
+
+
+  def getJobPageSummaryWeb( self, selectDict, sortList, startItem, maxItems, selectJobs = True ):
     """ Get the summary of the job information for a given page in the
         job monitor in a generic format
     """
@@ -303,18 +420,18 @@ class JobMonitoringHandler( RequestHandler ):
       orderAttribute = None
 
     if selectJobs:
-      result = jobDB.selectJobs( selectDict, orderAttribute = orderAttribute,
+      result = gJobDB.selectJobs( selectDict, orderAttribute = orderAttribute,
                                 newer = startDate, older = endDate )
       if not result['OK']:
         return S_ERROR( 'Failed to select jobs: ' + result['Message'] )
 
       jobList = result['Value']
-      
+
       # A.T. This needs optimization
       #validJobList, invalidJobList, nonauthJobList, ownerJobList = self.jobPolicy.evaluateJobRights( jobList,
       #                                                                                               RIGHT_GET_INFO )
       #jobList = validJobList
-      
+
       nJobs = len( jobList )
       resultDict['TotalRecords'] = nJobs
       if nJobs == 0:
@@ -329,7 +446,7 @@ class JobMonitoringHandler( RequestHandler ):
         lastJob = nJobs
 
       summaryJobList = jobList[iniJob:lastJob]
-      result = jobDB.getAttributesForJobList( summaryJobList, SUMMARY )
+      result = gJobDB.getAttributesForJobList( summaryJobList, SUMMARY )
       if not result['OK']:
         return S_ERROR( 'Failed to get job summary: ' + result['Message'] )
 
@@ -348,7 +465,7 @@ class JobMonitoringHandler( RequestHandler ):
             jobDict['LastSignOfLife'] = jobDict['LastUpdateTime']
 
       tqDict = {}
-      result = taskQueueDB.getTaskQueueForJobs( summaryJobList )
+      result = gTaskQueueDB.getTaskQueueForJobs( summaryJobList )
       if result['OK']:
         tqDict = result['Value']
 
@@ -371,7 +488,7 @@ class JobMonitoringHandler( RequestHandler ):
       resultDict['Records'] = records
 
     statusDict = {}
-    result = jobDB.getCounters( 'Jobs', ['Status'], selectDict,
+    result = gJobDB.getCounters( 'Jobs', ['Status'], selectDict,
                                newer = startDate,
                                older = endDate,
                                timeStamp = 'LastUpdateTime' )
@@ -384,7 +501,8 @@ class JobMonitoringHandler( RequestHandler ):
 
 ##############################################################################
   types_getJobStats = [ StringTypes, DictType ]
-  def export_getJobStats ( self, attribute, selectDict ):
+  @staticmethod
+  def export_getJobStats ( attribute, selectDict ):
     """ Get job statistics distribution per attribute value with a given selection
     """
     startDate = selectDict.get( 'FromDate', None )
@@ -399,55 +517,65 @@ class JobMonitoringHandler( RequestHandler ):
     if endDate:
       del selectDict['ToDate']
 
-    result = jobDB.getCounters( 'Jobs', [attribute], selectDict,
+    result = gJobDB.getCounters( 'Jobs', [attribute], selectDict,
                                newer = startDate,
                                older = endDate,
                                timeStamp = 'LastUpdateTime' )
     resultDict = {}
     if result['OK']:
       for cDict, count in result['Value']:
-         resultDict[cDict[attribute]] = count
+        resultDict[cDict[attribute]] = count
 
     return S_OK( resultDict )
 
 ##############################################################################
   types_getJobsPrimarySummary = [ ListType ]
-  def export_getJobsPrimarySummary ( self, jobIDs ):
-    return jobDB.getAttributesForJobList( jobIDs, PRIMARY_SUMMARY )
+  @staticmethod
+  def export_getJobsPrimarySummary ( jobIDs ):
+    return gJobDB.getAttributesForJobList( jobIDs, PRIMARY_SUMMARY )
 
 ##############################################################################
-  types_getJobParameter = [ [StringType, IntType, LongType] , StringType ]
-  def export_getJobParameter( self, jobID, parName ):
-    return jobDB.getJobParameters( int( jobID ), [parName] )
+  types_getJobParameter = [ [IntType, LongType] , StringType ]
+  @staticmethod
+  def export_getJobParameter( jobID, parName ):
+    return gJobDB.getJobParameters( jobID, [parName] )
 
 ##############################################################################
-  types_getJobParameters = [ [StringType, IntType, LongType] ]
-  def export_getJobParameters( self, jobID ):
-    return jobDB.getJobParameters( int( jobID ) )
+  types_getJobParameters = [ [IntType, LongType] ]
+  @staticmethod
+  def export_getJobParameters( jobID ):
+    return gJobDB.getJobParameters( jobID )
 
 ##############################################################################
-  types_getAtticJobParameters = [ [StringType, IntType, LongType] ]
-  def export_getAtticJobParameters( self, jobID, parameters = [], rescheduleCycle = -1 ):
-    return jobDB.getAtticJobParameters( int( jobID ), parameters, rescheduleCycle )
+  types_getAtticJobParameters = [ [IntType, LongType] ]
+  @staticmethod
+  def export_getAtticJobParameters( jobID, parameters = None, rescheduleCycle = -1 ):
+    if not parameters:
+      parameters = []
+    return gJobDB.getAtticJobParameters( jobID, parameters, rescheduleCycle )
 
 ##############################################################################
-  types_getJobAttributes = [ [StringType, IntType, LongType] ]
-  def export_getJobAttributes( self, jobID ):
-    return jobDB.getJobAttributes( int( jobID ) )
+  types_getJobAttributes = [ IntType ]
+  @staticmethod
+  def export_getJobAttributes( jobID ):
+    return gJobDB.getJobAttributes( jobID )
 
 ##############################################################################
   types_getSiteSummary = [ ]
-  def export_getSiteSummary( self ):
-    return jobDB.getSiteSummary()
+  @staticmethod
+  def export_getSiteSummary():
+    return gJobDB.getSiteSummary()
 
 ##############################################################################
-  types_getJobHeartBeatData = [ [StringType, IntType, LongType] ]
-  def export_getJobHeartBeatData( self, jobID ):
-    return jobDB.getHeartBeatData( int( jobID ) )
+  types_getJobHeartBeatData = [ IntType ]
+  @staticmethod
+  def export_getJobHeartBeatData( jobID ):
+    return gJobDB.getHeartBeatData( jobID )
 
 ##############################################################################
-  types_getInputData = [ [StringType, IntType, LongType] ]
-  def export_getInputData( self, jobID ):
+  types_getInputData = [ [IntType, LongType] ]
+  @staticmethod
+  def export_getInputData( jobID ):
     """ Get input data for the specified jobs
     """
-    return  jobDB.getInputData( int( jobID ) )
+    return  gJobDB.getInputData( jobID )


### PR DESCRIPTION
Avoid doing a selection of all Jobs, first count matching jobs and then use "limit" to select only the required JobIDs.
