### PR TITLE
!!! [v6r10] Change default SharedArea in SSHComputingElement

### DIFF
--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -166,7 +166,8 @@ class SSHComputingElement( ComputingElement ):
       self.ceParameters['ExecQueue'] = self.ceParameters.get( 'Queue', '' )
 
     if 'SharedArea' not in self.ceParameters:
-      self.ceParameters['SharedArea'] = '.'
+      #. isn't a good location, move to $HOME  
+      self.ceParameters['SharedArea'] = '$HOME'
 
     if 'BatchOutput' not in self.ceParameters:
       self.ceParameters['BatchOutput'] = 'data' 


### PR DESCRIPTION
Relative directories cannot work. Assume $HOME instead.

Needs checking/testing as even if it should work, not guaranteed.
