### PR TITLE
[v6r11] Remove all traces of getRequestObject function

### DIFF
--- a/DataManagementSystem/Client/FailoverTransfer.py
+++ b/DataManagementSystem/Client/FailoverTransfer.py
@@ -3,7 +3,6 @@
     The failover transfer client exposes the following methods:
     - transferAndRegisterFile()
     - transferAndRegisterFileFailover()
-    - getRequestObject()
 
     Initially these methods were developed inside workflow modules but
     have evolved to a generic 'transfer file with failover' client.
@@ -16,8 +15,6 @@
     to the original target SE as well as the removal request for the
     temporary replica.
 
-    getRequestObject() allows to retrieve the modified request object
-    after transfer operations.
 """
 
 __RCSID__ = "$Id$"

--- a/Workflow/Modules/test/Test_Modules.py
+++ b/Workflow/Modules/test/Test_Modules.py
@@ -63,7 +63,6 @@ class ModulesTestCase( unittest.TestCase ):
     self.ft_mock = Mock()
     self.ft_mock.transferAndRegisterFile.return_value = {'OK': True, 'Value': {'uploadedSE':''}}
     self.ft_mock.transferAndRegisterFileFailover.return_value = {'OK': True, 'Value': {}}
-    self.ft_mock.getRequestObject.return_value = {'OK': True, 'Value': request_mock}
 
     self.nc_mock = Mock()
     self.nc_mock.sendMail.return_value = {'OK': True, 'Value': ''}


### PR DESCRIPTION
the getRequestObject function was removed some while ago, but it was still mentioned in the documentation string and was present in the tests.
