### PR TITLE
[v6r10] Added index DataFiles(LFN)

### DIFF
--- a/TransformationSystem/DB/TransformationDB.sql
+++ b/TransformationSystem/DB/TransformationDB.sql
@@ -53,6 +53,7 @@ CREATE TABLE DataFiles (
    LFN VARCHAR(255) NOT NULL DEFAULT '',
    Status varchar(32) DEFAULT 'AprioriGood',
    INDEX (Status),
+   INDEX (LFN),
    PRIMARY KEY (FileID)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
There was a missing index in the InnoDB TransformationDB definition.

Note: this won't merge in integration, because there the DB definition is in the .py file, while for v6r10 is in the .sql.

To "merge", you should add the following line at line 143 of TransformationDB.py:

```
                          'Indexes': {'LFN': ['LFN]},
```
