### PR TITLE
[v6r12] Add XROOT to registration protocols

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -58,7 +58,7 @@ class DataManager( object ):
 
     self.fc = FileCatalog( catalogs = catalogsToUse, vo = self.vo )
     self.accountingClient = None
-    self.registrationProtocol = ['SRM2', 'DIP']
+    self.registrationProtocol = ['SRM2', 'DIP', 'XROOT']
     self.thirdPartyProtocols = ['SRM2', 'DIP']
     self.resourceStatus = ResourceStatus()
     self.ignoreMissingInFC = Operations( self.vo ).getValue( 'DataManagement/IgnoreMissingInFC', False )


### PR DESCRIPTION
This is needed to run replicateAndRegister to SEs where only the XROOT protocol is available