### PR TITLE
[v6r12] Add masterCatalogOnly in the DataManager init

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -53,7 +53,7 @@ class DataManager( object ):
     self.log = gLogger.getSubLogger( self.__class__.__name__, True )
 
 
-    catalogsToUse = FileCatalog().getMasterCatalogsName()['Value'] if masterCatalogOnly else catalogs
+    catalogsToUse = FileCatalog().getMasterCatalogNames()['Value'] if masterCatalogOnly else catalogs
 
     self.fc = FileCatalog( catalogsToUse )
     self.accountingClient = None

--- a/Resources/Catalog/FileCatalog.py
+++ b/Resources/Catalog/FileCatalog.py
@@ -54,7 +54,7 @@ class FileCatalog:
   def getWriteCatalogs( self ):
     return self.writeCatalogs
   
-  def getMasterCatalogsName( self ):
+  def getMasterCatalogNames( self ):
     """ Returns the list of names of the Master catalogs """
 
     masterNames = [catalogName for catalogName, oCatalog, master in self.writeCatalogs if master]


### PR DESCRIPTION
The masterCatalogOnly flag is a shortcut to avoid to hardcode the catalog name in the init when one only wants to register in the master catalog
