### PR TITLE
[v6r15] Enable CodeDocumentation via READTHEDOCS

### DIFF
--- a/docs/Tools/MakeDoc.py
+++ b/docs/Tools/MakeDoc.py
@@ -41,6 +41,7 @@ def mkRest( filename, modulename, fullmodulename, subpackages=None, modules=None
     lines.append("   :maxdepth: 1")
     lines.append("")
 
+  subpackages = [ s for s in subpackages if not s.endswith( ("scripts", ) ) ]
   if subpackages:
     print modulename, " subpackages ", subpackages
     lines.append( "SubPackages" )
@@ -137,8 +138,8 @@ def createDoc():
     if any( root.lower().endswith( f.lower() ) for f in ("/docs", ) ):
       #print "Skipping:", root
       continue
-    elif any( f.lower() in root.lower() for f in ("test", "scripts", "/db", "/AccountingDB", "/framework" ) ):
-      #print "Skipping:", root
+    elif any( f.lower() in root.lower() for f in ("test", "scripts",
+                                                 ) ):
       continue
     
     #print root, direc, files

--- a/docs/Tools/MakeDoc.py
+++ b/docs/Tools/MakeDoc.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+""" create rst files for documentation of DIRAC """
+import os
+
+import fakeEnvironment
+import fakeEnv
+
+def mkdir( folder ):
+  """create a folder, ignore if it exists"""
+  try:
+    folder = os.path.join(os.getcwd(),folder)
+    os.mkdir( folder )
+  except OSError as e:
+    print "Exception for",folder,repr(e)
+
+
+BASEPATH = "docs/source/CodeDocumentation"
+DIRACPATH = os.environ.get("DIRAC") + "/DIRAC"
+
+ORIGDIR = os.getcwd()
+
+BASEPATH = os.path.join( DIRACPATH, BASEPATH )
+
+def mkRest( filename, modulename, fullmodulename, subpackages=None, modules=None ):
+  """make a rst file for filename"""
+  if modulename == "scripts":
+    return
+    #modulefinal = fullmodulename.split(".")[-2]+" Scripts"
+  else:
+    modulefinal = modulename
+
+  print fullmodulename, "\n++subpackages",subpackages, "\n++Modules",modules
+  lines = []
+  lines.append("%s" % modulefinal)
+  lines.append("="*len(modulefinal))
+  lines.append(".. module:: %s " % fullmodulename )
+  lines.append("" )
+
+  if subpackages or modules:
+    lines.append(".. toctree::")
+    lines.append("   :maxdepth: 1")
+    lines.append("")
+
+  if subpackages:
+    print modulename, " subpackages ", subpackages
+    lines.append( "SubPackages" )
+    lines.append( "..........." )
+    lines.append( "" )
+    lines.append(".. toctree::")
+    lines.append("   :maxdepth: 1")
+    lines.append("")
+    for package in sorted(subpackages):
+      lines.append("   %s/%s_Module.rst" % (package,package.split("/")[-1] ) )
+      #lines.append("   %s " % (package, ) )
+
+  ##remove CLI because we drop them earlier
+  modules = [ m for m in modules if not m.endswith("CLI") ]
+  if modules:
+    lines.append( "Modules" )
+    lines.append( "......." )
+    lines.append( "" )
+    lines.append(".. toctree::")
+    lines.append("   :maxdepth: 1")
+    lines.append("")
+    for module in sorted(modules):
+      lines.append("   %s.rst" % (module.split("/")[-1],) )
+      #lines.append("   %s " % (package, ) )
+
+  with open(filename, 'w') as rst:
+    rst.write("\n".join(lines))
+
+    
+def mkModuleRest( classname, fullclassname ):
+  """ create rst file for class"""
+  filename = classname+".rst"
+
+  lines = []
+  lines.append("%s" % classname)
+  lines.append("="*len(classname))
+
+  # if "-" not in classname:
+  #   lines.append(".. autosummary::" )
+  #   lines.append("   :toctree: %sGen" % classname )
+  #   lines.append("")
+  #   lines.append("   %s " % fullclassname )
+  #   lines.append("")
+
+  lines.append(".. automodule:: %s" % fullclassname )
+  lines.append("   :members:" )
+  lines.append("   :inherited-members:" )
+  lines.append("   :undoc-members:" )
+  lines.append("   :show-inheritance:" )
+  if classname.startswith("_"):
+    lines.append( "   :private-members:" )
+
+  with open(filename, 'w') as rst:
+    rst.write("\n".join(lines))
+
+  
+def getsubpackages( abspath, direc):
+  """return list of subpackages with full path"""
+  packages = []
+  for dire in direc:
+    if "test" in dire.lower():
+      continue
+    #print os.path.join( DIRACPATH,abspath,dire, "__init__.py" )
+    if os.path.exists( os.path.join( DIRACPATH,abspath,dire, "__init__.py" ) ):
+      #packages.append( os.path.join( "DOC", abspath, dire) )
+      packages.append( os.path.join( dire ) )
+  #print "packages",packages
+  return packages
+
+def getmodules( _abspath, _direc, files ):
+  """return list of subpackages with full path"""
+  packages = []
+  for filename in files:
+    if "test" in filename.lower():
+      continue
+    if filename != "__init__.py":
+      packages.append( filename.split(".py")[0] )
+
+  return packages
+
+
+def createDoc():
+  """create the rst files for all the things we want them for"""
+  print "DIRACPATH",DIRACPATH
+  print "BASEPATH", BASEPATH
+  mkdir(BASEPATH)
+  os.chdir(BASEPATH)
+  
+  for root,direc,files in os.walk(DIRACPATH):
+    files = [ _ for _ in files if _.endswith(".py") ]
+    if "__init__.py" not in files:
+      continue
+
+    if any( root.lower().endswith( f.lower() ) for f in ("/docs", ) ):
+      #print "Skipping:", root
+      continue
+    elif any( f.lower() in root.lower() for f in ("test", "scripts", "/db", "/AccountingDB", "/framework" ) ):
+      #print "Skipping:", root
+      continue
+    
+    #print root, direc, files
+    modulename = root.split("/")[-1]
+    abspath = root.split(DIRACPATH)[1].strip("/")
+    fullmodulename = ".".join(abspath.split("/"))
+    packages = getsubpackages(abspath,direc)
+    #print "packages for ", root, packages
+    if abspath:
+      mkdir( abspath )
+      os.chdir( abspath )
+    #print "Making rst",modulename
+    if modulename == "DIRAC":
+      createCodeDocIndex(subpackages=packages, modules=getmodules(abspath, direc, files))
+    else:
+      mkRest( modulename+"_Module.rst", modulename, fullmodulename, subpackages=packages, modules=getmodules(abspath, direc, files) )
+
+    for filename in files:
+      if filename.lower().startswith("test"):
+        continue
+      ## Skip things that call parseCommandLine or similar issues
+      if any( f in filename for f in ("lfc_dfc_copy", "lfc_dfc_db_copy", "JobWrapperTemplate", "Refresher") ):
+        continue
+      if filename.endswith("CLI.py"):
+        continue
+      if filename == "__init__.py":
+        continue
+      if not filename.endswith(".py"):
+        continue
+      fullclassname = ".".join(abspath.split("/")+[filename])
+      if not fullclassname.startswith( "DIRAC." ):
+        fullclassname = "DIRAC."+fullclassname
+      mkModuleRest( filename.split(".py")[0], fullclassname.split(".py")[0] )
+
+    os.chdir(BASEPATH)
+  return 0
+
+def createCodeDocIndex( subpackages, modules):
+  """create the main index file"""
+  filename = "index.rst"
+  lines = []
+  lines.append( ".. _code_documentation:")
+  lines.append("")
+  lines.append( "Code Documentation (|release|)" )
+  lines.append( "------------------------------" )
+                
+
+  if subpackages or modules:
+    lines.append(".. toctree::")
+    lines.append("   :maxdepth: 1")
+    lines.append("")
+
+  if subpackages:
+    systemPackages = sorted([ pck for pck in subpackages if pck.endswith("System") ])
+    otherPackages = sorted([ pck for pck in subpackages if not pck.endswith("System") ])
+
+    lines.append( "=======" )
+    lines.append( "Systems" )
+    lines.append( "=======" )
+    lines.append("")
+    lines.append(".. toctree::")
+    lines.append("   :maxdepth: 1")
+    lines.append("")
+    for package in systemPackages:
+      lines.append("   %s/%s_Module.rst" % (package,package.split("/")[-1] ) )
+
+    lines.append("")
+    lines.append( "=====" )
+    lines.append( "Other" )
+    lines.append( "=====" )
+    lines.append("")
+    lines.append(".. toctree::")
+    lines.append("   :maxdepth: 1")
+    lines.append("")
+    for package in otherPackages:
+      lines.append("   %s/%s_Module.rst" % (package,package.split("/")[-1] ) )
+
+  if modules:
+    for module in sorted(modules):
+      lines.append("   %s.rst" % (module.split("/")[-1],) )
+      #lines.append("   %s " % (package, ) )
+
+  with open(filename, 'w') as rst:
+    rst.write("\n".join(lines))
+  
+if __name__ == "__main__":
+  exit(createDoc())

--- a/docs/Tools/makeDocs.sh
+++ b/docs/Tools/makeDocs.sh
@@ -91,6 +91,7 @@ python $tmpdir/DIRACDocs/Tools/buildCodeDOC.py $codeDIR
 # Make html web pages from rst's
 
 # This command hangs, so we kill it after 5 minutes
+# FYI: This command hangs because of the thread that the PlotCache creates
 ( make -C $tmpdir/DIRACDocs html ) & sleep 300 ; kill -9 $!; echo "killed make"
 
 #make -C $tmpdir/DIRACDocs html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 Sphinx
+mock

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,17 +18,22 @@ import subprocess
 
 sys.path.insert(0, ".")
 
-import fakeEnvironment
-import fakeEnv
-
 try:
-  diracRelease = os.environ[ 'DIRACVERSION' ]
-except KeyError:
-  diracRelease = 'integration'
+  import fakeEnvironment
+except ImportError:
+  pass
+try:
+  import fakeEnv
+except ImportError:
+  pass
 
+diracRelease = os.environ.get( 'DIRACVERSION', 'integration' )
+if os.environ.get('READTHEDOCS') == 'True':
+  diracRelease = os.path.basename( os.path.abspath( "../../" ) )
+  if diracRelease.startswith("rel-"):
+    diracRelease = diracRelease[4:]
 print 'conf.py: %s as DIRACVERSION' % diracRelease
 
-print os.getcwd()
 
 #...............................................................................
 # configuration
@@ -36,51 +41,48 @@ print os.getcwd()
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.append(os.path.abspath('.'))
-diracPath = os.path.abspath( os.path.join( os.getcwd(), "../..") )
-print "DiracPath",diracPath
 
-buildfolder = "build"
 if os.environ.get('READTHEDOCS') == 'True':
-  diracRelease = os.path.basename( os.path.abspath( "../../" ) )
-  if diracRelease.startswith("rel-"):
-    diracRelease = diracRelease[4:]
+  sys.path.append(os.path.abspath('.'))
+  diracPath = os.path.abspath( os.path.join( os.getcwd(), "../..") )
+  print "DiracPath",diracPath
+
   buildfolder ="_build"
   try:
     os.mkdir( os.path.abspath( "../"+buildfolder) )
   except:
     pass
 
-##We need to have the DIRAC module somewhere, or we cannot import it, as readtheDocs clones the repo into something based on the branchname
-if not os.path.exists( "../../DIRAC" ):
-  diracLink =  os.path.abspath( os.path.join( os.getcwd()  , "../" , buildfolder, "DIRAC" ) )
-  print "DiracLink",diracLink
-  if not os.path.exists( diracLink ):
-    RES = subprocess.check_output( ["ln","-s", diracPath, diracLink ] )
-  diracPath = os.path.abspath( os.path.join( diracLink, ".." ) )
+  ##We need to have the DIRAC module somewhere, or we cannot import it, as readtheDocs clones the repo into something based on the branchname
+  if not os.path.exists( "../../DIRAC" ):
+    diracLink =  os.path.abspath( os.path.join( os.getcwd()  , "../" , buildfolder, "DIRAC" ) )
+    print "DiracLink",diracLink
+    if not os.path.exists( diracLink ):
+      RES = subprocess.check_output( ["ln","-s", diracPath, diracLink ] )
+    diracPath = os.path.abspath( os.path.join( diracLink, ".." ) )
 
 
-sys.path.insert(0, diracPath)
+  sys.path.insert(0, diracPath)
 
-for path in sys.path:
-  os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '')+":"+path
+  for path in sys.path:
+    os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '')+":"+path
 
