### PR TITLE
[v6r14] dirac-dms-user-lfns: Add error message when proxy is expired

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-user-lfns.py
+++ b/DataManagementSystem/scripts/dirac-dms-user-lfns.py
@@ -74,6 +74,9 @@ if not res['OK']:
   gLogger.error( "Failed to get client proxy information.", res['Message'] )
   DIRAC.exit( 2 )
 proxyInfo = res['Value']
+if proxyInfo['secondsLeft'] == 0:
+  gLogger.error( "Proxy expired" )
+  DIRAC.exit( 2 )
 username = proxyInfo['username']
 vo = ''
 if 'group' in proxyInfo:


### PR DESCRIPTION
When the proxy is expired the username field is not present, and the command fails with an exception.