### PR TITLE
[v6r15] Fix SiteDirector.voGroups unnecesary growth between iterations

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -117,6 +117,7 @@ class SiteDirector( AgentModule ):
         result = Registry.getGroupsForVO( self.vo )
         if not result['OK']:
           return result
+        self.voGroups = []
         for group in result['Value']:
           if 'NormalUser' in Registry.getPropertiesForGroup( group ):
             self.voGroups.append( group )


### PR DESCRIPTION
voGroups gets very long in time with copies of the same groups.
Not really important but annoying in the logs.