### PR TITLE
[v6r14] Task manager plugins

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -1,3 +1,32 @@
+""" This helper looks in the /Operations section of the CS, considering its specific nature:
+    the /Operations section is designed in a way that each configuration can be specific to a Setup, while maintaining a default.
+
+    So, for example, given the following /Operations section:
+    Operations/
+        Default/
+            someSection/
+                someOption = someValue
+                aSecondOption = aSecondValue
+        Production/
+            someSection/
+                someOption = someValueInProduction
+                aSecondOption = aSecondValueInProduction
+        Certification/
+            someSection/
+                someOption = someValueInCertification
+
+    The following calls would give different results based on the setup:
+
+    Operations().getValue('someSection/someOption')
+      -> someValueInProduction if we are in 'Production' setup
+      -> someValueInCertification if we are in 'Certification' setup
+
+    Operations().getValue('someSection/aSecondOption')
+      -> aSecondValueInProduction if we are in 'Production' setup
+      -> aSecondValue if we are in 'Certification' setup     <- looking in Default since there's no Certification/someSection/aSecondOption
+
+"""
+
 import thread
 import types
 import os
@@ -8,12 +37,20 @@ from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationDat
 from DIRAC.Core.Security.ProxyInfo import getVOfromProxyGroup
 
 class Operations( object ):
+  """ Operations class
+
+      The /Operations CFG section is maintained in a cache by an Operations object
+  """
 
   __cache = {}
   __cacheVersion = 0
   __cacheLock = LockRing.LockRing().getLock()
 
   def __init__( self, vo = False, group = False, setup = False ):
+    """ c'tor
+
+        Setting some defaults
+    """
     self.__uVO = vo
     self.__uGroup = group
     self.__uSetup = setup

--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -195,4 +195,43 @@ class Operations( object ):
     return ''  
     
       
-
+  def getSiteMapping( self, resourceType, mapping='' ):
+    """ Get site mapping to resources of a given type 
+    """
+    resultDict = {}
+    
+    if mapping:
+      result = self.getOptions( "SiteTo%sMapping/%s" % ( resourceType, mapping ) )
+      if not result['OK']:
+        return result
+      for site in result['Value']:
+        if site != "UseLocalResources":
+          resultDict[site] = self.getValue( "SiteTo%sMapping/%s/%s" % ( resourceType, mapping, site ), [] )
+      
+    useLocalResources = self.getValue( "SiteTo%sMapping/%s/UseLocalResources" % ( resourceType, mapping), False )
+    if useLocalResources:  
+      reHelper = Resources.Resources( vo = self.__vo )
+      result = reHelper.getEligibleResources( resourceType )
+      if result['OK']:
+        for site in result['Value']:
+          resultDict.setdefault( site, [] )
+          resultDict[site].extend( result['Value'][site] )
+          resultDict[site] = List.uniqueElements( resultDict[site] )
+    
+    return S_OK( resultDict )      
+  
+  def getResourceMapping( self, resourceType, mapping = '' ):
+    """ Get mapping of resources of a given type to sites 
+    """ 
+    result = self.getSiteMapping( resourceType, mapping )
+    if not result['OK']:
+      return result
+    
+    resultDict = {}
+    for site in result['Value']:
+      for resource in result['Value'][site]:
+        resultDict.setdefault( resource, [] )
+        if not site in resultDict[resource]:
+          resultDict[resource].append( site ) 
+    
+    return S_OK( resultDict )        

--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -196,6 +196,30 @@ class Operations( object ):
     
   def getActivityMapping( self, activityType = '' ):
     """ Looks in ActivityMapping section
+
+        The section may looks like this:
+
+        ActivityMapping
+        {
+          User
+          {
+            Exclude = PAK
+            Exclude += Ferrara
+            Exclude += Bologna
+            Exclude += Paris
+            Exclude += CERN
+            Exclude += IN2P3
+            Allow = Paris <- IN2P3
+            Allow += CERN <- CERN
+            Allow += IN2P3 <- IN2P3
+          }
+          Merge
+          {
+            Exclude = ALL
+            Allow = CERN <- CERN
+            Allow += IN2P3 <- IN2P3
+          }
+        }
     """
     if not activityType:
       return S_ERROR( "No activityType specified" )

--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -194,44 +194,14 @@ class Operations( object ):
         return optionPath
     return ''  
     
