### PR TITLE
[v6r11] Fix for getCompatiblePlatforms

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -202,6 +202,8 @@ def getCompatiblePlatforms( originalPlatforms ):
   else:
     platforms = list( originalPlatforms )
 
+  platforms = list( platform.replace( ' ', '' ) for platform in platforms )
+
   result = gConfig.getOptionsDict( '/Resources/Computing/OSCompatibility' )
   if not ( result['OK'] and result['Value'] ):
     return S_ERROR( "OS compatibility info not found" )


### PR DESCRIPTION
Whitespace is removed from the OSCompatibility list, but not from the
originalPlatforms, this prohibits jobs to be send to CEs with spaces in the OS
version name e.g. "Scientific Linux"