### PR TITLE
[v6r11] fix for SSH torque submission specifying the remote user for running/waiting jobs with BatchUser

### DIFF
--- a/Resources/Computing/SSHTorqueComputingElement.py
+++ b/Resources/Computing/SSHTorqueComputingElement.py
@@ -69,10 +69,10 @@ class SSHTorqueComputingElement( SSHComputingElement ):
 
     ssh = SSH( parameters = self.ceParameters )
 
-    if self.ceParameters.has_key('batchUser') :
+    if self.ceParameters.has_key('BatchUser') :
 
-#      cmd = ["qstat", "-i", "-u", self.ceParameters['batchUser'], self.queue, "|", "grep", self.queue, "|", "wc", "-l"]
-      cmd = ["qselect", "-u", self.ceParameters['batchUser'], "-s", "QW", "|", "wc", "-l"]
+#      cmd = ["qstat", "-i", "-u", self.ceParameters['BatchUser'], self.queue, "|", "grep", self.queue, "|", "wc", "-l"]
+      cmd = ["qselect", "-u", self.ceParameters['BatchUser'], "-s", "QW", "|", "wc", "-l"]
 
       ret = self.__execRemoteSSH( ssh, cmd )
 
@@ -82,8 +82,8 @@ class SSHTorqueComputingElement( SSHComputingElement ):
 
       waitingJobs = int(ret['Value'])
 
-#      cmd = ["qstat", "-r", "-u", self.ceParameters['batchUser'], self.queue, "|", "grep", self.queue, "|", "wc", "-l"]
-      cmd = ["qselect", "-u", self.ceParameters['batchUser'], "-s", "R", "|", "wc", "-l"]
+#      cmd = ["qstat", "-r", "-u", self.ceParameters['BatchUser'], self.queue, "|", "grep", self.queue, "|", "wc", "-l"]
+      cmd = ["qselect", "-u", self.ceParameters['BatchUser'], "-s", "R", "|", "wc", "-l"]
 
       ret = self.__execRemoteSSH( ssh, cmd )
 


### PR DESCRIPTION
Please include this fix into the upcoming v6r11 release

in some cases the remote torque batch system would show jobs in all
states for ALL users with qstat when computing the running and waiting
jobs. In this case a CE entry "batchUser" should be provided and this
CE will check only for the user specified as value for running/waiting
jobs. 

Additional change for CS entry in camel case
