### PR TITLE
[v6r13] fix reset/cancel request and SRM2 stage request

### DIFF
--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -450,7 +450,6 @@ def printRequest( request, status = None, full = False, verbose = True, terse = 
   except Exception, e:
     gLogger.debug( "Could not instantiate FtsClient", e )
 
-
   if full:
     output = ''
     prettyPrint( request.toJSON()['Value'] )
@@ -459,7 +458,7 @@ def printRequest( request, status = None, full = False, verbose = True, terse = 
     if not status:
       status = request.Status
     gLogger.always( "Request name='%s' ID=%s Status='%s'%s%s%s" % ( request.RequestName,
-                                                                     request.RequestID,
+                                                                     request.RequestID if hasattr( request, 'RequestID' ) else '(not set yet)',
                                                                      request.Status, " ('%s' in DB)" % status if status != request.Status else '',
                                                                      ( " Error='%s'" % request.Error ) if request.Error and request.Error.strip() else "" ,
                                                                      ( " Job=%s" % request.JobID ) if request.JobID else "" ) )
@@ -500,7 +499,7 @@ def printOperation( indexOperation, verbose = True, onlyFailed = False ):
       prStr += '\n      Arguments:\n' + output.strip( '\n' )
     else:
       prStr += '\n      Service: %s' % decode[0][0]
-  gLogger.always( "  [%s] Operation Type='%s' ID=%s Order=%s Status='%s'%s%s" % ( i, op.Type, op.OperationID,
+  gLogger.always( "  [%s] Operation Type='%s' ID=%s Order=%s Status='%s'%s%s" % ( i, op.Type, op.OperationID if hasattr( op, 'OperationID' ) else '(not set yet)',
                                                                                        op.Order, op.Status,
                                                                                        ( " Error='%s'" % op.Error ) if op.Error and op.Error.strip() else "",
                                                                                        ( " Catalog=%s" % op.Catalog ) if op.Catalog else "" ) )
@@ -512,7 +511,7 @@ def printOperation( indexOperation, verbose = True, onlyFailed = False ):
 
 def printFile( indexFile ):
   j, f = indexFile
-  gLogger.always( "    [%02d] ID=%s LFN='%s' Status='%s'%s%s" % ( j + 1, f.FileID, f.LFN, f.Status,
+  gLogger.always( "    [%02d] ID=%s LFN='%s' Status='%s'%s%s" % ( j + 1, f.FileID if hasattr( f, 'FileID' ) else '(not set yet)', f.LFN, f.Status,
                                                                        ( " Error='%s'" % f.Error ) if f.Error and f.Error.strip() else "",
                                                                        ( " Attempts=%d" % f.Attempt ) if f.Attempt > 1 else "" ) )
 

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -450,7 +450,7 @@ class Request( object ):
 
     # If the RequestID is not the default one (0), it probably means
     # the Request is already in the DB, so we don't touch anything
-    if self.RequestID:
+    if hasattr( self, 'RequestID' ) and self.RequestID:
       return S_ERROR( "Cannot optimize because Request seems to be already in the DB (RequestID %s)" % self.RequestID )
     # Set to True if the request could be optimized
     optimized = False

--- a/RequestManagementSystem/Client/test/OperationTests.py
+++ b/RequestManagementSystem/Client/test/OperationTests.py
@@ -149,27 +149,30 @@ class OperationTests( unittest.TestCase ):
     self.assertEqual( op.Status, "Queued", "2. wrong status %s" % op.Status )
 
     op.addFile( File( {"Status": "Scheduled" } ) )
-    self.assertEqual( op.Status, "Queued", "3. wrong status %s" % op.Status )
+    self.assertEqual( op.Status, "Scheduled", "3. wrong status %s" % op.Status )
 
     op.addFile( File( {"Status": "Done" } ) )
-    self.assertEqual( op.Status, "Queued", "4. wrong status %s" % op.Status )
+    self.assertEqual( op.Status, "Scheduled", "4. wrong status %s" % op.Status )
 
     op.addFile( File( { "Status": "Failed" } ) )
-    self.assertEqual( op.Status, "Queued", "5. wrong status %s" % op.Status )
+    self.assertEqual( op.Status, "Scheduled", "5. wrong status %s" % op.Status )
 
     op[3].Status = "Scheduled"
-    self.assertEqual( op.Status, "Queued", "6. wrong status %s" % op.Status )
+    self.assertEqual( op.Status, "Scheduled", "6. wrong status %s" % op.Status )
 
     op[0].Status = "Scheduled"
     self.assertEqual( op.Status, "Scheduled", "7. wrong status %s" % op.Status )
 
     op[0].Status = "Waiting"
-    self.assertEqual( op.Status, "Queued", "8. wrong status %s" % op.Status )
+    self.assertEqual( op.Status, "Scheduled", "8. wrong status %s" % op.Status )
 
     for f in op:
       f.Status = "Done"
     self.assertEqual( op.Status, "Done", "9. wrong status %s" % op.Status )
 
+    for f in op:
+      f.Status = "Failed"
+    self.assertEqual( op.Status, "Failed", "9. wrong status %s" % op.Status )
 
   def test05List( self ):
     """ getitem, setitem, delitem and dirty """

--- a/RequestManagementSystem/Client/test/RequestTests.py
+++ b/RequestManagementSystem/Client/test/RequestTests.py
@@ -401,28 +401,7 @@ class RequestTests( unittest.TestCase ):
     del r[0]
     self.assertEqual( len( r ), 4, "__delitem__ failed" )
 
-    r.RequestID = 1
-    del r[0]
-    self.assertEqual( r.cleanUpSQL(), None, "cleanUpSQL failed after __delitem__ (no opId)" )
 
-    r[0].OperationID = 1
-    del r[0]
-    clean = r.cleanUpSQL()
-    self.assertEqual( clean,
-                      ['DELETE FROM `Operation` WHERE `RequestID`=1 AND `OperationID` IN (1);\n',
-                       'DELETE FROM `File` WHERE `OperationID`=1;\n'],
-                      "cleanUpSQL failed after __delitem__ (opId set)\n%s" % clean )
-
-    r[0].OperationID = 2
-    r[0] = Operation()
-    clean = r.cleanUpSQL()
-    self.assertEqual( clean,
-                      ['DELETE FROM `Operation` WHERE `RequestID`=1 AND `OperationID` IN (1,2);\n',
-                      'DELETE FROM `File` WHERE `OperationID`=1;\n', 'DELETE FROM `File` WHERE `OperationID`=2;\n'],
-                      "cleanUpSQL failed after __setitem_ (opId set):\n%s" % clean )
-
-    json = r.toJSON()
-    self.assertEqual( "__dirty" in json["Value"], True, "__dirty missing in json" )
 
 
   def test08Optimize( self ):
@@ -440,7 +419,7 @@ class RequestTests( unittest.TestCase ):
       print ''
     for reqType in title:
       r = createRequest( reqType )
-      res = optimizeRequest( r, printOutput = title[reqType] if debug == reqType else False )
+      res = optimizeRequest( r, printOutput = title[reqType] if ( debug == reqType and debug is not False ) else False )
       self.assertEqual( res['OK'], True )
       self.assertEqual( res['Value'], True )
       if reqType in ( 0, 1 ):

--- a/RequestManagementSystem/scripts/dirac-rms-cancel-request.py
+++ b/RequestManagementSystem/scripts/dirac-rms-cancel-request.py
@@ -29,7 +29,15 @@ if __name__ == "__main__":
     DIRAC.exit( 1 )
 
   for requestID in requests:
-    reqID = int( requestID.strip() )
+    requestID = requestID.strip()
+    try:
+      reqID = int( requestID )
+    except ValueError:
+      reqID = reqClient.getRequestIDForName( requestID )
+      if not reqID['OK']:
+        gLogger.always( reqID['Message'] )
+        continue
+      reqID = reqID['Value']
     res = reqClient.cancelRequest( reqID )
     if res['OK']:
       DIRAC.gLogger.always( "Request %s canceled" % reqID )

--- a/RequestManagementSystem/scripts/dirac-rms-reset-request.py
+++ b/RequestManagementSystem/scripts/dirac-rms-reset-request.py
@@ -47,8 +47,20 @@ if __name__ == "__main__":
   if not jobs:
     args = Script.getPositionalArgs()
 
+    requests = list()
     if len( args ) == 1:
-      requests = args[0].split( ',' )
+      requestsSplit = args[0].split( ',' )
+      for reqID in requestsSplit:
+        try:
+          requestID = int( reqID )
+        except ValueError:
+          requestID = reqClient.getRequestIDForName( reqID )
+          if not requestID['OK']:
+            gLogger.always( requestID['Message'] )
+            continue
+          requestID = requestID['Value']
+        requests.append( requestID )
+
   else:
     res = reqClient.getRequestIDsForJobs( jobs )
     if not res['OK']:

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -388,7 +388,8 @@ class SRM2Storage( StorageBase ):
         elif urlDict['status'] == 1:
           self.log.debug( "prestageFile: File found to be already staged.", pathSURL )
           successful[pathSURL] = urlDict['SRMReqID']
-        elif urlDict['status'] == 22:
+        # It can be 11 or 22 depending on the srm-ifce version...
+        elif urlDict['status'] in ( 11, 22 ):
           self.log.debug( "prestageFile: Stage request for file %s queued.", pathSURL )
           successful[pathSURL] = urlDict['SRMReqID']
         elif urlDict['status'] == 2:


### PR DESCRIPTION
* Adapt the reset and cancel RMS script to also accept request name, providing it is unique
* The error code for SRM_REQUEST_QUEUED changed in a more recent version of srm-ifce, so now we handle both case
* There were some error in the difficult merging when converting the RMS to SQLAlchemy and json, mostly in tests. Corrected that 