### PR TITLE
[v6r10] add SSHOptions to interface, allows parsing from SSH options that are

### DIFF
--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -39,9 +39,9 @@ class SSH:
     self.key = key
     if not key:
       self.key = parameters.get( 'SSHKey', '' )
-    if not options:
-      self.options = parameters.get( 'SSHOptions', '' )
     self.options = options
+    if not len(options):
+      self.options = parameters.get( 'SSHOptions', '' )
     self.log = gLogger.getSubLogger( 'SSH' )  
 
   def __ssh_call( self, command, timeout ):


### PR DESCRIPTION
Allow SSH options to be passed from CS setup of SSH Computing Element. Will implement arbitrary set of options (such as -o UseKnownHosts=/location/file etc.) in ssh and scp calls.
