### PR TITLE
[v6r15] Fall back to IPv4 only if AF_INET6 doesn't work.

### DIFF
--- a/Core/DISET/private/Transports/PlainTransport.py
+++ b/Core/DISET/private/Transports/PlainTransport.py
@@ -33,7 +33,11 @@ class PlainTransport( BaseTransport ):
   def initAsServer( self ):
     if not self.serverMode():
       raise RuntimeError( "Must be initialized as server mode" )
-    self.oSocket = socket.socket( socket.AF_INET6, socket.SOCK_STREAM )
+    try:
+      self.oSocket = socket.socket( socket.AF_INET6, socket.SOCK_STREAM )
+    except socket.error:
+      # IPv6 is probably disabled on this node, try IPv4 only instead
+      self.oSocket = socket.socket( socket.AF_INET, socket.SOCK_STREAM )
     if self.bAllowReuseAddress:
       self.oSocket.setsockopt( socket.SOL_SOCKET, socket.SO_REUSEADDR, 1 )
     self.oSocket.bind( self.stServerAddress )

--- a/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
@@ -160,7 +160,11 @@ class SocketInfoFactory:
     return S_OK( socketInfo )
 
   def getListeningSocket( self, hostAddress, listeningQueueSize = 5, reuseAddress = True, **kwargs ):
-    osSocket = socket.socket( socket.AF_INET6, socket.SOCK_STREAM )
+    try:
+      osSocket = socket.socket( socket.AF_INET6, socket.SOCK_STREAM )
+    except socket.error:
+      # IPv6 is probably disabled on this node, try IPv4 only instead
+      osSocket = socket.socket( socket.AF_INET, socket.SOCK_STREAM )
     if reuseAddress:
       osSocket.setsockopt( socket.SOL_SOCKET, socket.SO_REUSEADDR, 1 )
     retVal = self.generateServerInfo( kwargs )


### PR DESCRIPTION
Hi,

This is a fix for the IPv6 "Address family not supported by protocol" problems mentioned on the diracgrid-forum mailing list. I think the bug exists in all version which support IPv6.

Regards,
Simon
