### PR TITLE
[v6r13] Fixing relative paths for put and get operations

### DIFF
--- a/Resources/Storage/GFAL2_HTTPStorage.py
+++ b/Resources/Storage/GFAL2_HTTPStorage.py
@@ -1,0 +1,48 @@
+""" :mod: GFAL2_HTTPStorage
+    =================
+
+    .. module: python
+    :synopsis: HTTP module based on the GFAL2_StorageBase class.
+"""
+
+# from DIRAC
+from DIRAC.Resources.Storage.GFAL2_StorageBase import GFAL2_StorageBase
+from DIRAC import gLogger
+
+
+class GFAL2_HTTPStorage( GFAL2_StorageBase ):
+
+  """ .. class:: GFAL2_HTTPStorage
+
+  HTTP interface to StorageElement using gfal2
+  """
+
+  def __init__( self, storageName, parameters ):
+    """ c'tor
+
+    :param self: self reference
+    :param str storageName: SE name
+    :param str protocol: protocol to use
+    :param str rootdir: base path for vo files
+    :param str host: SE host
+    :param int port: port to use to communicate with :host:
+    :param str spaceToken: space token
+    :param str wspath: location of HTTP on :host:
+    """
+    self.log = gLogger.getSubLogger( "GFAL2_HTTPStorage", True )
+    # # init base class
+    GFAL2_StorageBase.__init__( self, storageName, parameters )
+
+    # TODO: test if HTTP can handle checksums.
+    self.checksumType = None
+
+#     self.log.setLevel( "DEBUG" )
+
+    self.pluginName = 'GFAL2_HTTP'
+    self.protocol = self.protocolParameters['Protocol']
+    self.host = self.protocolParameters['Host']
+
+
+    self.protocolParameters['Port'] = 0
+    self.protocolParameters['WSUrl'] = 0
+    self.protocolParameters['SpaceToken'] = 0

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -285,6 +285,8 @@ class GFAL2_StorageBase( StorageBase ):
 
     # file is local so we can set the protocol and determine source size accordingly
       else:
+        if not os.path.isabs( src_file ):
+          src_file = os.path.join( os.getcwd(), src_file )
         if not os.path.exists( src_file ) or not os.path.isfile( src_file ):
           errStr = "GFAL2_StorageBase.__putFile: The local source file does not exist or is a directory"
           self.log.error( errStr, src_file )
@@ -404,6 +406,8 @@ class GFAL2_StorageBase( StorageBase ):
     """
     self.log.info( "GFAL2_StorageBase.__getSingleFile: Trying to download %s to %s" % ( src_url, dest_file ) )
 
+    if not os.path.isabs( dest_file ):
+      dest_file = os.path.join( os.getcwd(), dest_file )
     if not os.path.exists( os.path.dirname( dest_file ) ):
       self.log.debug( "GFAL2_StorageBase.__getSingleFile: Local directory does not yet exist. Creating it", os.path.dirname( dest_file ) )
       try:
@@ -1339,6 +1343,8 @@ class GFAL2_StorageBase( StorageBase ):
       self.log.error( errStr, src_dir )
       return S_ERROR( errStr )
 
+    if not os.path.isabs( dest_dir ):
+      dest_dir = os.path.join( os.getcwd(), dest_dir )
     if not os.path.exists( dest_dir ):
       try:
         os.makedirs( dest_dir )
@@ -1450,7 +1456,8 @@ class GFAL2_StorageBase( StorageBase ):
 
     filesPut = 0
     sizePut = 0
-
+    if not os.path.isabs( src_directory ):
+      src_directory = os.path.join( os.getcwd(), src_directory )
     if not os.path.isdir( src_directory ):
       errStr = 'GFAL2_StorageBase.__putSingleDirectory: The supplied source directory does not exist or is not a directory.'
       self.log.error( errStr, src_directory )

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -285,13 +285,11 @@ class GFAL2_StorageBase( StorageBase ):
 
     # file is local so we can set the protocol and determine source size accordingly
       else:
-        if not os.path.isabs( src_file ):
-          src_file = os.path.join( os.getcwd(), src_file )
         if not os.path.exists( src_file ) or not os.path.isfile( src_file ):
           errStr = "GFAL2_StorageBase.__putFile: The local source file does not exist or is a directory"
           self.log.error( errStr, src_file )
           return S_ERROR( errStr )
-        src_url = 'file://%s' % src_file
+        src_url = 'file:%s' % src_file
         sourceSize = getSize( src_file )
         if sourceSize == -1:
           errStr = "GFAL2_StorageBase.__putFile: Failed to get file size"
@@ -406,8 +404,6 @@ class GFAL2_StorageBase( StorageBase ):
     """
     self.log.info( "GFAL2_StorageBase.__getSingleFile: Trying to download %s to %s" % ( src_url, dest_file ) )
 
-    if not os.path.isabs( dest_file ):
-      dest_file = os.path.join( os.getcwd(), dest_file )
     if not os.path.exists( os.path.dirname( dest_file ) ):
       self.log.debug( "GFAL2_StorageBase.__getSingleFile: Local directory does not yet exist. Creating it", os.path.dirname( dest_file ) )
       try:
@@ -443,7 +439,7 @@ class GFAL2_StorageBase( StorageBase ):
     # Params set, copying file now
     try:
       # gfal2 needs a protocol to copy local which is 'file:'
-      dest = 'file://' + dest_file
+      dest = 'file:' + dest_file
       self.gfal2.filecopy( params, src_url, dest )
       if self.checksumType:
         # gfal2 did a checksum check, so we should be good
@@ -1343,8 +1339,7 @@ class GFAL2_StorageBase( StorageBase ):
       self.log.error( errStr, src_dir )
       return S_ERROR( errStr )
 
-    if not os.path.isabs( dest_dir ):
-      dest_dir = os.path.join( os.getcwd(), dest_dir )
+
     if not os.path.exists( dest_dir ):
       try:
         os.makedirs( dest_dir )
@@ -1456,8 +1451,7 @@ class GFAL2_StorageBase( StorageBase ):
 
     filesPut = 0
     sizePut = 0
-    if not os.path.isabs( src_directory ):
-      src_directory = os.path.join( os.getcwd(), src_directory )
+
     if not os.path.isdir( src_directory ):
       errStr = 'GFAL2_StorageBase.__putSingleDirectory: The supplied source directory does not exist or is not a directory.'
       self.log.error( errStr, src_directory )


### PR DESCRIPTION
Relative paths didn't work because the 'file:' protocol specifier (that gfal2 needs) was set as such that it interpreted all paths as absolute, resulting in an error for relative paths.