### PR TITLE
[v6r11] Fix for missing Content-Length header, e.g. for cern git service

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -786,7 +786,10 @@ def urlretrieveTimeout( url, fileName = '', timeout = 0 ):
     #   #opener = urllib2.build_opener()
     #  urllib2.install_opener( opener )
     remoteFD = urllib2.urlopen( url )
-    expectedBytes = long( remoteFD.info()[ 'Content-Length' ] )
+    remoteInfo = remoteFD.info()
+    expectedBytes = -1
+    if 'Content-Lentgth' in remoteInfo:
+      expectedBytes = long( remoteInfo[ 'Content-Length' ] )
     if fileName:
       localFD = open( fileName, "wb" )
     receivedBytes = 0L
@@ -812,7 +815,7 @@ def urlretrieveTimeout( url, fileName = '', timeout = 0 ):
     if fileName:
       localFD.close()
     remoteFD.close()
-    if receivedBytes != expectedBytes:
+    if receivedBytes != expectedBytes and expectedBytes != -1:
       logERROR( "File should be %s bytes but received %s" % ( expectedBytes, receivedBytes ) )
       return False
   except urllib2.HTTPError, x:


### PR DESCRIPTION
See discussion here:
https://groups.google.com/forum/?hl=en#!topic/diracgrid-develop/Uw0FAYMo6R0
TL,DR: The cern git service does not send Content-Length header, I can't make distributions from there.
This is a fix for ignoring that header when it is not there.
