### PR TITLE
[v6r13] New fix for populating script

### DIFF
--- a/FrameworkSystem/Client/SystemAdministratorIntegrator.py
+++ b/FrameworkSystem/Client/SystemAdministratorIntegrator.py
@@ -25,6 +25,9 @@ class SystemAdministratorIntegrator( object ):
         self.__hosts = result['Value']
       else:
         self.__hosts = []
+      # Excluded hosts
+      if 'exclude' in kwargs:
+        self.__hosts = list ( set( self.__hosts ) - set( kwargs[ 'exclude' ] ) )
 
     # Ping the hosts to remove those that don't have a SystemAdministrator service
     sysAdminHosts = []

--- a/FrameworkSystem/scripts/dirac-populate-component-db.py
+++ b/FrameworkSystem/scripts/dirac-populate-component-db.py
@@ -44,12 +44,12 @@ args = Script.getPositionalArgs()
 componentType = ''
 
 # Retrieve information from all the hosts
-client = SystemAdministratorIntegrator()
+client = SystemAdministratorIntegrator( exclude = excludedHosts )
 resultAll = client.getOverallStatus()
 
 notificationClient = NotificationClient()
 for host in resultAll[ 'Value' ]:
-  if not host in excludedHosts and not resultAll[ 'Value' ][ host ][ 'OK' ]:
+  if not resultAll[ 'Value' ][ host ][ 'OK' ]:
     # If the host cannot be contacted, exclude it and send message
     excludedHosts.append( host )
 


### PR DESCRIPTION
Modified SystemAdministratorIntegrator so that it can be told to exclude hosts during initialization. This way, the SysAdminIntegrator calls will not take into account these hosts and the populating script is also
relieved from checking if hosts are in the excludedHosts list.