### PR TITLE
[v6r14] Better implementation of ldap query for getCEStatus

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -298,7 +298,7 @@ class ARCComputingElement( ComputingElement ):
       waiting = [y for y in ldapValues if 'GlueCEStateWaitingJobs' in y]
       result['RunningJobs'] = int(running[0].split(":")[1])
       result['WaitingJobs'] = int(waiting[0].split(":")[1])
-    except:
+    except IndexError:
       result = S_ERROR('Unknown ldap failure for site %s' % self.ceHost)
       result['RunningJobs'] = 0
       result['WaitingJobs'] = 0

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -289,7 +289,8 @@ class ARCComputingElement( ComputingElement ):
     cmd = 'ldapsearch -x -LLL -H ldap://%s:2135 -b mds-vo-name=resource,o=grid "(GlueVOViewLocalID=%s)"' %(self.ceHost, vo.lower())
     res = shellCall( 0, cmd )
     if not res['OK']:
-      return S_ERROR("Could not query CE - is it down?")
+      gLogger.debug("Could not query CE %s - is it down?" % self.ceHost)
+      return res
     ldapValues = res['Value'][1].split("\n")
     running = [y for y in ldapValues if 'GlueCEStateRunningJobs' in y]
     waiting = [y for y in ldapValues if 'GlueCEStateWaitingJobs' in y]

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -14,11 +14,10 @@ import os
 import stat
 
 import arc # Has to work if this module is called
-from DIRAC                                               import S_OK, S_ERROR, gConfig, gLogger
+from DIRAC                                               import S_OK, S_ERROR, gConfig, gLogger, shellCall
 from DIRAC.Resources.Computing.ComputingElement          import ComputingElement
 from DIRAC.Core.Utilities.SiteCEMapping                  import getSiteForCE
 from DIRAC.Core.Utilities.File                           import makeGuid
-from DIRAC.Core.Utilities.Grid import ldapsearchBDII
 from DIRAC.Core.Security.ProxyInfo                       import getVOfromProxyGroup
 
 # Uncomment the following 5 lines for getting verbose ARC api output (debugging)
@@ -282,23 +281,23 @@ class ARCComputingElement( ComputingElement ):
     """ Method to return information on running and pending jobs.
     """
     vo = ''
-    result = getVOfromProxyGroup()
-    if result['OK']:
-      vo = result['Value']
+    res = getVOfromProxyGroup()
+    if res['OK']:
+      vo = res['Value']
     else: # A backup solution which may work
       vo = self.ceParameters['VO']
-    voFilters = '(GlueCEAccessControlBaseRule=VOMS:/%s/*)' % vo
-    voFilters += '(GlueCEAccessControlBaseRule=VOMS:/%s)' % vo
-    voFilters += '(GlueCEAccessControlBaseRule=VO:%s)' % vo
-    filt = '(&(GlueCEUniqueID=%s*)(|%s))' % ( self.ceHost, voFilters )
-    result = ldapsearchBDII( filt, attr=None, host=None, base=None )
-    ces = result['Value']
-    filt = '(&(objectClass=GlueVOView)(|%s))' % ( voFilters )
-    dn = ces[0]['dn']
-    result = ldapsearchBDII( filt, attr=None, host=None, base = dn )
-    stats = result['Value'][0]['attr']
-    result['RunningJobs'] = int(stats["GlueCEStateRunningJobs"])
-    result['WaitingJobs'] = int(stats["GlueCEStateTotalJobs"])
+    cmd = 'ldapsearch -x -LLL -H ldap://%s:2135 -b mds-vo-name=resource,o=grid "(GlueVOViewLocalID=%s)"' %(self.ceHost, vo.lower())
+    res = shellCall( 0, cmd )
+    if not res['OK']:
+      return S_ERROR("Could not query CE - is it down?")
+    ldapValues = res['Value'][1].split("\n")
+    running = [y for y in ldapValues if 'GlueCEStateRunningJobs' in y]
+    waiting = [y for y in ldapValues if 'GlueCEStateWaitingJobs' in y]
+    result = S_OK()
+    result['RunningJobs'] = int(running[0].split(":")[1])
+    result['WaitingJobs'] = int(waiting[0].split(":")[1])
+    gLogger.debug("Running jobs for CE %s : %s" % (self.ceHost, result['RunningJobs']))
+    gLogger.debug("Waiting jobs for CE %s : %s" % (self.ceHost, result['WaitingJobs']))
     result['SubmittedJobs'] = 0
     return result
 

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -291,12 +291,17 @@ class ARCComputingElement( ComputingElement ):
     if not res['OK']:
       gLogger.debug("Could not query CE %s - is it down?" % self.ceHost)
       return res
-    ldapValues = res['Value'][1].split("\n")
-    running = [y for y in ldapValues if 'GlueCEStateRunningJobs' in y]
-    waiting = [y for y in ldapValues if 'GlueCEStateWaitingJobs' in y]
     result = S_OK()
-    result['RunningJobs'] = int(running[0].split(":")[1])
-    result['WaitingJobs'] = int(waiting[0].split(":")[1])
+    try:
+      ldapValues = res['Value'][1].split("\n")
+      running = [y for y in ldapValues if 'GlueCEStateRunningJobs' in y]
+      waiting = [y for y in ldapValues if 'GlueCEStateWaitingJobs' in y]
+      result['RunningJobs'] = int(running[0].split(":")[1])
+      result['WaitingJobs'] = int(waiting[0].split(":")[1])
+    except:
+      result = S_ERROR('Unknown ldap failure for site %s' % self.ceHost)
+      result['RunningJobs'] = 0
+      result['WaitingJobs'] = 0
     gLogger.debug("Running jobs for CE %s : %s" % (self.ceHost, result['RunningJobs']))
     gLogger.debug("Waiting jobs for CE %s : %s" % (self.ceHost, result['WaitingJobs']))
     result['SubmittedJobs'] = 0


### PR DESCRIPTION
The query should in principle work for all CEs and is probably the best that can be done.

For sites which support ALICE, the query should return correct values as we expect. This is because of a patch which is installed at such sites.

For other sites (which do not have the above patch), the information is for all VOs in the CE. So, we will see a much higher number of running jobs than reality for our VO. This cannot be escaped for now.

We probably need to ask all sites to install the patch mentioned above and push the ARC developers to include the patch in their official release and ask sites to upgrade.