### PR TITLE
[v6r15] fix importing Time from DIRAC

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -117,6 +117,7 @@ rootPath = os.path.dirname( pythonPath )
 #from DIRAC.Core.Utilities import *
 from DIRAC.Core.Utilities.Network import getFQDN
 import DIRAC.Core.Utilities.ExitCallback as ExitCallback
+import DIRAC.Core.Utilities.Time as Time
 
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 


### PR DESCRIPTION
`from DIRAC import Time` was failing in JobWrapper