### PR TITLE
[v6r14] JobWrapper default for outputData + other fixes

### DIFF
--- a/FrameworkSystem/scripts/dirac-populate-component-db.py
+++ b/FrameworkSystem/scripts/dirac-populate-component-db.py
@@ -56,7 +56,7 @@ result = getProxyInfo()
 if result[ 'OK' ]:
   user = result[ 'Value' ][ 'username' ]
 else:
-  return result
+  DIRACexit( -1 )
 if not user:
   user = 'unknown'
 

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -697,8 +697,7 @@ class JobWrapper( object ):
       outputSandbox = [ outputSandbox ]
     if outputSandbox:
       self.log.verbose( 'OutputSandbox files are: %s' % ', '.join( outputSandbox ) )
-    outputData = []
-    outputData = self.jobArgs.get( 'OutputData', outputData )
+    outputData = self.jobArgs.get( 'OutputData', [] )
     if outputData and isinstance( outputData, basestring ):
       outputData = outputData.split( ';' )
     if outputData:

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -697,8 +697,9 @@ class JobWrapper( object ):
       outputSandbox = [ outputSandbox ]
     if outputSandbox:
       self.log.verbose( 'OutputSandbox files are: %s' % ', '.join( outputSandbox ) )
-    outputData = self.jobArgs.get( 'OutputData', '' )
-    if isinstance( outputData, basestring ):
+    outputData = []
+    outputData = self.jobArgs.get( 'OutputData', outputData )
+    if outputData and isinstance( outputData, basestring ):
       outputData = outputData.split( ';' )
     if outputData:
       self.log.verbose( 'OutputData files are: %s' % ', '.join( outputData ) )


### PR DESCRIPTION
FIX: JobWrapper - avoid defaulting outputData to ['']
BUGFIX: dirac-populate-component-db - DIRACexit instead of return 