### PR TITLE
!!! [v6r12] PhC fixes 150217: URGENT

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1494,7 +1494,10 @@ class DataManager( object ):
     if not result['OK']:
       return S_ERROR( 'SE not known' )
     resolvedName = result['Value']
-    res = self.resourceStatus.getStorageElementStatus( resolvedName, default = None )
+    for _i in range( 5 ):
+      res = self.resourceStatus.getStorageElementStatus( resolvedName, default = None )
+      if res['OK']:
+        break
     if not res[ 'OK' ]:
       return S_ERROR( 'SE not known' )
 

--- a/DataManagementSystem/Client/FTSJob.py
+++ b/DataManagementSystem/Client/FTSJob.py
@@ -496,6 +496,8 @@ class FTSJob( Record ):
 
     # Returns a non zero status if error
     if returnCode != 0:
+      if 'was not found' in outputStr and not errStr:
+        errStr = 'Job was not found'
       return S_ERROR( errStr )
 
     outputStr = outputStr.replace( "'" , "" ).replace( "<", "" ).replace( ">", "" )

--- a/DataManagementSystem/Utilities/CSHelpers.py
+++ b/DataManagementSystem/Utilities/CSHelpers.py
@@ -1,0 +1,41 @@
+"""
+  This module contains helper methods for accessing operational attributes or parameters of DMS objects
+
+"""
+
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC import gConfig, gLogger
+
+def _resolveSEGroup( seGroupList ):
+  seList = []
+  for se in seGroupList:
+    seConfig = gConfig.getValue( '/Resources/StorageElementGroups/%s' % se, se )
+    if seConfig != se:
+      seList += [se.strip() for se in seConfig.split( ',' )]
+      # print seList
+    else:
+      seList.append( se )
+    res = gConfig.getSections( '/Resources/StorageElements' )
+    if not res['OK']:
+      gLogger.fatal( 'Error getting list of SEs from CS', res['Message'] )
+      return []
+    for se in seList:
+      if se not in res['Value']:
+        gLogger.fatal( '%s is not a valid SE' % se )
+        seList = []
+        break
+
+  return seList
+
+class CSHelpers( object ):
+
+  def __init__( self ):
+    self.__operations = Operations()
+
+  def isSEFailover( self, storageElement ):
+    seList = self.__operations.getValue( 'DataManagement/SEsUsedForFailover', [] )
+    return storageElement in _resolveSEGroup( seList )
+
+  def isSEForJobs( self, storageElement ):
+    seList = self.__operations.getValue( 'DataManagement/SEsNotToBeUsedForJobs', [] )
+    return storageElement not in _resolveSEGroup( seList )

--- a/DataManagementSystem/Utilities/CSHelpers.py
+++ b/DataManagementSystem/Utilities/CSHelpers.py
@@ -27,15 +27,11 @@ def _resolveSEGroup( seGroupList ):
 
   return seList
 
-class CSHelpers( object ):
 
-  def __init__( self ):
-    self.__operations = Operations()
+def isSEFailover( storageElement ):
+  seList = Operations().getValue( 'DataManagement/SEsUsedForFailover', [] )
+  return storageElement in _resolveSEGroup( seList )
 
-  def isSEFailover( self, storageElement ):
-    seList = self.__operations.getValue( 'DataManagement/SEsUsedForFailover', [] )
-    return storageElement in _resolveSEGroup( seList )
-
-  def isSEForJobs( self, storageElement ):
-    seList = self.__operations.getValue( 'DataManagement/SEsNotToBeUsedForJobs', [] )
-    return storageElement not in _resolveSEGroup( seList )
+def isSEForJobs( storageElement ):
+  seList = Operations().getValue( 'DataManagement/SEsNotToBeUsedForJobs', [] )
+  return storageElement not in _resolveSEGroup( seList )

--- a/DataManagementSystem/Utilities/CSHelpers.py
+++ b/DataManagementSystem/Utilities/CSHelpers.py
@@ -35,3 +35,7 @@ def isSEFailover( storageElement ):
 def isSEForJobs( storageElement ):
   seList = Operations().getValue( 'DataManagement/SEsNotToBeUsedForJobs', [] )
   return storageElement not in _resolveSEGroup( seList )
+
+def isSEArchive( storageElement ):
+  seList = Operations().getValue( 'DataManagement/SEsUsedForArchive', [] )
+  return storageElement in _resolveSEGroup( seList )

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1253,10 +1253,8 @@ class Dirac( API ):
     result = dm.putAndRegister( lfn, fullPath, diracSE, guid = fileGuid )
     if not result['OK']:
       return self._errorReport( 'Problem during putAndRegister call', result['Message'] )
-    if not printOutput:
-      return result
-
-    print self.pPrint.pformat( result['Value'] )
+    if printOutput:
+      print self.pPrint.pformat( result['Value'] )
     return result
 
   #############################################################################
@@ -1294,10 +1292,8 @@ class Dirac( API ):
         print self.pPrint.pformat( result['Value'] )
       return S_ERROR( result['Value'] )
 
-    if not printOutput:
-      return result
-
-    print self.pPrint.pformat( result['Value'] )
+    if printOutput:
+      print self.pPrint.pformat( result['Value'] )
     return result
 
   #############################################################################
@@ -1344,10 +1340,8 @@ class Dirac( API ):
     result = dm.replicateAndRegister( lfn, destinationSE, sourceSE, '', localCache )
     if not result['OK']:
       return self._errorReport( 'Problem during replicateFile call', result['Message'] )
-    if not printOutput:
-      return result
-
-    print self.pPrint.pformat( result['Value'] )
+    if  printOutput:
+      print self.pPrint.pformat( result['Value'] )
     return result
 
   def replicate( self, lfn, destinationSE, sourceSE = '', printOutput = False ):
@@ -1387,10 +1381,8 @@ class Dirac( API ):
     result = dm.replicate( lfn, destinationSE, sourceSE, '' )
     if not result['OK']:
       return self._errorReport( 'Problem during replicate call', result['Message'] )
-    if not printOutput:
-      return result
-
-    print self.pPrint.pformat( result['Value'] )
+    if printOutput:
+      print self.pPrint.pformat( result['Value'] )
     return result
 
   #############################################################################
@@ -1421,10 +1413,8 @@ class Dirac( API ):
     result = dm.getReplicaAccessUrl( lfn, storageElement )
     if not result['OK']:
       return self._errorReport( 'Problem during getAccessURL call', result['Message'] )
-    if not printOutput:
-      return result
-
-    print self.pPrint.pformat( result['Value'] )
+    if printOutput:
+      print self.pPrint.pformat( result['Value'] )
     return result
 
   #############################################################################
@@ -1454,10 +1444,8 @@ class Dirac( API ):
     result = StorageElement( storageElement ).getAccessUrl( pfn )
     if not result['OK']:
       return self._errorReport( 'Problem during getAccessURL call', result['Message'] )
-    if not printOutput:
-      return result
-
-    print self.pPrint.pformat( result['Value'] )
+    if printOutput:
+      print self.pPrint.pformat( result['Value'] )
     return result
 
   #############################################################################
@@ -1488,10 +1476,8 @@ class Dirac( API ):
     result = StorageElement( storageElement ).getFileMetadata( pfn )
     if not result['OK']:
       return self._errorReport( 'Problem during getStorageFileMetadata call', result['Message'] )
