### PR TITLE
[v6r15] Remove gMonitor instantiation from DIRAC.__init__.py

### DIFF
--- a/AccountingSystem/DB/AccountingDB.py
+++ b/AccountingSystem/DB/AccountingDB.py
@@ -6,7 +6,8 @@ import types
 import threading
 import random
 from DIRAC.Core.Base.DB import DB
-from DIRAC import S_OK, S_ERROR, gMonitor, gConfig
+from DIRAC import S_OK, S_ERROR, gConfig
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Utilities import List, ThreadSafe, Time, DEncode
 from DIRAC.AccountingSystem.private.TypeLoader import TypeLoader
 from DIRAC.Core.Utilities.ThreadPool import ThreadPool

--- a/AccountingSystem/Service/ReportGeneratorHandler.py
+++ b/AccountingSystem/Service/ReportGeneratorHandler.py
@@ -4,7 +4,8 @@ import types
 import os
 import datetime
 
-from DIRAC import S_OK, S_ERROR, rootPath, gConfig, gLogger, gMonitor
+from DIRAC import S_OK, S_ERROR, rootPath, gConfig, gLogger
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.AccountingSystem.DB.MultiAccountingDB import MultiAccountingDB
 from DIRAC.AccountingSystem.private.DataCache import gDataCache
 from DIRAC.AccountingSystem.private.MainReporter import MainReporter

--- a/Core/Base/AgentModule.py
+++ b/Core/Base/AgentModule.py
@@ -13,7 +13,8 @@ import threading
 import types
 import time
 import DIRAC
-from DIRAC import S_OK, S_ERROR, gConfig, gLogger, gMonitor, rootPath
+from DIRAC import S_OK, S_ERROR, gConfig, gLogger, rootPath
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.ConfigurationSystem.Client import PathFinder
 from DIRAC.FrameworkSystem.Client.MonitoringClient import MonitoringClient
 from DIRAC.Core.Utilities.Shifter import setupShifterProxyInEnv

--- a/Core/DISET/private/Service.py
+++ b/Core/DISET/private/Service.py
@@ -3,7 +3,8 @@ import os
 import time
 import DIRAC
 import threading
-from DIRAC import gConfig, gLogger, S_OK, S_ERROR, gMonitor
+from DIRAC import gConfig, gLogger, S_OK, S_ERROR
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Utilities import List, Time, MemStat
 from DIRAC.Core.DISET.private.LockManager import LockManager
 from DIRAC.FrameworkSystem.Client.MonitoringClient import MonitoringClient

--- a/Core/Utilities/Os.py
+++ b/Core/Utilities/Os.py
@@ -6,7 +6,6 @@
 
 __RCSID__ = "$Id$"
 
-from types                          import StringTypes
 import os
 import multiprocessing
 
