### PR TITLE
!!! [v6r16] Next step for multi protocol support

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -288,10 +288,19 @@ def getCatalogPath( catalogName ):
   """
   return '/Resources/FileCatalogs/%s' % catalogName
 
-def getRegistrationProtocols():
-  """ Returns the Favorite registration protocol defined in the CS, or 'srm' as default """
-  return gConfig.getValue( '/Resources/FileCatalogs/RegistrationProtocols', ['srm', 'dips'] )
+# def getRegistrationProtocols():
+#   """ Returns the Favorite registration protocol defined in the CS, or 'srm' as default """
+#   return gConfig.getValue( '/Resources/FileCatalogs/RegistrationProtocols', ['srm', 'dips'] )
+#
+# def getThirdPartyProtocols():
+#   """ Returns the Favorite third party protocol defined in the CS, or 'srm' as default """
+#   return gConfig.getValue( '/Resources/FileCatalogs/ThirdPartyProtocols', ['srm', 'dips'] )
+#
+# def getAccessProtocols():
+#   """ Returns the Favorite access protocol defined in the CS, or 'srm' as default """
+#   return gConfig.getValue( '/Resources/StorageElements/AccessProtocols', ['srm', 'dips'] )
+#
+# def getWriteProtocols():
+#   """ Returns the Favorite access protocol defined in the CS, or 'srm' as default """
+#   return gConfig.getValue( '/Resources/StorageElements/WriteProtocols', ['srm', 'dips'] )
 
-def getThirdPartyProtocols():
-  """ Returns the Favorite third party protocol defined in the CS, or 'srm' as default """
-  return gConfig.getValue( '/Resources/FileCatalogs/ThirdPartyProtocols', ['srm', 'dips'] )

--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -17,7 +17,7 @@
 
 import os
 import traceback
-
+import errno
 
 # To avoid conflict, the error numbers should be greater than 1000
 
@@ -56,7 +56,7 @@ dStrError = { ERRX : "A human readable error message for ERRX",
 # these strings are used to test the error. 
 compatErrorString = {
                      # ERRX : ['not found', 'X'],
-
+                       errno.ENOENT : ['File does not exist']
                      }
 
 def strerror(code):
@@ -144,7 +144,7 @@ class DError( object ):
   
   def __cmp__( self, errorStr ):
     """ For compatibility reasons.
-        Checks whether 'other', which should be a string, is equal to the human readable form of the error msg
+        Checks whether 'errorStr', which should be a string, is equal to the human readable form of the error msg
     """
     # !!! Caution, if there is equality, we have to return 0 (rules of __cmp__)
 
@@ -192,6 +192,10 @@ def cmpError( inErr, candidate ):
     return inErr == candidate
   elif isinstance( inErr, DError ):
     return inErr.errno == candidate
+  elif isinstance( inErr, dict ):  # S_ERROR object is given
+    # Create a DError object to represent the candidate
+    derr = DError( candidate )
+    return inErr.get( 'Message', '' ) == derr
 
   return False
 

--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -45,7 +45,6 @@ import re
 from DIRAC import S_OK, S_ERROR, gLogger
 # # from CS
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getUsernameForDN
-from DIRAC.ConfigurationSystem.Client.Helpers.Resources     import getRegistrationProtocols
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 
@@ -63,6 +62,7 @@ from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.DataManagementSystem.private.FTSPlacement import FTSPlacement
 from DIRAC.DataManagementSystem.private.FTSHistoryView import FTSHistoryView
 from DIRAC.DataManagementSystem.Client.FTSFile import FTSFile
+from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 # # from RMS
 from DIRAC.RequestManagementSystem.Client.ReqClient import ReqClient
 from DIRAC.RequestManagementSystem.Client.Operation import Operation
@@ -312,7 +312,7 @@ class FTSAgent( AgentModule ):
     self.am_setOption( 'shifterProxy', 'DataManager' )
     log.info( "will use DataManager proxy" )
 
-    self.registrationProtocols = getRegistrationProtocols()
+    self.registrationProtocols = DMSHelpers().getRegistrationProtocols()
 
 
     # # gMonitor stuff here

--- a/DataManagementSystem/Agent/RequestOperations/DMSRequestOperationsBase.py
+++ b/DataManagementSystem/Agent/RequestOperations/DMSRequestOperationsBase.py
@@ -9,16 +9,16 @@ __RCSID__ = "$Id $"
 from DIRAC import S_OK, S_ERROR
 
 from DIRAC.RequestManagementSystem.Client.Operation             import Operation
-from DIRAC.ConfigurationSystem.Client.Helpers.Resources         import getRegistrationProtocols 
 from DIRAC.RequestManagementSystem.Client.File                  import File
 from DIRAC.Resources.Storage.StorageElement                     import StorageElement
 from DIRAC.RequestManagementSystem.private.OperationHandlerBase import OperationHandlerBase
+from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 
 class DMSRequestOperationsBase( OperationHandlerBase ):
 
   def __init__( self, operation = None, csPath = None ):
     OperationHandlerBase.__init__( self, operation, csPath )
-    self.registrationProtocols = getRegistrationProtocols()
+    self.registrationProtocols = DMSHelpers().getRegistrationProtocols()
 
 
   def checkSEsRSS( self, checkSEs = None, access = 'WriteAccess' ):

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -22,7 +22,6 @@ import errno
 import DIRAC
 from DIRAC import S_OK, S_ERROR, gLogger, gConfig, DError, DErrno
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
-from DIRAC.ConfigurationSystem.Client.Helpers.Resources     import getRegistrationProtocols, getThirdPartyProtocols
 from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
 from DIRAC.AccountingSystem.Client.Types.DataOperation import DataOperation
 from DIRAC.Core.Utilities.Adler import fileAdler, compareAdler
@@ -97,12 +96,12 @@ class DataManager( object ):
 
     self.fc = FileCatalog( catalogs = catalogsToUse, vo = self.vo )
     self.accountingClient = None
-    self.registrationProtocol = getRegistrationProtocols()
-    self.thirdPartyProtocols = getThirdPartyProtocols()
     self.resourceStatus = ResourceStatus()
     self.ignoreMissingInFC = Operations( self.vo ).getValue( 'DataManagement/IgnoreMissingInFC', False )
     self.useCatalogPFN = Operations( self.vo ).getValue( 'DataManagement/UseCatalogPFN', True )
-    self.dmsHelper = DMSHelpers()
+    self.dmsHelper = DMSHelpers( vo = vo )
+    self.registrationProtocol = self.dmsHelper.getRegistrationProtocols()
+    self.thirdPartyProtocols = self.dmsHelper.getThirdPartyProtocols()
 
   def setAccountingClient( self, client ):
     """ Set Accounting Client instance
