### PR TITLE
[v6r14] JobWrapper default for outputData + other fixes

### DIFF
--- a/FrameworkSystem/scripts/dirac-populate-component-db.py
+++ b/FrameworkSystem/scripts/dirac-populate-component-db.py
@@ -56,7 +56,7 @@ result = getProxyInfo()
 if result[ 'OK' ]:
   user = result[ 'Value' ][ 'username' ]
 else:
-  return result
+  DIRACexit( -1 )
 if not user:
   user = 'unknown'
 

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -306,7 +306,7 @@ class Dirac( API ):
     if isinstance( job, basestring ):
       if os.path.exists( job ):
         self.log.verbose( 'Found job JDL file %s' % ( job ) )
-        fd = os.open( job, 'r' )
+        fd = open( job, 'r' )
         jdlAsString = fd.read()
       else:
         self.log.verbose( 'Job is a JDL string' )

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -697,8 +697,7 @@ class JobWrapper( object ):
       outputSandbox = [ outputSandbox ]
     if outputSandbox:
       self.log.verbose( 'OutputSandbox files are: %s' % ', '.join( outputSandbox ) )
-    outputData = []
-    outputData = self.jobArgs.get( 'OutputData', outputData )
+    outputData = self.jobArgs.get( 'OutputData', [] )
     if outputData and isinstance( outputData, basestring ):
       outputData = outputData.split( ';' )
     if outputData:

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -697,8 +697,9 @@ class JobWrapper( object ):
       outputSandbox = [ outputSandbox ]
     if outputSandbox:
       self.log.verbose( 'OutputSandbox files are: %s' % ', '.join( outputSandbox ) )
-    outputData = self.jobArgs.get( 'OutputData', '' )
-    if isinstance( outputData, basestring ):
+    outputData = []
+    outputData = self.jobArgs.get( 'OutputData', outputData )
+    if outputData and isinstance( outputData, basestring ):
       outputData = outputData.split( ';' )
     if outputData:
       self.log.verbose( 'OutputData files are: %s' % ', '.join( outputData ) )


### PR DESCRIPTION
FIX: JobWrapper - avoid defaulting outputData to ['']
BUGFIX: dirac-populate-component-db - DIRACexit instead of return
FIX: Matcher - use VO specific Operations helper
BUGFIX: Dirac - use open and not os.open

This PR replaces #2584 