### PR TITLE
[v6r14] Requested script to run jobs locally using job().runlocal() from the API

### DIFF
--- a/TransformationSystem/scripts/dirac-production-runjoblocal.py
+++ b/TransformationSystem/scripts/dirac-production-runjoblocal.py
@@ -102,47 +102,17 @@ def __downloadPilotScripts(basepath, diracpath):
   Downloads the scripts necessary to configure the pilot
   
   """
-  ### dirac path = /afs/cern.ch/lhcb/software/releases/DIRAC/DIRAC_v6r14p5/DIRAC/WorkloadManagementSystem/PilotAgent
   shutil.copyfile(str(diracpath) + "/WorkloadManagementSystem/PilotAgent/dirac-pilot.py"   , basepath + "/dirac-pilot.py")
   shutil.copyfile(str(diracpath) + "/WorkloadManagementSystem/PilotAgent/pilotCommands.py" , basepath + "/pilotCommands.py")
   shutil.copyfile(str(diracpath) + "/WorkloadManagementSystem/PilotAgent/pilotTools.py"    , basepath + "/pilotTools.py")
-  
-  
-#   #include retry function
-#   out = os.system("wget -P " + basepath + "/ http://lhcbproject.web.cern.ch/lhcbproject/Operations/VM/pilotscripts/LHCbPilotCommands.py")
-#   if not out:
-#     S_OK("LHCbPilotCommands.py script successfully download.\n")
-#   else:
-#     print "LHCbPilotCommands.py script download error.\n"
-#     #DError(errno.ENETUNREACH, "LHCbPilotCommands.py script download error.\n" )
-#   out = os.system("wget -P " + basepath +  "/ http://lhcbproject.web.cern.ch/lhcbproject/Operations/VM/pilotscripts/dirac-pilot.py")
-#   if not out:
-#     S_OK("dirac-pilot.py script successfully download.\n")
-#   else:
-#     print "dirac-pilot.py script download error.\n"
-#     #DError(errno.ENETUNREACH, "dirac-pilot.py script download error.\n" )
-#   out = os.system("wget -P " + basepath +  "/ http://lhcbproject.web.cern.ch/lhcbproject/Operations/VM/pilotscripts/pilotCommands.py")
-#   if not out:
-#     S_OK("pilotCommands.py script successfully download.\n")
-#   else:
-#     print "pilotCommands.py script download error.\n"
-#     #DError(errno.ENETUNREACH, "pilotCommands.py script download error.\n" )
-#   out = os.system("wget -P " + basepath +  "/ http://lhcbproject.web.cern.ch/lhcbproject/Operations/VM/pilotscripts/pilotTools.py")
-#   if not out:
-#     S_OK("pilotTools.py script successfully download.\n")
-#   else:
-#     print "pilotTools.py script download error.\n"
-#     #DError(errno.ENETUNREACH, "pilotTools.py script download error.\n" )
-    
-    
+      
 def __configurePilot(basepath, vo):
   """
   Configures the pilot.
   This method was created specifically for LHCb pilots, more info
   about othe VOs is needed to make it more general.
   """
-#   out = os.system("python " + basepath + "/dirac-pilot.py -S LHCb-Production -l LHCb -C dips://lbvobox18.cern.ch:9135/Configuration/Server -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -M 1 -E LHCbPilot -X LHCbConfigureBasics,LHCbConfigureSite,LHCbConfigureArchitecture,LHCbConfigureCPURequirements -dd")
-#   if not out:
+
   from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals    import getVO, getSetup
   from DIRAC.ConfigurationSystem.Client.ConfigurationData    import gConfigurationData
   
@@ -155,11 +125,6 @@ def __configurePilot(basepath, vo):
   masterCS = gConfigurationData.getMasterServer()
 
   os.system("python " + basepath + "/dirac-pilot.py -S %s -l %s -C %s -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -dd" %(currentSetup, vo, masterCS))
-
-#     return S_OK("Pilot successfully configured.")
-  
-#   else:
-#     some DErrno message
 
 def __runJobLocally(jobID, basepath, vo):
   """

