### PR TITLE
[v6r12] Improved ls in the dirac filecatalog

### DIFF
--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -1699,8 +1699,8 @@ File Catalog Client $Revision: 1.17 $Date:
                                                          -d  directory metadata
                                                          -f  file metadata
                                                          -r  remove the specified metadata index
-          meta set <path> <metaname> <metavalue> - set metadata value for directory or file
-          meta remove <path> <metaname>  - remove metadata value for directory or file
+          meta set <path> <metaname> <metavalue> [<metaname> <metavalue> ...]- set metadata values for directory or file
+          meta remove <path> <metaname> [<metaname> ...] - remove metadata values for directory or file
           meta get [-e] [<path>] - get metadata for the given directory or file
           meta tags <path> <metaname> where <meta_selection> - get values (tags) of the given metaname compatible with 
                                                         the metadata selection
@@ -1714,7 +1714,7 @@ File Catalog Client $Revision: 1.17 $Date:
     option = argss[0]
     del argss[0]
     if option == 'set':
-      if (len(argss) != 3):
+      if (len(argss) < 3 or len(argss)%2 != 1):
         print self.do_meta.__doc__
         return
       return self.setMeta(argss)
@@ -1740,7 +1740,7 @@ File Catalog Client $Revision: 1.17 $Date:
     elif option == 'show':
       return self.showMeta()
     elif option == 'remove' or option == "rm":
-      if (len(argss) != 2):
+      if (len(argss) < 2):
         print self.do_meta.__doc__
         return
       return self.removeMeta(argss) 
@@ -1800,19 +1800,19 @@ File Catalog Client $Revision: 1.17 $Date:
   def setMeta(self,argss):
     """ Set metadata value for a directory
     """      
-    if len(argss) != 3:
-      print "Error: command requires 3 arguments, %d given" % len(argss)
+    if (len(argss) < 3 or len(argss)%2 != 1):
+      print "Error: command requires at least 3 arguments (or odd number of arguments > 3), %d given" % len(argss)
       return
     path = argss[0]
     if path == '.':
       path = self.cwd
     elif path[0] != '/':
       path = self.cwd+'/'+path  
-    meta = argss[1]
-    value = argss[2]
-    print path,meta,value
-    metadict = {}
-    metadict[meta]=value
+    del argss[0]
+    meta = argss[::2]
+    value = argss[1::2]
+    metadict = {meta[n]:value[n] for n in range(len(meta))}
+    print path,metadict
     result = self.fc.setMetadata(path,metadict)
     if not result['OK']:
       print ("Error: %s" % result['Message'])     

--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -262,7 +262,7 @@ File Catalog Client $Revision: 1.17 $Date:
       path = apath
     else:
       path = self.cwd+'/'+apath
-      path = path.replace('//','/')
+    path = path.replace('//','/')
 
     return os.path.normpath(path)
   
@@ -1117,7 +1117,7 @@ File Catalog Client $Revision: 1.17 $Date:
     else:
       newdir = self.cwd + '/' + path
       
-    newdir = newdir.replace(r'//','/')
+    newdir = self.getPath(newdir)
     
     result =  self.fc.createDirectory(newdir)    
     if result['OK']:
@@ -1292,11 +1292,7 @@ File Catalog Client $Revision: 1.17 $Date:
         path = argss[0]       
         if path[0] != '/':
           path = self.cwd+'/'+path      
-    path = path.replace(r'//','/')
-
-    # remove last character if it is "/"    
-    if path[-1] == '/' and path != '/':
-      path = path[:-1]
+    path = self.getPath(path)
     
     # Check if the target path is a file
     result =  self.fc.isFile(path)          
@@ -1659,6 +1655,7 @@ File Catalog Client $Revision: 1.17 $Date:
       print self.do_guid.__doc__
       return
     path = argss[0]
+    path = self.getPath(path)
     try:
       result =  self.fc.getFileMetadata(path)
       if result['OK']:
