### PR TITLE
[v6r12] certif dfc 2

### DIFF
--- a/ConfigurationSystem/private/Refresher.py
+++ b/ConfigurationSystem/private/Refresher.py
@@ -143,6 +143,11 @@ class Refresher( threading.Thread ):
     else:
       lInitialListOfServers = gConfigurationData.getServers()
       gLogger.debug( "Refreshing from list %s" % str( lInitialListOfServers ) )
+
+    # If no servers in the initial list, we are supposed to use the local configuration only
+    if not lInitialListOfServers:
+      return S_OK()
+
     lRandomListOfServers = List.randomize( lInitialListOfServers )
     gLogger.debug( "Randomized server list is %s" % ", ".join( lRandomListOfServers ) )
 

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryLevelTree.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryLevelTree.py
@@ -246,6 +246,9 @@ class DirectoryLevelTree(DirectoryTreeBase):
     dirs = dirIDList
     if type(dirIDList) != ListType:
       dirs = [dirIDList]
+
+    if not dirs:
+      return S_OK( {} )
       
     dirListString = ','.join( [ str( d ) for d in dirs ] )
 

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
@@ -9,7 +9,7 @@ from DIRAC.Core.Utilities.List              import intListToString
 from DIRAC.Core.Utilities.Pfn               import pfnparse, pfnunparse
 
 import os, stat
-from types import ListType, StringTypes
+from types import ListType, StringTypes, DictType
 
 class FileManagerBase( object ):
 
@@ -114,6 +114,11 @@ class FileManagerBase( object ):
 
   def _getFileIDFromGUID( self, guid, connection = False ):
     """To be implemented on derived class
+    """
+    return S_ERROR( "To be implemented on derived class" )
+
+  def getLFNForGUID( self, guids, connection = False ):
+    """Returns the LFN matching a given GUID
     """
     return S_ERROR( "To be implemented on derived class" )
 
@@ -271,7 +276,9 @@ class FileManagerBase( object ):
 
     # If GUIDs are supposed to be unique check their pre-existance 
     if self.db.uniqueGUID:
+      print "unique ? "
       fail = self._checkUniqueGUID( masterLfns, connection = connection )
+      print fail
       failed.update( fail )
       for lfn in fail:
         masterLfns.pop( lfn )
@@ -625,12 +632,14 @@ class FileManagerBase( object ):
     return successful, failed
 
   def _checkUniqueGUID( self, lfns, connection = False ):
+    print "lfns %s" % lfns
     connection = self._getConnection( connection )
     guidLFNs = {}
     failed = {}
     for lfn, fileDict in lfns.items():
       guidLFNs[fileDict['GUID']] = lfn
     res = self._getFileIDFromGUID( guidLFNs.keys(), connection = connection )
+    print "res %s" % res
     if not res['OK']:
       return dict.fromkeys( lfns, res['Message'] )
     for guid, fileID in res['Value'].items():
@@ -883,7 +892,43 @@ class FileManagerBase( object ):
     for lfn in successful:
       successful[lfn] = lfn
     failed = {}
+
+    if self.db.uniqueGUID:
+      guidList = []
+      val = None
+      #Try to identify if the GUID is given
+      # We consider only 2 options :
+      # either {lfn : guid}
+      # or P lfn : {PFN : .., GUID : ..} }
+      if type( lfns ) == DictType:
+        val = lfns.values()
+
+      # We have values, take the first to identify the type
+      if val:
+        val = val[0]
+
+      if type( val ) == DictType and 'GUID' in val:
+        # We are in the case {lfn : {PFN:.., GUID:..}}
+        guidList = [lfns[lfn]['GUID'] for lfn in lfns]
+        pass
+      elif type( val ) == StringTypes:
+        # We hope that it is the GUID which is given
+        guidList = lfns.values()
+
+
+      if guidList:
+        # A dict { guid: lfn to which it is supposed to be associated }
+        guidToGivenLfn = dict( zip( guidList, lfns ) )
+        guidLfns = self.getLFNForGUID( guidList, connection )
+        for guid, realLfn in guidLfns.items():
+          successful[guidToGivenLfn[guid]] = realLfn
+
+        
+    
     for lfn, error in res['Value']['Failed'].items():
