### PR TITLE
!!! [v6r13] Retrieval of trusted hosts from Registry

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/ConfigurationSystem/Client/Helpers/Registry.py
@@ -169,19 +169,6 @@ def getHostOption( hostName, optName, defaultValue = "" ):
 def getHosts():
   return gConfig.getSections( '%s/Hosts' % gBaseRegistrySection )
 
-def getTrustedHosts():
-  trustedHosts = []
-  result = gConfig.getSections( '%s/Hosts' % gBaseRegistrySection )
-  if not result[ 'OK' ]:
-    return result
-  hosts = result[ 'Value' ]
-
-  for host in hosts:
-    properties = gConfig.getValue( 'Registry/Hosts/%s/Properties' % host )
-    if properties and 'TrustedHost' in properties.split( ', ' ):
-        trustedHosts.append( host )
-  return S_OK( trustedHosts )
-
 def getVOOption( voName, optName, defaultValue = "" ):
   return gConfig.getValue( "%s/VO/%s/%s" % ( gBaseRegistrySection, voName, optName ), defaultValue )
 

--- a/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/ConfigurationSystem/Client/Helpers/Registry.py
@@ -169,6 +169,19 @@ def getHostOption( hostName, optName, defaultValue = "" ):
 def getHosts():
   return gConfig.getSections( '%s/Hosts' % gBaseRegistrySection )
 
+def getTrustedHosts():
+  trustedHosts = []
+  result = gConfig.getSections( '%s/Hosts' % gBaseRegistrySection )
+  if not result[ 'OK' ]:
+    return result
+  hosts = result[ 'Value' ]
+
+  for host in hosts:
+    properties = gConfig.getValue( 'Registry/Hosts/%s/Properties' % host )
+    if properties and 'TrustedHost' in properties.split( ', ' ):
+        trustedHosts.append( host )
+  return S_OK( trustedHosts )
+
 def getVOOption( voName, optName, defaultValue = "" ):
   return gConfig.getValue( "%s/VO/%s/%s" % ( gBaseRegistrySection, voName, optName ), defaultValue )
 

--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -529,7 +529,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
       if not result['OK']:
         self.__errMsg( result['Message'] )
       hostSetup = result['Value']['Setup']
-      result = InstallTools.addDatabaseOptionsToCS( gConfig, system, database, hostSetup )
+      result = InstallTools.addDatabaseOptionsToCS( gConfig, system, database, hostSetup, overwrite = True )
       if not result['OK']:
         self.__errMsg( result['Message'] )
         return

--- a/FrameworkSystem/Client/SystemAdministratorIntegrator.py
+++ b/FrameworkSystem/Client/SystemAdministratorIntegrator.py
@@ -20,11 +20,20 @@ class SystemAdministratorIntegrator( object ):
       self.__hosts = kwargs['hosts']
       del kwargs['hosts']
     else:  
-      result = Registry.getTrustedHosts()
+      result = Registry.getHosts()
       if result['OK']:
         self.__hosts = result['Value']
       else:
         self.__hosts = []
+
+    # Ping the hosts to remove those that don't have a SystemAdministrator service
+    sysAdminHosts = []
+    for host in self.__hosts:
+      client = SystemAdministratorClient( host )
+      result = client.ping()
+      if result[ 'OK' ]:
+        sysAdminHosts.append( host )
+    self.__hosts = sysAdminHosts
       
     self.__kwargs = dict( kwargs )  
     self.__pool = ThreadPool( len( self.__hosts ) )  

--- a/FrameworkSystem/Client/SystemAdministratorIntegrator.py
+++ b/FrameworkSystem/Client/SystemAdministratorIntegrator.py
@@ -24,7 +24,7 @@ class SystemAdministratorIntegrator:
       self.__hosts = kwargs['hosts']
       del kwargs['hosts']
     else:  
-      result = Registry.getHosts()
+      result = Registry.getTrustedHosts()
       if result['OK']:
         self.__hosts = result['Value']
       else:


### PR DESCRIPTION
Added a new 'getTrustedHosts' method to Registry so that only host with the 'TrustedHost' property are retrieved by the SystemAdministratorIntegrator, instead of every single host in the installation.