### PR TITLE
[v6r11] Fix Bugs for findFilesByMetadata

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/FileMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileMetadata.py
@@ -324,6 +324,7 @@ class FileMetadata:
 
     insertValueList = []
     for fileID in fileList:
+      #FIXME: There is somethingwrong here, meta not defined
       insertValueList.append( "( %d,'%s' )" % ( fileID, meta ) )
 
     req = "INSERT INTO FC_FileMeta_%s (FileID,Value) VALUES %s" % ( metaname, ', '.join( insertValueList ) )
@@ -498,7 +499,7 @@ class FileMetadata:
             escapedOperand = self.db._escapeString( operand )
             if not escapedOperand['OK']:
               return escapedOperand
-            escapedOperand = escapeValue['Value']
+            escapedOperand = escapedOperand['Value']
 
           if operation in ['>', '<', '>=', '<=']:
             if type( operand ) == types.ListType:


### PR DESCRIPTION
tolower does not exist. It is just "lower"
Use escapedValue['Value'] instead of escapedValue['Value']['Value'], which the assignment did.

Note for line 328: There seems to be something wrong there. "meta" is coming from the previous loop, but I guess this should be the value to the corresponding fileID?

escapeValue does not exist. should be escapedOperand