+      # It could be in successful because the guid exists with another lfn
+      if lfn in successful:
+        continue
       if error == 'No such file or directory':
         successful[lfn] = False
       else:

--- a/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/DirectoryClosure.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/DirectoryClosure.py
@@ -387,10 +387,7 @@ class DirectoryClosure( DirectoryTreeBase ):
       if not result['OK']:
         return result
 
-      dirId, errmsg = result['Value'][0]
-
-      if not dirId:
-        return S_ERROR( "Failed to create directory %s (%s)" % ( path, errmsg ) )
+      dirId = result['Value'][0][0]
 
       result = S_OK( dirId )
       result['NewDirectory'] = True

--- a/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/FileManagerPs.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/FileManagerPs.py
@@ -366,6 +366,7 @@ class FileManagerPs( FileManagerBase ):
     return S_OK(guidDict)
 
   def getLFNForGUID( self, guids, connection = False ):
+    """ Returns the lfns matching given guids"""
     connection = self._getConnection( connection )
     if not guids:
       return S_OK( {} )
@@ -380,8 +381,9 @@ class FileManagerPs( FileManagerBase ):
       return result
 
     guidDict = dict( ( guid, lfn ) for guid, lfn in result['Value'] )
-
-    return S_OK( guidDict )
+    failedGuid = set( guids ) - set( guidDict )
+    failed = dict.fromkeys( failedGuid, "GUID does not exist" ) if failedGuid else {}
+    return S_OK( {"Successful" : guidDict, "Failed" : failed} )
 
   ######################################################
   #

--- a/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/FileManagerPs.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/FileManagerPs.py
@@ -365,6 +365,24 @@ class FileManagerPs( FileManagerBase ):
 
     return S_OK(guidDict)
 
+  def getLFNForGUID( self, guids, connection = False ):
+    connection = self._getConnection( connection )
+    if not guids:
+      return S_OK( {} )
+
+    if type( guids ) not in [ListType, TupleType]:
+      guids = [guids]
+
+    formatedGuids = stringListToString( guids )
+    result = self.db.executeStoredProcedureWithCursor( 'ps_get_lfns_from_guids', ( formatedGuids, ) )
+
+    if not result['OK']:
+      return result
+
+    guidDict = dict( ( guid, lfn ) for guid, lfn in result['Value'] )
+
+    return S_OK( guidDict )
+
   ######################################################
   #
   # _deleteFiles related methods

--- a/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/FileManagerPs.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/FileManagerPs.py
@@ -328,13 +328,11 @@ class FileManagerPs( FileManagerBase ):
                                                                              checksum, checksumtype, mode ) )
 
       if not result['OK']:
-        return result
-
-      fileID, errMsg = result['Value'][0]
-
-      if not fileID:
-        failed[lfn] = errMsg
+        failed[lfn] = result['Message']
       else:
+
+        fileID = result['Value'][0][0]
+
         successful[lfn] = lfns[lfn]
         successful[lfn]['FileID'] = fileID
 
@@ -544,8 +542,8 @@ class FileManagerPs( FileManagerBase ):
         allIds = result['Value']
         for fileId, seId, repId in allIds:
           lfn = repDesc[ ( fileId, seId ) ]
-          successful[lfn] = lfns[lfn]
-          successful[lfn]['RepID'] = repId
+          successful[lfn] = True
+          lfns[lfn]['RepID'] = repId
       else:
         lfnsToRetry.extend( lfnChunk )
 
@@ -558,14 +556,12 @@ class FileManagerPs( FileManagerBase ):
                                                          ( fileID, seID, statusID, replicaType, pfn ) )
 
       if not result['OK']:
-        return result
-
-      replicaID, errMsg = result['Value'][0]
-      if replicaID:
+        failed[lfn] = result['Message']
+      else:
+        replicaID = result['Value'][0][0]
         lfns[lfn]['RepID'] = replicaID
         successful[lfn] = True
-      else:
-        failed[lfn] = errMsg
+
 
     return S_OK({'Successful':successful,'Failed':failed})
 
