### PR TITLE
[v6r13] Changes on InstallTools

### DIFF
--- a/Core/Utilities/InstallTools.py
+++ b/Core/Utilities/InstallTools.py
@@ -103,7 +103,7 @@ def loadDiracCfg( verbose = False ):
   global mysqlRootPwd, mysqlUser, mysqlPassword, mysqlHost, mysqlMode
   global mysqlSmallMem, mysqlLargeMem, mysqlPort, mysqlRootUser
   global monitoringClient
-  global componentTypes
+  global COMPONENT_TYPES
 
   from DIRAC.Core.Utilities.Network import getFQDN
 
@@ -240,7 +240,7 @@ mysqlPort = ''
 mysqlRootUser = ''
 mysqlSmallMem = ''
 mysqlLargeMem = ''
-componentTypes = [ 'service', 'agent', 'executor' ]
+COMPONENT_TYPES = [ 'service', 'agent', 'executor' ]
 loadDiracCfg()
 
 def getInfo( extensions ):
@@ -922,7 +922,7 @@ def getSoftwareComponents( extensions ):
 
   resultDict = {}
 
-  remainingTypes = [ cType for cType in componentTypes if cType not in [ 'service', 'agent', 'executor' ] ]
+  remainingTypes = [ cType for cType in COMPONENT_TYPES if cType not in [ 'service', 'agent', 'executor' ] ]
   resultIndexes = {}
   # Components other than services, agents and executors
   for cType in remainingTypes:
@@ -1009,7 +1009,7 @@ def getInstalledComponents():
 
   resultDict = {}
   resultIndexes = {}
-  for cType in componentTypes:
+  for cType in COMPONENT_TYPES:
     result = _getSectionName( cType )
     if not result[ 'OK' ]:
       return result
@@ -1027,7 +1027,7 @@ def getInstalledComponents():
         body = rfile.read()
         rfile.close()
 
-        for cType in componentTypes:
+        for cType in COMPONENT_TYPES:
           if body.find( 'dirac-%s' % ( cType ) ) != -1:
             if not resultDict[ resultIndexes[ cType ] ].has_key( system ):
               resultDict[ resultIndexes[ cType ] ][system] = []
@@ -1045,7 +1045,7 @@ def getSetupComponents():
 
   resultDict = {}
   resultIndexes = {}
-  for cType in componentTypes:
+  for cType in COMPONENT_TYPES:
     result = _getSectionName( cType )
     if not result[ 'OK' ]:
       return result
@@ -1062,7 +1062,7 @@ def getSetupComponents():
       body = rfile.read()
       rfile.close()
 
-      for cType in componentTypes:
+      for cType in COMPONENT_TYPES:
         if body.find( 'dirac-%s' % ( cType ) ) != -1:
           system, compT = component.split( '_' )[0:2]
           if not resultDict[ resultIndexes[ cType ] ].has_key( system ):
@@ -1182,7 +1182,7 @@ def getOverallStatus( extensions ):
   # Collect the info now
   resultDict = {}
   resultIndexes = {}
-  for cType in componentTypes:
+  for cType in COMPONENT_TYPES:
     result = _getSectionName( cType )
     if not result[ 'OK' ]:
       return result

--- a/Core/Utilities/InstallTools.py
+++ b/Core/Utilities/InstallTools.py
@@ -2,6 +2,7 @@
 # File :    InstallTools.py
 # Author :  Ricardo Graciani
 ########################################################################
