### PR TITLE
v6r14 : extend the JobMonitoring Service 

### DIFF
--- a/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -242,6 +242,14 @@ class JobMonitoringHandler( RequestHandler ):
     return gJobLoggingDB.getJobLoggingInfo( jobID )
 
 ##############################################################################
+  types_getJobsParameters = [ ListType, ListType ]
+  @staticmethod
+  def export_getJobsParameters ( jobIDs, parameters ):
+    if not ( jobIDs and parameters ) : 
+      return S_OK( {} )
+    return gJobDB.getAttributesForJobList( jobIDs, parameters )
+
+##############################################################################
   types_getJobsStatus = [ ListType ]
   @staticmethod
   def export_getJobsStatus ( jobIDs ):


### PR DESCRIPTION
I want to propose to extend the JobMonitoring Service with this function, it would allow to retrieve multiple parameters for multiple jobs. Otherwise when going through a list of jobs and retrieving the same parameters for each of them it takes a very long time. This would allow to do it in one shot. 

My concrete example where I can use this is the monitoring of mesh processing, here I will need to retrieve multiple parameters, such as the JobGroup, RunNumber, Status  for a "helper site" to jobs it has done for a given job type in order to further digest which site it was contributing to for each job. 