### PR TITLE
[v6r14] VOMS: get VO information from the fqan VOMS attribute

### DIFF
--- a/Core/Security/VOMS.py
+++ b/Core/Security/VOMS.py
@@ -31,12 +31,6 @@ class VOMS( BaseSecurity ):
 
     #Get a list of known VOMS attributes
     validVOMSAttrs = []
-    result = gConfig.getOptions( "/Registry/VOMS/Mapping" )
-    if result[ 'OK' ]:
-      for group in result[ 'Value' ]:
-        vA = gConfig.getValue( "/Registry/VOMS/Mapping/%s" % group, "" )
-        if vA and vA not in validVOMSAttrs:
-          validVOMSAttrs.append( vA )
     result = gConfig.getSections( "/Registry/Groups" )
     if result[ 'OK' ]:
       for group in result[ 'Value' ]:
@@ -50,7 +44,7 @@ class VOMS( BaseSecurity ):
     nickName = ''
     for line in vomsInfoOutput:
       fields = List.fromChar( line, ":" )
-      key = fields[0]
+      key = fields[0].strip()
       value = " ".join( fields[1:] )
       if key == "VO":
         voName = value
@@ -137,7 +131,8 @@ class VOMS( BaseSecurity ):
         lines.append( "issuer : %s" % data[ 'issuer' ] )
         for fqan in data[ 'fqan' ]:
           lines.append( "attribute : %s" % fqan )
-        lines.append( "attribute : %s" % data[ 'attribute' ] )
+        if 'attribute' in data:
+          lines.append( "attribute : %s" % data[ 'attribute' ] )
         now = Time.dateTime()
         left = ( data[ 'notAfter' ] - now ).total_seconds()
         h = int( left / 3600 )

--- a/Core/Security/X509Certificate.py
+++ b/Core/Security/X509Certificate.py
@@ -204,6 +204,8 @@ class X509Certificate:
             attr = attr[0][0][1][0]
             data[ 'attribute' ] = "%s = %s (%s)" % attr
             data[ 'vo' ] = attr[2]
+        if not 'vo' in data and 'fqan' in data:
+          data['vo'] = data['fqan'][0].split( '/' )[1]
         return S_OK( data )
     return S_ERROR( "No VOMS data available" )
 


### PR DESCRIPTION
In case no VOMS attributes are defined for a given VO, fqan is the only source of the VO information