@@ -807,54 +806,74 @@ class DataManager( object ):
         continue
 
 
-      replicationProtocol = res['Value']
+      replicationProtocols = res['Value']
 
-      if not replicationProtocol:
+      if not replicationProtocols:
         possibleIntermediateSEs.append( candidateSE )
         log.debug( "No protocol suitable for replication found" )
         continue
 
-      log.debug( 'Found common protocols', replicationProtocol )
+      log.debug( 'Found common protocols', replicationProtocols )
 
       # THIS WOULD NOT WORK IF PROTO == file !!
+      # Why did I write that comment ?!
+      
+      # We try the protocols one by one
+      # That obviously assumes that there is an overlap and not only
+      # a compatibility between the  output protocols of the source
+      # and the input protocols of the destination.
+      # But that is the only way to make sure we are not replicating
+      # over ourselves.
+      for compatibleProtocol in replicationProtocols:
 
-      # Compare the urls to make sure we are not overwriting
-      res = returnSingleResult( candidateSE.getURL( lfn, protocol = replicationProtocol ) )
-      if not res['OK']:
-        log.debug( "Cannot get sourceURL", res['Message'] )
-        continue
+        # Compare the urls to make sure we are not overwriting
+        res = returnSingleResult( candidateSE.getURL( lfn, protocol = compatibleProtocol ) )
+        if not res['OK']:
+          log.debug( "Cannot get sourceURL", res['Message'] )
+          continue
 
-      sourceURL = res['Value']
+        sourceURL = res['Value']
 
-      res = returnSingleResult( destStorageElement.getURL( destPath, protocol = replicationProtocol ) )
-      if not res['OK']:
-        log.debug( "Cannot get destURL", res['Message'] )
-        continue
-      destURL = res['Value']
+        destURL = ''
+        res = returnSingleResult( destStorageElement.getURL( destPath, protocol = compatibleProtocol ) )
+        if not res['OK']:
 
-      if sourceURL == destURL:
-        log.debug( "Same source and destination, give up" )
-        continue
+          # for some protocols, in particular srm
+          # you might get an error because the file does not exist
+          # which is exactly what we want
+          # in that case, we just keep going with the comparison
+          # since destURL will be an empty string
+          if not DErrno.cmpError( res, errno.ENOENT ):
+            log.debug( "Cannot get destURL", res['Message'] )
+            continue
+        else:
+          destURL = res['Value']
 
-      # Attempt the transfer
-      res = returnSingleResult( destStorageElement.replicateFile( {destPath:sourceURL}, sourceSize = catalogSize ) )
+        if sourceURL == destURL:
+          log.debug( "Same source and destination, give up" )
+          continue
 
-      if not res['OK']:
-        log.debug( "Replication failed", "%s from %s to %s." % ( lfn, candidateSEName, destSEName ) )
-        continue
+        # Attempt the transfer
+        res = returnSingleResult( destStorageElement.replicateFile( {destPath:sourceURL},
+                                                                     sourceSize = catalogSize,
+                                                                     inputProtocol = compatibleProtocol ) )
+
+        if not res['OK']:
+          log.debug( "Replication failed", "%s from %s to %s." % ( lfn, candidateSEName, destSEName ) )
+          continue
 
 
-      log.debug( "Replication successful.", res['Value'] )
+        log.debug( "Replication successful.", res['Value'] )
 
