### PR TITLE
Added option to override VOMS URLs in UserAndGroup instances

### DIFF
--- a/ConfigurationSystem/Agent/UsersAndGroups.py
+++ b/ConfigurationSystem/Agent/UsersAndGroups.py
@@ -15,7 +15,15 @@ class UsersAndGroups( AgentModule ):
 
   def initialize( self ):
     self.am_setOption( "PollingTime", 3600 * 6 ) # Every 6 hours
-    self.vomsSrv = VOMSService()
+    self.vomsAdminUrl = self.am_getOption( "VOMSAdmin", None )
+    self.vomsAttrUrl = self.am_getOption( "VOMSAttributes", None )
+    if self.vomsAdminUrl and self.vomsAttrUrl:
+      self.log.info( "Using VOMSAdmin URL '%s'..." % self.vomsAdminUrl )
+      self.log.info( "Using VOMSAttribute URL '%s'..." % self.vomsAttrUrl )
+      self.vomsSrv = VOMSService( self.vomsAdminUrl, self.vomsAttrUrl )
+    else:
+      self.log.info( "Using default VOMS URLs." )
+      self.vomsSrv = VOMSService()
     self.proxyLocation = os.path.join( self.am_getWorkDirectory(), ".volatileId" )
     self.__adminMsgs = {}
     # print self.getLFCRegisteredDNs()

--- a/ConfigurationSystem/ConfigTemplate.cfg
+++ b/ConfigurationSystem/ConfigTemplate.cfg
@@ -27,6 +27,8 @@ Agents
   {
     MailTo =
     mailFrom = 
+    VOMSAdmin =
+    VOMSAttributes =
     LFCCheckEnabled = False
   }
 }


### PR DESCRIPTION
Hi,

This is a quick patch I wrote to allow multiple Configuration/UserAndGroup agents to access different VOMS servers so that multiple VOs can be imported.

Regards,
Simon
