### PR TITLE
[v6r14] VOMSService outputs only string type

### DIFF
--- a/Core/Security/VOMSService.py
+++ b/Core/Security/VOMSService.py
@@ -99,9 +99,9 @@ class VOMSService:
 
     if result is not None:
       if 'listUserAttributesReturn' in dir( result ):
-        return S_OK( result.listUserAttributesReturn[0].value )
+        return S_OK( str( result.listUserAttributesReturn[0].value ) )
 
-      return S_OK( result[0].value )
+      return S_OK( str( result[0].value ) )
     else:
       return S_ERROR( result )
 


### PR DESCRIPTION
Seal down the evilish suds.sax.text.Text type into VOMSService. The fix is already running in production in LHCb