-      res = returnSingleResult( destStorageElement.getURL( destPath, protocol = self.registrationProtocol ) )
-      if not res['OK']:
-        log.debug( 'Error getting the registration URL', res['Message'] )
-        # it's maybe pointless to try the other candidateSEs...
-        continue
+        res = returnSingleResult( destStorageElement.getURL( destPath, protocol = self.registrationProtocol ) )
+        if not res['OK']:
+          log.debug( 'Error getting the registration URL', res['Message'] )
+          # it's maybe pointless to try the other candidateSEs...
+          continue
 
-      registrationURL = res['Value']
+        registrationURL = res['Value']
 
-      return S_OK( {'DestSE':destSEName, 'DestPfn':registrationURL} )
+        return S_OK( {'DestSE':destSEName, 'DestPfn':registrationURL} )
 
 
 

--- a/DataManagementSystem/Client/FailoverTransfer.py
+++ b/DataManagementSystem/Client/FailoverTransfer.py
@@ -23,7 +23,6 @@ from DIRAC import S_OK, S_ERROR, gLogger
 
 
 from DIRAC.DataManagementSystem.Client.DataManager          import DataManager
-from DIRAC.ConfigurationSystem.Client.Helpers.Resources     import getRegistrationProtocols
 from DIRAC.Resources.Storage.StorageElement                 import StorageElement
 from DIRAC.Resources.Catalog.FileCatalog                    import FileCatalog
 from DIRAC.RequestManagementSystem.Client.Request           import Request
@@ -31,6 +30,7 @@ from DIRAC.RequestManagementSystem.Client.Operation         import Operation
 from DIRAC.RequestManagementSystem.Client.File              import File
 from DIRAC.RequestManagementSystem.private.RequestValidator import RequestValidator
 from DIRAC.RequestManagementSystem.Client.ReqClient         import ReqClient
+from DIRAC.DataManagementSystem.Utilities.DMSHelpers        import DMSHelpers
 
 class FailoverTransfer( object ):
   """ .. class:: FailoverTransfer
@@ -53,7 +53,7 @@ class FailoverTransfer( object ):
       self.request.SourceComponent = 'FailoverTransfer'
 
     self.defaultChecksumType = defaultChecksumType
-    self.registrationProtocols = getRegistrationProtocols()
+    self.registrationProtocols = DMSHelpers().getRegistrationProtocols()
 
   #############################################################################
   def transferAndRegisterFile( self,

--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -310,18 +310,18 @@ class DMSHelpers( object ):
 
   def getRegistrationProtocols( self ):
     """ Returns the Favorite registration protocol defined in the CS, or 'srm' as default """
-    return S_OK( self.__opsHelper.getValue( 'DataManagement/RegistrationProtocols', ['srm', 'dips'] ) )
+    return self.__opsHelper.getValue( 'DataManagement/RegistrationProtocols', ['srm', 'dips'] )
 
   def getThirdPartyProtocols( self ):
     """ Returns the Favorite third party protocol defined in the CS, or 'srm' as default """
-    return S_OK( self.__opsHelper.getValue( 'DataManagement/ThirdPartyProtocols', ['srm', 'dips'] ) )
+    return self.__opsHelper.getValue( 'DataManagement/ThirdPartyProtocols', ['srm', 'dips'] )
 
   def getAccessProtocols( self ):
     """ Returns the Favorite access protocol defined in the CS, or 'srm' as default """
-    return S_OK( self.__opsHelper.getValue( 'DataManagement/AccessProtocols', ['srm', 'dips'] ) )
+    return self.__opsHelper.getValue( 'DataManagement/AccessProtocols', ['srm', 'dips'] )
 
 
   def getWriteProtocols( self ):
     """ Returns the Favorite Write protocol defined in the CS, or 'srm' as default """
-    return S_OK( self.__opsHelper.getValue( 'DataManagement/WriteProtocols', ['srm', 'dips'] ) )
+    return self.__opsHelper.getValue( 'DataManagement/WriteProtocols', ['srm', 'dips'] )
 

--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -65,11 +65,11 @@ def _getConnectionIndex( connectionLevel, default = None ):
 
 class DMSHelpers( object ):
 
-  def __init__( self ):
+  def __init__( self, vo = None ):
     self.siteSEMapping = {}
     self.storageElementSet = set()
     self.siteSet = set()
-    self.__opsHelper = Operations()
+    self.__opsHelper = Operations( vo = vo )
 
 
   def getSiteSEMapping( self ):
@@ -307,3 +307,21 @@ class DMSHelpers( object ):
       gLogger.warn( 'No SE found at that site', 'in group %s at %s' % ( seGroup, site ) )
       return S_OK()
     return S_OK( list( se )[0] )
+
+  def getRegistrationProtocols( self ):
+    """ Returns the Favorite registration protocol defined in the CS, or 'srm' as default """
+    return S_OK( self.__opsHelper.getValue( 'DataManagement/RegistrationProtocols', ['srm', 'dips'] ) )
+
+  def getThirdPartyProtocols( self ):
+    """ Returns the Favorite third party protocol defined in the CS, or 'srm' as default """
+    return S_OK( self.__opsHelper.getValue( 'DataManagement/ThirdPartyProtocols', ['srm', 'dips'] ) )
+
+  def getAccessProtocols( self ):
+    """ Returns the Favorite access protocol defined in the CS, or 'srm' as default """
+    return S_OK( self.__opsHelper.getValue( 'DataManagement/AccessProtocols', ['srm', 'dips'] ) )
+
+
+  def getWriteProtocols( self ):
+    """ Returns the Favorite Write protocol defined in the CS, or 'srm' as default """
+    return S_OK( self.__opsHelper.getValue( 'DataManagement/WriteProtocols', ['srm', 'dips'] ) )
+

--- a/Resources/Storage/DIPStorage.py
+++ b/Resources/Storage/DIPStorage.py
@@ -24,6 +24,10 @@ import os, random
 
 class DIPStorage( StorageBase ):
 
+  _InputProtocols = ['file', 'dip', 'dips']
+  _OutputProtocols = ['dip', 'dips']
+
+
   def __init__( self, storageName, parameters ):
     """
     """

--- a/Resources/Storage/FileStorage.py
+++ b/Resources/Storage/FileStorage.py
@@ -126,7 +126,7 @@ class FileStorage( StorageBase ):
 
         fileSize = os.path.getsize( dest_url )
         successful[src_url] = fileSize
-      except OSError as ose:
+      except (IOError, OSError) as ose:
         failed[src_url] = str( ose )
 
     return S_OK( { 'Failed' : failed, 'Successful' : successful } )
@@ -167,8 +167,9 @@ class FileStorage( StorageBase ):
           failed[dest_url] = "Source and destination file sizes do not match (%s vs %s)." % ( sourceSize, fileSize )
         else:
           successful[dest_url] = fileSize
-      except OSError as ose:
+      except ( IOError, OSError ) as ose:
         failed[dest_url] = str( ose )
+
 
     return S_OK( { 'Failed' : failed, 'Successful' : successful } )
 

--- a/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/Resources/Storage/GFAL2_SRM2Storage.py
@@ -20,6 +20,11 @@ class GFAL2_SRM2Storage( GFAL2_StorageBase ):
   """ SRM2 SE class that inherits from GFAL2StorageBase
   """
 
+  _InputProtocols = ['file', 'root', 'srm']
+  _OutputProtocols = ['file', 'root', 'dcap', 'gsidcap', 'rfio', 'srm']
+
+
+
   def __init__( self, storageName, parameters ):
     """ """
     self.log = gLogger.getSubLogger( "GFAL2_SRM2Storage", True )
@@ -98,6 +103,13 @@ class GFAL2_SRM2Storage( GFAL2_StorageBase ):
       listProtocols = protocols
     else:
       return S_ERROR( "getTransportURL: Must supply desired protocols to this plug-in." )
+
+    # Compatibility because of castor returning a castor: url if you ask
+    # for a root URL, and a root: url if you ask for a xroot url...
+    if 'root' in listProtocols and 'xroot' not in listProtocols:
+      listProtocols.insert( listProtocols.index( 'root' ), 'xroot' )
+    elif 'xroot' in listProtocols and 'root' not in listProtocols:
+      listProtocols.insert( listProtocols.index( 'xroot' ) + 1, 'root' )
 
     if self.protocolParameters['Protocol'] in listProtocols:
       successful = {}

--- a/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/Resources/Storage/GFAL2_XROOTStorage.py
@@ -18,6 +18,11 @@ class GFAL2_XROOTStorage( GFAL2_StorageBase ):
 
   Xroot interface to StorageElement using gfal2
   """
