### PR TITLE
[v6r12] TransformationCLI: resetFile change doc string, fix crash

### DIFF
--- a/TransformationSystem/Client/TransformationCLI.py
+++ b/TransformationSystem/Client/TransformationCLI.py
@@ -365,7 +365,7 @@ class TransformationCLI( cmd.Cmd, API ):
   def do_resetFile( self, args ):
     """Reset file status for the given transformation
 
-    usage: resetFile <transName|ID> <lfn>
+    usage: resetFile <transName|ID> <lfns>
     """
     argss = args.split()
     if not len( argss ) > 1:
@@ -377,7 +377,7 @@ class TransformationCLI( cmd.Cmd, API ):
     if not res['OK']:
       print "Failed to reset file status: %s" % res['Message']
     else:
-      if res['Value']['Failed']:
+      if 'Failed' in res['Value']:
         print "Could not reset some files: "
         for lfn, reason in res['Value']['Failed'].items():
           print lfn, reason


### PR DESCRIPTION
resetFile can have more than one lfn as argument, 
Failed might not exist in res causing a crash; not sure if 'Failed' is ever in res.