### PR TITLE
[v6r15] Added default methods to the FileCatalogClientBase

### DIFF
--- a/Resources/Catalog/FileCatalogClient.py
+++ b/Resources/Catalog/FileCatalogClient.py
@@ -12,54 +12,55 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOMSAttributeFo
 from DIRAC.Resources.Catalog.Utilities                 import checkCatalogArguments
 from DIRAC.Resources.Catalog.FileCatalogClientBase     import FileCatalogClientBase
 
-# The list of methods below is defining the client interface
-READ_METHODS = ['exists', 'isFile', 'getFileMetadata', 'getReplicas',
-                'getReplicaStatus', 'getFileSize', 'isDirectory', 'getDirectoryReplicas',
-                'listDirectory', 'getDirectoryMetadata', 'getDirectorySize', 'getDirectoryContents',
-                'getPathPermissions', 'hasAccess', 'getLFNForPFN', 'getLFNForGUID',
-                'findFilesByMetadata','getMetadataFields','getDirectoryUserMetadata',
-                'findDirectoriesByMetadata','getReplicasByMetadata','findFilesByMetadataDetailed',
-                'findFilesByMetadataWeb','getCompatibleMetadata','getMetadataSet', 'getDatasets',
-                'checkDataset', 'getDatasetParameters', 'getDatasetFiles', 'getDatasetAnnotation']
-
-WRITE_METHODS = ['createLink', 'removeLink', 'addFile', 'setFileStatus', 'addReplica', 'removeReplica',
-                 'removeFile', 'setReplicaStatus', 'setReplicaHost', 'setReplicaProblematic', 'createDirectory',
-                 'setDirectoryStatus', 'removeDirectory', 'changePathMode', 'changePathOwner', 'changePathGroup',
-                 'addMetadataField','deleteMetadataField','setMetadata','setMetadataBulk','removeMetadata',
-                 'addMetadataSet', 'addDataset', 'addDatasetAnnotation', 'removeDataset', 'updateDataset',
-                 'freezeDataset', 'releaseDataset']
-
-NO_LFN_METHODS = ['findFilesByMetadata','addMetadataField','deleteMetadataField','getMetadataFields','setMetadata',
-                  'setMetadataBulk','removeMetadata','getDirectoryUserMetadata','findDirectoriesByMetadata',
-                  'getReplicasByMetadata','findFilesByMetadataDetailed','findFilesByMetadataWeb',
-                  'getCompatibleMetadata','addMetadataSet','getMetadataSet']
-
-ADMIN_METHODS = [ 'addUser', 'deleteUser', 'addGroup', 'deleteGroup', 'getUsers', 'getGroups',
-                  'getCatalogCounters', 'repairCatalog', 'rebuildDirectoryUsage' ]
-
 class FileCatalogClient( FileCatalogClientBase ):
   """ Client code to the DIRAC File Catalogue
   """
+
+  # The list of methods below is defining the client interface
+  READ_METHODS = FileCatalogClientBase.READ_METHODS + \
+                 [ 'isFile', 'getFileMetadata',
+                   'getReplicas', 'getReplicaStatus', 'getFileSize', 'isDirectory', 'getDirectoryReplicas',
+                   'listDirectory', 'getDirectoryMetadata', 'getDirectorySize', 'getDirectoryContents',
+                   'getLFNForPFN', 'getLFNForGUID', 'findFilesByMetadata','getMetadataFields','getDirectoryUserMetadata',
+                   'findDirectoriesByMetadata','getReplicasByMetadata','findFilesByMetadataDetailed',
+                   'findFilesByMetadataWeb','getCompatibleMetadata','getMetadataSet', 'getDatasets',
+                   'checkDataset', 'getDatasetParameters', 'getDatasetFiles', 'getDatasetAnnotation']
+
+  WRITE_METHODS = ['createLink', 'removeLink', 'addFile', 'setFileStatus', 'addReplica', 'removeReplica',
+                   'removeFile', 'setReplicaStatus', 'setReplicaHost', 'setReplicaProblematic', 'createDirectory',
+                   'setDirectoryStatus', 'removeDirectory', 'changePathMode', 'changePathOwner', 'changePathGroup',
+                   'addMetadataField','deleteMetadataField','setMetadata','setMetadataBulk','removeMetadata',
+                   'addMetadataSet', 'addDataset', 'addDatasetAnnotation', 'removeDataset', 'updateDataset',
+                   'freezeDataset', 'releaseDataset']
+
+  NO_LFN_METHODS = ['findFilesByMetadata','addMetadataField','deleteMetadataField','getMetadataFields','setMetadata',
+                    'setMetadataBulk','removeMetadata','getDirectoryUserMetadata','findDirectoriesByMetadata',
+                    'getReplicasByMetadata','findFilesByMetadataDetailed','findFilesByMetadataWeb',
+                    'getCompatibleMetadata','addMetadataSet','getMetadataSet']
+
+  ADMIN_METHODS = [ 'addUser', 'deleteUser', 'addGroup', 'deleteGroup', 'getUsers', 'getGroups',
+                    'getCatalogCounters', 'repairCatalog', 'rebuildDirectoryUsage' ]
+
   def __init__( self, url = None, **kwargs ):
     """ Constructor function.
     """
     self.serverURL = 'DataManagement/FileCatalog' if not url else url
     super( FileCatalogClient, self ).__init__( self.serverURL, **kwargs )
 
