### PR TITLE
[v6r13] Permission fix for ComponentMonitoring

### DIFF
--- a/FrameworkSystem/ConfigTemplate.cfg
+++ b/FrameworkSystem/ConfigTemplate.cfg
@@ -141,6 +141,12 @@ Services
     Authorization
     {
       Default = ServiceAdministrator
+      componentExists = authenticated
+      getComponents = authenticated
+      hostExists = authenticated
+      getHosts = authenticated
+      installationExists = authenticated
+      getInstallations = authenticated
     }  
   }
 }


### PR DESCRIPTION
Read-only methods in the ComponentMonitoring service no longer require ServiceAdministrator permissions