-      
-  def getSiteMapping( self, resourceType, mapping='' ):
-    """ Get site mapping to resources of a given type 
+  def getActivityMapping( self, activityType = '' ):
+    """ Looks in ActivityMapping section
     """
-    resultDict = {}
-    
-    if mapping:
-      result = self.getOptions( "SiteTo%sMapping/%s" % ( resourceType, mapping ) )
-      if not result['OK']:
-        return result
-      for site in result['Value']:
-        if site != "UseLocalResources":
-          resultDict[site] = self.getValue( "SiteTo%sMapping/%s/%s" % ( resourceType, mapping, site ), [] )
-      
-    useLocalResources = self.getValue( "SiteTo%sMapping/%s/UseLocalResources" % ( resourceType, mapping), False )
-    if useLocalResources:  
-      reHelper = Resources.Resources( vo = self.__vo )
-      result = reHelper.getEligibleResources( resourceType )
-      if result['OK']:
-        for site in result['Value']:
-          resultDict.setdefault( site, [] )
-          resultDict[site].extend( result['Value'][site] )
-          resultDict[site] = List.uniqueElements( resultDict[site] )
-    
-    return S_OK( resultDict )      
-  
-  def getResourceMapping( self, resourceType, mapping = '' ):
-    """ Get mapping of resources of a given type to sites 
-    """ 
-    result = self.getSiteMapping( resourceType, mapping )
-    if not result['OK']:
-      return result
-    
-    resultDict = {}
-    for site in result['Value']:
-      for resource in result['Value'][site]:
-        resultDict.setdefault( resource, [] )
-        if not site in resultDict[resource]:
-          resultDict[resource].append( site ) 
-    
-    return S_OK( resultDict )        
+    if not activityType:
+      return S_ERROR( "No activityType specified" )
+    res = self.getOptionsDict( 'ActivityMapping/%s/' % activityType )
+    if not res['OK']:
+      return res
+    activityMapping = res['Value']
+    # FIXME: here we should add the obvious relation in allow
+    return S_OK( activityMapping )

--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -193,39 +193,3 @@ class Operations( object ):
       if value != "NoValue":
         return optionPath
     return ''  
-    
-  def getActivityMapping( self, activityType = '' ):
-    """ Looks in ActivityMapping section
-
-        The section may looks like this:
-
-        ActivityMapping
-        {
-          User
-          {
-            Exclude = PAK
-            Exclude += Ferrara
-            Exclude += Bologna
-            Exclude += Paris
-            Exclude += CERN
-            Exclude += IN2P3
-            Allow = Paris <- IN2P3
-            Allow += CERN <- CERN
-            Allow += IN2P3 <- IN2P3
-          }
-          Merge
-          {
-            Exclude = ALL
-            Allow = CERN <- CERN
-            Allow += IN2P3 <- IN2P3
-          }
-        }
-    """
-    if not activityType:
-      return S_ERROR( "No activityType specified" )
-    res = self.getOptionsDict( 'ActivityMapping/%s/' % activityType )
-    if not res['OK']:
-      return res
-    activityMapping = res['Value']
-    # FIXME: here we should add the obvious relation in allow
-    return S_OK( activityMapping )

--- a/Core/Utilities/SiteSEMapping.py
+++ b/Core/Utilities/SiteSEMapping.py
@@ -122,7 +122,7 @@ def getSitesForSE( storageElement, gridName = '', withSiteLocalSEMapping = False
 def getSEsForSite( siteName, withSiteLocalSEMapping = False ):
   """ Given a DIRAC site name this method returns a list of corresponding SEs.
   """
-  result = getSiteSEMapping( withSiteLocalSEMapping )
+  result = getSiteSEMapping( withSiteLocalSEMapping = withSiteLocalSEMapping )
   if not result['OK']:
     return result
 

--- a/Core/Utilities/SiteSEMapping.py
+++ b/Core/Utilities/SiteSEMapping.py
@@ -1,8 +1,3 @@
-########################################################################
-# $HeadURL$
-# File :   SiteSEMapping.py
-########################################################################
-
 """  The SiteSEMapping module performs the necessary CS gymnastics to
      resolve site and SE combinations.  These manipulations are necessary
      in several components.

--- a/Core/Utilities/SiteSEMapping.py
+++ b/Core/Utilities/SiteSEMapping.py
@@ -18,7 +18,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 
 
 #############################################################################
-def getSiteSEMapping( gridName = '' ):
+def getSiteSEMapping( gridName = '', withSiteLocalSEMapping = False ):
   """ Returns a dictionary of all sites and their localSEs as a list, e.g.
       {'LCG.CERN.ch':['CERN-RAW','CERN-RDST',...]}
       If gridName is specified, result is restricted to that Grid type.
@@ -45,24 +45,25 @@ def getSiteSEMapping( gridName = '' ):
       if candidateSEs:
         siteSEMapping[candidate] = candidateSEs
 
-  # Add Sites from the SiteLocalSEMapping in the CS
-  cfgLocalSEPath = cfgPath( 'SiteLocalSEMapping' )
-  opsHelper = Operations()
-  result = opsHelper.getOptionsDict( cfgLocalSEPath )
-  if result['OK']:
-    mapping = result['Value']
-    for site in mapping:
-      ses = opsHelper.getValue( cfgPath( cfgLocalSEPath, site ), [] )
-      if not ses:
-        continue
-      if gridName:
-        if gridName != site.split( '.' )[0]:
+  if withSiteLocalSEMapping:
+    # Add Sites from the SiteLocalSEMapping in the CS
+    cfgLocalSEPath = cfgPath( 'SiteLocalSEMapping' )
+    opsHelper = Operations()
+    result = opsHelper.getOptionsDict( cfgLocalSEPath )
+    if result['OK']:
+      mapping = result['Value']
+      for site in mapping:
+        ses = opsHelper.getValue( cfgPath( cfgLocalSEPath, site ), [] )
+        if not ses:
           continue
-      if site not in siteSEMapping:
-        siteSEMapping[site] = []
-      for se in ses:
-        if se not in siteSEMapping[site]:
-          siteSEMapping[site].append( se )
+        if gridName:
+          if gridName != site.split( '.' )[0]:
+            continue
+        if site not in siteSEMapping:
+          siteSEMapping[site] = []
+        for se in ses:
+          if se not in siteSEMapping[site]:
+            siteSEMapping[site].append( se )
 
   return S_OK( siteSEMapping )
 
@@ -103,12 +104,12 @@ def getSESiteMapping( gridName = '' ):
   return S_OK( seSiteMapping )
 
 #############################################################################
-def getSitesForSE( storageElement, gridName = '' ):
+def getSitesForSE( storageElement, gridName = '', withSiteLocalSEMapping = False ):
   """ Given a DIRAC SE name this method returns a list of corresponding sites.
       Optionally restrict to Grid specified by name.
   """
 
-  result = getSiteSEMapping( gridName )
+  result = getSiteSEMapping( gridName, withSiteLocalSEMapping )
   if not result['OK']:
     return result
 
@@ -123,10 +124,10 @@ def getSitesForSE( storageElement, gridName = '' ):
 
 
 #############################################################################
-def getSEsForSite( siteName ):
+def getSEsForSite( siteName, withSiteLocalSEMapping = False ):
   """ Given a DIRAC site name this method returns a list of corresponding SEs.
   """
-  result = getSiteSEMapping()
+  result = getSiteSEMapping( withSiteLocalSEMapping )
   if not result['OK']:
     return result
 
@@ -308,7 +309,6 @@ def getTier1WithTier2( siteName = '' ):
   """
   It returns the T1 sites with the attached T2 using the SiteLocalSEMapping
   """
-  tier1andTier2Maps = {}
   retVal = Operations().getOptionsDict( 'SiteLocalSEMapping' )
   if not retVal['OK']:
     return retVal

--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -43,13 +43,14 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
 
     self.transClient = None
     self.transType = []
-    self.pluginLocation = ''
 
     self.tasksPerLoop = 50
 
     self.owner = ''
     self.ownerGroup = ''
     self.ownerDN = ''
+
+    self.pluginLocation = ''
 
     # for the threading
     self.transQueue = Queue()
@@ -234,6 +235,7 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
     """
     threadTransformationClient = TransformationClient()
     threadTaskManager = WorkflowTasks()  # this is for wms tasks, replace it with something else if needed
