### PR TITLE
Allow setting the repo file name

### DIFF
--- a/Interfaces/API/JobRepository.py
+++ b/Interfaces/API/JobRepository.py
@@ -12,10 +12,10 @@ class JobRepository( object ):
   def __init__( self, repository = None ):
     self.location = repository
     if not self.location:
-      if os.environ.has_key( 'HOME' ):
-        self.location = '%s/.dirac.repo.cfg' % os.environ['HOME']
+      if "HOME" in os.environ:
+        self.location = '%s/.dirac.repo.rep' % os.environ['HOME']
       else:
-        self.location = '%s/.dirac.repo.cfg' % os.getcwd()
+        self.location = '%s/.dirac.repo.rep' % os.getcwd()
     self.repo = CFG()
     if os.path.exists( self.location ):
       self.repo.loadFromFile( self.location )

--- a/Interfaces/scripts/dirac-wms-job-submit.py
+++ b/Interfaces/scripts/dirac-wms-job-submit.py
@@ -30,10 +30,13 @@ if len( args ) < 1:
 from DIRAC.Interfaces.API.Dirac                              import Dirac
 unprocessed_switches = Script.getUnprocessedSwitches()
 use_repo = False
+repo_name = ""
 for sw, value in unprocessed_switches:
   if sw.lower() in ["r", "usejobrepo"]:
     use_repo = True
-dirac = Dirac(use_repo)
+    repo_name = value
+    repo_name = repo_name.replace(".cfg", ".repo")
+dirac = Dirac(use_repo, repo_name)
 exitCode = 0
 errorList = []
 


### PR DESCRIPTION
Use the same switch but use the value as file name. Means it cannot use the default file name ($HOME/.dirac.repo.cfg, will create another fix for that).