### PR TITLE
[v6r12] set TERMINFO also to local installations if they exist

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1319,7 +1319,7 @@ def createBashrc():
                      'export DIRACBIN=%s' % os.path.join( proPath, cliParams.platform, 'bin' ),
                      'export DIRACSCRIPTS=%s' % os.path.join( proPath, 'scripts' ),
                      'export DIRACLIB=%s' % os.path.join( proPath, cliParams.platform, 'lib' ),
-                     'export TERMINFO=%s' % os.path.join( proPath, cliParams.platform, 'share', 'terminfo' ),
+                     'export TERMINFO=%s' % __getTerminfoLocations( os.path.join( proPath, cliParams.platform, 'share', 'terminfo' ) ),
                      'export RRD_DEFAULT_FONT=%s' % os.path.join( proPath, cliParams.platform, 'share', 'rrdtool', 'fonts', 'DejaVuSansMono-Roman.ttf' ) ] )
 
       lines.extend( ['# Clear the PYTHONPATH and the LD_LIBRARY_PATH',
@@ -1367,7 +1367,7 @@ def createCshrc():
                      'setenv DIRACBIN %s' % os.path.join( proPath, cliParams.platform, 'bin' ),
                      'setenv DIRACSCRIPTS %s' % os.path.join( proPath, 'scripts' ),
                      'setenv DIRACLIB %s' % os.path.join( proPath, cliParams.platform, 'lib' ),
-                     'setenv TERMINFO %s' % os.path.join( proPath, cliParams.platform, 'share', 'terminfo' ) ] )
+                     'setenv TERMINFO %s' % __getTerminfoLocations( os.path.join( proPath, cliParams.platform, 'share', 'terminfo' ) ) ] )
 
       lines.extend( ['# Clear the PYTHONPATH and the LD_LIBRARY_PATH',
                     'setenv PYTHONPATH',
@@ -1407,6 +1407,16 @@ def writeDefaultConfiguration():
   except Exception, excp:
     logERROR( "Could not write %s: %s" % ( filePath, excp ) )
   logNOTICE( "Defaults written to %s" % filePath )
+
+def __getTerminfoLocations( defaultLocation=None ):
+  """returns the terminfo locations as a colon separated string"""
+  terminfoLocations = [ defaultLocation ] if defaultLocation else []
+
+  for termpath in [ '/usr/share/terminfo', '/etc/terminfo' ]:
+    if os.path.exists( termpath ):
+      terminfoLocations.append( termpath )
+
+  return ":".join( terminfoLocations )
 
 if __name__ == "__main__":
   logNOTICE( "Processing installation requirements" )


### PR DESCRIPTION
At least in the client externals v6r2 glibc2.12 python 2.7 the share/terminfo is missing, this breaks for example the reset command, which is in the externals bin/reset.
I.e. the bashrc contains
```
export TERMINFO=[...]/DIRAC/Linux_x86_64_glibc-2.12/share/terminfo
```
So either these things have to be part of the client externals again, or TERMINFO needs to point to the local installation, if it exists, as is done in this PR.

