### PR TITLE
[v6r15] Machine/Job Features support

### DIFF
--- a/Core/Utilities/TimeLeft/MJFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/MJFTimeLeft.py
@@ -2,12 +2,11 @@
 # $Id$
 ########################################################################
 
-""" The Machine/Job Features TimeLeft utility interrogates the MJF environment 
+""" The Machine/Job Features TimeLeft utility interrogates the MJF values
     for the current CPU and Wallclock consumed, as well as their limits.
 """
 
 from DIRAC import gLogger, S_OK, S_ERROR
-from DIRAC.Core.Utilities.TimeLeft.TimeLeft import runCommand
 
 __RCSID__ = "$Id$"
 

--- a/Core/Utilities/TimeLeft/MJFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/MJFTimeLeft.py
@@ -1,0 +1,94 @@
+########################################################################
+# $Id$
+########################################################################
+
+""" The Machine/Job Features TimeLeft utility interrogates the MJF environment 
+    for the current CPU and Wallclock consumed, as well as their limits.
+"""
+
+from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC.Core.Utilities.TimeLeft.TimeLeft import runCommand
+
+__RCSID__ = "$Id$"
+
+import os, re, time, urllib
+
+class MJFTimeLeft:
+
+  #############################################################################
+  def __init__( self ):
+    """ Standard constructor
+    """
+    self.log = gLogger.getSubLogger( 'MJFTimeLeft' )
+    self.jobID = None
+    if os.environ.has_key( 'JOB_ID' ):
+      self.jobID = os.environ['JOB_ID']
+    self.queue = None
+    if os.environ.has_key( 'QUEUE' ):
+      self.queue = os.environ['QUEUE']
+
+    self.cpuLimit = None
+    self.wallClockLimit = None
+    self.log.verbose( 'jobID=%s, queue=%s' % ( self.jobID, self.queue ) )
+    self.startTime = time.time()
+
+  #############################################################################
+  def getResourceUsage( self ):
+    """Returns a dictionary containing CPUConsumed, CPULimit, WallClockConsumed
+       and WallClockLimit for current slot.  All values returned in seconds.
+    """
+
+    cpu = None
+    cpuLimit = None
+    wallClock = None
+    wallClockLimit = None
+
+    try:
+      # We are not called from TimeLeft.py if these are not set
+      jobFeaturesPath = os.environ['JOBFEATURES']
+      machineFeaturesPath = os.environ['MACHINEFEATURES']
+    except:
+      self.log.warn( '$JOBFEATURES and $MACHINEFEATURES not set' )
+
+    try:
+      wallClockLimit = int( urllib.urlopen(jobFeaturesPath + '/wall_limit_secs').read() )
+    except:
+      self.log.warn( 'Could not determine wallclock limit from $JOBFEATURES/wall_limit_secs' )
+
+    try:
+      jobStartSecs = int( urllib.urlopen(jobFeaturesPath + '/jobstart_secs').read() )
+    except:
+      self.log.warn( 'Could not determine job start time from $JOBFEATURES/jobstart_secs' )
+      jobStartSecs = self.startTime
+
+    try:
+      shutdownTime = int( urllib.urlopen(machineFeaturesPath + '/shutdowntime').read() )
+    except:
+      self.log.info( 'Could not determine a shutdowntime value from $MACHINEFEATURES/shutdowntime' )
+    else:
+      if int(time.time()) + wallClockLimit > shutdownTime:
+        # reduce wallClockLimit if would overrun shutdownTime
+        wallClockLimit = shutdownTime - jobStartSecs
+
+    try:
+      cpuLimit = int( urllib.urlopen(jobFeaturesPath + '/cpu_limit_secs').read() )
+    except:
+      self.log.warn( 'Could not determine cpu limit from $JOBFEATURES/cpu_limit_secs' )
+      cpuLimit = wallClockLimit
+
+    wallClock = int(time.time()) - jobStartSecs
+    # We cannot get CPU usage from MJF, so for now use wallClock figure
+    cpu = wallClock
+      
+    consumed = {'CPU':cpu, 'CPULimit':cpuLimit, 'WallClock':wallClock, 'WallClockLimit':wallClockLimit}
+    self.log.debug( consumed )
+
+    if cpu and cpuLimit and wallClock and wallClockLimit:
+      return S_OK( consumed )
+    else:
+      self.log.info( 'Could not determine some parameters' )
+      retVal = S_ERROR( 'Could not determine some parameters' )
+      retVal['Value'] = consumed
+      return retVal
+
+#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#

--- a/Core/Utilities/TimeLeft/TimeLeft.py
+++ b/Core/Utilities/TimeLeft/TimeLeft.py
@@ -1,5 +1,5 @@
 ########################################################################
-# 650893b (2012-11-27 11:27:36 +0100) ricardo <Ricardo.Graciani@gmail.com>
+# $Id$
 ########################################################################
 
 """ The TimeLeft utility allows to calculate the amount of CPU time
