### PR TITLE
[v6r11-onwards]CHANGE: Force use of TLSv1 from the client side

### DIFF
--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -98,6 +98,13 @@ class BaseClient:
       return S_ERROR( "URL is malformed: %s" % retVal[ 'Message' ] )
     self.__URLTuple = retVal[ 'Value' ]
     self._serviceName = self.__URLTuple[-1]
+    print self.__URLTuple[1:3]
+    res = gConfig.getOptionsDict( "/DIRAC/Security/ConnConf/%s:%s" % self.__URLTuple[1:3] )
+    if res[ 'OK' ]:
+      opts = res[ 'Value' ]
+      for k in opts:
+        if k not in self.kwargs:
+          self.kwargs[k] = opts[k]
     return S_OK()
 
   def __discoverTimeout( self ):

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -98,8 +98,7 @@ class BaseClient:
       return S_ERROR( "URL is malformed: %s" % retVal[ 'Message' ] )
     self.__URLTuple = retVal[ 'Value' ]
     self._serviceName = self.__URLTuple[-1]
-    print self.__URLTuple[1:3]
-    res = gConfig.getOptionsDict( "/DIRAC/Security/ConnConf/%s:%s" % self.__URLTuple[1:3] )
+    res = gConfig.getOptionsDict( "/DIRAC/ConnConf/%s:%s" % self.__URLTuple[1:3] )
     if res[ 'OK' ]:
       opts = res[ 'Value' ]
       for k in opts:

--- a/Core/DISET/private/SSLSocketFactory.py
+++ b/Core/DISET/private/SSLSocketFactory.py
@@ -21,7 +21,7 @@ class SSLSocketFactory:
   def __checkKWArgs( self, kwargs ):
     for arg, value in ( ( self.KW_TIMEOUT, False ),
                         ( self.KW_ENABLE_SESSIONS, True ),
-                        ( self.KW_SSL_METHOD, "SSLv3" ) ):
+                        ( self.KW_SSL_METHOD, "TLSv1" ) ):
       if arg not in kwargs:
         kwargs[ arg ] = value
 

--- a/Core/DISET/private/SSLSocketFactory.py
+++ b/Core/DISET/private/SSLSocketFactory.py
@@ -29,7 +29,7 @@ class SSLSocketFactory:
   def createClientSocket( self, addressTuple , **kwargs ):
     if type( addressTuple ) not in ( types.ListType, types.TupleType ):
       return S_ERROR( "hostAdress is not in a tuple form ( 'hostnameorip', port )" )
-    res = gConfig.getOptionsDict( "/DIRAC/Security/ConnConf/%s:%s" % addressTuple )
+    res = gConfig.getOptionsDict( "/DIRAC/ConnConf/%s:%s" % addressTuple )
     if res[ 'OK' ]:
       opts = res[ 'Value' ]
       for k in opts:

--- a/Core/DISET/private/SSLSocketFactory.py
+++ b/Core/DISET/private/SSLSocketFactory.py
@@ -2,7 +2,7 @@
 __RCSID__ = "$Id$"
 
 import types
-from DIRAC import S_OK, S_ERROR
+from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.Core.DISET.private.Transports.SSL.FakeSocket import FakeSocket
 from DIRAC.Core.DISET.private.Transports.SSL.SocketInfoFactory import gSocketInfoFactory
 from DIRAC.Core.DISET.private.Transports.SSLTransport import checkSanity
@@ -17,6 +17,7 @@ class SSLSocketFactory:
   KW_TIMEOUT = "timeout"
   KW_ENABLE_SESSIONS = 'enableSessions'
   KW_SSL_METHOD = "sslMethod"
+  KW_SSL_CIPHERS = "sslCiphers"
 
   def __checkKWArgs( self, kwargs ):
     for arg, value in ( ( self.KW_TIMEOUT, False ),
@@ -28,6 +29,12 @@ class SSLSocketFactory:
   def createClientSocket( self, addressTuple , **kwargs ):
     if type( addressTuple ) not in ( types.ListType, types.TupleType ):
       return S_ERROR( "hostAdress is not in a tuple form ( 'hostnameorip', port )" )
+    res = gConfig.getOptionsDict( "/DIRAC/Security/ConnConf/%s:%s" % addressTuple )
+    if res[ 'OK' ]:
+      opts = res[ 'Value' ]
+      for k in opts:
+        if k not in kwargs:
+          kwargs[k] = opts[k]
     self.__checkKWArgs( kwargs )
     result = checkSanity( addressTuple, kwargs )
     if not result[ 'OK' ]:

--- a/Core/DISET/private/Transports/SSL/SocketInfo.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfo.py
@@ -12,6 +12,8 @@ from DIRAC.Core.Security import Locations
 from DIRAC.Core.Security.X509Chain import X509Chain
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
+DEFAULT_SSL_CIPHERS = "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS"
+
 class SocketInfo:
 
   __cachedCAsCRLs = False
@@ -217,6 +219,7 @@ class SocketInfo:
     except:
       return S_ERROR( "SSL method %s is not valid" % self.infoDict[ 'sslMethod' ] )
     self.sslContext = GSI.SSL.Context( method )
+    self.sslContext.set_cipher_list( self.infoDict.get( 'sslCiphers', DEFAULT_SSL_CIPHERS ) )
     if contextOptions:
       self.sslContext.set_options( contextOptions )
     #self.sslContext.set_read_ahead( 1 )


### PR DESCRIPTION
This just enables TLSv1 for outgoing connections via suds (mainly to connect to VOMS admin/whatever servers). DIRAC connections were already TLSv1