### PR TITLE
V6r11 ssh options

### DIFF
--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -140,7 +140,7 @@ class SSH:
     if upload:
       command = "scp %s %s %s %s@%s:%s" % ( key, self.options, localFile, self.user, self.host, destinationPath )
     else:
-      command = "scp %s %s@%s:%s %s" % ( key, self.user, self.host, destinationPath, localFile )
+      command = "scp %s %s %s@%s:%s %s" % ( key, self.options, self.user, self.host, destinationPath, localFile )
     self.log.debug( "SCP command %s" % command )
     return self.__ssh_call( command, timeout )
 


### PR DESCRIPTION
as described in my previous pull request, the SSHOptions are parsed at the wrong place in the current code in integration. In fact the SSHOptions should also be present in the 2nd scp call.
