### PR TITLE
!!! [v6r15] Allow extensions to extend DErrno

### DIFF
--- a/ConfigurationSystem/Client/Helpers/CSGlobals.py
+++ b/ConfigurationSystem/Client/Helpers/CSGlobals.py
@@ -36,7 +36,7 @@ class Extensions( object ):
 
   def getCSExtensions( self ):
     if not self.__csExt:
-      from DIRAC import gConfig
+      from DIRAC.ConfigurationSystem.Client.Config import gConfig
       exts = gConfig.getValue( '/DIRAC/Extensions', [] )
       for iP in range( len( exts ) ):
         ext = exts[ iP ]

--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -17,7 +17,7 @@ __RCSID__ = "$Id$"
 
 import types
 import datetime
-from DErrno import DError
+from DIRAC.Core.Utilities.DErrno import DError
 
 _dateTimeObject = datetime.datetime.utcnow()
 _dateTimeType = type( _dateTimeObject )

--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -41,15 +41,7 @@ import traceback
 
 
 # To avoid conflict, the error numbers should be greater than 1000
-
-ERRX = 1001
-ERRY = 1002
-EIMPERR = 1003
-ENOMETH = 1004
-EFILESIZE = 1005
-ECONF = 1006
-EGFAL = 1007
-EBADCKS = 1008
+# We decided to group the by range of 100 per system
 
 # 1000: Generic
 # 1100: Core
@@ -63,16 +55,33 @@ EBADCKS = 1008
 # 1900: TS
 # 2000: RSS
 
+# Generic
+ERRX = 1001
+ERRY = 1002
+EIMPERR = 1003
+ENOMETH = 1004
+ECONF = 1006
+
+# DMS/StorageManagement
+EFILESIZE = 1601
+EGFAL = 1602
+EBADCKS = 1603
+
+
+
 
 # This translates the integer number into the name of the variable
 dErrorCode = { 1001 : 'ERRX',
                1002 : 'ERRY',
                1003 : 'EIMPERR',
                1004 : 'ENOMETH',
-               1005 : 'EFILESIZE',
                1006 : 'ECONF',
-               1007 : 'EGFAL',
-               1008 : 'EBADCKS',
+
+               # DMS/StorageManagement
+               1601 : 'EFILESIZE',
+               1602 : 'EGFAL',
+               1603 : 'EBADCKS',
+
                 }
 
 
@@ -80,10 +89,13 @@ dStrError = { ERRX : "A human readable error message for ERRX",
               ERRY : "A nice message for ERRY",
               EIMPERR : "Failed to import library",
               ENOMETH : "No such method or function",
-              EFILESIZE : "Bad file size",
               ECONF : "Configuration error",
+
+              # DMS/StorageManagement
+              EFILESIZE : "Bad file size",
               EGFAL : "Error with the gfal call",
-              EBADCKS : "Bad checksum", }
+              EBADCKS : "Bad checksum",
+}
 
 
 # In case the error is returned as a string, and not as a DErrno object, 

--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -30,6 +30,19 @@ ECONF = 1006
 EGFAL = 1007
 EBADCKS = 1008
 