+  
+
+  _InputProtocols = ['file', 'root']
+  _OutputProtocols = ['root']
+
 
   def __init__( self, storageName, parameters ):
     """ c'tor

--- a/Resources/Storage/ProxyStorage.py
+++ b/Resources/Storage/ProxyStorage.py
@@ -14,6 +14,9 @@ import os
 
 class ProxyStorage( StorageBase ):
 
+  _InputProtocols = ['file', 'dip', 'dips']
+  _OutputProtocols = ['dip', 'dips']
+
   def __init__( self, storageName, parameters ):
 
     StorageBase.__init__( self, storageName, parameters )

--- a/Resources/Storage/RFIOStorage.py
+++ b/Resources/Storage/RFIOStorage.py
@@ -18,6 +18,9 @@ from DIRAC.Core.Utilities.File                  import getSize
 
 class RFIOStorage( StorageBase ):
 
+  _InputProtocols = ['file', 'rfio']
+  _OutputProtocols = ['rfio']
+  
   def __init__( self, storageName, parameters ):
     
     StorageBase.__init__( self, storageName, parameters )

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -33,6 +33,9 @@ class SRM2Storage( StorageBase ):
   SRM v2 interface to StorageElement using lcg_util and gfal
   """
 
+  _InputProtocols = ['file', 'srm']
+  _OutputProtocols = ['file', 'srm']
+
   def __init__( self, storageName, parameters ):
     """ c'tor
 
@@ -41,6 +44,7 @@ class SRM2Storage( StorageBase ):
     :param dict parameters: dictionary of protocol parameters
     """
     StorageBase.__init__( self, storageName, parameters )
+
     self.spaceToken = self.protocolParameters['SpaceToken']
 
     self.log = gLogger.getSubLogger( "SRM2Storage", True )
@@ -347,7 +351,7 @@ class SRM2Storage( StorageBase ):
           self.log.debug( "getTransportURL: Obtained tURL for file. %s" % pathSURL )
           successful[pathSURL] = urlDict['turl']
         elif urlDict['status'] == 2:
