### PR TITLE
[v6r15] Add standard metadata to all plugins

### DIFF
--- a/DataManagementSystem/Service/IRODSStorageElementHandler.py
+++ b/DataManagementSystem/Service/IRODSStorageElementHandler.py
@@ -37,6 +37,8 @@ from DIRAC import gLogger, S_OK, S_ERROR, gConfig
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
 
+from DIRAC.Resources.Storage.StorageBase import StorageBase
+
 from irods import rcConnect , rcDisconnect , clientLoginWithPassword, \
                   irodsCollection, irodsOpen, \
                   getResources , getResource
@@ -208,6 +210,7 @@ class IRODSStorageElementHandler( RequestHandler ):
       resultDict['Lost'] = 0
       resultDict['Unavailable'] = 0
       resultDict['Mode'] = 0o755
+      resultDict = StorageBase._addCommonMetadata( resultDict )
       return S_OK( resultDict )
     else:
       coll = irodsCollection( conn, file_path )
@@ -221,6 +224,7 @@ class IRODSStorageElementHandler( RequestHandler ):
         resultDict['Lost'] = 0
         resultDict['Unavailable'] = 0
         resultDict['Mode'] = 0o755
+        resultDict = StorageBase._addCommonMetadata( resultDict )
         return S_OK( resultDict )
       else:
         return S_ERROR( 'Path does not exist' )

--- a/DataManagementSystem/Service/IRODSStorageElementHandler.py
+++ b/DataManagementSystem/Service/IRODSStorageElementHandler.py
@@ -202,6 +202,8 @@ class IRODSStorageElementHandler( RequestHandler ):
     irodsFile = irodsOpen( conn , file_path , "r" )
     if irodsFile:
       resultDict['Exists'] = True
+      resultDict['File'] = True
+      resultDict['Directory'] = False
       resultDict['Type'] = "File"
       resultDict['Size'] = irodsFile.getSize()
       resultDict['TimeStamps'] = ( irodsFile.getCreateTs(), irodsFile.getModifyTs(), irodsFile.getCreateTs() )
@@ -217,6 +219,8 @@ class IRODSStorageElementHandler( RequestHandler ):
       if coll:
         resultDict['Exists'] = True
         resultDict['Type'] = "Directory"
+        resultDict['File'] = False
+        resultDict['Directory'] = True
         resultDict['Size'] = 0
         resultDict['TimeStamps'] = ( 0,0,0 )
         resultDict['Cached'] = 1

--- a/DataManagementSystem/Service/StorageElementHandler.py
+++ b/DataManagementSystem/Service/StorageElementHandler.py
@@ -41,6 +41,8 @@ from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
 from DIRAC.Core.Utilities.Os import getDirectorySize
 from DIRAC.Core.Utilities.Subprocess import shellCall
 
+from DIRAC.Resources.Storage.StorageBase import StorageBase
+
 BASE_PATH = ""
 MAX_STORAGE_SIZE = 0
 USE_TOKENS = False
@@ -143,6 +145,9 @@ class StorageElementHandler( RequestHandler ):
     resultDict['Lost'] = 0
     resultDict['Unavailable'] = 0
     resultDict['Mode'] = S_IMODE( mode )
+    resultDict = StorageBase._addCommonMetadata( resultDict
+
+                                                  )
     return S_OK( resultDict )
 
   types_exists = [StringTypes]

--- a/DataManagementSystem/Service/StorageElementHandler.py
+++ b/DataManagementSystem/Service/StorageElementHandler.py
@@ -40,6 +40,7 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
 from DIRAC.Core.Utilities.Os import getDirectorySize
 from DIRAC.Core.Utilities.Subprocess import shellCall
+from DIRAC.Core.Utilities.Adler            import fileAdler
 
 from DIRAC.Resources.Storage.StorageBase import StorageBase
 
@@ -136,8 +137,12 @@ class StorageElementHandler( RequestHandler ):
     resultDict['Exists'] = True
     mode = statTuple[ST_MODE]
     resultDict['Type'] = "File"
+    resultDict['File'] = True
+    resultDict['Directory'] = False
     if S_ISDIR( mode ):
       resultDict['Type'] = "Directory"
+      resultDict['File'] = False
+    resultDict['Directory'] = True
     resultDict['Size'] = statTuple[ST_SIZE]
     resultDict['TimeStamps'] = ( statTuple[ST_ATIME], statTuple[ST_MTIME], statTuple[ST_CTIME] )
     resultDict['Cached'] = 1
@@ -145,9 +150,16 @@ class StorageElementHandler( RequestHandler ):
     resultDict['Lost'] = 0
     resultDict['Unavailable'] = 0
     resultDict['Mode'] = S_IMODE( mode )
-    resultDict = StorageBase._addCommonMetadata( resultDict
+    
 
-                                                  )
+    if resultDict['File']:
+      cks = fileAdler( path )
+      resultDict['Checksum'] = cks
+
+    
+    resultDict = StorageBase._addCommonMetadata( resultDict )
+
+
     return S_OK( resultDict )
 
   types_exists = [StringTypes]

