### PR TITLE
[v6r15] Don't block the ReqProxy sweeping if one of the request is buggy

### DIFF
--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -138,7 +138,7 @@ class Request( object ):
       opStatus, op = opStatusList.pop( 0 )
 
       # # Failed -> Failed
-      if opStatus == "Failed":
+      if opStatus == "Failed" and self.__waiting is None:
         rStatus = "Failed"
         break
 

--- a/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -118,7 +118,7 @@ class ReqProxyHandler( RequestHandler ):
           gLogger.info( "sweeper: successfully put request '%s' @ ReqManager" % cachedName )
           os.unlink( cachedFile )
         except Exception as error:
-          gLogger.exception( "sweeper: hit by exception %s" % str( error ) )
+          gLogger.exception( "sweeper: hit by exception", lException = error )
       return S_OK()
 
   def __saveRequest( self, requestName, requestJSON ):

--- a/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -117,9 +117,8 @@ class ReqProxyHandler( RequestHandler ):
             continue
           gLogger.info( "sweeper: successfully put request '%s' @ ReqManager" % cachedName )
           os.unlink( cachedFile )
-        except Exception, error:
+        except Exception as error:
           gLogger.exception( "sweeper: hit by exception %s" % str( error ) )
-          return S_ERROR( "sweeper: hit by exception: %s" % str( error ) )
       return S_OK()
 
   def __saveRequest( self, requestName, requestJSON ):


### PR DESCRIPTION
If one of the request is malformed for a reason or another, the rest of the requests could not be swiped. This PR fixes this behavior.