### PR TITLE
Fix stop_agent location

### DIFF
--- a/Core/Utilities/InstallTools.py
+++ b/Core/Utilities/InstallTools.py
@@ -1870,7 +1870,7 @@ exec python $DIRAC/DIRAC/Core/scripts/dirac-%(componentType)s.py %(system)s/%(co
 """#!/bin/bash
 echo %(controlDir)s/%(system)s/%(component)s/stop_agent
 touch %(controlDir)s/%(system)s/%(component)s/stop_agent
-""" % {'controlDir': runitDir,
+""" % {'controlDir': controlDir,
        'system' : system,
        'component': component } )
       fd.close()


### PR DESCRIPTION
stop_agent should be located below controlDir as discussed in
https://groups.google.com/forum/#!topic/diracgrid-forum/V2tDSO8XH94