-          errMessage = "getTransportURL: File does not exist."
+          errMessage = "File does not exist"
           self.log.error( errMessage, pathSURL )
           failed[pathSURL] = errMessage
         else:
@@ -715,6 +719,7 @@ class SRM2Storage( StorageBase ):
     :param str dest_url: destination url on storage
     :param int sourceSize: :src_file: size in B
     """
+
     if checkExists:
       # Pre-transfer check
       res = self.__executeOperation( dest_url, 'exists' )

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -21,8 +21,8 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
 from DIRAC.Core.Utilities.Subprocess import pythonCall
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Utilities.File import getSize
-from DIRAC.AccountingSystem.Client.Types.DataOperation import DataOperation
-from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
+# from DIRAC.AccountingSystem.Client.Types.DataOperation import DataOperation
+# from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
 
 # # RCSID
 __RCSID__ = "$Id$"
@@ -34,7 +34,7 @@ class SRM2Storage( StorageBase ):
   """
 
   _InputProtocols = ['file', 'srm']
-  _OutputProtocols = ['file', 'srm']
+  _OutputProtocols = ['file', 'root', 'dcap', 'gsidcap', 'rfio', 'srm']
 
   def __init__( self, storageName, parameters ):
     """ c'tor
@@ -1668,7 +1668,7 @@ class SRM2Storage( StorageBase ):
       res = self.__gfal_operation_wrapper( 'gfal_prestage',
                                            gfalDict,
                                            timeout_sendreceive = self.fileTimeout * len( urls ) )
-      gDataStoreClient.addRegister( res['AccountingOperation'] )
+#       gDataStoreClient.addRegister( res['AccountingOperation'] )
       if not res['OK']:
         for url in urls:
           failed[url] = res['Message']
@@ -1695,7 +1695,7 @@ class SRM2Storage( StorageBase ):
       gfalDict['nbfiles'] = len( urls )
       gfalDict['timeout'] = self.fileTimeout * len( urls )
       res = self.__gfal_operation_wrapper( 'gfal_turlsfromsurls', gfalDict )
-      gDataStoreClient.addRegister( res['AccountingOperation'] )
+#       gDataStoreClient.addRegister( res['AccountingOperation'] )
       if not res['OK']:
         for url in urls:
           failed[url] = res['Message']
@@ -1721,7 +1721,7 @@ class SRM2Storage( StorageBase ):
       gfalDict['nbfiles'] = len( urls )
       gfalDict['timeout'] = self.fileTimeout * len( urls )
       res = self.__gfal_operation_wrapper( 'gfal_deletesurls', gfalDict )
-      gDataStoreClient.addRegister( res['AccountingOperation'] )
+#       gDataStoreClient.addRegister( res['AccountingOperation'] )
       if not res['OK']:
         for url in urls:
           failed[url] = res['Message']
@@ -1747,7 +1747,7 @@ class SRM2Storage( StorageBase ):
       gfalDict['nbfiles'] = len( urls )
       gfalDict['timeout'] = self.fileTimeout * len( urls )
       res = self.__gfal_operation_wrapper( 'gfal_removedir', gfalDict )
-      gDataStoreClient.addRegister( res['AccountingOperation'] )
+#       gDataStoreClient.addRegister( res['AccountingOperation'] )
       if not res['OK']:
         for url in urls:
           failed[url] = res['Message']
@@ -1786,7 +1786,7 @@ class SRM2Storage( StorageBase ):
         gfalDict['nbfiles'] = len( urls )
         gfalDict['timeout'] = self.fileTimeout * len( urls )
         res = self.__gfal_operation_wrapper( 'gfal_pin', gfalDict, srmRequestID = srmRequestID )
-        gDataStoreClient.addRegister( res['AccountingOperation'] )
+#         gDataStoreClient.addRegister( res['AccountingOperation'] )
         if not res['OK']:
           for url in urls:
             failed[url] = res['Message']
@@ -1823,7 +1823,7 @@ class SRM2Storage( StorageBase ):
         gfalDict['nbfiles'] = len( urls )
         gfalDict['timeout'] = self.fileTimeout * len( urls )
         res = self.__gfal_operation_wrapper( 'gfal_prestagestatus', gfalDict, srmRequestID = srmRequestID )
-        gDataStoreClient.addRegister( res['AccountingOperation'] )
+#         gDataStoreClient.addRegister( res['AccountingOperation'] )
         if not res['OK']:
           for url in urls:
             failed[url] = res['Message']
@@ -1859,7 +1859,7 @@ class SRM2Storage( StorageBase ):
         gfalDict['nbfiles'] = len( urls )
         gfalDict['timeout'] = self.fileTimeout * len( urls )
         res = self.__gfal_operation_wrapper( 'gfal_release', gfalDict, srmRequestID = srmRequestID )
-        gDataStoreClient.addRegister( res['AccountingOperation'] )
+#         gDataStoreClient.addRegister( res['AccountingOperation'] )
         if not res['OK']:
           for url in urls:
             failed[url] = res['Message']
@@ -1879,18 +1879,18 @@ class SRM2Storage( StorageBase ):
     :param int timeout_sendreceive: gfal sendreceive timeout in seconds
     """
     # Create an accounting DataOperation record for each operation
