### PR TITLE
[v6r14] Silence the constant update of the site description with funny whitespace

### DIFF
--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -184,6 +184,8 @@ def getSiteUpdates( vo, bdiiInfo = None, log = None ):
         newcoor = "%s:%s" % ( longitude, latitude )
       newmail = ceBdiiDict[site].get( 'GlueSiteSysAdminContact', '' ).replace( 'mailto:', '' ).strip()
       newdescription = ceBdiiDict[site].get( 'GlueSiteDescription', '' ).strip()
+      newdescription = ", ".join( [ line.strip() for line in newdescription.split( "," ) ] )
+
       # Adding site data to the changes list
       addToChangeSet( ( siteSection, 'Coordinates', coor, newcoor ), changeSet )
       addToChangeSet( ( siteSection, 'Mail', mail, newmail ), changeSet )


### PR DESCRIPTION
One site with a space before a comma was constantly being "updated" because the CS splits by comma and cleans whitespace afterwards (or something?).
This will cleanup the string around commas to make the "new" description the same as the old one
