### PR TITLE
[v6r11] Remove systemConfig again

### DIFF
--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -80,7 +80,6 @@ class Job( API ):
     self.addToInputSandbox = []
     self.addToOutputSandbox = []
     self.addToInputData = []
-    self.systemConfig = 'ANY'
     ##Add member to handle Parametric jobs
     self.parametric = {}
     self.script = script


### PR DESCRIPTION
In this commit the Job systemConfig variable is back, it was removed a few commits before that.
https://github.com/DIRACGrid/DIRAC/commit/54698cbc7c1a914ecfb671fe1d200102a30e932b#diff-5a3781fc3ad213deb16fdcb4b002a97fR83