+    threadTaskManager.pluginLocation = self.pluginLocation
 
     return {'TransformationClient': threadTransformationClient, 
             'TaskManager': threadTaskManager}

--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -43,6 +43,7 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
 
     self.transClient = None
     self.transType = []
+    self.pluginLocation = ''
 
     self.tasksPerLoop = 50
 
@@ -68,6 +69,8 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
 
     gMonitor.registerActivity( "SubmittedTasks", "Automatically submitted tasks", "Transformation Monitoring", "Tasks",
                                gMonitor.OP_ACUM )
+
+    self.pluginLocation = self.am_getOption( 'PluginLocation', 'DIRAC.TransformationSystem.Client.TaskManagerPlugin' )
 
     # Default clients
     self.transClient = TransformationClient()

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -601,8 +601,8 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
         fileName = self.cacheFile
         cacheFile = open( fileName, 'r' )
         cache = pickle.load( cacheFile )
-        for id in [id for id in cache if id not in self.replicaCache]:
-          self.replicaCache[id] = cache[id]
+        for t_id in [t_id for t_id in cache if t_id not in self.replicaCache]:
+          self.replicaCache[t_id] = cache[t_id]
         self.replicaCache[transID] = cache.get( transID, {} )
       else:
         cacheFile = open( fileName, 'r' )
@@ -630,14 +630,14 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
       transList = [transID] if transID else set( self.replicaCache )
       filesInCache = 0
       nCache = 0
-      for id in transList:
+      for t_id in transList:
         # Protect the copy of the cache
-        filesInCache += self.__filesInCache( id )
+        filesInCache += self.__filesInCache( t_id )
         # write to a temporary file in order to avoid corrupted files
-        cacheFile = self.__cacheFile( id )
+        cacheFile = self.__cacheFile( t_id )
         tmpFile = cacheFile + '.tmp'
         f = open( tmpFile, 'w' )
-        pickle.dump( self.replicaCache.get( id, {} ), f )
+        pickle.dump( self.replicaCache.get( t_id, {} ), f )
         f.close()
         # Now rename the file as it shold
         os.rename( tmpFile, cacheFile )
