### PR TITLE
[v6r14] - ipv6: Address family not supported by protocol

### DIFF
--- a/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
@@ -58,7 +58,7 @@ class SocketInfoFactory:
     try:
       osSocket = socket.socket( sockType, socket.SOCK_STREAM )
     except Exception as e:
-      gLogger.error( "ipv6 can not be used! Rollback to ipv4! Please update your machine", e ) 
+      gLogger.warn( "ipv6 can not be used! Rollback to ipv4! Please update your machine", e ) 
       return S_ERROR( e )
     #osSocket.setblocking( 0 )
     if timeout:

--- a/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
@@ -57,8 +57,8 @@ class SocketInfoFactory:
   def __sockConnect( self, hostAddress, sockType, timeout, retries ):
     try:
       osSocket = socket.socket( sockType, socket.SOCK_STREAM )
-    except Exception as e:
-      gLogger.warn( "ipv6 can not be used! Rollback to ipv4! Please update your machine", e ) 
+    except socket.error as e:
+      gLogger.warn( "Exception while creating a socket:", str( e ) ) 
       return S_ERROR( e )
     #osSocket.setblocking( 0 )
     if timeout:

--- a/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
@@ -59,8 +59,8 @@ class SocketInfoFactory:
       osSocket = socket.socket( sockType, socket.SOCK_STREAM )
     except socket.error as e:
       gLogger.warn( "Exception while creating a socket:", str( e ) ) 
-      return S_ERROR( e )
-    #osSocket.setblocking( 0 )
+      return S_ERROR( "Exception while creating a socket:%s" % str( e ) )
+    # osSocket.setblocking( 0 )
     if timeout:
       osSocket.settimeout( 5 )
     try:

--- a/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
@@ -15,6 +15,7 @@ from DIRAC.Core.DISET.private.Transports.SSL.SocketInfo import SocketInfo
 from DIRAC.Core.DISET.private.Transports.SSL.SessionManager import gSessionManager
 from DIRAC.Core.DISET.private.Transports.SSL.FakeSocket import FakeSocket
 from DIRAC.Core.DISET.private.Transports.SSL.ThreadSafeSSLObject import ThreadSafeSSLObject
+from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
 if GSI.__version__ < "0.5.0":
   raise Exception( "Required GSI version >= 0.5.0" )
@@ -54,7 +55,11 @@ class SocketInfoFactory:
     return S_ERROR( ", ".join( errs ) )
 
   def __sockConnect( self, hostAddress, sockType, timeout, retries ):
-    osSocket = socket.socket( sockType, socket.SOCK_STREAM )
+    try:
+      osSocket = socket.socket( sockType, socket.SOCK_STREAM )
+    except Exception as e:
+      gLogger.error( "ipv6 can not be used! Rollback to ipv4! Please update your machine", e ) 
+      return S_ERROR( e )
     #osSocket.setblocking( 0 )
     if timeout:
       osSocket.settimeout( 5 )


### PR DESCRIPTION
I have a very strange error message using my local PC. I try to connect to certification without any success. I am using the latest LHCbDIRAC version:
/cvmfs/lhcb.cern.ch/lib/lcg/releases/LCG_79/Python/2.7.9.p1/x86_64-slc6-gcc48-opt/bin/python
>>> import socket
>>> osSocket = socket.socket( socket.AF_INET6, socket.SOCK_STREAM )
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/cvmfs/lhcb.cern.ch/lib/lcg/releases/LCG_79/Python/2.7.9.p1/x86_64-slc6-gcc48-opt/lib/python2.7/socket.py", line 187, in __init__
    _sock = _realsocket(family, type, proto)
socket.error: [Errno 97] Address family not supported by protocol
>>>

I have a feeling that some library is not up to date.
A real example when I try to ping the Bookkeeping service:
[zmathe@pclhcb63 LHCbDirac_v8r2p7]$ python ~/tt.py
Info ('128.142.152.39', 9135) 2
Connect: ('128.142.152.39', 9135)
Info ('128.142.152.84', 9200) 2
Connect: ('128.142.152.84', 9200)
f 0.000657081604004
Info ('2001:1458:301:48::100:46', 9200, 0, 0) 10
{'Message': "Can't connect to dips://lbtestvobox.cern.ch:9200/Bookkeeping/BookkeepingManager: [Errno 97] Address family not supported by protocol", 'OK': False, 'rpcStub': (('Bookkeeping/BookkeepingManager', {'skipCACheck': True, 'keepAliveLapse': 150, 'delegatedGroup': 'lhcb_user', 'delegatedDN': '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=zmathe/CN=674937/CN=Zoltan Mathe', 'timeout': 600}), 'ping', ())}

The solution is: I try the next address which is ipv4!

[zmathe@pclhcb63 LHCbDirac_v8r2p7]$ python ~/tt.py
Info ('128.142.152.39', 9135) 2
Connect: ('128.142.152.39', 9135)
Info ('128.142.140.250', 9200) 2
Connect: ('128.142.140.250', 9200)
{'OK': True, 'rpcStub': (('Bookkeeping/BookkeepingManager', {'skipCACheck': True, 'keepAliveLapse': 150, 'delegatedGroup': 'lhcb_user', 'delegatedDN': '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=zmathe/CN=674937/CN=Zoltan Mathe', 'timeout': 600}), 'ping', ()), 'Value': {'load': '0.00 0.00 0.00', 'service uptime': 2367, 'name': 'Bookkeeping/BookkeepingManager', 'service start time': datetime.datetime(2015, 10, 21, 8, 37, 39, 983974), 'host uptime': 2312056L, 'version': 'v6r14p7', 'time': datetime.datetime(2015, 10, 21, 9, 17, 7, 540572), 'cpu times': {'user time': 69.58, 'children system time': 0.01, 'system time': 17.46, 'elapsed real time': 6605719.78, 'children user time': 0.0}}}

This will not break nothing, but it allows to use ipv4 in case ipv6 does not work.