### PR TITLE
[v6r14] Fixes

### DIFF
--- a/WorkloadManagementSystem/Client/CPUNormalization.py
+++ b/WorkloadManagementSystem/Client/CPUNormalization.py
@@ -177,7 +177,7 @@ def getCPUTime( cpuNormalizationFactor ):
     if not cpuNormalizationFactor:  # if cpuNormalizationFactor passed in is 0, try get it from the local cfg
       cpuNormalizationFactor = gConfig.getValue( '/LocalSite/CPUNormalizationFactor', 0.0 )
     if cpuNormalizationFactor:
-      cpuTimeLeft = cpuWorkLeft / cpuNormalizationFactor
+      cpuTimeLeft = cpuWorkLeft / cpuNormalizationFactor  # this is a float
 
   if not cpuTimeLeft:
     # now we know that we have to find the CPUTimeLeft by looking in the CS
@@ -194,22 +194,22 @@ def getCPUTime( cpuNormalizationFactor ):
       if not res['OK']:
         raise RuntimeError( res['Message'] )
       queues = res['Value']
-      cpuTimes = [gConfig.getValue( queueSection + '/' + queue + '/maxCPUTime', 10000 ) for queue in queues]
+      cpuTimes = [gConfig.getValue( queueSection + '/' + queue + '/maxCPUTime', 10000. ) for queue in queues]
       # These are (real, wall clock) minutes - damn BDII!
       cpuTimeLeft = min( cpuTimes ) * 60
     else:
       queueInfo = getQueueInfo( '%s/%s' % ( gridCE, ceQueue ) )
-      cpuTimeLeft = 3600
+      cpuTimeLeft = 3600.
       if not queueInfo['OK'] or not queueInfo['Value']:
         gLogger.warn( "Can't find a CE/queue, defaulting CPUTime to %d" % cpuTimeLeft )
       else:
         queueCSSection = queueInfo['Value']['QueueCSSection']
         # These are (real, wall clock) minutes - damn BDII!
-        cpuTimeInMinutes = gConfig.getValue( '%s/maxCPUTime' % queueCSSection )
+        cpuTimeInMinutes = gConfig.getValue( '%s/maxCPUTime' % queueCSSection, 0. )
         if cpuTimeInMinutes:
           cpuTimeLeft = cpuTimeInMinutes * 60.
-          gLogger.info( "CPUTime for %s: %d" % ( queueCSSection, cpuTimeLeft ) )
+          gLogger.info( "CPUTime for %s: %f" % ( queueCSSection, cpuTimeLeft ) )
         else:
-          gLogger.warn( "Can't find maxCPUTime for %s, defaulting CPUTime to %d" % ( queueCSSection, cpuTimeLeft ) )
+          gLogger.warn( "Can't find maxCPUTime for %s, defaulting CPUTime to %f" % ( queueCSSection, cpuTimeLeft ) )
 
   return int( cpuTimeLeft )

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -373,16 +373,19 @@ class CheckCECapabilities( CommandBase ):
     """ Setup CE/Queue Tags
     """
 
+    cfg = []
     if self.pp.useServerCertificate:
-      self.cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
+      cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
+      cfg.append( "-o /DIRAC/Security/CertFile=%s/hostcert.pem" % self.pp.certsLocation )
+      cfg.append( "-o /DIRAC/Security/KeyFile=%s/hostkey.pem" % self.pp.certsLocation )
     if self.pp.localConfigFile:
-      self.cfg.append( self.pp.localConfigFile )  # this file is as input
+      cfg.append( self.pp.localConfigFile )  # this file is as input
 
 
     checkCmd = 'dirac-resource-get-parameters -S %s -N %s -Q %s %s' % ( self.pp.site,
                                                                         self.pp.ceName,
                                                                         self.pp.queueName,
-                                                                        " ".join( self.cfg ) )
+                                                                        " ".join( cfg ) )
     retCode, resourceDict = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
 
     import json
@@ -392,9 +395,15 @@ class CheckCECapabilities( CommandBase ):
     if resourceDict.get( 'Tag' ):
       self.pp.tags.append( resourceDict['Tag'] )
       self.cfg.append( '-FDMH' )
+
+      if self.pp.useServerCertificate:
+        self.cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
+        self.cfg.append( "-o /DIRAC/Security/CertFile=%s/hostcert.pem" % self.pp.certsLocation )
+        self.cfg.append( "-o /DIRAC/Security/KeyFile=%s/hostkey.pem" % self.pp.certsLocation )
+
       if self.pp.localConfigFile:
-        self.cfg.append( '-O %s' % self.pp.localConfigFile )
-        self.cfg.append( self.pp.localConfigFile )
+        self.cfg.append( '-O %s' % self.pp.localConfigFile )  # this file is as output
+        self.cfg.append( self.pp.localConfigFile )  # this file is as input
 
       if self.debugFlag:
         self.cfg.append( '-ddd' )


### PR DESCRIPTION
- cpuTimeLeft is now always a float in CPUNormalization.py -- @phicharp 
- pilot commands CheckCECapabilities and CheckWNCapabilities were not considering the case of missing proxy (e.g. every VM) -- @CinziaLu 