### PR TITLE
v6r14 - fix gzip buffer size

### DIFF
--- a/FrameworkSystem/private/SecurityFileLog.py
+++ b/FrameworkSystem/private/SecurityFileLog.py
@@ -77,10 +77,10 @@ class SecurityFileLog( threading.Thread ):
       fd = gzip.open( "%s.gz" % filePath, "w" )
       fO = file( filePath )
       bS = 1048576
-      buf = fO.read()
+      buf = fO.read(2**31-1)
       while buf:
         fd.write( buf )
-        buf = fO.read()
+        buf = fO.read(2**31-1)
       fd.close()
       fO.close()
     except Exception, e:


### PR DESCRIPTION
 fix the buffer size for reading when zipping a file to maximum 2^31-1 bytes. Gzip internally does a crc32 check which will otherwise fail.