### PR TITLE
[v6r16] DynamicMonitoringConsumer

### DIFF
--- a/FrameworkSystem/Consumer/DynamicMonitoringConsumer.py
+++ b/FrameworkSystem/Consumer/DynamicMonitoringConsumer.py
@@ -25,7 +25,22 @@ class DynamicMonitoringConsumer ( object ):
     """
     Reads messages from RabbitMQ and sends them to ElasticSearch
     """
-    result = self.rabbitMQ.setupConnection( 'Framework', 'ComponentMonitoring', True )
+
+    # Read RabbitMQ parameters
+    result = gConfig.getOption( 'DIRAC/Setup' )
+    if not result[ 'OK' ]:
+      return result
+    setup = result[ 'Value' ]
+    result = gConfig.getOption( 'DIRAC/Setups/%s/%s' % ( setup, system ) )
+    if not result[ 'OK' ]:
+      return result
+    sysSetup = result[ 'Value' ]
+    result = gConfig.getOptionsDict( 'Systems/%s/%s/MessageQueueing/%s' % ( system, sysSetup, queueName ) )
+    if not result[ 'OK' ]:
+      return result
+    parameters = result[ 'Value' ]
+
+    result = self.rabbitMQ.setupConnection( 'Framework', 'ComponentMonitoring', parameters, True )
     if not result[ 'OK' ]:
       gLogger.error( result[ 'Message' ] )
       return result

--- a/FrameworkSystem/Consumer/DynamicMonitoringConsumer.py
+++ b/FrameworkSystem/Consumer/DynamicMonitoringConsumer.py
@@ -1,0 +1,51 @@
+"""
+Consumer in charge of reading from RabbitMQ and sending the information to Elasticsearch
+"""
+
+from dateutil import parser
+import elasticsearch, time
+from DIRAC import gLogger, gConfig, S_OK, S_ERROR
+from DIRAC.Core.Utilities.RabbitMQ import RabbitConnection
+from DIRAC.FrameworkSystem.DB.DynamicMonitoringDB import DynamicMonitoringDB
+
+class DynamicMonitoringConsumer ( object ):
+  """
+  Consumer class
+  """
+
+  def __init__( self ):
+    self.rabbitMQ = RabbitConnection()
+
+    self.docType = 'ComponentMonitoring'
+
+    # ElasticSearch initialization
+    self.elasticDB = DynamicMonitoringDB()
+
+  def start( self ):
+    """
+    Reads messages from RabbitMQ and sends them to ElasticSearch
+    """
+    result = self.rabbitMQ.setupConnection( 'Framework', 'ComponentMonitoring', True )
+    if not result[ 'OK' ]:
+      gLogger.error( result[ 'Message' ] )
+      return result
+
+    while True:
+      time.sleep( 1 )
+      # Get logs from the queue
+      result = self.rabbitMQ.get()
+      if result[ 'OK' ]:
+        # insert the logs into ElasticSearch
+        result = self.elasticDB.insertLog( result[ 'Value' ] )
+        if not result[ 'OK' ]:
+          gLogger.error( result[ 'Message' ] )
+      else:
+        gLogger.error( result[ 'Message' ] )
+
+    result = self.rabbitMQ.unsetupConnection()
+    if not result[ 'OK' ]:
+      gLogger.error( result[ 'Message' ] )
+      return result
+
+consumer = DynamicMonitoringConsumer()
+consumer.start()


### PR DESCRIPTION
Added a consumer class that connects to RabbitMQ, retrieving logs from the queue and sending them to ElasticSearch in an infinite loop.
Requires PR's #2619 and #2798 to be merged before.