### PR TITLE
[v6r14] JobAgent and other fixes

### DIFF
--- a/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -11,7 +11,7 @@
 
 __RCSID__ = "$Id$"
 
-from DIRAC                                              import S_OK, S_ERROR
+from DIRAC                                              import S_OK, S_ERROR, gConfig
 from DIRAC.Core.Base.AgentModule                        import AgentModule
 from DIRAC.Core.Utilities.Grid                          import getBdiiCEInfo, getBdiiSEInfo
 from DIRAC.FrameworkSystem.Client.NotificationClient    import NotificationClient
@@ -82,6 +82,9 @@ class Bdii2CSAgent( AgentModule ):
     result = self.csAPI.downloadCSData()
     if not result['OK']:
       self.log.warn( "Could not download a fresh copy of the CS data", result[ 'Message' ] )
+
+    # Refresh the configuration from the master server
+    gConfig.forceRefresh( fromMaster = True )
 
     if self.processCEs:
       self.__lookForNewCEs()

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -158,8 +158,6 @@ def getSiteUpdates( vo, bdiiInfo = None, log = None ):
     ceBdiiDict = result['Value']
 
   changeSet = set()
-  gConfig.forceRefresh()
-
   for site in ceBdiiDict:
     result = getDIRACSiteName( site )
     if not result['OK']:
@@ -210,7 +208,7 @@ def getSiteUpdates( vo, bdiiInfo = None, log = None ):
         OS = ceDict.get( 'OS', 'Unknown' )
         si00 = ceDict.get( 'SI00', 'Unknown' )
         ceType = ceDict.get( 'CEType', 'Unknown' )
-        ram = ceDict.get( 'HostRAM', 'Unknown' )
+        ram = ceDict.get( 'MaxRAM', 'Unknown' )
         submissionMode = ceDict.get( 'SubmissionMode', 'Unknown' )
   
         # Current BDII CE info
@@ -247,17 +245,18 @@ def getSiteUpdates( vo, bdiiInfo = None, log = None ):
   
         queues = ceInfo['Queues'].keys()
         for queue in queues:
+          queueInfo = ceInfo['Queues'][queue]
+          queueStatus = queueInfo['GlueCEStateStatus']
           queueSection = cfgPath( ceSection, 'Queues', queue )
           queueDict = {}
           result = gConfig.getOptionsDict( queueSection )
           if result['OK']:
             queueDict = result['Value']
           else:
-            log.notice( "Adding new queue %s to CE %s" % (queue, ce) )
-          queueInfo = ceInfo['Queues'][queue]
-          queueStatus = queueInfo['GlueCEStateStatus']
-          if queueStatus.lower() != "production":
-            continue
+            if queueStatus.lower() == "production":
+              log.notice( "Adding new queue %s to CE %s" % (queue, ce) )
+            else:
+              continue
   
           # Current CS queue info
           maxCPUTime = queueDict.get( 'maxCPUTime', 'Unknown' )

--- a/ConfigurationSystem/private/ConfigurationClient.py
+++ b/ConfigurationSystem/private/ConfigurationClient.py
@@ -24,8 +24,8 @@ class ConfigurationClient:
   def loadCFG( self, cfg ):
     return gConfigurationData.mergeWithLocal( cfg )
 
-  def forceRefresh( self ):
-    return gRefresher.forceRefresh()
+  def forceRefresh( self, fromMaster = False ):
+    return gRefresher.forceRefresh( fromMaster = fromMaster )
 
   def dumpLocalCFGToFile( self, fileName ):
     return gConfigurationData.dumpLocalCFGToFile( fileName )

--- a/ConfigurationSystem/private/Refresher.py
+++ b/ConfigurationSystem/private/Refresher.py
@@ -83,9 +83,9 @@ class Refresher( threading.Thread ):
     thd.start()
 
 
-  def forceRefresh( self ):
+  def forceRefresh( self, fromMaster = False ):
     if self.__refreshEnabled:
-      return self.__refresh()
+      return self.__refresh( fromMaster = fromMaster )
     return S_OK()
 
   def autoRefreshAndPublish( self, sURL ):
@@ -132,7 +132,7 @@ class Refresher( threading.Thread ):
       gLogger.warn( "No master server is specified in the configuration, trying to get data from other slaves" )
       return self.__refresh()[ 'OK' ]
 
-  def __refresh( self ):
+  def __refresh( self, fromMaster = False ):
     self.__lastUpdateTime = time.time()
     gLogger.debug( "Refreshing configuration..." )
     gatewayList = getGatewayURLs( "Configuration/Server" )