@@ -647,7 +647,7 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
                      method = method, transID = transID if transID else None )
     except Exception:
       self._logException( "Could not write replica cache file %s" % cacheFile,
-                          method = method, transID = id )
+                          method = method, transID = t_id )
 
   def __generatePluginObject( self, plugin, clients ):
     """ This simply instantiates the TransformationPlugin class with the relevant plugin name

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -268,7 +268,7 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
     oPlugin.setParameters( transDict )
     oPlugin.setInputData( dataReplicas )
     oPlugin.setTransformationFiles( transFiles )
-    res = oPlugin.generateTasks()
+    res = oPlugin.run()
     if not res['OK']:
       self._logError( "Failed to generate tasks for transformation:", res['Message'],
                        method = "processTransformation", transID = transID )

--- a/TransformationSystem/Agent/TransformationPlugin.py
+++ b/TransformationSystem/Agent/TransformationPlugin.py
@@ -1,19 +1,19 @@
 """  TransformationPlugin is a class wrapping the supported transformation plugins
 """
-import re
 import random
 
 from DIRAC                              import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.SiteSEMapping import getSitesForSE, getSEsForSite
 from DIRAC.Core.Utilities.List          import breakListIntoChunks
 
+from DIRAC.TransformationSystem.Client.Plugins import Plugins
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.Resources.Catalog.FileCatalog  import FileCatalog
 
 __RCSID__ = "$Id$"
 
-class TransformationPlugin( object ):
+class TransformationPlugin( Plugins ):
   """ A TransformationPlugin object should be instantiated by every transformation.
   """
 
@@ -21,9 +21,9 @@ class TransformationPlugin( object ):
     """ plugin name has to be passed in: it will then be executed as one of the functions below, e.g.
         plugin = 'BySize' will execute TransformationPlugin('BySize')._BySize()
     """
-    self.params = {}
+    super( TransformationPlugin, self ).__init__( plugin )
+
     self.data = {}
-    self.plugin = plugin
     self.files = False
     if transClient is None:
       self.transClient = TransformationClient()
@@ -49,24 +49,6 @@ class TransformationPlugin( object ):
 
   def setTransformationFiles( self, files ): #TODO ADDED
     self.files = files
-
-  def setParameters( self, params ):
-    self.params = params
-
-  def generateTasks( self ):
-    """ this is a wrapper to invoke the plugin (self._%s()" % self.plugin)
-    """
-    try:
-      evalString = "self._%s()" % self.plugin
-      return eval( evalString )
-    except AttributeError, x:
-      if re.search( self.plugin, str( x ) ):
-        return S_ERROR( "Plugin not found" )
-      else:
-        raise AttributeError, x
-    except Exception, x:
-      gLogger.exception()
-      raise Exception, x
 
   def _Standard( self ):
     """ Simply group by replica location

--- a/TransformationSystem/Client/Plugins.py
+++ b/TransformationSystem/Client/Plugins.py
@@ -2,7 +2,6 @@
 """
 
 import re
-import ast
 
 from DIRAC import S_ERROR, gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
@@ -31,7 +30,7 @@ class Plugins( object ):
     """
     try:
       evalString = "self._%s()" % self.plugin
-      return ast.literal_eval( evalString )
+      return eval( evalString )
     except AttributeError, x:
       if re.search( self.plugin, str( x ) ):
         return S_ERROR( "Plugin not found" )

--- a/TransformationSystem/Client/Plugins.py
+++ b/TransformationSystem/Client/Plugins.py
@@ -1,0 +1,43 @@
+""" Base class for plugins as used in the transformation system
+"""
+
+import re
+import ast
+
+from DIRAC import S_ERROR, gLogger
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+
+class Plugins( object ):
+  
+  def __init__( self, plugin, transClient = None, operationsHelper = None ):
+    """ plugin name has to be passed in: it will then be executed as one of the functions below, e.g.
+        plugin = 'BySize' will execute TransformationPlugin('BySize')._BySize()
+    """
+    self.plugin = plugin
+    self.params = {}
+
+    if not operationsHelper:
+      self.opsH = Operations()
+    else:
+      self.opsH = operationsHelper
+
+  def setParameters( self, params ):
+    """ Extensions may re-define it
+    """
+    self.params = params
+
+  def run( self ):
+    """ this is a wrapper to invoke the plugin (self._%s()" % self.plugin)
+    """
+    try:
+      evalString = "self._%s()" % self.plugin
+      return ast.literal_eval( evalString )
+    except AttributeError, x:
+      if re.search( self.plugin, str( x ) ):
+        return S_ERROR( "Plugin not found" )
+      else:
+        raise AttributeError, x
+    except Exception, x:
+      gLogger.exception( x )
+      raise Exception, x
+

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -340,6 +340,8 @@ class WorkflowTasks( TaskBase ):
     else:
       self.destinationPlugin = destinationPlugin
 
+    self.destinationPlugin_o = None
+
   def prepareTransformationTasks( self, transBody, taskDict, owner = '', ownerGroup = '', ownerDN = '' ):
     """ Prepare tasks, given a taskDict, that is created (with some manipulation) by the DB
         jobClass is by default "DIRAC.Interfaces.API.Job.Job". An extension of it also works.
@@ -417,7 +419,7 @@ class WorkflowTasks( TaskBase ):
 
   #############################################################################
 
-  def _handleDestination( self, paramsDict, getSitesForSE = None, activityType = '' ):
+  def _handleDestination( self, paramsDict ):
     """ Handle Sites and TargetSE in the parameters
     """
 
@@ -429,17 +431,18 @@ class WorkflowTasks( TaskBase ):
     except KeyError:
       pass
 
-    res = self.__generatePluginObject( self.destinationPlugin )
-    if not res['OK']:
-      self.log.fatal( 'Could not generate a destination plugin object' )
-
-    self.destinationPlugin_o = res['Value']
-    self.destinationPlugin_o.setParameters( paramsDict )
+    if not self.destinationPlugin_o:
+      res = self.__generatePluginObject( self.destinationPlugin )
+      if not res['OK']:
+        self.log.fatal( "Could not generate a destination plugin object" )
+        return res
+      self.destinationPlugin_o = res['Value']
+      self.destinationPlugin_o.setParameters( paramsDict )
 
     destSites = self.destinationPlugin_o.run()
     if not destSites:
       return sites
-    print "AAAAAAAAAAAA", destSites
+
     # Now we need to make the AND with the sites, if defined
     if sites != ['ANY']:
       # Need to get the AND

--- a/TransformationSystem/Client/TaskManagerPlugin.py
+++ b/TransformationSystem/Client/TaskManagerPlugin.py
@@ -1,0 +1,90 @@
+""" Container for TaskManager plug-ins, to handle the destination of the tasks
+"""
+
+from DIRAC import S_OK, S_ERROR
+
+from DIRAC.Core.Utilities.List import fromChar
+from DIRAC.Core.Utilities.SiteSEMapping import getSitesForSE
+from DIRAC.TransformationSystem.Client.Plugins import Plugins
+
+
+class TaskManagerPlugin( Plugins ):
+  """ A TaskManagerPlugin object should be instantiated by every TaskManager object.
+  
+      self.params here could be 
+      {'Status': 'Created', 'TargetSE': 'Unknown', 'TransformationID': 1086L, 'RunNumber': 0L, 
+      'Site': 'DIRAC.Test.ch', 'TaskID': 21L, 'InputData': '', 'JobType': 'MCSimulation'}
+      which corresponds to paramsDict in TaskManager (which is in fact a tasks dict)
+  """
+
+  def _BySE( self ):
+    """ Matches using TargetSE. This is the standard plugin.
+    """
+
+    destSites = set()
+
+    try:
+      seList = ['Unknown']
+      if self.params['TargetSE']:
+        seList = fromChar( self.params['TargetSE'] )
+    except KeyError:
+      pass
+
+    if not seList or seList == ['Unknown']:
+      return destSites
+    
+    for se in self.params['TargetSEs']:
+      res = getSitesForSE( se )
+      if not res['OK']:
+        self.log.warn( "Could not get Sites associated to SE", res['Message'] )
+      else:
+        thisSESites = res['Value']
+        if thisSESites:
+          # We make an OR of the possible sites
+          destSites.update( thisSESites )
+          
+    return destSites
+    
+
+  def _ByJobType( self ):
+    """ Looks in ActivityMapping section
+
+        The section may look like this:
+
+        ActivityMapping
+        {
+          User
+          {
+            Exclude = PAK
+            Exclude += Ferrara
+            Exclude += Bologna
+            Exclude += Paris
+            Exclude += CERN
+            Exclude += IN2P3
+            Allow = Paris <- IN2P3
+            Allow += CERN <- CERN
+            Allow += IN2P3 <- IN2P3
+          }
+          Merge
+          {
+            Exclude = ALL
+            Allow = CERN <- CERN
+            Allow += IN2P3 <- IN2P3
+          }
+        }
+        
+        Then it will look into...
+        
+        
+    """
+    jobType = self.params['JobType']
+    if not jobType:
+      return S_ERROR( "No jobType specified" )
+    res = self.opsH.getOptionsDict( 'JobTypeMapping/%s/' % jobType )
+    if not res['OK']:
+      self.log.error( "Could not get mapping by job type", res['Message'] )
+      return res
+    jobTypeMapping = res['Value']
+    # FIXME: here we should add the obvious relation in allow
+    return S_OK( jobTypeMapping )
+

--- a/TransformationSystem/Client/TaskManagerPlugin.py
+++ b/TransformationSystem/Client/TaskManagerPlugin.py
@@ -1,7 +1,7 @@
 """ Container for TaskManager plug-ins, to handle the destination of the tasks
 """
 
-from DIRAC import S_OK, S_ERROR, gLogger
+from DIRAC import gLogger
 
 from DIRAC.Core.Utilities.List import fromChar
 from DIRAC.Core.Utilities.SiteSEMapping import getSitesForSE
@@ -108,7 +108,7 @@ class TaskManagerPlugin( Plugins ):
     # 2. get JobTypeMapping "Exclude" value (and add autoAddedSites)
     jobType = self.params['JobType']
     if not jobType:
-      return S_ERROR( "No jobType specified" )
+      raise RuntimeError( "No jobType specified" )
     excludedSites = self.opsH.getValue( 'JobTypeMapping/%s/Exclude' % jobType, '' )
     excludedSites = excludedSites + ',' + ','.join( fromChar( self.opsH.getValue( 'JobTypeMapping/AutoAddedSites', '' ) ) )
 

--- a/TransformationSystem/Client/TaskManagerPlugin.py
+++ b/TransformationSystem/Client/TaskManagerPlugin.py
@@ -26,14 +26,17 @@ class TaskManagerPlugin( Plugins ):
     try:
       seList = ['Unknown']
       if self.params['TargetSE']:
-        seList = fromChar( self.params['TargetSE'] )
+        if type( self.params['TargetSE'] ) == type( '' ):
+          seList = fromChar( self.params['TargetSE'] )
+        elif type( self.params['TargetSE'] ) == type( [] ):
+          seList = self.params['TargetSE']
     except KeyError:
       pass
 
     if not seList or seList == ['Unknown']:
       return destSites
     
-    for se in self.params['TargetSEs']:
+    for se in seList:
       res = getSitesForSE( se )
       if not res['OK']:
         self.log.warn( "Could not get Sites associated to SE", res['Message'] )

--- a/TransformationSystem/Client/test/test_Client.py
+++ b/TransformationSystem/Client/test/test_Client.py
@@ -1,10 +1,12 @@
 import unittest, types
 
-from mock import Mock, MagicMock
+from mock import MagicMock
+
 from DIRAC.RequestManagementSystem.Client.Request             import Request
 from DIRAC.TransformationSystem.Client.TaskManager            import TaskBase, WorkflowTasks, RequestTasks
 from DIRAC.TransformationSystem.Client.TransformationClient   import TransformationClient
 from DIRAC.TransformationSystem.Client.Transformation         import Transformation
+from DIRAC.TransformationSystem.Client.TaskManagerPlugin      import TaskManagerPlugin
 
 def getSitesForSE( ses ):
   if ses == 'pippo':
@@ -19,17 +21,17 @@ class ClientsTestCase( unittest.TestCase ):
   """
   def setUp( self ):
 
-    self.mockTransClient = Mock()
+    self.mockTransClient = MagicMock()
     self.mockTransClient.setTaskStatusAndWmsID.return_value = {'OK':True}
 
-    self.WMSClientMock = Mock()
-    self.jobMonitoringClient = Mock()
-    self.mockReqClient = Mock()
+    self.WMSClientMock = MagicMock()
+    self.jobMonitoringClient = MagicMock()
+    self.mockReqClient = MagicMock()
 
-    self.jobMock = Mock()
-    self.jobMock2 = Mock()
-    mockWF = Mock()
-    mockPar = Mock()
+    self.jobMock = MagicMock()
+    self.jobMock2 = MagicMock()
+    mockWF = MagicMock()
+    mockPar = MagicMock()
     mockWF.findParameter.return_value = mockPar
     mockPar.getValue.return_value = 'MySite'
 
@@ -45,8 +47,12 @@ class ClientsTestCase( unittest.TestCase ):
                                   outputDataModule = "mock",
                                   jobClass = self.jobMock )
     self.requestTasks = RequestTasks( transClient = self.mockTransClient,
+<<<<<<< HEAD
                                       requestClient = self.mockReqClient,
                                       requestValidator = MagicMock() )
