### PR TITLE
[v6r13] ReqClient.printFile: need to check if Error exists before checking fo…

### DIFF
--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -512,7 +512,7 @@ def printOperation( indexOperation, verbose = True, onlyFailed = False ):
 def printFile( indexFile ):
   j, f = indexFile
   gLogger.always( "    [%02d] ID=%s LFN='%s' Status='%s'%s%s%s" % ( j + 1, f.FileID if hasattr( f, 'FileID' ) else '(not set yet)', f.LFN, f.Status,
-                                                                    ( " Checksum='%s'" % f.Checksum ) if f.Checksum or 'checksum' in f.Error.lower() else "",
+                                                                    ( " Checksum='%s'" % f.Checksum ) if f.Checksum or ( f.Error and 'checksum' in f.Error.lower() ) else "",
                                                                     ( " Error='%s'" % f.Error ) if f.Error and f.Error.strip() else "",
                                                                     ( " Attempts=%d" % f.Attempt ) if f.Attempt > 1 else ""
                                                                     )


### PR DESCRIPTION
…r checksum

I think this is the intention for this line. 
If one should be so lucky to have no error for their requests this could otherwise end with
```
Traceback (most recent call last):
  File "/home/sailer/software/DIRAC/DiracDevV6r13/DIRAC/RequestManagementSystem/scripts/dirac-rms-show-request.py", line 186, in <module>
    printRequest( request, status = dbStatus, full = full, verbose = verbose, terse = terse )
  File "/home/sailer/software/DIRAC/DiracDevV6r13/DIRAC/RequestManagementSystem/Client/ReqClient.py", line 471, in printRequest
    printOperation( indexOperation, verbose, onlyFailed = terse )
  File "/home/sailer/software/DIRAC/DiracDevV6r13/DIRAC/RequestManagementSystem/Client/ReqClient.py", line 510, in printOperation
    printFile( indexFile )
  File "/home/sailer/software/DIRAC/DiracDevV6r13/DIRAC/RequestManagementSystem/Client/ReqClient.py", line 515, in printFile
    ( " Checksum='%s'" % f.Checksum ) if f.Checksum or 'checksum' in f.Error.lower() else "",
AttributeError: 'NoneType' object has no attribute 'lower'
```
