### PR TITLE
[v6r14] Fix Service class

### DIFF
--- a/Core/DISET/private/Service.py
+++ b/Core/DISET/private/Service.py
@@ -29,7 +29,7 @@ class Service:
 
   def __init__( self, serviceData ):
     self._svcData = serviceData
-    self._name = serviceData[ 'loadName' ]
+    self._name = serviceData[ 'modName' ]
     self._startTime = Time.dateTime()
     self._validNames = [ serviceData[ 'modName' ]  ]
     if serviceData[ 'loadName' ] not in self._validNames:
@@ -115,28 +115,6 @@ class Service:
     gThreadScheduler.addPeriodicTask( 30, self.__reportThreadPoolContents )
 
     return S_OK()
-
-  def _discoverHandlerLocation( self ):
-    handlerLocation = self._cfg.getHandlerLocation()
-    if handlerLocation:
-      if handlerLocation.find( "Handler.py" ) != len( handlerLocation ) - 10:
-        return S_ERROR( "CS defined file %s does not have a valid handler name" % handlerLocation )
-      return handlerLocation
-    fields = [ field.strip() for field in self._name.split( "/" ) if field.strip() ]
-    if len( fields ) != 2:
-      gLogger.error( "Oops. Invalid service name!", self._name )
-      return False
-    gLogger.debug( "Trying to auto discover handler" )
-    rootModulesToLook = [ "%sDIRAC" % ext for ext in gConfig.getValue( "/DIRAC/Extensions", [] ) ] + [ 'DIRAC' ]
-    for rootModule in rootModulesToLook:
-      gLogger.debug( "Trying to find handler in %s root module" % rootModule )
-      filePath = os.path.join( rootModule, "%sSystem" % fields[0], "Service", "%sHandler.py" % fields[1] )
-      absPath = os.path.join ( DIRAC.rootPath, filePath )
-      if os.path.isfile( absPath ):
-        gLogger.debug( "Auto discovered handler %s" % filePath )
-        return filePath
-      gLogger.debug( "%s is not a valid file" % filePath )
-    return False
 
   def __searchInitFunctions( self, handlerClass, currentClass = None ):
     if not currentClass:


### PR DESCRIPTION
After enabling Service configuration to inherit another Service configuration with Module option, the Service name can be different from the name of the class of the service handler. The private self._name variable was still pointing to the class name. This was wrong and caused the StorageElement service to fail in case it was configured with the Module option.

Removed obsoleted _discoverHandlerLocation. This function is performed by the ModuleLoader.