### PR TITLE
[v6r15] Log message in case the Email cache database is locked

### DIFF
--- a/ResourceStatusSystem/PolicySystem/Actions/EmailAction.py
+++ b/ResourceStatusSystem/PolicySystem/Actions/EmailAction.py
@@ -1,6 +1,6 @@
 ''' EmailAction
 
-  This action writes all the necessary data to a cache file ( cache.json ) that
+  This action writes all the necessary data to a cache file ( cache.db ) that
   will be used later by the EmailAgent in order to send the emails for each site.
 
 '''
@@ -67,14 +67,18 @@ class EmailAction( BaseAction ):
 
     with sqlite3.connect(self.cacheFile) as conn:
 
-      conn.execute('''CREATE TABLE IF NOT EXISTS ResourceStatusCache(
-                    SiteName VARCHAR(64) NOT NULL,
-                    ResourceName VARCHAR(64) NOT NULL,
-                    Status VARCHAR(8) NOT NULL DEFAULT "",
-                    PreviousStatus VARCHAR(8) NOT NULL DEFAULT "",
-                    StatusType VARCHAR(128) NOT NULL DEFAULT "all",
-                    Time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                   );''')
+      try:
+        conn.execute('''CREATE TABLE IF NOT EXISTS ResourceStatusCache(
+                      SiteName VARCHAR(64) NOT NULL,
+                      ResourceName VARCHAR(64) NOT NULL,
+                      Status VARCHAR(8) NOT NULL DEFAULT "",
+                      PreviousStatus VARCHAR(8) NOT NULL DEFAULT "",
+                      StatusType VARCHAR(128) NOT NULL DEFAULT "all",
+                      Time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                     );''')
+                     
+      except sqlite3.OperationalError:
+        self.log.error('Email cache database is locked')
 
       conn.execute("INSERT INTO ResourceStatusCache (SiteName, ResourceName, Status, PreviousStatus, StatusType)"
                    " VALUES ('" + siteName + "', '" + name + "', '" + status + "', '" + previousStatus + "', '" + statusType + "' ); "


### PR DESCRIPTION
The database can be locked due to concurrency, I added an error message log.
Database locks are different than table locks. In most cases python retries the query automatically as far as I know.