@@ -22,8 +21,7 @@ def uniquePath( path = None ):
      Utility to squeeze the string containing a PATH-like value to
      leave only unique elements preserving the original order
   """
-
-  if not StringTypes.__contains__( type( path ) ):
+  if not isinstance( path, basestring ):
     return None
 
   try:

--- a/DataManagementSystem/Agent/CleanFTSDBAgent.py
+++ b/DataManagementSystem/Agent/CleanFTSDBAgent.py
@@ -23,7 +23,8 @@ __RCSID__ = "$Id: $"
 # # imports
 import datetime
 # # from DIRAC
-from DIRAC import S_OK, gMonitor
+from DIRAC import S_OK
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.DataManagementSystem.Client.FTSClient import FTSClient
 from DIRAC.DataManagementSystem.Client.FTSJob import FTSJob

--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -42,7 +42,7 @@ import time
 import datetime
 import re
 # # from DIRAC
-from DIRAC import S_OK, S_ERROR, gLogger, gMonitor
+from DIRAC import S_OK, S_ERROR, gLogger
 # # from CS
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getUsernameForDN
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources     import getRegistrationProtocols
@@ -50,6 +50,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 
 # # from Core
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Utilities.LockRing import LockRing
 from DIRAC.Core.Utilities.ThreadPool import ThreadPool
 from DIRAC.Core.Base.AgentModule import AgentModule

--- a/DataManagementSystem/Agent/RequestOperations/PhysicalRemoval.py
+++ b/DataManagementSystem/Agent/RequestOperations/PhysicalRemoval.py
@@ -25,7 +25,8 @@ __RCSID__ = "$Id $"
 # # imports
 import os
 # # from DIRAC
-from DIRAC import S_OK, gMonitor
+from DIRAC import S_OK
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.DataManagementSystem.Agent.RequestOperations.DMSRequestOperationsBase  import DMSRequestOperationsBase
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 

--- a/DataManagementSystem/Agent/RequestOperations/PutAndRegister.py
+++ b/DataManagementSystem/Agent/RequestOperations/PutAndRegister.py
@@ -24,7 +24,8 @@ __RCSID__ = "$Id $"
 # @brief Definition of PutAndRegister class.
 
 # # imports
-from DIRAC import S_OK, S_ERROR, gMonitor
+from DIRAC import S_OK, S_ERROR
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.DataManagementSystem.Agent.RequestOperations.DMSRequestOperationsBase  import DMSRequestOperationsBase
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 

--- a/DataManagementSystem/Agent/RequestOperations/ReTransfer.py
+++ b/DataManagementSystem/Agent/RequestOperations/ReTransfer.py
@@ -23,7 +23,8 @@ __RCSID__ = "$Id $"
 # @brief Definition of ReTransfer class.
 
 # # imports
-from DIRAC import S_OK, S_ERROR, gMonitor
+from DIRAC import S_OK, S_ERROR
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.DataManagementSystem.Agent.RequestOperations.DMSRequestOperationsBase   import DMSRequestOperationsBase
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 

--- a/DataManagementSystem/Agent/RequestOperations/RemoveReplica.py
+++ b/DataManagementSystem/Agent/RequestOperations/RemoveReplica.py
@@ -26,7 +26,8 @@ __RCSID__ = "$Id $"
 # # imports
 import os
 # # from DIRAC
-from DIRAC import S_OK, S_ERROR, gMonitor
+from DIRAC import S_OK, S_ERROR
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.DataManagementSystem.Agent.RequestOperations.DMSRequestOperationsBase   import DMSRequestOperationsBase
 
 ########################################################################

--- a/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
+++ b/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
@@ -23,8 +23,9 @@ __RCSID__ = "$Id $"
 # # imports
 import re
 # # from DIRAC
-from DIRAC import S_OK, S_ERROR, gMonitor, gLogger
+from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities.Adler import compareAdler
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 
 from DIRAC.DataManagementSystem.Client.DataManager                                import DataManager
 from DIRAC.DataManagementSystem.Agent.RequestOperations.DMSRequestOperationsBase  import DMSRequestOperationsBase

--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -17,7 +17,8 @@ import os
 from types import IntType, LongType, DictType, StringTypes, BooleanType, ListType
 ## from DIRAC
 from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
-from DIRAC import gLogger, S_OK, S_ERROR, gMonitor
+from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.DataManagementSystem.DB.FileCatalogDB import FileCatalogDB
 from DIRAC.Core.Utilities.List import sortList
 

--- a/FrameworkSystem/Service/PlottingHandler.py
+++ b/FrameworkSystem/Service/PlottingHandler.py
@@ -8,7 +8,8 @@ import os
 import hashlib
 from types import DictType, ListType
 
-from DIRAC import S_OK, S_ERROR, rootPath, gConfig, gLogger, gMonitor
+from DIRAC import S_OK, S_ERROR, rootPath, gConfig, gLogger
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.ConfigurationSystem.Client import PathFinder
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.FrameworkSystem.Service.PlotCache import gPlotCache

--- a/FrameworkSystem/scripts/dirac-monitoring-get-components-status.py
+++ b/FrameworkSystem/scripts/dirac-monitoring-get-components-status.py
@@ -12,7 +12,9 @@ args = Script.getPositionalArgs()
 
 fieldsToShow = ( 'ComponentName', 'Type', 'Host', 'Port', 'Status', 'Message' )
 
-result = DIRAC.gMonitor.getComponentsStatusWebFormatted( sortingList = [ [ 'ComponentName', 'ASC' ] ] )
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
+
+result = gMonitor.getComponentsStatusWebFormatted( sortingList = [ [ 'ComponentName', 'ASC' ] ] )
 if not result[ 'OK' ]:
   print "ERROR: %s" % result[ 'Message' ]
   sys.exit( 1 )

--- a/RequestManagementSystem/Agent/CleanReqDBAgent.py
+++ b/RequestManagementSystem/Agent/CleanReqDBAgent.py
@@ -23,7 +23,8 @@ __RCSID__ = "$Id: $"
 # # imports
 import datetime
 # # from DIRAC
-from DIRAC import S_OK, gMonitor
+from DIRAC import S_OK
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.RequestManagementSystem.Client.ReqClient import ReqClient
 from DIRAC.RequestManagementSystem.Client.Request import Request

--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -24,7 +24,8 @@ __RCSID__ = '$Id$'
 # # imports
 import time
 # # from DIRAC
-from DIRAC import gMonitor, S_OK, S_ERROR, gConfig
+from DIRAC import S_OK, S_ERROR, gConfig
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.ConfigurationSystem.Client import PathFinder
 from DIRAC.Core.Utilities.ProcessPool import ProcessPool

--- a/RequestManagementSystem/private/RequestTask.py
+++ b/RequestManagementSystem/private/RequestTask.py
@@ -24,7 +24,8 @@ __RCSID__ = "$Id $"
 import os
 import time
 # # from DIRAC
-from DIRAC import gLogger, S_OK, S_ERROR, gMonitor, gConfig
+from DIRAC import gLogger, S_OK, S_ERROR, gConfig
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.RequestManagementSystem.Client.ReqClient import ReqClient
 from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.private.OperationHandlerBase import OperationHandlerBase

--- a/TransformationSystem/Agent/InputDataAgent.py
+++ b/TransformationSystem/Agent/InputDataAgent.py
@@ -8,11 +8,12 @@ key set in the DIRAC FileCatalog.
 
 import time, datetime
 
-from DIRAC                                                                import S_OK, gLogger, gMonitor
-from DIRAC.Core.Base.AgentModule                                          import AgentModule
-from DIRAC.TransformationSystem.Client.TransformationClient               import TransformationClient
-from DIRAC.Resources.Catalog.FileCatalogClient                            import FileCatalogClient
-from DIRAC.ConfigurationSystem.Client.Helpers.Operations                  import Operations
+from DIRAC                                                   import S_OK, gLogger
+from DIRAC.FrameworkSystem.Client.MonitoringClient           import gMonitor
+from DIRAC.Core.Base.AgentModule                             import AgentModule
+from DIRAC.TransformationSystem.Client.TransformationClient  import TransformationClient
+from DIRAC.Resources.Catalog.FileCatalogClient               import FileCatalogClient
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations     import Operations
 
 __RCSID__ = "$Id$"
 

--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -19,7 +19,6 @@ from DIRAC import S_OK
 from DIRAC.FrameworkSystem.Client.MonitoringClient                  import gMonitor
 from DIRAC.Core.Base.AgentModule                                    import AgentModule
 from DIRAC.Core.Utilities.ThreadPool                                import ThreadPool
-from DIRAC.Core.Utilities.ThreadSafe                                import Synchronizer
 from DIRAC.TransformationSystem.Client.FileReport                   import FileReport
 from DIRAC.Core.Security.ProxyInfo                                  import getProxyInfo
 
@@ -28,7 +27,6 @@ from DIRAC.TransformationSystem.Client.TransformationClient         import Trans
 from DIRAC.TransformationSystem.Agent.TransformationAgentsUtilities import TransformationAgentsUtilities
 
 AGENT_NAME = 'Transformation/TaskManagerAgentBase'
-gSynchro = Synchronizer()
 
 class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
   """ To be extended. Please look at WorkflowTaskAgent and RequestTaskAgent.
