### PR TITLE
[v6r10] The outputSandbox should be always uploaded

### DIFF
--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -736,6 +736,8 @@ class JobWrapper:
     if not self.failedFlag:
       self.__report( 'Completed', 'Uploading Output Sandbox' )
 
+    uploadOutputDataInAnyCase = False
+
     if fileList and self.jobID:
       self.outputSandboxSize = getGlobbedTotalSize( fileList )
       self.log.info( 'Attempting to upload Sandbox with limit:', self.sandboxSizeLimit )
@@ -747,7 +749,11 @@ class JobWrapper:
         if result.has_key( 'SandboxFileName' ):
           outputSandboxData = result['SandboxFileName']
           self.log.info( 'Attempting to upload %s as output data' % ( outputSandboxData ) )
-          outputData.append( outputSandboxData )
+          if self.failedFlag:
+            outputData = [outputSandboxData]
+            uploadOutputDataInAnyCase = True
+          else:
+            outputData.append( outputSandboxData )
           self.jobReport.setJobParameter( 'OutputSandbox', 'Sandbox uploaded to grid storage', sendFlag = False )
           self.jobReport.setJobParameter( 'OutputSandboxLFN',
                                           self.__getLFNfromOutputFile( outputSandboxData )[0], sendFlag = False )
@@ -760,8 +766,9 @@ class JobWrapper:
           self.__report( 'Completed', 'Output Sandbox Uploaded' )
         self.log.info( 'Sandbox uploaded successfully' )
 
-    if outputData and not self.failedFlag:
+    if ( outputData and not self.failedFlag ) or uploadOutputDataInAnyCase:
       # Do not upload outputdata if the job has failed.
+      # The exception is when the outputData is what was the OutputSandbox, which should be uploaded in any case
       if self.jobArgs.has_key( 'OutputSE' ):
         outputSE = self.jobArgs['OutputSE']
         if type( outputSE ) in types.StringTypes:


### PR DESCRIPTION
The case when a job was failed, but the outputSandbox was to be uploaded to an SE was not considered
