### PR TITLE
[v6r15] compute DIRAC platform only when requested

### DIFF
--- a/Core/Base/AgentModule.py
+++ b/Core/Base/AgentModule.py
@@ -170,7 +170,7 @@ class AgentModule( object ):
         self.log.error( "Missing property", prop[0] )
         self.__codeProperties[ prop[1] ] = 'unset'
     self.__codeProperties[ 'DIRACVersion' ] = DIRAC.version
-    self.__codeProperties[ 'platform' ] = DIRAC.platform
+    self.__codeProperties[ 'platform' ] = DIRAC.getPlatform()
 
   def am_initialize( self, *initArgs ):
     agentName = self.am_getModuleParam( 'fullName' )
@@ -199,7 +199,7 @@ class AgentModule( object ):
     self.log.notice( " Base Module version: %s " % __RCSID__ )
     self.log.notice( " Agent version: %s" % self.__codeProperties[ 'version' ] )
     self.log.notice( " DIRAC version: %s" % DIRAC.version )
-    self.log.notice( " DIRAC platform: %s" % DIRAC.platform )
+    self.log.notice( " DIRAC platform: %s" % DIRAC.getPlatform() )
     pollingTime = int( self.am_getOption( 'PollingTime' ) )
     if pollingTime > 3600:
       self.log.notice( " Polling time: %s hours" % ( pollingTime / 3600. ) )

--- a/Core/DISET/private/Service.py
+++ b/Core/DISET/private/Service.py
@@ -224,7 +224,7 @@ class Service( object ):
     self._monitor.registerActivity( 'MaxFD', "Max File Descriptors", 'Framework', 'fd', MonitoringClient.OP_MEAN )
 
     self._monitor.setComponentExtraParam( 'DIRACVersion', DIRAC.version )
-    self._monitor.setComponentExtraParam( 'platform', DIRAC.platform )
+    self._monitor.setComponentExtraParam( 'platform', DIRAC.getPlatform() )
     self._monitor.setComponentExtraParam( 'startTime', Time.dateTime() )
     for prop in ( ( "__RCSID__", "version" ), ( "__doc__", "description" ) ):
       try:

--- a/Core/Utilities/Os.py
+++ b/Core/Utilities/Os.py
@@ -87,7 +87,7 @@ def sourceEnv( timeout, cmdTuple, inputEnv = None ):
   envAsDict = '&& python -c "import os,sys ; print >> sys.stderr, os.environ"'
 
   # 1.- Choose the right version of the configuration file
-  if DIRAC.platformTuple[0] == 'Windows':
+  if DIRAC.getPlatformTuple()[0] == 'Windows':
     cmdTuple[0] += '.bat'
   else:
     cmdTuple[0] += '.sh'
@@ -102,7 +102,7 @@ def sourceEnv( timeout, cmdTuple, inputEnv = None ):
   # Source it in a platform dependent way:
   # On windows the execution makes the environment to be inherit
   # On Linux or Darwin use bash and source the file.
-  if DIRAC.platformTuple[0] == 'Windows':
+  if DIRAC.getPlatformTuple()[0] == 'Windows':
     # this needs to be tested
     cmd = ' '.join( cmdTuple ) + envAsDict
     ret = shellCall( timeout, [ cmd ], env = inputEnv )
@@ -149,7 +149,7 @@ def unifyLdLibraryPath( path, newpath ):
       newpath. For that we go along the path in a reverse order and link all files
       from the path, the latest appearance of a file will take precedence
   """
-  if not DIRAC.platformTuple[0] == 'Windows':
+  if not DIRAC.getPlatformTuple()[0] == 'Windows':
     if os.path.exists( newpath ):
       if not os.path.isdir( newpath ):
         try:

--- a/Core/Utilities/Platform.py
+++ b/Core/Utilities/Platform.py
@@ -131,3 +131,19 @@ def getPlatformString():
   platformString = "%s_%s_%s" % platformTuple
 
   return platformString
+
+_gPlatform = None
+_gPlatformTuple = None
+
+def getPlatform():
+  global _gPlatform, _gPlatformTuple
+
+  if _gPlatform is None:
+    _gPlatform = getPlatformString()
+    _gPlatformTuple = tuple( _gPlatform.split( '_' ) )
+
+  return _gPlatform
+
+def getPlatformTuple():
+  getPlatform()
+  return _gPlatformTuple

--- a/Core/scripts/dirac-info.py
+++ b/Core/scripts/dirac-info.py
@@ -30,12 +30,12 @@ records.append( ('Setup', gConfig.getValue( '/DIRAC/Setup', 'Unknown' ) ) )
 records.append( ('ConfigurationServer', str( gConfig.getValue( '/DIRAC/Configuration/Servers', [] ) ) ) )
 records.append( ('Installation path', DIRAC.rootPath ) )
 
-if os.path.exists( os.path.join( DIRAC.rootPath, DIRAC.platform, 'bin', 'mysql' ) ):
+if os.path.exists( os.path.join( DIRAC.rootPath, DIRAC.getPlatform(), 'bin', 'mysql' ) ):
   records.append( ('Installation type', 'server' ) )
 else:
   records.append( ('Installation type', 'client' ) )
 
-records.append( ('Platform', DIRAC.platform ) )
+records.append( ( 'Platform', DIRAC.getPlatform() ) )
 
 ret = getProxyInfo( disableVOMS = True )
 if ret['OK']:

--- a/__init__.py
+++ b/__init__.py
@@ -45,9 +45,6 @@
     - pythonPath:    absolute real path to the directory that contains this file
     - rootPath:      absolute real path to the parent of DIRAC.pythonPath
 
-    - platform:      DIRAC platform string for current host
-    - platformTuple: DIRAC platform tuple for current host
-
     It loads Modules from :
     - DIRAC.Core.Utililies
 
@@ -61,6 +58,9 @@
     - abort:          aborts execution
     - exit:           finish execution using callbacks
     - siteName:       returns DIRAC name for current site
+
+    - getPlatform():      DIRAC platform string for current host
+    - getPlatformTuple(): DIRAC platform tuple for current host
 
 """
 __RCSID__ = "$Id$"
@@ -177,10 +177,8 @@ def siteName():
 #Callbacks
 ExitCallback.registerSignals()
 
-#Set the platform
-from DIRAC.Core.Utilities.Platform import getPlatformString
-platform = getPlatformString()
-platformTuple = tuple( platform.split( '_' ) )
+# platform detection
+from DIRAC.Core.Utilities.Platform import getPlatformString, getPlatform, getPlatformTuple
 
 def exit( exitCode = 0 ):
   """


### PR DESCRIPTION
Importing DIRAC module in a scripts implied computing of `DIRAC.platform` with `Platform.getPlatformString()` which is a bit long (see #2854).

This PR hides this field in a variable of the`Platform` module accessible through a `getPlatform()` method. All client scripts will be a few tens of seconds faster than before (except those who explicitly need platform string, like dirac-info).