### PR TITLE
[v6r14] conditional lock in the DictCache for the __del__

### DIFF
--- a/Core/Utilities/DictCache.py
+++ b/Core/Utilities/DictCache.py
@@ -158,11 +158,14 @@ class DictCache( object ):
     finally:
       self.lock.release()
 
-  def purgeAll( self ):
+  def purgeAll( self, useLock = True ):
     """
     Purge all entries
+    CAUTION: useLock param should ALWAYS be True except when called from __del__
     """
-    self.lock.acquire()
+
+    if useLock:
+      self.lock.acquire()
     try:
       keys = self.__cache.keys()
       for cKey in keys:
@@ -170,7 +173,8 @@ class DictCache( object ):
           self.__deleteFunction( self.__cache[ cKey ][ 'value' ] )
         del( self.__cache[ cKey ] )
     finally:
-      self.lock.release()
+      if useLock:
+        self.lock.release()
 
   def __del__( self ):
     """ When the DictCache is deleted, all the entries should be purged.
@@ -179,7 +183,7 @@ class DictCache( object ):
         caveat of __del__. In particular, no guaranty that it is called...
         (https://docs.python.org/2/reference/datamodel.html#object.__del__)
     """
-    self.purgeAll()
+    self.purgeAll( useLock = False )
     del self.__lock
     del self.__cache
 


### PR DESCRIPTION
The property does not seem very __del__ friendly. 
An exception is *sometimes* thrown, however it is ignored and transformed into warning. No consequences, just printout.
This should fix it