### PR TITLE
[v6r13] Minor Fix for StorageElement

### DIFF
--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -15,7 +15,7 @@ from DIRAC.Core.Security.ProxyInfo import getVOfromProxyGroup
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Utilities.DictCache import DictCache
 from DIRAC.Resources.Utilities import checkArgumentFormat
-from DIRAC.Resources.Catalog import FileCatalog
+from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 
 class StorageElementCache( object ):
 


### PR DESCRIPTION
This was importing the Module and later trying to call it (line 541), so this needs to import the Class
(also found by pylint).