### PR TITLE
Arcdev v0002

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -82,7 +82,7 @@ class ARCComputingElement( ComputingElement ):
     j.JobManagementURL = arc.URL( mangURL )
     j.JobManagementInterfaceName = "org.nordugrid.gridftpjob"
     j.ServiceInformationURL = j.JobManagementURL
-    #j.ServiceInformationInterfaceName = "org.nordugrid.ldapng"
+    j.ServiceInformationInterfaceName = "org.nordugrid.ldapng"
     userCfg = arc.UserConfig()
     j.PrepareHandler( userCfg )
     return j, userCfg


### PR DESCRIPTION
One obvious bug fix.

A big change in the way the number of running & waiting jobs in a CE is calculated. The previous method using the arc api was clean, but returned only the results for the whole CE, and not just for the current VO. This part may need to be better protected over time, looking at the return codes of the various functions.