### PR TITLE
[v6r15] DErrno: compatible string for ENOENT and fix in cmpErr

### DIFF
--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -37,9 +37,9 @@
 
 import os
 import traceback
+import errno
 import imp
 import sys
-
 
 # To avoid conflict, the error numbers should be greater than 1000
 # We decided to group the by range of 100 per system
@@ -101,8 +101,9 @@ dStrError = { ERRX : "A human readable error message for ERRX",
 
 # In case the error is returned as a string, and not as a DErrno object, 
 # these strings are used to test the error. 
-compatErrorString = { ERRX : ['not found', 'X'],
-
+compatErrorString = {
+                     # ERRX : ['not found', 'X'],
+                       errno.ENOENT : ['File does not exist']
                      }
 
 def strerror(code):
@@ -190,7 +191,7 @@ class DError( object ):
   
   def __cmp__( self, errorStr ):
     """ For compatibility reasons.
-        Checks whether 'other', which should be a string, is equal to the human readable form of the error msg
+        Checks whether 'errorStr', which should be a string, is equal to the human readable form of the error msg
     """
     # !!! Caution, if there is equality, we have to return 0 (rules of __cmp__)
 
@@ -257,10 +258,13 @@ def cmpError( inErr, candidate ):
     return inErr == candidate
   elif isinstance( inErr, DError ):
     return inErr.errno == candidate
+  elif isinstance( inErr, dict ):  # S_ERROR object is given
+    # Create a DError object to represent the candidate
+    derr = DError( candidate )
+    return inErr.get( 'Message', '' ) == derr
   else:
     raise TypeError( "Unknown input error type %s" % type( inErr ) )
 
-  return False
 
 
 


### PR DESCRIPTION
This is a port of fixes that are included in this https://github.com/DIRACGrid/DIRAC/pull/2668, which will probably not be merged in v6r15 