### PR TITLE
Update pilotCommands.py

### DIFF
--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -738,8 +738,8 @@ class LaunchAgent( CommandBase ):
     extraCFG = []
     for i in os.listdir( self.pp.rootPath ):
       cfg = os.path.join( self.pp.rootPath, i )
-      if os.path.isfile( cfg ) and re.search( '.cfg&', cfg ):
-        extraCFG.append( cfg )
+      if os.path.isfile( cfg ) and re.search( '\.extra\.cfg$', cfg ):
+        extraCFG.append( open(cfg, 'r').read().replace('\n', ' ') )
 
     if self.pp.executeCmd:
       # Execute user command
@@ -750,9 +750,9 @@ class LaunchAgent( CommandBase ):
     os.environ['PYTHONUNBUFFERED'] = 'yes'
 
     jobAgent = '%s WorkloadManagement/JobAgent %s %s %s' % ( diracAgentScript,
+                                                             " ".join( extraCFG ) ),
                                                              " ".join( self.jobAgentOpts ),
-                                                             " ".join( self.inProcessOpts ),
-                                                             " ".join( extraCFG ) )
+                                                             " ".join( self.inProcessOpts ))
 
 
     retCode, _output = self.executeAndGetOutput( jobAgent, self.pp.installEnv )


### PR DESCRIPTION
This replaces the regular expression '.cfg&' for the extra options file names test (which would match files with "cfg&" anywhere in them) with a test for the suffix ".extra.cfg" and uses the contents of the files rather than the name of the files as the extra options. I've also placed these extra options at the start of the generated options, as some (eg -o CEType) don't work if placed at the end. This functionality is useful for testing and up to now I was using it for the LHCb VMs (to specify the glexec CEType and to force stop on failure.)
