### PR TITLE
svnweb -> svn.cern.ch

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -275,8 +275,8 @@ class ReleaseConfig:
     self.__instName = instName
     self.__projectName = projectName
     self.__projectReleaseLocation = {
-        'DIRAC' : "http://svnweb.cern.ch/guest/dirac/DIRAC/trunk/DIRAC/releases.cfg",
-        'LHCb' : "http://svnweb.cern.ch/guest/lbdirac/LHCbDIRAC/trunk/LHCbDIRAC/releases.cfg"
+        'DIRAC' : "http://svn.cern.ch/guest/dirac/DIRAC/trunk/DIRAC/releases.cfg",
+        'LHCb' : "http://svn.cern.ch/guest/lbdirac/LHCbDIRAC/trunk/LHCbDIRAC/releases.cfg"
         }
     self.__projectTarLocation = {
         'DIRAC' : "http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/installSource",


### PR DESCRIPTION
svn.cern.ch rather than svnweb.cern.ch is now needed for direct HTTP access to files in SVN.
