### PR TITLE
[v6r11] DataManager: putAndRegister: Fix check for existing LFN

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -414,7 +414,7 @@ class DataManager( object ):
       self.log.debug( errStr, lfn )
       return S_ERROR( errStr )
     if res['Value']['Successful'][lfn]:
-      if res['Value']['Successful'][lfn] == lfn:
+      if res['Value']['Successful'][lfn]:
         errStr = "putAndRegister: The supplied LFN already exists in the File Catalog."
         self.log.debug( errStr, lfn )
       else:


### PR DESCRIPTION
The value for res['Value']['Successful'][lfn] is True/False and not the lfn, so this comparison was always False