### PR TITLE
[v6r14] Several changes on ComponentMonitoring

### DIFF
--- a/Core/scripts/dirac-install-agent.py
+++ b/Core/scripts/dirac-install-agent.py
@@ -11,6 +11,7 @@ __RCSID__ = "$Id$"
 #
 from DIRAC.Core.Utilities import InstallTools
 from DIRAC.ConfigurationSystem.Client.Helpers import getCSExtensions
+from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 #
 from DIRAC import gConfig, S_OK, S_ERROR
 from DIRAC import exit as DIRACexit
@@ -86,7 +87,7 @@ else:
     if not result['OK']:
       print "ERROR:", result['Message']
       DIRACexit( 1 )
-    result = InstallTools.monitorInstallation( 'agent', system, agent, module )
+    result = monitoringUtilities.monitorInstallation( 'agent', system, agent, module )
     if not result['OK']:
       print "ERROR:", result['Message']
       DIRACexit( 1 )

--- a/Core/scripts/dirac-install-agent.py
+++ b/Core/scripts/dirac-install-agent.py
@@ -86,6 +86,9 @@ else:
     if not result['OK']:
       print "ERROR:", result['Message']
       DIRACexit( 1 )
-    else:
-      print "Successfully completed the installation of agent %s in %s system" % ( agent, system )
-      DIRACexit()
+    result = InstallTools.monitorInstallation( 'agent', system, agent, module )
+    if not result['OK']:
+      print "ERROR:", result['Message']
+      DIRACexit( 1 )
+    print "Successfully completed the installation of agent %s in %s system" % ( agent, system )
+    DIRACexit()

--- a/Core/scripts/dirac-install-db.py
+++ b/Core/scripts/dirac-install-db.py
@@ -10,6 +10,7 @@ Create a new DB on the local MySQL server
 __RCSID__ = "$Id$"
 #
 from DIRAC.Core.Utilities import InstallTools
+from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 #
 from DIRAC import gConfig
 InstallTools.exitOnError = True
@@ -38,6 +39,6 @@ for db in args:
     InstallTools.addDatabaseOptionsToCS( gConfig, system, db, overwrite = True )
 
     if db != 'InstalledComponentsDB':
-      result = InstallTools.monitorInstallation( 'DB', system, db )
+      result = MonitoringUtilities.monitorInstallation( 'DB', system, db )
       if not result[ 'OK' ]:
         print "ERROR: failed to register installation in database: %s" % result[ 'Message' ]

--- a/Core/scripts/dirac-install-db.py
+++ b/Core/scripts/dirac-install-db.py
@@ -36,3 +36,8 @@ for db in args:
   else:
     extension, system = result['Value']
     InstallTools.addDatabaseOptionsToCS( gConfig, system, db, overwrite = True )
+
+    if db != 'InstalledComponentsDB':
+      result = InstallTools.monitorInstallation( 'DB', system, db )
+      if not result[ 'OK' ]:
+        print "ERROR: failed to register installation in database: %s" % result[ 'Message' ]

--- a/Core/scripts/dirac-install-executor.py
+++ b/Core/scripts/dirac-install-executor.py
@@ -11,6 +11,7 @@ __RCSID__ = "$Id$"
 #
 from DIRAC.Core.Utilities import InstallTools
 from DIRAC.ConfigurationSystem.Client.Helpers import getCSExtensions
+from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 #
 from DIRAC import gConfig, S_OK, S_ERROR
 InstallTools.exitOnError = True
@@ -87,7 +88,7 @@ else:
     if not result['OK']:
       print "ERROR:", result['Message']
       DIRACexit( 1 )
-    result = InstallTools.monitorInstallation( 'executor', system, executor, module )
+    result = MonitoringUtilities.monitorInstallation( 'executor', system, executor, module )
     if not result['OK']:
       print "ERROR:", result['Message']
       DIRACexit( 1 )

--- a/Core/scripts/dirac-install-executor.py
+++ b/Core/scripts/dirac-install-executor.py
@@ -87,6 +87,9 @@ else:
     if not result['OK']:
       print "ERROR:", result['Message']
       DIRACexit( 1 )
-    else:
-      print "Successfully completed the installation of executor %s in %s system" % ( executor, system )
-      DIRACexit()
+    result = InstallTools.monitorInstallation( 'executor', system, executor, module )
+    if not result['OK']:
+      print "ERROR:", result['Message']
+      DIRACexit( 1 )
+    print "Successfully completed the installation of executor %s in %s system" % ( executor, system )
+    DIRACexit()

--- a/Core/scripts/dirac-install-service.py
+++ b/Core/scripts/dirac-install-service.py
@@ -11,6 +11,7 @@ __RCSID__ = "$Id$"
 #
 from DIRAC.Core.Utilities import InstallTools
 from DIRAC.ConfigurationSystem.Client.Helpers import getCSExtensions
+from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 #
 from DIRAC import gConfig, S_OK, S_ERROR
 InstallTools.exitOnError = True
@@ -89,11 +90,11 @@ else:
       print "ERROR:", result['Message']
       DIRACexit( 1 )
     if service == 'ComponentMonitoring':