+from _mysql import result
 
 """
 Collection of Tools for installation of DIRAC components:
@@ -618,7 +619,10 @@ def addDefaultOptionsToCS( gConfig, componentType, systemName,
   if not compInstance:
     return S_ERROR( '%s not defined in %s' % ( instanceOption, cfgFile ) )
 
-  sectionName = _getSectionName ( componentType )[ 'Value' ]
+  result = _getSectionName( componentType )
+  if not result[ 'OK' ]:
+    return result
+  sectionName = result[ 'Value' ]
 
   # Check if the component CS options exist
   addOptions = True
@@ -673,7 +677,11 @@ def addCfgToComponentCfg( componentType, systemName, component, cfg ):
   """
   Add some extra configuration to the local component cfg
   """
-  sectionName = _getSectionName ( componentType )[ 'Value' ]
+  result = _getSectionName( componentType )
+  if not result[ 'OK' ]:
+    return result
+  sectionName = result[ 'Value' ]
+
   if not cfg:
     return S_OK()
   system = systemName.replace( 'System', '' )
@@ -701,7 +709,10 @@ def getComponentCfg( componentType, system, component, compInstance, extensions,
   """
   Get the CFG object of the component configuration
   """
-  sectionName = _getSectionName ( componentType )[ 'Value' ]
+  result = _getSectionName( componentType )
+  if not result[ 'OK' ]:
+    return result
+  sectionName = result[ 'Value' ]
 
   componentModule = component
   if "Module" in specialOptions:
@@ -915,7 +926,10 @@ def getSoftwareComponents( extensions ):
   resultIndexes = {}
   # Components other than services, agents and executors
   for cType in remainingTypes:
-    resultIndexes[ cType ] = _getSectionName( cType )[ 'Value' ]
+    result = _getSectionName( cType )
+    if not result[ 'OK' ]:
+      return result
+    resultIndexes[ cType ] = result[ 'Value' ]
     resultDict[ resultIndexes[ cType ] ] = {}
     remainders[ cType ] = {}
 
@@ -996,7 +1010,10 @@ def getInstalledComponents():
   resultDict = {}
   resultIndexes = {}
   for cType in componentTypes:
-    resultIndexes[ cType ] = _getSectionName( cType )[ 'Value' ]
+    result = _getSectionName( cType )
+    if not result[ 'OK' ]:
+      return result
+    resultIndexes[ cType ] = result[ 'Value' ]
     resultDict[ resultIndexes[ cType ] ] = {}
 
   systemList = os.listdir( runitDir )
@@ -1029,7 +1046,10 @@ def getSetupComponents():
   resultDict = {}
   resultIndexes = {}
   for cType in componentTypes:
-    resultIndexes[ cType ] = _getSectionName( cType )[ 'Value' ]
+    result = _getSectionName( cType )
+    if not result[ 'OK' ]:
+      return result
+    resultIndexes[ cType ] = result[ 'Value' ]
     resultDict[ resultIndexes[ cType ] ] = {}
 
   if not os.path.isdir( startDir ):
@@ -1163,7 +1183,10 @@ def getOverallStatus( extensions ):
   resultDict = {}
   resultIndexes = {}
   for cType in componentTypes:
-    resultIndexes[ cType ] = _getSectionName( cType )[ 'Value' ]
+    result = _getSectionName( cType )
+    if not result[ 'OK' ]:
+      return result
+    resultIndexes[ cType ] = result[ 'Value' ]
     resultDict[ resultIndexes[ cType ] ] = {}
 
   for compType in resultIndexes.values():
@@ -1257,9 +1280,14 @@ def checkComponentSoftware( componentType, system, component, extensions ):
   result = getSoftwareComponents( extensions )
   if not result['OK']:
     return result
+  softComp = result[ 'Value' ]
+
+  result = _getSectionName( componentType )
+  if not result[ 'OK' ]:
+    return result
 
   try:
-    softDict = result[ 'Value' ][ _getSectionName( componentType )[ 'Value' ] ]
+    softDict = softComp[ result[ 'Value' ] ]
   except KeyError, e:
     return S_ERROR( 'Unknown component type %s' % componentType )
 

--- a/Core/Utilities/InstallTools.py
+++ b/Core/Utilities/InstallTools.py
@@ -211,8 +211,6 @@ def loadDiracCfg( verbose = False ):
   if verbose and monitoringClient:
     gLogger.notice( 'Client configured for Component Monitoring' )
 
-  componentTypes = [ 'service', 'agent', 'executor' ]
-
 # FIXME: we probably need a better way to do this
 mysqlRootPwd = ''
 mysqlPassword = ''
@@ -932,11 +930,10 @@ def getSoftwareComponents( extensions ):
         agentDir = os.path.join( rootPath, extension, sys, 'Agent' )
         agentList = os.listdir( agentDir )
         for agent in agentList:
-          if agent[-3:] == ".py":
+          if os.path.splitext( agent )[1] == ".py":
             agentFile = os.path.join( agentDir, agent )
-            afile = open( agentFile, 'r' )
-            body = afile.read()
-            afile.close()
+            with open( agentFile, 'r' ) as afile:
+              body = afile.read()
             if body.find( 'AgentModule' ) != -1 or body.find( 'OptimizerModule' ) != -1:
               if not agents.has_key( system ):
                 agents[system] = []
@@ -947,7 +944,7 @@ def getSoftwareComponents( extensions ):
         serviceDir = os.path.join( rootPath, extension, sys, 'Service' )
         serviceList = os.listdir( serviceDir )
         for service in serviceList:
-          if service.find( 'Handler' ) != -1 and service[-3:] == '.py':
+          if service.find( 'Handler' ) != -1 and os.path.splitext( service )[1] == '.py':
             if not services.has_key( system ):
               services[system] = []
             if system == 'Configuration' and service == 'ConfigurationHandler.py':
@@ -959,11 +956,10 @@ def getSoftwareComponents( extensions ):
         executorDir = os.path.join( rootPath, extension, sys, 'Executor' )
         executorList = os.listdir( executorDir )
         for executor in executorList:
-          if executor[-3:] == ".py":
+          if os.path.splitext( executor )[1] == ".py":
             executorFile = os.path.join( executorDir, executor )
-            afile = open( executorFile, 'r' )
-            body = afile.read()
-            afile.close()
+            with open( executorFile, 'r' ) as afile:
+              body = afile.read()
             if body.find( 'OptimizerExecutor' ) != -1:
               if not executors.has_key( system ):
                 executors[system] = []
@@ -977,11 +973,7 @@ def getSoftwareComponents( extensions ):
           remainDir = os.path.join( rootPath, extension, sys, cType.title() )
           remainList = os.listdir( remainDir )
           for remainder in remainList:
-            if remainder[-3:] == ".py":
-              remainFile = os.path.join( remainDir, remainder )
-              afile = open( remainFile, 'r' )
-              body = afile.read()
-              afile.close()
+            if os.path.splitext( remainder )[1] == ".py":
               if not remainders[ cType ].has_key( system ):
                 remainders[ cType ][system] = []
               remainders[ cType ][system].append( remainder.replace( '.py', '' ) )

--- a/Core/Utilities/InstallTools.py
+++ b/Core/Utilities/InstallTools.py
@@ -2,7 +2,6 @@
 # File :    InstallTools.py
 # Author :  Ricardo Graciani
 ########################################################################
-from _mysql import result
 
 """
 Collection of Tools for installation of DIRAC components:

--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -534,7 +534,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         self.__errMsg( result['Message'] )
         return
       gLogger.notice( "Database %s from %s/%s installed successfully" % ( database, extension, system ) )
-    elif option in ["service","agent","executor"] :
+    elif option in self.runitComponents:
       if len( argss ) < 2:
         gLogger.notice( self.do_install.__doc__ )
         return


### PR DESCRIPTION
Now all runnable components use the same code in some of the functions, avoiding repeating identical blocks of code for every different component, therefore making it easier to add new types of components
(for extensions, for instance).