### PR TITLE
!!! [v6r12] Proposal of modification for codes in ResourceStatus to make VO extension easy. 

### DIFF
--- a/ResourceStatusSystem/Agent/CacheFeederAgent.py
+++ b/ResourceStatusSystem/Agent/CacheFeederAgent.py
@@ -10,10 +10,11 @@ from DIRAC.AccountingSystem.Client.ReportsClient                import ReportsCl
 from DIRAC.Core.Base.AgentModule                                import AgentModule
 from DIRAC.Core.DISET.RPCClient                                 import RPCClient
 from DIRAC.Core.LCG.GOCDBClient                                 import GOCDBClient
-from DIRAC.ResourceStatusSystem.Client.ResourceManagementClient import ResourceManagementClient
 from DIRAC.ResourceStatusSystem.Client.ResourceStatusClient     import ResourceStatusClient
 from DIRAC.ResourceStatusSystem.Command                         import CommandCaller
 #from DIRAC.ResourceStatusSystem.Utilities                       import CSHelpers
+from DIRAC.ResourceStatusSystem.Utilities                       import Utils
+ResourceManagementClient = getattr(Utils.voimport( 'DIRAC.ResourceStatusSystem.Client.ResourceManagementClient' ),'ResourceManagementClient')
 
 __RCSID__  = '$Id:  $'
 AGENT_NAME = 'ResourceStatus/CacheFeederAgent'

--- a/ResourceStatusSystem/Agent/ElementInspectorAgent.py
+++ b/ResourceStatusSystem/Agent/ElementInspectorAgent.py
@@ -13,8 +13,9 @@ from DIRAC                                                      import S_ERROR, 
 from DIRAC.Core.Base.AgentModule                                import AgentModule
 from DIRAC.Core.Utilities.ThreadPool                            import ThreadPool
 from DIRAC.ResourceStatusSystem.Client.ResourceStatusClient     import ResourceStatusClient
-from DIRAC.ResourceStatusSystem.Client.ResourceManagementClient import ResourceManagementClient
 from DIRAC.ResourceStatusSystem.PolicySystem.PEP                import PEP
+from DIRAC.ResourceStatusSystem.Utilities                       import Utils
+ResourceManagementClient = getattr(Utils.voimport( 'DIRAC.ResourceStatusSystem.Client.ResourceManagementClient' ),'ResourceManagementClient')
 
 
 __RCSID__  = '$Id:  $'

--- a/ResourceStatusSystem/PolicySystem/Actions/LogPolicyResultAction.py
+++ b/ResourceStatusSystem/PolicySystem/Actions/LogPolicyResultAction.py
@@ -4,8 +4,9 @@
 '''
 
 from DIRAC                                                      import S_OK, S_ERROR
-from DIRAC.ResourceStatusSystem.Client.ResourceManagementClient import ResourceManagementClient
 from DIRAC.ResourceStatusSystem.PolicySystem.Actions.BaseAction import BaseAction
+from DIRAC.ResourceStatusSystem.Utilities                       import Utils
+ResourceManagementClient = getattr(Utils.voimport( 'DIRAC.ResourceStatusSystem.Client.ResourceManagementClient' ),'ResourceManagementClient')
 
 __RCSID__ = '$Id:  $'
 

--- a/ResourceStatusSystem/PolicySystem/PEP.py
+++ b/ResourceStatusSystem/PolicySystem/PEP.py
@@ -14,9 +14,9 @@
 
 from DIRAC                                                      import gLogger, S_OK, S_ERROR
 from DIRAC.ResourceStatusSystem.Client.ResourceStatusClient     import ResourceStatusClient
-from DIRAC.ResourceStatusSystem.Client.ResourceManagementClient import ResourceManagementClient
 from DIRAC.ResourceStatusSystem.PolicySystem.PDP                import PDP
 from DIRAC.ResourceStatusSystem.Utilities                       import Utils
+ResourceManagementClient = getattr(Utils.voimport( 'DIRAC.ResourceStatusSystem.Client.ResourceManagementClient' ),'ResourceManagementClient')
 
 __RCSID__  = '$Id: $'
 
@@ -43,7 +43,7 @@ class PEP:
     if clients is None:
       clients = {}
     
-    # PEP uses internally two of the clients: ResourceStatusClient and ResouceManagementClient   
+    # PEP uses internally two of the clients: ResourceStatusClient and ResourceManagementClient   
     if 'ResourceStatusClient' in clients:           
       self.rsClient = clients[ 'ResourceStatusClient' ]
     else:

--- a/ResourceStatusSystem/Service/PublisherHandler.py
+++ b/ResourceStatusSystem/Service/PublisherHandler.py
@@ -13,8 +13,8 @@ from types    import NoneType
 from DIRAC                                                      import gLogger, S_OK, gConfig, S_ERROR
 from DIRAC.Core.DISET.RequestHandler                            import RequestHandler
 from DIRAC.ResourceStatusSystem.Client.ResourceStatusClient     import ResourceStatusClient
-from DIRAC.ResourceStatusSystem.Client.ResourceManagementClient import ResourceManagementClient
-from DIRAC.ResourceStatusSystem.Utilities                       import CSHelpers
+from DIRAC.ResourceStatusSystem.Utilities                       import CSHelpers, Utils
+ResourceManagementClient = getattr(Utils.voimport( 'DIRAC.ResourceStatusSystem.Client.ResourceManagementClient' ),'ResourceManagementClient')
 
 __RCSID__ = '$Id: PublisherHandler.py 65921 2013-05-14 13:05:43Z ubeda $'
 

--- a/ResourceStatusSystem/Service/ResourceManagementHandler.py
+++ b/ResourceStatusSystem/Service/ResourceManagementHandler.py
@@ -7,8 +7,8 @@
 
 from DIRAC                                              import gConfig, S_OK, gLogger
 from DIRAC.Core.DISET.RequestHandler                    import RequestHandler
-from DIRAC.ResourceStatusSystem.DB.ResourceManagementDB import ResourceManagementDB
-from DIRAC.ResourceStatusSystem.Utilities               import Synchronizer
+from DIRAC.ResourceStatusSystem.Utilities               import Synchronizer, Utils
+ResourceManagementDB = getattr(Utils.voimport( 'DIRAC.ResourceStatusSystem.DB.ResourceManagementDB' ),'ResourceManagementDB')
 
 __RCSID__ = '$Id: $'
 db        = False

--- a/ResourceStatusSystem/Utilities/Synchronizer.py
+++ b/ResourceStatusSystem/Utilities/Synchronizer.py
@@ -12,9 +12,10 @@ __RCSID__ = '$Id:  $'
 
 from DIRAC                                                 import gLogger, S_OK
 from DIRAC.ResourceStatusSystem.Client                     import ResourceStatusClient
-from DIRAC.ResourceStatusSystem.Client                     import ResourceManagementClient
 from DIRAC.ResourceStatusSystem.Utilities                  import CSHelpers
 from DIRAC.ResourceStatusSystem.Utilities.RssConfiguration import RssConfiguration
+from DIRAC.ResourceStatusSystem.Utilities                  import Utils
+ResourceManagementClient = getattr(Utils.voimport( 'DIRAC.ResourceStatusSystem.Client.ResourceManagementClient' ),'ResourceManagementClient')
 
 class Synchronizer( object ):
   '''