+=======
+                                      requestClient = self.mockReqClient )
+>>>>>>> ede5c20... Several bug fixes by running the unittest
     self.tc = TransformationClient()
     self.transformation = Transformation()
 
@@ -87,27 +93,34 @@ class WorkflowTasksSuccess( ClientsTestCase ):
                             }
                     )
 
-  def test__handleDestination( self ):
-    res = self.wfTasks._handleDestination( {'Site':'', 'TargetSE':''} )
-    self.assertEqual( res, ['ANY'] )
-    res = self.wfTasks._handleDestination( {'Site':'ANY', 'TargetSE':''} )
-    self.assertEqual( res, ['ANY'] )
-    res = self.wfTasks._handleDestination( {'TargetSE':'Unknown'} )
-    self.assertEqual( res, ['ANY'] )
-    res = self.wfTasks._handleDestination( {'Site':'Site1;Site2', 'TargetSE':''} )
-    self.assertEqual( res, ['Site1', 'Site2'] )
-    res = self.wfTasks._handleDestination( {'Site':'Site1;Site2', 'TargetSE':'pippo'}, getSitesForSE )
-    self.assertEqual( res, ['Site2'] )
-    res = self.wfTasks._handleDestination( {'Site':'Site1;Site2', 'TargetSE':'pippo, pluto'}, getSitesForSE )
-    self.assertEqual( res, ['Site2'] )
-    res = self.wfTasks._handleDestination( {'Site':'Site1;Site2;Site3', 'TargetSE':'pippo, pluto'}, getSitesForSE )
-    self.assertEqual( res, ['Site2', 'Site3'] )
-    res = self.wfTasks._handleDestination( {'Site':'Site2', 'TargetSE':'pippo, pluto'}, getSitesForSE )
-    self.assertEqual( res, ['Site2'] )
-    res = self.wfTasks._handleDestination( {'Site':'ANY', 'TargetSE':'pippo, pluto'}, getSitesForSE )
-    self.assertEqual( res, ['Site2', 'Site3'] )
-    res = self.wfTasks._handleDestination( {'Site':'Site1', 'TargetSE':'pluto'}, getSitesForSE )
-    self.assertEqual( res, [] )
+#############################################################################
+
+class TaskManagerPluginSuccess(ClientsTestCase):
+
+  def test__BySE( self ):
+    res = TaskManagerPlugin( 'BySE', operationsHelper = MagicMock() )
+
+
+#     res = self.wfTasks._handleDestination( {'Site':'', 'TargetSE':''} )
+#     self.assertEqual( res, ['ANY'] )
+#     res = self.wfTasks._handleDestination( {'Site':'ANY', 'TargetSE':''} )
+#     self.assertEqual( res, ['ANY'] )
+#     res = self.wfTasks._handleDestination( {'TargetSE':'Unknown'} )
+#     self.assertEqual( res, ['ANY'] )
+#     res = self.wfTasks._handleDestination( {'Site':'Site1;Site2', 'TargetSE':''} )
+#     self.assertEqual( res, ['Site1', 'Site2'] )
+#     res = self.wfTasks._handleDestination( {'Site':'Site1;Site2', 'TargetSE':'pippo'}, getSitesForSE )
+#     self.assertEqual( res, ['Site2'] )
+#     res = self.wfTasks._handleDestination( {'Site':'Site1;Site2', 'TargetSE':'pippo, pluto'}, getSitesForSE )
+#     self.assertEqual( res, ['Site2'] )
+#     res = self.wfTasks._handleDestination( {'Site':'Site1;Site2;Site3', 'TargetSE':'pippo, pluto'}, getSitesForSE )
+#     self.assertEqual( res, ['Site2', 'Site3'] )
+#     res = self.wfTasks._handleDestination( {'Site':'Site2', 'TargetSE':'pippo, pluto'}, getSitesForSE )
+#     self.assertEqual( res, ['Site2'] )
+#     res = self.wfTasks._handleDestination( {'Site':'ANY', 'TargetSE':'pippo, pluto'}, getSitesForSE )
+#     self.assertEqual( res, ['Site2', 'Site3'] )
+#     res = self.wfTasks._handleDestination( {'Site':'Site1', 'TargetSE':'pluto'}, getSitesForSE )
+#     self.assertEqual( res, [] )
 
 #############################################################################
 

