### PR TITLE
[v6r14] Matching jobs by hosts in a multi-VO environment

### DIFF
--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -401,14 +401,14 @@ class ComputingElement(object):
 
     ceDict = {}
     for option, value in self.ceParameters.items():
-      if type( value ) == type( [] ):
+      if isinstance( value, list ):
         ceDict[option] = value
-      elif type( value ) == type( ' ' ):
+      elif isinstance( value, basestring ):
         try:
           ceDict[option] = int( value )
         except:
           ceDict[option] = value  
-      elif type( value ) == type( 1 ) or type( value ) == type( 1. ):
+      elif isinstance( value, ( int, long, float ) ):
         ceDict[option] = value
       else:
         self.log.warn( 'Type of option %s = %s not determined' % ( option, value ) )
@@ -428,7 +428,8 @@ class ComputingElement(object):
           tagList = []
           for i in range( 2, cores+1 ):
             tagList.append( '%dCore' % i )
-          ceDict['Tag'] = tagList  
+          ceDict.setdefault( 'Tag', [] )
+          ceDict['Tag'] += tagList
 
     return S_OK( ceDict )
 

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -428,8 +428,7 @@ class ComputingElement(object):
           tagList = []
           for i in range( 2, cores+1 ):
             tagList.append( '%dCore' % i )
-          ceDict.setdefault( 'Tag', [] )
-          ceDict['Tag'] += tagList
+          ceDict.setdefault( 'Tag', [] ).extend( tagList )
 
     return S_OK( ceDict )
 

--- a/WorkloadManagementSystem/Client/Matcher.py
+++ b/WorkloadManagementSystem/Client/Matcher.py
@@ -6,10 +6,10 @@
 __RCSID__ = "$Id"
 
 import time
-from types import StringTypes
 
-from DIRAC import gLogger, gMonitor
+from DIRAC import gLogger
 
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
 from DIRAC.Core.Security import Properties
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
@@ -150,7 +150,7 @@ class Matcher( object ):
     """
 
     resourceDict = {}
-    if type( resourceDescription ) in StringTypes:
+    if isinstance( resourceDescription, basestring ):
       classAdAgent = ClassAd( resourceDescription )
       if not classAdAgent.isOK():
         raise ValueError( 'Illegal Resource JDL' )
@@ -276,10 +276,14 @@ class Matcher( object ):
   def _checkCredentials( self, resourceDict, credDict ):
     """ Check if we can get a job given the passed credentials
     """
-    # Check credentials if not generic pilot
     if Properties.GENERIC_PILOT in credDict[ 'properties' ]:
       # You can only match groups in the same VO
-      vo = Registry.getVOForGroup( credDict[ 'group' ] )
+      if credDict[ 'group' ] == "hosts":
+        # for the host case the VirtualOrganization parameter
+        # is mandatory in resourceDict
+        vo = resourceDict.get( 'VirtualOrganization', '' )
+      else:
+        vo = Registry.getVOForGroup( credDict[ 'group' ] )
       result = Registry.getGroupsForVO( vo )
       if result[ 'OK' ]:
         resourceDict[ 'OwnerGroup' ] = result[ 'Value' ]


### PR DESCRIPTION
The hosts requesting jobs as GenericPilot must provide a VirtualOrganization parameter in the resource description, then they are allowed to match jobs.
Plus a bug fix in the resource description evaluation where Tags were sometimes overwritten