@@ -683,10 +679,7 @@ class FileManagerPs( FileManagerBase ):
     if not result['OK']:
       return result
 
-    errno, affected, errMsg = result['Value'][0]  # Affected is the number of raws updated
-
-    if errno:
-      return S_ERROR( errMsg )
+    affected = result['Value'][0][0]  # Affected is the number of raws updated
 
     if not affected:
       return S_ERROR( "Replica does not exist" )
@@ -723,9 +716,9 @@ class FileManagerPs( FileManagerBase ):
     if not result['OK']:
       return result
 
-    errno, errMsg = result['Value'][0]
-    if errno:
-      return S_ERROR( errMsg )
+    affected = result['Value'][0][0]
+    if not affected:
+      return S_ERROR( "Replica does not exist" )
     else:
       return S_OK()
 
@@ -763,9 +756,8 @@ class FileManagerPs( FileManagerBase ):
       if not result['OK']:
         return result
 
-      errno, errMsg = result['Value'][0]
-      if errno:
-        return S_ERROR( errMsg )
+      _affected = result['Value'][0][0]
+      # If affected = 0, the file does not exist, but who cares...
 
 
     # In case this is a 'new' parameter, we have a failback solution, but we should add a specific ps for it
@@ -868,11 +860,12 @@ class FileManagerPs( FileManagerBase ):
     directorySESizeDict = {}
     return S_OK( directorySESizeDict )
 
-  def _checkUniqueGUID( self, lfns, connection = False ):
-    """ The GUID unicity is ensured at the DB level, so we will have similar message if the insertion fails"""
-
-    failed = {}
-    return failed
+#   "REMARQUE : THIS IS STILL TRUE, BUT YOU MIGHT WANT TO CHECK FOR A GIVEN GUID ANYWAY
+#   def _checkUniqueGUID( self, lfns, connection = False ):
+#     """ The GUID unicity is ensured at the DB level, so we will have similar message if the insertion fails"""
+#
+#     failed = {}
+#     return failed
 
 
 

