### PR TITLE
[v7r0] quiet display option in do_find()

### DIFF
--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -2060,13 +2060,19 @@ File Catalog Client $Revision: 1.17 $Date:
   def do_find(self,args):
     """ Find all files satisfying the given metadata information 
     
-        usage: find <path> <meta_name>=<meta_value> [<meta_name>=<meta_value>]
+        usage: find [-q] <path> <meta_name>=<meta_value> [<meta_name>=<meta_value>]
     """   
    
     argss = args.split()
     if (len(argss) < 2):
       print self.do_find.__doc__
       return
+    
+    verbose = True
+    if argss[0] == "-q":
+      verbose  = False
+      del argss[0]
+
     path = argss[0]
     path = self.getPath(path)
     del argss[0]
@@ -2075,23 +2081,28 @@ File Catalog Client $Revision: 1.17 $Date:
       metaDict = eval(argss[0])
     else:  
       metaDict = self.__createQuery(' '.join(argss))
-      print "Query:",metaDict
+      if verbose: print "Query:",metaDict
           
     result = self.fc.findFilesByMetadata(metaDict,path)
     if not result['OK']:
       print ("Error: %s" % result['Message']) 
       return 
     if result['Value']:
-      for dir in result['Value']:
-        print dir
+      for dir_ in result['Value']:
+        print dir_
     else:
       print "No matching data found"      
-    if "QueryTime" in result:
+    if verbose and "QueryTime" in result:
       print "QueryTime %.2f sec" % result['QueryTime']  
 
   def complete_find(self, text, line, begidx, endidx):
     result = []
     args = line.split()
+
+    # skip "-q" optional switch
+    if len(args) >= 2 and args[1] == "-q":
+      if len(args) > 2 or line.endswith(" "):
+        del args[1]
 
     # the first argument -- LFN.
     if (1<=len(args)<=2):


### PR DESCRIPTION
Add a command line option for FileCatalogClientCLI.do_find() in order to provide easier to parse output
