### PR TITLE
[v6r13] Check read access for getURL only if service is required (SRM2)

### DIFF
--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -485,7 +485,7 @@ class FTSAgent( AgentModule ):
         log.info( "monitoring of FTSJobs completed" )
         for key, ftsFiles in ftsFilesDict.items():
           if ftsFiles:
-            log.debug( " => %s FTSFiles to %s" % ( len( ftsFiles ), key[2:].lower() ) )
+            log.verbose( " => %s FTSFiles to %s" % ( len( ftsFiles ), key[2:].lower() ) )
 
       # # PHASE ONE - check ready replicas
       missingReplicas = self.__checkReadyReplicas( request, operation )
@@ -772,7 +772,7 @@ class FTSAgent( AgentModule ):
         route = route["Value"]
 
         routeValid = self.__ftsPlacement.isRouteValid( route )
-        
+
         if not routeValid['OK']:
           log.error( "Route invalid : %s" % routeValid['Message'] )
           continue
@@ -852,6 +852,7 @@ class FTSAgent( AgentModule ):
       log.error( monitor["Message"] )
       if "getTransferJobSummary2: Not authorised to query request" in monitor["Message"] or \
          'was not found' in monitor['Message'] or\
+         "Not found" in monitor['Message'] or\
          'Unknown transfer state' in monitor['Message']:
         log.error( "FTSJob not known (expired on server?): delete it" )
         for ftsFile in ftsJob:
@@ -904,7 +905,7 @@ class FTSAgent( AgentModule ):
     ftsFilesDict = dict( [ ( k, list() ) for k in ( "toRegister", "toSubmit", "toFail", "toReschedule", "toUpdate" ) ] )
 
 
-    monitor = ftsJob.monitorFTS(self.__ftsVersion, command = self.MONITOR_COMMAND, full = True )
+    monitor = ftsJob.monitorFTS( self.__ftsVersion, command = self.MONITOR_COMMAND, full = True )
     if not monitor["OK"]:
       log.error( monitor["Message"] )
       return monitor

--- a/DataManagementSystem/Client/FTSFile.py
+++ b/DataManagementSystem/Client/FTSFile.py
@@ -3,7 +3,7 @@
 # Author: Krzysztof.Ciba@NOSPAMgmail.com
 # Date: 2013/04/08 09:28:29
 ########################################################################
-""" 
+"""
 :mod: FTSFile
 
 .. module: FTSFile
@@ -37,7 +37,7 @@ class FTSFile( object ):
   class representing a single file in the FTS job
   """
   # # all FTS states
-  ALL_STATES = ( "Submitted", "Ready", "Active", "Failed", "Finished", "Staging", "Canceled", 'Started' )
+  ALL_STATES = ( "Submitted", "Ready", "Active", "Failed", "Finished", "Staging", "Canceled", 'Started', 'Waiting' )
   # # final FTS states
   FINAL_STATES = ( "Canceled" "Failed", "Finished" )
   # # successful states

--- a/DataManagementSystem/Client/FTSJob.py
+++ b/DataManagementSystem/Client/FTSJob.py
@@ -736,7 +736,7 @@ class FTSJob( object ):
       failedFiles = register.get( "Failed", {} )
       errorReason = {}
       for lfn, reason in failedFiles.items():
-        errorReason.setdefault( reason, [] ).append( lfn )
+        errorReason.setdefault( str( reason ), [] ).append( lfn )
       for reason in errorReason:
         self._log.error( 'Error registering %d replicas' % len( errorReason[reason] ), reason )
       for ftsFile in toRegister:

--- a/DataManagementSystem/Client/FTSJob.py
+++ b/DataManagementSystem/Client/FTSJob.py
@@ -53,11 +53,10 @@ class FTSJob( object ):
 
   # # missing source regexp patterns
   missingSourceErrors = [
-    re.compile( r"SOURCE error during TRANSFER_PREPARATION phase: \[INVALID_PATH\] Failed" ),
-    re.compile( r"SOURCE error during TRANSFER_PREPARATION phase: \[INVALID_PATH\] No such file or directory" ),
-    re.compile( r"SOURCE error during PREPARATION phase: \[INVALID_PATH\] Failed" ),
-    re.compile( r"SOURCE error during PREPARATION phase: \[INVALID_PATH\] The requested file either does not exist" ),
-    re.compile( r"TRANSFER error during TRANSFER phase: \[INVALID_PATH\] the server sent an error response: 500 500"\
+    re.compile( r".*INVALID_PATH\] Failed" ),
+    re.compile( r".*INVALID_PATH\] No such file or directory" ),
+    re.compile( r".*INVALID_PATH\] The requested file either does not exist" ),
+    re.compile( r".*INVALID_PATH\] the server sent an error response: 500 500"\
                " Command failed. : open error: No such file or directory" ),
     re.compile( r"SOURCE error during TRANSFER_PREPARATION phase: \[USER_ERROR\] source file doesnt exist" ) ]
 
@@ -666,10 +665,10 @@ class FTSJob( object ):
         candidateFile.Error = reason
         candidateFile._duration = duration
 
-#       if candidateFile.Status == "Failed":
-#         for missingSource in self.missingSourceErrors:
-#           if missingSource.match( reason ):
-#             candidateFile.Error = "MissingSource"
+        if candidateFile.Status == "Failed":
+          for missingSource in self.missingSourceErrors:
+            if missingSource.match( reason ):
+              candidateFile.Error = "MissingSource"
 
     # # register successful files
     if self.Status in FTSJob.FINALSTATES:

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -42,7 +42,7 @@ class SRM2Storage( StorageBase ):
     """
     StorageBase.__init__( self, storageName, parameters )
     self.spaceToken = self.protocolParameters['SpaceToken']
