### PR TITLE
[v6r11] Remove trailing slash(s) from baseDir path

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-user-lfns.py
+++ b/DataManagementSystem/scripts/dirac-dms-user-lfns.py
@@ -84,6 +84,8 @@ if not baseDir:
     Script.showHelp()
   baseDir = '/%s/user/%s/%s' % ( vo, username[0], username )
 
+baseDir = baseDir.rstrip('/')
+
 gLogger.info( 'Will search for files in %s' % baseDir )
 activeDirs = [baseDir]
 


### PR DESCRIPTION
Remove the trailing slash from baseDir given is input , otherwise the outputfile will contain too many slashes and errors will show up if the list is used in other circumstances. E.g. when doing inputSandbox downloads via LFNs containing more than one slash.
