### PR TITLE
 [v6r15] dirac-rss-sync is also syncing sites now

### DIFF
--- a/ResourceStatusSystem/scripts/dirac-rss-sync.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-sync.py
@@ -23,6 +23,9 @@ from DIRAC                                            import gConfig, gLogger, e
 from DIRAC.Core.Base                                  import Script
 from DIRAC.WorkloadManagementSystem.DB.JobDB          import JobDB
 from DIRAC.ResourceStatusSystem.DB.ResourceStatusDB   import ResourceStatusDB
+from DIRAC.ResourceStatusSystem.Utilities             import Synchronizer, CSHelpers, RssConfiguration
+from DIRAC.ResourceStatusSystem.Client                import ResourceStatusClient
+from DIRAC.ResourceStatusSystem.PolicySystem          import StateMachine
 
 __RCSID__  = '$Id$'
 
@@ -30,9 +33,8 @@ subLogger  = None
 switchDict = {}
 
 DEFAULT_STATUS = 'Banned'
-Datetime       = datetime.utcnow()
 #Add 24 hours to the datetime (it is going to be inserted in the "TokenExpiration" Column of "SiteStatus")
-Datetime       += timedelta(hours=24)
+Datetime       = datetime.utcnow() + timedelta(hours=24)
 
 def registerSwitches():
   '''
@@ -97,7 +99,6 @@ def synchronize():
     Given the element switch, adds rows to the <element>Status tables with Status
     `Unknown` and Reason `Synchronized`.
   '''
-  from DIRAC.ResourceStatusSystem.Utilities      import Synchronizer
 
   synchronizer = Synchronizer.Synchronizer()
 
@@ -152,9 +153,6 @@ def initSEs():
   '''
     Initializes SEs statuses taking their values from the CS.
   '''
-  from DIRAC.ResourceStatusSystem.Client         import ResourceStatusClient
-  from DIRAC.ResourceStatusSystem.PolicySystem   import StateMachine
-  from DIRAC.ResourceStatusSystem.Utilities      import CSHelpers, RssConfiguration
 
   #WarmUp local copy
   CSHelpers.warmUp()

--- a/ResourceStatusSystem/scripts/dirac-rss-sync.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-sync.py
@@ -30,7 +30,7 @@ subLogger  = None
 switchDict = {}
 
 DEFAULT_STATUS = 'Banned'
-Datetime       = datetime.now()
+Datetime       = datetime.utcnow()
 #Add 24 hours to the datetime (it is going to be inserted in the "TokenExpiration" Column of "SiteStatus")
 Datetime       += timedelta(hours=24)
 
@@ -133,6 +133,7 @@ def initSites():
 
   if not sites[ 'OK' ]:
     subLogger.error( sites[ 'Message' ] )
+    DIRACExit( 1 )
 
   for site, elements in sites['Value'].iteritems():
     table  = { 'table': 'SiteStatus' }
@@ -143,7 +144,7 @@ def initSites():
 
     if not result[ 'OK' ]:
       subLogger.error( result[ 'Message' ] )
-      continue
+      DIRACExit( 1 )
 
   return S_OK()
 

--- a/ResourceStatusSystem/scripts/dirac-rss-sync.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-sync.py
@@ -1,25 +1,28 @@
 #!/usr/bin/env python
 """
   dirac-rss-sync
-  
+
     Script that synchronizes the resources described on the CS with the RSS.
-    By default, it sets their Status to `Unknown`, StatusType to `all` and 
-    reason to `Synchronized`. However, it can copy over the status on the CS to 
+    By default, it sets their Status to `Unknown`, StatusType to `all` and
+    reason to `Synchronized`. However, it can copy over the status on the CS to
     the RSS. Important: If the StatusType is not defined on the CS, it will set
     it to Banned !
-    
+
     Usage:
       dirac-rss-sync
         --init                Initialize the element to the status in the CS ( applicable for StorageElements )
         --element=            Element family to be Synchronized ( Site, Resource or Node ) or `all`
-    
-    
+
+
     Verbosity:
-        -o LogLevel=LEVEL     NOTICE by default, levels available: INFO, DEBUG, VERBOSE..        
+        -o LogLevel=LEVEL     NOTICE by default, levels available: INFO, DEBUG, VERBOSE..
 """
 
