### PR TITLE
[v6r14] HTCondorCE tweaks, log output

### DIFF
--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -10,7 +10,9 @@
 
 """
 
-__RCSID__ = "$Id$"
+import os
+import tempfile
+import commands
 
 from DIRAC.Resources.Computing.ComputingElement          import ComputingElement
 from DIRAC.Core.Utilities.Grid                           import executeGridCommand
@@ -21,9 +23,8 @@ from DIRAC.WorkloadManagementSystem.Agent.SiteDirector   import WAITING_PILOT_ST
 from DIRAC.Core.Utilities.File                           import makeGuid
 from DIRAC.Core.Utilities.Subprocess                     import Subprocess
 
-import os
-import tempfile
-import commands
+__RCSID__ = "$Id$"
+
 CE_NAME = 'HTCondorCE'
 MANDATORY_PARAMETERS = [ 'Queue' ]
 DEFAULT_WORKINGDIRECTORY = '/opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT'

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -252,7 +252,7 @@ Queue %(nJobs)s
     for job,jobID in condorIDs.iteritems():
 
       pilotStatus = parseCondorStatus( lines, jobID )
-      if pilotStatus == 'Held':
+      if pilotStatus == 'HELD':
         #make sure the pilot stays dead and gets taken out of the condor_q
         _rmStat, _rmOut = commands.getstatusoutput( 'condor_rm %s ' % jobID )
         #self.log.debug( "condor job killed: job %s, stat %s, message %s " % ( jobID, rmStat, rmOut ) )

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -26,7 +26,7 @@ import tempfile
 import commands
 CE_NAME = 'HTCondorCE'
 MANDATORY_PARAMETERS = [ 'Queue' ]
-
+DEFAULT_WORKINGDIRECTORY = '/opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT'
 
 def condorIDFromJobRef( jobRef ):
   """return tuple of "jobURL" and condorID from the jobRef string"""
@@ -276,9 +276,8 @@ Queue %(nJobs)s
     ## FIXME: the WMSAdministrator does not know about the
     ## SiteDirector WorkingDirectory, it might not even run on the
     ## same machine
-    workingDirectory = self.ceParameters.get( 'WorkingDirectory',
-                                              '/opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT' )
-    workingDirectory = '/opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT'
+    workingDirectory = self.ceParameters.get( 'WorkingDirectory', DEFAULT_WORKINGDIRECTORY )
+    workingDirectory = DEFAULT_WORKINGDIRECTORY
 
     output = ''
     error = ''
@@ -331,9 +330,8 @@ Queue %(nJobs)s
 
   def __cleanup( self ):
     """ clean the working directory of old jobs"""
-    workingDirectory = self.ceParameters.get( 'WorkingDirectory',
-                                              '/opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT' )
-    workingDirectory = '/opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT'
+    workingDirectory = self.ceParameters.get( 'WorkingDirectory', DEFAULT_WORKINGDIRECTORY )
+    workingDirectory = DEFAULT_WORKINGDIRECTORY
 
     self.log.debug( "Cleaning working directory: %s" % workingDirectory )
 

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -92,7 +92,7 @@ class HTCondorCEComputingElement( ComputingElement ):
 
     """
     workingDirectory = self.ceParameters['WorkingDirectory']
-    initialDir = '/'.join( workingDirectory.split('/')[:-1] )
+    initialDir = os.path.dirname( workingDirectory )
     self.log.debug( "Working directory: %s " % workingDirectory )
     ##We randomize the location of the pilotoutput and log, because there are just too many of them
     pre1 = makeGuid()[:3]

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -119,6 +119,7 @@ initialdir = %(initialDir)s
 grid_resource = condor %(ceName)s %(ceName)s:9619
 ShouldTransferFiles = YES
 WhenToTransferOutput = ON_EXIT_OR_EVICT
+kill_sig=SIGTERM
 Queue %(nJobs)s
 
 """ % dict( executable=executable,

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -55,7 +55,7 @@ def findFile( workingDir, fileName ):
   res = Subprocess().systemCall("find %s -name '%s'" % (workingDir, fileName), shell=True)
   if not res['OK']:
     return res
-  paths = res['Value'].splitlines()
+  paths = res['Value'][1].splitlines()
   return S_OK(paths)
 
 def getCondorLogFile( pilotRef ):

--- a/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -93,6 +93,14 @@ def getPilotLoggingInfo( grid, pilotRef ):
     cmd = [ 'glite-wms-job-logging-info', '-v', '3', '--noint', pilotRef ]
   elif grid == 'CREAM':
     cmd = [ 'glite-ce-job-status', '-L', '2', '%s' % pilotRef ]
+  elif grid == 'HTCondorCE':
+    ## need to import here, otherwise import errors happen
+    from DIRAC.Resources.Computing.HTCondorCEComputingElement import getCondorLogFile
+    resLog = getCondorLogFile( pilotRef )
+    if not resLog['OK']:
+      return resLog
+    logFile = resLog['Value']
+    cmd = [ 'cat', logFile ]
   else:
     return S_ERROR( 'Pilot logging not available for %s CEs' % grid )
 

--- a/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -100,7 +100,7 @@ def getPilotLoggingInfo( grid, pilotRef ):
     if not resLog['OK']:
       return resLog
     logFile = resLog['Value']
-    cmd = [ 'cat', logFile ]
+    cmd = [ 'cat', " ".join(logFile) ]
   else:
     return S_ERROR( 'Pilot logging not available for %s CEs' % grid )
 


### PR DESCRIPTION
Some improvements for the HTCondorCE, still some open issues about the WorkingDirectory...
(Maybe adding a section in Operations for WorkingDirectory and how long the condor out/err/log files are kept?)

The Condor logging can now be obtained in the webinterface (that are the changes in WMSUtilities)

The pilot out and err files and the log files for each job are now placed in random locations.
Using find to find the files (which is fast enough...)
All log/out/err files older than 15 days are removed (using find again).

SIGTERM (instead of SIGKILL) is send to the application in case jobs are killed by the host site.

When pilots are put in held status we kill them in condor and mark them as aborted.
Some OSG sites allow opportunistic resources only 2 hours of uninterrupted running, after which jobs are held, but might be restarted later, to avoid this we have to kill the pilot. There are also other reasons (missing input files, outputfiles, resource offline) jobs are put in "Held" status all of which are bad and pilots are cheap enough to just kill them in this case.
Note that the "HELD" we use in this file should never make it outside as we set the status to "Aborted" after the pilot is killed