--- a/Resources/Storage/FileStorage.py
+++ b/Resources/Storage/FileStorage.py
@@ -241,6 +241,8 @@ class FileStorage( StorageBase ):
       metadataDict['Lost'] = 0
       metadataDict['Unavailable'] = 0
 
+      metadataDict = FileStorage._addCommonMetadata( metadataDict )
+
     except OSError as ose:
       return S_ERROR( str( ose ) )
 

--- a/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/Resources/Storage/GFAL2_SRM2Storage.py
@@ -83,6 +83,7 @@ class GFAL2_SRM2Storage( GFAL2_StorageBase ):
     metadataDict['Migrated'] = int( 'NEARLINE' in user_status )
     metadataDict['Lost'] = int( user_status == 'LOST' )
     metadataDict['Unavailable'] = int( user_status == 'UNAVAILABLE' )
+    metadataDict['Accessible'] = not metadataDict['Lost'] and metadataDict['Cached'] and not metadataDict['Unavailable']
 
   def getTransportURL( self, path, protocols = False ):
     """ obtain the tURLs for the supplied path and protocols

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -684,11 +684,14 @@ class GFAL2_StorageBase( StorageBase ):
       else:
         metadataDict['Checksum'] = ""
 
+    metadataDict = self._addCommonMetadata( metadataDict )
+
     res = self._getExtendedAttributes( path )
     # add extended attributes to the dict if available
     if res['OK']:
       attributeDict = res.get( 'Value', {} )
       self._updateMetadataDict( metadataDict, attributeDict )
+
 
     return S_OK ( metadataDict )
 

--- a/Resources/Storage/RFIOStorage.py
+++ b/Resources/Storage/RFIOStorage.py
@@ -202,6 +202,12 @@ class RFIOStorage( StorageBase ):
     for pfn in urls:
       if not successful[pfn].has_key( 'Migrated' ):
         successful[pfn]['Migrated'] = False
+        
+        
+    # Update all the metadata with the common one
+    for lfn in successful:
+      successful[lfn] = self._addCommonMetadata( successful[lfn] )
+
     resDict = {'Failed':{}, 'Successful':successful}
     return S_OK( resDict )
 

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -1522,6 +1522,12 @@ class SRM2Storage( StorageBase ):
           statDict['Unavailable'] = 1
         
         statDict['Accessible'] = not statDict['Lost'] and statDict['Cached'] and not statDict['Unavailable']
+      else:
+        statDict['Cached'] = 0
+        statDict['Migrated'] = 0
+        statDict['Lost'] = 0
+        statDict['Unavailable'] = 1
+        statDict['Accessible'] = False
 
 
     

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -1520,8 +1520,13 @@ class SRM2Storage( StorageBase ):
         statDict['Unavailable'] = 0
         if re.search( 'UNAVAILABLE', urlLocality ):
           statDict['Unavailable'] = 1
+        
+        statDict['Accessible'] = not statDict['Lost'] and statDict['Cached'] and not statDict['Unavailable']
 
-    return statDict
+
+    
+    return self._addCommonMetadata( statDict )
+
 
   def __getProtocols( self ):
     """ returns list of protocols to use at a given site

--- a/Resources/Storage/StorageBase.py
+++ b/Resources/Storage/StorageBase.py
@@ -352,3 +352,26 @@ class StorageBase( object ):
     urlDict = res['Value']
     return S_OK( urlDict['Protocol'] == self.protocolParameters['Protocol'] )
   
+  @staticmethod
+  def _addCommonMetadata( metadataDict ):
+    """ To make the output of getFileMetadata uniform throughout the protocols
+        this returns a minimum set of metadata with default value,
+        that are then complemented with the protocol specific metadata
+
+        :param metadataDict: specific metadata of the protocol
+
+        :returns: dictionnary with all the metadata (specific and basic)
+    """
+    commonMetadata = { 'Checksum' : '',
+                       'Directory' : False,
+                       'File' : False,
+                       'Mode' : 0o000,
+                       'Size' : 0,
+                       'Accessible' : True,
+                      }
+
+    commonMetadata.update( metadataDict )
+
+    return commonMetadata
+
+

--- a/Resources/Storage/XROOTStorage.py
+++ b/Resources/Storage/XROOTStorage.py
@@ -634,6 +634,8 @@ class XROOTStorage( StorageBase ):
       metadataDict['Lost'] = 0
       metadataDict['Cached'] = 1
       metadataDict['Unavailable'] = 0
+
+      metadataDict = self._addCommonMetadata( metadataDict )
       # If we expect a given type, we return a boolean
       if expectedType:
         isExpectedType = metadataDict[expectedType]


### PR DESCRIPTION
This PR is the first part of https://github.com/DIRACGrid/DIRAC/issues/2502

It defines a standard set of metadata that all the plugins have to return:
Checksum
Directory
File
Mode
Size
Accessible

In v6r16, once the next multi protocol steps will finally be merged (https://github.com/DIRACGrid/DIRAC/pull/2668), we will make use of it by checking the specific metadata (Lost, Cached...) only where it is really relevant, and by specifying getFileMetadata with the proper protocols

I also added the checksum computation in the DIPS storage handler, which was an other part of the bug  https://github.com/DIRACGrid/DIRAC/issues/2413