-    if not printOutput:
-      return result
-
-    print self.pPrint.pformat( result['Value'] )
+    if printOutput:
+      print self.pPrint.pformat( result['Value'] )
     return result
 
   #############################################################################

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -81,6 +81,24 @@ class Dirac( API ):
 
     self.__clients = None
 
+  def __checkFileArgument( self, fnList, prefix = None, single = False ):
+    if prefix is None:
+      prefix = 'LFN'
+    if type( fnList ) in types.StringTypes:
+      otherPrefix = 'LFN:' if prefix == 'PFN' else 'PFN:'
+      if otherPrefix in fnList:
+        return S_ERROR( self._errorReport( 'Expected %s string, not %s' ) % ( prefix, otherPrefix ) )
+      return S_OK( fnList.replace( '%s:' % prefix, '' ) )
+    elif type( fnList ) == type.ListType:
+      if single:
+        return S_ERROR( self._errorReport( 'Expected single %s string' % prefix ) )
+      try:
+        return S_OK( [fn.replace( '%s:' % prefix, '' ) for fn in fnList] )
+      except Exception, x:
+        return S_ERROR( self._errorReport( str( x ), 'Expected strings in list of %ss' % prefix ) )
+    else:
+      return S_ERROR( self._errorReport( 'Expected single string or list of strings for %s(s)' % prefix ) )
+
   #############################################################################
   # Repository specific methods
   #############################################################################
@@ -97,8 +115,7 @@ class Dirac( API ):
     if not self.jobRepo:
       gLogger.warn( "No repository is initialised" )
       return S_OK()
-    jobs = self.jobRepo.readRepository()['Value']
-    jobIDs = jobs.keys()
+    jobIDs = self.jobRepo.readRepository()['Value'].keys()
     if printOutput:
       print self.pPrint.pformat( jobIDs )
     return S_OK( jobIDs )
@@ -122,15 +139,10 @@ class Dirac( API ):
     if not res['OK']:
       return self._errorReport( res['Message'], 'Failed to get status of jobs from WMS' )
 
-    jobs = self.jobRepo.readRepository()['Value']
     statusDict = {}
     for jobDict in jobs.values():
-      state = 'Unknown'
-      if jobDict.has_key( 'State' ):
-        state = jobDict['State']
-      if not statusDict.has_key( state ):
-        statusDict[state] = 0
-      statusDict[state] += 1
+      state = jobDict.get( 'State', 'Unknown' )
+      statusDict[state] = statusDict.setdefault( state, 0 ) + 1
     if printOutput:
       print self.pPrint.pformat( statusDict )
     return S_OK( statusDict )
@@ -157,9 +169,8 @@ class Dirac( API ):
     jobs = self.jobRepo.readRepository()['Value']
     for jobID in sorted( jobs ):
       jobDict = jobs[jobID]
-      if jobDict.has_key( 'State' ) and ( jobDict['State'] in requestedStates ):
-        if ( jobDict.has_key( 'Retrieved' ) and ( not int( jobDict['Retrieved'] ) ) ) \
-           or ( not jobDict.has_key( 'Retrieved' ) ):
+      if jobDict.get( 'State' ) in requestedStates:
+        if not jobDict.get( 'Retrieved' ) :
           self.getOutputSandbox( jobID, destinationDirectory )
     return S_OK()
 
@@ -185,9 +196,8 @@ class Dirac( API ):
     jobs = self.jobRepo.readRepository()['Value']
     for jobID in sorted( jobs ):
       jobDict = jobs[jobID]
-      if jobDict.has_key( 'State' ) and ( jobDict['State'] in requestedStates ):
-        if ( jobDict.has_key( 'OutputData' ) and ( not int( jobDict['OutputData'] ) ) ) \
-           or ( not jobDict.has_key( 'OutputData' ) ):
+      if jobDict.get( 'State' ) in requestedStates:
+        if not jobDict.get( 'OutputData' ):
           destDir = jobID
           if destinationDirectory:
             destDir = "%s/%s" % ( destinationDirectory, jobID )
@@ -210,9 +220,9 @@ class Dirac( API ):
     jobs = self.jobRepo.readRepository()['Value']
     for jobID in sorted( jobs ):
       jobDict = jobs[jobID]
-      if jobDict.has_key( 'Sandbox' ) and os.path.exists( jobDict['Sandbox'] ):
+      if os.path.exists( jobDict.get( 'Sandbox', '' ) ):
         shutil.rmtree( jobDict['Sandbox'], ignore_errors = True )
-      if jobDict.has_key( 'OutputFiles' ):
+      if 'OutputFiles' in jobDict:
         for fileName in eval( jobDict['OutputFiles'] ):
           if os.path.exists( fileName ):
             os.remove( fileName )