--- a/TransformationSystem/scripts/dirac-production-runjoblocal.py
+++ b/TransformationSystem/scripts/dirac-production-runjoblocal.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+'''
+  dirac-production-runjoblocal
+ 
+  Module created to run failed jobs locally on a CVMFS-configured machine.
+  It creates the necessary environment, downloads the necessary files, modifies the necessary 
+  files and runs the job
+  
+  Usage:
+    dirac-production-diracrunjoblocal (job ID)  -  No parenthesis
+    
+'''
+
+__RCSID__ = "$transID: dirac-production-runjoblocal.py 61232 2015-09-22 16:20:00 msoares $"
+
+
+import DIRAC
+import os
+import sys
+import errno
+import shutil
+#from DIRAC.Core.Utilities import DError
+from DIRAC.Core.Base      import Script
+from DIRAC                import S_OK, S_ERROR
+
+Script.registerSwitch( 'D:', 'Download='    , 'Defines data acquisition as DownloadInputData'   )
+Script.registerSwitch( 'P:', 'Protocol='    , 'Defines data acquisition as InputDataByProtocol' )
+Script.parseCommandLine( ignoreErrors = False )
+
+Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
+                                      '\nUsage:',
+                                      'dirac-production-runjoblocal [Data imput mode] [job ID]'
+                                      '\nArguments:',
+                                      '  Download (Job ID): Defines data aquisition as DownloadInputData',
+                                      '  Protocol (Job ID): Defines data acquisition as InputDataByProtocol\n'] ) )
+
+_downloadinputdata = False
+_jobID = None
+
+for switch in Script.getUnprocessedSwitches():
+  if switch [ 0 ] in ( 'D', 'Download' ):
+    _downloadinputdata = True
+    _jobID = switch[1]
+  if switch [ 0 ] in ( 'I', 'Protocol' ):
+    _downloadinputdata = False
+    _jobID = switch[1]
+
+def __runSystemDefaults(jobID, vo):
+  """
+  Creates the environment for running the job and returns
+  the path for the other functions.
+  
+  """
+
+  
+  tempdir = str(vo) + "job" + str(jobID) + "temp"
+
+  try:
+    os.mkdir(tempdir)
+    if not sys.exc_info()[1][0]:
+      S_OK("Temporary directory created.")    
+    pass
+  except:    
+    if sys.exc_info()[1][0] == 17:
+      S_OK("Temporary directory already exists.")
+    elif sys.exc_info()[1][0] == 30:
+      print sys.exc_info()[1], "Unable to create temporary directory"
+#      DError(errno.EROFS, "Unable to create temporary directory")
+
+    
+  basepath = os.getcwd()
+  return basepath + "/" + tempdir
+
+def __downloadJobDescriptionXML(jobID, basepath):
+  """
+  Downloads the jobDescription.xml file into the temporary directory
+  created.
+  
+  """
+  from DIRAC.Interfaces.API.Dirac import Dirac
+  jdXML = Dirac()
+  jdXML.getInputSandbox(jobID, basepath)
+
+def __modifyJobDescription(jobID, basepath, downloadinputdata):
+  """
+  Modifies the jobDescription.xml to, instead of DownloadInputData, it 
+  uses InputDataByProtocol
+  
+  """
+  if not downloadinputdata:
+    from xml.etree import ElementTree as et
+    archive = et.parse(basepath + "/InputSandbox" + str(jobID) + "/jobDescription.xml")
+    for element in archive.getiterator():
+      if element.text == "DIRAC.WorkloadManagementSystem.Client.DownloadInputData":
+        element.text = "DIRAC.WorkloadManagementSystem.Client.InputDataByProtocol"
+        archive.write(basepath + "/InputSandbox" + str(jobID) + "/jobDescription.xml")
+        S_OK("Job parameter changed from DownloadInputData to InputDataByProtocol.")
+
+  
+def __downloadPilotScripts(basepath, diracpath):
+  """
+  Downloads the scripts necessary to configure the pilot
+  
+  """
+  ### dirac path = /afs/cern.ch/lhcb/software/releases/DIRAC/DIRAC_v6r14p5/DIRAC/WorkloadManagementSystem/PilotAgent
+  shutil.copyfile(str(diracpath) + "/WorkloadManagementSystem/PilotAgent/dirac-pilot.py"   , basepath + "/dirac-pilot.py")
+  shutil.copyfile(str(diracpath) + "/WorkloadManagementSystem/PilotAgent/pilotCommands.py" , basepath + "/pilotCommands.py")
+  shutil.copyfile(str(diracpath) + "/WorkloadManagementSystem/PilotAgent/pilotTools.py"    , basepath + "/pilotTools.py")
+  
+  
+#   #include retry function
+#   out = os.system("wget -P " + basepath + "/ http://lhcbproject.web.cern.ch/lhcbproject/Operations/VM/pilotscripts/LHCbPilotCommands.py")
+#   if not out:
+#     S_OK("LHCbPilotCommands.py script successfully download.\n")
+#   else:
+#     print "LHCbPilotCommands.py script download error.\n"
+#     #DError(errno.ENETUNREACH, "LHCbPilotCommands.py script download error.\n" )
+#   out = os.system("wget -P " + basepath +  "/ http://lhcbproject.web.cern.ch/lhcbproject/Operations/VM/pilotscripts/dirac-pilot.py")
+#   if not out:
+#     S_OK("dirac-pilot.py script successfully download.\n")
+#   else:
+#     print "dirac-pilot.py script download error.\n"
+#     #DError(errno.ENETUNREACH, "dirac-pilot.py script download error.\n" )
+#   out = os.system("wget -P " + basepath +  "/ http://lhcbproject.web.cern.ch/lhcbproject/Operations/VM/pilotscripts/pilotCommands.py")
+#   if not out:
+#     S_OK("pilotCommands.py script successfully download.\n")
+#   else:
+#     print "pilotCommands.py script download error.\n"
+#     #DError(errno.ENETUNREACH, "pilotCommands.py script download error.\n" )
+#   out = os.system("wget -P " + basepath +  "/ http://lhcbproject.web.cern.ch/lhcbproject/Operations/VM/pilotscripts/pilotTools.py")
+#   if not out:
+#     S_OK("pilotTools.py script successfully download.\n")
+#   else:
+#     print "pilotTools.py script download error.\n"
+#     #DError(errno.ENETUNREACH, "pilotTools.py script download error.\n" )
+    
+    
+def __configurePilot(basepath):
+  """
+  Configures the pilot.
+  This method was created specifically for LHCb pilots, more info
+  about othe VOs is needed to make it more general.
+  """
+#   out = os.system("python " + basepath + "/dirac-pilot.py -S LHCb-Production -l LHCb -C dips://lbvobox18.cern.ch:9135/Configuration/Server -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -M 1 -E LHCbPilot -X LHCbConfigureBasics,LHCbConfigureSite,LHCbConfigureArchitecture,LHCbConfigureCPURequirements -dd")
+#   if not out:
+  dir = str(os.getcwd())
+  os.rename(dir + '/.dirac.cfg', dir + '/.dirac.cfg.old')
+  os.system("cp " + dir + "/pilot.cfg " + dir + "/.dirac.cfg")
+#     return S_OK("Pilot successfully configured.")
+  
+#   else:
+#     some DErrno message
+
+def __runJobLocally(jobID, basepath, vo):
+  """
+  Runs the job!
+  
+  """
+  ipr = __import__(str(vo) + 'DIRAC.Interfaces.API.' + str(vo) + 'Job', globals(), locals(), [str(vo) + 'Job'], -1)
+  voJob = getattr(ipr, str(vo) + 'Job')
+  localJob = voJob(basepath + "/InputSandbox" + str(jobID) + "/jobDescription.xml")
+  localJob.setInputSandbox(os.getcwd()+"/pilot.cfg")
+  localJob.setConfigArgs(os.getcwd()+"/pilot.cfg")
+  os.chdir(basepath)
+  localJob.runLocal()
+  
+
+if __name__ == "__main__":
+  from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import Extensions
+  ext = Extensions()
+  _vo = ext.getCSExtensions()[0]
+  _diracPath = Extensions().getExtensionPath('DIRAC')
+  _dir = os.getcwd()
+  try:
+    _path = __runSystemDefaults(_jobID, _vo)
+      
+    __downloadJobDescriptionXML(_jobID, _path)
+      
+    __modifyJobDescription(_jobID, _path, _downloadinputdata)
+    
+    __downloadPilotScripts(_path, _diracPath)
+    
+#    __configurePilot(_path)
+    
+    __runJobLocally(_jobID, _path, _vo)
+    
+  finally:
+    os.chdir(_dir)
+    os.rename(_dir + '/.dirac.cfg.old', _dir + '/.dirac.cfg')

