### PR TITLE
[v6r12] Minor mysql server installation bugfix.

### DIFF
--- a/Core/Utilities/InstallTools.py
+++ b/Core/Utilities/InstallTools.py
@@ -1929,6 +1929,10 @@ def fixMySQLScripts( startupScript = mysqlStartupScript ):
       if line.find( 'basedir=' ) == 0:
         platform = getPlatformString()
         line = 'basedir=%s\n' % os.path.join( rootPath, platform )  
+      if line.find( 'extra_args=' ) == 0:
+        line = 'extra_args="-n"\n'
+      if line.find( '$bindir/mysqld_safe --' ) >= 0:
+        line = line.replace( 'mysqld_safe', 'mysqld_safe --no-defaults' )
       fd.write( line )
     fd.close()
   except Exception:


### PR DESCRIPTION
Hi,

The installation of the bundled mysql server fails if /etc/my.cnf is present. This file is installed by default on most machines via various dependencies which the user may not want (or have the permissions) to remove. This patch changes the DIRAC mysql start-up script at install time so that it correctly only consults the local my.cnf rather than the system-wide one.

Regards,
Simon
