### PR TITLE
[v6r15] Multicore jobagent

### DIFF
--- a/Core/Utilities/TimeLeft/TimeLeft.py
+++ b/Core/Utilities/TimeLeft/TimeLeft.py
@@ -44,7 +44,7 @@ class TimeLeft( object ):
       self.batchPlugin = None
       self.batchError = result['Message']
 
-  def getScaledCPU( self, cores = 1 ):
+  def getScaledCPU( self, processors = 1 ):
     """Returns the current CPU Time spend (according to batch system) scaled according
        to /LocalSite/CPUScalingFactor
     """
@@ -62,14 +62,14 @@ class TimeLeft( object ):
       if resourceDict['Value']['CPU']:
         return resourceDict['Value']['CPU'] * self.scaleFactor
       elif resourceDict['Value']['WallClock']:
-        # When CPU value missing, guess from WallClock and number of cores
-        return resourceDict['Value']['WallClock'] * self.scaleFactor * cores
+        # When CPU value missing, guess from WallClock and number of processors
+        return resourceDict['Value']['WallClock'] * self.scaleFactor * processors
 
 
     return 0
 
   #############################################################################
-  def getTimeLeft( self, cpuConsumed = 0.0, cores = 1 ):
+  def getTimeLeft( self, cpuConsumed = 0.0, processors = 1 ):
     """Returns the CPU Time Left for supported batch systems.  The CPUConsumed
        is the current raw total CPU.
     """
@@ -93,13 +93,13 @@ class TimeLeft( object ):
 
     # if one of CPULimit or WallClockLimit is missing, compute a reasonable value
     if not resources['CPULimit']:
-      resources['CPULimit'] = resources['WallClockLimit'] * cores
+      resources['CPULimit'] = resources['WallClockLimit'] * processors
     elif not resources['WallClockLimit']:
       resources['WallClockLimit'] = resources['CPULimit']
 
     # if one of CPU or WallClock is missing, compute a reasonable value
     if not resources['CPU']:
-      resources['CPU'] = resources['WallClock'] * cores
+      resources['CPU'] = resources['WallClock'] * processors
     elif not resources['WallClock']:
       resources['WallClock'] = resources['CPU']
 

--- a/Core/Utilities/TimeLeft/TimeLeft.py
+++ b/Core/Utilities/TimeLeft/TimeLeft.py
@@ -44,7 +44,7 @@ class TimeLeft( object ):
       self.batchPlugin = None
       self.batchError = result['Message']
 
-  def getScaledCPU( self ):
+  def getScaledCPU( self, cores = 1 ):
     """Returns the current CPU Time spend (according to batch system) scaled according
        to /LocalSite/CPUScalingFactor
     """
@@ -62,13 +62,14 @@ class TimeLeft( object ):
       if resourceDict['Value']['CPU']:
         return resourceDict['Value']['CPU'] * self.scaleFactor
       elif resourceDict['Value']['WallClock']:
-        # build a reasonable CPU value from WallClock
-        return resourceDict['Value']['WallClock'] * self.scaleFactor
+        # When CPU value missing, guess from WallClock and number of cores
+        return resourceDict['Value']['WallClock'] * self.scaleFactor * cores
+
 
     return 0
 
   #############################################################################
-  def getTimeLeft( self, cpuConsumed = 0.0 ):
+  def getTimeLeft( self, cpuConsumed = 0.0, cores = 1 ):
     """Returns the CPU Time Left for supported batch systems.  The CPUConsumed
        is the current raw total CPU.
     """
@@ -92,13 +93,13 @@ class TimeLeft( object ):
 
     # if one of CPULimit or WallClockLimit is missing, compute a reasonable value
     if not resources['CPULimit']:
-      resources['CPULimit'] = resources['WallClockLimit']
+      resources['CPULimit'] = resources['WallClockLimit'] * cores
     elif not resources['WallClockLimit']:
       resources['WallClockLimit'] = resources['CPULimit']
 
     # if one of CPU or WallClock is missing, compute a reasonable value
     if not resources['CPU']:
-      resources['CPU'] = resources['WallClock']
+      resources['CPU'] = resources['WallClock'] * cores
     elif not resources['WallClock']:
       resources['WallClock'] = resources['CPU']
 

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -17,6 +17,7 @@ from DIRAC.Core.Utilities.ModuleFactory                     import ModuleFactory
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight              import ClassAd
 from DIRAC.Core.Utilities.TimeLeft.TimeLeft                 import TimeLeft
 from DIRAC.Core.Utilities.CFG                               import CFG
+from DIRAC.Core.Utilities.Os                                import getNumberOfCores
 from DIRAC.Core.Base.AgentModule                            import AgentModule
 from DIRAC.Core.DISET.RPCClient                             import RPCClient
 from DIRAC.Core.Security.ProxyInfo                          import getProxyInfo
@@ -606,7 +607,12 @@ class JobAgent( AgentModule ):
 
     # look for a pattern like "12345Cores" in tag list
     m = re.match( r'^(.*\D)?(?P<cores>\d+)Cores([ \t,].*)?$', tag )