--- a/TransformationSystem/Client/test/test_Client.py
+++ b/TransformationSystem/Client/test/test_Client.py
@@ -108,12 +108,8 @@ class ClientsTestCase( unittest.TestCase ):
                                   outputDataModule = "mock",
                                   jobClass = self.jobMock )
     self.requestTasks = RequestTasks( transClient = self.mockTransClient,
-<<<<<<< HEAD
                                       requestClient = self.mockReqClient,
                                       requestValidator = MagicMock() )
-=======
-                                      requestClient = self.mockReqClient )
->>>>>>> ede5c20... Several bug fixes by running the unittest
     self.tc = TransformationClient()
     self.transformation = Transformation()
 

--- a/TransformationSystem/Client/test/test_Client.py
+++ b/TransformationSystem/Client/test/test_Client.py
@@ -1,5 +1,7 @@
 import unittest, types, importlib
 
+from DIRAC import S_OK
+
 from mock import MagicMock
 
 from DIRAC.RequestManagementSystem.Client.Request             import Request
@@ -8,11 +10,67 @@ from DIRAC.TransformationSystem.Client.TransformationClient   import Transformat
 from DIRAC.TransformationSystem.Client.Transformation         import Transformation
 from DIRAC.TransformationSystem.Client.TaskManagerPlugin      import TaskManagerPlugin
 