-    oDataOperation = self.__initialiseAccountingObject( operation, self.name, gfalDict['nbfiles'] )
+#     oDataOperation = self.__initialiseAccountingObject( operation, self.name, gfalDict['nbfiles'] )
 
-    oDataOperation.setStartTime()
-    start = time.time()
+#     oDataOperation.setStartTime()
+#     start = time.time()
 
     res = self.__importExternals()
     if not res['OK']:
-      oDataOperation.setEndTime()
-      oDataOperation.setValueByKey( 'TransferTime', 0. )
-      oDataOperation.setValueByKey( 'TransferOK', 0 )
-      oDataOperation.setValueByKey( 'FinalStatus', 'Failed' )
-      res['AccountingOperation'] = oDataOperation
+#       oDataOperation.setEndTime()
+#       oDataOperation.setValueByKey( 'TransferTime', 0. )
+#       oDataOperation.setValueByKey( 'TransferOK', 0 )
+#       oDataOperation.setValueByKey( 'FinalStatus', 'Failed' )
+#       res['AccountingOperation'] = oDataOperation
       return res
 
     # # timeout for one gfal_exec call
@@ -1899,26 +1899,27 @@ class SRM2Storage( StorageBase ):
     pyTimeout = 300 + ( timeout * ( 2 ** self.gfalRetry ) )
     res = pythonCall( pyTimeout, self.__gfal_wrapper, operation, gfalDict, srmRequestID, timeout_sendreceive )
 
-    end = time.time()
-    oDataOperation.setEndTime()
-    oDataOperation.setValueByKey( 'TransferTime', end - start )
+#     end = time.time()
+#     oDataOperation.setEndTime()
+#     oDataOperation.setValueByKey( 'TransferTime', end - start )
 
     if not res['OK']:
-      oDataOperation.setValueByKey( 'TransferOK', 0 )
-      oDataOperation.setValueByKey( 'FinalStatus', 'Failed' )
-      res['AccountingOperation'] = oDataOperation
+#       oDataOperation.setValueByKey( 'TransferOK', 0 )
+#       oDataOperation.setValueByKey( 'FinalStatus', 'Failed' )
+#       res['AccountingOperation'] = oDataOperation
       return res
     res = res['Value']
     if not res['OK']:
-      oDataOperation.setValueByKey( 'TransferOK', 0 )
-      oDataOperation.setValueByKey( 'FinalStatus', 'Failed' )
+      pass
+#       oDataOperation.setValueByKey( 'TransferOK', 0 )
+#       oDataOperation.setValueByKey( 'FinalStatus', 'Failed' )
     else:
       for urlDict in res['Value']:
         if 'surl' in urlDict:
           urlDict['surl'] = self.__convertRandomSRMOutputIntoAFullURL( urlDict['surl'] )['Value']
 
 
-    res['AccountingOperation'] = oDataOperation
+#     res['AccountingOperation'] = oDataOperation
     return res
 
   def __gfal_wrapper( self, operation, gfalDict, srmRequestID = None, timeout_sendreceive = None ):
@@ -1972,37 +1973,37 @@ class SRM2Storage( StorageBase ):
 
     return S_OK( resultList )
 
-  @staticmethod
-  def __initialiseAccountingObject( operation, se, files ):
-    """ create DataOperation accounting object
-
-    :param str operation: operation performed
-    :param str se: destination SE name
-    :param int files: nb of files
-    """
-    import DIRAC
-    accountingDict = {}
-    accountingDict['OperationType'] = operation
-    result = getProxyInfo()
-    if not result['OK']:
-      userName = 'system'
-    else:
-      userName = result['Value'].get( 'username', 'unknown' )
-    accountingDict['User'] = userName
-    accountingDict['Protocol'] = 'gfal'
-    accountingDict['RegistrationTime'] = 0.0
-    accountingDict['RegistrationOK'] = 0
-    accountingDict['RegistrationTotal'] = 0
-    accountingDict['Destination'] = se
-    accountingDict['TransferTotal'] = files
-    accountingDict['TransferOK'] = files
-    accountingDict['TransferSize'] = files
-    accountingDict['TransferTime'] = 0.0
-    accountingDict['FinalStatus'] = 'Successful'
-    accountingDict['Source'] = DIRAC.siteName()
-    oDataOperation = DataOperation()
-    oDataOperation.setValuesFromDict( accountingDict )
-    return oDataOperation
+#   @staticmethod
+#   def __initialiseAccountingObject( operation, se, files ):
+#     """ create DataOperation accounting object
+#
+#     :param str operation: operation performed
+#     :param str se: destination SE name
+#     :param int files: nb of files
+#     """
+#     import DIRAC
+#     accountingDict = {}
+#     accountingDict['OperationType'] = operation
+#     result = getProxyInfo()
+#     if not result['OK']:
+#       userName = 'system'
+#     else:
+#       userName = result['Value'].get( 'username', 'unknown' )
+#     accountingDict['User'] = userName
+#     accountingDict['Protocol'] = 'gfal'
+#     accountingDict['RegistrationTime'] = 0.0
+#     accountingDict['RegistrationOK'] = 0
+#     accountingDict['RegistrationTotal'] = 0
+#     accountingDict['Destination'] = se
+#     accountingDict['TransferTotal'] = files
+#     accountingDict['TransferOK'] = files
+#     accountingDict['TransferSize'] = files
+#     accountingDict['TransferTime'] = 0.0
+#     accountingDict['FinalStatus'] = 'Successful'
+#     accountingDict['Source'] = DIRAC.siteName()
+#     oDataOperation = DataOperation()
+#     oDataOperation.setValuesFromDict( accountingDict )
+#     return oDataOperation
 
 #######################################################################
 #

