### PR TITLE
FIX: Default group of the identity DN

### DIFF
--- a/Core/Security/X509Certificate.py
+++ b/Core/Security/X509Certificate.py
@@ -156,7 +156,7 @@ class X509Certificate:
         return S_OK( ext.get_value() )
     if ignoreDefault:
       return S_OK( False )
-    result = self.getSubjectDN()
+    result = self.getIssuerDN()
     if not result[ 'OK' ]:
       return result
     return Registry.findDefaultGroupForDN( result['Value'] )


### PR DESCRIPTION
FIX: When checking default group of the first proxy step, use the cert issuer DN instead of the subject so we can get the real DN