@@ -140,6 +140,10 @@ class Refresher( threading.Thread ):
     if gatewayList:
       initialServerList = gatewayList
       gLogger.debug( "Using configuration gateway", str( initialServerList[0] ) )
+    elif fromMaster:
+      masterServer = gConfigurationData.getMasterServer()
+      initialServerList = [masterServer]
+      gLogger.debug( "Refreshing from master %s" % masterServer )
     else:
       initialServerList = gConfigurationData.getServers()
       gLogger.debug( "Refreshing from list %s" % str( initialServerList ) )

--- a/Core/Utilities/Grid.py
+++ b/Core/Utilities/Grid.py
@@ -386,53 +386,54 @@ def getBdiiCEInfo( vo, host = None ):
   queueDict = {}
   
   for queue in result['Value']:
-    ceID = queue.get('GlueForeignKey','').replace('GlueClusterUniqueID=','')
+    clusterID = queue.get('GlueForeignKey','').replace('GlueClusterUniqueID=','')
+    ceID = queue.get('GlueCEUniqueID','').split(':')[0]
     queueDict[queue['GlueCEUniqueID']] = queue
     queueDict[queue['GlueCEUniqueID']]['CE'] = ceID
     if not ceID in ceDict:
-      result = ldapCluster( ceID, host = host )
+      result = ldapCluster( clusterID, host = host )
       if not result['OK']:
         continue
       if not result['Value']:
         continue
-  
+
       ce = result['Value'][0]
       ceDict[ceID] = ce
-  
+
       fKey = ce['GlueForeignKey']
       siteID = ''
       for key in fKey:
         if key.startswith('GlueSiteUniqueID'):
           siteID = key.replace('GlueSiteUniqueID=','')
       ceDict[ceID]['Site'] = siteID
-  
-      result = ldapCE( ceID, host = host )
+
+      result = ldapCE( clusterID, host = host )
       ce = {}
       if result['OK'] and result['Value']:
-        ce = result['Value'][0]  
+        ce = result['Value'][0]
       ceDict[ceID].update( ce )
-  
+
       if not siteID in siteDict:
         site = {}
         result = ldapSite( siteID, host = host )
         if result['OK'] and result['Value']:
           site = result['Value'][0]
         siteDict[siteID] = site
-  
+
   for ceID in ceDict:
     siteID = ceDict[ceID]['Site']
     if siteID in siteDict:
       siteDict[siteID].setdefault('CEs',{})
       siteDict[siteID]['CEs'][ceID] = ceDict[ceID]
-  
+
   for queueID in queueDict:
     ceID = queueDict[queueID]['CE']
     siteID = ceDict[ceID]['Site']
     siteDict[siteID]['CEs'][ceID].setdefault('Queues',{})
     queueName = re.split( ':\d+/', queueDict[queueID]['GlueCEUniqueID'] )[1]
     siteDict[siteID]['CEs'][ceID]['Queues'][queueName] = queueDict[queueID]