@@ -1808,6 +1805,7 @@ File Catalog Client $Revision: 1.17 $Date:
       path = self.cwd
     elif path[0] != '/':
       path = self.cwd+'/'+path  
+    path = self.getPath(path)
     del argss[0]
     meta = argss[::2]
     value = argss[1::2]
@@ -2076,7 +2074,7 @@ File Catalog Client $Revision: 1.17 $Date:
 
       listToPrint = None
       if dirsOnly:
-        listToPrint = set( "/".join(fullpath.split("/")[:-1]) for fullpath in result['Value'] )
+        listToPrint = set( os.path.dirname(fullpath) for fullpath in result['Value'] )
       else:
         listToPrint = result['Value']
 

--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -179,7 +179,7 @@ class DirectoryListing:
       
     return pstring  
   
-  def human_readable_size(self,num,suffix='B'):
+  def humanReadableSize(self,num,suffix='B'):
     """ Translate file size in bytes to human readable
 
         Powers of 2 are used (1Mi = 2^20 = 1048576 bytes).
@@ -215,9 +215,9 @@ class DirectoryListing:
     for d in self.entries:
       for i in range(7):
         if humanread and i == 4:
-          humanread_len = len(str(self.human_readable_size(d[4])))
-          if humanread_len > wList[4]:
-            wList[4] = humanread_len
+          humanreadlen = len(str(self.humanReadableSize(d[4])))
+          if humanreadlen > wList[4]:
+            wList[4] = humanreadlen
         else:
           if len(str(d[i])) > wList[i]:
             wList[i] = len(str(d[i]))
@@ -225,7 +225,7 @@ class DirectoryListing:
     for e in self.entries:
       size = e[4]
       if humanread:
-        size = self.human_readable_size(e[4])
+        size = self.humanReadableSize(e[4])
       print str(e[0]),
       print str(e[1]).rjust(wList[1]),
       print str(e[2]).ljust(wList[2]),
@@ -1310,12 +1310,12 @@ File Catalog Client $Revision: 1.17 $Date:
     numericid = False
     sizeorder = False
     humanread = False
-    short_opts = 'ltrnSH'
-    long_opts = ['long','timeorder','reverse','numericid','sizeorder','human-readable']
+    shortopts = 'ltrnSH'
+    longopts = ['long','timeorder','reverse','numericid','sizeorder','human-readable']
     path = self.cwd
     if len(argss) > 0:
       try:
-        optlist, arguments = getopt.getopt(argss,short_opts,long_opts)
+        optlist, arguments = getopt.getopt(argss,shortopts,longopts)
       except getopt.GetoptError, e:
         print str(e)
         print self.do_ls.__doc__
@@ -1351,13 +1351,13 @@ File Catalog Client $Revision: 1.17 $Date:
         
       # Get path    
       if arguments:
-        input_path = False
-        while arguments or not input_path:
+        inputpath = False
+        while arguments or not inputpath:
           tmparg = arguments.pop()
           # look for a non recognized option not starting with '-'
           if tmparg[0] != '-':
             path = tmparg
-            input_path = True
+            inputpath = True
             if path[0] != '/':
               path = self.cwd+'/'+path
     path = self.getPath(path)

--- a/release.notes
+++ b/release.notes
@@ -1,3 +1,15 @@
+[v6r12p49]
+
+*Resources
+FIX: GlobusComputingElement - in killJob added -f switch to globus-job-clean command
+FIX: ARCComputingElement - create working directory if it does not exist
+
+*DMS
+CHANGE: DataManager - added XROOTD to registration protocols
+
+*TMS
+FIX: TransformationCLI - doc string
+
 [v6r12p48]
 
 *DMS


### PR DESCRIPTION
Changed short option to list size i nhuman readable from '-h' to '-H'.
This is necessary in order to use same parameters in dls command
without conflicting with the script help (also '-h').