### PR TITLE
[v6r14] Do not use ReqProxy when submitting Request for Tasks

### DIFF
--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -202,7 +202,7 @@ class RequestTasks( TaskBase ):
     """ Submits a request using ReqClient
     """
     if isinstance( oRequest, self.requestClass ):
-      return self.requestClient.putRequest( oRequest )
+      return self.requestClient.putRequest( oRequest, useFailoverProxy = False, retryMainService = 2 )
     else:
       return S_ERROR( "Request should be a Request object" )
 


### PR DESCRIPTION
The return of putting the Request is used as ExternalID for the Task. if it goes through a proxy, we never get the RequestID