### PR TITLE
v6r14 : splitting TaskAgents 

### DIFF
--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -70,7 +70,7 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
     """
 
     self.moduloNumber = self.am_getOption('moduloNumber',0)
-    self.moduloResidual = self.am_getOption('moduloResidual',0)
+    self.moduloResidual = self.am_getOption('moduloResidual',-1)
     self.log.info('Split agents modulo %d, this agend resdiual %d' % (self.moduloNumber, self.moduloResidual))
 
     gMonitor.registerActivity( "SubmittedTasks", "Automatically submitted tasks", "Transformation Monitoring", "Tasks",

--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -71,7 +71,9 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
 
     self.moduloNumber = self.am_getOption('moduloNumber',0)
     self.moduloResidual = self.am_getOption('moduloResidual',-1)
-    self.log.info('Split agents modulo %d, this agend resdiual %d' % (self.moduloNumber, self.moduloResidual))
+    if self.moduloResidual >= self.moduloNumber :
+      self.log.error("Residual %d is equal or greater than the modulo number %d, this cannot be, check the configuration of this agent" % (self.moduloResidual, self.moduloNumber))
+    self.log.notice('Split agents modulo %d, this agents resdiual %d' % (self.moduloNumber, self.moduloResidual))
 
     gMonitor.registerActivity( "SubmittedTasks", "Automatically submitted tasks", "Transformation Monitoring", "Tasks",
                                gMonitor.OP_ACUM )
@@ -217,13 +219,11 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
     else:
       self.log.verbose( "Obtained %d transformations" % len( res['Value'] ) )
 
-    if (self.moduloNumber >= 2 and self.moduloResidual >= 0) :
-      if self.moduloResidual >= self.moduloNumber :
-        self.log.error("Residual %d is equal or greater than the modulo number %d, this cannot be, check the configuration of this agent" % (self.moduloResidual, self.moduloNumber))
+    if self.moduloNumber >= 2 and self.moduloResidual >= 0 :
       self.log.info("Retrieving only productions with production number modulo %d and resdidual %d" % (self.moduloNumber, self.moduloResidual))
-      self.log.verbose("Original list of productions is", [ x['TransformationID'] for x in res['Value']])
+      self.log.verbose("Original list of productions is", ', '.join([ x['TransformationID'] for x in res['Value']]))
       res['Value'] = [ x for x in res['Value'] if x['TransformationID']%self.moduloNumber == self.moduloResidual ]
-      self.log.verbose("New list of productions is", [ x['TransformationID'] for x in res['Value']])
+      self.log.verbose("New list of productions is", ', '.join([ x['TransformationID'] for x in res['Value']]))
 
     return res
 

--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -55,6 +55,9 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
     self.transInQueue = []
     self.transInThread = {}
 
+    self.moduloNumber = None
+    self.moduloResidual = None
+
   #############################################################################
 
   def initialize( self ):
@@ -65,6 +68,10 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
         - set the shifterProxy if different from the default one set here ('ProductionManager')
         - list of transformation types to be looked (self.transType)
     """
+
+    self.moduloNumber = self.am_getOption('moduloNumber',0)
+    self.moduloResidual = self.am_getOption('moduloResidual',0)
+    self.log.info('Split agents modulo %d, this agend resdiual %d' % (self.moduloNumber, self.moduloResidual))
 
     gMonitor.registerActivity( "SubmittedTasks", "Automatically submitted tasks", "Transformation Monitoring", "Tasks",
                                gMonitor.OP_ACUM )
@@ -209,6 +216,15 @@ class TaskManagerAgentBase( AgentModule, TransformationAgentsUtilities ):
       self.log.verbose( "No transformations found" )
     else:
       self.log.verbose( "Obtained %d transformations" % len( res['Value'] ) )
+
+    if (self.moduloNumber >= 2 and self.moduloResidual >= 0) :
+      if self.moduloResidual >= self.moduloNumber :
+        self.log.error("Residual %d is equal or greater than the modulo number %d, this cannot be, check the configuration of this agent" % (self.moduloResidual, self.moduloNumber))
+      self.log.info("Retrieving only productions with production number modulo %d and resdidual %d" % (self.moduloNumber, self.moduloResidual))
+      self.log.verbose("Original list of productions is", [ x['TransformationID'] for x in res['Value']])
+      res['Value'] = [ x for x in res['Value'] if x['TransformationID']%self.moduloNumber == self.moduloResidual ]
+      self.log.verbose("New list of productions is", [ x['TransformationID'] for x in res['Value']])
+
     return res
 
   def _fillTheQueue( self, operationsOnTransformationsDict ):


### PR DESCRIPTION
In LHCb we observe the WorkflowTaskAgent (for MCSimulation) being slow. Looking at the agent on the machine where it runs it was observed that it never goes beyond "140 % CPU" (in top), despite the machine having more CPU available. The agent being multi-threaded the suspicion is that its hit by the python global interpreter lock. 

To overcome this situation the fix below is proposed. I.e. workflow task agents working on different productions where the production number is a unique id, we allow to have N workflow task agents work in parallel, where each workflow task agent works on the productions where "productionNumber modulo N == X". X being the residual < N. 

The two parameters moduloNumber and moduloResidual need to be passed to each of the task agent instances.