### PR TITLE
[v6r10] Update glexecComputingElement.py

### DIFF
--- a/Resources/Computing/glexecComputingElement.py
+++ b/Resources/Computing/glexecComputingElement.py
@@ -282,7 +282,7 @@ class glexecComputingElement( ComputingElement ):
     stdOutput = resultTuple[1]
     stdError = resultTuple[2]
     self.log.info( "Status after the glexec execution is %s" % str( status ) )
-    if status:
+    if status >=127:
       error = S_ERROR( status )
       error['Value'] = ( status, stdOutput, stdError )
       return error


### PR DESCRIPTION
Status codes < 127 mean glexec worked but the script it ran produced an error. This change allows Application Failed with Errors results to show through, rather than be masked by false "glexec CE submission" errors.
