### PR TITLE
[v6r14] Fix for Repo retrieve sandbox/outputdata

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -193,7 +193,7 @@ class Dirac( API ):
     for jobID in sorted( jobs ):
       jobDict = jobs[jobID]
       if jobDict.get( 'State' ) in requestedStates:
-        if not jobDict.get( 'Retrieved' ) :
+        if not int( jobDict.get( 'Retrieved' ) ) :
           self.getOutputSandbox( jobID, destinationDirectory )
     return S_OK()
 
@@ -220,7 +220,7 @@ class Dirac( API ):
     for jobID in sorted( jobs ):
       jobDict = jobs[jobID]
       if jobDict.get( 'State' ) in requestedStates:
-        if not jobDict.get( 'OutputData' ):
+        if not int( jobDict.get( 'OutputData' ) ):
           destDir = jobID
           if destinationDirectory:
             destDir = "%s/%s" % ( destinationDirectory, jobID )


### PR DESCRIPTION
Retrieved and OutputData are strings '0' in the jobDict when repo file is read, need to cast to int

