### PR TITLE
[v6r13] Fixes for the GFAL2StorageBase and GFAL2_XROOTStorage plugin

### DIFF
--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -58,14 +58,8 @@ class GFAL2_StorageBase( StorageBase ):
     self.gfal2 = gfal2.creat_context()
     self.gfal2.set_opt_boolean( "BDII", "ENABLE", False )
     # # save c'tor params
-    self.name = storageName
-    self.protocol = parameters['Protocol']
-    self.spaceToken = parameters['SpaceToken']
-
     # #stage limit - 12h
     self.stageTimeout = gConfig.getValue( '/Resources/StorageElements/StageTimeout', 12 * 60 * 60 )
-    # # gfal2 timeout
-    self.gfal2Timeout = gConfig.getValue( "/Resources/StorageElements/GFAL_Timeout", 100 )
 
     # # set checksum type, by default this is 0 (GFAL_CKSM_NONE)
 

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -276,7 +276,7 @@ class GFAL2_StorageBase( StorageBase ):
       # we wont need this hard coded list below anymore but can implement a function in StorageBase
       # similar to isNativeURL which returns true if the src_file contains a known protocol.
       protocols = ['srm', 'root']
-      if any( protocol in src_file for protocol in protocols ):
+      if any( src_file.startswith( protocol + ':' ) for protocol in protocols ):
         src_url = src_file
         if not sourceSize:
           errStr = "GFAL2_StorageBase.__putFile: For file replication the source file size in bytes must be provided."

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -58,6 +58,8 @@ class GFAL2_StorageBase( StorageBase ):
     self.gfal2 = gfal2.creat_context()
     self.gfal2.set_opt_boolean( "BDII", "ENABLE", False )
     # # save c'tor params
+
+    self.spaceToken = parameters['SpaceToken']
     # #stage limit - 12h
     self.stageTimeout = gConfig.getValue( '/Resources/StorageElements/StageTimeout', 12 * 60 * 60 )
 

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -270,8 +270,13 @@ class GFAL2_StorageBase( StorageBase ):
       errStr = 'GFAL2_StorageBase.__putSingleFile: no source defined, please check argument format { destination : localfile }'
       return S_ERROR( errStr )
     else:
-      # check whether the source is local or on another srm storage
-      if src_file.startswith( 'srm' ):
+      # check whether the source is local or on another storage
+
+      # TODO: as soon as self.protocolParameters contains all known protocols to the SE
+      # we wont need this hard coded list below anymore but can implement a function in StorageBase
+      # similar to isNativeURL which returns true if the src_file contains a known protocol.
+      protocols = ['srm', 'root']
+      if any( protocol in src_file for protocol in protocols ):
         src_url = src_file
         if not sourceSize:
           errStr = "GFAL2_StorageBase.__putFile: For file replication the source file size in bytes must be provided."
@@ -681,7 +686,7 @@ class GFAL2_StorageBase( StorageBase ):
       if res['OK']:
         metadataDict['Checksum'] = res['Value']
       else:
-        metadataDict['Checksum'] = 'Failed to get checksum'
+        metadataDict['Checksum'] = ""
 
       # 'user.status' is the extended attribute we are interested in
       if 'user.status' in attributeDict.keys():

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -29,7 +29,7 @@ class GFAL2_StorageBase( StorageBase ):
 
   SRM v2 interface to StorageElement using gfal2
   """
-  
+
   def __init__( self, storageName, parameters ):
     """ c'tor
 

--- a/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/Resources/Storage/GFAL2_XROOTStorage.py
@@ -38,14 +38,6 @@ class GFAL2_XROOTStorage( GFAL2_StorageBase ):
 #     self.log.setLevel( "DEBUG" )
 
     self.pluginName = 'GFAL2_XROOT'
-    self.protocol = self.protocolParameters['Protocol']
-    self.host = self.protocolParameters['Host']
-
-    # Aweful hack to cope for the moment with the inability of RSS to deal with something else than SRM
-
-    # self.port = ""
-    # self.wspath = ""
-    # self.spaceToken = ""
 
     self.protocolParameters['Port'] = 0
     self.protocolParameters['WSUrl'] = 0

--- a/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/Resources/Storage/GFAL2_XROOTStorage.py
@@ -33,7 +33,7 @@ class GFAL2_XROOTStorage( GFAL2_StorageBase ):
     GFAL2_StorageBase.__init__( self, storageName, parameters )
 
     # XROOT has problems with checksums at the moment.
-    self.checksumType = None
+    self.checksumType = 'ADLER32'
 
 #     self.log.setLevel( "DEBUG" )
 

--- a/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/Resources/Storage/GFAL2_XROOTStorage.py
@@ -5,9 +5,12 @@
     :synopsis: XROOT module based on the GFAL2_StorageBase class.
 """
 
+
 # from DIRAC
 from DIRAC import gLogger
 from DIRAC.Resources.Storage.GFAL2_StorageBase import GFAL2_StorageBase
+
+
 
 class GFAL2_XROOTStorage( GFAL2_StorageBase ):
 
@@ -32,9 +35,6 @@ class GFAL2_XROOTStorage( GFAL2_StorageBase ):
     # # init base class
     GFAL2_StorageBase.__init__( self, storageName, parameters )
 
-    # XROOT has problems with checksums at the moment.
-    self.checksumType = 'ADLER32'
-
 #     self.log.setLevel( "DEBUG" )
 
     self.pluginName = 'GFAL2_XROOT'
@@ -50,3 +50,19 @@ class GFAL2_XROOTStorage( GFAL2_StorageBase ):
     self.protocolParameters['Port'] = 0
     self.protocolParameters['WSUrl'] = 0
     self.protocolParameters['SpaceToken'] = 0
+
+
+  def _getExtendedAttributes( self, path ):
+    """ Hard coding list of attributes and then call the base method of GFAL2_StorageBase
+
+    :param self: self reference
+    :param str path: path of which we want extended attributes
+    :return S_OK( attributeDict ) if successful. Where the keys of the dict are the attributes and values the respective values
+    """
+
+    # hard coding the attributes list for xroot because the plugin returns the wrong values
+    # xrootd.* instead of xroot.* see: https://its.cern.ch/jira/browse/DMC-664
+    attributes = ['xroot.cksum', 'xroot.space']
+    res = GFAL2_StorageBase._getExtendedAttributes( self, path, attributes )
+    return res
+


### PR DESCRIPTION
## GFAL2StorageBase:

* Cleand up \__init__: removed unused member variables
* __putSingleFile checks the origin of the source file whether it's local or from and srm or root storage. 
* Moved unrelated code out of try/except (__getSingleMetadata and __listSingleDirectory)
* __getChecksum needs a checksum set by the SE (set as self.checksumType) otherwise the checksum entry in the metadata will be empty

## GFAL2_XROOTStorage
* Cleaned up \__init__: removed unused member variables
* Added a _getExtendedAttributes method until gfal2-plugin-xrootd version 0.4 is available. Added hard coded list of extended attributes because plugin returns a wrong list