-    if m: return int( m.group( 'cores' ) )
+    if m:
+      return int( m.group( 'cores' ) )
+
+    # In WholeNode case, detect number of cores from the host
+    if re.match( r'^(.*,\s*)?WholeNode([ \t,].*)?$', tag ):
+      return getNumberOfCores()
 
     return 1
 

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -599,7 +599,7 @@ class JobAgent( AgentModule ):
   #############################################################################
   def __getCores( self ):
     """
-    Return number of cores from gConfig and a boolean indicating corresponding to WholeNode option
+    Return number of cores from gConfig and a boolean corresponding to WholeNode option
     """
     tag = gConfig.getValue( '/Resources/Computing/CEDefaults/Tag', None )
 

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -152,10 +152,10 @@ class JobAgent( AgentModule ):
       ceDict.update( requirementsDict )
       self.log.info( 'Requirements:', requirementsDict )
 
-    cores, wholeNode = self.__getCores()
-    ceDict['Cores'] = cores
+    processors, wholeNode = self.__getProcessors()
+    ceDict['Processors'] = processors
     ceDict['WholeNode'] = wholeNode
-    self.log.info( 'Configured number of cores: %d, WholeNode: %s' % ( cores, wholeNode ) )
+    self.log.info( 'Configured number of processors: %d, WholeNode: %s' % ( processors, wholeNode ) )
 
     self.log.verbose( ceDict )
     start = time.time()
@@ -296,7 +296,7 @@ class JobAgent( AgentModule ):
     # Sum all times but the last one (elapsed_time) and remove times at init (is this correct?)
     cpuTime = sum( os.times()[:-1] ) - sum( self.initTimes[:-1] )
 
-    result = self.timeLeftUtil.getTimeLeft( cpuTime, cores )
+    result = self.timeLeftUtil.getTimeLeft( cpuTime, processors )
     if result['OK']:
       self.timeLeft = result['Value']
     else:
@@ -306,7 +306,7 @@ class JobAgent( AgentModule ):
         # if the batch system is not defined, use the process time and the CPU normalization defined locally
         self.timeLeft = self.__getCPUTimeLeft()
 
-    scaledCPUTime = self.timeLeftUtil.getScaledCPU( cores )
+    scaledCPUTime = self.timeLeftUtil.getScaledCPU( processors )
     self.__setJobParam( jobID, 'ScaledCPUTime', str( scaledCPUTime - self.scaledCPUTime ) )
     self.scaledCPUTime = scaledCPUTime
 
@@ -597,20 +597,20 @@ class JobAgent( AgentModule ):
     return self.__finish( 'Job Rescheduled', stop )
 
   #############################################################################
-  def __getCores( self ):
+  def __getProcessors( self ):
     """
-    Return number of cores from gConfig and a boolean corresponding to WholeNode option
+    Return number of processors from gConfig and a boolean corresponding to WholeNode option
     """
     tag = gConfig.getValue( '/Resources/Computing/CEDefaults/Tag', None )
 
     if tag is None: return 1, False
 
-    self.log.verbose( "__getCores: /Resources/Computing/CEDefaults/Tag", repr( tag ) )
+    self.log.verbose( "__getProcessors: /Resources/Computing/CEDefaults/Tag", repr( tag ) )
 
-    # look for a pattern like "12345Cores" in tag list
-    m = re.match( r'^(.*\D)?(?P<cores>\d+)Cores([ \t,].*)?$', tag )
+    # look for a pattern like "12345Processors" in tag list
+    m = re.match( r'^(.*\D)?(?P<processors>\d+)Processors([ \t,].*)?$', tag )
     if m:
-      return int( m.group( 'cores' ) ), False
+      return int( m.group( 'processors' ) ), False
 
     # In WholeNode case, detect number of cores from the host
     if re.match( r'^(.*,\s*)?WholeNode([ \t,].*)?$', tag ):

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -152,8 +152,10 @@ class JobAgent( AgentModule ):
       ceDict.update( requirementsDict )
       self.log.info( 'Requirements:', requirementsDict )
 
-    cores = self.__getCores()
-    self.log.info( 'Configured number of cores: ', cores )
+    cores, wholeNode = self.__getCores()
+    ceDict['Cores'] = cores
+    ceDict['WholeNode'] = wholeNode
+    self.log.info( 'Configured number of cores: %d, WholeNode: %s' % ( cores, wholeNode ) )
 
     self.log.verbose( ceDict )
     start = time.time()
@@ -597,24 +599,24 @@ class JobAgent( AgentModule ):
   #############################################################################
   def __getCores( self ):
     """
-    Return number of cores from gConfig
+    Return number of cores from gConfig and a boolean indicating corresponding to WholeNode option
     """
     tag = gConfig.getValue( '/Resources/Computing/CEDefaults/Tag', None )
 
-    if tag is None: return 1
+    if tag is None: return 1, False
 
     self.log.verbose( "__getCores: /Resources/Computing/CEDefaults/Tag", repr( tag ) )
 
     # look for a pattern like "12345Cores" in tag list
     m = re.match( r'^(.*\D)?(?P<cores>\d+)Cores([ \t,].*)?$', tag )
     if m:
