### PR TITLE
[v6r15] Extensions information

### DIFF
--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -279,14 +279,14 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         
         fields = ['Parameter','Value']
         records = []
-        for key, value in result['Value'].items():
-          if key == 'Extension':
-            extensions = value.split( ',' )
+        for parameter in result['Value'].iteritems():
+          if parameter[0] == 'Extension':
+            extensions = parameter[1].split( ',' )
             for extension in extensions:
-              extKey, extValue = extension.split( ':' )
-              records.append( [ '%sVersion' % extKey, str( extValue ) ] )
+              extensionName, extensionVersion = extension.split( ':' )
+              records.append( [ '%sVersion' % extensionName, str( extensionVersion ) ] )
           else:
-            records.append( [ key, str( value ) ] )
+            records.append( [ parameter[0], str( parameter[1] ) ] )
           
         printTable( fields, records )  
     elif option == "hosts":

--- a/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -280,7 +280,13 @@ class SystemAdministratorClientCLI( cmd.Cmd ):
         fields = ['Parameter','Value']
         records = []
         for key, value in result['Value'].items():
-          records.append( [key, str( value ) ] )
+          if key == 'Extension':
+            extensions = value.split( ',' )
+            for extension in extensions:
+              extKey, extValue = extension.split( ':' )
+              records.append( [ '%sVersion' % extKey, str( extValue ) ] )
+          else:
+            records.append( [ key, str( value ) ] )
           
         printTable( fields, records )  
     elif option == "hosts":

--- a/FrameworkSystem/DB/InstalledComponentsDB.py
+++ b/FrameworkSystem/DB/InstalledComponentsDB.py
@@ -255,6 +255,7 @@ class HostLogging( Base ):
   hostName = Column( 'HostName', String( 32 ), nullable = False, primary_key = True )
   # status
   DIRAC = Column( 'DIRACVersion', String( 32 ) )
+  Extension = Column( 'Extension', String( 64 ) )
   Load1 = Column( 'Load1', String( 32 ) ) # float
   Load5 = Column( 'Load5', String( 32 ) ) # float
   Load15 = Column( 'Load15', String( 32 ) ) # float
@@ -309,6 +310,7 @@ class HostLogging( Base ):
     dictionary = {
                   'HostName': self.hostName,
                   'DIRACVersion': self.DIRAC,
+                  'Extension': self.Extension,
                   'Load1': self.Load1,
                   'Load5': self.Load5,
                   'Load15': self.Load15,


### PR DESCRIPTION
Added a new field, 'Extension', to the HostLogging database in order to log the version of the different extensions installed in a given host ( this information will be displayed by both the CLI and the SysAdmin web page: #2785 ).
Updated the CLI 'show host' command to display the new information.