### PR TITLE
[v6r12] make successful removeReplica if missing in one catalog

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1271,7 +1271,7 @@ class DataManager( object ):
       # Ignore error if file doesn't exist
       # This assumes all catalogs return an error as { catalog : error }
       for catalog, err in error.items():
-        if 'no such file' in err:
+        if 'no such file' in err.lower():
           success.setdefault( lfn, {} ).update( { catalog : True} )
           error.pop( catalog )
       if not failed[lfn]:

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1269,9 +1269,13 @@ class DataManager( object ):
     failed = res['Value']['Failed']
     for lfn, error in failed.items():
       # Ignore error if file doesn't exist
-      if 'no such file or directory' in str( error ).lower():
+      # This assumes all catalogs return an error as { catalog : error }
+      for catalog, err in error.items():
+        if 'no such file' in err:
+          success.setdefault( lfn, {} ).update( { catalog : True} )
+          error.pop( catalog )
+      if not failed[lfn]:
         failed.pop( lfn )
-        success.setdefault( lfn, {} ).update( { ','.join( error.keys() ) : True} )
       else:
         self.log.error( "__removeCatalogReplica: Failed to remove replica.", "%s %s" % ( lfn, error ) )
 

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1245,14 +1245,14 @@ class DataManager( object ):
       return S_ERROR( errStr )
     return self.__removeCatalogReplica( replicaTuples )
 
-  def __removeCatalogReplica( self, replicaTuple ):
+  def __removeCatalogReplica( self, replicaTuples ):
     """ remove replica form catalogue """
-    oDataOperation = self.__initialiseAccountingObject( 'removeCatalogReplica', '', len( replicaTuple ) )
+    oDataOperation = self.__initialiseAccountingObject( 'removeCatalogReplica', '', len( replicaTuples ) )
     oDataOperation.setStartTime()
     start = time.time()
     # HACK!
     replicaDict = {}
-    for lfn, pfn, se in replicaTuple:
+    for lfn, pfn, se in replicaTuples:
       replicaDict[lfn] = {'SE':se, 'PFN':pfn}
     res = self.fc.removeReplica( replicaDict )
     oDataOperation.setEndTime()
@@ -1261,25 +1261,25 @@ class DataManager( object ):
       oDataOperation.setValueByKey( 'RegistrationOK', 0 )
       oDataOperation.setValueByKey( 'FinalStatus', 'Failed' )
       gDataStoreClient.addRegister( oDataOperation )
-      errStr = "__removeCatalogReplica: Completely failed to remove replica."
-      self.log.debug( errStr, res['Message'] )
+      errStr = "__removeCatalogReplica: Completely failed to remove replica: " + res['Message']
+      self.log.debug( errStr )
       return S_ERROR( errStr )
 
-
-    for lfn in res['Value']['Successful']:
-      infoStr = "__removeCatalogReplica: Successfully removed replica."
-      self.log.debug( infoStr, lfn )
-    if res['Value']['Successful']:
-      self.log.debug( "__removeCatalogReplica: Removed %d replicas" % len( res['Value']['Successful'] ) )
-
     success = res['Value']['Successful']
+    failed = res['Value']['Failed']
+    for lfn, error in failed.items():
+      # Ignore error if file doesn't exist
+      if 'no such file or directory' in str( error ).lower():
+        failed.pop( lfn )
+        success.setdefault( lfn, {} ).update( { ','.join( error.keys() ) : True} )
+      else:
+        self.log.error( "__removeCatalogReplica: Failed to remove replica.", "%s %s" % ( lfn, error ) )
+
+    # Only for logging information
     if success:
-      self.log.info( "__removeCatalogReplica: Removed %d replicas" % len( success ) )
+      self.log.debug( "__removeCatalogReplica: Removed %d replicas" % len( success ) )
       for lfn in success:
         self.log.debug( "__removeCatalogReplica: Successfully removed replica.", lfn )
-
-    for lfn, error in res['Value']['Failed'].items():
-      self.log.error( "__removeCatalogReplica: Failed to remove replica.", "%s %s" % ( lfn, error ) )
 
     oDataOperation.setValueByKey( 'RegistrationOK', len( success ) )
     gDataStoreClient.addRegister( oDataOperation )

--- a/DataManagementSystem/scripts/dirac-dms-remove-catalog-files.py
+++ b/DataManagementSystem/scripts/dirac-dms-remove-catalog-files.py
@@ -7,6 +7,7 @@ __RCSID__ = "$Id:  $"
 import DIRAC
 from DIRAC.Core.Base import Script
 from DIRAC import exit as dexit
+from DIRAC import gLogger
 Script.setUsageMessage( """
 Remove the given file or a list of files from the File Catalog
 
@@ -16,6 +17,16 @@ Usage:
 
 Script.parseCommandLine()
 
+from DIRAC.Core.Security.ProxyInfo import getProxyInfo
+res = getProxyInfo()
+if not res['OK']:
+  gLogger.fatal( "Can't get proxy info", res['Message'] )
+  dexit( 1 )
+properties = res['Value'].get( 'groupProperties', [] )
+if not 'FileCatalogManagement' in properties:
+  gLogger.error( "You need to use a proxy from a group with FileCatalogManagement" )
+  dexit( 5 )
+
 from DIRAC.Core.Utilities.List import sortList
 from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 fc = FileCatalog()
@@ -23,7 +34,7 @@ import os
 
 args = Script.getPositionalArgs()
 
-if len( args) < 1:
+if len( args ) < 1:
   Script.showHelp()
   DIRAC.exit( -1 )
 else:
@@ -40,7 +51,7 @@ else:
 res = fc.removeFile( lfns )
 if not res['OK']:
   print "Error:", res['Message']
-  dexit(1)
+  dexit( 1 )
 for lfn in sortList( res['Value']['Failed'].keys() ):
   message = res['Value']['Failed'][lfn]
   print 'Error: failed to remove %s: %s' % ( lfn, message )

--- a/RequestManagementSystem/Client/Operation.py
+++ b/RequestManagementSystem/Client/Operation.py
@@ -328,7 +328,7 @@ class Operation( Record ):
     """ error setter """
     if type( value ) != str:
       raise TypeError( "Error has to be a string!" )
-    self.__data__["Error"] = self._escapeStr( value, 255 )
+    self.__data__["Error"] = self._escapeStr( value[:240], 255 )
 
   @property
   def Status( self ):

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -448,7 +448,7 @@ class Request( Record ):
     """ error setter """
     if type( value ) != str:
       raise TypeError( "Error has to be a string!" )
-    self.__data__["Error"] = self._escapeStr( value, 255 )
+    self.__data__["Error"] = self._escapeStr( value[:240], 255 )
 
   def toSQL( self ):
     """ prepare SQL INSERT or UPDATE statement """


### PR DESCRIPTION
This fix is necessary because LHCb has more than one catalog and some files are only registered in the DFC and not in the LFC (sandboxes).