@@ -627,15 +637,10 @@ class Dirac( API ):
        :returns: S_OK,S_ERROR
 
     """
-    if type( lfns ) == type( " " ):
-      lfns = [lfns.replace( 'LFN:', '' )]
-    elif type( lfns ) == type( [] ):
-      try:
-        lfns = [str( lfn.replace( 'LFN:', '' ) ) for lfn in lfns]
-      except Exception, x:
-        return self._errorReport( str( x ), 'Expected strings for LFNs' )
-    else:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfns, 'LFN' )
+    if not ret['OK']:
+      return ret['Message']
+    lfns = ret['Value']
 
     if not siteName:
       siteName = DIRAC.siteName()
@@ -653,14 +658,12 @@ class Dirac( API ):
     if not inputDataPolicy:
       return self._errorReport( 'Could not retrieve DIRAC/VOPolicy/InputDataModule for VO' )
 
-    catalogFailed = {}
     self.log.info( 'Attempting to resolve data for %s' % siteName )
     self.log.verbose( '%s' % ( '\n'.join( lfns ) ) )
     replicaDict = self.getReplicas( lfns )
     if not replicaDict['OK']:
       return replicaDict
-    if replicaDict['Value'].has_key( 'Failed' ):
-      catalogFailed = replicaDict['Value']['Failed']
+    catalogFailed = replicaDict['Value'].get( 'Failed', {} )
 
     guidDict = self.getMetadata( lfns )
     if not guidDict['OK']:
@@ -695,16 +698,15 @@ class Dirac( API ):
     result = module.execute()
     self.log.debug( result )
     if not result['OK']:
-      if result.has_key( 'Failed' ):
+      if 'Failed' in result:
         self.log.error( 'Input data resolution failed for the following files:\n', '\n'.join( result['Failed'] ) )
 
     if catalogFailed:
       self.log.error( 'Replicas not found for the following files:' )
       for key, value in catalogFailed.items():
         self.log.error( '%s %s' % ( key, value ) )
-      if result.has_key( 'Failed' ):
-        failedKeys = catalogFailed.keys()
-        result['Failed'] = failedKeys
+      if 'Failed' in result:
+        result['Failed'] = catalogFailed.keys()
 
     return result
 
@@ -729,9 +731,7 @@ class Dirac( API ):
     replicaDict = self.getReplicas( inputData )
     if not replicaDict['OK']:
       return replicaDict
-    catalogFailed = {}
-    if replicaDict['Value'].has_key( 'Failed' ):
-      catalogFailed = replicaDict['Value']['Failed']
+    catalogFailed = replicaDict['Value'].get( 'Failed', {} )
 
     guidDict = self.getMetadata( inputData )
     if not guidDict['OK']:
@@ -762,9 +762,8 @@ class Dirac( API ):
       self.log.error( 'Replicas not found for the following files:' )
       for key, value in catalogFailed.items():
         self.log.error( '%s %s' % ( key, value ) )
-      if result.has_key( 'Failed' ):
-        failedKeys = catalogFailed.keys()
-        result['Failed'] = failedKeys
+      if 'Failed' in result:
+        result['Failed'] = catalogFailed.keys()
 
     return result
 
@@ -798,12 +797,10 @@ class Dirac( API ):
       return parameters
 
     self.log.verbose( parameters )
-    inputData = None
-    if parameters['Value'].has_key( 'InputData' ):
-      if parameters['Value']['InputData']:
-        inputData = parameters['Value']['InputData']
-        if type( inputData ) == type( " " ):
-          inputData = [inputData]
+    inputData = parameters['Value'].get( 'InputData' )
+    if inputData:
+      if type( inputData ) == type( " " ):
+        inputData = [inputData]
 
     jobParamsDict = {'Job':parameters['Value']}
 
@@ -874,8 +871,8 @@ class Dirac( API ):
       self.log.verbose( 'Could not retrieve DIRAC/VOPolicy/SoftwareDistModule for VO' )
       # return self._errorReport( 'Could not retrieve DIRAC/VOPolicy/SoftwareDistModule for VO' )
 
-    if parameters['Value'].has_key( 'InputSandbox' ):
-      sandbox = parameters['Value']['InputSandbox']
+    sandbox = parameters['Value'].get( 'InputSandbox' )
+    if sandbox:
       if type( sandbox ) in types.StringTypes:
         sandbox = [sandbox]
       for isFile in sandbox:
@@ -907,22 +904,20 @@ class Dirac( API ):
 
     self.log.info( 'Attempting to submit job to local site: %s' % DIRAC.siteName() )
 
-    if parameters['Value'].has_key( 'Executable' ):
+    if 'Executable' in parameters['Value']:
       executable = os.path.expandvars( parameters['Value']['Executable'] )
     else:
       return self._errorReport( 'Missing job "Executable"' )
 
-    arguments = ''
-    if parameters['Value'].has_key( 'Arguments' ):
-      arguments = parameters['Value']['Arguments']
+    arguments = parameters['Value'].get( 'Arguments', '' )
 
     command = '%s %s' % ( executable, arguments )
 
     self.log.info( 'Executing: %s' % command )
     executionEnv = dict( os.environ )
-    if parameters['Value'].has_key( 'ExecutionEnvironment' ):
+    variableList = parameters['Value'].get( 'ExecutionEnvironment' )
+    if variableList:
       self.log.verbose( 'Adding variables to execution environment' )
-      variableList = parameters['Value']['ExecutionEnvironment']
       if type( variableList ) == type( " " ):
         variableList = [variableList]
       for var in variableList:
@@ -942,13 +937,9 @@ class Dirac( API ):
     status = result['Value'][0]
     self.log.verbose( 'Status after execution is %s' % ( status ) )
 
-    outputFileName = None
-    errorFileName = None
     # FIXME: if there is an callbackFunction, StdOutput and StdError will be empty soon
-    if parameters['Value'].has_key( 'StdOutput' ):
-      outputFileName = parameters['Value']['StdOutput']
-    if parameters['Value'].has_key( 'StdError' ):
-      errorFileName = parameters['Value']['StdError']
+    outputFileName = parameters['Value'].get( 'StdOutput' )
+    errorFileName = parameters['Value'].get( 'StdError' )
 
     if outputFileName:
       stdout = result['Value'][1]
@@ -969,16 +960,12 @@ class Dirac( API ):
       errorFile = open( errorFileName, 'w' )
       print >> errorFile, stderr
       errorFile.close()
+      sandbox = None
     else:
       self.log.warn( 'Job JDL has no StdError file parameter defined' )
+      sandbox = parameters['Value'].get( 'OutputSandbox' )
 
-      if parameters['Value'].has_key( 'OutputSandbox' ):
-        sandbox = parameters['Value']['OutputSandbox']
-        if type( sandbox ) in types.StringTypes:
-          sandbox = [sandbox]
-
-    if parameters['Value'].has_key( 'OutputSandbox' ):
-      sandbox = parameters['Value']['OutputSandbox']
+    if sandbox:
       if type( sandbox ) in types.StringTypes:
         sandbox = [sandbox]
       for i in sandbox:
@@ -1054,15 +1041,10 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( lfns ) == type( " " ):
-      lfns = lfns.replace( 'LFN:', '' )
-    elif type( lfns ) == type( [] ):
-      try:
-        lfns = [str( lfn.replace( 'LFN:', '' ) ) for lfn in lfns]
-      except Exception, x:
-        return self._errorReport( str( x ), 'Expected strings for LFNs' )
-    else:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfns, 'LFN' )
+    if not ret['OK']:
+      return ret['Message']
+    lfns = ret['Value']
 
     start = time.time()
     dm = DataManager()
@@ -1115,15 +1097,10 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( lfns ) == type( " " ):
-      lfns = lfns.replace( 'LFN:', '' )
-    elif type( lfns ) == type( [] ):
-      try:
-        lfns = [str( lfn.replace( 'LFN:', '' ) ) for lfn in lfns]
-      except Exception, x:
-        return self._errorReport( str( x ), 'Expected strings for LFNs' )
-    else:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfns, 'LFN' )
+    if not ret['OK']:
+      return ret['Message']
+    lfns = ret['Value']
 
 #     rm = ReplicaManager()
 #     start = time.time()
@@ -1167,15 +1144,10 @@ class Dirac( API ):
     """
     from DIRAC.Core.Utilities.SiteSEMapping import getSitesForSE
     sitesForSE = {}
-    if type( lfns ) == type( " " ):
-      lfns = lfns.replace( 'LFN:', '' )
-    elif type( lfns ) == type( [] ):
-      try:
-        lfns = [str( lfn.replace( 'LFN:', '' ) ) for lfn in lfns]
-      except Exception, x:
-        return self._errorReport( str( x ), 'Expected strings for LFNs' )
-    else:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfns, 'LFN' )
+    if not ret['OK']:
+      return ret['Message']
+    lfns = ret['Value']
 
     if not type( maxFilesPerJob ) == types.IntType:
       try:
@@ -1222,15 +1194,10 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( lfns ) == type( " " ):
-      lfns = lfns.replace( 'LFN:', '' )
-    elif type( lfns ) == type( [] ):
-      try:
-        lfns = [str( lfn.replace( 'LFN:', '' ) ) for lfn in lfns]
-      except Exception, x:
-        return self._errorReport( str( x ), 'Expected strings for LFNs' )
-    else:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfns, 'LFN' )
+    if not ret['OK']:
+      return ret['Message']
+    lfns = ret['Value']
 
     fc = FileCatalog()
     start = time.time()
@@ -1271,10 +1238,10 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( lfn ) == type( " " ):
-      lfn = lfn.replace( 'LFN:', '' )
-    else:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfn, 'LFN', single = True )
+    if not ret['OK']:
+      return ret['Message']
+    lfn = ret['Value']
 
     if not os.path.exists( fullPath ):
       return self._errorReport( 'Local file %s does not exist' % ( fullPath ) )
