### PR TITLE
[v6r16] DynamicMonitoring task in SysAdmin

### DIFF
--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -54,21 +54,25 @@ class SystemAdministratorHandler( RequestHandler ):
       # Get the RabbitMQ parameters from the CS
       result = gConfig.getOption( 'DIRAC/Setup' )
       if not result[ 'OK' ]:
+        gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
         return result
       setup = result[ 'Value' ]
       result = gConfig.getOption( 'DIRAC/Setups/%s/%s' % ( setup, system ) )
       if not result[ 'OK' ]:
+        gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
         return result
       sysSetup = result[ 'Value' ]
       result = gConfig.getOptionsDict( 'Systems/%s/%s/MessageQueueing/%s' % ( system, sysSetup, queueName ) )
       if not result[ 'OK' ]:
+        gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
         return result
       parameters = result[ 'Value' ]
 
       # Setup the RabbitMQ connection with the retrieved parameters
       result = SystemAdministratorHandler.rabbitMQ.setupConnection( 'Framework', 'ComponentMonitoring', parameters, False )
       if not result[ 'OK' ]:
-        gLogger.error( result[ 'Message' ] )
+        gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
+        return result
 
       gThreadScheduler.addPeriodicTask( 120, client.storeProfiling )
 


### PR DESCRIPTION
Added a periodic task to the SysAdmin service (can be enabled from CS by setting a flag, just like the pseudostatic monitoring) that retrieves profiling information from running components and sends it to a RabbitMQ queue for later storage in ElasticSearch.
Requires PR's #2619 and #2827 to be merged before.