### PR TITLE
[v6r13] Fixed DB-populating script

### DIFF
--- a/FrameworkSystem/scripts/dirac-populate-component-db.py
+++ b/FrameworkSystem/scripts/dirac-populate-component-db.py
@@ -21,7 +21,6 @@ from DIRAC.FrameworkSystem.Client.SystemAdministratorIntegrator \
 from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient \
   import ComponentMonitoringClient
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
-from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 
 global excludedHosts
 excludedHosts = []
@@ -43,16 +42,6 @@ Script.parseCommandLine( ignoreErrors = False )
 args = Script.getPositionalArgs()
 
 componentType = ''
-
-result = getProxyInfo()
-if not result[ 'OK' ]:
-  gLogger.error( result[ 'Message' ] )
-  DIRACexit( -1 )
-
-# If the user is not a ServiceAdministrator the script will not work
-if not 'ServiceAdministrator' in result['Value']['groupProperties']:
-  gLogger.error( 'ServiceAdministrator property missing' )
-  DIRACexit( -1 )
 
 # Retrieve information from all the hosts
 client = SystemAdministratorIntegrator()


### PR DESCRIPTION
Excluded hosts are no longer checked for availability ( it is pointless to do so, since they are not going to be used ). The script now also checks whether the 'ServiceAdministrator' group property is present or not in the proxy, stopping its execution in the latter case.