### PR TITLE
[v6r14] Check the CRLs

### DIFF
--- a/Core/DISET/private/Transports/SSL/SocketInfo.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfo.py
@@ -174,7 +174,7 @@ class SocketInfo:
               continue
             except Exception, e:
               if fileName.find( ".r0" ) == len( fileName ) - 2:
-                gLogger.exception( "LOADING %s ,Exception:" % ( filePath , e ) )
+                gLogger.exception( "LOADING %s ,Exception: %s" % ( filePath , str(e) ) )
 
         gLogger.debug( "Loaded %s CAs [%s CRLs]" % ( casFound, crlsFound ) )
         SocketInfo.__cachedCAsCRLs = ( [ casDict[k][1] for k in casDict ],

--- a/Core/DISET/private/Transports/SSL/SocketInfo.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfo.py
@@ -169,21 +169,16 @@ class SocketInfo:
               if crl.has_expired():
                 continue
               crlID = crl.get_issuer().one_line()
-              crlNotAfter = crl.get_not_after()
-              if crlID not in crlsDict:
-                crlsDict[ crlID ] = ( crlNotAfter, crl )
-                crlsFound += 1
-              else:
-                if crlsDict[ crlID ][0] < crlNotAfter:
-                  crlsDict[ crlID ] = ( crlNotAfter, crl )
+              crlsDict[ crlID ] = crl 
+              crlsFound += 1
               continue
-            except:
+            except Exception, e:
               if fileName.find( ".r0" ) == len( fileName ) - 2:
-                gLogger.exception( "LOADING %s" % filePath )
+                gLogger.exception( "LOADING %s ,Exception:" % ( filePath , e ) )
 
         gLogger.debug( "Loaded %s CAs [%s CRLs]" % ( casFound, crlsFound ) )
         SocketInfo.__cachedCAsCRLs = ( [ casDict[k][1] for k in casDict ],
-                                       [ crlsDict[k][1] for k in crlsDict ] )
+                                       [ crlsDict[k] for k in crlsDict ] )
         SocketInfo.__cachedCAsCRLsLastLoaded = time.time()
     except:
       gLogger.exception( "ASD" )

--- a/Core/DISET/private/Transports/SSL/SocketInfo.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfo.py
@@ -172,7 +172,7 @@ class SocketInfo:
               crlsDict[ crlID ] = crl 
               crlsFound += 1
               continue
-            except Exception, e:
+            except Exception as e:
               if fileName.find( ".r0" ) == len( fileName ) - 2:
                 gLogger.exception( "LOADING %s ,Exception: %s" % ( filePath , str(e) ) )
 


### PR DESCRIPTION
DIRAC allowed to connect users with revoked certificates, because the CRLs was not correctly handled.
Problem:
get_not_after() is a method of the certificate. Revoked certificates do not have this method.

Solution:
I removed the line and each time when we start a DIRAC component or client (skipCACheck == False) the CRLs cache will be recreated.