--- a/DataManagementSystem/DB/FileCatalogDB.py
+++ b/DataManagementSystem/DB/FileCatalogDB.py
@@ -303,7 +303,6 @@ class FileCatalogDB(DB):
 
       :return Successful/Failed dict.
     """
-
     res = self._checkPathPermissions('Write', lfns, credDict)
     if not res['OK']:
       return res
@@ -664,6 +663,23 @@ class FileCatalogDB(DB):
       
     return S_OK(resultDict) 
 
+  def getLFNForGUID( self, guids, credDict ):
+    """
+        Gets the lfns that match a list of guids
+        :param list lfns: list of guid to look for
+        :param creDict credential
+
+        :return S_OK({guid:lfn}) dict.
+    """
+
+    res = self._checkAdminPermission( credDict )
+    if not res['OK']:
+      return res
+    if not res['Value']:
+      return S_ERROR( "Permission denied" )
+    res = self.fileManager.getLFNForGUID( guids )
+
+    return res
   ########################################################################
   #
   #  Directory based Write methods

--- a/DataManagementSystem/DB/FileCatalogWithFkAndPsDB.sql
+++ b/DataManagementSystem/DB/FileCatalogWithFkAndPsDB.sql
@@ -845,7 +845,7 @@ DELIMITER //
 CREATE PROCEDURE ps_get_lfns_from_guids
 (IN  guids TEXT)
 BEGIN
-  SET @sql = CONCAT('SELECT SQL_NO_CACHE GUID, LFN FROM FC_Files f WHERE GUID IN (', guids, ')');
+  SET @sql = CONCAT('SELECT SQL_NO_CACHE GUID, CONCAT(d.Name, "/", f.FileName) FROM FC_Files f JOIN FC_DirectoryList d on f.DirID = d.DirID WHERE GUID IN (', guids, ')');
 
   PREPARE stmt FROM @sql;
   EXECUTE stmt;

--- a/DataManagementSystem/DB/FileCatalogWithFkAndPsDB.sql
+++ b/DataManagementSystem/DB/FileCatalogWithFkAndPsDB.sql
@@ -403,21 +403,7 @@ CREATE PROCEDURE ps_insert_dir
 BEGIN
   DECLARE dir_id INT DEFAULT 0;
   
-  DECLARE EXIT HANDLER FOR 1062 BEGIN
-    ROLLBACK;
-    SELECT 0 as dir_id, 'Error, duplicate key occurred' as msg;
-  END;
 
-  DECLARE EXIT HANDLER FOR 1452 BEGIN
-    ROLLBACK;
-    SELECT 0 as dir_id, 'Cannot add or update a child row: a foreign key constraint fails' as msg;
-  END;
-  
-  DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN
-      ROLLBACK;
-      SELECT 0 as dir_id, 'Unknown error occured' as msg;
-  END;
-    
   
   START TRANSACTION;
    
@@ -434,7 +420,7 @@ BEGIN
     END IF;
     
     
-    SELECT dir_id, 'OK';
+    SELECT dir_id;
     
    COMMIT;
 END //
@@ -777,22 +763,7 @@ CREATE PROCEDURE ps_insert_file
 BEGIN
   DECLARE file_id INT DEFAULT 0;
   
-  DECLARE EXIT HANDLER FOR 1062 BEGIN
-    ROLLBACK;
-    SELECT 0 as file_id, 'Error, duplicate key occurred' as msg;
-  END;
-
-  DECLARE EXIT HANDLER FOR 1452 BEGIN
-    ROLLBACK;
-    SELECT 0 as file_id, 'Cannot add or update a child row: a foreign key constraint fails' as msg;
-  END;
-  
-  DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN
-      ROLLBACK;
-      SELECT 0 as file_id, 'Unknown error occured' as msg;
-  END;
-    
-  
+ 
   START TRANSACTION;
   INSERT INTO FC_Files (DirID, Size, UID, GID, Status, FileName,GUID, Checksum, ChecksumType, CreationDate, ModificationDate, Mode )
   VALUES (dir_id, size, UID, GID, status_id, filename, GUID, checksum, checksumtype, UTC_TIMESTAMP(), UTC_TIMESTAMP(), mode);
@@ -802,7 +773,7 @@ BEGIN
 
   COMMIT;
 
-  SELECT file_id, 'OK' as msg;
+  SELECT file_id;
  
 END //
 DELIMITER ;
@@ -948,21 +919,12 @@ CREATE PROCEDURE ps_insert_replica
 BEGIN
   DECLARE replica_id INT DEFAULT 0;
   
+  -- The replica already exists
   DECLARE EXIT HANDLER FOR 1062 BEGIN
     ROLLBACK;
-    SELECT RepID as replica_id, 'Replica already exists' as msg from FC_Replicas where FileID = file_id and SEID = se_id;
+    SELECT RepID as replica_id from FC_Replicas where FileID = file_id and SEID = se_id;
   END;
 
-  DECLARE EXIT HANDLER FOR 1452 BEGIN
-    ROLLBACK;
-    SELECT 0 as replica_id, 'Cannot add or update a child row: a foreign key constraint fails' as msg;
-  END;
-  
-  DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN
-      ROLLBACK;
-      SELECT 0 as replica_id, 'Unknown error occured' as msg;
-  END;
-    
     
   START TRANSACTION;
   INSERT INTO FC_Replicas (FileID, SEID, Status, RepType, CreationDate, ModificationDate, PFN)
@@ -972,7 +934,7 @@ BEGIN
 
   COMMIT;
   
-  SELECT replica_id, 'OK' as msg;
+  SELECT replica_id;
  
 END //
 DELIMITER ;
@@ -1080,7 +1042,7 @@ BEGIN
 
   UPDATE FC_Replicas SET Status = status_id WHERE FileID = file_id AND SEID = se_id;
   
-  SELECT 0 as errno, ROW_COUNT() as affected, 'OK' as msg;
+  SELECT ROW_COUNT() as affected;
 
 END //
 DELIMITER ;
@@ -1102,10 +1064,7 @@ CREATE PROCEDURE ps_set_replica_host
 BEGIN
   DECLARE file_size INT DEFAULT 0;
   DECLARE dir_id INT DEFAULT 0;
-  DECLARE EXIT HANDLER FOR 1452 BEGIN
-    ROLLBACK;
-    SELECT 1 , 'Cannot add or update a child row: a foreign key constraint fails' as msg;
-  END;
+
   
 
   SELECT Size, DirID INTO file_size, dir_id from FC_Files WHERE FileID = file_id;
@@ -1116,7 +1075,7 @@ BEGIN
     UPDATE FC_Replicas SET SEID = new_se_id WHERE FileID = file_id AND SEID = old_se_id;
   COMMIT;
 
-  SELECT 0 as errno, ROW_COUNT() as affected, 'OK' as msg;
+  SELECT ROW_COUNT() as affected;
 
 END //
 DELIMITER ;
@@ -1133,14 +1092,10 @@ DELIMITER //
 CREATE PROCEDURE ps_set_file_uid
 (IN  file_id INT, IN in_uid INT) 
 BEGIN
-  DECLARE EXIT HANDLER FOR 1452 BEGIN
-    ROLLBACK;
-    SELECT 1 , 'Cannot add or update a child row: a foreign key constraint fails' as msg;
-  END;
 
   UPDATE FC_Files SET UID = in_uid, ModificationDate = UTC_TIMESTAMP() where FileID = file_id;
  
-  SELECT 0, 'OK';
+  SELECT ROW_COUNT();
 
 END //
 DELIMITER ;
@@ -1157,14 +1112,11 @@ DELIMITER //
 CREATE PROCEDURE ps_set_file_gid
 (IN  file_id INT, IN in_gid INT) 
 BEGIN
-  DECLARE EXIT HANDLER FOR 1452 BEGIN
-    ROLLBACK;
-    SELECT 1 , 'Cannot add or update a child row: a foreign key constraint fails' as msg;
-  END;
+
   
   UPDATE FC_Files SET GID = in_gid, ModificationDate = UTC_TIMESTAMP() where FileID = file_id;
   
-  SELECT 0, 'OK';
+  SELECT ROW_COUNT();
 
 END //
 DELIMITER ;
@@ -1181,14 +1133,11 @@ DELIMITER //
 CREATE PROCEDURE ps_set_file_status
 (IN  file_id INT, IN status_id INT) 
 BEGIN
-  DECLARE EXIT HANDLER FOR 1452 BEGIN
-    ROLLBACK;
-    SELECT 1 , 'Cannot add or update a child row: a foreign key constraint fails' as msg;
-  END;
+
 
   UPDATE FC_Files SET Status = status_id, ModificationDate = UTC_TIMESTAMP() where FileID = file_id;
 
-  SELECT 0, 'OK';
+  SELECT ROW_COUNT();
 
 END //
 DELIMITER ;
@@ -1208,7 +1157,7 @@ BEGIN
 
   UPDATE FC_Files SET Mode = in_mode, ModificationDate = UTC_TIMESTAMP()  WHERE FileID = file_id;
 
-  SELECT 0, 'OK';
+  SELECT ROW_COUNT();
 
 END //
 DELIMITER ;

--- a/DataManagementSystem/DB/FileCatalogWithFkAndPsDB.sql
+++ b/DataManagementSystem/DB/FileCatalogWithFkAndPsDB.sql
@@ -837,6 +837,24 @@ BEGIN
 END //
 DELIMITER ;
 
+-- ps_get_lfns_from_guids : return list of file lfns for given guids
+-- guids : list of guids
+-- output : GUID, LFN
+
+DELIMITER //
+CREATE PROCEDURE ps_get_lfns_from_guids
+(IN  guids TEXT)
+BEGIN
+  SET @sql = CONCAT('SELECT SQL_NO_CACHE GUID, LFN FROM FC_Files f WHERE GUID IN (', guids, ')');
+
+  PREPARE stmt FROM @sql;
+  EXECUTE stmt;
+  DEALLOCATE PREPARE stmt;
+  
+ 
+END //
+DELIMITER ;
+
 
 -- ps_delete_replicas_from_file_ids : delete all the replicas for given file ids and update the DirectoryUsage table
 -- file_ids : list of file ids

--- a/DataManagementSystem/DB/test/TestFileCatalogDB.py
+++ b/DataManagementSystem/DB/test/TestFileCatalogDB.py
@@ -5,6 +5,8 @@ import unittest
 import itertools
 from DIRAC.DataManagementSystem.DB.FileCatalogDB import FileCatalogDB
 
+from DIRAC.Core.Security.Properties import FC_MANAGEMENT
+
 seName = "mySE"
 testUser  = 'atsareg'
 testGroup = 'dirac_user'
@@ -20,7 +22,7 @@ credDict = {'DN': '/DC=ch/DC=cern/OU=computers/CN=volhcb12.cern.ch',
             'x509Chain': "<X509Chain 3 certs [/DC=ch/DC=cern/OU=computers/CN=volhcb12.cern.ch][/DC=ch/DC=cern/CN=CERN Trusted Certification Authority][/DC=ch/DC=cern/CN=CERN Root CA]>",
             'username': 'anonymous',
             'isLimitedProxy': False,
-            'properties': [],
+            'properties': [FC_MANAGEMENT],
             'isProxy': False}
 
 
@@ -79,7 +81,7 @@ ALL_MANAGERS_NO_CS = { "UserGroupManager"  : ["UserAndGroupManagerDB"],
 
 DEFAULT_MANAGER = { "UserGroupManager"  : ["UserAndGroupManagerDB"],
                     "SEManager" : ["SEManagerDB"],
-                    "SecurityManager" : ["NoSecurityManager"],
+                    "SecurityManager" : ["DirectorySecurityManagerWithDelete"],
                     "DirectoryManager" : ["DirectoryClosure"],
                     "FileManager" : ["FileManagerPs"],
                     }

--- a/DataManagementSystem/DB/test/TestFileCatalogDB.py
+++ b/DataManagementSystem/DB/test/TestFileCatalogDB.py
@@ -86,6 +86,13 @@ DEFAULT_MANAGER = { "UserGroupManager"  : ["UserAndGroupManagerDB"],
                     "FileManager" : ["FileManagerPs"],
                     }
 
+DEFAULT_MANAGER_2 = { "UserGroupManager"  : ["UserAndGroupManagerDB"],
+                    "SEManager" : ["SEManagerDB"],
+                    "SecurityManager" : ["NoSecurityManager"],
+                    "DirectoryManager" : ["DirectoryLevelTree"],
+                    "FileManager" : ["FileManager"],
+                    }
+
 MANAGER_TO_TEST = DEFAULT_MANAGER
 
 
@@ -170,19 +177,63 @@ class FileCase( FileCatalogDBTestCase ):
     result = self.db.addFile( { testFile: { 'PFN': 'testfile',
                                          'SE': 'testSE' ,
                                          'Size':123,
-                                         'GUID':1000,
+                                         'GUID':'1000',
                                          'Checksum':'0' } }, credDict )
     self.assert_( result['OK'], "addFile failed when adding new file %s" % result )
 
+    result = self.db.exists( testFile , credDict )
+    self.assert_( result['OK'] )
+    self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
+                       testFile, "exists( testFile) should be the same lfn %s" % result )
+
+
+    result = self.db.exists( {testFile:'1000'} , credDict )
+    self.assert_( result['OK'] )
+    self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
+                       testFile, "exists( testFile : 1000) should be the same lfn %s" % result )
+    
+    result = self.db.exists( {testFile:{'GUID' : '1000', 'PFN' : 'blabla'}} , credDict )
+    self.assert_( result['OK'] )
+    self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
+                       testFile, "exists( testFile : 1000) should be the same lfn %s" % result )
+
+    # In fact, we don't check if the GUID is correct...
+    result = self.db.exists( {testFile:'1001'}, credDict )
+    self.assert_( result['OK'] )
+    self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
+                       testFile, "exists( testFile : 1001) should be the same lfn %s" % result )
+
+    result = self.db.exists( {testFile + '2' : '1000'}, credDict )
+    self.assert_( result['OK'] )
+    self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile + '2' ),
+                       testFile, "exists( testFile2 : 1000) should return testFile %s" % result )
 
     # Re-adding the same file
     result = self.db.addFile( { testFile: { 'PFN': 'testfile',
                                          'SE': 'testSE' ,
                                          'Size':123,
-                                         'GUID':1000,
+                                         'GUID':'1000',
+                                         'Checksum':'0' } }, credDict )
+    self.assert_( result["OK"], "addFile failed when adding existing file with same param %s" % result )
+    self.assert_( testFile in result["Value"]["Successful"], "addFile failed: it should be possible to add an existing lfn with same param %s" % result )
+
+    # Adding same file with different param
+    result = self.db.addFile( { testFile: { 'PFN': 'testfile',
+                                         'SE': 'testSE' ,
+                                         'Size':123,
+                                         'GUID':'1000',
+                                         'Checksum':'1' } }, credDict )
+    self.assert_( result["OK"], "addFile failed when adding existing file with different parem %s" % result )
+    self.assert_( testFile in result["Value"]["Failed"], "addFile failed: it should not be possible to add an existing lfn with different param %s" % result )
+
+
+    result = self.db.addFile( { testFile + '2':  { 'PFN': 'testfile',
+                                         'SE': 'testSE' ,
+                                         'Size':123,
+                                         'GUID':'1000',
                                          'Checksum':'0' } }, credDict )
     self.assert_( result["OK"], "addFile failed when adding existing file %s" % result )
-    self.assert_( testFile in result["Value"]["Failed"], "addFile failed: it should not be possible to add an existing lfn %s" % result )
+    self.assert_( testFile + '2' in result["Value"]["Failed"], "addFile failed: it should not be possible to add a new lfn with existing GUID %s" % result )
 
     ##################################################################################
     # Setting existing status of existing file
@@ -264,7 +315,7 @@ class ReplicaCase( FileCatalogDBTestCase ):
     result = self.db.addFile( { testFile: { 'PFN': 'testfile',
                                          'SE': 'testSE' ,
                                          'Size':123,
-                                         'GUID':1000,
+                                         'GUID':'1000',
                                          'Checksum':'0' } }, credDict )
     self.assert_( result['OK'], "addFile failed when adding new file %s" % result )
 
@@ -367,7 +418,7 @@ class DirectoryCase( FileCatalogDBTestCase ):
     result = self.db.addFile( { testFile: { 'PFN': 'testfile',
                                          'SE': 'testSE' ,
                                          'Size':123,
-                                         'GUID':1000,
+                                         'GUID':'1000',
                                          'Checksum':'0' } }, credDict )
     self.assert_( result['OK'], "addFile failed when adding new file %s" % result )
 

--- a/DataManagementSystem/DB/test/TestFileCatalogDB.py
+++ b/DataManagementSystem/DB/test/TestFileCatalogDB.py
@@ -55,7 +55,7 @@ DATABASE_CONFIG = {  'UserGroupManager'  : 'UserAndGroupManagerDB',  # UserAndGr
                        'DirectoryMetadata' : 'DirectoryMetadata',
                        'FileMetadata'      : 'FileMetadata',
                        'DatasetManager'    : 'DatasetManager',
-                       'UniqueGUID'          : False,
+                       'UniqueGUID'          : True,
                        'GlobalReadAccess'    : True,
                        'LFNPFNConvention'    : 'Strong',
                        'ResolvePFN'          : True,

--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -321,6 +321,11 @@ class FileCatalogHandler( RequestHandler ):
       dList = [depths]
     lfnDict = dict.fromkeys( lfns, True )
     return gFileCatalogDB.getFileDescendents( lfnDict, dList, self.getRemoteCredentials() )
+  
+  types_getLFNForGUID = [ [ ListType, DictType ] + list( StringTypes ) ]
+  def export_getLFNForGUID( self, guids ):
+    """Get the matching lfns for given guids"""
+    return gFileCatalogDB.getLFNForGUID( guids, self.getRemoteCredentials() )
 
   ########################################################################
   #

--- a/DataManagementSystem/scripts/dirac-dms-resolve-guid.py
+++ b/DataManagementSystem/scripts/dirac-dms-resolve-guid.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+########################################################################
+# $HeadURL$
+########################################################################
+__RCSID__ = "$Id$"
+
+from DIRAC.Core.Base import Script
+
+Script.setUsageMessage( """
+Returns the LFN matching given GUIDs
+Usage:
+   %s <GUIDs>
+""" % Script.scriptName )
+
+Script.parseCommandLine()
+
+import sys, os
+import DIRAC
+from DIRAC import gLogger
+
+args = Script.getPositionalArgs()
+if len(args) != 1:
+  Script.showHelp()
+  DIRAC.exit( 0 )
+guids = args[0]
+
+try:
+  guids= guids.split(',')
+except:
+  pass
+
+from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
+
+fc = FileCatalog()
+res = fc.getLFNForGUID( guids )
+if not res['OK']:
+  gLogger.error( "Failed to get the LFNs", res['Message'] )
+  DIRAC.exit( -2 )
+
+errorGuid = {}
+for guid, reason in res['Value']['Failed'].items():
+  errorGuid.setdefault( reason, [] ).append( guid )
+
+for error, guidList in errorGuid.items():
+  gLogger.notice( "Error '%s' for guids %s" % ( error, guidList ) )
+
+for guid, lfn in res['Value']['Successful'].items():
+  gLogger.notice( "%s -> %s" % ( guid, lfn ) )
+
+DIRAC.exit( 0 )
+

--- a/Resources/Catalog/FileCatalog.py
+++ b/Resources/Catalog/FileCatalog.py
@@ -15,7 +15,7 @@ class FileCatalog( object ):
   ro_methods = ['exists', 'isLink', 'readLink', 'isFile', 'getFileMetadata', 'getReplicas',
                 'getReplicaStatus', 'getFileSize', 'isDirectory', 'getDirectoryReplicas',
                 'listDirectory', 'getDirectoryMetadata', 'getDirectorySize', 'getDirectoryContents',
-                'resolveDataset', 'getPathPermissions', 'getLFNForPFN', 'getUsers', 'getGroups'] 
+                'resolveDataset', 'getPathPermissions', 'getLFNForPFN', 'getUsers', 'getGroups', 'getLFNForGUID']
   
   ro_meta_methods = ['getFileUserMetadata', 'getMetadataFields', 'findFilesByMetadata', 'getDirectoryMetadata',
                      'getFileUserMetadata', 'findDirectoriesByMetadata', 'getReplicasByMetadata',
@@ -103,6 +103,7 @@ class FileCatalog( object ):
       
       method = getattr( oCatalog, self.call )
       res = method( fileInfo, *parms, **kws )
+
       if not res['OK']:
         if master:
           # If this is the master catalog and it fails we dont want to continue with the other catalogs

--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -1310,6 +1310,24 @@ class LcgFileCatalogClient( FileCatalogueBase ):
     """
     error = lfc.lfc_access( self.__fullLfn( lfn ), 0 )
     return returnCode( error and lfc.cvar.serrno != 2, error == 0 )