@@ -1311,15 +1278,10 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( lfn ) == type( " " ):
-      lfn = lfn.replace( 'LFN:', '' )
-    elif type( lfn ) == type( [] ):
-      try:
-        lfn = [str( lfnName.replace( 'LFN:', '' ) ) for lfnName in lfn]
-      except Exception, x:
-        return self._errorReport( str( x ), 'Expected strings for LFN(s)' )
-    else:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfn, 'LFN', single = True )
+    if not ret['OK']:
+      return ret['Message']
+    lfn = ret['Value']
 
     dm = DataManager()
     result = dm.getFile( lfn, destinationDir = destDir )
@@ -1364,10 +1326,10 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( lfn ) in types.StringTypes:
-      lfn = lfn.replace( 'LFN:', '' )
-    elif type( lfn ) != types.ListType:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfn, 'LFN', single = True )
+    if not ret['OK']:
+      return ret['Message']
+    lfn = ret['Value']
 
     if not sourceSE:
       sourceSE = ''
@@ -1410,10 +1372,10 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( lfn ) == type( " " ):
-      lfn = lfn.replace( 'LFN:', '' )
-    else:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfn, 'LFN', single = True )
+    if not ret['OK']:
+      return ret['Message']
+    lfn = ret['Value']
 
     if not sourceSE:
       sourceSE = ''
@@ -1450,13 +1412,13 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( lfn ) == type( " " ):
-      lfn = lfn.replace( 'LFN:', '' )
-    else:
-      return self._errorReport( 'Expected single string for LFN' )
+    ret = self.__checkFileArgument( lfn, 'LFN' )
+    if not ret['OK']:
+      return ret['Message']
+    lfn = ret['Value']
 
     dm = DataManager()
-    result = dm.getReplicaAccessUrl( [lfn], storageElement )
+    result = dm.getReplicaAccessUrl( lfn, storageElement )
     if not result['OK']:
       return self._errorReport( 'Problem during getAccessURL call', result['Message'] )
     if not printOutput:
@@ -1484,19 +1446,12 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( pfn ) == type( " " ):
-      if re.search( 'LFN:', pfn ):
-        return self._errorReport( 'Expected PFN not LFN' )
-      pfn = pfn.replace( 'PFN:', '' )
-    elif type( pfn ) == type( [] ):
-      try:
-        pfn = [str( pfnName.replace( 'PFN:', '' ) ) for pfnName in pfn]
-      except Exception, x:
-        return self._errorReport( str( x ), 'Expected strings for PFN(s)' )
-    else:
-      return self._errorReport( 'Expected single string for PFN' )
+    ret = self.__checkFileArgument( pfn, 'PFN' )
+    if not ret['OK']:
+      return ret['Message']
+    pfn = ret['Value']
 
-    result = StorageElement( storageElement ).getAccessUrl( [pfn] )
+    result = StorageElement( storageElement ).getAccessUrl( pfn )
     if not result['OK']:
       return self._errorReport( 'Problem during getAccessURL call', result['Message'] )
     if not printOutput:
@@ -1525,18 +1480,10 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( pfn ) == type( " " ):
-      if re.search( 'LFN:', pfn ):
-        return self._errorReport( 'Expected PFN not LFN' )
-      pfn = pfn.replace( 'PFN:', '' )
-      pfn = [pfn]
-    elif type( pfn ) == type( [] ):
-      try:
-        pfn = [str( pfile.replace( 'PFN:', '' ) ) for pfile in pfn]
-      except Exception, x:
-        return self._errorReport( str( x ), 'Expected list of strings for PFNs' )
-    else:
-      return self._errorReport( 'Expected single string or list of strings for PFN(s)' )
+    ret = self.__checkFileArgument( pfn, 'PFN' )
+    if not ret['OK']:
+      return ret['Message']
+    pfn = ret['Value']
 
     result = StorageElement( storageElement ).getFileMetadata( pfn )
     if not result['OK']:
@@ -1564,10 +1511,10 @@ class Dirac( API ):
        :returns: S_OK,S_ERROR
 
     """
-    if type( lfn ) in types.StringTypes:
-      lfn = lfn.replace( 'LFN:', '' )
-    elif type( lfn ) != types.ListType:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfn, 'LFN' )
+    if not ret['OK']:
+      return ret['Message']
+    lfn = ret['Value']
 
     dm = DataManager()
     result = dm.removeFile( lfn )
@@ -1591,10 +1538,10 @@ class Dirac( API ):
        :type storageElement: string
        :returns: S_OK,S_ERROR
     """
-    if type( lfn ) in types.StringTypes:
-      lfn = lfn.replace( 'LFN:', '' )
-    elif type( lfn ) != types.ListType:
-      return self._errorReport( 'Expected single string or list of strings for LFN(s)' )
+    ret = self.__checkFileArgument( lfn, 'LFN' )
+    if not ret['OK']:
+      return ret['Message']
+    lfn = ret['Value']
 
     dm = DataManager()
     result = dm.removeReplica( storageElement, lfn )
@@ -1617,10 +1564,10 @@ class Dirac( API ):
        :type printOutput: boolean
        :returns: S_OK,S_ERROR
     """
-    if type( lfn ) == type( " " ):
-      lfn = lfn.replace( 'LFN:', '' )
-    else:
-      return self._errorReport( 'Expected single string for LFN' )
+    ret = self.__checkFileArgument( lfn, 'LFN' )
+    if not ret['OK']:
+      return ret['Message']
+    lfn = ret['Value']
 
     dataLogging = RPCClient( 'DataManagement/DataLogging' )
     result = dataLogging.getFileLoggingInfo( lfn )
@@ -1792,7 +1739,7 @@ class Dirac( API ):
       self.log.verbose( 'Could not retrieve job parameters to check for oversized sandbox' )
       return params
 
-    if not params['Value'].has_key( 'OutputSandboxLFN' ):
+    if not params['Value'].get( 'OutputSandboxLFN' ):
       self.log.verbose( 'No oversized output sandbox for job %s:\n%s' % ( jobID, params ) )
       return result
 
@@ -1986,9 +1933,8 @@ class Dirac( API ):
       result[job].update( vals )
     for job, vals in minorStatusDict['Value'].items():
       result[job].update( vals )
-    for job, vals in result.items():
-      if result[job].has_key( 'JobID' ):
-        del result[job]['JobID']
+    for job in result:
+      result[job].pop( 'JobID', None )
 
     return S_OK( result )
 
@@ -2057,7 +2003,7 @@ class Dirac( API ):
     result = self.parameters( int( jobID ) )
     if not result['OK']:
       return result
-    if not result['Value'].has_key( 'UploadedOutputData' ):
+    if not result['Value'].get( 'UploadedOutputData' ):
       self.log.info( 'Parameters for job %s do not contain uploaded output data:\n%s' % ( jobID, result ) )
       return S_ERROR( 'No output data found for job %s' % jobID )
 
@@ -2097,7 +2043,7 @@ class Dirac( API ):
     result = self.parameters( int( jobID ) )
     if not result['OK']:
       return result
-    if not result['Value'].has_key( 'UploadedOutputData' ):
+    if not result['Value'].get( 'UploadedOutputData' ):
       self.log.info( 'Parameters for job %s do not contain uploaded output data:\n%s' % ( jobID, result ) )
       return S_ERROR( 'No output data found for job %s' % jobID )
 
@@ -2267,13 +2213,9 @@ class Dirac( API ):
     for job in jobID:
       summary[job] = {}
       for key in headers:
-        if not jobSummary.has_key( job ):
+        if job not in jobSummary:
           self.log.warn( 'No records for JobID %s' % job )
-          value = 'None'
-        elif jobSummary[job].has_key( key ):
-          value = jobSummary[job][key]
-        else:
-          value = 'None'
+        value = jobSummary.get( job, {} ).get( key, 'None' )
         summary[job][key] = value
 
     if outputFile:
@@ -2550,8 +2492,7 @@ class Dirac( API ):
     if not result['OK']:
       return result
 
-    if result['Value'].has_key( 'StandardOutput' ):
-      del result['Value']['StandardOutput']
+    result['Value'].pop( 'StandardOutput', None )
 
     if printOutput:
       print self.pPrint.pformat( result['Value'] )
@@ -2631,13 +2572,14 @@ class Dirac( API ):
     if not result['OK']:
       return self._errorReport( result, 'Could not retrieve job attributes' )
 
-    stdout = 'Not available yet.'
-    if result['Value'].has_key( 'StandardOutput' ):
-      self.log.verbose( result['Value']['StandardOutput'] )
-      stdout = result['Value']['StandardOutput']
+    stdout = result['Value'].get( 'StandardOutput' )
+    if stdout:
       if printout:
-        print stdout
+        self.log.always( stdout )
+      else:
+        self.log.verbose( stdout )
     else:
+      stdout = 'Not available yet.'
       self.log.info( 'No standard output available to print.' )
 
     return S_OK( stdout )

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1072,8 +1072,6 @@ class Dirac( API ):
 
       printTable( fields, records, numbering = False )
 
-      print self.pPrint.pformat( repsResult['Value'] )
-
     return repsResult
 
   #############################################################################

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -2684,7 +2684,7 @@ class Dirac( API ):
     return result
 
   #############################################################################
-  def getJobJDL( self, jobID, printOutput = False ):
+  def getJobJDL( self, jobID, original = False, printOutput = False ):
     """Simple function to retrieve the current JDL of an existing job in the
        workload management system.  The job JDL is converted to a dictionary
        and returned in the result structure.
