### PR TITLE
[v6r13] Bug fix to prevent crashes

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -76,7 +76,8 @@ class ARCComputingElement( ComputingElement ):
 
   def _reset( self ):
     self.queue = self.ceParameters['Queue']
-    self.gridEnv = self.ceParameters['GridEnv']
+    if 'GridEnv' in self.ceParameters:
+      self.gridEnv = self.ceParameters['GridEnv']
 
   #############################################################################
   def submitJob( self, executableFile, proxy, numberOfJobs = 1 ):


### PR DESCRIPTION
The 'GridEnv' string may not be defined and hence a call to _reset causes crashes in the WMSAdministrator when trying to get the pilot stdout.