### PR TITLE
[v6r14] Enable ThirdPartyCopy with XROOTStorage

### DIFF
--- a/Resources/Storage/XROOTStorage.py
+++ b/Resources/Storage/XROOTStorage.py
@@ -416,16 +416,17 @@ class XROOTStorage( StorageBase ):
           self.log.debug( "XROOTStorage.__putSingleFile: Successfully removed remote file" )
 
     # get the absolute path needed by the xroot api
-    src_file = os.path.abspath( src_file )
-    if not os.path.exists( src_file ):
-      errStr = "XROOTStorage.__putSingleFile: The local source file does not exist."
-      gLogger.error( errStr, src_file )
-      return S_ERROR( errStr )
-    sourceSize = getSize( src_file )
-    if sourceSize == -1:
-      errStr = "XROOTStorage.__putSingleFile: Failed to get file size."
-      gLogger.error( errStr, src_file )
-      return S_ERROR( errStr )
+    if not src_file.startswith( "root:" ):
+      src_file = os.path.abspath( src_file )
+      if not os.path.exists( src_file ):
+        errStr = "XROOTStorage.__putSingleFile: The local source file does not exist."
+        gLogger.error( errStr, src_file )
+        return S_ERROR( errStr )
+      sourceSize = getSize( src_file )
+      if sourceSize == -1:
+        errStr = "XROOTStorage.__putSingleFile: Failed to get file size."
+        gLogger.error( errStr, src_file )
+        return S_ERROR( errStr )
 
     # Perform the copy with the API
     status = self.xrootClient.copy( src_file, dest_url )

--- a/Resources/Storage/XROOTStorage.py
+++ b/Resources/Storage/XROOTStorage.py
@@ -59,7 +59,6 @@ class XROOTStorage( StorageBase ):
     # The API instance to be used
     self.xrootClient = client.FileSystem( self.host )
 
-
   def exists( self, path ):
     """Check if the given path exists. The 'path' variable can be a string or a list of strings.
 
@@ -288,9 +287,13 @@ class XROOTStorage( StorageBase ):
         return S_ERROR( errStr )
 
 
-    status = self.xrootClient.copy( src_url, dest_file )
+    ##create this local to get clean job queue
+    copyProc = client.CopyProcess()
+    copyProc.add_job( source=src_url, target=dest_file, thirdparty="first" )
+    copyProc.prepare()
+    runStatusTuple = copyProc.run()
     # For some reason, the copy method returns a tuple (status,None)
-    status = status[0]
+    status = runStatusTuple[0]
 
     if status.ok:
       self.log.debug( 'XROOTStorage.__getSingleFile: Got a file from storage.' )
@@ -428,10 +431,13 @@ class XROOTStorage( StorageBase ):
         gLogger.error( errStr, src_file )
         return S_ERROR( errStr )
 
-    # Perform the copy with the API
-    status = self.xrootClient.copy( src_file, dest_url )
+    # Perform the copy with the API, create CopyProcess locally to get clean job queue
+    copyProc = client.CopyProcess()
+    copyProc.add_job( source=src_file, target=dest_url, thirdparty="first" )
+    copyProc.prepare()
+    runStatusTuple = copyProc.run()
     # For some reason, the copy method returns a tuple (status,None)
-    status = status[0]
+    status = runStatusTuple[0]
 
     if status.ok:
       self.log.debug( 'XROOTStorage.__putSingleFile: Put file on storage.' )

--- a/Resources/Storage/XROOTStorage.py
+++ b/Resources/Storage/XROOTStorage.py
@@ -1606,30 +1606,17 @@ class XROOTStorage( StorageBase ):
     return S_OK( fullUrl )
 
   def constructURLFromLFN( self, lfn, withWSUrl = False ):
-    """ Construct URL from the given LFN according to the VO convention for the
-    primary protocol of the storage plagin
-
-    Copy of :function:`StorageBase.constructURLFromLFN`, appends the svcClass addition to the URL
+    """ Calls :function:`StorageBase.constructURLFromLFN` and appends the svcClass addition to the URL
+    if spaceToken is set for this SE
 
     :param str lfn: file LFN
     :param boolean withWSUrl: flag to include the web service part into the resulting URL
-    :return result: result['Value'] - resulting URL
+    :return: result['Value'] - resulting URL
     """
-
-    # Check the LFN convention:
-    # 1. LFN must start with the VO name as the top level directory
-    # 2. VO name must not appear as any subdirectory or file name
-    lfnSplitList = lfn.split( '/' )
-    voLFN = lfnSplitList[1]
-    # TODO comparison to Sandbox below is for backward compatibility, should be removed in the next release
-    if voLFN != self.se.vo and voLFN != "SandBox" and voLFN != "Sandbox" :
-      return S_ERROR( 'LFN does not follow the DIRAC naming convention %s' % lfn )
-
-    result = self.getURLBase( withWSUrl = withWSUrl )
+    result = super( XROOTStorage, self ).constructURLFromLFN( lfn = lfn, withWSUrl = withWSUrl )
     if not result['OK']:
       return result
-    urlBase = result['Value']
-    url = os.path.join( urlBase, lfn.lstrip( '/' ) )
+    url = result['Value']
     if self.protocolParameters.get('SpaceToken', None):
       url += "?svcClass=%(SpaceToken)s" % self.protocolParameters
     return S_OK( url )