+class opsHelperFakeUser( object ):
+  def getValue( self, foo = '', bar = '' ):
+    if foo == 'JobTypeMapping/AutoAddedSites':
+      return 'CERN, IN2P3'
+    return 'PAK, Ferrara, Bologna, Paris'
+  def getOptionsDict( self, foo = '' ):
+    return {'OK': True, 'Value': {'Paris': 'IN2P3'}}
+
+class opsHelperFakeUser2( object ):
+  def getValue( self, foo = '', bar = '' ):
+    if foo == 'JobTypeMapping/AutoAddedSites':
+      return ''
+    return 'PAK, Ferrara, Bologna, Paris, CERN, IN2P3'
+  def getOptionsDict( self, foo = '' ):
+    return {'OK': True, 'Value': {'Paris': 'IN2P3', 'CERN': 'CERN', 'IN2P3':'IN2P3'}}
+
+class opsHelperFakeDataReco( object ):
+  def getValue( self, foo = '', bar = '' ):
+    if foo == 'JobTypeMapping/AutoAddedSites':
+      return 'CERN, IN2P3'
+    return 'PAK, Ferrara, CERN, IN2P3'
+  def getOptionsDict(self, foo = ''):
+    return {'OK': True, 'Value': {'Ferrara': 'CERN', 'IN2P3': 'IN2P3, CERN'}}
+
+class opsHelperFakeMerge( object ):
+  def getValue( self, foo = '', bar = '' ):
+    if foo == 'JobTypeMapping/AutoAddedSites':
+      return 'CERN, IN2P3'
+    return 'ALL'
+  def getOptionsDict( self, foo = '' ):
+    return {'OK': False, 'Message': 'JobTypeMapping/MCSimulation/Allow in Operations does not exist'}
+
+class opsHelperFakeMerge2( object ):
+  def getValue( self, foo = '', bar = '' ):
+    if foo == 'JobTypeMapping/AutoAddedSites':
+      return ''
+    return 'ALL'
+  def getOptionsDict( self, foo = '' ):
+    return {'OK': True, 'Value': {'CERN': 'CERN', 'IN2P3': 'IN2P3'}}
+
+class opsHelperFakeMC( object ):
+  def getValue( self, foo = '', bar = '' ):
+    if foo == 'JobTypeMapping/AutoAddedSites':
+      return 'CERN, IN2P3'
+    return ''
+  def getOptionsDict( self, foo = '' ):
+    return {'OK': False, 'Message': 'JobTypeMapping/MCSimulation/Allow in Operations does not exist'}
+
+
+def getSitesFake():
+  return S_OK( ['Ferrara', 'Bologna', 'Paris', 'CSCS', 'PAK', 'CERN', 'IN2P3'] )
+
 def getSitesForSE( ses ):
-  if ses == 'pippo':
-    return {'OK':True, 'Value':['Site2', 'Site3']}
-  else:
-    return {'OK':True, 'Value':['Site3']}
+  if ses == ['CERN-DST'] or ses == 'CERN-DST':
+    return S_OK( ['CERN'] )
+  elif ses == ['IN2P3-DST'] or ses == 'IN2P3-DST':
+    return S_OK( ['IN2P3'] )
+  elif ses == ['CSCS-DST'] or ses == 'CSCS-DST':
+    return S_OK( ['CSCS'] )
+  elif ses == ['CERN-DST', 'CSCS-DST'] or ses == 'CERN-DST,CSCS-DST':
+    return S_OK( ['CERN', 'CSCS'] )
 
 #############################################################################
 
@@ -20,6 +78,9 @@ class ClientsTestCase( unittest.TestCase ):
   """ Base class for the clients test cases
   """
   def setUp( self ):
+
+    from DIRAC import gLogger
+    gLogger.setLevel( 'DEBUG' )
 
     self.mockTransClient = MagicMock()
     self.mockTransClient.setTaskStatusAndWmsID.return_value = {'OK':True}
@@ -57,7 +118,6 @@ class ClientsTestCase( unittest.TestCase ):
     self.transformation = Transformation()
 
     self.maxDiff = None
-
 
   def tearDown( self ):
     pass
@@ -160,21 +220,103 @@ class TaskManagerPluginSuccess(ClientsTestCase):
     res = p_o.run()
     self.assertEqual( res, set( [] ) )
 
-    p_o.params = {'TargetSE':'pippo'}
+    p_o.params = {'TargetSE':'CERN-DST'}
     res = p_o.run()
-    self.assertEqual( res, set( ['Site2', 'Site3'] ) )
+    self.assertEqual( res, set( ['CERN'] ) )
 
