### PR TITLE
!!! [v6r12] Add dealing with status 22 to SRM2Storag.exists

### DIFF
--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -80,6 +80,8 @@ class SRM2Storage( StorageBase ):
     self.gfalLongTimeOut = gConfig.getValue( "/Resources/StorageElements/GFAL_LongTimeout", 1200 )
     # # gfal retry on errno.ECONN
     self.gfalRetry = gConfig.getValue( "/Resources/StorageElements/GFAL_Retry", 3 )
+    # # should busy files be considered to exist
+    self.busyFilesExist = gConfig.getValue( "/Resources/StorageElements/SRMBusyFilesExist", False )
 
     # # set checksum type, by default this is 0 (GFAL_CKSM_NONE)
     self.checksumType = gConfig.getValue( "/Resources/StorageElements/ChecksumType", None )
@@ -763,7 +765,7 @@ class SRM2Storage( StorageBase ):
         if urlDict['status'] == 0:
           self.log.debug( "SRM2Storage.exists: Path exists: %s" % pathSURL )
           successful[pathSURL] = True
-        elif urlDict['status'] == 22:
+        elif urlDict['status'] == 22 and self.busyFilesExist:
           self.log.debug( "SRM2Storage.exists: Path exists, file busy (e.g., stage-out): %s" % pathSURL )
           successful[pathSURL] = True
         elif urlDict['status'] == 2:

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -763,6 +763,9 @@ class SRM2Storage( StorageBase ):
         if urlDict['status'] == 0:
           self.log.debug( "SRM2Storage.exists: Path exists: %s" % pathSURL )
           successful[pathSURL] = True
+        elif urlDict['status'] == 22:
+          self.log.debug( "SRM2Storage.exists: Path exists, file busy (e.g., stage-out): %s" % pathSURL )
+          successful[pathSURL] = True
         elif urlDict['status'] == 2:
           self.log.debug( "SRM2Storage.exists: Path does not exist: %s" % pathSURL )
           successful[pathSURL] = False


### PR DESCRIPTION
I've had the problem for quite some time, that my FailoverRequests failed because the file already existed on the cern Castor, it had size 0 and I had to remove it by hand.
Now I figured out that the reason is that the SRM2Storage.exists function encountered status 22
(added some debug printout of urldict etc. during investigation)
```
2015-07-02 11:29:52 UTC RequestManagement/RequestExecutingAgent/SRM2Storage   INFO: SRM2Storage.exists: Checking the existance of 1 path(s) 
2015-07-02 11:29:52 UTC RequestManagement/RequestExecutingAgent/SRM2Storage   INFO: SRM2Storage.exists urlDict:  {'status': 0, 'estimated_wait_time': 0, 'stat': [16893, 0L, 0, 1, 2, 2, 0L, 0L, 1435832987L, 1435832987L], 'SRMReqID': None, 'locality': 'ONLINE_AND_NEARLINE', 'explanation': None, 'turl': None, 'surl': '/castor/cern.ch/grid/ilc/prod/clic/365gev/yyveyx_o/ILD/SIM/00005250/000'}  
2015-07-02 11:29:52 UTC RequestManagement/RequestExecutingAgent/SRM2Storage   INFO: __putFile: Checking for existance of file True  
2015-07-02 11:29:52 UTC RequestManagement/RequestExecutingAgent/SRM2Storage   INFO: SRM2Storage.exists: Checking the existance of 1 path(s) 
2015-07-02 11:29:52 UTC RequestManagement/RequestExecutingAgent/SRM2Storage   INFO: SRM2Storage.exists urlDict:  {'status': 22, 'estimated_wait_time': 0, 'SRMReqID': None, 'explanation': '[SE][Ls][SRM_FILE_BUSY] <none>', 'ErrorMessage': '[SE][Ls][SRM_FILE_BUSY] <none>', 'turl': None, 'surl': '/castor/cern.ch/grid/ilc/prod/clic/365gev/yyveyx_o/ILD/SIM/00005250/000/yyveyx_o_sim_5250_587.slcio'}  
2015-07-02 11:29:52 UTC RequestManagement/RequestExecutingAgent/SRM2Storage   INFO: SRM2Storage.exists pathSURL: {'OK': True, 'Value': 'srm://srm-public.cern.ch:8443/srm/managerv2?SFN=/castor/cern.ch/grid/ilc/prod/clic/365gev/yyveyx_o/ILD/SIM/00005250/000/yyveyx_o_sim_5250_587.slcio'}  
2015-07-02 11:29:52 UTC RequestManagement/RequestExecutingAgent/SRM2Storage  ERROR: SRM2Storage.exists: Failed to get path metadata. srm://srm-public.cern.ch:8443/srm/managerv2?SFN=/castor/cern.ch/grid/ilc/prod/clic/365gev/yyveyx_o/ILD/SIM/00005250/000/yyveyx_o_sim_5250_587.slcio: [SE][Ls][SRM_FILE_BUSY] <none>
2015-07-02 11:29:52 UTC RequestManagement/RequestExecutingAgent/SRM2Storage   INFO: __putFile: Failed to find pre-existance of destination file: SRM2Storage.exists: Failed to get path metadata. [SE][Ls][SRM_FILE_BUSY] <none> 
2015-07-02 11:29:52 UTC RequestManagement/RequestExecutingAgent/00005250_00000587_job_12539118/0/ReplicateAndRegister  ERROR: DataManager error: DataManager.replicateAndRegister: Completely failed to replicate file. 
```
which caused the __putFile to fail in the end.