--- a/Resources/Storage/StorageBase.py
+++ b/Resources/Storage/StorageBase.py
@@ -57,6 +57,8 @@ class StorageBase( object ):
         self.protocolParameters[protocolType] = getattr( self, '_%s' % protocolType )
       else:
         self.protocolParameters[protocolType] = [ self.protocolParameters['Protocol']]
+        if protocolType == 'InputProtocols':
+          self.protocolParameters[protocolType].append( 'file' )
 
 
     

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -817,8 +817,13 @@ class StorageElementItem( object ):
 
     successful = {}
     failed = {}
+    filteredPlugins = self.__filterPlugins( self.methodName, kwargs.get( 'protocols' ), inputProtocol )
+    if not filteredPlugins:
+      return DError( errno.EPROTONOSUPPORT, "No storage plugins matching the requirements\
+                                           (operation %s protocols %s inputProtocol %s)"\
+                                            % ( self.methodName, kwargs.get( 'protocols' ), inputProtocol ) )
     # Try all of the storages one by one
-    for storage in self.__filterPlugins( self.methodName, kwargs.get( 'protocols' ), inputProtocol ):
+    for storage in filteredPlugins:
       # Determine whether to use this storage object
       storageParameters = storage.getParameters()
       pluginName = storageParameters['PluginName']

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -182,11 +182,11 @@ class StorageElementItem( object ):
     self.__dmsHelper = DMSHelpers( vo = vo )
 
     # Allow SE to overwrite general operation config
-    accessProto = gConfig.getValue( '/Resources/StorageElements/%s/AccessProtocols' )
+    accessProto = self.options.get( 'AccessProtocols' )
     self.localAccessProtocolList = accessProto if accessProto else self.__dmsHelper.getAccessProtocols()
     self.log.debug( "localAccessProtocolList %s" % self.localAccessProtocolList )
 
-    writeProto = gConfig.getValue( '/Resources/StorageElements/%s/WriteProtocols' )
+    writeProto = self.options.get( 'WriteProtocols' )
     self.localWriteProtocolList = writeProto if writeProto else self.__dmsHelper.getWriteProtocols()
     self.log.debug( "localWriteProtocolList %s" % self.localWriteProtocolList )
 
@@ -707,6 +707,7 @@ class StorageElementItem( object ):
     else:
       potentialProtocols = allowedProtocols
       
+    log.debug( 'Potential protocols %s' % potentialProtocols )
 
     localSE = self.__isLocalSE()['Value']
 

--- a/Resources/Storage/StorageFactory.py
+++ b/Resources/Storage/StorageFactory.py
@@ -205,7 +205,7 @@ class StorageFactory( object ):
         return S_ERROR( errStr )
       for option in set( res['Value'] ) - set( ( 'ReadAccess', 'WriteAccess', 'CheckAccess', 'RemoveAccess' ) ):
         optionConfigPath = cfgPath( storageConfigPath, option )
-        default = [] if option in [ 'VO' ] else ''
+        default = [] if option in [ 'VO', 'AccessProtocols', 'WriteProtocols' ] else ''
         optionsDict[option] = gConfig.getValue( optionConfigPath, default )
 
     # The status is that of the derived SE only

--- a/Resources/Storage/StorageFactory.py
+++ b/Resources/Storage/StorageFactory.py
@@ -291,6 +291,7 @@ class StorageFactory( object ):
     # This is a temporary for backward compatibility: move ProtocolName to PluginName
     protocolDict.setdefault( 'PluginName', protocolDict.pop( 'ProtocolName', None ) )
 
+
     # Evaluate the base path taking into account possible VO specific setting
     if self.vo:
       result = gConfig.getOptionsDict( cfgPath( protocolConfigPath, 'VOPath' ) )

--- a/Resources/Storage/XROOTStorage.py
+++ b/Resources/Storage/XROOTStorage.py
@@ -23,6 +23,8 @@ class XROOTStorage( StorageBase ):
 
   Xroot interface to StorageElement using pyxrootd
   """
+  _InputProtocols = ['file', 'root']
+  _OutputProtocols = ['root']
 
   def __init__( self, storageName, parameters ):
     """ c'tor

--- a/Resources/Storage/test/TestFilePlugin.py
+++ b/Resources/Storage/test/TestFilePlugin.py
@@ -15,15 +15,17 @@ def mock_StorageFactory_getConfigStorageName( storageName, referenceType ):
   resolvedName = storageName
   return S_OK( resolvedName )
 
