### PR TITLE
[v6r15] Fix landscape

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,3 +1,6 @@
+pylint:
+  run: true
+
 pep8:
   disable:
     - E114


### PR DESCRIPTION
Landscape does not work at the moment because there is a missing line for pylint. Sorry was testing on a more advanced example, and then wanted to make it as simple as possible, apparently too simple. 