### PR TITLE
[v6r12] GOCDBClient creates unique DowntimeID using the ENDPOINT

### DIFF
--- a/Core/LCG/GOCDBClient.py
+++ b/Core/LCG/GOCDBClient.py
@@ -13,8 +13,7 @@ from DIRAC import S_OK, S_ERROR, gLogger
 
 def _parseSingleElement( element, attributes = None ):
   """
-  Given a DOM Element, return a dictionary of its
-  child elements and values (as strings).
+  Given a DOM Element, return a dictionary of its child elements and values (as strings).
   """
 
   handler = {}
@@ -274,15 +273,18 @@ class GOCDBClient( object ):
     dtDict = {}
 
     for dtElement in downtimeElements:
-      elements = _parseSingleElement( dtElement, ['SEVERITY', 'SITENAME', 'HOSTNAME',
+      elements = _parseSingleElement( dtElement, ['SEVERITY', 'SITENAME', 'HOSTNAME', 'ENDPOINT',
                                                   'HOSTED_BY', 'FORMATED_START_DATE',
                                                   'FORMATED_END_DATE', 'DESCRIPTION',
                                                   'GOCDB_PORTAL_URL', 'SERVICE_TYPE' ] )
 
       try:
-        dtDict[ str( dtElement.getAttributeNode( "PRIMARY_KEY" ).nodeValue ) + ' ' + elements['HOSTNAME'] ] = elements
+        dtDict[ str( dtElement.getAttributeNode( "PRIMARY_KEY" ).nodeValue ) + ' ' + elements['ENDPOINT'] ] = elements
       except Exception:
-        dtDict[ str( dtElement.getAttributeNode( "PRIMARY_KEY" ).nodeValue ) + ' ' + elements['SITENAME'] ] = elements
+        try:
+          dtDict[ str( dtElement.getAttributeNode( "PRIMARY_KEY" ).nodeValue ) + ' ' + elements['HOSTNAME'] ] = elements
+        except Exception:
+          dtDict[ str( dtElement.getAttributeNode( "PRIMARY_KEY" ).nodeValue ) + ' ' + elements['SITENAME'] ] = elements
 
     for dt_ID in dtDict.keys():
       if siteOrRes in ( 'Site', 'Sites' ):

--- a/ResourceStatusSystem/Command/test/Test_RSS_Command_GOCDBStatusCommand.py
+++ b/ResourceStatusSystem/Command/test/Test_RSS_Command_GOCDBStatusCommand.py
@@ -26,10 +26,12 @@ class GOCDBStatusCommand_TestCase( unittest.TestCase ):
 
     self.getGOCSiteNameMock = mock.MagicMock()
     self.CSHelpersMock = mock.MagicMock()
+    self.getStorageElementOptionsMock = mock.MagicMock()
     self.CSHelpersMock.getSEHost.return_value = 'aRealName'
     self.dowtimeCommandModule = importlib.import_module( 'DIRAC.ResourceStatusSystem.Command.DowntimeCommand' )
     self.dowtimeCommandModule.getGOCSiteName = self.getGOCSiteNameMock
     self.dowtimeCommandModule.CSHelpers = self.CSHelpersMock
+    self.dowtimeCommandModule.getStorageElementOptions = self.getStorageElementOptionsMock
     self.mock_GOCDBClient = mock.MagicMock()
     self.args = {'name':'aName', 'element':'Resource', 'elementType': 'StorageElement'}
 
@@ -99,6 +101,10 @@ class GOCDBStatusCommand_Success( GOCDBStatusCommand_TestCase ):
     """
     self.mock_GOCDBClient.selectDowntimeCache.return_value = {'OK':True, 'Value':{}}
     command = DowntimeCommand( self.args, {'ResourceManagementClient':self.mock_GOCDBClient} )
+    self.getStorageElementOptionsMock.return_value = {'OK':True, 'Value': {'TapeSE':True, 'DiskSE': False}}
+    res = command.doCache()
+    self.assert_( res['OK'] )
+    self.getStorageElementOptionsMock.return_value = {'OK':True, 'Value': {'TapeSE':False, 'DiskSE': True}}
     res = command.doCache()
     self.assert_( res['OK'] )
     


### PR DESCRIPTION
Instead of using HOSTNAME, which could lead to ignore downtime elements