### PR TITLE
[v6r12] Fix job rescheduling on (glexec) error

### DIFF
--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -456,7 +456,8 @@ class JobAgent( AgentModule ):
       self.log.error( 'Job submission failed', jobID )
       self.__setJobParam( jobID, 'ErrorMessage', '%s CE Submission Error' % ( self.ceName ) )
       if 'ReschedulePayload' in submission:
-        rescheduleFailedJob( jobID, submission['Message'], self.__report )
+        rescheduleFailedJob( jobID, submission['Message'] )
+        return S_OK()  # Without this job is marked as failed at line 265 above
       else:
         if 'Value' in submission:
           self.log.error( 'Error in DIRAC JobWrapper:', 'exit code = %s' % ( str( submission['Value'] ) ) )


### PR DESCRIPTION
We found that when a glexec wrapped job failed and rescheduleOnError was True, the rescheduling would trigger an exception. This patch fixes that problem and also returns S_OK() so that the outer layer of the JobAgent doesn't immediately mark the job as failed again.

Regards,
Simon
