### PR TITLE
[v6r15] Multicore enabled JobAgent

### DIFF
--- a/Core/Utilities/TimeLeft/BQSTimeLeft.py
+++ b/Core/Utilities/TimeLeft/BQSTimeLeft.py
@@ -59,21 +59,20 @@ class BQSTimeLeft:
     except Exception:
       self.log.warn( 'Problem parsing "%s" for CPU usage' % ( result['Value'] ) )
 
-    #BQS has no wallclock limit so will simply return the same as for CPU to the TimeLeft utility
-    wallClock = cpu
-    wallClockLimit = cpuLimit
     # Divide the numbers by 5 to bring it to HS06 units from the CC UI units
     # and remove HS06 normalization factor
     consumed = {'CPU':cpu / 5. / self.scaleFactor,
-                'CPULimit':cpuLimit / 5. / self.scaleFactor,
-                'WallClock':wallClock / 5. / self.scaleFactor,
-                'WallClockLimit':wallClockLimit / 5. / self.scaleFactor}
+                'CPULimit':cpuLimit / 5. / self.scaleFactor}
     self.log.debug( consumed )
     failed = False
     for key, val in consumed.items():
       if val == None:
         failed = True
         self.log.warn( 'Could not determine %s' % key )
+
+    # BQS has no wallclock limit so will simply return None
+    consumed.update( {'WallClock':None,
+                     'WallClockLimit':None} )
 
     if not failed:
       return S_OK( consumed )

--- a/Core/Utilities/TimeLeft/MJFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/MJFTimeLeft.py
@@ -73,16 +73,14 @@ class MJFTimeLeft:
       cpuLimit = int( urllib.urlopen(jobFeaturesPath + '/cpu_limit_secs').read() )
     except:
       self.log.warn( 'Could not determine cpu limit from $JOBFEATURES/cpu_limit_secs' )
-      cpuLimit = wallClockLimit
 
     wallClock = int(time.time()) - jobStartSecs
-    # We cannot get CPU usage from MJF, so for now use wallClock figure
-    cpu = wallClock
+    # We cannot get CPU usage from MJF
       
     consumed = {'CPU':cpu, 'CPULimit':cpuLimit, 'WallClock':wallClock, 'WallClockLimit':wallClockLimit}
     self.log.debug( consumed )
 
-    if cpu and cpuLimit and wallClock and wallClockLimit:
+    if cpuLimit and wallClock and wallClockLimit:
       return S_OK( consumed )
     else:
       self.log.info( 'Could not determine some parameters' )

--- a/Core/Utilities/TimeLeft/PBSTimeLeft.py
+++ b/Core/Utilities/TimeLeft/PBSTimeLeft.py
@@ -110,13 +110,7 @@ class PBSTimeLeft:
       return S_OK( consumed )
 
     if cpuLimit or wallClockLimit:
-      # We have got a partial result from PBS, assume that we ran for too short time
-      if not cpuLimit:
-        consumed['CPULimit'] = wallClockLimit
-      if not wallClockLimit:
-        consumed['WallClockLimit'] = cpuLimit  
-      if not cpu:          
-        consumed['CPU'] = int( time.time() - self.startTime )
+      # We have got a partial result from PBS, we can only restore WallClock
       if not wallClock:  
         consumed['WallClock'] = int( time.time() - self.startTime )
       self.log.debug( "TimeLeft counters restored: " + str( consumed ) )  

--- a/Core/Utilities/TimeLeft/SGETimeLeft.py
+++ b/Core/Utilities/TimeLeft/SGETimeLeft.py
@@ -47,7 +47,7 @@ class SGETimeLeft:
     result = runCommand( cmd )
     if not result['OK']:
       return result
-    example = """ Example of output from qstat -f -j $JOB_ID
+    _example = """ Example of output from qstat -f -j $JOB_ID
 ==============================================================
 job_number:                 620685
 exec_file:                  job_scripts/620685
