### PR TITLE
[v6r13] fixing relative path issues

### DIFF
--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -289,7 +289,7 @@ class GFAL2_StorageBase( StorageBase ):
           errStr = "GFAL2_StorageBase.__putFile: The local source file does not exist or is a directory"
           self.log.error( errStr, src_file )
           return S_ERROR( errStr )
-        src_url = 'file://%s' % src_file
+        src_url = 'file:%s' % src_file
         sourceSize = getSize( src_file )
         if sourceSize == -1:
           errStr = "GFAL2_StorageBase.__putFile: Failed to get file size"
@@ -439,7 +439,7 @@ class GFAL2_StorageBase( StorageBase ):
     # Params set, copying file now
     try:
       # gfal2 needs a protocol to copy local which is 'file:'
-      dest = 'file://' + dest_file
+      dest = 'file:' + dest_file
       self.gfal2.filecopy( params, src_url, dest )
       if self.checksumType:
         # gfal2 did a checksum check, so we should be good


### PR DESCRIPTION
Relative paths didn't work because the 'file:' protocol specifier (that gfal2 needs) was set as such that it interpreted all paths as absolute, resulting in an error for relative paths.

This is the same PR as before but on a clean branch.