### PR TITLE
[v6r11] DFC exists() return value

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
@@ -122,7 +122,7 @@ class DirectoryTreeBase:
       if not res['Value']:
         successful[lfn] = False
       else:
-        successful[lfn] = True
+        successful[lfn] = lfn
     return S_OK( {'Successful':successful, 'Failed':failed} )
 
   def existsDir( self, path ):

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
@@ -813,7 +813,9 @@ class FileManagerBase:
     """ Determine whether a file exists in the catalog """
     connection = self._getConnection( connection )
     res = self._findFiles( lfns, connection = connection )
-    successful = dict.fromkeys( res['Value']['Successful'], True )
+    successful = res['Value']['Successful']
+    for lfn in successful:
+      successful[lfn] = lfn
     failed = {}
     for lfn, error in res['Value']['Failed'].items():
       if error == 'No such file or directory':


### PR DESCRIPTION
FIX: FileCatalog - exists() method returns the LFN name instead of boolean True if the LFN is already present in the catalog

This PR replaces #2232 