### PR TITLE
[v6r13] SystemLoggingDB.ClientIPs.ClientIPNumberString too short for IPv6

### DIFF
--- a/FrameworkSystem/DB/SystemLoggingDB.py
+++ b/FrameworkSystem/DB/SystemLoggingDB.py
@@ -41,7 +41,7 @@ CREATE  TABLE IF NOT EXISTS `Sites` (
 
 CREATE  TABLE IF NOT EXISTS `ClientIPs` (
   `ClientIPNumberID` INT NOT NULL AUTO_INCREMENT ,
-  `ClientIPNumberString` VARCHAR(15) NOT NULL DEFAULT '0.0.0.0' ,
+  `ClientIPNumberString` VARCHAR(45) NOT NULL DEFAULT '0.0.0.0' ,
   `ClientFQDN` VARCHAR(128) NOT NULL DEFAULT 'unknown' ,
   `SiteID` INT NOT NULL ,
   PRIMARY KEY (`ClientIPNumberID`, `SiteID`) ,
@@ -111,7 +111,7 @@ CREATE  TABLE IF NOT EXISTS `AgentPersistentData` (
                             'Engine': 'InnoDB',
                             },
                 'ClientIPs':{ 'Fields': { 'ClientIPNumberID': 'INT NOT NULL AUTO_INCREMENT',
-                                          'ClientIPNumberString': "VARCHAR(15) NOT NULL DEFAULT '0.0.0.0'",
+                                          'ClientIPNumberString': "VARCHAR(45) NOT NULL DEFAULT '0.0.0.0'",
                                           'ClientFQDN': "VARCHAR(128) NOT NULL DEFAULT 'unknown'",
                                           'SiteID': 'INT NOT NULL' },
                               'PrimaryKey': [ 'ClientIPNumberID', 'SiteID' ],


### PR DESCRIPTION
My SystemLogging Test instance had lots of errors, because the IPaddress of the machine could not be inserted fully.
Apparently one needs 45 characters to account for all cases (see google)

And of course for existing DBs
```
ALTER TABLE ClientIPs MODIFY Column `ClientIPNumberString` varchar(45) NOT NULL DEFAULT '0.0.0.0';
```