### PR TITLE
[DIRACv6r12] If one instance is down, it tries to use the next one

### DIFF
--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -201,7 +201,7 @@ class BaseClient:
       # we run only one service! In that case we increase the retry delay.
       self.__retryDelay = 5
     else:
-      self.__retryDelay = 1 / len ( urls )
+      self.__retryDelay = 5 / len ( urls )
       
     if len( urls ) == len( self.__bannedUrls ):
       self.__bannedUrls = []  # retry all urls

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -1,6 +1,7 @@
 # $HeadURL$
 __RCSID__ = "$Id$"
 
+import time
 import types
 import thread
 import DIRAC
@@ -45,6 +46,9 @@ class BaseClient:
     self.__idDict = {}
     self.__extraCredentials = ""
     self.__enableThreadCheck = False
+    self.__retry = 0
+    self.__retryDelay = 2
+    self.__bannedUrls = []
     for initFunc in ( self.__discoverSetup, self.__discoverVO, self.__discoverTimeout,
                       self.__discoverURL, self.__discoverCredentialsToUse,
                       self.__checkTransportSanity,
@@ -190,7 +194,22 @@ class BaseClient:
       return S_ERROR( "Cannot get URL for %s in setup %s: %s" % ( self._destinationSrv, self.setup, str( e ) ) )
     if not urls:
       return S_ERROR( "URL for service %s not found" % self._destinationSrv )
-    sURL = List.randomize( List.fromChar( urls, "," ) )[0]
+    
+    urls = List.fromChar( urls, "," )
+    
+    if len( urls ) == len( self.__bannedUrls ):
+      self.__bannedUrls = []  # retry all urls
+      gLogger.debug( "Retrying all URLs" )      
+      
+    if len( self.__bannedUrls ) > 0 and len( urls ) > 1 :
+      # we have host which is not accessible. We remove that host from the list.
+      # We only remove if we have more than one instance
+      for i in self.__bannedUrls:
+        gLogger.debug( "Removing banned URL", "%s" % i )
+        urls.remove( i )
+        
+    sURL = List.randomize( urls )[0]
+
     gLogger.debug( "Discovering URL for service", "%s -> %s" % ( self._destinationSrv, sURL ) )
     return S_OK( sURL )
 
@@ -224,7 +243,18 @@ and this is thread %s
       transport = gProtocolDict[ self.__URLTuple[0] ][ 'transport' ]( self.__URLTuple[1:3], **self.kwargs )
       retVal = transport.initAsClient()
       if not retVal[ 'OK' ]:
-        return S_ERROR( "Can't connect to %s: %s" % ( self.serviceURL, retVal ) )
+        if self.__retry < 5:
+          url = "%s://%s:%d/%s" % ( self.__URLTuple[0], self.__URLTuple[1], int( self.__URLTuple[2] ), self.__URLTuple[3] )
+          if url not in self.__bannedUrls: 
+            gLogger.info( "URL banned", "%s" % url )
+            self.__bannedUrls += [url]   
+          self.__retry += 1
+          gLogger.info( "Retry connection: ", "%d" % self.__retry )
+          time.sleep( self.__retryDelay )
+          self.__discoverURL()
+          return self._connect()
+        else:
+          return S_ERROR( "Can't connect to %s: %s" % ( self.serviceURL, retVal ) )
     except Exception, e:
       return S_ERROR( "Can't connect to %s: %s" % ( self.serviceURL, e ) )
     trid = getGlobalTransportPool().add( transport )

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -47,7 +47,7 @@ class BaseClient:
     self.__extraCredentials = ""
     self.__enableThreadCheck = False
     self.__retry = 0
-    self.__retryDelay = 2
+    self.__retryDelay = 0
     self.__bannedUrls = []
     for initFunc in ( self.__discoverSetup, self.__discoverVO, self.__discoverTimeout,
                       self.__discoverURL, self.__discoverCredentialsToUse,
@@ -196,16 +196,11 @@ class BaseClient:
       return S_ERROR( "URL for service %s not found" % self._destinationSrv )
     
     urls = List.fromChar( urls, "," )
-    
-    if len( urls ) == 1:
-      # we run only one service! In that case we increase the retry delay.
-      self.__retryDelay = 5
-    else:
-      self.__retryDelay = 5 / len ( urls )
       
     if len( urls ) == len( self.__bannedUrls ):
       self.__bannedUrls = []  # retry all urls
-      gLogger.debug( "Retrying all URLs" )      
+      self.__retryDelay = 5 / len ( urls )  # we run only one service! In that case we increase the retry delay.
+      gLogger.debug( "Retrying again all URLs" )      
       
     if len( self.__bannedUrls ) > 0 and len( urls ) > 1 :
       # we have host which is not accessible. We remove that host from the list.

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -199,9 +199,9 @@ class BaseClient:
     
     if len( urls ) == 1:
       # we run only one service! In that case we increase the retry delay.
-      self.__retryDelay = 20
+      self.__retryDelay = 5
     else:
-      self.__retryDelay = 10 / len ( urls )
+      self.__retryDelay = 1 / len ( urls )
       
     if len( urls ) == len( self.__bannedUrls ):
       self.__bannedUrls = []  # retry all urls

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -197,6 +197,12 @@ class BaseClient:
     
     urls = List.fromChar( urls, "," )
     
+    if len( urls ) == 1:
+      # we run only one service! In that case we increase the retry delay.
+      self.__retryDelay = 20
+    else:
+      self.__retryDelay = 10 / len ( urls )
+      
     if len( urls ) == len( self.__bannedUrls ):
       self.__bannedUrls = []  # retry all urls
       gLogger.debug( "Retrying all URLs" )      


### PR DESCRIPTION
I have implemented a retry mechanism in DISET. It works as the follow:
We have two URLs A,B in the CS. Lest say B is down.
1. The client try to connect to B. As B is not responding it goes to the banned hosts.
2. Retry the connection using A. 

It retries 5 times and it does not manage to connect to any services than it will fail. 
If we have A,B, and C hosts and all banned, it will retry to all.

I can not explain very well but check in the code.
