### PR TITLE
[v6r12] DFC: RebuildDirectoryUsage, fix table Engine

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
@@ -1026,7 +1026,7 @@ class DirectoryTreeBase:
   PRIMARY KEY (`DirID`,`SEID`),
   KEY `DirID` (`DirID`),
   KEY `SEID` (`SEID`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
 """
     result = self.db._update( req )
     if not result['OK']:


### PR DESCRIPTION
Change table engine to InnoDB when rebuilding DirectoryUsage