### PR TITLE
[v6r14] dirac-install: Make hashlib optional again

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -7,17 +7,17 @@ __RCSID__ = "$Id$"
 import sys
 import os
 import getopt
-import tarfile
 import urllib2
 import imp
 import signal
-import re
 import time
 import stat
 import types
 import shutil
-import zipfile
-import hashlib as md5
+try:
+  import hashlib as md5
+except ImportError:
+  import md5
 
 executablePerms = stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
 


### PR DESCRIPTION
hashlib does not exist on SL5 by default (python 2.4) so use md5 instead (as it was before).
Also remove unused imports (pylint)