### PR TITLE
[v6r12] allow to re-register a file that has no replica in the DB

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
@@ -618,9 +618,6 @@ class FileManagerBase( object ):
            ( existingSize != newSize ) or \
            ( existingChecksum != newChecksum ):
           failed[lfn] = "File already registered with alternative metadata"
-        # If the DB does not have replicas for this file return an error
-        elif not fileID in replicaDict or not replicaDict[fileID]:
-          failed[lfn] = "File already registered with no replicas"
         # If the supplied SE is not in the existing replicas return an error
         elif not lfns[lfn]['SE'] in replicaDict[fileID].keys():
           failed[lfn] = "File already registered with alternative replicas"


### PR DESCRIPTION
no reason that a file could not be added again if it has no replica in the DB.
This is actually needed in case the addFile fails in the middle