### PR TITLE
[v6r12]  PilotStatusAgent: split error messages, pylint cleanup

### DIFF
--- a/WorkloadManagementSystem/Agent/PilotStatusAgent.py
+++ b/WorkloadManagementSystem/Agent/PilotStatusAgent.py
@@ -531,15 +531,15 @@ class PilotStatusAgent( AgentModule ):
   def _checkJobLastUpdateTime( self, joblist , StalledDays ):
     timeLimitToConsider = Time.dateTime() - Time.day * StalledDays 
     ret = False
-    for JobID in joblist:
-      result = self.jobDB.getJobAttributes(int(JobID))
+    for jobID in joblist:
+      result = self.jobDB.getJobAttributes( int( jobID ) )
       if result['OK']:
-         if result['Value'].has_key('LastUpdateTime'):
-           LastUpdateTime = result['Value']['LastUpdateTime']
-           if Time.fromString(LastUpdateTime) > timeLimitToConsider:
-             ret = True
-             self.log.debug('Since '+str(JobID)+' updates LastUpdateTime on '+str(LastUpdateTime)+', this does not to need to be deleted.')
-             break
+        if 'LastUpdateTime' in result['Value']:
+          lastUpdateTime = result['Value']['LastUpdateTime']
+          if Time.fromString( lastUpdateTime ) > timeLimitToConsider:
+            ret = True
+            self.log.debug( 'Since %s updates LastUpdateTime on %s this does not to need to be deleted.' % ( str( jobID ), str( lastUpdateTime ) ) )
+            break
       else:
         self.log.error( "Error taking job info from DB", result['Message'] )
     return ret

--- a/WorkloadManagementSystem/Agent/PilotStatusAgent.py
+++ b/WorkloadManagementSystem/Agent/PilotStatusAgent.py
@@ -524,9 +524,9 @@ class PilotStatusAgent( AgentModule ):
         if ret['OK']:
           self.log.info("Successfully deleted: %s (Status : %s)" % (i, result['Value'][i]['Status'] ) )
         else:
-          self.log.error("Failed to delete %s : %s"  % ( i, ret['Message']))
+          self.log.error( "Failed to delete pilot: ", "%s : %s" % ( i, ret['Message'] ) )
       else:
-        self.log.error("Failed to get info. of %s : %s" % ( i, str(result)))
+        self.log.error( "Failed to get pilot info", "%s : %s" % ( i, str( result ) ) )
 
   def _checkJobLastUpdateTime( self, joblist , StalledDays ):
     timeLimitToConsider = Time.dateTime() - Time.day * StalledDays 
@@ -541,6 +541,6 @@ class PilotStatusAgent( AgentModule ):
              self.log.debug('Since '+str(JobID)+' updates LastUpdateTime on '+str(LastUpdateTime)+', this does not to need to be deleted.')
              break
       else:
-        self.log.error("Error taking job info. from DB:%s" % str( result['Message'] ) )
+        self.log.error( "Error taking job info from DB", result['Message'] )
     return ret
 


### PR DESCRIPTION
PilotStatusAgent log messages were not split between static and dynamic part
Also some cleanup for wrong indendation (off by 1) and variable naming and whitespaces after and before parentheses.
