### PR TITLE
[v6r12]  Make systematic use of getPath to avoid '//' in path names

### DIFF
--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -2074,7 +2074,7 @@ File Catalog Client $Revision: 1.17 $Date:
 
       listToPrint = None
       if dirsOnly:
-        listToPrint = set( self.getPath(fullpath) for fullpath in result['Value'] )
+        listToPrint = set( os.path.dirname(fullpath) for fullpath in result['Value'] )
       else:
         listToPrint = result['Value']
 

--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -262,7 +262,7 @@ File Catalog Client $Revision: 1.17 $Date:
       path = apath
     else:
       path = self.cwd+'/'+apath
-      path = path.replace('//','/')
+    path = path.replace('//','/')
 
     return os.path.normpath(path)
   
@@ -1117,7 +1117,7 @@ File Catalog Client $Revision: 1.17 $Date:
     else:
       newdir = self.cwd + '/' + path
       
-    newdir = newdir.replace(r'//','/')
+    newdir = self.getPath(newdir)
     
     result =  self.fc.createDirectory(newdir)    
     if result['OK']:
@@ -1292,11 +1292,7 @@ File Catalog Client $Revision: 1.17 $Date:
         path = argss[0]       
         if path[0] != '/':
           path = self.cwd+'/'+path      
-    path = path.replace(r'//','/')
-
-    # remove last character if it is "/"    
-    if path[-1] == '/' and path != '/':
-      path = path[:-1]
+    path = self.getPath(path)
     
     # Check if the target path is a file
     result =  self.fc.isFile(path)          
@@ -1659,6 +1655,7 @@ File Catalog Client $Revision: 1.17 $Date:
       print self.do_guid.__doc__
       return
     path = argss[0]
+    path = self.getPath(path)
     try:
       result =  self.fc.getFileMetadata(path)
       if result['OK']:
@@ -1808,6 +1805,7 @@ File Catalog Client $Revision: 1.17 $Date:
       path = self.cwd
     elif path[0] != '/':
       path = self.cwd+'/'+path  
+    path = self.getPath(path)
     meta = argss[1]
     value = argss[2]
     print path,meta,value
@@ -2076,7 +2074,7 @@ File Catalog Client $Revision: 1.17 $Date:
 
       listToPrint = None
       if dirsOnly:
-        listToPrint = set( "/".join(fullpath.split("/")[:-1]) for fullpath in result['Value'] )
+        listToPrint = set( self.getPath(fullpath) for fullpath in result['Value'] )
       else:
         listToPrint = result['Value']
 


### PR DESCRIPTION
Some functions receiving a path as argument were not normalizing
this path, which may cause some functions fail.
Normalizing all paths using the member function
getPath makes code more readable.

For instance following function call fail because path ends with '/':

```
meta set /ilc/user/c/calanchac/stdhep/E500/ Energy 500

Error: Server error while serving setMetadata: '/ilc/user/c/calanchac/stdhep/E500/'
```