--- a/Resources/Storage/test/TestXROOTStorage.py
+++ b/Resources/Storage/test/TestXROOTStorage.py
@@ -38,7 +38,7 @@ class XROOTStorage_TestCase( unittest.TestCase ):
                              Path='path',
                              Host='host',
                              Port='',
-                             SpaceTolen='spaceToken',
+                             SpaceToken='spaceToken',
                              WSPath='wspath',
                             )
     self.testClass = self.moduleTested.XROOTStorage
@@ -191,7 +191,7 @@ class XROOTStorage_Success( XROOTStorage_TestCase ):
     self.assertEqual( 'path'       , resource.protocolParameters['Path'] )
     self.assertEqual( 'host'       , resource.protocolParameters['Host'] )
     self.assertEqual( 0       , resource.protocolParameters['Port'] )
-    self.assertEqual( 0       , resource.protocolParameters['SpaceToken'] )
+    self.assertEqual( 'spaceToken' , resource.protocolParameters['SpaceToken'] )
     self.assertEqual( 0       , resource.protocolParameters['WSUrl'] )
 
   def test_getParameters( self ):
@@ -206,7 +206,7 @@ class XROOTStorage_Success( XROOTStorage_TestCase ):
     self.assertEqual( 'path'       , res['Path'] )
     self.assertEqual( 'host'       , res['Host'] )
     self.assertEqual( 0       , res['Port'] )
-    self.assertEqual( 0 , res['SpaceToken'] )
+    self.assertEqual( 'spaceToken' , res['SpaceToken'] )
     self.assertEqual( 0     , res['WSUrl'] )
 
   # def test_getProtocolPfn( self ):
@@ -1045,7 +1045,25 @@ class XROOTStorage_Success( XROOTStorage_TestCase ):
     self.assertEqual( {"remoteA" : { "Files" : 0, "Size" : 0}}, res['Value']['Failed'] )
 
 
+  def test_constructURLFromLFN( self ):
 
+    resource = self.testClass( 'storageName', self.parameterDict )
+    resource.se  = MagicMock()
+    voName = "voName"
+    resource.se.vo = voName
+    testLFN= "/%s/path/to/filename" % voName
+
+    ## with spaceToken
+    res = resource.constructURLFromLFN( testLFN )
+    self.assertTrue( res['OK'] )
+    self.assertEqual( "protocol://host/path%s?svcClass=%s" % ( testLFN, self.parameterDict['SpaceToken'] )
+                      , res['Value'] )
+
+    ## no spaceToken
+    resource.protocolParameters['SpaceToken']  = ""
+    res = resource.constructURLFromLFN( testLFN )
+    self.assertTrue( res['OK'] )
+    self.assertEqual( "protocol://host/path%s" % ( testLFN,  ) , res['Value'] )
 
 
 if __name__ == '__main__':

--- a/Resources/Storage/test/TestXROOTStorage.py
+++ b/Resources/Storage/test/TestXROOTStorage.py
@@ -771,6 +771,9 @@ class XROOTStorage_Success( XROOTStorage_TestCase ):
 
 
     # This test should be completely okay
+    copymock = mock.Mock()
+    copymock.run.return_value = (statusMock, None)
+    self.moduleTested.client.CopyProcess = mock.Mock(return_value=copymock)
     res = resource.getFile( "a", "/tmp" )
     self.assertEqual( True, res['OK'] )
     self.assertEqual( {"a" :-1}, res['Value']['Successful'] )
@@ -864,6 +867,9 @@ class XROOTStorage_Success( XROOTStorage_TestCase ):
     resource.xrootClient.dirlist = MagicMock( side_effect = [( statusStatDirMock, directoryListMock1 ), ( statusStatDirMock, directoryListMock2 ), ( statusStatDirMock, directoryListMock3 )] )
 
     # This test should get the 3 files
+    copymock = mock.Mock()
+    copymock.run.return_value = (statusMock, None)
+    self.moduleTested.client.CopyProcess = mock.Mock(return_value=copymock)
     res = resource.getDirectory( "A" )
     self.assertEqual( True, res['OK'] )
     self.assertEqual( {"A" : { "Files" : 3, "Size" :-3}}, res['Value']['Successful'] )
@@ -940,6 +946,9 @@ class XROOTStorage_Success( XROOTStorage_TestCase ):
 
 
     # This test should be completely okay
+    copymock = mock.Mock()
+    copymock.run.return_value = (statusMock, None)
+    self.moduleTested.client.CopyProcess = mock.Mock(return_value=copymock)
     res = resource.putFile( {"remoteA" : "localA"} )
     self.assertEqual( True, res['OK'] )
     self.assertEqual( {"remoteA" : 1}, res['Value']['Successful'] )
@@ -1017,6 +1026,9 @@ class XROOTStorage_Success( XROOTStorage_TestCase ):
 
 
     # This test should upload the 3 files
+    copymock = mock.Mock()
+    copymock.run.return_value = (statusCopyMock, None)
+    self.moduleTested.client.CopyProcess = mock.Mock(return_value=copymock)
     res = resource.putDirectory( {"remoteA" : "localA"} )
     self.assertEqual( True, res['OK'] )
     self.assertEqual( {"remoteA" : { "Files" : 3, "Size" :3}}, res['Value']['Successful'] )


### PR DESCRIPTION
These changes allow one to use third party copy between storage elements based on xroot.