-  @staticmethod
-  def getInterfaceMethods():
-    """ Get the methods implemented by the File Catalog client
-
-    :return tuple: ( read_methods_list, write_methods_list, nolfn_methods_list )
-    """
-    return ( READ_METHODS, WRITE_METHODS, NO_LFN_METHODS )
-
-  def hasCatalogMethod( self, methodName ):
-    """ Check of a method with the given name is implemented
-    :param str methodName: the name of the method to check
-    :return: boolean Flag
-    """
-    return methodName in ( READ_METHODS + WRITE_METHODS + NO_LFN_METHODS )
+#  @staticmethod
+#  def getInterfaceMethods():
+#    """ Get the methods implemented by the File Catalog client
+#
+#    :return tuple: ( read_methods_list, write_methods_list, nolfn_methods_list )
+#    """
+#    return ( FileCatalogClient.READ_METHODS, FileCatalogClient.WRITE_METHODS, FileCatalogClient.NO_LFN_METHODS )
+#
+#  def hasCatalogMethod( self, methodName ):
+#    """ Check of a method with the given name is implemented
+#    :param str methodName: the name of the method to check
+#    :return: boolean Flag
+#    """
+#    return methodName in ( FileCatalogClient.READ_METHODS + FileCatalogClient.WRITE_METHODS + FileCatalogClient.NO_LFN_METHODS )
 
 ##################################################################################
 #

--- a/Resources/Catalog/FileCatalogClient.py
+++ b/Resources/Catalog/FileCatalogClient.py
@@ -47,21 +47,6 @@ class FileCatalogClient( FileCatalogClientBase ):
     self.serverURL = 'DataManagement/FileCatalog' if not url else url
     super( FileCatalogClient, self ).__init__( self.serverURL, **kwargs )
 
-#  @staticmethod
-#  def getInterfaceMethods():
-#    """ Get the methods implemented by the File Catalog client
-#
-#    :return tuple: ( read_methods_list, write_methods_list, nolfn_methods_list )
-#    """
-#    return ( FileCatalogClient.READ_METHODS, FileCatalogClient.WRITE_METHODS, FileCatalogClient.NO_LFN_METHODS )
-#
-#  def hasCatalogMethod( self, methodName ):
-#    """ Check of a method with the given name is implemented
-#    :param str methodName: the name of the method to check
-#    :return: boolean Flag
-#    """
-#    return methodName in ( FileCatalogClient.READ_METHODS + FileCatalogClient.WRITE_METHODS + FileCatalogClient.NO_LFN_METHODS )
-
 ##################################################################################
 #
 ##################################################################################

--- a/Resources/Catalog/FileCatalogClientBase.py
+++ b/Resources/Catalog/FileCatalogClientBase.py
@@ -7,6 +7,7 @@ __RCSID__ = "$Id$"
 
 from DIRAC.Core.Base.Client import Client
 from DIRAC.Core.Utilities.ReturnValues import S_OK
+from DIRAC.Resources.Catalog.Utilities import checkCatalogArguments
 
 class FileCatalogClientBase( Client ):
   """ Client code to the DIRAC File Catalogue
@@ -49,3 +50,48 @@ class FileCatalogClientBase( Client ):
     :return: boolean Flag True if the method is implemented
     """
     raise AttributeError( "hasCatalogMethod must be implemented in the FC derived class" )