--- a/TransformationSystem/scripts/dirac-production-runjoblocal.py
+++ b/TransformationSystem/scripts/dirac-production-runjoblocal.py
@@ -124,8 +124,11 @@ def __configurePilot(basepath, vo):
 
   os.system("python " + basepath + "dirac-pilot.py -S %s -l %s -C %s -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -dd" %(currentSetup, vo, masterCS))
   
-  dir = str(os.getcwd()) + os.path.sep
-  os.rename(dir + '.dirac.cfg', dir + '.dirac.cfg.old')
+  dir = os.path.expanduser('~') + os.path.sep
+  try:
+    os.rename(dir + '.dirac.cfg', dir + '.dirac.cfg.old')
+  except OSError:
+    pass
   shutil.copyfile(dir + 'pilot.cfg', dir + '.dirac.cfg')
 
 def __runJobLocally(jobID, basepath, vo):
@@ -147,7 +150,7 @@ if __name__ == "__main__":
   ext = Extensions()
   _vo = ext.getCSExtensions()[0]
   _diracPath = Extensions().getExtensionPath('DIRAC')
-  _dir = str(os.getcwd()) + os.path.sep
+  _dir = os.path.expanduser('~') + os.path.sep
   try:
     _path = __runSystemDefaults(_jobID, _vo)
       

