### PR TITLE
[v6r13] SandboxStoreClient is vo aware in the web portal context

### DIFF
--- a/ResourceStatusSystem/Utilities/CSHelpers.py
+++ b/ResourceStatusSystem/Utilities/CSHelpers.py
@@ -281,14 +281,6 @@ def getSpaceTokenEndpoints():
   
   return Utils.getCSTree( 'Shares/Disk' )
 
-#def getVOMSEndpoints():
-#  ''' Get VOMS endpoints '''
-#  
-#  endpoints = gConfig.getSections( '/Registry/VOMS/Servers/lhcb' )
-#  if endpoints[ 'OK' ]:
-#    return endpoints[ 'Value' ]
-#  return [] 
-
 def getFileCatalogs():
   '''
     Gets all storage elements from /Resources/FileCatalogs

--- a/Resources/Computing/BatchSystems/GE.py
+++ b/Resources/Computing/BatchSystems/GE.py
@@ -123,7 +123,7 @@ class GE( object ):
     
     if status != 0:
       resultDict['Status'] = status
-      resultDict['Output'] = output
+      resultDict['Message'] = output
       return resultDict
       
     jobDict = {}
@@ -181,7 +181,7 @@ class GE( object ):
 
     if status != 0:
       resultDict['Status'] = status
-      resultDict['Output'] = output
+      resultDict['Message'] = output
       return resultDict
 
     waitingJobs = 0

--- a/Resources/Computing/BatchSystems/Torque.py
+++ b/Resources/Computing/BatchSystems/Torque.py
@@ -84,7 +84,7 @@ class Torque( object ):
     
     if status != 0:
       resultDict['Status'] = status
-      resultDict['Output'] = output
+      resultDict['Message'] = output
       return resultDict
 
     statusDict = {}

--- a/Resources/Computing/BatchSystems/Torque.py
+++ b/Resources/Computing/BatchSystems/Torque.py
@@ -131,7 +131,7 @@ class Torque( object ):
   
     if status != 0:
       resultDict['Status'] = status
-      resultDict['Output'] = output
+      resultDict['Message'] = output
       return resultDict
   
     waitingJobs, runningJobs = output.split()[:2]

--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -20,6 +20,7 @@ from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.Core.Utilities.File import getGlobbedTotalSize
 from DIRAC import gLogger, S_OK, S_ERROR, gConfig
+from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
 
 class SandboxStoreClient( object ):
 
@@ -32,6 +33,9 @@ class SandboxStoreClient( object ):
     self.__rpcClient = rpcClient
     self.__transferClient = transferClient
     self.__kwargs = kwargs
+    self.__vo = None
+    if 'delegatedGroup' in kwargs:
+      self.__vo = getVOForGroup( kwargs['delegatedGroup'] )
     if SandboxStoreClient.__smdb == None:
       try:
         from DIRAC.WorkloadManagementSystem.DB.SandboxMetadataDB import SandboxMetadataDB
@@ -165,7 +169,7 @@ class SandboxStoreClient( object ):
     except Exception, e:
       return S_ERROR( "Cannot create temporal file: %s" % str( e ) )
 
-    se = StorageElement( SEName )
+    se = StorageElement( SEName, vo = self.__vo )
     result = returnSingleResult( se.getFile( SEPFN, localPath = tmpSBDir ) )
 
     if not result[ 'OK' ]:


### PR DESCRIPTION
FIX: SandboxStoreClient - get the vo info from the delegatedGroup argument to use for the StorageElement instantiation
FIX: BatchSystems - always return Message in case of errors ( cherry-picked from integration ) 