### PR TITLE
[v6r12] fix: cleanDirectory fails for empty directories

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1007,6 +1007,8 @@ class DataManager( object ):
 
         'lfn' is the file to be removed
     """
+    if not lfn:
+      return S_OK( { 'Successful': {}, 'Failed': {} } )
     if force == None:
       force = self.ignoreMissingInFC
     if type( lfn ) == ListType:


### PR DESCRIPTION
cleanDirectory (e.g., called from dirac-dms-clean-directory) fails when the directory itself is empty,
```
Failed to clean directory. /ilc/prod/ilc/mc-dbd/ild/dst/250-TDR_ws/higgs_ffh/ILD_o1_v05/v01-16-p10_250/00005972/000 Failed to perform exists from any catalog
```
 because the function passes an empty list to removeFile here https://github.com/andresailer/DIRAC/blob/de7cc06e8d86f8ff0787e315faf76824688413ab/DataManagementSystem/Client/DataManager.py#L128
, removeFile then passes an empty list to exists which returns an error.

Now there are three locations to fix that: 
 * in cleanDirectory not passing an empty list
 * in removeFile returning success for empty input 
 * in exists to also return success in case of empty input (I guess, did not actually try that...)

I chose the second option here because it has the smallest footprint of changes as far as I can tell