### PR TITLE
[v6r14] Fix on CLI

### DIFF
--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -429,13 +429,16 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         else:
           installedBy = installation[ 'InstalledBy' ]
 
+        if not installation[ 'UnInstalledBy' ]:
+          uninstalledBy = ''
+        else:
+          uninstalledBy = installation[ 'UnInstalledBy' ]
+
         if installation[ 'UnInstallationTime' ]:
           uninstalledOn = installation[ 'UnInstallationTime' ].strftime( "%d-%m-%Y %H:%M" )
-          uninstalledBy = installation[ 'UnInstalledBy' ]
           isInstalled = 'No'
         else:
           uninstalledOn = ''
-          uninstalledBy = ''
           isInstalled = 'Yes'
 
         if display == 'table':


### PR DESCRIPTION
Fixed a bug that made the CLI crash upon calling the 'show installations' command when there was an entry such that the UninstallationTime was present, but not the person that uninstalled the component. Now it is not assumed that the uninstalled person is always registered, even if the component is uninstalled.