### PR TITLE
[v6r10] Race condition that causes a job to remain in Staging

### DIFF
--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -385,6 +385,13 @@ class JobScheduling( OptimizerExecutor ):
     self.jobLog.verbose( "Stage request will be \n\t%s" % "\n\t".join( [ "%s:%s" % ( lfn, stageLFNs[ lfn ] ) for lfn in stageLFNs ] ) )
 
     stagerClient = StorageManagerClient()
+    result = jobState.setStatus( self.ex_getOption( 'StagingStatus', 'Staging' ),
+                                 self.ex_getOption( 'StagingMinorStatus', 'Request To Be Sent' ),
+                                 appStatus = "",
+                                 source = self.ex_optimizerName() )
+    if not result[ 'OK' ]:
+      return result
+
     result = stagerClient.setRequest( stageLFNs, 'WorkloadManagement',
                                       'updateJobFromStager@WorkloadManagement/JobStateUpdate',
                                       int( jobState.jid ) )
@@ -395,12 +402,14 @@ class JobScheduling( OptimizerExecutor ):
     rid = str( result[ 'Value' ] )
     self.jobLog.info( "Stage request %s sent" % rid )
     jobState.setParameter( "StageRequest", rid )
+
     result = jobState.setStatus( self.ex_getOption( 'StagingStatus', 'Staging' ),
                                  self.ex_getOption( 'StagingMinorStatus', 'Request Sent' ),
                                  appStatus = "",
                                  source = self.ex_optimizerName() )
     if not result[ 'OK' ]:
       return result
+
     return S_OK( stageLFNs )
 
 


### PR DESCRIPTION
 The set of events:
 JobScheduling sets a request to the stager system, and within this request (setRequest method):
    1 Stager service creates a New task for it
    2 Stager service checks if all files already exist in the system. If they are all Staged, the status of the task is set to Staged _immediately_
    3 Request finalization agent _very quickly_ finds that the task is Staged, issues a callback to JobStateUpdateHandler service
    4 JobStateUpdateHandler checks the last JobDB status for this job, finds that it's not Staging at all, ignores it (see below why)
  JobScheduling only _NOW_ updates the Job state = Staging.

causes a race-condition. As a result, even though all files are staged, the job will remain in staging.
