### PR TITLE
[v6r15] fix double underscore name mangling bug

### DIFF
--- a/Core/Utilities/TimeLeft/SGETimeLeft.py
+++ b/Core/Utilities/TimeLeft/SGETimeLeft.py
@@ -108,7 +108,7 @@ scheduling info:            (Collecting of scheduler job information is turned o
 
     # Some SGE batch systems apply CPU scaling factor to the CPU consumption figures
     if cpu:
-      factor = __getCPUScalingFactor()
+      factor = _getCPUScalingFactor()
       if factor:
         cpu = cpu / factor
 
@@ -138,7 +138,7 @@ scheduling info:            (Collecting of scheduler job information is turned o
       retVal['Value'] = consumed
       return retVal
 
-def __getCPUScalingFactor():
+def _getCPUScalingFactor():
 
   host = socket.getfqdn()
   cmd = 'qconf -se %s' % host


### PR DESCRIPTION
Except if I misunderstand something in DIRAC import internals, I think there is a problem with `__getCPUScalingFactor`.

Double underscore name mangling leads to this error:
```
  File "/home/pigay/dirac-mt/DIRAC/Core/Utilities/TimeLeft/SGETimeLeft.py", line 111, in getResourceUsage
    factor = __getCPUScalingFactor()
NameError: global name '_SGETimeLeft__getCPUScalingFactor' is not defined
```

This PR tries to fix it.