+
+########################################################################################
+#  Some default methods to always return successfully if we do not care
+########################################################################################
+  @checkCatalogArguments
+  def hasAccess( self, paths, _opType ):
+    """ Default method: returns True for all paths and all actions
+
+      :param lfn paths: has to be formatted this way :
+                  { lfn : { se1 : pfn1, se2 : pfn2, ...}, ...}
+      :param str _opType: dummy string
+
+      :return: { successful : { lfn : [ ses ] } : failed : { lfn : { se : msg } } }
+    """
+    lfns = paths.keys()
+    return S_OK( {'Failed' : {}, 'Successful' : dict.fromkeys( lfns, True )} )
+
+  @checkCatalogArguments
+  def exists( self, lfns ):
+    """ Default method: returns False for all paths
+
+      :param lfn paths: has to be formatted this way :
+                  { lfn : { se1 : pfn1, se2 : pfn2, ...}, ...}
+
+      :return: { successful : { lfn : [ ses ] } : failed : { lfn : { se : msg } } }
+
+    """
+    return S_OK( {'Failed' : {}, 'Successful' : dict.fromkeys( lfns, False )} )
+
+  @checkCatalogArguments
+  def getPathPermissions( self, lfns ):
+    """ Default method: returns Read & Write permission for all the paths
+
+      :param lfn paths: has to be formatted this way :
+                  { lfn : { se1 : pfn1, se2 : pfn2, ...}, ...}
+
+      :return: { successful : { lfn : [ ses ] } : failed : { lfn : { se : msg } } }
+
+    """
+    failed = {}
+    successful = {}
+    for lfn in lfns.keys():
+      successful[lfn] = { 'Write': True, "Read": True }
+    resDict = {'Failed':failed, 'Successful':successful}
+    return S_OK( resDict )

--- a/Resources/Catalog/FileCatalogClientBase.py
+++ b/Resources/Catalog/FileCatalogClientBase.py
@@ -12,6 +12,15 @@ from DIRAC.Resources.Catalog.Utilities import checkCatalogArguments
 class FileCatalogClientBase( Client ):
   """ Client code to the DIRAC File Catalogue
   """
+
+  # Default mandatory methods having all-allowing implementation in the base class
+  READ_METHODS = [ 'hasAccess', 'exists', 'getPathPermissions' ]
+
+  # List of methods that can be complemented in the derived classes
+  WRITE_METHODS = []
+  NO_LFN_METHODS = []
+  ADMIN_METHODS = []
+
   def __init__( self, url = None, **kwargs ):
     """ Constructor function.
     """
@@ -36,20 +45,23 @@ class FileCatalogClientBase( Client ):
 #  The following methods must be implemented in derived classes
 #######################################################################################
 
-  @staticmethod
-  def getInterfaceMethods():
+  @classmethod
+  def getInterfaceMethods( cls ):
     """ Get the methods implemented by the File Catalog client
 
     :return tuple: ( read_methods_list, write_methods_list, nolfn_methods_list )
     """
-    raise AttributeError( "getInterfaceMethods must be implemented in the FC derived class" )
+    return ( cls.READ_METHODS,
+             cls.WRITE_METHODS,
+             cls.NO_LFN_METHODS )
 
-  def hasCatalogMethod( self, methodName ):
+  @classmethod
+  def hasCatalogMethod( cls, methodName ):
     """ Check of a method with the given name is implemented
     :param str methodName: the name of the method to check
     :return: boolean Flag True if the method is implemented
     """
-    raise AttributeError( "hasCatalogMethod must be implemented in the FC derived class" )
+    return methodName in ( cls.READ_METHODS + cls.WRITE_METHODS + cls.NO_LFN_METHODS )
 
 ########################################################################################
 #  Some default methods to always return successfully if we do not care

--- a/Resources/Catalog/FileCatalogClientBase.py
+++ b/Resources/Catalog/FileCatalogClientBase.py
@@ -1,6 +1,15 @@
 """
     FileCatalogClientBase is a base class for the clients of file catalog-like
     services built within the DIRAC framework.
+
+    The class contains variables defining lists of implemented catalog methods
+    READ_METHODS
+    WRITE_METHODS
+    NO_LFN_METHODS
+    ADMIN_METHODS
+
+    Those lists must be complemented in the derived classes to include specific
+    implemented methods.
 """
 
 __RCSID__ = "$Id$"

