### PR TITLE
[v6r14] Increase verbosity in error message

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -2029,7 +2029,7 @@ class Dirac( API ):
     jobIDs = result['Value']
     self.log.verbose( '%s job(s) selected' % ( len( jobIDs ) ) )
     if not jobIDs:
-      return S_ERROR( 'No jobs selected for conditions: %s' % conditions )
+      return S_ERROR( "No jobs selected with date '%s' for conditions: %s" % (str(date), conditions) )
     else:
       return result
 

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -2029,7 +2029,8 @@ class Dirac( API ):
     jobIDs = result['Value']
     self.log.verbose( '%s job(s) selected' % ( len( jobIDs ) ) )
     if not jobIDs:
-      return S_ERROR( "No jobs selected with date '%s' for conditions: %s" % (str(date), conditions) )
+      self.log.error( "No jobs selected", "with date '%s' for conditions: %s" % (str(date), conditions))
+      return S_ERROR( "No jobs selected" )
     else:
       return result
 


### PR DESCRIPTION
* Interfaces/API/Dirac.py (selectJobs):
Include in error message the date used to select the jobs.