### PR TITLE
[v6r12] SRM2Storage, busyfile new return code?; GraphData protect against missing key

### DIFF
--- a/Core/Utilities/Graphs/GraphData.py
+++ b/Core/Utilities/Graphs/GraphData.py
@@ -400,9 +400,9 @@ class PlotData:
     else:
       self.keys = self.sortKeys()
 
-    self.values = [ self.parsed_data[k] for k in self.keys ]
-    self.errors = [ self.parsed_errors[k] for k in self.keys ]
-    values_to_sum = [ self.parsed_data[k] for k in self.keys if k != '' ]
+    self.values = [ self.parsed_data.get(k, 0.0) for k in self.keys ]
+    self.errors = [ self.parsed_errors.get(k, 0.0) for k in self.keys ]
+    values_to_sum = [ self.parsed_data.get(k, 0.0) for k in self.keys if k != '' ]
 
     self.real_values = []
     for k in self.keys:

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -766,7 +766,7 @@ class SRM2Storage( StorageBase ):
         if urlDict['status'] == 0:
           self.log.debug( "SRM2Storage.exists: Path exists: %s" % pathSURL )
           successful[pathSURL] = True
-        elif urlDict['status'] == 22 and self.busyFilesExist:
+        elif urlDict['status'] in ( 16, 22 ) and self.busyFilesExist:
           self.log.debug( "SRM2Storage.exists: Path exists, file busy (e.g., stage-out): %s" % pathSURL )
           successful[pathSURL] = True
         elif urlDict['status'] == 2:


### PR DESCRIPTION
a) I am not sure, but now the Castor-SRM return status 16 for SRM_FILE_BUSY. I don't know if this is a new return code for the same issue as before, or a different Issue.

b) I was trying to plot WMSHistory NumberOfJobs grouped by Status, limited to two groups , limited to the last two days and got an exception for a missing key in the parsed_errors