--- a/Resources/Catalog/FileCatalogClientBase.py
+++ b/Resources/Catalog/FileCatalogClientBase.py
@@ -110,9 +110,5 @@ class FileCatalogClientBase( Client ):
       :return: { successful : { lfn : [ ses ] } : failed : { lfn : { se : msg } } }
 
     """
-    failed = {}
-    successful = {}
-    for lfn in lfns.keys():
-      successful[lfn] = { 'Write': True, "Read": True }
-    resDict = {'Failed':failed, 'Successful':successful}
-    return S_OK( resDict )
+    return S_OK( {'Failed' : {},
+                  'Successful' : dict.fromkeys( lfns, { 'Write': True, "Read": True } )} )

--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -10,31 +10,17 @@ import re
 import time
 
 import DIRAC
-from DIRAC                                              import S_OK, S_ERROR, gLogger, gConfig
+from DIRAC                                              import S_OK, S_ERROR, gLogger
 from DIRAC.Resources.Catalog.Utilities                  import checkCatalogArguments
 from DIRAC.Core.Utilities.Time                          import fromEpoch
 from DIRAC.Core.Utilities.List                          import breakListIntoChunks
 from DIRAC.Core.Security.ProxyInfo                      import getProxyInfo, formatProxyInfoAsString
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry  import getDNForUsername, getVOMSAttributeForGroup, \
                                                                getVOForGroup, getVOOption
+from DIRAC.Resources.Catalog.FileCatalogClientBase      import FileCatalogClientBase
+
 lfc = None
 importedLFC = None
-
-READ_METHODS = ['exists', 'isLink', 'readLink', 'isFile', 'getFileMetadata', 'getReplicas',
-                'getReplicaStatus', 'getFileSize', 'isDirectory', 'getDirectoryReplicas',
-                'listDirectory', 'getDirectoryMetadata', 'getDirectorySize', 'getDirectoryContents',
-                'resolveDataset', 'getPathPermissions', 'getLFNForPFN', 'getUserDirectory']
-
-WRITE_METHODS = ['createLink', 'removeLink', 'addFile', 'addReplica', 'removeReplica',
-                 'removeFile', 'setReplicaStatus', 'setReplicaHost', 'createDirectory',
-                 'removeDirectory', 'removeDataset', 'removeFileFromDataset', 'createDataset',
-                 'changePathOwner', 'changePathMode']
-
-NO_LFN_METHODS = ['getUserDirectory', 'createUserDirectory', 'createUserMapping',
-                 'removeUserDirectory']
-
-ADMIN_METHODS = ['getUserDirectory', 'createUserDirectory', 'createUserMapping',
-                 'removeUserDirectory']
 
 ####################################################################
 #
@@ -174,7 +160,25 @@ def returnCode( error, value = '', errMsg = '' ):
 #
 #####################################################
 
-class LcgFileCatalogClient( object ):
+class LcgFileCatalogClient( FileCatalogClientBase ):
+
+  READ_METHODS = FileCatalogClientBase.READ_METHODS + [ 'isLink', 'readLink', 'isFile', 'getFileMetadata',
+                 'getReplicas', 'getReplicaStatus', 'getFileSize', 'isDirectory', 'getDirectoryReplicas',
+                 'listDirectory', 'getDirectoryMetadata', 'getDirectorySize', 'getDirectoryContents',
+                 'resolveDataset', 'getLFNForPFN', 'getUserDirectory']
+
+  WRITE_METHODS = FileCatalogClientBase.WRITE_METHODS + ['createLink', 'removeLink', 'addFile', 'addReplica',
+                  'removeReplica',
+                  'removeFile', 'setReplicaStatus', 'setReplicaHost', 'createDirectory',
+                  'removeDirectory', 'removeDataset', 'removeFileFromDataset', 'createDataset',
+                  'changePathOwner', 'changePathMode']
+
+  NO_LFN_METHODS = FileCatalogClientBase.NO_LFN_METHODS + ['getUserDirectory', 'createUserDirectory',
+                   'createUserMapping', 'removeUserDirectory']
+
+  ADMIN_METHODS = FileCatalogClientBase.ADMIN_METHODS + ['getUserDirectory', 'createUserDirectory',
+                  'createUserMapping',
+                  'removeUserDirectory']
 
   def __init__( self, **options ):
     global lfc, importedLFC
@@ -226,21 +230,20 @@ class LcgFileCatalogClient( object ):
   # These are the get/set methods for use within the client
   #
 
-  def hasCatalogMethod( self, methodName ):
-    """
-    :param methodName: the name of the method to check
-    :return: bollean if the method is implemented
-    """
-    return hasattr( self, methodName )
-
-  @staticmethod
-  def getInterfaceMethods():
-    """ Get the methods implemented by the File Catalog client
-
-    :return tuple: ( read_methods_list, write_methods_list, nolfn_methods_list )
-    """
-    global READ_METHODS, WRITE_METHODS
-    return ( READ_METHODS, WRITE_METHODS, [] )
+  # def hasCatalogMethod( self, methodName ):
+  #   """
+  #   :param methodName: the name of the method to check
+  #   :return: bollean if the method is implemented
+  #   """
+  #   return hasattr( self, methodName )
+  #
+  # @staticmethod
+  # def getInterfaceMethods():
+  #   """ Get the methods implemented by the File Catalog client
+  #
+  #   :return tuple: ( read_methods_list, write_methods_list, nolfn_methods_list )
+  #   """
+  #   return ( LcgFileCatalogClient.READ_METHODS, LcgFileCatalogClient.WRITE_METHODS, [] )
 
   def isOK( self ):
     return self.valid