@@ -129,12 +129,6 @@ scheduling info:            (Collecting of scheduler job information is turned o
 
     if cpuLimit or wallClockLimit:
       # We have got a partial result from SGE
-      if not cpuLimit:
-        consumed['CPULimit'] = wallClockLimit
-      if not wallClockLimit:
-        consumed['WallClockLimit'] = cpuLimit
-      if not cpu:
-        consumed['CPU'] = time.time() - self.startTime
       if not wallClock:
         consumed['WallClock'] = time.time() - self.startTime
       self.log.debug( "TimeLeft counters restored: " + str( consumed ) )

--- a/Core/Utilities/TimeLeft/TimeLeft.py
+++ b/Core/Utilities/TimeLeft/TimeLeft.py
@@ -46,7 +46,7 @@ class TimeLeft:
       self.batchPlugin = None
       self.batchError = result['Message']
 
-  def getScaledCPU( self ):
+  def getScaledCPU( self, cores = 1 ):
     """Returns the current CPU Time spend (according to batch system) scaled according
        to /LocalSite/CPUScalingFactor
     """
@@ -64,13 +64,13 @@ class TimeLeft:
       if resourceDict['Value']['CPU']:
         return S_OK( resourceDict['Value']['CPU'] * self.scaleFactor )
       elif resourceDict['Value']['WallClock']:
-        # build a reasonable CPU value from WallClock
-        return S_OK( resourceDict['Value']['WallClock'] * self.scaleFactor )
+        # When CPU value missing, guess from WallClock and number of cores
+        return S_OK( resourceDict['Value']['WallClock'] * self.scaleFactor * cores )
 
     return S_OK( 0.0 )
 
   #############################################################################
-  def getTimeLeft( self, cpuConsumed = 0.0 ):
+  def getTimeLeft( self, cpuConsumed = 0.0, cores = 1 ):
     """Returns the CPU Time Left for supported batch systems.  The CPUConsumed
        is the current raw total CPU.
     """
@@ -93,13 +93,13 @@ class TimeLeft:
 
     # if one of CPULimit or WallClockLimit is missing, compute a reasonable value
     if not resources['CPULimit']:
-      resources['CPULimit'] = resources['WallClockLimit']
+      resources['CPULimit'] = resources['WallClockLimit'] * cores
     elif not resources['WallClockLimit']:
       resources['WallClockLimit'] = resources['CPULimit']
 
     # if one of CPU or WallClock is missing, compute a reasonable value
     if not resources['CPU']:
-      resources['CPU'] = resources['WallClock']
+      resources['CPU'] = resources['WallClock'] * cores
     elif not resources['WallClock']:
       resources['WallClock'] = resources['CPU']
 

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -12,6 +12,7 @@ from DIRAC.Core.Utilities.ModuleFactory                     import ModuleFactory
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight              import ClassAd
 from DIRAC.Core.Utilities.TimeLeft.TimeLeft                 import TimeLeft
 from DIRAC.Core.Utilities.CFG                               import CFG
+from DIRAC.Core.Utilities.Os                                import getNumberOfCores
 from DIRAC.Core.Base.AgentModule                            import AgentModule
 from DIRAC.Core.DISET.RPCClient                             import RPCClient
 from DIRAC.Core.Security.ProxyInfo                          import getProxyInfo
@@ -622,7 +623,12 @@ class JobAgent( AgentModule ):
 
     # look for a pattern like "12345Cores" in tag list
     m = re.match( r'^(.*\D)?(?P<cores>\d+)Cores([ \t,].*)?$', tag )
-    if m: return int( m.group( 'cores' ) )
+    if m:
+      return int( m.group( 'cores' ) )
+
+    # In WhileNode case, detect number of cores from the host
+    if re.match( r'^(.*,\s*)?WholeNode([ \t,].*)?$', tag ):
+      return getNumberOfCores()
 
     return 1
 

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -626,7 +626,7 @@ class JobAgent( AgentModule ):
     if m:
       return int( m.group( 'cores' ) )
 
-    # In WhileNode case, detect number of cores from the host
+    # In WholeNode case, detect number of cores from the host
     if re.match( r'^(.*,\s*)?WholeNode([ \t,].*)?$', tag ):
       return getNumberOfCores()
 

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -141,8 +141,10 @@ class JobAgent( AgentModule ):
       ceDict.update( requirementsDict )
       self.log.info( 'Requirements:', requirementsDict )
 
-    cores = self.__getCores()
-    self.log.info( 'Configured number of cores: ', cores )
+    cores, wholeNode = self.__getCores()
+    ceDict['Cores'] = cores
+    ceDict['WholeNode'] = wholeNode
+    self.log.info( 'Configured number of cores: %d, WholeNode: %s' % ( cores, wholeNode ) )
 
     self.log.verbose( ceDict )
     start = time.time()
@@ -613,24 +615,24 @@ class JobAgent( AgentModule ):
   #############################################################################
   def __getCores( self ):
     """
-    Resturn number of cores from gConfig
+    Return number of cores from gConfig and a boolean indicating corresponding to WholeNode option
     """
     tag = gConfig.getValue( '/Resources/Computing/CEDefaults/Tag', None )
 
-    if tag is None: return 1
+    if tag is None: return 1, False
 
     self.log.verbose( "__getCores: /Resources/Computing/CEDefaults/Tag", repr( tag ) )
 
     # look for a pattern like "12345Cores" in tag list
     m = re.match( r'^(.*\D)?(?P<cores>\d+)Cores([ \t,].*)?$', tag )
     if m:
-      return int( m.group( 'cores' ) )
+      return int( m.group( 'cores' ) ), False
 
     # In WholeNode case, detect number of cores from the host
     if re.match( r'^(.*,\s*)?WholeNode([ \t,].*)?$', tag ):
-      return getNumberOfCores()
+      return getNumberOfCores(), True
 
-    return 1
+    return 1, False
 
   #############################################################################
   def finalize( self ):

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -273,6 +273,12 @@ class JobWrapper( object ):
     os.environ['DIRACSITE'] = DIRAC.siteName()
     self.log.verbose( 'DIRACSITE = %s' % ( DIRAC.siteName() ) )
 
+    os.environ['DIRAC_CORES'] = str( self.ceArgs.get( 'Cores', 1 ) )
+    self.log.verbose( 'DIRAC_CORES = %s' % ( self.ceArgs.get( 'Cores', 1 ) ) )
+
+    os.environ['DIRAC_WHOLENODE'] = str( self.ceArgs.get( 'WholeNode', False ) )
+    self.log.verbose( 'DIRAC_WHOLENODE = %s' % ( self.ceArgs.get( 'WholeNode', False ) ) )
+
     errorFile = self.jobArgs.get( 'StdError', self.defaultErrorFile )
     outputFile = self.jobArgs.get( 'StdOutput', self.defaultOutputFile )
 


### PR DESCRIPTION
Allows JobAgent to handle multicore jobs.

Matching is done with "XCores" or "WholeNode" tags.

TimeLeft and its batch plugins are modified. The plugins won't mix CPU and walltime values anymore, missing values are handled by the TimeLeft object itself which is aware of cores numbers.

Multicore information is sent to the JobWrapper.

I wonder if cores number and wholenode flag are to be sent to the Accounting database.