### PR TITLE
[v6r14] Minor fixes

### DIFF
--- a/Core/Utilities/TimeLeft/LSFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/LSFTimeLeft.py
@@ -146,10 +146,12 @@ class LSFTimeLeft( object ):
         else:
           self.log.error( 'Cannot source the LSF environment', ret['Message'] )
     if not self.normRef:
+      # If nothing works take this as the unit
+      self.normRef = 1.
       # If nothing worked, take the maximum defined for a Model
-      if modelMaxNorm:
-        self.normRef = modelMaxNorm
-        self.log.info( 'Reference Normalization taken from Max Model:', self.normRef )
+      # if modelMaxNorm:
+      #  self.normRef = modelMaxNorm
+      #  self.log.info( 'Reference Normalization taken from Max Model:', self.normRef )
 
     # Now get the Normalization for the current Host
     if self.host:

--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -548,9 +548,13 @@ class FTSAgent( AgentModule ):
 
             # Recover files that are Failed but were not spotted
             for ftsFile in [f for f in ftsFiles if f.Status == 'Failed' and f.TargetSE in missingReplicas.get( f.LFN, [] )]:
-              _r, _s, fail = self.__checkFailed( ftsFile )
-              if fail:
+              reschedule, submit, fail = self.__checkFailed( ftsFile )
+              if fail and ftsFile not in ftsFilesDict['toFail']:
                 ftsFilesDict['toFail'].append( ftsFile )
+              elif reschedule and ftsFile not in ftsFilesDict['toReschedule']:
+                ftsFilesDict['toReschedule'].append( ftsFile )
+              elif submit and ftsFile not in ftsFilesDict['toSubmit']:
+                ftsFilesDict['toSubmit'].append( ftsFile )
 
             # If all transfers are finished for unregistered files and there is already a registration operation, set it Done
             for lfn in missingReplicas:

--- a/TransformationSystem/Client/PluginBase.py
+++ b/TransformationSystem/Client/PluginBase.py
@@ -35,6 +35,7 @@ class PluginBase( object ):
       if re.search( self.plugin, str( x ) ):
         return S_ERROR( "Plugin not found" )
       else:
+        gLogger.exception( 'Exception in plugin', self.plugin, x )
         raise AttributeError( x )
     except Exception as x:
       gLogger.exception( 'Exception in plugin', self.plugin, x )

--- a/TransformationSystem/Client/Utilities.py
+++ b/TransformationSystem/Client/Utilities.py
@@ -189,6 +189,8 @@ class PluginUtilities( object ):
             taskSize = 0
     if flush and taskLfns:
       tasks.append( ( replicaSE, taskLfns ) )
+    if not tasks and not flush and taskLfns:
+      self.logVerbose( 'Not enough data to create a task, and flush not set (%d bytes for groupSize %d)' % ( taskSize, self.groupSize ) )
     return tasks
 
 

--- a/WorkloadManagementSystem/Client/CPUNormalization.py
+++ b/WorkloadManagementSystem/Client/CPUNormalization.py
@@ -41,7 +41,7 @@ def getPowerFromMJF():
   jobSlots = float( features.get( 'jobslots', 0 ) )
   denom = min( max( logCores, physCores ), jobSlots ) if ( logCores or physCores ) and jobSlots else None
   if totalPower and denom:
-    return int( 10. * float( totalPower ) / denom ) / 10.
+    return round( float( totalPower ) / denom , 2 )
   else:
     return None
 
@@ -123,9 +123,12 @@ def getCPUNormalization( reference = 'HS06', iterations = 1 ):
   except ( TypeError, ValueError ), x :
     return S_ERROR( x )
 
-  # This number of iterations corresponds to 250 HS06 seconds
+  # This number of iterations corresponds to 1kHS2k.seconds, i.e. 250 HS06 seconds
+  # 06.11.2015: fixed absolute normalization w.r.t. MJF at GRIDKA
+  from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+  corr = Operations().getValue( 'JobScheduling/CPUNormalizationCorrection', 1. )
   n = int( 1000 * 1000 * 12.5 )
-  calib = 250.0 / UNITS[reference]
+  calib = 250.0 / UNITS[reference] / corr
 
   m = long( 0 )
   m2 = long( 0 )

--- a/WorkloadManagementSystem/scripts/dirac-wms-cpu-normalization.py
+++ b/WorkloadManagementSystem/scripts/dirac-wms-cpu-normalization.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
   if not result['OK']:
     gLogger.error( result['Message'] )
 
-  norm = int( ( result['Value']['NORM'] + 0.05 ) * 10 ) / 10.
+  norm = round( result['Value']['NORM'], 1 )
 
   gLogger.notice( 'Estimated CPU power is %.1f %s' % ( norm, result['Value']['UNIT'] ) )
 

--- a/WorkloadManagementSystem/scripts/dirac-wms-get-queue-cpu-time.py
+++ b/WorkloadManagementSystem/scripts/dirac-wms-get-queue-cpu-time.py
@@ -22,11 +22,10 @@ args = Script.getPositionalArgs()
 CPUNormalizationFactor = 0.0
 for unprocSw in Script.getUnprocessedSwitches():
   if unprocSw[0] in ( "C", "CPUNormalizationFactor" ):
-    CPUNormalizationFactor = float( unprocSw[1] )    
+    CPUNormalizationFactor = float( unprocSw[1] )
 
 if __name__ == "__main__":
   from DIRAC.WorkloadManagementSystem.Client.CPUNormalization import getCPUTime
   cpuTime = getCPUTime( CPUNormalizationFactor )
-  print cpuTime
-
-DIRAC.exit( 0 )
+  DIRAC.gLogger.info( 'Queue CPU time:', str( cpuTime ) )
+  DIRAC.exit( 0 )

--- a/WorkloadManagementSystem/scripts/dirac-wms-get-queue-cpu-time.py
+++ b/WorkloadManagementSystem/scripts/dirac-wms-get-queue-cpu-time.py
@@ -27,5 +27,6 @@ for unprocSw in Script.getUnprocessedSwitches():
 if __name__ == "__main__":
   from DIRAC.WorkloadManagementSystem.Client.CPUNormalization import getCPUTime
   cpuTime = getCPUTime( CPUNormalizationFactor )
-  DIRAC.gLogger.info( 'Queue CPU time:', str( cpuTime ) )
+  # I hate this kind of output... PhC
+  print cpuTime
   DIRAC.exit( 0 )


### PR DESCRIPTION
Change to allow a renormalization of the estimated CPU power, as this is drifting with time... 
The default behavior is the same as before.

getCPUTime() was only looking into the CS to get the time left, but this is incorrect for LSF @ CERN in particular as the queue size in the CS is not in real seconds but must be renormalized which is what TimeLeft() does... Therefore try TimeLeft first and then CS if unsuccessful