### PR TITLE
[v6r14] Ignored MaxCPUTime restored

### DIFF
--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -545,6 +545,7 @@ class Job( API ):
 
     description = 'CPU time in secs'
     self._addParameter( self.workflow, 'MaxCPUTime', 'JDL', timeInSecs, description )
+    self._addParameter( self.workflow, 'CPUTime', 'JDL', timeInSecs, description )
     return S_OK()
 
   #############################################################################

--- a/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -111,7 +111,7 @@ class JobManagerHandler( RequestHandler ):
     if jobDesc[-1] != "]":
       jobDesc = "%s]" % jobDesc
 
-    # Check if the job is a parameteric one
+    # Check if the job is a parametric one
     jobClassAd = ClassAd( jobDesc )
     parametricJob = False
     if jobClassAd.lookupAttribute( 'Parameters' ):


### PR DESCRIPTION
Set both CPUTime and MaxCPUTime in setCPUTime() method. Otherwise only MaxCPUTime was set and in the job checking logic the CPUTime was assigned a default value of 86400. But If CPUTime is defined the MaxCPUTime was ignored ( just kept for backward compatibility ). It is still kept in this patch but in v6r15 will be dropped altogether