### PR TITLE
[v6r14] Enable Coveralls and Landscape

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ script:
   - export PYTHONPATH=${PWD%/*}
   - ls $PYTHONPATH
   - py.test
+after_success:
+  - coveralls

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ DIRAC
 =====
 .. image:: https://travis-ci.org/DIRACGrid/DIRAC.svg?branch=rel-v6r14
     :target: https://travis-ci.org/DIRACGrid/DIRAC
+.. image:: https://img.shields.io/coveralls/DIRACGrid/DIRAC/rel-v6r14.svg?maxAge=2592000
+    :target: https://coveralls.io/github/DIRACGrid/DIRAC
+
 DIRAC (Distributed Infrastructure with Remote Agent Control) INTERWARE is a software framework for distributed computing providing a complete solution to one or more user community requiring access to distributed resources. DIRAC builds a layer between the users and the resources offering a common interface to a number of heterogeneous providers, integrating them in a seamless manner, providing interoperability, at the same time as an optimized, transparent and reliable usage of the resources.
 
 DIRAC has been started by the `LHCb collaboration <https://lhcb.web.cern.ch/lhcb/>`_ who still maintains it. It is now used by several communities (AKA VO=Virtual Organizations) for their distributed computing workflows.

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,8 @@ DIRAC
     :target: https://travis-ci.org/DIRACGrid/DIRAC
 .. image:: https://img.shields.io/coveralls/DIRACGrid/DIRAC/rel-v6r14.svg?maxAge=2592000
     :target: https://coveralls.io/github/DIRACGrid/DIRAC
-
+.. image:: https://landscape.io/github/DIRACGrid/DIRAC/rel-v6r14/landscape.svg?style=flat
+   :target: https://landscape.io/github/DIRACGrid/DIRAC/rel-v6r14
 DIRAC (Distributed Infrastructure with Remote Agent Control) INTERWARE is a software framework for distributed computing providing a complete solution to one or more user community requiring access to distributed resources. DIRAC builds a layer between the users and the resources offering a common interface to a number of heterogeneous providers, integrating them in a seamless manner, providing interoperability, at the same time as an optimized, transparent and reliable usage of the resources.
 
 DIRAC has been started by the `LHCb collaboration <https://lhcb.web.cern.ch/lhcb/>`_ who still maintains it. It is now used by several communities (AKA VO=Virtual Organizations) for their distributed computing workflows.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 #Configuration file for py.test
 [pytest]
 python_files=Test_*.py
-addopts = -rx -v --color=yes --tb=long --ignore=tests --cov
+addopts = -rx -v --color=yes --tb=long --ignore=tests --cov=. --cov-report term-missing

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ pytest-cov>=2.2.0
 coverage>=4.0.3
 rst2pdf>=0.93
 ipython
+python-coveralls


### PR DESCRIPTION
Use Coveralls for coverage. 

Go to https://coveralls.io/ and link DIRACGrid to coveralls and enable coveralls for the DIRAC and Pilot (I will do it later) repos.

I have already formed the badge to point to the right place.  