### PR TITLE
[v6r13] Make sure we use source replicas with correct checksum

### DIFF
--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -134,8 +134,6 @@ class FTSAgent( AgentModule ):
   __threadPool = None
   # # update lock
   __updateLock = None
-  # # se cache
-  __seCache = dict()
   # # request cache
   __reqCache = dict()
 
@@ -167,17 +165,6 @@ class FTSAgent( AgentModule ):
     if not cls.__rssClient:
       cls.__rssClient = ResourceStatus()
     return cls.__rssClient
-
-  @classmethod
-  def getSE( cls, seName ):
-    """ keep SEs in cache """
-    if seName not in cls.__seCache:
-      cls.__seCache[seName] = StorageElement( seName )
-    return cls.__seCache[seName]
-
-  @classmethod
-  def getSECache( cls ):
-    return cls.__seCache
 
   @classmethod
   def getRequest( cls, reqID ):
@@ -777,14 +764,14 @@ class FTSAgent( AgentModule ):
           log.error( "Route invalid : %s" % routeValid['Message'] )
           continue
 
-        sourceSE = self.getSE( source )
+        sourceSE = StorageElement( source )
         sourceToken = sourceSE.getStorageParameters( "SRM2" )
         if not sourceToken["OK"]:
           log.error( "unable to get sourceSE '%s' parameters: %s" % ( source, sourceToken["Message"] ) )
           continue
         seStatus = sourceSE.getStatus()['Value']
 
-        targetSE = self.getSE( target )
+        targetSE = StorageElement( target )
         targetToken = targetSE.getStorageParameters( "SRM2" )
         if not targetToken["OK"]:
           log.error( "unable to get targetSE '%s' parameters: %s" % ( target, targetToken["Message"] ) )
@@ -1007,7 +994,7 @@ class FTSAgent( AgentModule ):
       registerOperation.Type = "RegisterReplica"
       registerOperation.Status = "Waiting"
       registerOperation.TargetSE = target
-      targetSE = self.getSE( target )
+      targetSE = StorageElement( target )
       for ftsFile in ftsFileList:
         opFile = File()
         opFile.LFN = ftsFile.LFN
@@ -1110,4 +1097,4 @@ class FTSAgent( AgentModule ):
   def __filterReplicas( self, opFile ):
     """ filter out banned/invalid source SEs """
     from DIRAC.DataManagementSystem.Agent.RequestOperations.ReplicateAndRegister import filterReplicas
-    return filterReplicas( opFile, logger = self.log, dataManager = self.dataManager, seCache = self.getSECache() )
+    return filterReplicas( opFile, logger = self.log, dataManager = self.dataManager )

--- a/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
+++ b/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
@@ -57,12 +57,13 @@ def filterReplicas( opFile, logger = None, dataManager = None ):
 
   replicas = replicas["Successful"].get( opFile.LFN, {} )
 
-  # FC checksum is more likely better than opFile.Checksum
-  fcMetadata = FileCatalog().getFileMetadata( opFile.LFN )
-  fcChecksum = fcMetadata.get( 'Value', {} ).get( 'Successful', {} ).get( opFile.LFN, {} ).get( 'Checksum', '' )
-  # Replace opFile.Checksum if it doesn't match a valid FC checksum
-  if fcChecksum and ( not opFile.Checksum or not compareAdler( fcChecksum, opFile.Checksum ) ):
-    opFile.Checksum = fcChecksum
+  if not opFile.Checksum:
+    # Set Checksum to FC checksum if not set in the request
+    fcMetadata = FileCatalog().getFileMetadata( opFile.LFN )
+    fcChecksum = fcMetadata.get( 'Value', {} ).get( 'Successful', {} ).get( opFile.LFN, {} ).get( 'Checksum', '' )
+    # Replace opFile.Checksum if it doesn't match a valid FC checksum
+    if fcChecksum:
+      opFile.Checksum = fcChecksum
 
   for repSEName in replicas:
 

--- a/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
+++ b/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
@@ -87,7 +87,7 @@ def filterReplicas( opFile, logger = None, dataManager = None ):
         # # All checksums are OK
         ret["Valid"].append( repSEName )
       else:
-        log.warn( " %s checksum mismatch, FC: %s @%s: %s" % ( opFile.LFN,
+        log.warn( " %s checksum mismatch, FC: '%s' @%s: '%s'" % ( opFile.LFN,
                                                               opFile.Checksum,
                                                               repSEName,
                                                               seChecksum ) )


### PR DESCRIPTION
Some replicas don't have a valid checksum registered, which makes  transfers fail.
We check the SE checksum against either the operation or the FC checksum before considering a replica.

Use this opportunity for removing the useless StorageElement caching as StorageElement is already a cache!