+# 1000: Generic
+# 1100: Core
+# 1200: Framework
+# 1300: Interfaces
+# 1400: Config
+# 1500: WMS / Workflow
+# 1600: DMS/StorageManagement
+# 1700: RMS
+# 1800: Accounting
+# 1900: TS
+# 2000: RSS
+
+
 # This translates the integer number into the name of the variable
 dErrorCode = { 1001 : 'ERRX',
                1002 : 'ERRY',

--- a/Core/Utilities/__init__.py
+++ b/Core/Utilities/__init__.py
@@ -16,3 +16,4 @@ from DIRAC.Core.Utilities.ExitCallback       import gCallbackList, registerSigna
 from DIRAC.Core.Utilities.ThreadSafe         import Synchronizer, WORM
 from DIRAC.Core.Utilities.DEncode            import encode, decode
 from DIRAC.Core.Utilities                    import List
+from DIRAC.Core.Utilities.DErrno             import DError

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -16,7 +16,8 @@ from datetime import datetime, timedelta
 import fnmatch, os, time
 # # from DIRAC
 import DIRAC
-from DIRAC import S_OK, S_ERROR, DError, DErrno, gLogger, gConfig
+from DIRAC import S_OK, S_ERROR, gLogger, gConfig
+from DIRAC.Core.Utilities import DErrno, DError
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources     import getRegistrationProtocols, getThirdPartyProtocols
 from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -12,7 +12,8 @@ import errno
 from types import StringType, StringTypes, ListType, IntType
 from stat import S_ISREG, S_ISDIR, S_IMODE, ST_MODE, ST_SIZE
 # # from DIRAC
-from DIRAC import gLogger, gConfig, DError, DErrno
+from DIRAC import gLogger, gConfig
+from DIRAC.Core.Utilities import DErrno, DError
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Resources.Utilities import checkArgumentFormat
 from DIRAC.Resources.Storage.StorageBase import StorageBase

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -7,7 +7,8 @@ __RCSID__ = "$Id$"
 import re
 import errno
 # # from DIRAC
-from DIRAC import gLogger, gConfig, DError, DErrno
+from DIRAC import gLogger, gConfig
+from DIRAC.Core.Utilities import DErrno, DError
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR, returnSingleResult
 from DIRAC.Resources.Storage.StorageFactory import StorageFactory
 from DIRAC.Core.Utilities.Pfn import pfnparse

--- a/__init__.py
+++ b/__init__.py
@@ -119,8 +119,6 @@ from DIRAC.Core.Utilities import *
 
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 
-from DIRAC.Core.Utilities import DErrno
-from DIRAC.Core.Utilities.DErrno import DError
 
 # Logger
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
@@ -144,30 +142,30 @@ __siteName = False
 
 
 
-# Update DErrno with the extensions errors
-from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
-from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
-allExtensions = CSGlobals.getCSExtensions()
-
-# Update for each extension. Careful to conflict :-)
-for extension in allExtensions:
-  ol = ObjectLoader( baseModules = ["%sDIRAC" % extension] )
-  extraErrorModule = ol.loadModule( 'Core.Utilities.DErrno' )
-  if extraErrorModule['OK']:
-    extraErrorModule = extraErrorModule['Value']
-
-    # The next 3 dictionary MUST be present for consistency
-
-    # Global name of errors
-    DErrno.__dict__.update( extraErrorModule.extra_dErrName )
-    # Dictionary with the error codes
-    DErrno.dErrorCode.update( extraErrorModule.extra_dErrorCode )
-    # Error description string
-    DErrno.dStrError.update( extraErrorModule.extra_dStrError )
-
-    # extra_compatErrorString is optional
-    for err in getattr( extraErrorModule, 'extra_compatErrorString', [] ) :
-      DErrno.compatErrorString.setdefault( err, [] ).extend( extraErrorModule.extra_compatErrorString[err] )
+# # Update DErrno with the extensions errors
+# from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
+# from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
+# allExtensions = CSGlobals.getCSExtensions()
+#
+# # Update for each extension. Careful to conflict :-)
+# for extension in allExtensions:
+#   ol = ObjectLoader( baseModules = ["%sDIRAC" % extension] )
+#   extraErrorModule = ol.loadModule( 'Core.Utilities.DErrno' )
+#   if extraErrorModule['OK']:
+#     extraErrorModule = extraErrorModule['Value']
+#
+#     # The next 3 dictionary MUST be present for consistency
+#
+#     # Global name of errors
+#     DErrno.__dict__.update( extraErrorModule.extra_dErrName )
+#     # Dictionary with the error codes
+#     DErrno.dErrorCode.update( extraErrorModule.extra_dErrorCode )
+#     # Error description string
+#     DErrno.dStrError.update( extraErrorModule.extra_dStrError )
+#
+#     # extra_compatErrorString is optional
+#     for err in getattr( extraErrorModule, 'extra_compatErrorString', [] ) :
+#       DErrno.compatErrorString.setdefault( err, [] ).extend( extraErrorModule.extra_compatErrorString[err] )
 
 
 def siteName():


### PR DESCRIPTION
This allows extensions to define their specific error codes
It also groups the error number by system for better tracking of them