### PR TITLE
[v6r12] ARCComputingElement: check against missing ceParameters

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -120,7 +120,12 @@ class ARCComputingElement( ComputingElement ):
     """ Kill the specified jobs
     """
     
-    workingDirectory = self.ceParameters['WorkingDirectory']
+    workingDirectory = "temp"
+    if "WorkingDirectory" in self.ceParameters:
+      workingDirectory = os.path.join( self.ceParameters['WorkingDirectory'], "temp" )
+    if not os.path.exists( workingDirectory ):
+      os.mkdir( workingDirectory )
+
     fd, name = tempfile.mkstemp( suffix = '.list', prefix = 'KillJobs_', dir = workingDirectory )
     jobListFile = os.fdopen( fd, 'w' )
     
@@ -231,7 +236,12 @@ class ARCComputingElement( ComputingElement ):
     """ Get the status information for the given list of jobs
     """
 
-    workingDirectory = self.ceParameters['WorkingDirectory']
+    workingDirectory = "temp"
+    if "WorkingDirectory" in self.ceParameters:
+      workingDirectory = os.path.join( self.ceParameters['WorkingDirectory'], "temp" )
+    if not os.path.exists( workingDirectory ):
+      os.mkdir( workingDirectory )
+
     fd, name = tempfile.mkstemp( suffix = '.list', prefix = 'StatJobs_', dir = workingDirectory )
     jobListFile = os.fdopen( fd, 'w' )
     


### PR DESCRIPTION
Check if WorkingDirectory is set
Create WorkingDirectory if it does not exist

This also happens now that the PilotStatusAgent is calling killJob