### PR TITLE
[Only for discussion] use python provided ThreadPool and other

### DIFF
--- a/Core/DISET/ServiceReactor.py
+++ b/Core/DISET/ServiceReactor.py
@@ -124,9 +124,12 @@ class ServiceReactor( object ):
     for svcName in self.__listeningConnections:
       gLogger.always( "Listening at %s" % self.__services[ svcName ].getConfig().getURL() )
     #Multiple clones not yet working. Disabled by default
-    if False and multiprocessing:
+    if multiprocessing:
+      print self.__listeningConnections
+      print self.__services
       for svcName in self.__listeningConnections:
         clones = self.__services[ svcName ].getConfig().getCloneProcesses()
+        print clones
         for i in range( 1, clones ):
           p = multiprocessing.Process( target = self.__startCloneProcess, args = ( svcName, i ) )
           p.start()

--- a/Core/DISET/ServiceReactor.py
+++ b/Core/DISET/ServiceReactor.py
@@ -125,11 +125,8 @@ class ServiceReactor( object ):
       gLogger.always( "Listening at %s" % self.__services[ svcName ].getConfig().getURL() )
     #Multiple clones not yet working. Disabled by default
     if multiprocessing:
-      print self.__listeningConnections
-      print self.__services
       for svcName in self.__listeningConnections:
         clones = self.__services[ svcName ].getConfig().getCloneProcesses()
-        print clones
         for i in range( 1, clones ):
           p = multiprocessing.Process( target = self.__startCloneProcess, args = ( svcName, i ) )
           p.start()

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -103,8 +103,6 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
 #     threadPool = ThreadPool( maxNumberOfThreads, maxNumberOfThreads )
     self.log.info( "Multithreaded with %d threads" % maxNumberOfThreads )
     self.threadPool.map_async( self._execute, xrange( maxNumberOfThreads ) )
-#     threadPool.close()
-#     threadPool.join()
 #     for i in xrange( maxNumberOfThreads ):
 #       threadPool.generateJobAndQueueIt( self._execute, [i] )
 


### PR DESCRIPTION
This PR is just for discussion (for now). There are 2 things:

1) Replacing our custom ThreadPool with a "standard python" ThreadPool

I took the [completely undocumented](https://docs.python.org/2/library/multiprocessing.html#module-multiprocessing.dummy) native [python ThreadPool](http://stackoverflow.com/questions/3033952/python-thread-pool-similar-to-the-multiprocessing-pool) and used it instead of our custom ThreadPool implementation in one agent. It works our of the box.
Now, I didn't take a close look of weather there may be a critical capability for which one implementation is "better" than the other. So I am proposing this change only because:
- we'd need to maintain less code
- standard is (usually) better than custom

It should also be noted that a ProcessPool can be instantiated with 

```
from multiprocessing.pool import Pool
p = Pool()
```

and has exactly the same methods as ThreadPool

2) service processes

The change I made simply makes it possible to have several processes per service. I don't know if this has consequences.
