### PR TITLE
[v6r14] Add a way for an operator to drain nodes quicker then just condor_off…

### DIFF
--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -8,7 +8,6 @@
 __RCSID__ = "$Id$"
 
 import os
-import os.path
 import sys
 import re
 import time

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -8,6 +8,7 @@
 __RCSID__ = "$Id$"
 
 import os
+import os.path
 import sys
 import re
 import time
@@ -93,6 +94,8 @@ class JobAgent( AgentModule ):
     """The JobAgent execution method.
     """
     if self.jobCount:
+      if os.path.exists('/var/lib/dirac_drain'):
+        return self.__finish( 'Node is being drained by an operator' )
       # Only call timeLeft utility after a job has been picked up
       self.log.info( 'Attempting to check CPU time left for filling mode' )
       if self.fillingMode:


### PR DESCRIPTION
… -peaceful

At our site, we would like to be able to drain our condor compute nodes when we detect things like failing hardware. We currently can drain a node with condor_off -peaceful to prevent new jobs from starting.

Unfortunately, jobs submitted through dirac still execute multiple subjobs per single condor job, blocking the node from maintenance often for more then 24 hours after start of draining. The only option at present is to kill the pilot job ungracefully or wait a very long time for the pilot job to finish running as many subjobs as it thinks are reasonable.

This patch proposes a simple way for the operator to notify the existing pilot jobs that it shouldn't start any further subjobs once it has completed its current one. This, when combined with the condor_off -peaceful should allow operators to much more quickly pull a node out for maintenance while allowing existing work to complete without issue.

Note, I'm not tied to this particular implementation, so if there's a better way to do this, please let me know.

Thanks,
Kevin