### PR TITLE
[v6r14] Gives string LFN to LFC

### DIFF
--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -1886,6 +1886,6 @@ class LcgFileCatalogClient( FileCatalogClientBase ):
     return returnCode( lfc.lfc_chmod( self.__fullLfn( lfn ), mode ) )
 
   def __fullLfn( self, lfn ):
-    return self.prefix + lfn
+    return str( self.prefix + lfn )
 
   # THIS IS NOT YET WORKING


### PR DESCRIPTION
LFC wrapper does not accept unicode but only string.
This patch converts any basestring to string.