### PR TITLE
[v6r14] Subprocess: Fix two possible infinite loops

### DIFF
--- a/Core/Utilities/Subprocess.py
+++ b/Core/Utilities/Subprocess.py
@@ -368,6 +368,10 @@ class Subprocess:
         if nB == "":
           break
         dataString += nB
+        #break out of potential infinite loop, indicated by dataString growing beyond reason
+        if len( dataString ) + baseLength > self.bufferLimit:
+          self.log.error( "DataString is getting too long (%s): %s " %( len( dataString ), dataString[-10000:] ) )
+          break
     except Exception, x:
       self.log.exception( "SUBPROCESS: readFromFile exception" )
       try:
@@ -514,6 +518,7 @@ class Subprocess:
         self.log.exception( 'Exception while calling callback function',
                             '%s' % self.callback.__name__ )
         self.log.showStack()
+        return False
 
       return True
     return False


### PR DESCRIPTION
While looking for that memory consumption in the JobWrapper or JobAgent I found two possible issues. I can reliably cause a large memory consumption by starting a JobWrapper and after it ran for a minute or so remove the output folder of the jobwrapper (a folder named with the job id of the jobwrapper). I don't know if something like this is also causing the issue on the grid, but that was the best lead I had and I would like to try this out in reality.

So there are two locations where infinite loops can be caused, and in the first case this leads to an ever growing string.

* dataString can grow infinitely if select.select always returns something. 10000000 is an arbitrary number that is maybe large enough for anybody? text output shouldn't ever be that large on purpose, should it?

* After exception in callback function True was returned, which means the function is called again because callLineCallback is called in while statement, if the exception happens again we might end up in an infinite loop giving constant print out of stack traces