-from DIRAC                                     import gConfig, gLogger, exit as DIRACExit, S_OK, version
-from DIRAC.Core.Base                           import Script
+from datetime import datetime, timedelta
+from DIRAC                                            import gConfig, gLogger, exit as DIRACExit, S_OK, version
+from DIRAC.Core.Base                                  import Script
+from DIRAC.WorkloadManagementSystem.DB.JobDB          import JobDB
+from DIRAC.ResourceStatusSystem.DB.ResourceStatusDB   import ResourceStatusDB
 
 __RCSID__  = '$Id$'
 
@@ -27,18 +30,21 @@ subLogger  = None
 switchDict = {}
 
 DEFAULT_STATUS = 'Banned'
+Datetime       = datetime.now()
+#Add 24 hours to the datetime (it is going to be inserted in the "TokenExpiration" Column of "SiteStatus")
+Datetime       += timedelta(hours=24)
 
 def registerSwitches():
   '''
     Registers all switches that can be used while calling the script from the
     command line interface.
   '''
-  
+
   switches = (
     ( 'init',     'Initialize the element to the status in the CS ( applicable for StorageElements )' ),
     ( 'element=', 'Element family to be Synchronized ( Site, Resource or Node ) or `all`' ),
              )
-  
+
   for switch in switches:
     Script.registerSwitch( '', switch[ 0 ], switch[ 1 ] )
 