@@ -2706,7 +2706,7 @@ class Dirac( API ):
         return self._errorReport( str( x ), 'Expected integer or string for existing jobID' )
 
     monitoring = RPCClient( 'WorkloadManagement/JobMonitoring' )
-    result = monitoring.getJobJDL( jobID )
+    result = monitoring.getJobJDL( jobID, original )
     if not result['OK']:
       return result
 

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -47,6 +47,12 @@ from DIRAC.Core.Utilities.PrettyPrint                    import printTable
 
 COMPONENT_NAME = 'DiracAPI'
 
+def parseArguments( args ):
+  argList = []
+  for arg in args:
+    argList += arg.split( ',' )
+  return argList
+
 class Dirac( API ):
   """
    DIRAC API Class
@@ -1080,10 +1086,10 @@ class Dirac( API ):
           records.append( ( lfnPrint, se, url ) )
           lfnPrint = ''
       for lfn in repsResult['Value']['Failed']:
-        records.append( ( lfn, 'Unknown', str( repsResult['Value']['Failed'][lfn] ) ) )    
-      
+        records.append( ( lfn, 'Unknown', str( repsResult['Value']['Failed'][lfn] ) ) )
+
       printTable( fields, records, numbering = False )
-      
+
       print self.pPrint.pformat( repsResult['Value'] )
 
     return repsResult
@@ -2587,12 +2593,12 @@ class Dirac( API ):
 
     if printOutput:
       loggingTupleList = result['Value']
-      
+
       fields = [ 'Source', 'Status', 'MinorStatus', 'ApplicationStatus', 'DateTime' ]
       records = []
       for l in loggingTupleList:
         records.append( [ l[i] for i in ( 4, 0, 1, 2, 3 ) ] )
-      printTable( fields, records, numbering = False, columnSeparator = '  ' )  
+      printTable( fields, records, numbering = False, columnSeparator = '  ' )
 
     return result
 

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -89,7 +89,7 @@ class Dirac( API ):
       if otherPrefix in fnList:
         return S_ERROR( self._errorReport( 'Expected %s string, not %s' ) % ( prefix, otherPrefix ) )
       return S_OK( fnList.replace( '%s:' % prefix, '' ) )
-    elif type( fnList ) == type.ListType:
+    elif type( fnList ) == types.ListType:
       if single:
         return S_ERROR( self._errorReport( 'Expected single %s string' % prefix ) )
       try:

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1177,6 +1177,8 @@ class Dirac( API ):
 
   #############################################################################
   def getMetadata( self, lfns, printOutput = False ):
+    return self.getLfnMetadata( lfns, printOutput = printOutput )
+  def getLfnMetadata( self, lfns, printOutput = False ):
     """Obtain replica metadata from file catalogue client. Input LFN(s) can be string or list.
 
        Example usage:
@@ -1777,6 +1779,8 @@ class Dirac( API ):
 
   #############################################################################
   def delete( self, jobID ):
+    return self.jobDelete( jobID )
+  def jobDelete( self, jobID ):
     """Delete job or list of jobs from the WMS, if running these jobs will
        also be killed.
 
@@ -1846,6 +1850,9 @@ class Dirac( API ):
     return result
 
   def kill( self, jobID ):
+    return self.jobKill( jobID )
+
+  def jobKill( self, jobID ):
     """Issue a kill signal to a running job.  If a job has already completed this
        action is harmless but otherwise the process will be killed on the compute
        resource by the Watchdog.
@@ -2418,6 +2425,9 @@ class Dirac( API ):
 
   #############################################################################
   def attributes( self, jobID, printOutput = False ):
+    return self.jobAttributes( jobID, printOutput = printOutput )
+
+  def jobAttributes( self, jobID, printOutput = False ):
     """Return DIRAC attributes associated with the given job.
 
        Each job will have certain attributes that affect the journey through the
@@ -2460,6 +2470,8 @@ class Dirac( API ):
 
   #############################################################################
   def parameters( self, jobID, printOutput = False ):
+    return self.jobParameters( jobID, printOutput = printOutput )
+  def jobParameters( self, jobID, printOutput = False ):
     """Return DIRAC parameters associated with the given job.
 
        DIRAC keeps track of several job parameters which are kept in the job monitoring
@@ -2499,6 +2511,8 @@ class Dirac( API ):
 
   #############################################################################
   def loggingInfo( self, jobID, printOutput = False ):
+    return self.jobLoggingInfo( jobID, printOutput = printOutput )
+  def jobLoggingInfo( self, jobID, printOutput = False ):
     """DIRAC keeps track of job transitions which are kept in the job monitoring
        service, see example below.  Logging summary also printed to screen at the
        INFO level.
@@ -2542,7 +2556,9 @@ class Dirac( API ):
     return result
 
   #############################################################################
-  def peek( self, jobID, printout = False ):
+  def peek( self, jobID, printout = False, printOutput = False ):
+    return self.jobPeek( jobID, printOutput = printout or printOutput )
+  def jobPeek( self, jobID, printOutput = False ):
     """The peek function will attempt to return standard output from the WMS for
        a given job if this is available.  The standard output is periodically
        updated from the compute resource via the application Watchdog. Available
@@ -2572,7 +2588,7 @@ class Dirac( API ):
 
     stdout = result['Value'].get( 'StandardOutput' )
     if stdout:
-      if printout:
+      if printOutput:
         self.log.always( stdout )
       else:
         self.log.verbose( stdout )