-        result = InstallTools.monitorInstallation( 'DB', system, 'InstalledComponentsDB' )
+        result = MonitoringUtilities.monitorInstallation( 'DB', system, 'InstalledComponentsDB' )
         if not result['OK']:
           print "ERROR:", result['Message']
           DIRACexit( 1 )
-    result = InstallTools.monitorInstallation( 'service', system, service, module )
+    result = MonitoringUtilities.monitorInstallation( 'service', system, service, module )
     if not result['OK']:
       print "ERROR:", result['Message']
       DIRACexit( 1 )

--- a/Core/scripts/dirac-install-service.py
+++ b/Core/scripts/dirac-install-service.py
@@ -88,6 +88,14 @@ else:
     if not result['OK']:
       print "ERROR:", result['Message']
       DIRACexit( 1 )
-    else:
-      print "Successfully completed the installation of service %s in %s system" % ( service, system )
-      DIRACexit()
+    if service == 'ComponentMonitoring':
+        result = InstallTools.monitorInstallation( 'DB', system, 'InstalledComponentsDB' )
+        if not result['OK']:
+          print "ERROR:", result['Message']
+          DIRACexit( 1 )
+    result = InstallTools.monitorInstallation( 'service', system, service, module )
+    if not result['OK']:
+      print "ERROR:", result['Message']
+      DIRACexit( 1 )
+    print "Successfully completed the installation of service %s in %s system" % ( service, system )
+    DIRACexit()

--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -17,6 +17,7 @@ from DIRAC.Core.Utilities.ColorCLI import colorize
 from DIRAC.FrameworkSystem.Client.SystemAdministratorClient import SystemAdministratorClient
 from DIRAC.FrameworkSystem.Client.SystemAdministratorIntegrator import SystemAdministratorIntegrator
 from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient import ComponentMonitoringClient
+from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 import DIRAC.Core.Utilities.InstallTools as InstallTools
 from DIRAC.ConfigurationSystem.Client.Helpers import getCSExtensions
 from DIRAC.Core.Utilities import List
@@ -537,7 +538,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         return
 
       if database != 'InstalledComponentsDB':
-        result = InstallTools.monitorInstallation( 'DB', system.replace( 'System', '' ), database, cpu = cpu, hostname = hostname )
+        result = MonitoringUtilities.monitorInstallation( 'DB', system.replace( 'System', '' ), database, cpu = cpu, hostname = hostname )
         if not result['OK']:
           self.__errMsg( result['Message'] )
           return
@@ -618,11 +619,11 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         cpu = result[ 'Value' ][ 'CPUModel' ]
       hostname = self.host
       if component == 'ComponentMonitoring':
-        result = InstallTools.monitorInstallation( 'DB', system, 'InstalledComponentsDB', cpu = cpu, hostname = hostname )
+        result = MonitoringUtilities.monitorInstallation( 'DB', system, 'InstalledComponentsDB', cpu = cpu, hostname = hostname )
         if not result['OK']:
           self.__errMsg( 'Error registering installation into database: %s' % result[ 'Message' ] )
           return
-      result = InstallTools.monitorInstallation( option, system, component, module, cpu = cpu, hostname = hostname )
+      result = MonitoringUtilities.monitorInstallation( option, system, component, module, cpu = cpu, hostname = hostname )
       if not result['OK']:
         self.__errMsg( 'Error registering installation into database: %s' % result[ 'Message' ] )
         return
@@ -666,7 +667,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         self.__errMsg( result[ 'Message' ] )
         return
       system = result[ 'Value' ][ component ][ 'System' ]
-      result = InstallTools.monitorUninstallation( system , component, hostname = hostname, cpu = cpu )
+      result = MonitoringUtilities.monitorUninstallation( system , component, hostname = hostname, cpu = cpu )
       if not result[ 'OK' ]:
         self.__errMsg( result[ 'Message' ] )
         return
@@ -720,7 +721,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
       else:
         cpu = result[ 'Value' ][ 'CPUModel' ]
       hostname = self.host
-      result = InstallTools.monitorUninstallation( system, component, hostname = hostname, cpu = cpu )
+      result = MonitoringUtilities.monitorUninstallation( system, component, hostname = hostname, cpu = cpu )
       if not result[ 'OK' ]:
         return result
 

--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -536,10 +536,11 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         self.__errMsg( result[ 'Message' ] )
         return
 
-      result = InstallTools.monitorInstallation( 'DB', system.replace( 'System', '' ), database, cpu = cpu, hostname = hostname )
-      if not result['OK']:
-        self.__errMsg( result['Message'] )
-        return
+      if database != 'InstalledComponentsDB':
+        result = InstallTools.monitorInstallation( 'DB', system.replace( 'System', '' ), database, cpu = cpu, hostname = hostname )
+        if not result['OK']:
+          self.__errMsg( result['Message'] )
+          return
       # result = client.addDatabaseOptionsToCS( system, database )
       InstallTools.mysqlHost = self.host
       result = client.getInfo()

--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -2,7 +2,6 @@
 ########################################################################
 # $HeadURL$
 """ File Catalog Client Command Line Interface. """
