### PR TITLE
[v6r14] Fix Cumulative plots with enddate != now

### DIFF
--- a/AccountingSystem/private/Plots.py
+++ b/AccountingSystem/private/Plots.py
@@ -66,7 +66,7 @@ def generateCumulativePlot( fileName, data, metadata ):
     return S_ERROR( "Can't open %s" % fileName )
   checkMetadata( metadata )
   if 'sort_labels' not in metadata:
-    metadata[ 'sort_labels' ] = 'last_value'
+    metadata[ 'sort_labels' ] = 'max_value'
   lineGraph( data, fn, **metadata )
   fn.close()
   return S_OK()

--- a/AccountingSystem/private/Plotters/JobPlotter.py
+++ b/AccountingSystem/private/Plotters/JobPlotter.py
@@ -101,7 +101,7 @@ class JobPlotter( BaseReporter ):
                  'endtime' : reportRequest[ 'endTime' ],
                  'span' : plotInfo[ 'granularity' ],
                  'ylabel' : plotInfo[ 'unit' ],
-                 'sort_labels' : 'last_value' }
+                 'sort_labels' : 'max_value' }
     return self._generateCumulativePlot( filename, plotInfo[ 'graphDataDict' ], metadata )
 
   _reportCPUUsageName = "CPU time"
@@ -169,7 +169,7 @@ class JobPlotter( BaseReporter ):
                  'endtime' : reportRequest[ 'endTime' ],
                  'span' : plotInfo[ 'granularity' ],
                  'ylabel' : plotInfo[ 'unit' ],
-                 'sort_labels' : 'last_value' }
+                 'sort_labels' : 'max_value' }
     return self._generateCumulativePlot( filename, plotInfo[ 'graphDataDict' ], metadata )
 
   _reportNormCPUUsageName = "Normalized CPU power"
@@ -332,7 +332,7 @@ class JobPlotter( BaseReporter ):
                  'endtime' : reportRequest[ 'endTime' ],
                  'span' : plotInfo[ 'granularity' ],
                  'ylabel' : plotInfo[ 'unit' ],
-                 'sort_labels' : 'last_value' }
+                 'sort_labels' : 'max_value' }
     return self._generateCumulativePlot( filename, plotInfo[ 'graphDataDict' ], metadata )
 
   _reportTotalWallTimeName = "Pie plot of wall time usage"
@@ -395,7 +395,7 @@ class JobPlotter( BaseReporter ):
                  'endtime' : reportRequest[ 'endTime' ],
                  'span' : plotInfo[ 'granularity' ],
                  'ylabel' : plotInfo[ 'unit' ],
-                 'sort_labels' : 'last_value' }
+                 'sort_labels' : 'max_value' }
     return self._generateCumulativePlot( filename, plotInfo[ 'graphDataDict' ], metadata )
 
 


### PR DESCRIPTION
The sorting for cumulative plots where the enddate is not now, for example Q3 and Q4 of 2015
is not correct.

Before:
![cumulativejobssite_lastvalue](https://cloud.githubusercontent.com/assets/2115797/13774019/e7db268e-ea9c-11e5-8834-d3f6975eb28d.png)

After:
![cumulativejobssite_maxvalue](https://cloud.githubusercontent.com/assets/2115797/13774024/eb8b8062-ea9c-11e5-9065-7f5e4e9efa44.png)

Plots with enddate == now E.g. Q1 2016 are still correct (anyway the last_value should be the max_value for cumulative plots, I don't know where the logic goes wrong for the different enddate...)
![cumulativesites_enddate](https://cloud.githubusercontent.com/assets/2115797/13774068/31a03b92-ea9d-11e5-9802-15949df73100.png)

![cumulativesites_enddate_maxvalue](https://cloud.githubusercontent.com/assets/2115797/13774075/35b3b16e-ea9d-11e5-936d-1cb67b4400a1.png)


