### PR TITLE
[v6r11] Fix the registerFile method of the DataManager

### DIFF
--- a/DataManagementSystem/Agent/RequestOperations/RegisterReplica.py
+++ b/DataManagementSystem/Agent/RequestOperations/RegisterReplica.py
@@ -40,9 +40,6 @@ class RegisterReplica( OperationHandlerBase ):
     """ call me maybe """
     # # counter for failed replicas
 
-    print "YEAHHH"
-    import time
-    time.sleep( 2 )
     failedReplicas = 0
     # # catalog to use
     catalog = self.operation.Catalog
@@ -58,7 +55,7 @@ class RegisterReplica( OperationHandlerBase ):
       # # and others
       replicaTuple = ( lfn , opFile.PFN, self.operation.targetSEList[0] )
       # # call ReplicaManager
-      registerReplica = self.replicaManager().registerReplica( replicaTuple, catalog )
+      registerReplica = self.dm.registerReplica( replicaTuple, catalog )
       # # check results
       if not registerReplica["OK"] or lfn in registerReplica["Value"]["Failed"]:
 

--- a/Resources/Storage/XROOTStorage.py
+++ b/Resources/Storage/XROOTStorage.py
@@ -1638,7 +1638,7 @@ class XROOTStorage( StorageBase ):
 
     # pfnunparse does not take into account the double // so I have to trick it
     # The problem is that I cannot take into account the port, which is always empty (it seems..)
-    return S_OK( 'root://%s/%s/%s' % ( self.host, pfnDict['Path'], pfnDict['FileName'] ) )
+    return S_OK( 'root://%s%s/%s' % ( self.host, pfnDict['Path'], pfnDict['FileName'] ) )
 
 
   def getCurrentURL( self, fileName ):
@@ -1664,4 +1664,4 @@ class XROOTStorage( StorageBase ):
     :returns PFN
     """
     return S_OK( { True : 'root://%s:%s/%s' % ( self.host, self.port, self.rootdir ),
-                   False : 'root://%s/%s' % ( self.host, self.rootdir ) }[withPort] )
+                   False : 'root://%s%s' % ( self.host, self.rootdir ) }[withPort] )


### PR DESCRIPTION
Fix the registerFile method of the DataManager so that it does not make useless checks on the StorageElement (see https://github.com/DIRACGrid/DIRAC/issues/1796)

Fix a small mistake in the XROOT storage plugin
