### PR TITLE
[v6r12] Try to not remove the pid files to prevent bad scheduling

### DIFF
--- a/Resources/Computing/remote_scripts/sshce
+++ b/Resources/Computing/remote_scripts/sshce
@@ -18,7 +18,7 @@ return_running()
 
     ls $infoarea | grep ".pid" > /dev/null && for i in `ls -1 $infoarea/*.pid`; do
         test_pid=`cat $i`                        
-        q=`ps -f -p $test_pid | wc -l`                     
+        q=`ps -f -p $test_pid --no-headers | wc -l`                     
         if (( $q -ge 1 ))
         then                          
             let running=running+1    

--- a/Resources/Computing/remote_scripts/sshce
+++ b/Resources/Computing/remote_scripts/sshce
@@ -18,8 +18,8 @@ return_running()
 
     ls $infoarea | grep ".pid" > /dev/null && for i in `ls -1 $infoarea/*.pid`; do
         test_pid=`cat $i`                        
-        q=`ps -f -p $test_pid | grep $user | wc -l`                     
-        if (( $q == 1 ))
+        q=`ps -f -p $test_pid | wc -l`                     
+        if (( $q -ge 1 ))
         then                          
             let running=running+1    
         else

--- a/Resources/Computing/remote_scripts/sshce
+++ b/Resources/Computing/remote_scripts/sshce
@@ -19,7 +19,7 @@ return_running()
     ls $infoarea | grep ".pid" > /dev/null && for i in `ls -1 $infoarea/*.pid`; do
         test_pid=`cat $i`                        
         q=`ps -f -p $test_pid --no-headers | wc -l`                     
-        if (( $q -ge 1 ))
+        if [ "$q" -ge "1" ]
         then                          
             let running=running+1    
         else


### PR DESCRIPTION
Do not grep by user as on some platforms ps truncates the user name (on fedora 20, dirac_user becomes dirac_u+ and that grep fails). Normally, a process name should be unique...
Also the wc returns more than 1 line on some platforms (again fedora 20 returns column headers always).