-    p_o.params = {'TargetSE':'pluto'}
+    p_o.params = {'TargetSE':'IN2P3-DST'}
     res = p_o.run()
-    self.assertEqual( res, set( ['Site3'] ) )
+    self.assertEqual( res, set( ['IN2P3'] ) )
 
-    p_o.params = {'TargetSE':'pippo,pluto'}
+    p_o.params = {'TargetSE':'CERN-DST,CSCS-DST'}
     res = p_o.run()
-    self.assertEqual( res, set( ['Site2', 'Site3'] ) )
+    self.assertEqual( res, set( ['CERN', 'CSCS'] ) )
 
-    p_o.params = {'TargetSE':['pippo', 'pluto']}
+    p_o.params = {'TargetSE':['CERN-DST', 'CSCS-DST']}
     res = p_o.run()
-    self.assertEqual( res, set( ['Site2', 'Site3'] ) )
+    self.assertEqual( res, set( ['CERN', 'CSCS'] ) )
+
+
+  def test__ByJobType( self ):
+
+    ourPG = importlib.import_module( 'DIRAC.TransformationSystem.Client.TaskManagerPlugin' )
+    ourPG.getSites = getSitesFake
+    ourPG.getSitesForSE = getSitesForSE
+
+    # "User" case - 1
+    p_o = TaskManagerPlugin( 'ByJobType', operationsHelper = opsHelperFakeUser() )
+
+    p_o.params = {'Site':'', 'TargetSE':'CERN-DST', 'JobType':'User'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['CERN', 'CSCS'] ) )
+
+    p_o.params = {'Site':'', 'TargetSE':'IN2P3-DST', 'JobType':'User'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['IN2P3', 'Paris', 'CSCS'] ) )
+
+    p_o.params = {'Site':'', 'TargetSE':['CERN-DST', 'CSCS-DST'], 'JobType':'User'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['CERN', 'CSCS'] ) )
+
+    # "User" case - 2
+    p_o = TaskManagerPlugin( 'ByJobType', operationsHelper = opsHelperFakeUser2() )
+
+    p_o.params = {'Site':'', 'TargetSE':'CERN-DST', 'JobType':'User'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['CERN', 'CSCS'] ) )
+
+    p_o.params = {'Site':'', 'TargetSE':'IN2P3-DST', 'JobType':'User'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['IN2P3', 'Paris', 'CSCS'] ) )
+
+    p_o.params = {'Site':'', 'TargetSE':['CERN-DST', 'CSCS-DST'], 'JobType':'User'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['CERN', 'CSCS'] ) )
+
+    # "DataReconstruction" case
+    p_o = TaskManagerPlugin( 'ByJobType', operationsHelper = opsHelperFakeDataReco() )
+
+    p_o.params = {'Site':'', 'TargetSE':'CERN-DST', 'JobType':'DataReconstruction'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['Bologna', 'Ferrara', 'Paris', 'CSCS', 'CERN', 'IN2P3'] ) )
+
+    p_o.params = {'Site':'', 'TargetSE':'IN2P3-DST', 'JobType':'DataReconstruction'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['Bologna', 'Paris', 'CSCS', 'IN2P3'] ) )
+
+
+    # "Merge" case - 1
+    p_o = TaskManagerPlugin( 'ByJobType', operationsHelper = opsHelperFakeMerge() )
+
+    p_o.params = {'Site':'', 'TargetSE':'CERN-DST', 'JobType':'Merge'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['CERN'] ) )
+
+    p_o.params = {'Site':'', 'TargetSE':'IN2P3-DST', 'JobType':'Merge'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['IN2P3'] ) )
+
+    # "Merge" case - 2
+    p_o = TaskManagerPlugin( 'ByJobType', operationsHelper = opsHelperFakeMerge2() )
+
+    p_o.params = {'Site':'', 'TargetSE':'CERN-DST', 'JobType':'Merge'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['CERN'] ) )
+
+    p_o.params = {'Site':'', 'TargetSE':'IN2P3-DST', 'JobType':'Merge'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['IN2P3'] ) )
+
+    # "MC" case
+    p_o = TaskManagerPlugin( 'ByJobType', operationsHelper = opsHelperFakeMC() )
+
+    p_o.params = {'Site':'', 'TargetSE':'', 'JobType':'MC'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['CERN', 'IN2P3', 'Bologna', 'Ferrara', 'Paris', 'CSCS', 'PAK'] ) )
+
+    p_o.params = {'Site':'', 'TargetSE':'', 'JobType':'MC'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['CERN', 'IN2P3', 'Bologna', 'Ferrara', 'Paris', 'CSCS', 'PAK'] ) )
 
 
 #############################################################################


### PR DESCRIPTION
I added a task manager plugins mechanism. I introduced a base plugin class simply named "Plugins" and "TransformationPlugins" inherits from it. Also the new "TaskManagerPlugin" inherits from it. The method "generateTasks" has been renamed simply "run" (this may affect extensions, we need to pay attention to that). 

The plugins for TaskManager are 2, and define how the list of destination sites is created: "BySE" and "ByJobType". By default nothing changes, as for using a plugin that is not "BySE" VOs need to explicitely set a CS entry (/Operations/<Setup>/Transformations/DestinationPlugin) and at the moment the value can only be "ByJobType" other then "BySE". 
If "ByJobType" is selected, the CS section "JobTypeMapping" in Operations have to be present. A list of exclusions and allowance can define how each and every job can be routed based on its type. A proper configuration can allow any kind of computing model. Special flags like "ALL" can be specified. 