### PR TITLE
[v6r13] Fix pilot cpu time - urgent

### DIFF
--- a/ConfigurationSystem/Agent/CE2CSAgent.py
+++ b/ConfigurationSystem/Agent/CE2CSAgent.py
@@ -1,4 +1,9 @@
-﻿""" Queries BDII for unknown CE.
+﻿"""
+
+!!!Out-dated!!! Moved to Bdii2CSAgent!!!!!! Out-dated!!! Moved to Bdii2CSAgent
+
+
+    Queries BDII for unknown CE.
     Queries BDII for CE information and puts it to CS.
 """
 __RCSID__ = "$Id$"
@@ -14,17 +19,17 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Path      import cfgPath
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import getVO
 
 class CE2CSAgent( AgentModule ):
+  """ !!!Out-dated!!! Moved to Bdii2CSAgent
+  """
 
-  def __init__(self):
-    """ c'tor
-    """
-    self.addressTo = ''
-    self.addressFrom = ''
-    self.voName = ''
-    self.subject = "CE2CSAgent"
-    self.alternativeBDIIs = []
+  addressTo = ''
+  addressFrom = ''
+  voName = ''
+  subject = "CE2CSAgent"
+  alternativeBDIIs = []
 
-    self.csAPI = None
+  csAPI = None
+
 
   def initialize( self ):
 

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -456,7 +456,6 @@ def getCEConfigDict( ceName ):
 def getResourceDict( ceName = None ):
   """Look into LocalSite for Resource Requirements
   """
-  from DIRAC.WorkloadManagementSystem.private.Queues import maxCPUSegments
   ret = gConfig.getOptionsDict( '/LocalSite/ResourceDict' )
   if not ret['OK']:
     resourceDict = {}
@@ -472,7 +471,7 @@ def getResourceDict( ceName = None ):
   # now add some defaults
   resourceDict['Setup'] = gConfig.getValue( '/DIRAC/Setup', 'None' )
   if not 'CPUTime' in resourceDict:
-    resourceDict['CPUTime'] = maxCPUSegments[-1]
+    resourceDict['CPUTime'] = gConfig.getValue( '/LocalSite/CPUTime' )
 
   return resourceDict
 

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -472,7 +472,8 @@ def getResourceDict( ceName = None ):
   # now add some defaults
   resourceDict['Setup'] = gConfig.getValue( '/DIRAC/Setup', 'None' )
   if not 'CPUTime' in resourceDict:
-    resourceDict['CPUTime'] = gConfig.getValue( '/LocalSite/CPUTime' )
+    from DIRAC.WorkloadManagementSystem.private.Queues import maxCPUSegments
+    resourceDict['CPUTime'] = gConfig.getValue( '/LocalSite/CPUTime', maxCPUSegments[-1] )
 
   return resourceDict
 

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -456,6 +456,7 @@ def getCEConfigDict( ceName ):
 def getResourceDict( ceName = None ):
   """Look into LocalSite for Resource Requirements
   """
+  # FIXME: this /LocalSite/ResourceDict is probably a relic, no no idea why it's here
   ret = gConfig.getOptionsDict( '/LocalSite/ResourceDict' )
   if not ret['OK']:
     resourceDict = {}

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -702,8 +702,8 @@ class LaunchAgent( CommandBase ):
     self.inProcessOpts.append( '-o WorkingDirectory=%s' % self.pp.workingDir )
     # FIXME: this is artificial
     self.inProcessOpts.append( '-o TotalCPUs=%s' % 1 )
-    self.inProcessOpts.append( '-o MaxCPUTime=%s' % ( int( self.pp.jobCPUReq ) ) )
-    self.inProcessOpts.append( '-o CPUTime=%s' % ( int( self.pp.jobCPUReq ) ) )
+    self.inProcessOpts.append( '-o /LocalSite/MaxCPUTime=%s' % ( int( self.pp.jobCPUReq ) ) )
+    self.inProcessOpts.append( '-o /LocalSite/CPUTime=%s' % ( int( self.pp.jobCPUReq ) ) )
     self.inProcessOpts.append( '-o MaxRunningJobs=%s' % 1 )
     # To prevent a wayward agent picking up and failing many jobs.
     self.inProcessOpts.append( '-o MaxTotalJobs=%s' % 10 )


### PR DESCRIPTION
Since... ever we've been passing to the JobAgent CPU time variables that are unused. Also the initial default used made little sense.