--- a/TransformationSystem/scripts/dirac-production-runjoblocal.py
+++ b/TransformationSystem/scripts/dirac-production-runjoblocal.py
@@ -135,7 +135,7 @@ def __downloadPilotScripts(basepath, diracpath):
 #     #DError(errno.ENETUNREACH, "pilotTools.py script download error.\n" )
     
     
-def __configurePilot(basepath):
+def __configurePilot(basepath, vo):
   """
   Configures the pilot.
   This method was created specifically for LHCb pilots, more info
@@ -143,9 +143,19 @@ def __configurePilot(basepath):
   """
 #   out = os.system("python " + basepath + "/dirac-pilot.py -S LHCb-Production -l LHCb -C dips://lbvobox18.cern.ch:9135/Configuration/Server -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -M 1 -E LHCbPilot -X LHCbConfigureBasics,LHCbConfigureSite,LHCbConfigureArchitecture,LHCbConfigureCPURequirements -dd")
 #   if not out:
+  from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals    import getVO, getSetup
+  from DIRAC.ConfigurationSystem.Client.ConfigurationData    import gConfigurationData
+  
   dir = str(os.getcwd())
   os.rename(dir + '/.dirac.cfg', dir + '/.dirac.cfg.old')
   os.system("cp " + dir + "/pilot.cfg " + dir + "/.dirac.cfg")
+  
+  vo = getVO()
+  currentSetup = getSetup()
+  masterCS = gConfigurationData.getMasterServer()
+
+  os.system("python " + basepath + "/dirac-pilot.py -S %s -l %s -C %s -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -dd" %(currentSetup, vo, masterCS))
+
 #     return S_OK("Pilot successfully configured.")
   
 #   else:
@@ -180,7 +190,7 @@ if __name__ == "__main__":
     
     __downloadPilotScripts(_path, _diracPath)
     
-#    __configurePilot(_path)
+    __configurePilot(_path)
     
     __runJobLocally(_jobID, _path, _vo)
     

--- a/TransformationSystem/scripts/dirac-production-runjoblocal.py
+++ b/TransformationSystem/scripts/dirac-production-runjoblocal.py
@@ -69,7 +69,7 @@ def __runSystemDefaults(jobID, vo):
 
     
   basepath = os.getcwd()
-  return basepath + "/" + tempdir
+  return basepath + os.path.sep + tempdir + os.path.sep
 
 def __downloadJobDescriptionXML(jobID, basepath):
   """
@@ -89,11 +89,11 @@ def __modifyJobDescription(jobID, basepath, downloadinputdata):
   """
   if not downloadinputdata:
     from xml.etree import ElementTree as et
-    archive = et.parse(basepath + "/InputSandbox" + str(jobID) + "/jobDescription.xml")
+    archive = et.parse(basepath + "InputSandbox" + str(jobID) + os.path.sep + "jobDescription.xml")
     for element in archive.getiterator():
       if element.text == "DIRAC.WorkloadManagementSystem.Client.DownloadInputData":
         element.text = "DIRAC.WorkloadManagementSystem.Client.InputDataByProtocol"
-        archive.write(basepath + "/InputSandbox" + str(jobID) + "/jobDescription.xml")
+        archive.write(basepath + "InputSandbox" + str(jobID) + os.path.sep + "jobDescription.xml")
         S_OK("Job parameter changed from DownloadInputData to InputDataByProtocol.")
 
   
