### PR TITLE
[v6r13] Added getDirectoryMetadata to the DFC interface

### DIFF
--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -1849,7 +1849,7 @@ File Catalog Client $Revision: 1.17 $Date:
       dirFlag = not result['Value']['Successful'][path]        
         
     if dirFlag:    
-      result = self.fc.getDirectoryMetadata(path)      
+      result = self.fc.getDirectoryUserMetadata(path)
       if not result['OK']:
         print ("Error: %s" % result['Message']) 
         return

--- a/DataManagementSystem/DB/FileCatalogDB.py
+++ b/DataManagementSystem/DB/FileCatalogDB.py
@@ -822,7 +822,27 @@ class FileCatalogDB(DB):
     successful = res['Value']['Successful']
     queryTime = res['Value'].get('QueryTime',-1.)
     return S_OK( {'Successful':successful,'Failed':failed,'QueryTime':queryTime} )
-  
+
+  def getDirectoryMetadata( self, lfns, credDict ):
+    ''' Get standard directory metadata
+    :param list lfns: list of directory paths
+    :param dict credDict: credentials
+    :return: Successful/Failed dict.
+    '''
+    res = self._checkPathPermissions('Read', lfns, credDict)
+    if not res['OK']:
+      return res
+    failed = res['Value']['Failed']
+    successful = {}
+    for lfn in res['Value']['Successful']:
+      result = self.dtree.getDirectoryParameters( lfn )
+      if result['OK']:
+        successful[lfn] = result['Value']
+      else:
+        failed[lfn] = result['Message']
+
+    return S_OK( { 'Successful': successful, 'Failed': failed } )
+
   def rebuildDirectoryUsage(self):
     """ Rebuild DirectoryUsage table from scratch
     """

--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -358,6 +358,11 @@ class FileCatalogHandler( RequestHandler ):
     """ Determine whether supplied path is a directory """
     return gFileCatalogDB.isDirectory( lfns, self.getRemoteCredentials() )
 
+  types_getDirectoryMetadata = [ [ ListType, DictType ] + list( StringTypes ) ]
+  def export_getDirectoryMetadata( self, lfns ):
+    """ Get the size of the supplied directory """
+    return gFileCatalogDB.getDirectoryMetadata( lfns, self.getRemoteCredentials() )
+
   types_getDirectorySize = [ [ ListType, DictType ] + list( StringTypes ) ]
   def export_getDirectorySize( self, lfns, longOut = False, fromFiles = False ):
     """ Get the size of the supplied directory """
@@ -451,8 +456,8 @@ class FileCatalogHandler( RequestHandler ):
     """
     return gFileCatalogDB.removeMetadata( pathMetadataDict, self.getRemoteCredentials() )
 
-  types_getDirectoryMetadata = [ StringTypes ]
-  def export_getDirectoryMetadata( self, path ):
+  types_getDirectoryUserMetadata = [ StringTypes ]
+  def export_getDirectoryUserMetadata( self, path ):
     """ Get all the metadata valid for the given directory path
     """
     return gFileCatalogDB.dmeta.getDirectoryMetadata( path, self.getRemoteCredentials() )

--- a/Resources/Catalog/FileCatalog.py
+++ b/Resources/Catalog/FileCatalog.py
@@ -18,7 +18,7 @@ class FileCatalog( object ):
                 'resolveDataset', 'getPathPermissions', 'getLFNForPFN', 'getUsers', 'getGroups', 'getLFNForGUID']
 
   ro_meta_methods = ['getFileUserMetadata', 'getMetadataFields', 'findFilesByMetadata',
-                     'getFileUserMetadata', 'findDirectoriesByMetadata', 'getReplicasByMetadata',
+                     'getDirectoryUserMetadata', 'findDirectoriesByMetadata', 'getReplicasByMetadata',
                      'findFilesByMetadataDetailed', 'findFilesByMetadataWeb', 'getCompatibleMetadata',
                      'getMetadataSet']
 


### PR DESCRIPTION
CHANGE: FileCatalog - replace getDirectoryMetadata by getDirectoryUserMetadata
NEW: FileCatalog - added new getDirectoryMetadata() interface to get standard directory metadata