### PR TITLE
[v6r15] Fix dirac-rss-sync command to not call JobDB directly

### DIFF
--- a/ResourceStatusSystem/scripts/dirac-rss-sync.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-sync.py
@@ -19,13 +19,8 @@
 """
 
 from datetime import datetime, timedelta
-from DIRAC                                            import gConfig, gLogger, exit as DIRACExit, S_OK, version
-from DIRAC.Core.Base                                  import Script
-from DIRAC.WorkloadManagementSystem.DB.JobDB          import JobDB
-from DIRAC.ResourceStatusSystem.DB.ResourceStatusDB   import ResourceStatusDB
-from DIRAC.ResourceStatusSystem.Utilities             import Synchronizer, CSHelpers, RssConfiguration
-from DIRAC.ResourceStatusSystem.Client                import ResourceStatusClient
-from DIRAC.ResourceStatusSystem.PolicySystem          import StateMachine
+from DIRAC import version, gLogger, exit as DIRACExit, S_OK
+from DIRAC.Core.Base  import Script
 
 __RCSID__  = '$Id$'
 
@@ -92,7 +87,20 @@ def parseSwitches():
 
   return switches
 
-#...............................................................................
+#Script initialization
+subLogger  = gLogger.getSubLogger( __file__ )
+registerSwitches()
+registerUsageMessage()
+switchDict = parseSwitches()
+
+#############################################################################
+# We can define the script body now
+
+from DIRAC.WorkloadManagementSystem.Client.ServerUtils import jobDB
+from DIRAC                                             import gConfig
+from DIRAC.ResourceStatusSystem.Utilities              import Synchronizer, CSHelpers, RssConfiguration
+from DIRAC.ResourceStatusSystem.Client                 import ResourceStatusClient
+from DIRAC.ResourceStatusSystem.PolicySystem           import StateMachine
 
 def synchronize():
   '''
@@ -127,10 +135,9 @@ def initSites():
     Initializes Sites statuses taking their values from the "SiteMask" table of "JobDB" database.
   '''
 
-  jobClient = JobDB()
-  rssClient = ResourceStatusDB()
+  rssClient = ResourceStatusClient.ResourceStatusClient()
 
-  sites = jobClient.getAllSiteMaskStatus()
+  sites = jobDB.getAllSiteMaskStatus()
 
   if not sites[ 'OK' ]:
     subLogger.error( sites[ 'Message' ] )
@@ -256,13 +263,6 @@ def run():
 #...............................................................................
 
 if __name__ == "__main__":
-
-  subLogger  = gLogger.getSubLogger( __file__ )
-
-  #Script initialization
-  registerSwitches()
-  registerUsageMessage()
-  switchDict = parseSwitches()
 
   #Run script
   run()

--- a/ResourceStatusSystem/scripts/dirac-rss-sync.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-sync.py
@@ -148,7 +148,7 @@ def initSites():
     insert = { 'Status': elements[0], 'Reason': 'Synchronized', 'Name': site, 'DateEffective': elements[1], 'TokenExpiration': Datetime,
              'ElementType': 'Site', 'StatusType': 'all', 'LastCheckTime': None, 'TokenOwner': elements[2] }
 
-    result = rssClient.addIfNotThere(insert, table)
+    result = rssClient.addIfNotThereStatusElement( insert, table )
 
     if not result[ 'OK' ]:
       subLogger.error( result[ 'Message' ] )

--- a/ResourceStatusSystem/scripts/dirac-rss-sync.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-sync.py
@@ -145,10 +145,18 @@ def initSites():
 
   for site, elements in sites['Value'].iteritems():
     table  = { 'table': 'SiteStatus' }
-    insert = { 'Status': elements[0], 'Reason': 'Synchronized', 'Name': site, 'DateEffective': elements[1], 'TokenExpiration': Datetime,
-             'ElementType': 'Site', 'StatusType': 'all', 'LastCheckTime': None, 'TokenOwner': elements[2] }
+    parameters = { 'status': elements[0],
+                   'reason': 'Synchronized',
+                   'name': site,
+                   'dateEffective': elements[1],
+                   'tokenExpiration': Datetime,
+                   'elementType': 'Site',
+                   'statusType': 'all',
+                   'lastCheckTime': None,
+                   'tokenOwner': elements[2],
+                   'meta': table }
 
-    result = rssClient.addIfNotThereStatusElement( insert, table )
+    result = rssClient.addIfNotThereStatusElement( "Site", "Status", **parameters )
 
     if not result[ 'OK' ]:
       subLogger.error( result[ 'Message' ] )

--- a/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -70,6 +70,12 @@ class WMSAdministratorHandler(RequestHandler):
     """
     return jobDB.getSiteMask( 'Active' )
 
+  types_getAllSiteMaskStatus = []
+  def export_getAllSiteMaskStatus(self):
+    """ Get all the site parameters in the site mask
+    """
+    return jobDB.getAllSiteMaskStatus()
+
 ##############################################################################
   types_banSite = [StringTypes]
   def export_banSite(self, site,comment='No comment'):


### PR DESCRIPTION
Accessing ResourceStatusDB and JobDB through clients rather than directly.
Proper order in the script initialization and import statements