--- a/Interfaces/API/DiracAdmin.py
+++ b/Interfaces/API/DiracAdmin.py
@@ -351,7 +351,7 @@ class DiracAdmin( API ):
     serviceSetups = gConfig.getOptionsDict( '/DIRAC/Setups/%s' % setup )
     if not serviceSetups['OK']:
       return S_ERROR( 'Could not get /DIRAC/Setups/%s options' % setup )
-    serviceSetups = serviceSetups['Value'] #dict
+    serviceSetups = serviceSetups['Value']  # dict
     systemList = gConfig.getSections( '/Systems' )
     if not systemList['OK']:
       return S_ERROR( 'Could not get Systems sections' )
@@ -439,7 +439,7 @@ class DiracAdmin( API ):
        counter for a job or list of jobs and allows them to run as new.
 
        Example::
-       
+
          >>> print dirac.reset(12345)
          {'OK': True, 'Value': [12345]}
 
@@ -515,7 +515,7 @@ class DiracAdmin( API ):
     else:
       self.log.warn( 'No standard error returned' )
 
-    self.log.info( 'Outputs retrieved in %s' % outputPath )
+    self.log.always( 'Outputs retrieved in %s' % outputPath )
     return result
 
   #############################################################################
@@ -575,7 +575,7 @@ class DiracAdmin( API ):
     else:
       self.log.warn( 'No standard error returned' )
 
-    self.log.notice( 'Outputs retrieved in %s' % outputPath )
+    self.log.always( 'Outputs retrieved in %s' % outputPath )
     return result
 
   #############################################################################
@@ -595,7 +595,7 @@ class DiracAdmin( API ):
     wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
     result = wmsAdmin.getPilotInfo( gridReference )
     return result
-  
+
   #############################################################################
   def killPilot( self, gridReference ):
     """Kill the pilot specified
@@ -700,7 +700,7 @@ class DiracAdmin( API ):
                       requestType = None, status = None, operation = None, ownerDN = None,
                       ownerGroup = None, requestStart = 0, limit = 100, printOutput = False ):
     """Select requests from the request management system. A few notes on the selection criteria:
-    
+
          - jobID is the WMS JobID for the request (if applicable)
          - requestID is assigned during submission of the request
          - requestName is the corresponding XML file name
@@ -712,7 +712,7 @@ class DiracAdmin( API ):
 
        >>> dirac.selectRequests(jobID='4894')
        {'OK': True, 'Value': [[<Requests>]]}
-       
+
     """
     options = {'RequestID':requestID, 'RequestName':requestName, 'JobID':jobID, 'OwnerDN':ownerDN,
                'OwnerGroup':ownerGroup, 'RequestType':requestType, 'Status':status, 'Operation':operation}
@@ -765,7 +765,7 @@ class DiracAdmin( API ):
 
   #############################################################################
   def getRequestSummary( self, printOutput = False ):
-    """ 
+    """
     Get a summary of the requests in the request DB.
     """
     requestClient = RPCClient( "RequestManagement/centralURL", timeout = 120 )
@@ -781,7 +781,7 @@ class DiracAdmin( API ):
 
   #############################################################################
   def getExternalPackageVersions( self ):
-    """ 
+    """
     Simple function that attempts to obtain the external versions for
     the local DIRAC installation (frequently needed for debugging purposes).
     """
@@ -940,13 +940,13 @@ class DiracAdmin( API ):
   def csRegisterUser( self, username, properties ):
     """
     Registers a user in the CS.
-    
+
         - username: Username of the user (easy;)
         - properties: Dict containing:
             - DN
             - groups : list/tuple of groups the user belongs to
             - <others> : More properties of the user, like mail
-    
+
     """
     return self.csAPI.addUser( username, properties )
 
@@ -960,7 +960,7 @@ class DiracAdmin( API ):
   #############################################################################
   def csModifyUser( self, username, properties, createIfNonExistant = False ):
     """
-    Modify a user in the CS. Takes the same params as in addUser and 
+    Modify a user in the CS. Takes the same params as in addUser and
     applies the changes
     """
     return self.csAPI.modifyUser( username, properties, createIfNonExistant )
@@ -1041,7 +1041,7 @@ class DiracAdmin( API ):
 
   #############################################################################
   def sendMail( self, address, subject, body, fromAddress = None, localAttempt = True ):
-    """ 
+    """
     Send mail to specified address with body.
     """
     notification = NotificationClient()
@@ -1049,7 +1049,7 @@ class DiracAdmin( API ):
 
   #############################################################################
   def sendSMS( self, userName, body, fromAddress = None ):
-    """ 
+    """
     Send mail to specified address with body.
     """
     if len( body ) > 160:
@@ -1106,4 +1106,4 @@ class DiracAdmin( API ):
     """
     return ldapSE( site, useVO, host = host )
 
-#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#
+# EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#

--- a/Interfaces/scripts/dirac-wms-job-attributes.py
+++ b/Interfaces/scripts/dirac-wms-job-attributes.py
@@ -22,14 +22,14 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC.Interfaces.API.Dirac                              import Dirac
+from DIRAC.Interfaces.API.Dirac                              import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 errorList = []
 
-for job in args:
+for job in parseArguments( args ):
 
-  result = dirac.attributes( int(job), printOutput = True )
+  result = dirac.attributes( int( job ), printOutput = True )
   if not result['OK']:
     errorList.append( ( job, result['Message'] ) )
     exitCode = 2

--- a/Interfaces/scripts/dirac-wms-job-delete.py
+++ b/Interfaces/scripts/dirac-wms-job-delete.py
@@ -26,13 +26,13 @@ args = Script.getPositionalArgs()
 import os.path
 
 if __name__ == "__main__":
-  
-  from DIRAC.Interfaces.API.Dirac import Dirac
+
+  from DIRAC.Interfaces.API.Dirac import Dirac, parseArguments
   from DIRAC.Core.Utilities.Time import toString, date, day
   dirac = Dirac()
   exitCode = 0
   errorList = []
-  
+
   jobs = []
   for sw, value in Script.getUnprocessedSwitches():
     if sw.lower() in ( 'f', 'file' ):
@@ -40,9 +40,9 @@ if __name__ == "__main__":
         jFile = open( value )
         jobs += jFile.read().split()
         jFile.close()
-    elif sw.lower() in ( 'g', 'jobgroup' ):    
-      group = value    
-      jobDate = toString( date() - 30*day )
+    elif sw.lower() in ( 'g', 'jobgroup' ):
+      group = value
+      jobDate = toString( date() - 30 * day )
       result = dirac.selectJobs( jobGroup = value, date = jobDate )
       if not result['OK']:
         if not "No jobs selected" in result['Message']:
@@ -50,25 +50,25 @@ if __name__ == "__main__":
           DIRAC.exit( -1 )
       else:
         jobs += result['Value']
-  
-  for arg in args:
-    jobs.append(arg)
-  
+
+  for arg in parseArguments( args ):
+    jobs.append( arg )
+
   if not jobs:
     print "Warning: no jobs selected"
     Script.showHelp()
     DIRAC.exit( 0 )
-  
+
   for job in jobs:
-  
+
     result = dirac.delete( job )
     if result['OK']:
       print 'Deleted job %s' % ( result['Value'][0] )
     else:
       errorList.append( ( job, result['Message'] ) )
       exitCode = 2
-  
+
   for error in errorList:
     print "ERROR %s: %s" % error
-  
+
   DIRAC.exit( exitCode )

