### PR TITLE
[v6r14] Move getCEStatus function back to using the ARC API.

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -18,7 +18,6 @@ from DIRAC                                               import S_OK, S_ERROR, g
 from DIRAC.Resources.Computing.ComputingElement          import ComputingElement
 from DIRAC.Core.Utilities.SiteCEMapping                  import getSiteForCE
 from DIRAC.Core.Utilities.File                           import makeGuid
-from DIRAC.Core.Security.ProxyInfo                       import getVOfromProxyGroup
 
 # Uncomment the following 5 lines for getting verbose ARC api output (debugging)
 # import sys
@@ -286,30 +285,24 @@ class ARCComputingElement( ComputingElement ):
   def getCEStatus( self ):
     """ Method to return information on running and pending jobs.
     """
-    vo = ''
-    res = getVOfromProxyGroup()
-    if res['OK']:
-      vo = res['Value']
-    else: # A backup solution which may work
-      vo = self.ceParameters['VO']
-    cmd = 'ldapsearch -x -LLL -H ldap://%s:2135 -b mds-vo-name=resource,o=grid "(GlueVOViewLocalID=%s)"' %(self.ceHost, vo.lower())
-    res = shellCall( 0, cmd )
-    if not res['OK']:
-      gLogger.debug("Could not query CE %s - is it down?" % self.ceHost)
-      return res
+
+    result = self._prepareProxy()
+    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
+    if not result['OK']:
+      gLogger.error( 'ARCComputingElement: failed to set up proxy', result['Message'] )
+      return result
+    endpoints = [arc.Endpoint( "ldap://" + self.ceHost + "/MDS-Vo-name=local,o=grid",
+                               arc.Endpoint.COMPUTINGINFO, 'org.nordugrid.ldapng')]
+    retriever = arc.ComputingServiceRetriever(self.usercfg, endpoints)
+    retriever.wait() # Takes a bit of time to get and parse the ldap information
+    targets = retriever.GetExecutionTargets()
+    ceStats = targets[0].ComputingShare
+    gLogger.debug("Running jobs for CE %s : %s" % (self.ceHost, ceStats.RunningJobs))
+    gLogger.debug("Waiting jobs for CE %s : %s" % (self.ceHost, ceStats.WaitingJobs))
+
     result = S_OK()
-    try:
-      ldapValues = res['Value'][1].split("\n")
-      running = [y for y in ldapValues if 'GlueCEStateRunningJobs' in y]
-      waiting = [y for y in ldapValues if 'GlueCEStateWaitingJobs' in y]
-      result['RunningJobs'] = int(running[0].split(":")[1])
-      result['WaitingJobs'] = int(waiting[0].split(":")[1])
-    except IndexError:
-      result = S_ERROR('Unknown ldap failure for site %s' % self.ceHost)
-      result['RunningJobs'] = 0
-      result['WaitingJobs'] = 0
-    gLogger.debug("Running jobs for CE %s : %s" % (self.ceHost, result['RunningJobs']))
-    gLogger.debug("Waiting jobs for CE %s : %s" % (self.ceHost, result['WaitingJobs']))
+    result['RunningJobs'] = ceStats.RunningJobs
+    result['WaitingJobs'] = ceStats.WaitingJobs
     result['SubmittedJobs'] = 0
     return result
 


### PR DESCRIPTION
This is not an urgent patch and in principle, should give identical results to what already exists. Hopefully this code will be blind to what version of ldap or which glue schema is actually used to publish information in the future.

Here, we also avoid (unnecessary) knowledge of what VO this is, as that depends on the configuration which can be in a debatable state.

"Tested" in certification and by the Imperial College / GridPP instance.