### PR TITLE
[v6r14] MaxRAM option defined on the CE level

### DIFF
--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -233,6 +233,9 @@ def getSiteUpdates( vo, bdiiInfo = None, log = None ):
         if newCEType in ['ARC','CREAM']:
           newSubmissionMode = "Direct" 
         newRAM = ceInfo.get( 'GlueHostMainMemoryRAMSize', '' ).strip()
+        # Protect from unreasonable values
+        if newRAM and int( newRAM ) > 150000:
+          newRAM = ''
 
         # Adding CE data to the change list
         addToChangeSet( ( ceSection, 'architecture', arch, newarch ), changeSet )

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -425,10 +425,7 @@ class ComputingElement(object):
       if 'AvailableCores' in result:
         cores = result['AvailableCores']
         if cores > 1:
-          tagList = []
-          for i in range( 2, cores+1 ):
-            tagList.append( '%dCore' % i )
-          ceDict.setdefault( 'Tag', [] ).extend( tagList )
+          ceDict['NumberOfCores'] = cores
 
     return S_OK( ceDict )
 

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -425,7 +425,7 @@ class ComputingElement(object):
       if 'AvailableCores' in result:
         cores = result['AvailableCores']
         if cores > 1:
-          ceDict['NumberOfCores'] = cores
+          ceDict['NumberOfProcessors'] = cores
 
     return S_OK( ceDict )
 

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -741,10 +741,6 @@ class SiteDirector( AgentModule ):
     if self.defaultSubmitPools:
       pilotOptions.append( '-o /Resources/Computing/CEDefaults/SubmitPool=%s' % self.defaultSubmitPools )
 
-    # This is needed until the MaxRAM is properly evaluated in the pilot Commands
-    if 'MaxRAM' in queueDict:
-      pilotOptions.append( '-o /Resources/Computing/CEDefaults/MaxRAM=%s' % queueDict['MaxRAM'] )
-
     if self.group:
       pilotOptions.append( '-G %s' % self.group )
 

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -233,8 +233,7 @@ class SiteDirector( AgentModule ):
         ceTags = ceDict.get( 'Tag', [] )
         if isinstance( ceTags, basestring ):
           ceTags = fromChar( ceTags )
-        maxMemory = ceDict.get( 'MaxRAM', None )
-        ceTags += self.__getMemoryTags( maxMemory )
+        ceMaxMemory = ceDict.get( 'MaxRAM', None )
         qDict = ceDict.pop( 'Queues' )
         for queue in qDict:
           queueName = '%s_%s' % ( ce, queue )
@@ -267,10 +266,12 @@ class SiteDirector( AgentModule ):
               self.queueDict[queueName]['ParametersDict']['Tag'] = ceTags
 
           maxMemory = self.queueDict[queueName]['ParametersDict'].get( 'MaxRAM', None )
-          memoryTags = self.__getMemoryTags( maxMemory )
-          if memoryTags:
-            self.queueDict[queueName]['ParametersDict'].setdefault( 'Tag', [] )
-            self.queueDict[queueName]['ParametersDict']['Tag'] += memoryTags
+          maxMemory = ceMaxMemory if not maxMemory else maxMemory
+          if maxMemory:
+            memoryTags = self.__getMemoryTags( maxMemory )
+            if memoryTags:
+              self.queueDict[queueName]['ParametersDict'].setdefault( 'Tag', [] )
+              self.queueDict[queueName]['ParametersDict']['Tag'] += memoryTags
           qwDir = os.path.join( self.workingDirectory, queue )
           if not os.path.exists( qwDir ):
             os.makedirs( qwDir )

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -204,22 +204,6 @@ class SiteDirector( AgentModule ):
     hexstring = myMD5.hexdigest()
     return hexstring
 
-  def __getMemoryTags( self, maxMemory ):
-    """ Get memory tag list from the string value in MB
-
-    :param str or int maxMemory: max RAM value
-    :return: list of Tags
-    """
-    if maxMemory:
-      # MaxRAM value is supposed to be in MB
-      maxMemory = int( maxMemory )/1000
-      # No more 128 GB, otherwise likely a false value in the CS
-      if maxMemory < 128:
-        maxMemoryList = range( 1, maxMemory + 1 )
-        memoryTags = [ '%dGB' % mem for mem in maxMemoryList ]
-        return memoryTags
-    return []
-
   def getQueues( self, resourceDict ):
     """ Get the list of relevant CEs and their descriptions
     """
@@ -233,7 +217,7 @@ class SiteDirector( AgentModule ):
         ceTags = ceDict.get( 'Tag', [] )
         if isinstance( ceTags, basestring ):
           ceTags = fromChar( ceTags )
-        ceMaxMemory = ceDict.get( 'MaxRAM', None )
+        ceMaxRAM = ceDict.get( 'MaxRAM', None )
         qDict = ceDict.pop( 'Queues' )
         for queue in qDict:
           queueName = '%s_%s' % ( ce, queue )
