### PR TITLE
[v6r15] Improvements to installations monitoring

### DIFF
--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -12,6 +12,7 @@ import os
 import atexit
 import readline
 import datetime
+import time
 from DIRAC.Core.Utilities.ColorCLI import colorize
 from DIRAC.FrameworkSystem.Client.SystemAdministratorClient import SystemAdministratorClient
 from DIRAC.FrameworkSystem.Client.SystemAdministratorIntegrator import SystemAdministratorIntegrator
@@ -660,6 +661,20 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         cpu = result[ 'Value' ][ 'CPUModel' ]
       hostname = self.host
       if component == 'ComponentMonitoring':
+        # Make sure that the service is running before trying to use it
+        nTries = 0
+        maxTries = 5
+        mClient = ComponentMonitoringClient()
+        result = mClient.ping()
+        while not result[ 'OK' ] and nTries < maxTries:
+          time.sleep( 3 )
+          result = mClient.ping()
+          nTries = nTries + 1
+
+        if not result[ 'OK' ]:
+          self.__errMsg( 'ComponentMonitoring service taking too long to start. Installation will not be logged into the database' )
+          return
+
         result = MonitoringUtilities.monitorInstallation( 'DB', system, 'InstalledComponentsDB', cpu = cpu, hostname = hostname )
         if not result['OK']:
           self.__errMsg( 'Error registering installation into database: %s' % result[ 'Message' ] )

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -582,7 +582,7 @@ class SystemAdministratorHandler( RequestHandler ):
     if result[ 'OK' ]:
       return S_OK( result[ 'Value' ][0] )
     else:
-      return result
+      return self.__readHostInfo()
 
   types_getComponentDocumentation = [ StringTypes, StringTypes, StringTypes ]
   def export_getComponentDocumentation( self, cType, system, module ):


### PR DESCRIPTION
getHostInfo now resorts to reading the host information with __readHostInfo (i.e., asking the host to read and generate the dictionary), rather than reading from the database, which is faster, when it fails to do so, for whichever reason