### PR TITLE
[v6r12] Add getBulkRequest feature

### DIFF
--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -124,6 +124,30 @@ class ReqClient( Client ):
       return getRequest
     return S_OK( Request( getRequest["Value"] ) )
 
+  def getBulkRequests( self, numberOfRequest = 10 ):
+    """ get bulk requests from RequestDB
+
+    :param self: self reference
+    :param str numberOfRequest: size of the bulk (default 10)
+
+    :return: S_OK( Successful : { requestID, RequestInstance }, Failed : message  ) or S_ERROR
+    """
+    self.log.debug( "getRequests: attempting to get request." )
+    getRequests = self.requestManager().getBulkRequests( numberOfRequest )
+    if not getRequests["OK"]:
+      self.log.error( "getRequests: unable to get '%s' requests: %s" % ( numberOfRequest, getRequests["Message"] ) )
+      return getRequests
+    # No Request returned
+    if not getRequests["Value"]:
+      return getRequests
+    # No successful Request
+    if not getRequests["Value"]["Successful"]:
+      return getRequests
+
+    jsonReq = getRequests["Value"]["Successful"]
+    reqInstances = dict( ( rId, Request( jsonReq[rId] ) ) for rId in jsonReq )
+    return S_OK( {"Successful" : reqInstances, "Failed" : getRequests["Value"]["Failed"] } )
+
   def peekRequest( self, requestName ):
     """ peek request """
     self.log.debug( "peekRequest: attempting to get request." )

--- a/RequestManagementSystem/ConfigTemplate.cfg
+++ b/RequestManagementSystem/ConfigTemplate.cfg
@@ -52,6 +52,7 @@ Agents
  	#TimeOut = 300
  	#TimeOutPerFile = 300
     MaxAttempts = 256