@@ -48,19 +54,19 @@ def registerUsageMessage():
   '''
 
   hLine = '  ' + '='*78 + '\n'
-  
+
   usageMessage = hLine
   usageMessage += '  DIRAC %s\n' % version
   usageMessage += __doc__
   usageMessage += '\n' + hLine
-  
+
   Script.setUsageMessage( usageMessage )
 
 def parseSwitches():
   '''
     Parses the arguments passed by the user
   '''
-  
+
   Script.parseCommandLine( ignoreErrors = True )
   args = Script.getPositionalArgs()
   if args:
@@ -68,9 +74,9 @@ def parseSwitches():
     subLogger.error( "Please, check documentation below" )
     Script.showHelp()
     DIRACExit( 1 )
-  
-  switches = dict( Script.getUnprocessedSwitches() )  
-  
+
+  switches = dict( Script.getUnprocessedSwitches() )
+
   # Default values
   switches.setdefault( 'element', None )
   if not switches[ 'element' ] in ( 'all', 'Site', 'Resource', 'Node', None ):
@@ -94,25 +100,51 @@ def synchronize():
   from DIRAC.ResourceStatusSystem.Utilities      import Synchronizer
 
   synchronizer = Synchronizer.Synchronizer()
-  
+
   if switchDict[ 'element' ] in ( 'Site', 'all' ):
     subLogger.info( 'Synchronizing Sites' )
     res = synchronizer._syncSites()
     if not res[ 'OK' ]:
       return res
-    
+
   if switchDict[ 'element' ] in ( 'Resource', 'all' ):
     subLogger.info( 'Synchronizing Resource' )
     res = synchronizer._syncResources()
     if not res[ 'OK' ]:
       return res
-  
+
   if switchDict[ 'element' ] in ( 'Node', 'all' ):
     subLogger.info( 'Synchronizing Nodes' )
     res = synchronizer._syncNodes()
     if not res[ 'OK' ]:
       return res
-  
+
+  return S_OK()
+
+def initSites():
+  '''
+    Initializes Sites statuses taking their values from the "SiteMask" table of "JobDB" database.
+  '''
+
+  jobClient = JobDB()
+  rssClient = ResourceStatusDB()
+
+  sites = jobClient.getAllSiteMaskStatus()
+
+  if not sites[ 'OK' ]:
+    subLogger.error( sites[ 'Message' ] )
+
+  for site, elements in sites['Value'].iteritems():
+    table  = { 'table': 'SiteStatus' }
+    insert = { 'Status': elements[0], 'Reason': 'Synchronized', 'Name': site, 'DateEffective': elements[1], 'TokenExpiration': Datetime,
+             'ElementType': 'Site', 'StatusType': 'all', 'LastCheckTime': None, 'TokenOwner': elements[2] }
+
+    result = rssClient.addIfNotThere(insert, table)
+
+    if not result[ 'OK' ]:
+      subLogger.error( result[ 'Message' ] )
+      continue
+
   return S_OK()
 
 def initSEs():
@@ -127,21 +159,21 @@ def initSEs():
   CSHelpers.warmUp()
 
   subLogger.info( 'Initializing SEs' )
-  
+
   rssClient = ResourceStatusClient.ResourceStatusClient()
-  
+
   ses = CSHelpers.getStorageElements()
   if not ses[ 'OK' ]:
     return ses
-  ses = ses[ 'Value' ]  
+  ses = ses[ 'Value' ]
 
   statuses    = StateMachine.RSSMachine( None ).getStates()
   statusTypes = RssConfiguration.RssConfiguration().getConfigStatusType( 'StorageElement' )
   reason      = 'dirac-rss-sync'
-  
+
   subLogger.debug( statuses )
   subLogger.debug( statusTypes )
-  
+
   for se in ses:
 
     subLogger.debug( se )
@@ -151,14 +183,14 @@ def initSEs():
       subLogger.warn( opts[ 'Message' ] )
       continue
     opts = opts[ 'Value' ]
-    
+
     subLogger.debug( opts )
-    
+
     # We copy the list into a new object to remove items INSIDE the loop !
     statusTypesList = statusTypes[:]
-          
-    for statusType, status in opts.iteritems():    
-    
+
+    for statusType, status in opts.iteritems():
+
       #Sanity check...
       if not statusType in statusTypesList:
         continue
@@ -166,7 +198,7 @@ def initSEs():
       #Transforms statuses to RSS terms
       if status in ( 'NotAllowed', 'InActive' ):
         status = 'Banned'
-        
+
       if not status in statuses:
         subLogger.error( '%s not a valid status for %s - %s' % ( status, se, statusType ) )
         continue
@@ -179,12 +211,12 @@ def initSEs():
                                                    statusType = statusType, status = status,
                                                    elementType = 'StorageElement',
                                                    reason = reason )
-      
+
       if not result[ 'OK' ]:
         subLogger.error( 'Failed to modify' )
         subLogger.error( result[ 'Message' ] )
         continue
-      
+
     #Backtracking: statusTypes not present on CS
     for statusType in statusTypesList:
 
@@ -195,43 +227,49 @@ def initSEs():
       if not result[ 'OK' ]:
         subLogger.error( 'Error in backtracking for %s,%s,%s' % ( se, statusType, status ) )
         subLogger.error( result[ 'Message' ] )
-        
+
   return S_OK()
-              
+
 #...............................................................................
 
 def run():
   '''
     Main function of the script
   '''
-  
+
   result = synchronize()
   if not result[ 'OK' ]:
     subLogger.error( result[ 'Message' ] )
     DIRACExit( 1 )
 
   if 'init' in switchDict:
+
+    result = initSites()
+    if not result[ 'OK' ]:
+      subLogger.error( result[ 'Message' ] )
+      DIRACExit( 1 )
+
     result = initSEs()
     if not result[ 'OK' ]:
       subLogger.error( result[ 'Message' ] )
-      DIRACExit( 1 )   
+      DIRACExit( 1 )
 
 #...............................................................................
 
 if __name__ == "__main__":
-  
+
   subLogger  = gLogger.getSubLogger( __file__ )
-  
+
   #Script initialization
   registerSwitches()
   registerUsageMessage()
   switchDict = parseSwitches()
-  
+
   #Run script
   run()
-   
+
   #Bye
   DIRACExit( 0 )
-  
+
 ################################################################################
 #EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1497,24 +1497,6 @@ class JobDB( DB ):
 
     return S_OK( siteDict )
 
-  #############################################################################
-  def getAllSiteMaskLoggingStatus( self ):
-    """ Get the everything from site mask logging status
-    """
-    cmd = "SELECT Site,Status,UpdateTime,Author,Comment FROM SiteMaskLogging"
-
-    result = self._query( cmd )
-
-    if not result[ 'OK' ]:
-      return result[ 'Message' ]
-
-    siteDict = {}
-    if result['OK']:
-      for site, status, UpdateTime, Author, Comment in result['Value']:
-        siteDict[site] = status, UpdateTime, Author, Comment
-
-    return S_OK( siteDict )
-
 #############################################################################
   def setSiteMask( self, siteMaskList, authorDN = 'Unknown', comment = 'No comment' ):
     """ Set the Site Mask to the given mask in a form of a list of tuples (site,status)

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1311,7 +1311,7 @@ class JobDB( DB ):
       return S_ERROR( 'Job ' + str( jobID ) + ' not found in the system' )
 
     if not resultDict['VerifiedFlag']:
-      return S_ERROR( 'Job %s not Verified: Status = %s, MinorStatus = %s' % ( 
+      return S_ERROR( 'Job %s not Verified: Status = %s, MinorStatus = %s' % (
                                                                              jobID,
                                                                              resultDict['Status'],
                                                                              resultDict['MinorStatus'] ) )
@@ -1419,7 +1419,7 @@ class JobDB( DB ):
     classAdJob.insertAttributeInt( 'JobRequirements', reqJDL )
 
     jobJDL = classAdJob.asJDL()
-    
+
     # Replace the JobID placeholder if any
     if jobJDL.find( '%j' ) != -1:
       jobJDL = jobJDL.replace( '%j', str( jobID ) )
@@ -1476,6 +1476,34 @@ class JobDB( DB ):
     if result['OK']:
       for site, status in result['Value']:
         siteDict[site] = status
+
+    return S_OK( siteDict )
+
+#############################################################################
+  def getAllSiteMaskStatus( self ):
+    """ Get the everything from site mask status
+    """
+    cmd = "SELECT Site,Status,LastUpdateTime,Author,Comment FROM SiteMask"
+
+    result = self._query( cmd )
+    siteDict = {}
+    if result['OK']:
+      for site, status, LastUpdateTime, Author, Comment in result['Value']:
+        siteDict[site] = status, LastUpdateTime, Author, Comment
+
+    return S_OK( siteDict )
+
+  #############################################################################
+  def getAllSiteMaskLoggingStatus( self ):
+    """ Get the everything from site mask logging status
+    """
+    cmd = "SELECT Site,Status,UpdateTime,Author,Comment FROM SiteMaskLogging"
+
+    result = self._query( cmd )
+    siteDict = {}
+    if result['OK']:
+      for site, status, UpdateTime, Author, Comment in result['Value']:
+        siteDict[site] = status, UpdateTime, Author, Comment
 
     return S_OK( siteDict )
 

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1486,6 +1486,10 @@ class JobDB( DB ):
     cmd = "SELECT Site,Status,LastUpdateTime,Author,Comment FROM SiteMask"
 
     result = self._query( cmd )
+
+    if not result[ 'OK' ]:
+      return result[ 'Message' ]
+
     siteDict = {}
     if result['OK']:
       for site, status, LastUpdateTime, Author, Comment in result['Value']:
@@ -1500,6 +1504,10 @@ class JobDB( DB ):
     cmd = "SELECT Site,Status,UpdateTime,Author,Comment FROM SiteMaskLogging"
 
     result = self._query( cmd )
+
+    if not result[ 'OK' ]:
+      return result[ 'Message' ]
+
     siteDict = {}
     if result['OK']:
       for site, status, UpdateTime, Author, Comment in result['Value']:


### PR DESCRIPTION
The sites that reside in `SiteMask` table of `JobDB` database are taken and inserted (with the appropriate format) to the `SiteStatus` table of `ResourceStatusDB` database.

This is invoked when: `dirac-rss-sync --init` is executed.