### PR TITLE
[v6r14] Attempt to reconcile getCEStatus for LHCb and others

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -14,10 +14,11 @@ import os
 import stat
 
 import arc # Has to work if this module is called
-from DIRAC                                               import S_OK, S_ERROR, gConfig, gLogger
+from DIRAC                                               import S_OK, S_ERROR, gConfig, gLogger, shellCall
 from DIRAC.Resources.Computing.ComputingElement          import ComputingElement
 from DIRAC.Core.Utilities.SiteCEMapping                  import getSiteForCE
 from DIRAC.Core.Utilities.File                           import makeGuid
+from DIRAC.Core.Security.ProxyInfo                       import getVOfromProxyGroup
 
 # Uncomment the following 5 lines for getting verbose ARC api output (debugging)
 # import sys
@@ -284,6 +285,7 @@ class ARCComputingElement( ComputingElement ):
   #############################################################################
   def getCEStatus( self ):
     """ Method to return information on running and pending jobs.
+        We hope to satisfy both instances that use robot proxies and those which use proper configurations.
     """
 
     result = self._prepareProxy()
@@ -291,19 +293,49 @@ class ARCComputingElement( ComputingElement ):
     if not result['OK']:
       gLogger.error( 'ARCComputingElement: failed to set up proxy', result['Message'] )
       return result
-    endpoints = [arc.Endpoint( "ldap://" + self.ceHost + "/MDS-Vo-name=local,o=grid",
-                               arc.Endpoint.COMPUTINGINFO, 'org.nordugrid.ldapng')]
-    retriever = arc.ComputingServiceRetriever(self.usercfg, endpoints)
-    retriever.wait() # Takes a bit of time to get and parse the ldap information
-    targets = retriever.GetExecutionTargets()
-    ceStats = targets[0].ComputingShare
-    gLogger.debug("Running jobs for CE %s : %s" % (self.ceHost, ceStats.RunningJobs))
-    gLogger.debug("Waiting jobs for CE %s : %s" % (self.ceHost, ceStats.WaitingJobs))
+
+    # Try to find out which VO we are running for.
+    vo = ''
+    res = getVOfromProxyGroup()
+    if res['OK']:
+      vo = res['Value']
 
     result = S_OK()
-    result['RunningJobs'] = ceStats.RunningJobs
-    result['WaitingJobs'] = ceStats.WaitingJobs
     result['SubmittedJobs'] = 0
+    if (vo eq '') :
+      # Presumably the really proper way forward once the infosys-discuss WG comes up with a solution
+      # and it is implemented. Needed for DIRAC instances which use robot certificates for pilots.
+      endpoints = [arc.Endpoint( "ldap://" + self.ceHost + "/MDS-Vo-name=local,o=grid",
+                               arc.Endpoint.COMPUTINGINFO, 'org.nordugrid.ldapng')]
+      retriever = arc.ComputingServiceRetriever(self.usercfg, endpoints)
+      retriever.wait() # Takes a bit of time to get and parse the ldap information
+      targets = retriever.GetExecutionTargets()
+      ceStats = targets[0].ComputingShare
+      gLogger.debug("Running jobs for CE %s : %s" % (self.ceHost, ceStats.RunningJobs))
+      gLogger.debug("Waiting jobs for CE %s : %s" % (self.ceHost, ceStats.WaitingJobs))
+      result['RunningJobs'] = ceStats.RunningJobs
+      result['WaitingJobs'] = ceStats.WaitingJobs
+    else:
+      # The system which works properly for ARC CEs that are configured correctly. But for this,
+      # we need the VO to be known
+      cmd = 'ldapsearch -x -LLL -H ldap://%s:2135 -b mds-vo-name=resource,o=grid "(GlueVOViewLocalID=%s)"' %(self.ceHost, vo.lower())
+      res = shellCall( 0, cmd )
+      if not res['OK']:
+        gLogger.debug("Could not query CE %s - is it down?" % self.ceHost)
+        return res
+      try:
+        ldapValues = res['Value'][1].split("\n")
+        running = [y for y in ldapValues if 'GlueCEStateRunningJobs' in y]
+        waiting = [y for y in ldapValues if 'GlueCEStateWaitingJobs' in y]
+        result['RunningJobs'] = int(running[0].split(":")[1])
+        result['WaitingJobs'] = int(waiting[0].split(":")[1])
+      except IndexError:
+        res = S_ERROR('Unknown ldap failure for site %s' % self.ceHost)
+        res['RunningJobs'] = 0
+        res['WaitingJobs'] = 0
+        res['SubmittedJobs'] = 0
+        return res
+
     return result
 
   #############################################################################

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -14,7 +14,8 @@ import os
 import stat
 
 import arc # Has to work if this module is called
-from DIRAC                                               import S_OK, S_ERROR, gConfig, gLogger, shellCall
+from DIRAC                                               import S_OK, S_ERROR, gConfig, gLogger
+from DIRAC.Core.Utilities.Subprocess                     import shellCall
 from DIRAC.Resources.Computing.ComputingElement          import ComputingElement
 from DIRAC.Core.Utilities.SiteCEMapping                  import getSiteForCE
 from DIRAC.Core.Utilities.File                           import makeGuid
@@ -302,7 +303,7 @@ class ARCComputingElement( ComputingElement ):
 
     result = S_OK()
     result['SubmittedJobs'] = 0
-    if (vo eq '') :
+    if (vo == '') :
       # Presumably the really proper way forward once the infosys-discuss WG comes up with a solution
       # and it is implemented. Needed for DIRAC instances which use robot certificates for pilots.
       endpoints = [arc.Endpoint( "ldap://" + self.ceHost + "/MDS-Vo-name=local,o=grid",
@@ -316,8 +317,8 @@ class ARCComputingElement( ComputingElement ):
       result['RunningJobs'] = ceStats.RunningJobs
       result['WaitingJobs'] = ceStats.WaitingJobs
     else:
-      # The system which works properly for ARC CEs that are configured correctly. But for this,
-      # we need the VO to be known
+      # The system which works properly at present for ARC CEs that are configured correctly.
+      # But for this we need the VO to be known
       cmd = 'ldapsearch -x -LLL -H ldap://%s:2135 -b mds-vo-name=resource,o=grid "(GlueVOViewLocalID=%s)"' %(self.ceHost, vo.lower())
       res = shellCall( 0, cmd )
       if not res['OK']:


### PR DESCRIPTION
This is a PR to presumably be discussed further in this thread.

Aim : Reconcile the usage of getCEStatus for the configuration as used for GridPP (robot certificates for pilot proxy) and LHCb (human certificates).

Attempt : Try to get the VO information. If a valid VO can be obtained, assume that the proxy is not a robot certificate and proceed. Otherwise proceed the other way.

Future of this PR :
1. Depends on the outcome of the infosys-discuss mailing list where a proper implementation of Glue2 on ARC CEs (among others) is being discussed. Once this is implemented by the sites (and ARC), the "robot certificate" method of using just the ARC api will presumably become the formally standard way of doing this.
2. If GridPP (and other instances?) move to using human certificates, the "if" statement can be removed.

This code is so far tested in the LHCb test instance and seems to work okay.