--- a/Interfaces/scripts/dirac-wms-job-get-input.py
+++ b/Interfaces/scripts/dirac-wms-job-get-input.py
@@ -24,7 +24,7 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC.Interfaces.API.Dirac                              import Dirac
+from DIRAC.Interfaces.API.Dirac                              import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 errorList = []
@@ -34,7 +34,7 @@ for sw, v in Script.getUnprocessedSwitches():
   if sw in ( 'D', 'Dir' ):
     outputDir = v
 
-for job in args:
+for job in parseArguments( args ):
 
   result = dirac.getInputSandbox( job, outputDir = outputDir )
   if result['OK']:

--- a/Interfaces/scripts/dirac-wms-job-get-jdl.py
+++ b/Interfaces/scripts/dirac-wms-job-get-jdl.py
@@ -22,12 +22,12 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC.Interfaces.API.Dirac                              import Dirac
+from DIRAC.Interfaces.API.Dirac                              import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 errorList = []
 
-for job in args:
+for job in parseArguments( args ):
 
   result = dirac.getJobJDL( job, printOutput = True )
   if not result['OK']:

--- a/Interfaces/scripts/dirac-wms-job-get-jdl.py
+++ b/Interfaces/scripts/dirac-wms-job-get-jdl.py
@@ -11,6 +11,8 @@ __RCSID__ = "$Id$"
 import DIRAC
 from DIRAC.Core.Base import Script
 
+original = False
+Script.registerSwitch( '', 'Original', '   Gets the original JDL' )
 Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
                                      'Usage:',
                                      '  %s [option|cfgfile] ... JobID ...' % Script.scriptName,
@@ -18,6 +20,10 @@ Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
                                      '  JobID:    DIRAC Job ID' ] ) )
 Script.parseCommandLine( ignoreErrors = True )
 args = Script.getPositionalArgs()
+
+for switch in Script.getUnprocessedSwitches():
+  if switch[0] == 'Original':
+    original = True
 
 if len( args ) < 1:
   Script.showHelp()
@@ -29,7 +35,7 @@ errorList = []
 
 for job in parseArguments( args ):
 
-  result = dirac.getJobJDL( job, printOutput = True )
+  result = dirac.getJobJDL( job, original = original, printOutput = True )
   if not result['OK']:
     errorList.append( ( job, result['Message'] ) )
     exitCode = 2

--- a/Interfaces/scripts/dirac-wms-job-get-output-data.py
+++ b/Interfaces/scripts/dirac-wms-job-get-output-data.py
@@ -23,7 +23,7 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC.Interfaces.API.Dirac                              import Dirac
+from DIRAC.Interfaces.API.Dirac                              import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 errorList = []
@@ -33,7 +33,7 @@ for sw, v in Script.getUnprocessedSwitches():
   if sw in ( 'D', 'Dir' ):
     outputDir = v
 
-for job in args:
+for job in parseArguments( args ):
 
   result = dirac.getJobOutputData( job, destinationDir = outputDir )
   if result['OK']:

