### PR TITLE
[v6r13] Unify interface for changePathXXX functions

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
@@ -390,8 +390,7 @@ class DirectoryTreeBase:
     arguments = result['Value']
     successful = {}
     failed = {}
-    for path, dict in arguments.items():
-      owner = dict['Owner']
+    for path, owner in arguments.items():
       result = self.setDirectoryOwner( path, owner )
       if not result['OK']:
         failed[path] = result['Message']
@@ -433,8 +432,7 @@ class DirectoryTreeBase:
     arguments = result['Value']
     successful = {}
     failed = {}
-    for path, dict in arguments.items():
-      group = dict['Group']
+    for path, group in arguments.items():
       result = self.setDirectoryGroup( path, group )
       if not result['OK']:
         failed[path] = result['Message']
@@ -468,8 +466,7 @@ class DirectoryTreeBase:
     arguments = result['Value']
     successful = {}
     failed = {}
-    for path, dict in arguments.items():
-      mode = dict['Mode']
+    for path, mode in arguments.items():
       result = self.setDirectoryMode( path, mode )
       if not result['OK']:
         failed[path] = result['Message']


### PR DESCRIPTION
FIX: DirectoryTreeBase - unify interface for changePathXXX functions between files and directories, closes #2363 