### PR TITLE
[v6r13] FIX : Remove the local file when doing two hops transfer in the DataManager

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -868,6 +868,13 @@ class DataManager( object ):
         continue
 
       res = returnSingleResult( destStorageElement.putFile( {destPath:localFile} ) )
+
+      # Remove the local file whatever happened
+      try:
+        os.remove( localFile )
+      except Exception as e:
+        log.error( 'Error removing local file', '%s %s' % ( localFile, e ) )
+
       if not res['OK']:
         log.debug( 'Error putting file coming from %s' % candidateSE.name, res['Message'] )
         # if the put is the problem, it's maybe pointless to try the other candidateSEs...

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -872,7 +872,7 @@ class DataManager( object ):
       # Remove the local file whatever happened
       try:
         os.remove( localFile )
-      except Exception as e:
+      except OSError as e:
         log.error( 'Error removing local file', '%s %s' % ( localFile, e ) )
 
       if not res['OK']:


### PR DESCRIPTION
This bug has always been there....