### PR TITLE
[v6r12] Modified SiteDirector.py to change the way to count existing pilot jobs for SSH sites

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -505,8 +505,8 @@ class SiteDirector( AgentModule ):
         jobExecDir = ''
         if ceType == 'CREAM':
           jobExecDir = '.'
-        jobExecDir = self.queueDict[queue].get( 'JobExecDir', jobExecDir )
-        httpProxy = self.queueDict[queue].get( 'HttpProxy', '' )
+        jobExecDir = self.queueDict[queue]['ParametersDict'].get( 'JobExecDir', jobExecDir )          
+        httpProxy = self.queueDict[queue]['ParametersDict'].get( 'HttpProxy', '' )
 
         result = self.__getExecutable( queue, pilotsToSubmit, bundleProxy, httpProxy, jobExecDir )
         if not result['OK']:
@@ -588,7 +588,8 @@ class SiteDirector( AgentModule ):
         jobIDList = None
         result = pilotAgentsDB.selectPilots( {'DestinationSite':ceName,
                                               'Queue':queueName,
-                                              'Status':['Running','Submitted','Scheduled'] } )
+                                              'Status': TRANSIENT_PILOT_STATUS } )                                              
+
         if result['OK']:
           jobIDList = result['Value']
           


### PR DESCRIPTION
The change in L591 is made basically to include the status "Waiting", whose meaning is the same as "Scheduled" but used for SSH sites. In the current code, when only "Waiting" job exists (no "Running" job) in a SSH site,  accoring to  L251 of Resources/Computing/ComputingElement.py, it is recognized no job exists at this site and SiteDirector submits jobs until running jobs appear. Attached file shows the number of waiting jobs in our site where maximum number of waiting job is set to be several 10. We have tested this modification in r12, which is used at Belle II now.

The change in L508-L509 is already discussed in PR No2456 but we want to include it in r12, too.

![diracjob-week](https://cloud.githubusercontent.com/assets/13082637/8457009/fc3008c0-2049-11e5-9c0b-a448438fd2eb.png)

  