@@ -31,7 +32,7 @@ class Synchronizer( object ):
     if rStatus is None:
       self.rStatus     = ResourceStatusClient.ResourceStatusClient()
     if rManagement is None:   
-      self.rManagement = ResourceManagementClient.ResourceManagementClient()
+      self.rManagement = ResourceManagementClient()
       
     self.rssConfig = RssConfiguration()  
   

--- a/ResourceStatusSystem/scripts/dirac-rss-query-dtcache.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-query-dtcache.py
@@ -32,6 +32,9 @@ from DIRAC.Core.Utilities                      import Time
 from DIRAC.Core.Utilities.PrettyPrint          import printTable 
 import re
 import datetime
+from DIRAC.ResourceStatusSystem.Utilities      import Utils
+ResourceManagementClient = getattr(Utils.voimport( 'DIRAC.ResourceStatusSystem.Client.ResourceManagementClient' ),'ResourceManagementClient')
+
 
 __RCSID__ = '$Id:$'
 
@@ -244,7 +247,7 @@ def select( switchDict ):
     that gets from DowntimeCache all rows that match the parameters given.
   '''
 
-  rmsClient = ResourceManagementClient.ResourceManagementClient()
+  rmsClient = ResourceManagementClient()
 
   meta = { 'columns' : [ 'downtimeID', 'element', 'name', 'startDate', 'endDate',
                          'severity', 'description', 'link', 'dateEffective' ] }
@@ -280,7 +283,7 @@ def add( switchDict ):
     that inserts or updates-if-duplicated from DowntimeCache.
   '''
 
-  rmsClient = ResourceManagementClient.ResourceManagementClient()
+  rmsClient = ResourceManagementClient()
 
   result = { 'output': None, 'successful': None, 'message': None, 'match': None }
   output = rmsClient.addOrModifyDowntimeCache( downtimeID = switchDict[ 'downtimeID' ],
@@ -307,7 +310,7 @@ def delete( switchDict ):
     that deletes from DowntimeCache all rows that match the parameters given.
   '''
 
-  rmsClient = ResourceManagementClient.ResourceManagementClient()
+  rmsClient = ResourceManagementClient()
 
   result = { 'output': None, 'successful': None, 'message': None, 'match': None }
   output = rmsClient.deleteDowntimeCache( downtimeID = switchDict[ 'downtimeID' ],


### PR DESCRIPTION
We like to propose to modify code in RSS to make VO extension easy.
Some codes directly call ResourceManagementDB and ResourceManagemantClient.
But, when VO extension is made, they may be rewritten.
In the current codes, these codes directly calling them should be modified
to import VO-extended  ResourceManagementDB and ResourceManagemantClient.
In my proposal, ResourceManagementDB and ResourceManagemantClient are called
by voimport in DIRAC.ResourceStatusSystem.Utilities.Utils. So some codes do not need
to be modified.