@@ -478,9 +476,6 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
 
     return S_OK()
 
-  # This gSynchro is necessary in order to avoid race conditions when submitting to the WMS,
-  # because WMSClient wants jobDescription.xml to be present in the local directory prior to submission
-  @gSynchro
   def __actualSubmit( self, preparedTransformationTasks, clients, transID ):
     """ This function contacts either RMS or WMS depending on the type of transformation.
     """

--- a/WorkloadManagementSystem/Client/Matcher.py
+++ b/WorkloadManagementSystem/Client/Matcher.py
@@ -8,8 +8,9 @@ __RCSID__ = "$Id"
 import time
 from types import StringTypes
 
-from DIRAC import gLogger, gMonitor
+from DIRAC import gLogger
 
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
 from DIRAC.Core.Security import Properties
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry

--- a/__init__.py
+++ b/__init__.py
@@ -126,7 +126,7 @@ from DIRAC.FrameworkSystem.Client.Logger import gLogger
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 
 #Monitoring client
-from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
+#from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 
 # Some Defaults if not present in the configuration
 FQDN = getFQDN()


### PR DESCRIPTION
Remove instantiation of the global gMonitor object from DIRAC.__init__.py to be less dependent
on DIRAC internal details when instantiating various objects, for example to generate documentation. 