### PR TITLE
[v6r11] Bug in dirac-dms-remove-replicas

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-remove-replicas.py
+++ b/DataManagementSystem/scripts/dirac-dms-remove-replicas.py
@@ -41,6 +41,7 @@ for lfnList in breakListIntoChunks( sortList( lfns, True ), 500 ):
     res = dm.removeReplica( storageElementName, lfnList )
     if not res['OK']:
       print 'Error:', res['Message']
+      continue
     for lfn in sortList( res['Value']['Successful'].keys() ):
       print 'Successfully removed %s replica of %s' % ( storageElementName, lfn )
     for lfn in sortList( res['Value']['Failed'].keys() ):


### PR DESCRIPTION
dirac-dms-remove-replicas crashes with

```
Error: Failed to perform getPathPermissions from any catalog
Traceback (most recent call last):
  File "/home/sailer/software/DIRAC/DiracDevV6r8/DIRAC/DataManagementSystem/scripts/dirac-dms-remove-replicas.py", line 47, in <module>
    for lfn in sortList( res['Value']['Successful'].keys() ):
```

Or some other error message.

Do I understand correctly that if res['OK'] is False, then the previous function returned S_ERROR()
So there never is any res['Value'], so we have to continue after the error message
Right?
Otherwise there should be a check

```
if not 'Value' in res:
  continue
```

in line 44 instead
