### PR TITLE
[v6r11] Bugfix in FileCatalogClientCLI

### DIFF
--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -2126,10 +2126,9 @@ File Catalog Client $Revision: 1.17 $Date:
         value = value.replace(contMode,'')
         contMode = False  
       
-      if value[0] == '"' or value[0] == "'":
-        if value[-1] != '"' and value != "'":
-          contMode = value[0]
-          continue 
+      if value[0] in ['"', "'"] and value[-1] not in ['"', "'"]:
+        contMode = value[0]
+        continue 
       
       if value.find(',') != -1:
         valueList = [ x.replace("'","").replace('"','') for x in value.split(',') ]


### PR DESCRIPTION
The index selection was missing in line 2130.
This way is more concise and still does the same thing as intended before.
