### PR TITLE
[v6r12] Removed use of shifter proxy (read-only operations)

### DIFF
--- a/TransformationSystem/Agent/MCExtensionAgent.py
+++ b/TransformationSystem/Agent/MCExtensionAgent.py
@@ -32,8 +32,6 @@ class MCExtensionAgent( AgentModule ):
     '''Sets defaults
     '''
 
-    self.am_setOption( 'shifterProxy', 'DataManager' )
-
     gLogger.info( "Will consider the following transformation types: %s" % str( self.transformationTypes ) )
     gLogger.info( "Will create a maximum of %s tasks per iteration" % self.maxIterationTasks )
     gLogger.info( "Will not submit tasks for transformations with failure rate greater than %s%%" % ( self.maxFailRate ) )

--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -67,8 +67,6 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
     gMonitor.registerActivity( "SubmittedTasks", "Automatically submitted tasks", "Transformation Monitoring", "Tasks",
                                gMonitor.OP_ACUM )
 
-    self.am_setOption( 'shifterProxy', 'ProductionManager' )
-
     # Default clients
     self.transClient = TransformationClient()
 

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -80,9 +80,6 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
     # clients
     self.transfClient = TransformationClient()
 
-    # shifter
-    self.am_setOption( 'shifterProxy', 'ProductionManager' )
-
     # for caching using a pickle file
     self.__readCache()
     self.workDirectory = self.am_getWorkDirectory()

--- a/TransformationSystem/Agent/ValidateOutputDataAgent.py
+++ b/TransformationSystem/Agent/ValidateOutputDataAgent.py
@@ -43,11 +43,6 @@ class ValidateOutputDataAgent( AgentModule ):
   def initialize( self ):
     """ Sets defaults
     """
-    # This sets the Default Proxy to used as that defined under
-    # /Operations/Shifter/DataManager
-    # the shifterProxy option in the Configuration can be used to change this default.
-    self.am_setOption( 'shifterProxy', 'DataManager' )
-
     gLogger.info( "Will treat the following transformation types: %s" % str( self.transformationTypes ) )
     gLogger.info( "Will search for directories in the following locations: %s" % str( self.directoryLocations ) )
     gLogger.info( "Will check the following storage elements: %s" % str( self.activeStorages ) )

--- a/WorkloadManagementSystem/Agent/InputDataAgent.py
+++ b/WorkloadManagementSystem/Agent/InputDataAgent.py
@@ -32,8 +32,6 @@ class InputDataAgent( OptimizerModule ):
     #this will ignore failover SE files
     self.checkFileMetadata = self.am_getOption( 'CheckFileMetadata', True )
 
-    self.am_setOption( 'shifterProxy', 'DataManager' )
-
     self.dataManager = DataManager()
     self.resourceStatus = ResourceStatus()
     self.fc = FileCatalog()

--- a/WorkloadManagementSystem/Executor/InputData.py
+++ b/WorkloadManagementSystem/Executor/InputData.py
@@ -34,11 +34,6 @@ class InputData( OptimizerExecutor ):
     #this will ignore failover SE files
     cls.checkFileMetadata = cls.ex_getOption( 'CheckFileMetadata', True )
 
-    #Define the shifter proxy needed
-    # This sets the Default Proxy to used as that defined under
-    # the shifterProxy option in the Configuration can be used to change this default.
-    cls.ex_setProperty( 'shifterProxy', 'DataManager' )
-
     cls.__dataManDict = {}
     cls.__fcDict = {}
     cls.__SEToSiteMap = {}


### PR DESCRIPTION
@atsareg @phicharp IIUC these agents would keep working in case of DFC. In case the file catalog is instead the LFC we need the machines to be trusted, and the agents/optimizers should run with CSEC_MECH=ID env variable

If accepted I will update the documentation.

Not using the proxy demonstrated speedup. 