-    
+
     self.log = gLogger.getSubLogger( "SRM2Storage", True )
 
     self.isok = True
@@ -327,10 +327,10 @@ class SRM2Storage( StorageBase ):
           successful[url] = url
         else:
           failed[url] = 'getTransportURL: Failed to obtain turls.'
-      
       return S_OK( {'Successful' : successful, 'Failed' : failed} )
 
-
+    # FIXME: we should test here if the SE is banned as we cannot get the URL
+    # Here we must go out to the SRM service
     self.log.debug( "getTransportURL: Obtaining tURLs for %s file(s)." % len( urls ) )
     resDict = self.__gfalturlsfromsurls_wrapper( urls, listProtocols )
     if not resDict["OK"]:

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -69,7 +69,7 @@ class SRM2Storage( StorageBase ):
     self.gfalRetry = gConfig.getValue( "/Resources/StorageElements/GFAL_Retry", 3 )
 
     # # set checksum type, by default this is 0 (GFAL_CKSM_NONE)
-    self.checksumType = gConfig.getValue( "/Resources/StorageElements/ChecksumType", None )
+    checksumType = gConfig.getValue( "/Resources/StorageElements/ChecksumType", '' )
     # enum gfal_cksm_type, all in lcg_util
     # 	GFAL_CKSM_NONE = 0,
     # 	GFAL_CKSM_CRC32,
@@ -77,18 +77,15 @@ class SRM2Storage( StorageBase ):
     # 	GFAL_CKSM_MD5,
     # 	GFAL_CKSM_SHA1
     # GFAL_CKSM_NULL = 0
