### PR TITLE
[v6r13] Add options to ReqClient.putRequest

### DIFF
--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -640,7 +640,7 @@ class FTSAgent( AgentModule ):
       putRequest = self.putRequest( request, clearCache = ( request.Status != "Scheduled" ) )
       if not putRequest["OK"]:
         log.error( "unable to put back request:", putRequest["Message"] )
-     # #  put back jobs in all cases
+      # #  put back jobs in all cases
       if ftsJobs:
         for ftsJob in list( ftsJobs ):
           if not len( ftsJob ):

--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -190,7 +190,7 @@ class RequestExecutingAgent( AgentModule ):
     while request.RequestID in self.__requestCache:
       count -= 1
       if not count:
-        self.requestClient().putRequest( request )
+        self.requestClient().putRequest( request, useFailoverProxy = False, retryMainServer = 2 )
         return S_ERROR( "Duplicate request, ignore: %s" % request.RequestID )
       time.sleep( 1 )
     self.__requestCache[ request.RequestID ] = request
@@ -206,7 +206,7 @@ class RequestExecutingAgent( AgentModule ):
       if taskResult and taskResult['OK']:
         request = taskResult['Value']
 
-      reset = self.requestClient().putRequest( request )
+      reset = self.requestClient().putRequest( request, useFailoverProxy = False, retryMainServer = 2 )
       if not reset["OK"]:
         return S_ERROR( "putRequest: unable to reset request %s: %s" % ( requestID, reset["Message"] ) )
     else:

--- a/RequestManagementSystem/private/RequestTask.py
+++ b/RequestManagementSystem/private/RequestTask.py
@@ -231,7 +231,7 @@ class RequestTask( object ):
 
   def updateRequest( self ):
     """ put back request to the RequestDB """
-    updateRequest = self.requestClient.putRequest( self.request )
+    updateRequest = self.requestClient.putRequest( self.request, useFailoverProxy = False, retryMainServer = 2 )
     if not updateRequest["OK"]:
       self.log.error( updateRequest["Message"] )
     return updateRequest


### PR DESCRIPTION
This PR adds 2 options to the ReqClient.putRequest:
* useFailoverProxy : by default to True. If set to False, we will not try to send the Request to ReqProxy in case of failure on the RequestHandler. This is useful in the RequestExecutingAgent
* retryMainServer : in case the putRequest on the main RequestHandler fails, we retry that amount of time