-    
-  return S_OK( siteDict )  
+
+  return S_OK( siteDict )
 
 def getBdiiSEInfo( vo, host = None ):
   """ Get information for all the SEs for a given VO

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -472,28 +472,4 @@ def getCEConfigDict( ceName ):
       ceConfigDict = result['Value']
   return ceConfigDict
 
-def getResourceDict( ceName = None ):
-  """Look into LocalSite for Resource Requirements
-  """
-  # FIXME: this /LocalSite/ResourceDict is probably a relic, no no idea why it's here
-  ret = gConfig.getOptionsDict( '/LocalSite/ResourceDict' )
-  if not ret['OK']:
-    resourceDict = {}
-  else:
-    resourceDict = dict( ret['Value'] )
-
-  # if a CE Name is given, check the corresponding section
-  if ceName:
-    ret = gConfig.getOptionsDict( '/LocalSite/%s/ResourceDict' % ceName )
-    if ret['OK']:
-      resourceDict.update( dict( ret['Value'] ) )
-
-  # now add some defaults
-  resourceDict['Setup'] = gConfig.getValue( '/DIRAC/Setup', 'None' )
-  if not 'CPUTime' in resourceDict:
-    from DIRAC.WorkloadManagementSystem.private.Queues import maxCPUSegments
-    resourceDict['CPUTime'] = gConfig.getValue( '/LocalSite/CPUTime', maxCPUSegments[-1] )
-
-  return resourceDict
-
 #EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -529,30 +529,6 @@ class JobAgent( AgentModule ):
 
   #############################################################################
   # FIXME: this is not called anywhere...?
-  def __reportPilotInfo( self, jobID ):
-    """Sends back useful information for the pilotAgentsDB via the WMSAdministrator
-       service.
-    """
-
-    gridCE = gConfig.getValue( 'LocalSite/GridCE', 'Unknown' )
-
-    wmsAdmin = RPCClient( 'WorkloadManagement/WMSAdministrator' )
-    if gridCE != 'Unknown':
-      result = wmsAdmin.setJobForPilot( int( jobID ), str( self.pilotReference ), gridCE )
-    else:
-      result = wmsAdmin.setJobForPilot( int( jobID ), str( self.pilotReference ) )
-
-    if not result['OK']:
-      self.log.warn( result['Message'] )
-
-    result = wmsAdmin.setPilotBenchmark( str( self.pilotReference ), float( self.cpuFactor ) )
-    if not result['OK']:
-      self.log.warn( result['Message'] )
-
-    return S_OK()
-
-  #############################################################################
-  # FIXME: this is not called anywhere...?
   def __setJobSite( self, jobID, site ):
     """Wraps around setJobSite of state update client
     """

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -43,16 +43,24 @@ class JobAgent( AgentModule ):
       self.log.info( 'Defining CE from local configuration = %s' % localCE )
       ceType = localCE
 
+    # Create backend Computing Element
     ceFactory = ComputingElementFactory()
     self.ceName = ceType
     ceInstance = ceFactory.getCE( ceType )
     if not ceInstance['OK']:
       self.log.warn( ceInstance['Message'] )
       return ceInstance
+    self.computingElement = ceInstance['Value']
+
+    result = self.computingElement.getDescription()
+    if not result['OK']:
+      self.log.warn( "Can not get the CE description" )
+      return result
+    ceDict = result['Value']
+    self.timeLeft = ceDict.get( 'CPUTime', 0.0 )
+    self.timeLeft = gConfig.getValue( '/Resources/Computing/CEDefaults/MaxCPUTime', self.timeLeft )
 
     self.initTimes = os.times()
-
-    self.computingElement = ceInstance['Value']
     # Localsite options
     self.siteName = gConfig.getValue( '/LocalSite/Site', 'Unknown' )
     self.pilotReference = gConfig.getValue( '/LocalSite/PilotReference', 'Unknown' )
@@ -70,7 +78,6 @@ class JobAgent( AgentModule ):
     self.extraOptions = gConfig.getValue( '/AgentJobRequirements/ExtraOptions', '' )
     # Timeleft
     self.timeLeftUtil = TimeLeft()
-    self.timeLeft = gConfig.getValue( '/Resources/Computing/CEDefaults/MaxCPUTime', 0.0 )
     self.timeLeftError = ''
     self.scaledCPUTime = 0.0
     self.pilotInfoReportedFlag = False

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -266,8 +266,11 @@ class JobAgent( AgentModule ):
         return self.__finish( submission['Message'] )
       elif 'PayloadFailed' in submission:
         # Do not keep running and do not overwrite the Payload error
-        return self.__finish( 'Payload execution failed with error code %s' % submission['PayloadFailed'],
-                              self.stopOnApplicationFailure )
+        message = 'Payload execution failed with error code %s' % submission['PayloadFailed']
+        if self.stopOnApplicationFailure:
+          return self.__finish( message, self.stopOnApplicationFailure )
+        else:
+          self.log.info( message )
 
       self.log.debug( 'After %sCE submitJob()' % ( self.ceName ) )
     except Exception:
@@ -570,8 +573,8 @@ class JobAgent( AgentModule ):
   def __finish( self, message, stop = True ):
     """Force the JobAgent to complete gracefully.
     """
-    self.log.info( 'JobAgent will stop with message "%s", execution complete.' % message )
     if stop:
+      self.log.info( 'JobAgent will stop with message "%s", execution complete.' % message )
       self.am_stopExecution()
       return S_ERROR( message )
     else:

--- a/WorkloadManagementSystem/Agent/TaskQueueDirector.py
+++ b/WorkloadManagementSystem/Agent/TaskQueueDirector.py
@@ -126,13 +126,13 @@
 __RCSID__ = "$Id$"
 
 import random, time, threading
-from DIRAC                                                       import S_OK, S_ERROR, List, Time, abort
+from DIRAC                                                       import S_OK, S_ERROR, gConfig, abort
+from DIRAC.Core.Utilities                                        import List, Time
 from DIRAC.Core.Utilities.ThreadPool                             import ThreadPool
 from DIRAC.Core.Utilities.ObjectLoader                           import ObjectLoader
 from DIRAC.Core.DISET.RPCClient                                  import RPCClient
 from DIRAC.Core.Base.AgentModule                                 import AgentModule
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources          import getDIRACPlatforms
-from DIRAC.Resources.Computing.ComputingElement                  import getResourceDict
 from DIRAC.WorkloadManagementSystem.Client.ServerUtils           import pilotAgentsDB
 
 
@@ -188,7 +188,9 @@ class TaskQueueDirector( AgentModule ):
 
     self.__checkSubmitPools()
 
-    self.directorDict = getResourceDict()
+    self.directorDict = {}
+    self.directorDict['Setup'] = gConfig.getValue( '/DIRAC/Setup', 'None' )
+    self.directorDict['CPUTime'] = 9999999
     #Add all submit pools
     self.directorDict[ 'SubmitPool' ] = self.am_getOption( "SubmitPools" ) 
     #Add all DIRAC platforms if not specified otherwise

--- a/WorkloadManagementSystem/Agent/TaskQueueDirector.py
+++ b/WorkloadManagementSystem/Agent/TaskQueueDirector.py
@@ -125,7 +125,10 @@
 """
 __RCSID__ = "$Id$"
 
