### PR TITLE
[v7r0] fix a typo error for types_listMetadataSets.

### DIFF
--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -477,7 +477,7 @@ class FileCatalogHandler( RequestHandler ):
     """
     return gFileCatalogDB.dmeta.getMetadataSet( setName, expandFlag, self.getRemoteCredentials() )
 
-  types_listMetadatasets = []
+  types_listMetadataSets = []
   def export_listMetadataSets(self):
     """ Get the list of metadata sets with their definitions
     """


### PR DESCRIPTION
Fix a small typo error. 
