### PR TITLE
[v6r14] Correct location of Pilot version printout

### DIFF
--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -925,7 +925,7 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
     else:
       gLogger.notice( "Software successfully updated." )
       gLogger.notice( "You should restart the services to use the new software version." )
-      gLogger.notice( "Think of updating /Operation/<vo>/<setup>/Versions section in the CS" )
+      gLogger.notice( "Think of updating /Operations/<vo>/<setup>/Pilot/Versions section in the CS" )
 
   def do_revert( self, args ):
     """ Revert the last installed version of software to the previous one


### PR DESCRIPTION
This location printout was wrong.
Also in v6r12 and before, but as there were many changes in v6r13 it would cause issues so I just make a PR against v6r14.