### PR TITLE
[v6r10] Fix tdb stats

### DIFF
--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -962,7 +962,6 @@ class TransformationDB( DB ):
       status = attrDict['ExternalStatus']
       statusDict[status] = count
       total += count
-    created = statusDict.get( 'Created', 0 )
     statusDict['TotalCreated'] = total
     return S_OK( statusDict )
 


### PR DESCRIPTION
The number of Submitted tasks is in TotalCreated, and overrides tasks in status "Submitted".