--- a/Interfaces/scripts/dirac-wms-job-get-output.py
+++ b/Interfaces/scripts/dirac-wms-job-get-output.py
@@ -27,7 +27,7 @@ Script.registerSwitch( "g:", "JobGroup=", "Get output for jobs in the given grou
 Script.parseCommandLine( ignoreErrors = True )
 args = Script.getPositionalArgs()
 
-from DIRAC.Interfaces.API.Dirac  import Dirac
+from DIRAC.Interfaces.API.Dirac  import Dirac, parseArguments
 from DIRAC.Core.Utilities.Time import toString, date, day
 
 dirac = Dirac()
@@ -45,31 +45,31 @@ for sw, value in Script.getUnprocessedSwitches():
       jFile = open( value )
       jobs += jFile.read().split()
       jFile.close()
-  elif sw.lower() in ( 'g', 'jobgroup' ):    
+  elif sw.lower() in ( 'g', 'jobgroup' ):
     group = value
-    jobDate = toString( date() - 30*day )
-    
+    jobDate = toString( date() - 30 * day )
+
     # Choose jobs in final state, no more than 30 days old
-    result = dirac.selectJobs( jobGroup=value, date=jobDate, status='Done' )
-    if not result['OK']:
-      if not "No jobs selected" in result['Message']:
-        print "Error:", result['Message']
-        DIRAC.exit( -1 )
-    else:    
-      jobs += result['Value']      
-    result = dirac.selectJobs( jobGroup=value, date=jobDate, status='Failed' )
+    result = dirac.selectJobs( jobGroup = value, date = jobDate, status = 'Done' )
     if not result['OK']:
       if not "No jobs selected" in result['Message']:
         print "Error:", result['Message']
         DIRAC.exit( -1 )
     else:
-      jobs += result['Value']      
+      jobs += result['Value']
+    result = dirac.selectJobs( jobGroup = value, date = jobDate, status = 'Failed' )
+    if not result['OK']:
+      if not "No jobs selected" in result['Message']:
+        print "Error:", result['Message']
+        DIRAC.exit( -1 )
+    else:
+      jobs += result['Value']
 
-for arg in args:
-  if os.path.isdir(arg):  
+for arg in parseArguments( args ):
+  if os.path.isdir( arg ):
     print "Output for job %s already retrieved, remove the output directory to redownload" % arg
   else:
-    jobs.append(arg)
+    jobs.append( arg )
 
 if not jobs:
   print "No jobs selected"
@@ -77,25 +77,25 @@ if not jobs:
 
 if group:
   if outputDir:
-    outputDir = os.path.join(outputDir,group)
+    outputDir = os.path.join( outputDir, group )
   else:
-    outputDir = group  
+    outputDir = group
 
-if outputDir: 
-  if not os.path.exists(outputDir):
-    os.makedirs( outputDir)
+if outputDir:
+  if not os.path.exists( outputDir ):
+    os.makedirs( outputDir )
 else:
-  outputDir = os.getcwd()    
+  outputDir = os.getcwd()
 
-jobs = [ str(job) for job in jobs ]
+jobs = [ str( job ) for job in jobs ]
 doneJobs = os.listdir( outputDir )
 todoJobs = [ job for job in jobs if not job in doneJobs ]
-  
+
 for job in todoJobs:
 
   result = dirac.getOutputSandbox( job, outputDir = outputDir )
-  
-  jobDir = str(job)
+
+  jobDir = str( job )
   if outputDir:
     jobDir = os.path.join( outputDir, job )
   if result['OK']:

--- a/Interfaces/scripts/dirac-wms-job-kill.py
+++ b/Interfaces/scripts/dirac-wms-job-kill.py
@@ -22,12 +22,12 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC.Interfaces.API.Dirac                              import Dirac
+from DIRAC.Interfaces.API.Dirac                              import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 errorList = []
 
-for job in args:
+for job in parseArguments( args ):
 
   result = dirac.kill( job )
   if result['OK']:

--- a/Interfaces/scripts/dirac-wms-job-logging-info.py
+++ b/Interfaces/scripts/dirac-wms-job-logging-info.py
@@ -22,12 +22,12 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC.Interfaces.API.Dirac                              import Dirac
+from DIRAC.Interfaces.API.Dirac                              import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 errorList = []
 
-for job in args:
+for job in parseArguments( args ):
 
   result = dirac.loggingInfo( job, printOutput = True )
   if not result['OK']:

--- a/Interfaces/scripts/dirac-wms-job-parameters.py
+++ b/Interfaces/scripts/dirac-wms-job-parameters.py
@@ -22,12 +22,12 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC.Interfaces.API.Dirac                              import Dirac
+from DIRAC.Interfaces.API.Dirac                              import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 errorList = []
 
-for job in args:
+for job in parseArguments( args ):
 
   result = dirac.parameters( job, printOutput = True )
   if not result['OK']:

--- a/Interfaces/scripts/dirac-wms-job-peek.py
+++ b/Interfaces/scripts/dirac-wms-job-peek.py
@@ -22,14 +22,14 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC.Interfaces.API.Dirac                              import Dirac
+from DIRAC.Interfaces.API.Dirac                              import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 errorList = []
 
-for job in args:
+for job in parseArguments( args ):
 
-  result = dirac.peek( job, printout=True )
+  result = dirac.peek( job, printout = True )
   if not result['OK']:
     errorList.append( ( job, result['Message'] ) )
     exitCode = 2

--- a/Interfaces/scripts/dirac-wms-job-reschedule.py
+++ b/Interfaces/scripts/dirac-wms-job-reschedule.py
@@ -22,12 +22,12 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC.Interfaces.API.Dirac                              import Dirac
+from DIRAC.Interfaces.API.Dirac                              import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 errorList = []
 
-for job in args:
+for job in parseArguments( args ):
 
   result = dirac.reschedule( job )
   if result['OK']:

--- a/Interfaces/scripts/dirac-wms-job-status.py
+++ b/Interfaces/scripts/dirac-wms-job-status.py
@@ -27,31 +27,31 @@ Script.registerSwitch( "g:", "JobGroup=", "Get status for jobs in the given grou
 Script.parseCommandLine( ignoreErrors = True )
 args = Script.getPositionalArgs()
 
-from DIRAC.Interfaces.API.Dirac  import Dirac
+from DIRAC.Interfaces.API.Dirac  import Dirac, parseArguments
 dirac = Dirac()
 exitCode = 0
 
 jobs = []
-for key, value in Script.getUnprocessedSwitches():  
+for key, value in Script.getUnprocessedSwitches():
   if key.lower() in ( 'f', 'file' ):
     if os.path.exists( value ):
       jFile = open( value )
       jobs += jFile.read().split()
       jFile.close()
-  elif key.lower() in ( 'g', 'jobgroup' ):    
-    jobDate = toString( date() - 30*day )
+  elif key.lower() in ( 'g', 'jobgroup' ):
+    jobDate = toString( date() - 30 * day )
     # Choose jobs no more than 30 days old
-    result = dirac.selectJobs( jobGroup=value, date=jobDate )    
+    result = dirac.selectJobs( jobGroup = value, date = jobDate )
     if not result['OK']:
       print "Error:", result['Message']
       DIRACExit( -1 )
-    jobs += result['Value']  
-        
+    jobs += result['Value']
+
 if len( args ) < 1 and not jobs:
   Script.showHelp()
 
-if len(args) > 0:
-  jobs += args
+if len( args ) > 0:
+  jobs += parseArguments( args )
 
 try:
   jobs = [ int( job ) for job in jobs ]

--- a/Resources/Catalog/FileCatalog.py
+++ b/Resources/Catalog/FileCatalog.py
@@ -46,7 +46,7 @@ class FileCatalog( object ):
     self.vo = vo if vo else getVOfromProxyGroup().get( 'Value', None )
 
     self.opHelper = Operations( vo = self.vo )
-    if catalogs == None:
+    if not catalogs:
       catalogs = []
     elif type( catalogs ) in types.StringTypes:
       catalogs = catalogs.split( ',' )

--- a/WorkloadManagementSystem/Client/JobState/JobManifest.py
+++ b/WorkloadManagementSystem/Client/JobState/JobManifest.py
@@ -159,7 +159,7 @@ class JobManifest( object ):
       if k not in self.__manifest:
         return S_ERROR( "Missing var %s in manifest" % k )
     # Check CPUTime
-    
+
     # Hack, sorry Adri, for v6r7 branch only
     result = self.__checkNumericalVar( "MaxCPUTime", 86400, 0, 1500000 )
     if not result[ 'OK' ]:
@@ -182,7 +182,8 @@ class JobManifest( object ):
     result = self.__checkMultiChoice( "PilotTypes", [ 'private' ] )
     if not result[ 'OK' ]:
       return result
-    result = self.__checkMaxInputData( 500 )
+    maxInputData = Operations().getValue( "JobDescription/MaxInputData", 500 )
+    result = self.__checkMaxInputData( maxInputData )
     if not result[ 'OK' ]:
       return result
     transformationTypes = Operations().getValue( "Transformations/DataProcessing", [] )

--- a/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -6,7 +6,7 @@
 
 __RCSID__ = "$Id$"
 
-from types import IntType, LongType, ListType, DictType, StringTypes, StringType, NoneType
+from types import IntType, LongType, ListType, DictType, StringTypes, StringType, NoneType, BooleanType
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC import S_OK, S_ERROR
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
@@ -228,11 +228,11 @@ class JobMonitoringHandler( RequestHandler ):
     return gJobDB.getJobAttribute( jobID, 'Site' )
 
 ##############################################################################
-  types_getJobJDL = [ IntType ]
+  types_getJobJDL = [ IntType, BooleanType ]
   @staticmethod
-  def export_getJobJDL ( jobID ):
+  def export_getJobJDL ( jobID, original ):
 
-    return gJobDB.getJobJDL( jobID )
+    return gJobDB.getJobJDL( jobID, original = original )
 
 ##############################################################################
   types_getJobLoggingInfo = [ IntType ]
@@ -355,7 +355,7 @@ class JobMonitoringHandler( RequestHandler ):
         return S_ERROR( 'Failed to select jobs: ' + result['Message'] )
 
       summaryJobList = result['Value']
-      if not self.globalJobsInfo:      
+      if not self.globalJobsInfo:
         validJobs, _invalidJobs, _nonauthJobs, _ownJobs = self.jobPolicy.evaluateJobRights( summaryJobList,
                                                                                             RIGHT_GET_INFO )
         summaryJobList = validJobs
@@ -502,7 +502,7 @@ class JobMonitoringHandler( RequestHandler ):
     """ Get input data for the specified jobs
     """
     return  gJobDB.getInputData( jobID )
-  
+
 
 ##############################################################################
   types_getOwnerGroup = []
@@ -512,4 +512,3 @@ class JobMonitoringHandler( RequestHandler ):
     Return Distinct Values of OwnerGroup from the JobsDB
     """
     return gJobDB.getDistinctJobAttributes( 'OwnerGroup' )
-  


### PR DESCRIPTION
(Part of) this PR is required before the LFC->DFC migration

In decreasing order of importance:

* Fix in FileCatalog to allow a comma-separated string as list of catalogs
* Set the max number of files in a job through CS (was hardcoded to 500)
     - This should be replaced by a check that the JDL fits in the JobDB table
     - JobDB table: move to MEDIUMBLOB the JDL field
* Fix in FTSJob to recognize when an FTS job was not found 
* In dirac-wms-job scripts, allow passing the list of jobs in comma-separated list
* better code in Dirac API, more explicit method names
    - Still to be done: ambiguity between replicate() and replicateFile(), should be replicate() and replicateAndRegister() to be consistent
* Embryo of a CSHelpers module in DMS (not used yet)

Apologies for the mixed beautifying... 