### PR TITLE
[v6r13] Minor fixes to static monitoring

### DIFF
--- a/Core/Utilities/InstallTools.py
+++ b/Core/Utilities/InstallTools.py
@@ -1697,14 +1697,14 @@ def monitorInstallation( componentType, system, component, module = None ):
     ( 'There is already an installation of ' + component + ' in the database' )
 
   result = monitoringClient.addInstallation \
-                                ( { 'InstallationTime': datetime.datetime.now(),
-                                    'Instance': instance },
-                                  { 'Type': componentType,
-                                    'System': system,
-                                    'Module': module },
-                                  { 'HostName': hostname,
-                                    'CPU': cpu },
-                                  True )
+                            ( { 'InstallationTime': datetime.datetime.utcnow(),
+                                'Instance': instance },
+                              { 'Type': componentType,
+                                'System': system,
+                                'Module': module },
+                              { 'HostName': hostname,
+                                'CPU': cpu },
+                              True )
   return result
 
 def monitorUninstallation( system, component ):
@@ -1726,7 +1726,7 @@ def monitorUninstallation( system, component ):
                         ( { 'Instance': instance, 'UnInstallationTime': None },
                           { 'System': system },
                           { 'HostName': hostname, 'CPU': cpu },
-                          { 'UnInstallationTime': datetime.datetime.now() } )
+                          { 'UnInstallationTime': datetime.datetime.utcnow() } )
   return result
 
 def installComponent( componentType, system, component, extensions, componentModule = '', checkModule = True ):
@@ -2528,9 +2528,11 @@ def installDatabase( dbName ):
     return S_ERROR( error )
 
   # If everything went well, add the information to the ComponentMonitoring DB
-  result = monitorInstallation( 'DB', dbSystem, dbName )
-  if not result[ 'OK' ]:
-    return result
+  # Unless we are installing the monitoringDB
+  if dbName != 'InstalledComponentsDB':
+    result = monitorInstallation( 'DB', dbSystem, dbName )
+    if not result[ 'OK' ]:
+      return result
 
   return S_OK( dbFile.split( '/' )[-4:-2] )
 

--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -240,7 +240,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
       elif result['Value']:
         gLogger.notice( '' )
         for par, value in result['Value'].items():
-          gLogger.notice( par.rjust( 28 ), ':', value )
+          gLogger.notice( ( par.rjust( 28 ), ':', value ) )
       else:
         gLogger.notice( "No MySQL database found" )
     elif option == "log":
@@ -264,7 +264,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
       if not result['OK']:
         self.__errMsg( result['Message'] )
       else:   
-        gLogger.notice()
+        gLogger.notice( '' )
         gLogger.notice( "Host info:" )
         gLogger.notice( '' )
         
@@ -577,7 +577,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         else:
           gLogger.notice( "\nComponents started successfully, runit status:\n" )
         for comp in result['Value']:
-          gLogger.notice( comp.rjust( 32 ), ':', result['Value'][comp]['RunitStatus'] )
+          gLogger.notice( ( comp.rjust( 32 ), ':', result['Value'][comp]['RunitStatus'] ) )
     else:
       gLogger.notice( "Not yet implemented" )
 
@@ -619,7 +619,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         else:
           gLogger.notice( "\nComponents started successfully, runit status:\n" )
         for comp in result['Value']:
-          gLogger.notice( comp.rjust( 32 ), ':', result['Value'][comp]['RunitStatus'] )
+          gLogger.notice( ( comp.rjust( 32 ), ':', result['Value'][comp]['RunitStatus'] ) )
     else:
       gLogger.notice( "Not yet implemented" )
 
@@ -652,7 +652,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         else:
           gLogger.notice( "\nComponents stopped successfully, runit status:\n" )
         for comp in result['Value']:
-          gLogger.notice( comp.rjust( 32 ), ':', result['Value'][comp]['RunitStatus'] )
+          gLogger.notice( ( comp.rjust( 32 ), ':', result['Value'][comp]['RunitStatus'] ) )
     else:
       gLogger.notice( "Not yet implemented" )
 


### PR DESCRIPTION
The monitoring system now uses UTC times instead of the local ones.

Also, the InstalledComponentsDB no longer attempts to  add an entry to itself by calling the ComponentMonitoring service ( which is always installed AFTER the DB ). Instead, said service will add the entry along with its own upon installation.