### PR TITLE
[v6r11] job.setExecutable: bring back different logfile names if they have not b...

### DIFF
--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -139,12 +139,14 @@ class Job( API ):
       self.log.warn( 'The executable code could not be found locally' )
       logName = 'CodeOutput.log'
 
+    self.stepCount += 1
+    stepName = 'RunScriptStep%s' % ( self.stepCount )
+
     if logFile:
       if type( logFile ) == type( ' ' ):
         logName = str(logFile)
-
-    self.stepCount += 1
-    stepName = 'RunScriptStep%s' % ( self.stepCount )
+    else:
+      logName = "Script%s_%s" %( self.stepCount, logName )
 
     step = getStepDefinition( 'ScriptStep%s' % ( self.stepCount ), modulesList, parametersList = parameters )
     self.addToOutputSandbox.append( logName )


### PR DESCRIPTION
... if they have not been specified by the user

Multiple calls to setExecutable used to produce different logfiles, but this logic was simplified away.
