### PR TITLE
[v6r14] Remove the temporary file created when issueing getVOMSProxyInfo

### DIFF
--- a/Core/Security/VOMS.py
+++ b/Core/Security/VOMS.py
@@ -170,7 +170,7 @@ class VOMS( BaseSecurity ):
 
     finally:
       if proxyDict[ 'tempFile' ]:
-        self._unlinkFiles( proxyDict[ 'tempFile' ] )
+        self._unlinkFiles( proxyDict[ 'file' ] )
 
   def getVOMSESLocation( self ):
     #755


### PR DESCRIPTION
This is the responsible for the zillions of proxies created everywhere. 