### PR TITLE
[v6r10] FIX: Take the latest DT that fits

### DIFF
--- a/ResourceStatusSystem/Command/DowntimeCommand.py
+++ b/ResourceStatusSystem/Command/DowntimeCommand.py
@@ -182,7 +182,8 @@ class DowntimeCommand( Command ):
       
       if ( dt[ 'StartDate' ] < str( startDate ) ) and ( dt[ 'EndDate' ] > str( endDate ) ):
         result = dt
-        break        
+        #We want to take the latest one ( they are sorted by insertion time )
+        #break
            
     return S_OK( result )            
 
@@ -222,7 +223,8 @@ class DowntimeCommand( Command ):
       for dt in uniformResult:
         if ( dt[ 'StartDate' ] > dtDate ) and ( dt[ 'StartDate' ] < dtDateFuture ):
           result = dt
-          break
+          #We want to take the latest one ( they are sorted by insertion time )
+          #break
            
     return S_OK( result )       
 


### PR DESCRIPTION
When there is more than one Downtime declared for the same element, take the one that was declared last.
