### PR TITLE
[v6r15] fix backward compatibility has access

### DIFF
--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -140,13 +140,23 @@ class FileCatalogHandler( RequestHandler ):
     return gFileCatalogDB.getPathPermissions( lfns, self.getRemoteCredentials() )
   
   
-  types_hasAccess = [ dict, basestring ]
+  types_hasAccess = [ [basestring, dict], [basestring, list, dict] ]
   def export_hasAccess( self, paths, opType ):
     """ Determine if the given op can be performed on the paths
         The OpType is all the operations exported
+
+        The reason for the param types is backward compatibility. Between v6r14 and v6r15,
+        the signature of hasAccess has changed, and the two parameters were swapped.
     """
-    lfns = paths.keys()
-    return gFileCatalogDB.hasAccess( opType, lfns, self.getRemoteCredentials() )
+
+    # The signature of v6r15 is (dict, str)
+    # The signature of v6r14 is (str, [dict, str, list])
+    # We swap the two params if the first attribute is a string
+    if isinstance( paths, basestring ):
+      paths, opType = opType, paths
+
+    return gFileCatalogDB.hasAccess( opType, paths, self.getRemoteCredentials() )
+
   
 
   ###################################################################

--- a/DataManagementSystem/scripts/dirac-dms-remove-files.py
+++ b/DataManagementSystem/scripts/dirac-dms-remove-files.py
@@ -30,7 +30,7 @@ for inputFileName in args:
   else:
     lfns.append( inputFileName )
 
-from DIRAC.Core.Utilities.List import sortList, breakListIntoChunks
+from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 dm = DataManager()
 


### PR DESCRIPTION
the signature in v6r14 used to be (operationName (str), paths (str, list, dict)) while in v6r15 it is (paths (dict), operationName (str)).
If the first argument arriving to the serving is a string, we swap the parameters. This should go away as soon as v6r16 