### PR TITLE
[v6r14] dirac-wms-cpu-normalization, reduce memory footprint

### DIFF
--- a/WorkloadManagementSystem/Client/CPUNormalization.py
+++ b/WorkloadManagementSystem/Client/CPUNormalization.py
@@ -140,7 +140,7 @@ def getCPUNormalization( reference = 'HS06', iterations = 1 ):
     if i == 1:
       start = os.times()
     # Now the iterations
-    for _j in range( n ):
+    for _j in xrange( n ):
       t = random.normalvariate( 10, 1 )
       m += t
       m2 += t * t


### PR DESCRIPTION
This function is called in the dirac-wms-cpu-normalization run by pilots. 
Not creating a list with 12.5 million entries saves about 400 MB. Creating this list was not intentional, right?

Proper target branch