### PR TITLE
[v6r12] stop optimizing requests already in the DB

### DIFF
--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -114,7 +114,7 @@ class ReqClient( Client ):
     errorsDict["Message"] = "ReqClient.putRequest: unable to set request '%s'" % request.RequestName
     return errorsDict
 
-  def getRequest( self, requestName = "" ):
+  def getRequest( self, requestName = None ):
     """ get request from RequestDB
 
     :param self: self reference
@@ -125,7 +125,7 @@ class ReqClient( Client ):
     self.log.debug( "getRequest: attempting to get request." )
     getRequest = self.requestManager().getRequest( requestName )
     if not getRequest["OK"]:
-      self.log.error( "getRequest: unable to get request", "request: '%s' %s" % ( requestName, getRequest["Message"] ) )
+      self.log.error( "getRequest: unable to get request", "'%s' %s" % ( requestName, getRequest["Message"] ) )
       return getRequest
     if not getRequest["Value"]:
       return getRequest

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -524,9 +524,13 @@ class Request( Record ):
                 S_OK(False) if no optimization were carried out
     """
 
+    # If the RequestID is not the default one (0), it probably means
+    # the Request is already in the DB, so we don't touch anything
+    if self.RequestID:
+      return S_ERROR( "Cannot optimize because Request seems to be already in the DB (RequestID %s)" % self.RequestID )
+
     # Set to True if the request could be optimized
     optimized = False
-
     # Recognise Failover request series
     repAndRegList = []
     removeRepList = []
@@ -567,11 +571,6 @@ class Request( Record ):
     # List of attributes that must be equal for operations to be merged
     attrList = ["Type", "Arguments", "SourceSE", "TargetSE", "Catalog" ]
 
-    # If the RequestID is not the default one (0), it probably means
-    # the Request is already in the DB, so we don't touch anything
-    # unless it was optimized, in which case we reset the IDs to default
-    if self.RequestID:
-      return S_ERROR( "Cannot optimize because Request seems to be already in the DB (RequestID %s)" % self.RequestID )
 
     # We could do it with a single loop (the 2nd one), but by doing this,
     # we can replace

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -528,7 +528,6 @@ class Request( Record ):
     # the Request is already in the DB, so we don't touch anything
     if self.RequestID:
       return S_ERROR( "Cannot optimize because Request seems to be already in the DB (RequestID %s)" % self.RequestID )
-
     # Set to True if the request could be optimized
     optimized = False
     # Recognise Failover request series

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -570,16 +570,6 @@ class Request( Record ):
     # List of attributes that must be equal for operations to be merged
     attrList = ["Type", "Arguments", "SourceSE", "TargetSE", "Catalog" ]
 
-
-    # We could do it with a single loop (the 2nd one), but by doing this,
-    # we can replace
-    #   i += 1
-    #   continue
-    #
-    # with
-    #   break
-    #
-    # which is nicer in my opinion
     i = 0
     while i < len( self.__operations__ ):
       while  ( i + 1 ) < len( self.__operations__ ):

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -571,16 +571,7 @@ class Request( Record ):
     # the Request is already in the DB, so we don't touch anything
     # unless it was optimized, in which case we reset the IDs to default
     if self.RequestID:
-      if optimized:
-        self.RequestID = 0
-        for op in self.__operations__:
-          op.OperationID = 0
-          op.RequestID = 0
-          for f in op:
-            f.FileID = 0
-            f.OperationID = 0
-      else:
-        return S_ERROR( "Cannot optimize because Request seems to be already in the DB (RequestID %s)" % self.RequestID )
+      return S_ERROR( "Cannot optimize because Request seems to be already in the DB (RequestID %s)" % self.RequestID )
 
     # We could do it with a single loop (the 2nd one), but by doing this,
     # we can replace


### PR DESCRIPTION
This was a temporary patch for getting failover transfers done.
We forgot to remove it when all requests have been completed...