### PR TITLE
!!! [v6r14] Fix to WMSUtilities to obtain pilot logs from ARC CEs using the ARC api

### DIFF
--- a/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -13,13 +13,11 @@ import shutil, os
 from DIRAC.Core.Utilities.Grid import executeGridCommand
 from DIRAC.Resources.Computing.ComputingElementFactory     import ComputingElementFactory
 from DIRAC.Core.Utilities.SiteCEMapping import getCESiteMapping
-from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
 
 from DIRAC import S_OK, S_ERROR, gConfig
 
 import sys
 sys.path.append('/usr/lib64/python2.6/site-packages')
-import arc
 
 # List of files to be inserted/retrieved into/from pilot Output Sandbox
 # first will be defined as StdOut in JDL and the second as StdErr
@@ -80,19 +78,22 @@ def getCREAMPilotOutput( proxy, pilotRef, pilotStamp ):
   return result
 
 def getARCPilotOutput( proxy, pilotRef ):
+  try :
+    import arc
+  except :
+    return S_ERROR( "ARC api not available. Sorry." )
   tmp_dir = mkdtemp()
   myce = pilotRef.split(":")[1].strip("/")
   gridEnv = getGridEnv()
-  mySite = getCESiteMapping()['Value'][myce]
-  workDB = gConfig.getValue(cfgPath('Resources/Sites/LCG', mySite, 'CEs', myce, 'JobListFile'))
-  myWorkDB = os.path.join("/opt/dirac/runit/WorkloadManagement/SiteDirector-RAL", workDB)
-  cmd = [ 'arcget' ]
-  cmd.extend( ['-k', '-c', myce, '-j', myWorkDB, '-D', tmp_dir, pilotRef] )
-  ret = executeGridCommand( proxy, cmd, gridEnv )
-  if not ret['OK']:
-    shutil.rmtree( tmp_dir )
-    return ret
-  status, output, error = ret['Value']
+  usercfg = arc.UserConfig()
+  usercfg.CredentialString(proxy)
+  job = arc.Job()
+  job.jobID = pilotRef
+  job.JobStatusURL = arc.URL(os.path.join("ldap://", myce, ":2135/Mds-Vo-Name=local,o=grid??sub?(nordugrid-job-globalid=", job.JobID, ")"))
+  job.JobManagementURL = arc.URL(os.path.join("gsiftp://", myce, ":2811/jobs/"))
+  job.JobManagementInterfaceName = "org.nordugrid.gridftpjob"
+  job.Retrieve(usercfg, arc.URL(tmp_dir), False) 
+
   if 'Results stored at:' in output :
     tmp_dir = os.path.join( tmp_dir, os.listdir( tmp_dir )[0] )
     result = S_OK()


### PR DESCRIPTION


Should be simple and straightforward. Needs in particular the nordugrid-arc-python rpm.

Advantage - does not need the "job.xml" file which is needed in the CLI. So, with this, the WMSAdministrator will be decoupled from the SiteDirector and can be on different machines.

This updates only the obtaining of pilot logs to use the ARC API. The updates of the job submission and so on will come later, hopefully soon.
