### PR TITLE
[v6r13] Extra options file loaded within the JobWrapper

### DIFF
--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -204,6 +204,7 @@ class JobWrapper( object ):
       if extraOpts:
         if os.path.exists( '%s/%s' % ( self.root, extraOpts ) ):
           shutil.copyfile( '%s/%s' % ( self.root, extraOpts ), extraOpts )
+        self.__loadLocalCFGFiles( self.localSiteRoot )
     else:
       self.log.info( 'JobID is not defined, running in current directory' )
 
@@ -236,10 +237,10 @@ class JobWrapper( object ):
     """
     files = os.listdir( localRoot )
     self.log.debug( 'Checking directory %s for *.cfg files' % localRoot )
-    for i in files:
-      if re.search( '.cfg$', i ):
-        gConfig.loadFile( '%s/%s' % ( localRoot, i ) )
-        self.log.debug( 'Found local .cfg file %s' % i )
+    for localFile in files:
+      if re.search( '.cfg$', localFile ):
+        gConfig.loadFile( '%s/%s' % ( localRoot, localFile ) )
+        self.log.verbose( "Found local .cfg file '%s'" % localFile )
 
   #############################################################################
   def __dictAsInfoString( self, dData, infoString = '', currentBase = "" ):

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -674,7 +674,22 @@ class ConfigureCPURequirements( CommandBase ):
 
     # HS06s = seconds * HS06
     self.pp.jobCPUReq = float( cpuTime ) * float( cpuNormalizationFactor )
-    self.log.info( "Queue length is %f" % self.pp.jobCPUReq )
+    self.log.info( "Queue length (which is also set as CPUTimeLeft) is %f" % self.pp.jobCPUReq )
+
+    # now setting this value in local file
+    cfg = ['-FDMH']
+    if self.pp.useServerCertificate:
+      cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
+    if self.pp.localConfigFile:
+      cfg.append( '-O %s' % self.pp.localConfigFile )  # our target file for pilots
+      cfg.append( self.pp.localConfigFile )  # this file is also input
+    cfg.append( '-o /LocalSite/CPUTimeLeft=%s' % str( int( self.pp.jobCPUReq ) ) )  # the only real option
+
+    configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( cfg ) )
+    retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )
+    if retCode:
+      self.log.error( "Failed to update CFG file for CPUTimeLeft" )
+      sys.exit( 1 )
 
 
 class LaunchAgent( CommandBase ):


### PR DESCRIPTION
Here first of all for evaluation, this might not be the end of the story @phicharp 

@atsareg : extra options file passed from the JobAgent to the JobWrapper are not loaded. But still, it has to be seen if its configuration is passed correctly to the executable (which, if it is "dirac-jobexec", should have it).