### PR TITLE
Add info message when dowloading input SB LFNs

### DIFF
--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -1051,6 +1051,7 @@ class JobWrapper:
             self.inputSandboxSize += result[ 'Value' ]
 
     if lfns:
+      self.log.info( "Downloading Input SandBox LFNs, files to get:", len(lfns))
       self.__report( 'Running', 'Downloading InputSandbox LFN(s)' )
       lfns = [fname.replace( 'LFN:', '' ).replace( 'lfn:', '' ) for fname in lfns]
       download = self.dm.getFile( lfns )


### PR DESCRIPTION
There was a message for the other types of SB, and I was struggling to find out if my file was actually downloaded or not...