+    BulkRequest = 0
     OperationHandlers 
     {
       ForwardDISET 

--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -307,6 +307,85 @@ class RequestDB( DB ):
 
     return S_OK( request )
 
+
+
+  def getBulkRequests( self, numberOfRequest = 10, assigned = True ):
+    """ read as many requests as requested for execution
+
+    :param int numberOfRequest: Number of Request we want (default 10)
+    :param bool assigned: if True, the status of the selected requests are set to assign
+
+    :returns a dictionary of Request objects indexed on the RequestID
+
+    """
+
+    # r_RequestID : RequestID, r_LastUpdate : LastUpdate...
+    requestAttrDict = dict ( ("r_%s"%r, r) for r in Request.tableDesc()["Fields"])
+    # o_RequestID : RequestID, o_OperationID : OperationID...
+    operationAttrDict = dict ( ("o_%s"%o, o) for o in Operation.tableDesc()["Fields"])
+    # f_OperationID : OperationID, f_FileID : FileID...
+    fileAttrDict = dict ( ("f_%s"%f, f) for f in File.tableDesc()["Fields"])
+
+    # o.OperationID as o_OperationID, ..., r_RequestID, ..., f_FileID, ...
+    allFieldsStr = ",".join([ "o.%s as %s"%(operationAttrDict[o], o) for o in operationAttrDict]\
+                            + requestAttrDict.keys() + fileAttrDict.keys())
+
+    # RequestID as r_RequestID, LastUpdate as r_LastUpdate, ...
+    requestAttrStr = ",".join([ "%s as %s"%(requestAttrDict[r], r) for r in requestAttrDict])
+
+    # OperationID as f_OperationID, FileID as f_FileID...
+    fileAttrStr = ",".join([ "%s as %s"%(fileAttrDict[f], f) for f in fileAttrDict])
+
+
+    # Selects all the Request (limited to numberOfRequest, sorted by LastUpdate) , Operation and File information.
+    # The entries are sorted by the LastUpdate of the Requests, RequestID if several requests were update the last time
+    # at the same time, and finally according to the Operation Order
+    query = "SELECT %s FROM Operation o \
+            INNER JOIN (SELECT %s FROM Request WHERE Status = 'Waiting' ORDER BY `LastUpdate` ASC limit %s) r\
+            ON r_RequestID = o.RequestID\
+            INNER JOIN (SELECT %s from File) f ON f_OperationId = o.OperationId\
+            ORDER BY r_LastUpdate, r_RequestId, o_Order;"\
+             % ( allFieldsStr, requestAttrStr, numberOfRequest, fileAttrStr )
+
+    queryResult = self._transaction( query )
+    if not queryResult["OK"]:
+      self.log.error( "RequestDB.getRequests: %s" % queryResult["Message"] )
+      return queryResult
+
+    allResults = queryResult["Value"][query]
+
+    # We now construct a dict of Request indexed by their ID, and the same for Operation
+
+    requestDict = {}
+    operationDict = {}
+    for entry in allResults:
+      requestID = int( entry["r_RequestID"] )
+      # If the object already exists, we get it, otherwise we create it and assign it
+      requestObj = requestDict.setdefault( requestID, Request( dict( ( requestAttrDict[r], entry[r] ) for r in requestAttrDict ) ) )
+
+      operationID = int( entry["o_OperationID"] )
+      operationObj = operationDict.get( operationID, None )
+
+      # If the Operation object does not exist yet, we create it, and add it to the Request
+      if not operationObj:
+        operationObj = Operation( dict( ( operationAttrDict[o], entry[o] ) for o in operationAttrDict ) )
+        operationDict[operationID ] = operationObj
+        requestObj.addOperation( operationObj )
+
+      fileObj = File( dict( ( fileAttrDict[f], entry[f] ) for f in fileAttrDict ) )
+      operationObj.addFile( fileObj )
+
+
+    if assigned and len( requestDict ):
+      listOfReqId = ",".join( str( rId ) for rId in requestDict )
+      setAssigned = self._transaction( "UPDATE `Request` SET `Status` = 'Assigned' WHERE RequestID IN (%s);" % listOfReqId )
+      if not setAssigned["OK"]:
+        self.log.error( "getRequests: %s" % setAssigned["Message"] )
+        return setAssigned
+
+    return S_OK( requestDict )
+
+
   def peekRequest( self, requestName ):
     """ get request (ro), no update on states
 

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -123,6 +123,34 @@ class ReqManagerHandler( RequestHandler ):
       return toJSON
     return S_OK()
 
+
+  types_getBulkRequests = [ IntType ]
+  @classmethod
+  def export_getBulkRequests( cls, numberOfRequest = 10 ):
+    """ Get a request of given type from the database
+        :param numberOfRequest : size of the bulk (default 10)
+
+        :return S_OK( {Failed : message, Successful : list of Request.toJSON()} )
+    """
+    getRequests = cls.__requestDB.getBulkRequests( numberOfRequest )
+    if not getRequests["OK"]:
+      gLogger.error( "getRequests: %s" % getRequests["Message"] )
+      return getRequests
+    if getRequests["Value"]:
+      getRequests = getRequests["Value"]
+      toJSONDict = {"Successful" : {}, "Failed" : {}}
+
+      for rId in getRequests:
+        toJSON = getRequests[rId].toJSON()
+        if not toJSON["OK"]:
+          gLogger.error( toJSON["Message"] )
+          toJSONDict["Failed"][rId] = toJSON["Message"]
+        else:
+          toJSONDict["Successful"][rId] = toJSON["Value"]
+      return S_OK( toJSONDict )
+    return S_OK()
+
+
   types_peekRequest = [ StringTypes ]
   @classmethod
   def export_peekRequest( cls, requestName = "" ):


### PR DESCRIPTION
Allows to get several Requests from the DB at once. 

The requests returned are the oldest. It used to be the same for getRequest, but it now takes a random request from the 100 oldest and 50 newest. I did not find a clever and efficient way to do that in the bulk query. 

The RequestExecutingAgent is capable of using this feature, based on a new CS switch:
if BulkRequest == 0, then it will use getRequest and run as before. Otherwise, it will get (BulkRequest value) requests at once
