### PR TITLE
[v6r13] VOMS Policy compatible with old client

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/SecurityManager.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SecurityManager.py
@@ -17,7 +17,7 @@ _writeMethods = ['changePathOwner', 'changePathGroup', 'changePathMode',
                 'removeReplica','setReplicaStatus','setReplicaHost',
                 'setFileOwner','setFileGroup','setFileMode',
                 'addFileAncestors','createDirectory','removeDirectory',
-                'setMetadata','__removeMetadata']
+                'setMetadata', '__removeMetadata']
 
 
 class SecurityManagerBase( object ):
@@ -249,15 +249,17 @@ class DirectorySecurityManagerWithDelete( DirectorySecurityManager ):
     permissions = {}
     failed = {}
 
-
-
     for path in nonExistingObjects:
       permissions[path] = {'Read':True, 'Write':True, 'Execute':True}
         # The try catch is just to protect in case there are duplicate in the paths
       try:
         paths.remove( path )
       except Exception, _e:
-        pass
+        try:
+          paths.pop( path )
+        except Exception, _ee:
+          pass
+
 
     # For all the paths that exist, check the write permission
     if paths:
@@ -296,6 +298,14 @@ class PolicyBasedSecurityManager( SecurityManagerBase ):
 
     pluginCls = self.__loadPlugin( pluginPath )
     self.policyObj = pluginCls( database = database )
+
+    # For the old clients to work with the new policy (since getPathPermissions is meant to disappear...)
+    # we fetch the old SecurityManager, and we call it if needed in the plugin.
+    oldSecurityManagerName = gConfig.getValue( cfgPath( serviceSection, 'OldSecurityManager' ), '' )
+    self.policyObj.oldSecurityManager = None
+    if oldSecurityManagerName:
+      self.policyObj.oldSecurityManager = eval( "%s(self.db)" % oldSecurityManagerName )
+
 
 
   @staticmethod

--- a/DataManagementSystem/DB/FileCatalogComponents/SecurityManager.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SecurityManager.py
@@ -6,6 +6,7 @@ __RCSID__ = "$Id$"
 import os
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security.Properties import FC_MANAGEMENT
+import ast
 
 _readMethods = ['exists', 'isFile', 'getFileSize', 'getFileMetadata',
                'getReplicas','getReplicaStatus','getFileAncestors',
@@ -304,7 +305,7 @@ class PolicyBasedSecurityManager( SecurityManagerBase ):
     oldSecurityManagerName = gConfig.getValue( cfgPath( serviceSection, 'OldSecurityManager' ), '' )
     self.policyObj.oldSecurityManager = None
     if oldSecurityManagerName:
-      self.policyObj.oldSecurityManager = eval( "%s(self.db)" % oldSecurityManagerName )
+      self.policyObj.oldSecurityManager = ast.literal_eval( "%s(self.db)" % oldSecurityManagerName )
 
 
 

--- a/DataManagementSystem/DB/FileCatalogComponents/SecurityPolicies/VOMSPolicy.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SecurityPolicies/VOMSPolicy.py
@@ -608,3 +608,16 @@ class VOMSPolicy( SecurityManagerBase ):
     res = policyToExecute( paths, credDict )
 
     return res
+
+
+  def getPathPermissions( self, paths, credDict ):
+    """ This method is meant to disappear, hopefully soon,
+        but as long as we have clients from versions < v6r14,
+        we need a getPathPermissions method. Since it does not make
+        sense with that kind of fine grain policy, we return what used to
+        be returned...
+    """
+    if hasattr( self, 'oldSecurityManager' ) and self.oldSecurityManager:
+      return self.oldSecurityManager.getPathPermissions( paths, credDict )
+    else:
+      return super( VOMSPolicy, self ).getPathPermissions( paths, credDict )


### PR DESCRIPTION
make the vomspolicy compatible with the old client by calling in case of need the old SecurityManager