### PR TITLE
[v6r12] correct handling of replica cache for transformations with many

### DIFF
--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -562,12 +562,13 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
     self.__removeFromCache( transID, lfns, log = True )
 
   def __removeFromCache( self, transID, lfns, log = False ):
-    cachedReplicaSets = self.replicaCache.get( transID, {} )
+    if transID not in self.replicaCache:
+      return
     removed = 0
-    if cachedReplicaSets and lfns:
+    if self.replicaCache[transID] and lfns:
       for lfn in lfns:
-        for timeKey in cachedReplicaSets:
-          if cachedReplicaSets[timeKey].pop( lfn, None ):
+        for timeKey in self.replicaCache[transID]:
+          if self.replicaCache[transID][timeKey].pop( lfn, None ):
             removed += 1
     if removed:
       self.removedFromCache += removed


### PR DESCRIPTION
The replica cache was not handled properly when there were more files in the transformation than accepted to be executed: replicas of all other files were cleared.
This PR fixes the problem and sets logging levels at the required level for proper debugging.
It also doesn't require to get replicas for RemoveFile transformations (very useful when removing 100,000's files!)
This PR is solely for v6r12, there is another PR for v6r11 in order not to have conflicts with Federico's changes
