### PR TITLE
[v6r15] ConfigurationData.sync() performance

### DIFF
--- a/ConfigurationSystem/private/ConfigurationData.py
+++ b/ConfigurationSystem/private/ConfigurationData.py
@@ -20,7 +20,7 @@ class ConfigurationData( object ):
     self.threadingEvent.set()
     self.threadingLock = lr.getLock()
     self.runningThreadsNumber = 0
-    self.compressedConfigurationData = None
+    self.__compressedConfigurationData = None
     self.configurationPath = "/DIRAC/Configuration"
     self.backupsDir = os.path.join( DIRAC.rootPath, "etc", "csbackup" )
     self._isService = False
@@ -54,7 +54,7 @@ class ConfigurationData( object ):
     if remoteServers:
       self.remoteServerList.extend( List.fromChar( remoteServers, "," ) )
     self.remoteServerList = List.uniqueElements( self.remoteServerList )
-    self.compressedConfigurationData = None
+    self.__compressedConfigurationData = None
 
   def loadFile( self, fileName ):
     try:
@@ -283,9 +283,9 @@ class ConfigurationData( object ):
     self.sync()
 
   def getCompressedData( self ):
-    if self.compressedConfigurationData is None:
-      self.compressedConfigurationData = zlib.compress( str( self.remoteCFG ), 9 )
-    return self.compressedConfigurationData
+    if self.__compressedConfigurationData is None:
+      self.__compressedConfigurationData = zlib.compress( str( self.remoteCFG ), 9 )
+    return self.__compressedConfigurationData
 
   def isMaster( self ):
     value = self.extractOptionFromCFG( "%s/Master" % self.configurationPath,

--- a/ConfigurationSystem/private/ConfigurationData.py
+++ b/ConfigurationSystem/private/ConfigurationData.py
@@ -20,7 +20,7 @@ class ConfigurationData( object ):
     self.threadingEvent.set()
     self.threadingLock = lr.getLock()
     self.runningThreadsNumber = 0
-    self.compressedConfigurationData = ""
+    self.compressedConfigurationData = None
     self.configurationPath = "/DIRAC/Configuration"
     self.backupsDir = os.path.join( DIRAC.rootPath, "etc", "csbackup" )
     self._isService = False
@@ -54,7 +54,7 @@ class ConfigurationData( object ):
     if remoteServers:
       self.remoteServerList.extend( List.fromChar( remoteServers, "," ) )
     self.remoteServerList = List.uniqueElements( self.remoteServerList )
-    self.compressedConfigurationData = zlib.compress( str( self.remoteCFG ), 9 )
+    self.compressedConfigurationData = None
 
   def loadFile( self, fileName ):
     try:
@@ -283,6 +283,8 @@ class ConfigurationData( object ):
     self.sync()
 
   def getCompressedData( self ):
+    if self.compressedConfigurationData is None:
+      self.compressedConfigurationData = zlib.compress( str( self.remoteCFG ), 9 )
     return self.compressedConfigurationData
 
   def isMaster( self ):


### PR DESCRIPTION
Compressing `gConfigurationData.remoteCFG` data each time `sync()` is called takes only a few tens of a second. However, each user command does this a few times while it has no need to do so.

This PR should improve user experience a bit, especially with COMDIRAC cli.