-def mock_StorageFactory_getConfigStorageOptions( storageName ):
+def mock_StorageFactory_getConfigStorageOptions( storageName, derivedStorageName = None ):
   """ Get the options associated to the StorageElement as defined in the CS
   """
   optionsDict = {'BackendType': 'local',
                  'ReadAccess': 'Active',
-                 'WriteAccess': 'Active'}
+                 'WriteAccess': 'Active',
+                 'AccessProtocols' : ['file'],
+                 'WriteProtocols' : ['file'], }
   return S_OK( optionsDict )
 
-def mock_StorageFactory_getConfigStorageProtocols( storageName ):
+def mock_StorageFactory_getConfigStorageProtocols( storageName, derivedStorageName = None ):
   """ Protocol specific information is present as sections in the Storage configuration
   """
   protocolDetails = [{'Host': '',
@@ -117,7 +119,9 @@ class TestBase( unittest.TestCase ):
 
   @mock.patch( 'DIRAC.Resources.Storage.StorageElement.StorageElementItem._StorageElementItem__isLocalSE',
                 return_value = S_OK( True ) )  # Pretend it's local
-  def test_01_getURL( self, mk_isLocalSE ):
+  @mock.patch( 'DIRAC.Resources.Storage.StorageElement.StorageElementItem.addAccountingOperation',
+                return_value = None )  # Don't send accounting
+  def test_01_getURL( self, mk_isLocalSE, mk_accounting ):
     """Testing getURL"""
     # Testing the getURL 
     res = self.se.getURL( self.ALL )
@@ -131,7 +135,9 @@ class TestBase( unittest.TestCase ):
 
   @mock.patch( 'DIRAC.Resources.Storage.StorageElement.StorageElementItem._StorageElementItem__isLocalSE',
                 return_value = S_OK( True ) )  # Pretend it's local
-  def test_02_FileTest( self, mk_isLocalSE ):
+  @mock.patch( 'DIRAC.Resources.Storage.StorageElement.StorageElementItem.addAccountingOperation',
+                return_value = None )  # Don't send accounting
+  def test_02_FileTest( self, mk_isLocalSE, mk_accounting ):
     """Testing createDirectory"""
     # Putting the files
 
@@ -145,7 +151,7 @@ class TestBase( unittest.TestCase ):
     # wrong size
     res = localPutFile( self.existingFile, size = -1 )
     self.assert_( res['OK'], res )
-    self.assert_( self.existingFile in res['Value']['Failed'] )
+    self.assert_( self.existingFile in res['Value']['Failed'], res )
     self.assert_( 'not match' in res['Value']['Failed'][self.existingFile], res )
     self.assert_( not os.path.exists( self.basePath + self.existingFile ) )
 
@@ -229,7 +235,9 @@ class TestBase( unittest.TestCase ):
 
   @mock.patch( 'DIRAC.Resources.Storage.StorageElement.StorageElementItem._StorageElementItem__isLocalSE',
                 return_value = S_OK( True ) )  # Pretend it's local
-  def test_03_createDirectory( self, mk_isLocalSE ):
+  @mock.patch( 'DIRAC.Resources.Storage.StorageElement.StorageElementItem.addAccountingOperation',
+                return_value = None )  # Don't send accounting
+  def test_03_createDirectory( self, mk_isLocalSE, mk_accounting ):
     """Testing creating directories"""
 
 
@@ -241,7 +249,9 @@ class TestBase( unittest.TestCase ):
 
   @mock.patch( 'DIRAC.Resources.Storage.StorageElement.StorageElementItem._StorageElementItem__isLocalSE',
                 return_value = S_OK( True ) )  # Pretend it's local
-  def test_04_putDirectory( self, mk_isLocalSE ):
+  @mock.patch( 'DIRAC.Resources.Storage.StorageElement.StorageElementItem.addAccountingOperation',
+                return_value = None )  # Don't send accounting
+  def test_04_putDirectory( self, mk_isLocalSE, mk_accounting ):
     """Testing putDirectory"""
 
     nonExistingDir = '/lhcb/forsuredoesnotexist'


### PR DESCRIPTION
This PR contains the next steps in order to implement multi protocol support for storage elements. It is however far from final now. Some cleanup are still needed, and will be done once the gfal2 plugins are production ready. 

Basically, when performing an action on the StorageElement, instead of looping over all the protocol plugins, we loop over a filtered list. This list is built taking into account which action is taken (read vs write), and is also sorted according to lists defined in the CS. 
Two lists were already existing: RegistrationProtocols and ThirdPartyProtocols. They were moved into the Operation section where they belong to, and two more lists added: AccessProtocols and WriteProtocols. They all default to 'srm' and 'dips'. The utilities to fetch these lists are moved to DMSHelper, and each of them can be locally overwritten in the SE definition.

The negotiation for third party transfer is also improved: it takes into account all possible protocols the source SE is able to produce, and all protocols the target is able to receive as input.

Note that as of now, the behavior should not change, because the most used plugin (SRM2) still internally uses the DefaultProtocol list defined in the StorageElement section of the CS. This sort of bypasses  all the logic. But as I said, once gfal2 is production ready, we can do the final cleanup.

This will have to be veeeeery carefully tested :-)  