### PR TITLE
[v6r12] LastUpdate was not always correct

### DIFF
--- a/RequestManagementSystem/Client/File.py
+++ b/RequestManagementSystem/Client/File.py
@@ -32,6 +32,7 @@ import os
 from DIRAC import S_OK
 from DIRAC.RequestManagementSystem.private.Record import Record
 from DIRAC.Core.Utilities.File import checkGuid
+import datetime
 
 ########################################################################
 class File( Record ):
@@ -232,6 +233,11 @@ class File( Record ):
       raise ValueError( "Unknown Status: %s!" % str( value ) )
     if value == 'Done':
       self.__data__['Error'] = ''
+
+    updateTime = ( self.__data__["Status"] != value )
+    if updateTime and self._parent:
+      self._parent.LastUpdate = datetime.datetime.utcnow().replace( microsecond = 0 )
+
     self.__data__["Status"] = value
     if self._parent:
       self._parent._notify()

--- a/RequestManagementSystem/Client/Operation.py
+++ b/RequestManagementSystem/Client/Operation.py
@@ -136,7 +136,7 @@ class Operation( Record ):
       newStatus = 'Done'
 
     # If the status moved to Failed or Done, update the lastUpdate time
-    if newStatus in ( 'Failed', 'Done' ):
+    if newStatus in ( 'Failed', 'Done', 'Scheduled' ):
       if self.__data__["Status"] != newStatus:
         self.LastUpdate = datetime.datetime.utcnow().replace( microsecond = 0 )
 

--- a/RequestManagementSystem/Client/Operation.py
+++ b/RequestManagementSystem/Client/Operation.py
@@ -140,7 +140,6 @@ class Operation( Record ):
       if self.__data__["Status"] != newStatus:
         self.LastUpdate = datetime.datetime.utcnow().replace( microsecond = 0 )
 
-
     self.__data__["Status"] = newStatus
     if self._parent:
       self._parent._notify()
@@ -397,6 +396,8 @@ class Operation( Record ):
     if type( value ) == str:
       value = datetime.datetime.strptime( value.split( "." )[0], '%Y-%m-%d %H:%M:%S' )
     self.__data__["LastUpdate"] = value
+    if self._parent:
+      self._parent.LastUpdate = value
 
   def __str__( self ):
     """ str operator """

--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -328,6 +328,7 @@ class RequestDB( DB ):
     selectReq = selectReq["Value"]
 
     request = Request( selectReq[selectQuery[0]][0] )
+    origLastUpdate = request.LastUpdate
     if not requestName:
       log.verbose( "selected request '%s'%s" % ( request.RequestName, ' (Assigned)' if assigned else '' ) )
     for records in sorted( selectReq[selectQuery[1]], key = lambda k: k["Order"] ):
@@ -344,6 +345,8 @@ class RequestDB( DB ):
         getFileDict = dict( [ ( key, value ) for key, value in getFile.items() if value != None ] )
         operation.addFile( File( getFileDict ) )
       request.addOperation( operation )
+
+    request.LastUpdate = origLastUpdate
 
     if assigned:
       setAssigned = self._transaction( "UPDATE `Request` SET `Status` = 'Assigned', `LastUpdate`=UTC_TIMESTAMP() WHERE RequestID = %s;" % requestID )


### PR DESCRIPTION
There was a small bug making that the request would always show the current time for LastUpdate. Also, if the Operation was Scheduled, and some files move from Scheduled to Done but not all, the timestamp of the operation would not change. Now it does :-) Same goes from Operation to Request