-    self.checksumTypes = { None : 0, "CRC32" : 1, "ADLER32" : 2,
+    self.checksumTypes = { "CRC32" : 1, "ADLER32" : 2,
                            "MD5" : 3, "SHA1" : 4, "NONE" : 0, "NULL" : 0 }
+
+    self.checksumType = self.checksumTypes.get( checksumType.upper(), 0 )
     if self.checksumType:
-      if str( self.checksumType ).upper() in self.checksumTypes:
-        gLogger.debug( "SRM2Storage: will use %s checksum check" % self.checksumType )
-        self.checksumType = self.checksumTypes[ self.checksumType.upper() ]
-      else:
-        gLogger.warn( "SRM2Storage: unknown checksum type %s, checksum check disabled" )
-        # # GFAL_CKSM_NONE
-        self.checksumType = 0
+      gLogger.debug( "SRM2Storage: will use %s checksum check" % self.checksumType )
+    elif checksumType:
+      gLogger.warn( "SRM2Storage: unknown checksum, check disabled", checksumType )
     else:
-      self.checksumType = 0
       self.log.debug( "SRM2Storage: will use no checksum" )
 
     # setting some variables for use with lcg_utils

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -111,16 +111,6 @@ class SRM2Storage( StorageBase ):
     self.MAX_SINGLE_STREAM_SIZE = 1024 * 1024 * 10  # 10 MB ???
     self.MIN_BANDWIDTH = 0.5 * ( 1024 * 1024 )  # 0.5 MB/s ???
 
-    # Get SE status if needed
-    from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
-    res = ResourceStatus().getStorageElementStatus( storageName )
-    if not res[ 'OK' ]:
-      errStr = "SRM2Storage__init__: Failed to get storage status"
-      gLogger.error( errStr, "%s: %s" % ( storageName, res['Message'] ) )
-      self.seStatus = {}
-    else:
-      self.seStatus = res['Value'][storageName]
-
   def __importExternals( self ):
     """ import lcg_util and gfalthr or gfal
 
@@ -339,7 +329,7 @@ class SRM2Storage( StorageBase ):
           failed[url] = 'getTransportURL: Failed to obtain turls.'
       return S_OK( {'Successful' : successful, 'Failed' : failed} )
 
-    readAccess = self.seStatus.get( 'ReadAccess' )
+    readAccess = self.se.getStatus().get( 'Value', {} ).get( 'Read' )
     if not readAccess or readAccess not in ( 'Active', 'Degraded' ):
       return S_ERROR( "SRM2Storage.getTransportURL: Read access not currently permitted." )
 

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -69,7 +69,7 @@ class SRM2Storage( StorageBase ):
     self.gfalRetry = gConfig.getValue( "/Resources/StorageElements/GFAL_Retry", 3 )
 
     # # set checksum type, by default this is 0 (GFAL_CKSM_NONE)
-    self.checksumType = gConfig.getValue( "/Resources/StorageElements/ChecksumType", '' )
+    self.checksumType = gConfig.getValue( "/Resources/StorageElements/ChecksumType", None )
     # enum gfal_cksm_type, all in lcg_util
     # 	GFAL_CKSM_NONE = 0,
     # 	GFAL_CKSM_CRC32,

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -166,8 +166,8 @@ class StorageElementItem( object ):
     self.log = gLogger.getSubLogger( "SE[%s]" % self.name )
     self.useCatalogURL = gConfig.getValue( '/Resources/StorageElements/%s/UseCatalogURL' % self.name, False )
 
+    #                         'getTransportURL',
     self.readMethods = [ 'getFile',
-                         'getTransportURL',
                          'prestageFile',
                          'prestageFileStatus',
                          'getDirectory']

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -7,7 +7,7 @@ __RCSID__ = "$Id$"
 import re
 # # from DIRAC
 from DIRAC import gLogger, gConfig
-from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR, returnSingleResult 
+from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR, returnSingleResult
 from DIRAC.Resources.Storage.StorageFactory import StorageFactory
 from DIRAC.Core.Utilities.Pfn import pfnparse
 from DIRAC.Core.Utilities.SiteSEMapping import getSEsForSite
@@ -131,7 +131,7 @@ class StorageElementItem( object ):
         return
       self.vo = result['Value']
     self.opHelper = Operations( vo = self.vo )
-    
+
     proxiedProtocols = gConfig.getValue( '/LocalSite/StorageElements/ProxyProtocols', "" ).split( ',' )
     useProxy = ( gConfig.getValue( "/Resources/StorageElements/%s/AccessProtocol.1/Protocol" % name, "UnknownProtocol" )
                 in proxiedProtocols )
@@ -197,8 +197,9 @@ class StorageElementItem( object ):
                        'getRemoteProtocols',
                        'getStorageElementName',
                        'getStorageParameters',
+                       'getTransportURL',
                        'isLocalSE' ]
-    
+
     self.__fileCatalog = None
 
   def dump( self ):
@@ -306,16 +307,16 @@ class StorageElementItem( object ):
     if not self.valid:
       self.log.debug( "StorageElement.isValid: Failed to create StorageElement plugins.", self.errorReason )
       return S_ERROR( self.errorReason )
-    
+
     # Check if the Storage Element is eligible for the user's VO
     if 'VO' in self.options and not self.vo in self.options['VO']:
       self.log.debug( "StorageElementisValid: StorageElement is not allowed for VO %s" % self.vo )
-      return S_ERROR( "StorageElement.isValid: StorageElement is not allowed for VO" ) 
+      return S_ERROR( "StorageElement.isValid: StorageElement is not allowed for VO" )
     self.log.verbose( "StorageElement.isValid: Determining if the StorageElement %s is valid for %s" % ( self.name,
                                                                                                          operation ) )
     if ( not operation ) or ( operation in self.okMethods ):
       return S_OK()
-    
+
     if ( not operation ) or ( operation in self.okMethods ):
       return S_OK()
     # Determine whether the StorageElement is valid for checking, reading, writing
@@ -417,10 +418,10 @@ class StorageElementItem( object ):
     """ Negotiate what protocol could be used for a third party transfer
         between the sourceSE and ourselves. If protocols is given,
         the chosen protocol has to be among those
-        
+
         :param sourceSE : storageElement instance of the sourceSE
         :param protocols: protocol restriction list
-        
+
         :return a list protocols that fits the needs, or None
 
     """
@@ -486,7 +487,7 @@ class StorageElementItem( object ):
     result = checkArgumentFormat( urls )
     if result['OK']:
       urlDict = result['Value']
-    else:  
+    else:
       errStr = "StorageElement.getLFNFromURL: Supplied urls must be string, list of strings or a dictionary."
       self.log.debug( errStr )
       return S_ERROR( errStr )
@@ -513,7 +514,7 @@ class StorageElementItem( object ):
     """
 
     self.log.verbose( "StorageElement.getURL: Getting accessUrl %s for lfn in %s." % ( "(%s)" % protocol if protocol else "", self.name ) )
-    
+
     if not protocol:
       protocols = self.turlProtocols
     elif type( protocol ) is ListType:
@@ -522,7 +523,7 @@ class StorageElementItem( object ):
       protocols = [protocol]
 
     self.methodName = "getTransportURL"
-    result = self.__executeMethod( lfn, protocols = protocols )    
+    result = self.__executeMethod( lfn, protocols = protocols )
     return result
 
   def __isLocalSE( self ):
@@ -536,12 +537,12 @@ class StorageElementItem( object ):
       return S_OK( True )
     else:
       return S_OK( False )
-    
+
   def __getFileCatalog( self ):
-    
+
     if not self.__fileCatalog:
       self.__fileCatalog = FileCatalog( vo = self.vo )
-    return self.__fileCatalog  
+    return self.__fileCatalog
 
   def __generateURLDict( self, lfns, storage, replicaDict = {} ):
     """ Generates a dictionary (url : lfn ), where the url are constructed
@@ -566,7 +567,7 @@ class StorageElementItem( object ):
           if not result['OK']:
             failed[lfn] = result['Message']
           url = result['Value']['Successful'].get( lfn, {} ).get( self.name, '' )
-        
+
         if not url:
           failed[lfn] = 'Failed to get catalog replica'
         else:
@@ -575,8 +576,8 @@ class StorageElementItem( object ):
           if not result['OK']:
             failed[lfn] = result['Message']
           else:
-            urlDict[result['Value']] = lfn          
-      else:  
+            urlDict[result['Value']] = lfn
+      else:
         result = storage.constructURLFromLFN( lfn, withWSUrl = True )
         if not result['OK']:
           errStr = "StorageElement.__generateURLDict %s." % result['Message']
@@ -584,7 +585,7 @@ class StorageElementItem( object ):
           failed[lfn] = "%s %s" % ( failed[lfn], errStr ) if lfn in failed else errStr
         else:
           urlDict[result['Value']] = lfn
-          
+
     res = S_OK( {'Successful': urlDict, 'Failed' : failed} )
 #     res['Failed'] = failed
     return res
@@ -717,7 +718,7 @@ class StorageElementItem( object ):
               lfnDict.pop( lfn )
 
     return S_OK( { 'Failed': failed, 'Successful': successful } )
-  
+
 
   def __getattr__( self, name ):
     """ Forwards the equivalent Storage calls to StorageElement.__executeMethod"""


### PR DESCRIPTION
As now getTransportURL() is not checking the status of the SE, whenever access to a service is required, one should check the read access permission in the plugin.
This is done in SRM2, thus getting an "srm" URL is OK but not a "root" URL:

In [3]: se.getURL('/lhcb/MC/MC11a/ALLSTREAMS.DST/00013911/0000/00013911_00000017_1.allstreams.dst', 'srm')
Out[3]: 
{'OK': True,
 'Value': {'Failed': {},
  'Successful': {'/lhcb/MC/MC11a/ALLSTREAMS.DST/00013911/0000/00013911_00000017_1.allstreams.dst': 'srm://srm.grid.sara.nl:8443/srm/managerv2?SFN=/pnfs/grid.sara.nl/data/lhcb/archive/lhcb/MC/MC11a/ALLSTREAMS.DST/00013911/0000/00013911_00000017_1.allstreams.dst'}}}

In [4]: se.getURL('/lhcb/MC/MC11a/ALLSTREAMS.DST/00013911/0000/00013911_00000017_1.allstreams.dst', 'root')
Out[4]: 
{'OK': True,
 'Value': {'Failed': {'/lhcb/MC/MC11a/ALLSTREAMS.DST/00013911/0000/00013911_00000017_1.allstreams.dst': 'SRM2Storage.getTransportURL: Read access not currently permitted.'}