@@ -102,9 +102,9 @@ def __downloadPilotScripts(basepath, diracpath):
   Downloads the scripts necessary to configure the pilot
   
   """
-  shutil.copyfile(str(diracpath) + "/WorkloadManagementSystem/PilotAgent/dirac-pilot.py"   , basepath + "/dirac-pilot.py")
-  shutil.copyfile(str(diracpath) + "/WorkloadManagementSystem/PilotAgent/pilotCommands.py" , basepath + "/pilotCommands.py")
-  shutil.copyfile(str(diracpath) + "/WorkloadManagementSystem/PilotAgent/pilotTools.py"    , basepath + "/pilotTools.py")
+  shutil.copyfile(str(diracpath) + os.path.sep + "WorkloadManagementSystem/PilotAgent/dirac-pilot.py"   , basepath + "dirac-pilot.py")
+  shutil.copyfile(str(diracpath) + os.path.sep + "WorkloadManagementSystem/PilotAgent/pilotCommands.py" , basepath + "pilotCommands.py")
+  shutil.copyfile(str(diracpath) + os.path.sep + "WorkloadManagementSystem/PilotAgent/pilotTools.py"    , basepath + "pilotTools.py")
       
 def __configurePilot(basepath, vo):
   """
@@ -116,15 +116,17 @@ def __configurePilot(basepath, vo):
   from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals    import getVO, getSetup
   from DIRAC.ConfigurationSystem.Client.ConfigurationData    import gConfigurationData
   
-  dir = str(os.getcwd())
-  os.rename(dir + '/.dirac.cfg', dir + '/.dirac.cfg.old')
-  os.system("cp " + dir + "/pilot.cfg " + dir + "/.dirac.cfg")
+
   
   vo = getVO()
   currentSetup = getSetup()
   masterCS = gConfigurationData.getMasterServer()
 
-  os.system("python " + basepath + "/dirac-pilot.py -S %s -l %s -C %s -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -dd" %(currentSetup, vo, masterCS))
+  os.system("python " + basepath + "dirac-pilot.py -S %s -l %s -C %s -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -dd" %(currentSetup, vo, masterCS))
+  
+  dir = str(os.getcwd()) + os.path.sep
+  os.rename(dir + '.dirac.cfg', dir + '.dirac.cfg.old')
+  shutil.copyfile(dir + 'pilot.cfg', dir + '.dirac.cfg')
 
 def __runJobLocally(jobID, basepath, vo):
   """
@@ -133,9 +135,9 @@ def __runJobLocally(jobID, basepath, vo):
   """
   ipr = __import__(str(vo) + 'DIRAC.Interfaces.API.' + str(vo) + 'Job', globals(), locals(), [str(vo) + 'Job'], -1)
   voJob = getattr(ipr, str(vo) + 'Job')
-  localJob = voJob(basepath + "/InputSandbox" + str(jobID) + "/jobDescription.xml")
-  localJob.setInputSandbox(os.getcwd()+"/pilot.cfg")
-  localJob.setConfigArgs(os.getcwd()+"/pilot.cfg")
+  localJob = voJob(basepath + "InputSandbox" + str(jobID) + os.path.sep + "jobDescription.xml")
+  localJob.setInputSandbox(os.getcwd()+ os.path.sep+"pilot.cfg")
+  localJob.setConfigArgs(os.getcwd()+ os.path.sep+"pilot.cfg")
   os.chdir(basepath)
   localJob.runLocal()
   
@@ -145,7 +147,7 @@ if __name__ == "__main__":
   ext = Extensions()
   _vo = ext.getCSExtensions()[0]
   _diracPath = Extensions().getExtensionPath('DIRAC')
-  _dir = os.getcwd()
+  _dir = str(os.getcwd()) + os.path.sep
   try:
     _path = __runSystemDefaults(_jobID, _vo)
       
@@ -161,4 +163,4 @@ if __name__ == "__main__":
     
   finally:
     os.chdir(_dir)
-    os.rename(_dir + '/.dirac.cfg.old', _dir + '/.dirac.cfg')
+    os.rename(_dir + '.dirac.cfg.old', _dir + '.dirac.cfg')


### PR DESCRIPTION
this script gets the VO extension name (e.g. LHCb) in general and uses it to create the job object.
The original script was created to run LHCb jobs, so must of its functions might not be usefull to other VOs,
or might need extra procedures to make it functional for other VOs...

I left the commented cede lines on it to show how it's done on LHCb, it can be helpful for the necessary fixes in order to run multiple VOs

Marcelo Vilaca