-      return int( m.group( 'cores' ) )
+      return int( m.group( 'cores' ) ), False
 
     # In WholeNode case, detect number of cores from the host
     if re.match( r'^(.*,\s*)?WholeNode([ \t,].*)?$', tag ):
-      return getNumberOfCores()
+      return getNumberOfCores(), True
 
-    return 1
+    return 1, False
 
   #############################################################################
   def finalize( self ):

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -149,6 +149,10 @@ class JobAgent( AgentModule ):
     if result['OK']:
       requirementsDict = result['Value']
       ceDict.update( requirementsDict )
+      self.log.info( 'Requirements:', requirementsDict )
+
+    cores = self.__getCores()
+    self.log.info( 'Configured number of cores: ', cores )
 
     self.log.verbose( ceDict )
     start = time.time()
@@ -289,7 +293,7 @@ class JobAgent( AgentModule ):
     # Sum all times but the last one (elapsed_time) and remove times at init (is this correct?)
     cpuTime = sum( os.times()[:-1] ) - sum( self.initTimes[:-1] )
 
-    result = self.timeLeftUtil.getTimeLeft( cpuTime )
+    result = self.timeLeftUtil.getTimeLeft( cpuTime, cores )
     if result['OK']:
       self.timeLeft = result['Value']
     else:
@@ -299,7 +303,7 @@ class JobAgent( AgentModule ):
         # if the batch system is not defined, use the process time and the CPU normalization defined locally
         self.timeLeft = self.__getCPUTimeLeft()
 
-    scaledCPUTime = self.timeLeftUtil.getScaledCPU()
+    scaledCPUTime = self.timeLeftUtil.getScaledCPU( cores )
     self.__setJobParam( jobID, 'ScaledCPUTime', str( scaledCPUTime - self.scaledCPUTime ) )
     self.scaledCPUTime = scaledCPUTime
 
@@ -588,6 +592,23 @@ class JobAgent( AgentModule ):
 
     self.log.info( 'Job Rescheduled %s' % ( jobID ) )
     return self.__finish( 'Job Rescheduled', stop )
+
+  #############################################################################
+  def __getCores( self ):
+    """
+    Return number of cores from gConfig
+    """
+    tag = gConfig.getValue( '/Resources/Computing/CEDefaults/Tag', None )
+
+    if tag is None: return 1
+
+    self.log.verbose( "__getCores: /Resources/Computing/CEDefaults/Tag", repr( tag ) )
+
+    # look for a pattern like "12345Cores" in tag list
+    m = re.match( r'^(.*\D)?(?P<cores>\d+)Cores([ \t,].*)?$', tag )
+    if m: return int( m.group( 'cores' ) )
+
+    return 1
 
   #############################################################################
   def finalize( self ):

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -273,6 +273,12 @@ class JobWrapper( object ):
     os.environ['DIRACSITE'] = DIRAC.siteName()
     self.log.verbose( 'DIRACSITE = %s' % ( DIRAC.siteName() ) )
 
+    os.environ['DIRAC_CORES'] = str( self.ceArgs.get( 'Cores', 1 ) )
+    self.log.verbose( 'DIRAC_CORES = %s' % ( self.ceArgs.get( 'Cores', 1 ) ) )
+
+    os.environ['DIRAC_WHOLENODE'] = str( self.ceArgs.get( 'WholeNode', False ) )
+    self.log.verbose( 'DIRAC_WHOLENODE = %s' % ( self.ceArgs.get( 'WholeNode', False ) ) )
+
     errorFile = self.jobArgs.get( 'StdError', self.defaultErrorFile )
     outputFile = self.jobArgs.get( 'StdOutput', self.defaultOutputFile )
 

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -273,8 +273,8 @@ class JobWrapper( object ):
     os.environ['DIRACSITE'] = DIRAC.siteName()
     self.log.verbose( 'DIRACSITE = %s' % ( DIRAC.siteName() ) )
 
-    os.environ['DIRAC_CORES'] = str( self.ceArgs.get( 'Cores', 1 ) )
-    self.log.verbose( 'DIRAC_CORES = %s' % ( self.ceArgs.get( 'Cores', 1 ) ) )
+    os.environ['DIRAC_PROCESSORS'] = str( self.ceArgs.get( 'Processors', 1 ) )
+    self.log.verbose( 'DIRAC_PROCESSORS = %s' % ( self.ceArgs.get( 'Processors', 1 ) ) )
 
     os.environ['DIRAC_WHOLENODE'] = str( self.ceArgs.get( 'WholeNode', False ) )
     self.log.verbose( 'DIRAC_WHOLENODE = %s' % ( self.ceArgs.get( 'WholeNode', False ) ) )


### PR DESCRIPTION
Allows JobAgent to handle multicore jobs.

Matching is done with "XCores" or "WholeNode" in JDL variable `Tags`.

Multicore information is transmitted to the payload job through JobWrapper with environment variables.

I wonder if cores number and wholenode flag are to be sent to the Accounting database (can be helpful to compute multicore efficiency statistics).

This is the second part of the replacement of #2629

