### PR TITLE
[v6r15] SiteDirector enhanced logic for using empty sites

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -642,7 +642,7 @@ class SiteDirector( AgentModule ):
                                             'Status': WAITING_PILOT_STATUS } )
       if result['OK']:
         jobIDList = result['Value']
-        if len( jobIDList ) == 0:
+        if not jobIDList:
           return totalSlots
       return 0
 

--- a/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -198,6 +198,7 @@ Agents
     SendPilotAccounting = True
     FailedQueueCycleFactor = 10
     PilotStatusUpdateCycleFactor = 10
+    AddPilotsToEmptySites = False
   }
   StatesAccountingAgent
   {


### PR DESCRIPTION
This PR is solving the problem of the sites that are not getting pilots, although not having any waiting pilots, if there are already many pilots sent to other sites. In this case empty sites still will get some pilots at a lower than usual pace