### PR TITLE
[v6r12] Recognize 2-words long options

### DIFF
--- a/ConfigurationSystem/Client/LocalConfiguration.py
+++ b/ConfigurationSystem/Client/LocalConfiguration.py
@@ -308,7 +308,8 @@ class LocalConfiguration:
     self.unprocessedSwitches = []
 
     for optionName, optionValue in self.parsedOptionList:
-      optionName = optionName.replace( "-", "" )
+      while optionName.find( '-' ) == 0:
+        optionName = optionName[1:]
       for definedOptionTuple in self.commandOptionList:
         if optionName == definedOptionTuple[0].replace( ":", "" ) or \
           optionName == definedOptionTuple[1].replace( "=", "" ):


### PR DESCRIPTION
* DIRAC/ConfigurationSystem/Client/LocalConfiguration.py

Long options consisting of > 1 word are not recognized (they should).
For instance,
```
--foo-bar
```
was collapsed into:
```
foobar
```
instead of the expected:
```
foo-bar
```