-print "Pythonpath",os.environ['PYTHONPATH']
-buildCommand = os.path.join( os.getcwd() , "../Tools/buildScriptsDOC.py" )
-scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../", buildfolder, "scripts" ))
-print "command", buildCommand
-code = subprocess.Popen( ["python",buildCommand, scriptdir ], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-stdout , err = code.communicate()
-print "script",stdout
-print "script",err
+  print "Pythonpath",os.environ['PYTHONPATH']
+  buildCommand = os.path.join( os.getcwd() , "../Tools/buildScriptsDOC.py" )
+  scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../", buildfolder, "scripts" ))
+  print "command", buildCommand
+  code = subprocess.Popen( ["python",buildCommand, scriptdir ], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  stdout , err = code.communicate()
+  print "script",stdout
+  print "script",err
 
-os.environ["DIRAC"] = diracPath
-print "DIRAC ENVIRON", os.environ["DIRAC"]
-buildCommand =os.path.join( os.getcwd() , "../Tools/MakeDoc.py" )
-code = subprocess.Popen( ["python",buildCommand], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-stdout , err = code.communicate()
-print "code",stdout
-print "code",err
+  os.environ["DIRAC"] = diracPath
+  print "DIRAC ENVIRON", os.environ["DIRAC"]
+  buildCommand =os.path.join( os.getcwd() , "../Tools/MakeDoc.py" )
+  code = subprocess.Popen( ["python",buildCommand], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  stdout , err = code.communicate()
+  print "code",stdout
+  print "code",err
 
   
 # -- General configuration -----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,7 +85,9 @@ print "code",err
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary',
+              'sphinx.ext.intersphinx',
+             ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -261,5 +263,13 @@ latex_documents = [
 # If false, no module index is generated.
 #latex_use_modindex = True
 
+
+## link with the python standard library docs
+intersphinx_mapping = {
+                        'python': ('https://docs.python.org/2.7', None),
+                      }
+
+
 #...............................................................................
+
 #EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,16 +11,16 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-
-try:
-  import fakeEnv
-except:
-  pass
-
 import datetime
 import os
 import sys
 import subprocess
+
+sys.path.insert(0, ".")
+
+
+import fakeEnvironment
+import fakeEnv
 
 try:
   diracRelease = os.environ[ 'DIRACVERSION' ]
@@ -35,17 +35,20 @@ print 'conf.py: %s as DIRACVERSION' % diracRelease
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.append(os.path.abspath('.'))
+sys.path.append(os.path.abspath('.'))
 diracPath = os.path.abspath( os.path.join( os.getcwd(), "../..") )
 print "DiracPath",diracPath
 
-
-
 ##We need to have the DIRAC module somewhere, or we cannot import it, as readtheDocs clones the repo into something based on the branchname
-RES = subprocess.check_output( ["ln","-sf",diracPath,"../../DIRAC"] )
+if not os.path.exists( "../../DIRAC" ):
+  diracLink =  os.path.abspath( os.path.join( os.getcwd()  , "../build/DIRAC" ) )
+  print "DiracLink",diracLink
+  if not os.path.exists( diracLink ):
+    RES = subprocess.check_output( ["ln","-s", diracPath, diracLink ] )
+  diracPath = os.path.abspath( os.path.join( diracLink, ".." ) )
+
+
 sys.path.insert(0, diracPath)
-RES = subprocess.check_output( ["ls",diracPath] )
-print "LS dirac",RES
 
 for path in sys.path:
   os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '')+":"+path
@@ -59,12 +62,20 @@ stdout , err = code.communicate()
 print "script",stdout
 print "script",err
 
+# buildCommand = os.path.join( os.getcwd() , "../Tools/buildCodeDOC.py" )
+# if not os.path.exists( codedir ):
+#   os.mkdir( codedir )
+# print "command", buildCommand
+#codedir = os.path.abspath(os.path.join( os.getcwd() , "../build/codes" ))
+# ##buildcodedoc needs a copy of DIRAC so we give it a link
+# codeLink = os.path.join( codedir, "DIRAC")
+# if not os.path.exists( codeLink ):
+#   RES = subprocess.check_output( ["ln","-sf",diracPath, codeLink ] )
 
-
-buildCommand = os.path.join( os.getcwd() , "../Tools/buildCodeDOC.py" )
-codedir = os.path.abspath(os.path.join( os.getcwd() , "../build/codes" ))
-print "command", buildCommand
-code = subprocess.Popen( ["python",buildCommand, codedir ], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+os.environ["DIRAC"] = diracPath
+print "DIRAC ENVIRON", os.environ["DIRAC"]
+buildCommand =os.path.join( os.getcwd() , "../Tools/MakeDoc.py" )
+code = subprocess.Popen( ["python",buildCommand], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 stdout , err = code.communicate()
 print "code",stdout
 print "code",err

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,6 @@ import subprocess
 
 sys.path.insert(0, ".")
 
-
 import fakeEnvironment
 import fakeEnv
 
@@ -28,6 +27,8 @@ except KeyError:
   diracRelease = 'integration'
 
 print 'conf.py: %s as DIRACVERSION' % diracRelease
+
+print os.getcwd()
 
 #...............................................................................
 # configuration
@@ -39,9 +40,20 @@ sys.path.append(os.path.abspath('.'))
 diracPath = os.path.abspath( os.path.join( os.getcwd(), "../..") )
 print "DiracPath",diracPath
 
+buildfolder = "build"
+if os.environ.get('READTHEDOCS') == 'True':
+  diracRelease = os.path.basename( os.path.abspath( "../../" ) )
+  if diracRelease.startswith("rel-"):
+    diracRelease = diracRelease[4:]
+  buildfolder ="_build"
+  try:
+    os.mkdir( os.path.abspath( "../"+buildfolder) )
+  except:
+    pass
+
 ##We need to have the DIRAC module somewhere, or we cannot import it, as readtheDocs clones the repo into something based on the branchname
 if not os.path.exists( "../../DIRAC" ):
-  diracLink =  os.path.abspath( os.path.join( os.getcwd()  , "../build/DIRAC" ) )
+  diracLink =  os.path.abspath( os.path.join( os.getcwd()  , "../" , buildfolder, "DIRAC" ) )
   print "DiracLink",diracLink
   if not os.path.exists( diracLink ):
     RES = subprocess.check_output( ["ln","-s", diracPath, diracLink ] )
@@ -55,22 +67,12 @@ for path in sys.path:
 
 print "Pythonpath",os.environ['PYTHONPATH']
 buildCommand = os.path.join( os.getcwd() , "../Tools/buildScriptsDOC.py" )
-scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../build/scripts" ))
+scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../", buildfolder, "scripts" ))
 print "command", buildCommand
 code = subprocess.Popen( ["python",buildCommand, scriptdir ], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 stdout , err = code.communicate()
 print "script",stdout
 print "script",err
-
-# buildCommand = os.path.join( os.getcwd() , "../Tools/buildCodeDOC.py" )
-# if not os.path.exists( codedir ):
-#   os.mkdir( codedir )
-# print "command", buildCommand
-#codedir = os.path.abspath(os.path.join( os.getcwd() , "../build/codes" ))
-# ##buildcodedoc needs a copy of DIRAC so we give it a link
-# codeLink = os.path.join( codedir, "DIRAC")
-# if not os.path.exists( codeLink ):
-#   RES = subprocess.check_output( ["ln","-sf",diracPath, codeLink ] )
 
 os.environ["DIRAC"] = diracPath
 print "DIRAC ENVIRON", os.environ["DIRAC"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,6 +70,10 @@ if os.environ.get('READTHEDOCS') == 'True':
   print "Pythonpath",os.environ['PYTHONPATH']
   buildCommand = os.path.join( os.getcwd() , "../Tools/buildScriptsDOC.py" )
   scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../", buildfolder, "scripts" ))
+  try:
+    os.mkdir( scriptdir )
+  except:
+    pass
   print "command", buildCommand
   code = subprocess.Popen( ["python",buildCommand, scriptdir ], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   stdout , err = code.communicate()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,18 +67,19 @@ if os.environ.get('READTHEDOCS') == 'True':
   for path in sys.path:
     os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '')+":"+path
 
-  print "Pythonpath",os.environ['PYTHONPATH']
-  buildCommand = os.path.join( os.getcwd() , "../Tools/buildScriptsDOC.py" )
-  scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../", buildfolder, "scripts" ))
-  try:
-    os.mkdir( scriptdir )
-  except:
-    pass
-  print "command", buildCommand
-  code = subprocess.Popen( ["python",buildCommand, scriptdir ], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-  stdout , err = code.communicate()
-  print "script",stdout
-  print "script",err
+  ##  this is not working at the moment because the DIRAC folder is not found by the buildScriptsDOC script
+  # print "Pythonpath",os.environ['PYTHONPATH']
+  # buildCommand = os.path.join( os.getcwd() , "../Tools/buildScriptsDOC.py" )
+  # scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../", buildfolder, "scripts" ))
+  # try:
+  #   os.mkdir( scriptdir )
+  # except:
+  #   pass
+  # print "command", buildCommand
+  # code = subprocess.Popen( ["python", buildCommand, scriptdir ], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  # stdout , err = code.communicate()
+  # print "script",stdout
+  # print "script",err
 
   os.environ["DIRAC"] = diracPath
   print "DIRAC ENVIRON", os.environ["DIRAC"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,14 +13,13 @@
 
 
 try:
-  import fakeEnvironment
+  import fakeEnv
 except:
   pass
 
 import datetime
 import os
 import sys
-import tempfile
 import subprocess
 
 try:
@@ -28,20 +27,7 @@ try:
 except KeyError:
   diracRelease = 'integration'
 
-diracRelease = subprocess.check_output( ["git", "rev-parse", "--abbrev-ref", "HEAD" ] ).strip()
-
 print 'conf.py: %s as DIRACVERSION' % diracRelease
-
-buildCommand = os.path.join( os.getcwd() , "../Tools/buildScriptsDOC.py" )
-scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../build/scripts" ))
-print "command", buildCommand
-RES = subprocess.call( ["python",buildCommand, scriptdir ] )
-
-
-buildCommand = os.path.join( os.getcwd() , "../Tools/buildCodeDOC.py" )
-codedir = os.path.abspath(os.path.join( os.getcwd() , "../build/codes" ))
-print "command", buildCommand
-RES = subprocess.call( ["python",buildCommand, codedir ] )
 
 #...............................................................................
 # configuration
@@ -50,7 +36,40 @@ RES = subprocess.call( ["python",buildCommand, codedir ] )
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.append(os.path.abspath('.'))
+diracPath = os.path.abspath( os.path.join( os.getcwd(), "../..") )
+print "DiracPath",diracPath
 
+
+
+##We need to have the DIRAC module somewhere, or we cannot import it, as readtheDocs clones the repo into something based on the branchname
+RES = subprocess.check_output( ["ln","-sf",diracPath,"../../DIRAC"] )
+sys.path.insert(0, diracPath)
+RES = subprocess.check_output( ["ls",diracPath] )
+print "LS dirac",RES
+
+for path in sys.path:
+  os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '')+":"+path
+
+print "Pythonpath",os.environ['PYTHONPATH']
+buildCommand = os.path.join( os.getcwd() , "../Tools/buildScriptsDOC.py" )
+scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../build/scripts" ))
+print "command", buildCommand
+code = subprocess.Popen( ["python",buildCommand, scriptdir ], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+stdout , err = code.communicate()
+print "script",stdout
+print "script",err
+
+
+
+buildCommand = os.path.join( os.getcwd() , "../Tools/buildCodeDOC.py" )
+codedir = os.path.abspath(os.path.join( os.getcwd() , "../build/codes" ))
+print "command", buildCommand
+code = subprocess.Popen( ["python",buildCommand, codedir ], env = os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+stdout , err = code.communicate()
+print "code",stdout
+print "code",err
+
+  
 # -- General configuration -----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be extensions

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,13 +21,27 @@ import datetime
 import os
 import sys
 import tempfile
+import subprocess
 
 try:
   diracRelease = os.environ[ 'DIRACVERSION' ]
 except KeyError:
   diracRelease = 'integration'
 
+diracRelease = subprocess.check_output( ["git", "rev-parse", "--abbrev-ref", "HEAD" ] ).strip()
+
 print 'conf.py: %s as DIRACVERSION' % diracRelease
+
+buildCommand = os.path.join( os.getcwd() , "../Tools/buildScriptsDOC.py" )
+scriptdir = os.path.abspath(os.path.join( os.getcwd() , "../build/scripts" ))
+print "command", buildCommand
+RES = subprocess.call( ["python",buildCommand, scriptdir ] )
+
+
+buildCommand = os.path.join( os.getcwd() , "../Tools/buildCodeDOC.py" )
+codedir = os.path.abspath(os.path.join( os.getcwd() , "../build/codes" ))
+print "command", buildCommand
+RES = subprocess.call( ["python",buildCommand, codedir ] )
 
 #...............................................................................
 # configuration

--- a/docs/source/fakeEnvironment.py
+++ b/docs/source/fakeEnvironment.py
@@ -1,0 +1,64 @@
+''' fakeEnvironment
+   
+   this module allows to create the documentation without having to do
+   any kind of special installation. The list of mocked modules is:
+      
+   GSI
+   
+'''
+
+import mock
+import sys
+
+#...............................................................................
+# mocks...
+
+class MyMock(mock.Mock):
+  
+  def __len__(self):
+    return 0
+
+# GSI
+mockGSI                     = MyMock()
+mockGSI.__version__         = "1"
+mockGSI.version.__version__ = "1"
+
+# MySQLdb
+mockMySQLdb = mock.Mock()
+
+#...............................................................................
+# sys.modules hacked
+
+sys.modules[ 'GSI' ]     = mockGSI
+sys.modules[ 'MySQLdb' ] = mockMySQLdb
+sys.modules[ 'MySQLdb.cursors' ] = mock.Mock()
+
+#FIXME: do we need all them ??
+
+sys.modules[ 'suds' ]                            = mock.Mock()
+sys.modules[ 'irods' ]                           = mock.Mock()
+sys.modules[ 'pylab' ]                           = mock.Mock()
+sys.modules[ 'pytz' ]                            = mock.Mock()
+sys.modules[ 'numpy' ]                           = mock.Mock()
+sys.modules[ 'numpy.random' ]                    = mock.Mock()
+sys.modules[ 'matplotlib' ]                      = mock.Mock()
+sys.modules[ 'matplotlib.ticker' ]               = mock.Mock()
+sys.modules[ 'matplotlib.figure' ]               = mock.Mock()
+sys.modules[ 'matplotlib.patches' ]              = mock.Mock()
+sys.modules[ 'matplotlib.dates' ]                = mock.Mock()
+sys.modules[ 'matplotlib.text' ]                 = mock.Mock()
+sys.modules[ 'matplotlib.axes' ]                 = mock.Mock()
+sys.modules[ 'matplotlib.pylab' ]                = mock.Mock()
+sys.modules[ 'cx_Oracle' ]                       = mock.Mock()
+sys.modules[ 'dateutil' ]                        = mock.Mock()
+sys.modules[ 'dateutil.relativedelta' ]          = mock.Mock()
+sys.modules[ 'matplotlib.backends' ]             = mock.Mock()
+sys.modules[ 'matplotlib.backends.backend_agg' ] = mock.Mock()
+sys.modules[ 'fts3' ]                            = mock.Mock()
+sys.modules[ 'fts3.rest' ]                       = mock.Mock()
+sys.modules[ 'fts3.rest.client' ]                = mock.Mock()
+sys.modules[ 'fts3.rest.client.easy' ]           = mock.Mock()
+sys.modules[ 'pyparsing' ]                       = mock.MagicMock()
+
+#...............................................................................
+#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF

--- a/docs/source/fakeEnvironment.py
+++ b/docs/source/fakeEnvironment.py
@@ -35,6 +35,9 @@ sys.modules[ 'MySQLdb.cursors' ] = mock.Mock()
 
 #FIXME: do we need all them ??
 
+sys.modules[ 'sqlalchemy' ]                      = mock.Mock()
+sys.modules[ 'sqlalchemy.orm.exc' ]              = mock.Mock()
+sys.modules[ 'lcg_util' ]                        = mock.Mock()
 sys.modules[ 'suds' ]                            = mock.Mock()
 sys.modules[ 'suds.client' ]                     = mock.Mock()
 sys.modules[ 'irods' ]                           = mock.Mock()

--- a/docs/source/fakeEnvironment.py
+++ b/docs/source/fakeEnvironment.py
@@ -36,6 +36,7 @@ sys.modules[ 'MySQLdb.cursors' ] = mock.Mock()
 #FIXME: do we need all them ??
 
 sys.modules[ 'suds' ]                            = mock.Mock()
+sys.modules[ 'suds.client' ]                     = mock.Mock()
 sys.modules[ 'irods' ]                           = mock.Mock()
 sys.modules[ 'pylab' ]                           = mock.Mock()
 sys.modules[ 'pytz' ]                            = mock.Mock()
@@ -49,6 +50,11 @@ sys.modules[ 'matplotlib.dates' ]                = mock.Mock()
 sys.modules[ 'matplotlib.text' ]                 = mock.Mock()
 sys.modules[ 'matplotlib.axes' ]                 = mock.Mock()
 sys.modules[ 'matplotlib.pylab' ]                = mock.Mock()
+sys.modules[ 'matplotlib.lines' ]                = mock.Mock()
+sys.modules[ 'matplotlib.cbook' ]                = mock.Mock()
+sys.modules[ 'matplotlib.colors' ]               = mock.Mock()
+sys.modules[ 'matplotlib.cm' ]                   = mock.Mock()
+sys.modules[ 'matplotlib.colorbar' ]             = mock.Mock()
 sys.modules[ 'cx_Oracle' ]                       = mock.Mock()
 sys.modules[ 'dateutil' ]                        = mock.Mock()
 sys.modules[ 'dateutil.relativedelta' ]          = mock.Mock()
@@ -59,6 +65,18 @@ sys.modules[ 'fts3.rest' ]                       = mock.Mock()
 sys.modules[ 'fts3.rest.client' ]                = mock.Mock()
 sys.modules[ 'fts3.rest.client.easy' ]           = mock.Mock()
 sys.modules[ 'pyparsing' ]                       = mock.MagicMock()
+
+sys.modules[ '_arc' ]                            = mock.Mock()
+sys.modules[ 'arc' ]                             = mock.Mock()
+sys.modules[ 'arc.common' ]                      = mock.Mock()
+sys.modules[ 'gfal2' ]                           = mock.Mock()
+sys.modules[ 'XRootD' ]                          = mock.Mock()
+sys.modules[ 'XRootD.client' ] = mock.Mock()
+sys.modules[ 'XRootD.client.flags' ] = mock.Mock()
+
+#PlotCache and PlottingHandler create a thread and prevent sphinx from exiting
+#sys.modules[ 'DIRAC.FrameworkSystem.Service.PlotCache' ] = mock.MagicMock()
+#sys.modules[ 'DIRAC.FrameworkSystem.Service.PlottingHandler' ] = mock.MagicMock()
 
 #...............................................................................
 #EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF

--- a/docs/source/fakeEnvironment.py
+++ b/docs/source/fakeEnvironment.py
@@ -36,7 +36,10 @@ sys.modules[ 'MySQLdb.cursors' ] = mock.Mock()
 #FIXME: do we need all them ??
 
 sys.modules[ 'sqlalchemy' ]                      = mock.Mock()
+sys.modules[ 'sqlalchemy.orm' ]                  = mock.Mock()
 sys.modules[ 'sqlalchemy.orm.exc' ]              = mock.Mock()
+sys.modules[ 'sqlalchemy.engine' ]               = mock.Mock()
+sys.modules[ 'sqlalchemy.engine.reflection' ]    = mock.Mock()
 sys.modules[ 'lcg_util' ]                        = mock.Mock()
 sys.modules[ 'suds' ]                            = mock.Mock()
 sys.modules[ 'suds.client' ]                     = mock.Mock()


### PR DESCRIPTION
In the Read the Docs configuration for dirac
under "Admin" and "Advanced settings put "docs/source/conf.py" into "Python Configuration File"
and "docs/requirements.txt" into "Requirements file".

See the result here:
http://diracsailer.readthedocs.io/en/rel-v6r15/CodeDocumentation/index.html
To run this locally:
```
cd DIRAC/docs; READTHEDOCS=True make html
```

I added a MakeDoc script (couldn't figure out the buildCodeDoc). This script creates documentation stumps for all dirac code (except for PlotCache and PlottingHandler and some scripts not in scripts folders, because those crash or hang the sphinx build).