### PR TITLE
[v6r12] Several fixes

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1542,7 +1542,7 @@ class DataManager( object ):
 
 ##########################################
   #
-  # Defunct methods only there before checking backward compatability
+  # Defunct methods only there before checking backward compatibility
   #
 
 

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -662,6 +662,8 @@ class DataManager( object ):
         self.getFile( lfn, destinationDir = localDir )
         localFile = os.path.join( localDir, os.path.basename( lfn ) )
         fileDict = {destPfn:localFile}
+        #FIXME: This is to avoid third party transfer attempt by the SE, will be better treated in the future
+        catalogueSize = 0
 
       res = destStorageElement.replicateFile( fileDict, sourceSize = catalogueSize, singleFile = True )
       if localFile and os.path.exists( localFile ):

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -102,7 +102,6 @@ class SRM2Storage( StorageBase ):
         self.checksumType = 0
     else:
       self.checksumType = 0
-      # # invert and get name
       self.log.debug( "SRM2Storage: will use no checksum" )
 
     # setting some variables for use with lcg_utils

--- a/WorkloadManagementSystem/private/correctors/WMSHistoryCorrector.py
+++ b/WorkloadManagementSystem/private/correctors/WMSHistoryCorrector.py
@@ -90,7 +90,11 @@ class WMSHistoryCorrector( BaseCorrector ):
     if not result[ 'OK' ]:
       self.__log.error( "Cannot get history from Accounting", result[ 'Message' ] )
       return result
-    data = result[ 'Value' ][ 'data' ]
+    data = result['Value'].get( 'data', [] )
+    if not data:
+      message = "Empty history data from Accounting"
+      self.__log.error( message )
+      return S_ERROR( message )
 
     #Map the usernames to DNs
     if groupToUse:


### PR DESCRIPTION
FIX: WMSHistoryCorrector - explicit error if no data returned from the WMSHistory Accounting
FIX: DataManager - when replicate files, the file size should be zero ( indicating file upload ) if replication through a local cache - logic to be reviewed in the next release anyway