### PR TITLE
Get multiple wildcarded files from directory

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1261,6 +1261,22 @@ class Dirac( API ):
     return result
 
   #############################################################################
+  def getFilesFromDirectory( self, directory, destdir, wildcard='*', days=0):
+    dm = DataManager()
+    result = dm.getFilesFromDirectory(directory, wildcard=wildcard, days=days)
+    if not result['OK']:
+      self.log.error("Failure calling DataManager.getFilesFromDirectory")
+      return result
+    lfns = result['Value']
+    for lfn in lfns:
+      result = self.getFile(lfn, destDir=destdir)
+      if not result['OK']:
+        self.log.error("Failed to retrieve file: %s" % lfn)
+        return result
+      self.log.info("Successfully got file: %s" % lfn)
+    return S_OK(lfns)
+
+
   def getFile( self, lfn, destDir = '', printOutput = False ):
     """Retrieve a single file or list of files from Grid storage to the current directory. lfn is the
        desired logical file name for the file, fullPath is the local path to the file and diracSE is the

--- a/Interfaces/scripts/dirac-dms-get-files.py
+++ b/Interfaces/scripts/dirac-dms-get-files.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+########################################################################
+# $HeadURL$
+# File :    dirac-dms-get-files
+# Author :  Alexander Richards
+########################################################################
+"""
+  Retrieve multiple wildcarded files from Grid storage.
+"""
+__RCSID__ = "$Id$"
+import os
+import DIRAC
+from DIRAC.Core.Base import Script
+
+Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
+                                     'Usage:',
+                                     '  %s dir [dest] [wildcard] [days]' % Script.scriptName,
+                                     'Arguments:',
+                                     '  dir:      directory from which to get files',
+                                     '  dest:     location to copy into [default: $PWD]',
+                                     '  wildcard: optional pattern to match files against [default: *]',
+                                     '  days:     optional consider files older than days [default: 0]'] ) )
+Script.parseCommandLine( ignoreErrors = True )
+args = Script.getPositionalArgs()
+dest = os.getcwd()
+wildcard='*'
+days=0
+if len( args ) < 1:
+  Script.showHelp()
+if len(args) > 1:
+  dest = args[1]
+if len(args) > 2:
+  wildcard = args[2]
+if len(args) > 3:
+  days = int(args[3])
+from DIRAC.Interfaces.API.Dirac                       import Dirac
+dirac = Dirac()
+exitCode = 0
+
+result = dirac.getFilesFromDirectory( args[0], destdir=dest, wildcard=wildcard, days=days )
+if not result['OK']:
+  print 'ERROR %s' % ( result['Message'] )
+  exitCode = 2
+
+print "Returned the following:", result['Value']
+DIRAC.exit( exitCode )


### PR DESCRIPTION
Introduce a new script dirac-dms-get-files.py with a new API (getFilesFromDirectory) behind the scenes. This allows the user to get multiple wildcarded files from DIRAC to a local directory.

This was requested from one of our (GridPP) users.