@@ -354,9 +357,9 @@ class LcgFileCatalogClient( object ):
   @checkCatalogArguments
   def hasAccess(self, lfns, opType ):
 
-    if opType in READ_METHODS:
+    if opType in LcgFileCatalogClient.READ_METHODS:
       opType = 'Read'
-    elif opType in WRITE_METHODS:
+    elif opType in LcgFileCatalogClient.WRITE_METHODS:
       opType = 'Write'
 
     res = self.getPathPermissions( lfns )

--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -225,26 +225,6 @@ class LcgFileCatalogClient( FileCatalogClientBase ):
     self.session = False
     self.transaction = False
 
-  ####################################################################
-  #
-  # These are the get/set methods for use within the client
-  #
-
-  # def hasCatalogMethod( self, methodName ):
-  #   """
-  #   :param methodName: the name of the method to check
-  #   :return: bollean if the method is implemented
-  #   """
-  #   return hasattr( self, methodName )
-  #
-  # @staticmethod
-  # def getInterfaceMethods():
-  #   """ Get the methods implemented by the File Catalog client
-  #
-  #   :return tuple: ( read_methods_list, write_methods_list, nolfn_methods_list )
-  #   """
-  #   return ( LcgFileCatalogClient.READ_METHODS, LcgFileCatalogClient.WRITE_METHODS, [] )
-
   def isOK( self ):
     return self.valid
 

--- a/Resources/Catalog/TSCatalogClient.py
+++ b/Resources/Catalog/TSCatalogClient.py
@@ -9,16 +9,15 @@ from DIRAC.Core.Utilities.List                     import breakListIntoChunks
 from DIRAC.Resources.Catalog.Utilities             import checkCatalogArguments
 from DIRAC.Resources.Catalog.FileCatalogClientBase import FileCatalogClientBase
 
-# List of common File Catalog methods implemented by this client
-READ_METHODS = []
-WRITE_METHODS = [ "addFile", "removeFile" ]
-NO_LFN_METHODS= []
-
 class TSCatalogClient( FileCatalogClientBase ):
 
   """ Exposes the catalog functionality available in the DIRAC/TransformationHandler
 
   """
+
+  # List of common File Catalog methods implemented by this client
+  WRITE_METHODS = FileCatalogClientBase.WRITE_METHODS + [ "addFile", "removeFile" ]
+
   def __init__( self, url = None, **kwargs ):
 
     self.__kwargs = kwargs
@@ -26,21 +25,6 @@ class TSCatalogClient( FileCatalogClientBase ):
     self.serverURL = "Transformation/TransformationManager"
     if url is not None:
       self.serverURL = url
-
-  def hasCatalogMethod( self, methodName ):
-    """ Check of a method with the given name is implemented
-    :param str methodName: the name of the method to check
-    :return: boolean Flag
-    """
-    return methodName in ( READ_METHODS + WRITE_METHODS + NO_LFN_METHODS )
-
-  @staticmethod
-  def getInterfaceMethods():
-    """ Get the methods implemented by the File Catalog client
-
-    :return tuple: ( read_methods_list, write_methods_list, nolfn_methods_list )
-    """
-    return ( READ_METHODS, WRITE_METHODS, NO_LFN_METHODS )
 
   @checkCatalogArguments
   def addFile( self, lfns, force = False ):


### PR DESCRIPTION
Added default methods needed to be implemented by all the catalogs to be used in standard operations:

hasAccess()
exists()
getPathPermissions

In the default implementations the answer is True to all the requests