### PR TITLE
!!! [v6r9] BUGFIX: is catalogType is define, it should be used in the URL

### DIFF
--- a/Resources/Catalog/FileCatalogFactory.py
+++ b/Resources/Catalog/FileCatalogFactory.py
@@ -12,50 +12,50 @@ from DIRAC.Resources.Catalog.FileCatalogProxyClient import FileCatalogProxyClien
 from DIRAC.Core.Utilities import ObjectLoader
 
 class FileCatalogFactory:
-  
-  def __init__(self):
-    self.log = gLogger.getSubLogger('FileCatalogFactory')
-  
-  def createCatalog( self, catalogName, useProxy=False ):
+
+  def __init__( self ):
+    self.log = gLogger.getSubLogger( 'FileCatalogFactory' )
+
+  def createCatalog( self, catalogName, useProxy = False ):
     """ Create a file catalog object from its name and CS description
     """
     if useProxy:
       catalog = FileCatalogProxyClient( catalogName )
       return S_OK( catalog )
-    
+
     # get the CS description first
     catalogPath = getCatalogPath( catalogName )
-    catalogType = gConfig.getValue( catalogPath+'/CatalogType', catalogName )
-    catalogURL = gConfig.getValue( catalogPath+'/CatalogURL', "DataManagement/"+catalogName ) 
-    
+    catalogType = gConfig.getValue( catalogPath + '/CatalogType', catalogName )
+    catalogURL = gConfig.getValue( catalogPath + '/CatalogURL', "DataManagement/" + catalogType )
+
     self.log.verbose( 'Creating %s client' % catalogName )
-    
+
     objectLoader = ObjectLoader.ObjectLoader()
-    result = objectLoader.loadObject( 'Resources.Catalog.%sClient' % catalogType, catalogType+'Client' )
+    result = objectLoader.loadObject( 'Resources.Catalog.%sClient' % catalogType, catalogType + 'Client' )
     if not result['OK']:
       gLogger.error( 'Failed to load catalog object: %s' % result['Message'] )
       return result
-    
+
     catalogClass = result['Value']
-     
+
     try:
       if catalogType in [ 'LcgFileCatalogCombined', 'LcgFileCatalog' ]:
         # The LFC special case
-        infoSys = gConfig.getValue( catalogPath+'/LcgGfalInfosys', '' )
-        host = gConfig.getValue( catalogPath+'/MasterHost', '' )
+        infoSys = gConfig.getValue( catalogPath + '/LcgGfalInfosys', '' )
+        host = gConfig.getValue( catalogPath + '/MasterHost', '' )
         catalog = catalogClass( infoSys, host )
-      else:  
+      else:
         if catalogURL:
           catalog = catalogClass( url = catalogURL )
-        else:  
+        else:
           catalog = catalogClass()
-      self.log.debug('Loaded module %sClient' % catalogType )
+      self.log.debug( 'Loaded module %sClient' % catalogType )
       return S_OK( catalog )
     except Exception, x:
       errStr = "Failed to instantiate %s()" % ( catalogType )
       gLogger.exception( errStr, lException = x )
       return S_ERROR( errStr )
-      
+
     # Catalog module was not loaded  
-    return S_ERROR( 'No suitable client found for %s' % catalogName )  
- 
+    return S_ERROR( 'No suitable client found for %s' % catalogName )
+


### PR DESCRIPTION
`````` python
    catalogType = gConfig.getValue( catalogPath+'/CatalogType', catalogName )
    catalogURL = gConfig.getValue( catalogPath+'/CatalogURL',
"DataManagement/"+catalogName )


should rather be:

```python
    catalogType = gConfig.getValue( catalogPath+'/CatalogType', catalogName )
    catalogURL = gConfig.getValue( catalogPath+'/CatalogURL',
"DataManagement/"+catalogType )

CTA has:

CatalogName = DIRACFileCatalog
CatalogType = FileCatalog

and CatalogURL, that was not defined in the configuration, results
DataMamagement/DIRACFileCatalog. What it should be is:
DataManagement/FileCatalog
``````
