### PR TITLE
[v6r14] Make the StorageElementCache Thread safe

### DIFF
--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -5,6 +5,7 @@ from types import ListType
 __RCSID__ = "$Id$"
 # # custom duty
 import re
+import threading
 # # from DIRAC
 from DIRAC import gLogger, gConfig
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR, returnSingleResult
@@ -24,7 +25,8 @@ class StorageElementCache( object ):
 
   def __call__( self, name, protocols = None, vo = None, hideExceptions = False ):
     self.seCache.purgeExpired( expiredInSeconds = 60 )
-    argTuple = ( name, protocols, vo )
+    tId = threading.current_thread().ident
+    argTuple = ( tId, name, protocols, vo )
     seObj = self.seCache.get( argTuple )
 
     if not seObj:


### PR DESCRIPTION
For a yet unknown reason, the FTSAgent threads started to step on each other when using the StorageElement. One thread would ask for getFileMetadata, the other one for getURL, but the parameters of the two calls would be swapped (leading to exceptions, and to getFileMetadata returning an URL....). 
I tracked this down to the StorageElementCache not being thread safe, which is now fixed in this PR.
