### PR TITLE
[v6r15] Setup Indication in Emails

### DIFF
--- a/ResourceStatusSystem/Agent/EmailAgent.py
+++ b/ResourceStatusSystem/Agent/EmailAgent.py
@@ -48,7 +48,11 @@ class EmailAgent( AgentModule ):
         for site in result:
           cursor = conn.execute("SELECT StatusType, ResourceName, Status, Time, PreviousStatus from ResourceStatusCache WHERE SiteName='"+ site[0] +"';")
 
-          email_body = "(" + gConfig.getValue('/DIRAC/Setup') + ")\n\n"
+          if gConfig.getValue('/DIRAC/Setup'):
+            email_body = "(" + gConfig.getValue('/DIRAC/Setup') + ")\n\n"
+          else:
+            email_body = ""
+            
           for StatusType, ResourceName, Status, Time, PreviousStatus in cursor:
             email_body += StatusType + " of " + ResourceName + " has been " + Status + " since " + Time + " (Previous status: " + PreviousStatus + ")\n"
 

--- a/ResourceStatusSystem/Agent/EmailAgent.py
+++ b/ResourceStatusSystem/Agent/EmailAgent.py
@@ -9,7 +9,7 @@
 
 import os
 import sqlite3
-from DIRAC                                                       import S_OK, S_ERROR
+from DIRAC                                                       import gConfig, S_OK, S_ERROR
 from DIRAC.Core.Base.AgentModule                                 import AgentModule
 from DIRAC.ResourceStatusSystem.Utilities                        import RssConfiguration
 from DIRAC.Interfaces.API.DiracAdmin                             import DiracAdmin
@@ -48,7 +48,7 @@ class EmailAgent( AgentModule ):
         for site in result:
           cursor = conn.execute("SELECT StatusType, ResourceName, Status, Time, PreviousStatus from ResourceStatusCache WHERE SiteName='"+ site[0] +"';")
 
-          email_body = ""
+          email_body = "(" + gConfig.getValue('/DIRAC/Setup') + ")\n\n"
           for StatusType, ResourceName, Status, Time, PreviousStatus in cursor:
             email_body += StatusType + " of " + ResourceName + " has been " + Status + " since " + Time + " (Previous status: " + PreviousStatus + ")\n"
 


### PR DESCRIPTION
Indication of the setup added (e.g. "LHCb-Production" or "LHCb-Certification").
Now we can distinguish if an email is for a resource monitored in one setup or another.