### PR TITLE
[v6r9] CHANGE: inherited meta data is not used when doing a find

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata.py
@@ -571,7 +571,8 @@ class DirectoryMetadata:
     for meta in metaDict.keys():
       result = self.__getDirMeta(meta, pathString)
       if not result['OK']:
-        return result
+        #neither the dir nor the parents have this meta set
+        continue
       if len( result['Value'] ) > 1:
         return S_ERROR( 'Metadata conflict for directory %s' % path )
       if result['Value']:
@@ -579,6 +580,8 @@ class DirectoryMetadata:
         if finalmetadict[meta] == metaval:
           #the parent directory or the current directory is already OK for that meta data, no need to further check for that
           del finalmetadict[meta]
+        else:
+          return S_ERROR("Incompatible meta query with %s" % meta)
     
     if finalmetadict:
       pathSelection = ''


### PR DESCRIPTION
CHANGE: getDirectoryMetadata: extract the query that, given a meta name
and pathIDs string, return the values and DirIDs. This is a private
method __getDirMeta.

CHANGE: findDirIDsByMetadata: 
1) use the getPathIDs method to get the current path and its parents
IDs.
2) for the meta dict expanded, use the __getDirMeta method to get the
parents' meta values. If they are there, then delete from the input meta
dict the key as it should not be used for the subsequent query. This
part can also be used to identify conflicting meta data with a clear
message (not done here).
3) use the stripped dict for the DirID query, logic remains untouched. 

This allows queries where one of the parent meta data is used. Until
now, this would result in an empty list (not logical).