@@ -254,6 +238,7 @@ class SiteDirector( AgentModule ):
             si00 = float( self.queueDict[queueName]['ParametersDict']['SI00'] )
             queueCPUTime = 60. / 250. * maxCPUTime * si00
             self.queueDict[queueName]['ParametersDict']['CPUTime'] = int( queueCPUTime )
+
           queueTags = self.queueDict[queueName]['ParametersDict'].get( 'Tag' )
           if queueTags and isinstance( queueTags, basestring ):
             queueTags = fromChar( queueTags )
@@ -265,13 +250,11 @@ class SiteDirector( AgentModule ):
             else:
               self.queueDict[queueName]['ParametersDict']['Tag'] = ceTags
 
-          maxMemory = self.queueDict[queueName]['ParametersDict'].get( 'MaxRAM', None )
-          maxMemory = ceMaxMemory if not maxMemory else maxMemory
-          if maxMemory:
-            memoryTags = self.__getMemoryTags( maxMemory )
-            if memoryTags:
-              self.queueDict[queueName]['ParametersDict'].setdefault( 'Tag', [] )
-              self.queueDict[queueName]['ParametersDict']['Tag'] += memoryTags
+          maxRAM = self.queueDict[queueName]['ParametersDict'].get( 'MaxRAM' )
+          maxRAM = ceMaxRAM if not maxRAM else maxRAM
+          if maxRAM:
+            self.queueDict[queueName]['ParametersDict']['MaxRAM'] = maxRAM
+
           qwDir = os.path.join( self.workingDirectory, queue )
           if not os.path.exists( qwDir ):
             os.makedirs( qwDir )
@@ -757,10 +740,6 @@ class SiteDirector( AgentModule ):
     # Hack
     if self.defaultSubmitPools:
       pilotOptions.append( '-o /Resources/Computing/CEDefaults/SubmitPool=%s' % self.defaultSubmitPools )
-
-    if "Tag" in queueDict:
-      tagString = ','.join( queueDict['Tag'] )
-      pilotOptions.append( '-o /Resources/Computing/CEDefaults/Tag=%s' % tagString )
 
     if self.group:
       pilotOptions.append( '-G %s' % self.group )

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -741,6 +741,10 @@ class SiteDirector( AgentModule ):
     if self.defaultSubmitPools:
       pilotOptions.append( '-o /Resources/Computing/CEDefaults/SubmitPool=%s' % self.defaultSubmitPools )
 
+    # This is needed until the MaxRAM is properly evaluated in the pilot Commands
+    if 'MaxRAM' in queueDict:
+      pilotOptions.append( '-o /Resources/Computing/CEDefaults/MaxRAM=%s' % queueDict['MaxRAM'] )
+
     if self.group:
       pilotOptions.append( '-G %s' % self.group )
 

--- a/WorkloadManagementSystem/Client/Matcher.py
+++ b/WorkloadManagementSystem/Client/Matcher.py
@@ -187,8 +187,24 @@ class Matcher( object ):
         if resourceDescription.has_key( name ):
           resourceDict[name] = resourceDescription[name]
 
-      if resourceDescription.has_key( 'JobID' ):
+      if 'JobID' in resourceDescription:
         resourceDict['JobID'] = resourceDescription['JobID']
+
+      # Convert MaxRAM and NumberOfCores parameters into a list of tags
+      maxRAM = resourceDescription.get( 'MaxRAM' )
+      nCores = resourceDescription.get( 'NumberOfCores' )
+      for param, key in [ ( maxRAM, 'GB' ), ( nCores, 'Cores' ) ]:
+        if param:
+          try:
+            intValue = int( param )/1000
+            if intValue <= 128:
+              paramList = range( 1, intValue + 1 )
+              paramTags = [ '%d%s' % ( par, key ) for par in paramList ]
+              resourceDict.setdefault( "Tag", [] ).extend( paramTags )
+          except ValueError:
+            pass
+      if 'Tag' in resourceDict:
+        resourceDict['Tag'] = list( set( resourceDict['Tag'] ) )
 
       for k in ( 'DIRACVersion', 'ReleaseVersion', 'ReleaseProject', 'VirtualOrganization',
                  'PilotReference', 'PilotBenchmark', 'PilotInfoReportedFlag' ):

--- a/WorkloadManagementSystem/Client/Matcher.py
+++ b/WorkloadManagementSystem/Client/Matcher.py
@@ -192,7 +192,7 @@ class Matcher( object ):
 
       # Convert MaxRAM and NumberOfCores parameters into a list of tags
       maxRAM = resourceDescription.get( 'MaxRAM' )
-      nCores = resourceDescription.get( 'NumberOfCores' )
+      nCores = resourceDescription.get( 'NumberOfProcessors' )
       for param, key in [ ( maxRAM, 'GB' ), ( nCores, 'Cores' ) ]:
         if param:
           try:


### PR DESCRIPTION
The MaxRAM option can be defined both on the CE and Queue level. If defined in both places, Queue option takes precedence.
Also added protection on importing faulty MaxRAM values from BDII
The MaxRAM and other Tags generation is moved to the Matcher.