+  
+  def getLFNForGUID(self, guids):
+    res = checkArgumentFormat( guids )
+    if not res['OK']:
+      return res
+    guids = res['Value']
+    guidLFN = {}
+    failed = {}
+
+    for guid in guids:
+      # I somehow have the feeling that lfnlist[0] of __getLfnForGUID
+      # could throw an exception if the guid does not exist in the DB
+      # but... not touching this black magic
+      try:
+        guidLFN[guid] = self.__getLfnForGUID( guid )['Value']
+      except Exception, _e:
+        failed[guid] = "GUID does not exist"
+    return S_OK( {"Successful" : guidLFN, "Failed" : failed} )
 
   def __getLfnForGUID( self, guid ):
     """ Resolve the LFN for a supplied GUID


### PR DESCRIPTION
!!! IMPORTANT !!! The major change here is that the DFC.exists method behaves now like the LFC.exists method : 
if the GUID is given to the exists call together with the LFN, and if UniqueGUID is True, we will check whether the GUID already exists. If yes, we return the LFN to which it is associated. Note that the overall mechanism has a bit strange behavior, but that is what you end up with if you have two unique identifiers for one entity... anyway, it is now the same behavior as the LFC, and this was needed because the DM.putAndRegister does not behave the same depending on whether fc.exists or fc.addFile fails.