### PR TITLE
[v6r15] move missing wc/cpu time workaround fixes from batchPlugins to TimeLeft

### DIFF
--- a/Core/Utilities/TimeLeft/MJFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/MJFTimeLeft.py
@@ -78,7 +78,7 @@ class MJFTimeLeft:
     # We cannot get CPU usage from MJF
       
     consumed = {'CPU':cpu, 'CPULimit':cpuLimit, 'WallClock':wallClock, 'WallClockLimit':wallClockLimit}
-    self.log.debug( consumed )
+    self.log.debug( "MJF consumed: %s" % str( consumed ) )
 
     if cpuLimit and wallClock and wallClockLimit:
       return S_OK( consumed )

--- a/Core/Utilities/TimeLeft/MJFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/MJFTimeLeft.py
@@ -73,16 +73,14 @@ class MJFTimeLeft:
       cpuLimit = int( urllib.urlopen(jobFeaturesPath + '/cpu_limit_secs').read() )
     except:
       self.log.warn( 'Could not determine cpu limit from $JOBFEATURES/cpu_limit_secs' )
-      cpuLimit = wallClockLimit
 
     wallClock = int(time.time()) - jobStartSecs
-    # We cannot get CPU usage from MJF, so for now use wallClock figure
-    cpu = wallClock
+    # We cannot get CPU usage from MJF
       
     consumed = {'CPU':cpu, 'CPULimit':cpuLimit, 'WallClock':wallClock, 'WallClockLimit':wallClockLimit}
     self.log.debug( consumed )
 
-    if cpu and cpuLimit and wallClock and wallClockLimit:
+    if cpuLimit and wallClock and wallClockLimit:
       return S_OK( consumed )
     else:
       self.log.info( 'Could not determine some parameters' )

--- a/Core/Utilities/TimeLeft/PBSTimeLeft.py
+++ b/Core/Utilities/TimeLeft/PBSTimeLeft.py
@@ -100,14 +100,8 @@ class PBSTimeLeft( object ):
       return S_OK( consumed )
 
     if cpuLimit or wallClockLimit:
-      # We have got a partial result from PBS, assume that we ran for too short time
-      if not cpuLimit:
-        consumed['CPULimit'] = wallClockLimit
-      if not wallClockLimit:
-        consumed['WallClockLimit'] = cpuLimit
-      if not cpu:
-        consumed['CPU'] = int( time.time() - self.startTime )
-      if not wallClock:
+      # We have got a partial result from PBS, we can only restore WallClock
+      if not wallClock:  
         consumed['WallClock'] = int( time.time() - self.startTime )
       self.log.debug( "TimeLeft counters restored:", str( consumed ) )
       return S_OK( consumed )

--- a/Core/Utilities/TimeLeft/SGETimeLeft.py
+++ b/Core/Utilities/TimeLeft/SGETimeLeft.py
@@ -88,12 +88,6 @@ class SGETimeLeft( object ):
 
     if cpuLimit or wallClockLimit:
       # We have got a partial result from SGE
-      if not cpuLimit:
-        consumed['CPULimit'] = wallClockLimit
-      if not wallClockLimit:
-        consumed['WallClockLimit'] = cpuLimit
-      if not cpu:
-        consumed['CPU'] = time.time() - self.startTime
       if not wallClock:
         consumed['WallClock'] = time.time() - self.startTime
       self.log.debug( "TimeLeft counters restored:", str( consumed ) )

--- a/Core/Utilities/TimeLeft/TimeLeft.py
+++ b/Core/Utilities/TimeLeft/TimeLeft.py
@@ -56,7 +56,16 @@ class TimeLeft( object ):
     if not self.batchPlugin:
       return 0
 
-    return self.batchPlugin.getResourceUsage().get( 'Value', {} ).get( 'CPU', 0.0 ) * self.scaleFactor
+    resourceDict = self.batchPlugin.getResourceUsage()
+
+    if 'Value' in resourceDict:
+      if resourceDict['Value']['CPU']:
+        return resourceDict['Value']['CPU'] * self.scaleFactor
+      elif resourceDict['Value']['WallClock']:
+        # build a reasonable CPU value from WallClock
+        return resourceDict['Value']['WallClock'] * self.scaleFactor
+
+    return 0
 
   #############################################################################
   def getTimeLeft( self, cpuConsumed = 0.0 ):
@@ -76,9 +85,22 @@ class TimeLeft( object ):
       return resourceDict
 
     resources = resourceDict['Value']
-    if not resources['CPULimit'] or not resources['WallClockLimit']:
+    self.log.verbose( resources )
+    if not resources['CPULimit'] and not resources['WallClockLimit']:
       # This should never happen
       return S_ERROR( 'No CPU or WallClock limit obtained' )
+
+    # if one of CPULimit or WallClockLimit is missing, compute a reasonable value
+    if not resources['CPULimit']:
+      resources['CPULimit'] = resources['WallClockLimit']
+    elif not resources['WallClockLimit']:
+      resources['WallClockLimit'] = resources['CPULimit']
+
+    # if one of CPU or WallClock is missing, compute a reasonable value
+    if not resources['CPU']:
+      resources['CPU'] = resources['WallClock']
+    elif not resources['WallClock']:
+      resources['WallClock'] = resources['CPU']
 
     timeLeft = 0.
     cpu = float( resources['CPU'] )

--- a/Core/Utilities/TimeLeft/TimeLeft.py
+++ b/Core/Utilities/TimeLeft/TimeLeft.py
@@ -85,7 +85,7 @@ class TimeLeft( object ):
       return resourceDict
 
     resources = resourceDict['Value']
-    self.log.verbose( resources )
+    self.log.debug( "self.batchPlugin.getResourceUsage(): %s" % str( resources ) )
     if not resources['CPULimit'] and not resources['WallClockLimit']:
       # This should never happen
       return S_ERROR( 'No CPU or WallClock limit obtained' )


### PR DESCRIPTION
The batch plugins won't mix CPU and walltime values anymore, missing values are handled by the TimeLeft object.

This is the first part of the replacement of #2629