-import random, time, threading
+import random
+import time
+import threading
+
 from DIRAC                                                       import S_OK, S_ERROR, gConfig, abort
 from DIRAC.Core.Utilities                                        import List, Time
 from DIRAC.Core.Utilities.ThreadPool                             import ThreadPool

--- a/WorkloadManagementSystem/private/DIRACPilotDirector.py
+++ b/WorkloadManagementSystem/private/DIRACPilotDirector.py
@@ -19,11 +19,10 @@ import os, sys, tempfile, shutil, time, base64, bz2
 
 from DIRAC.WorkloadManagementSystem.private.PilotDirector import PilotDirector
 from DIRAC.Resources.Computing.ComputingElementFactory    import ComputingElementFactory
-from DIRAC.Resources.Computing.ComputingElement import getResourceDict
-from DIRAC.Core.Security import CS
+from DIRAC.Core.Security                                  import CS
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient      import gProxyManager
-from DIRAC import S_OK, S_ERROR, gConfig
-from DIRAC.Core.Utilities.DictCache import DictCache
+from DIRAC                                                import S_OK, S_ERROR, gConfig
+from DIRAC.Core.Utilities.DictCache                       import DictCache
 
 ERROR_CE         = 'No CE available'
 ERROR_JDL        = 'Could not create Pilot script'
@@ -34,6 +33,29 @@ COMPUTING_ELEMENTS = []
 WAITING_TO_RUNNING_RATIO = 0.5
 MAX_WAITING_JOBS = 50
 MAX_NUMBER_JOBS = 10000
+
+def getResourceDict( ceName = None ):
+  """Look into LocalSite for Resource Requirements
+  """
+  ret = gConfig.getOptionsDict( '/LocalSite/ResourceDict' )
+  if not ret['OK']:
+    resourceDict = {}
+  else:
+    resourceDict = dict( ret['Value'] )
+
+  # if a CE Name is given, check the corresponding section
+  if ceName:
+    ret = gConfig.getOptionsDict( '/LocalSite/%s/ResourceDict' % ceName )
+    if ret['OK']:
+      resourceDict.update( dict( ret['Value'] ) )
+
+  # now add some defaults
+  resourceDict['Setup'] = gConfig.getValue( '/DIRAC/Setup', 'None' )
+  if not 'CPUTime' in resourceDict:
+    from DIRAC.WorkloadManagementSystem.private.Queues import maxCPUSegments
+    resourceDict['CPUTime'] = gConfig.getValue( '/LocalSite/CPUTime', maxCPUSegments[-1] )
+
+  return resourceDict
 
 class DIRACPilotDirector(PilotDirector):
   """


### PR DESCRIPTION
This PR fixes four bugs:
- When the application finishes with errors but the agent continues to take jobs, the timeLeft was not evaluated
- The initial timeLeft value was always set to 0.0 because the /Resources/Computing/CEDefaults/MaxCPUTime is not set in the current pilot commands
- The Bdii2CSAgent logic was faulty in some cases because the BDII info was compared to the CS info from any CS server and not from the Master resulting in discrepancies in some rare cases.
- The Bdii2CSAgent logic did not distinguish the CE and the Cluster in the Glue 1.0 schema which can be sometimes different

Also removed legacy getResourceDict() from the ComputingElement.py and moved to DIRACPilotDirector which itself is a legacy, kept just in case somebody still uses it.