-from mock import self
 
 __RCSID__ = "$Id$"
 

--- a/FrameworkSystem/DB/InstalledComponentsDB.py
+++ b/FrameworkSystem/DB/InstalledComponentsDB.py
@@ -12,7 +12,8 @@ from sqlalchemy import MetaData, \
                         Integer, \
                         String, \
                         DateTime, \
-                        create_engine
+                        create_engine, \
+                        text
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, \
@@ -347,7 +348,7 @@ class InstalledComponentsDB( object ):
       else:
         sql = '%s %s %s' % ( actualKey, comparison, matchFields[ key ] )
 
-      filteredTemp = filtered.filter( sql )
+      filteredTemp = filtered.filter( text( sql ) )
       try:
         session.execute( filteredTemp )
         session.commit()
@@ -579,9 +580,9 @@ class InstalledComponentsDB( object ):
 
     try:
       query = session.query( Component )\
-                          .filter( Component.system == component.system )\
-                          .filter( Component.module == component.module )\
-                          .filter( Component.cType == component.cType )
+                          .filter( text( Component.system == component.system ) )\
+                          .filter( text( Component.module == component.module ) )\
+                          .filter( text( Component.cType == component.cType ) )
     except Exception, e:
       session.rollback()
       session.close()
@@ -762,8 +763,8 @@ class InstalledComponentsDB( object ):
 
     try:
       query = session.query( Host )\
-                          .filter( Host.hostName == host.hostName )\
-                          .filter( Host.cpu == host.cpu )
+                          .filter( text( Host.hostName == host.hostName ) )\
+                          .filter( text( Host.cpu == host.cpu ) )
     except Exception, e:
       session.rollback()
       session.close()

--- a/FrameworkSystem/Utilities/MonitoringUtilities.py
+++ b/FrameworkSystem/Utilities/MonitoringUtilities.py
@@ -1,0 +1,76 @@
+"""
+Utilities for ComponentMonitoring features
+"""
+
+import datetime
+from DIRAC import gConfig
+from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient import ComponentMonitoringClient
+
+def monitorInstallation( componentType, system, component, module = None, cpu = None, hostname = None ):
+  """
+  Register the installation of a component in the ComponentMonitoringDB
+  """
+  monitoringClient = ComponentMonitoringClient()
+
+  if not module:
+    module = component
+
+  if not cpu:
+    cpu = 'Not available'
+    for line in open( '/proc/cpuinfo' ):
+      if line.startswith( 'model name' ):
+        cpu = line.split( ':' )[1][ 0 : 64 ]
+        cpu = cpu.replace( '\n', '' ).lstrip().rstrip()
+
+  if not hostname:
+    hostname = socket.getfqdn()
+  instance = component[ 0 : 32 ]
+
+  result = monitoringClient.installationExists \
+                        ( { 'Instance': instance,
+                            'UnInstallationTime': None },
+                          { 'Type': componentType,
+                            'System': system,
+                            'Module': module },
+                          { 'HostName': hostname,
+                            'CPU': cpu } )
+
+  if not result[ 'OK' ]:
+    return result
+  if result[ 'Value' ]:
+    return S_OK( 'Monitoring of %s is already enabled' % component )
+
+  result = monitoringClient.addInstallation \
+                            ( { 'InstallationTime': datetime.datetime.utcnow(),
+                                'Instance': instance },
+                              { 'Type': componentType,
+                                'System': system,
+                                'Module': module },
+                              { 'HostName': hostname,
+                                'CPU': cpu },
+                              True )
+  return result
+
+def monitorUninstallation( system, component, cpu = None, hostname = None ):
+  """
+  Register the uninstallation of a component in the ComponentMonitoringDB
+  """
+  monitoringClient = ComponentMonitoringClient()
+
+  if not cpu:
+    cpu = 'Not available'
+    for line in open( '/proc/cpuinfo' ):
+      if line.startswith( 'model name' ):
+        cpu = line.split( ':' )[1][0:64]
+        cpu = cpu.replace( '\n', '' ).lstrip().rstrip()
+
+  if not hostname:
+    hostname = socket.getfqdn()
+  instance = component[ 0 : 32 ]
+
+  result = monitoringClient.updateInstallations \
+                        ( { 'Instance': instance, 'UnInstallationTime': None },
+                          { 'System': system },
+                          { 'HostName': hostname, 'CPU': cpu },
+                          { 'UnInstallationTime': datetime.datetime.utcnow() } )
+  return result


### PR DESCRIPTION
Due to the fact that the requests to the ComponentMonitoring service are currently made by the server's SysAdmin service ( and not from the original caller of the top level script/CLI command ) the certificate of the server is used instead, meaning that the calls turn out unauthorized.

To avoid this, the InstallTools' monitorInstallation/Uninstallation funcions that make the requests to the ComponentMonitoring service have been moved so that they are callable by the scripts or the CLI.

Also, some minor changes to the InstalledComponentsDB module have been made to avoid sqlAlchemy warnings.

Lastly, I'm PR'ing the DB-populating script again, since I made the last PR for it to integration by mistake.