@@ -13,7 +13,7 @@
     With this information the utility can calculate in normalized units the
     CPU time remaining for a given slot.
 """
-__RCSID__ = "650893b (2012-11-27 11:27:36 +0100) ricardo <Ricardo.Graciani@gmail.com>"
+__RCSID__ = "$Id$"
 
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR
 from DIRAC.Core.Utilities.Subprocess import shellCall

--- a/Core/Utilities/TimeLeft/TimeLeft.py
+++ b/Core/Utilities/TimeLeft/TimeLeft.py
@@ -140,7 +140,7 @@ class TimeLeft:
       if os.environ.has_key( envVar ):
         name = batchSystem
         break
-
+ 
     if name == None:
       self.log.warn( 'Batch system type for site %s is not currently supported' % DIRAC.siteName() )
       return S_ERROR( 'Current batch system is not supported' )

--- a/Core/Utilities/TimeLeft/TimeLeft.py
+++ b/Core/Utilities/TimeLeft/TimeLeft.py
@@ -1,5 +1,5 @@
 ########################################################################
-# $Id$
+# 650893b (2012-11-27 11:27:36 +0100) ricardo <Ricardo.Graciani@gmail.com>
 ########################################################################
 
 """ The TimeLeft utility allows to calculate the amount of CPU time
@@ -13,7 +13,7 @@
     With this information the utility can calculate in normalized units the
     CPU time remaining for a given slot.
 """
-__RCSID__ = "$Id$"
+__RCSID__ = "650893b (2012-11-27 11:27:36 +0100) ricardo <Ricardo.Graciani@gmail.com>"
 
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR
 from DIRAC.Core.Utilities.Subprocess import shellCall
@@ -140,7 +140,11 @@ class TimeLeft:
       if os.environ.has_key( envVar ):
         name = batchSystem
         break
- 
+
+    if name == None and os.environ.has_key( 'MACHINEFEATURES' ) and os.environ.has_key( 'JOBFEATURES' ):
+      # Only use MJF if legacy batch system information not available for now
+      name = 'MJF'
+
     if name == None:
       self.log.warn( 'Batch system type for site %s is not currently supported' % DIRAC.siteName() )
       return S_ERROR( 'Current batch system is not supported' )

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -454,9 +454,13 @@ class ConfigureSite( CommandBase ):
       pilotRef = 'sshoar://' + self.pp.ceName + '/' + os.environ['OAR_JOBID']
 
     # Grid Engine
-    if os.environ.has_key( 'JOB_ID' ):
+    if os.environ.has_key( 'JOB_ID' ) and os.environ.has_key( 'SGE_TASK_ID' ):
       self.pp.flavour = 'SSHGE'
       pilotRef = 'sshge://' + self.pp.ceName + '/' + os.environ['JOB_ID']
+    # Generic JOB_ID
+    elif os.environ.has_key( 'JOB_ID' ):
+       self.pp.flavour = 'Generic'
+       pilotRef = 'generic://' + self.pp.ceName + '/' + os.environ['JOB_ID']
 
     # Condor
     if os.environ.has_key( 'CONDOR_JOBID' ):


### PR DESCRIPTION
Hi, 

I've tested these changes to the code with jobs running in VMs. The Job Features CPU and Wallclock limits are used for the TimeLife calculation if the information is not available from a batch system. If the shutdowntime is set in Machine Features then that is used to decrease the wall clock time left. The presence of both $MACHINEFEATURES and $JOBFEATURES is used to enable the MJF plugin. urlopen().read() is used to read the values, which works with both local file (Batch, Vac) and remote HTTP URL (Cloud) scenarios in the MJF specifications.

The patch to pilotCommands.py makes the identification of SGE batch systems consistent with TimeLeft.py in that SGE_TASK_ID is checked too. If only $JOB_ID is set, that is used as a generic job id. The LHCb and GridPP DIRAC VMs set this with the site ID and VM UUID which is very useful for debugging but up to now has been misidentified as SGE.

Cheers

 Andrew