### PR TITLE
Ignore [v6r16] DynamicMonitoring service

### DIFF
--- a/FrameworkSystem/Client/DynamicMonitoringClient.py
+++ b/FrameworkSystem/Client/DynamicMonitoringClient.py
@@ -1,0 +1,17 @@
+"""
+Class for making requests to a DynamicMonitoring Service
+"""
+
+__RCSID__ = "$Id$"
+
+from DIRAC.Core.Base.Client import Client
+
+class DynamicMonitoringClient( Client ):
+
+  def __init__( self, **kwargs ):
+    """
+    Constructor function
+    """
+
+    Client.__init__( self, **kwargs )
+    self.setServer( 'Framework/DynamicMonitoring' )

--- a/FrameworkSystem/Client/DynamicMonitoringClient.py
+++ b/FrameworkSystem/Client/DynamicMonitoringClient.py
@@ -13,5 +13,5 @@ class DynamicMonitoringClient( Client ):
     Constructor function
     """
 
-    Client.__init__( self, **kwargs )
+    super( Client, self ).__init__( **kwargs )
     self.setServer( 'Framework/DynamicMonitoring' )

--- a/FrameworkSystem/ConfigTemplate.cfg
+++ b/FrameworkSystem/ConfigTemplate.cfg
@@ -141,6 +141,14 @@ Services
       getInstallations = authenticated
     }  
   }
+  DynamicMonitoring
+  {
+    Port = 9143
+    Authorization
+    {
+      Default = authenticated
+    }  
+  }
 }
 Agents
 {

--- a/FrameworkSystem/Service/DynamicMonitoringHandler.py
+++ b/FrameworkSystem/Service/DynamicMonitoringHandler.py
@@ -1,0 +1,50 @@
+"""
+This Service provides functionality to read logging information from the ElasticSearch database
+"""
+
+__RCSID__ = "$Id$"
+
+import types
+from DIRAC import gConfig, gLogger, S_OK, S_ERROR
+from DIRAC.Core.DISET.RequestHandler import RequestHandler
+from DIRAC.FrameworkSystem.DB.DynamicMonitoringDB import DynamicMonitoringDB
+
+class DynamicMonitoringHandler( RequestHandler ):
+
+  @classmethod
+  def initializeHandler( cls, serviceInfo ):
+    """
+    Handler class initialization
+    """
+
+    DynamicMonitoringHandler.elasticDB = DynamicMonitoringDB()
+
+  types_getLastLog = [ types.StringTypes, types.StringTypes ]
+  def export_getLastLog( self, host, component ):
+    """
+    Retrieves the last logging entry for the given component
+    :param str host: Host where the component is installed
+    :param str component: Name of the component
+    """
+    return DynamicMonitoringHandler.elasticDB.getLastLog( host, component )
+
+  types_getLogHistory = [ types.StringTypes, types.StringTypes, types.IntType ]
+  def export_getLogHistory( self, host, component, size ):
+    """
+    Retrieves the history of logging entries for the given component
+    :param str host: Host where the component is installed
+    :param str component: Name of the component
+    :param int size: Determines how many entries should be retrieved
+    """
+    return DynamicMonitoringHandler.elasticDB.getLogHistory( host, component, size )
+
+  types_getLogsPeriod = [ types.StringTypes, types.StringTypes, types.StringTypes, types.StringTypes ]
+  def export_getLogsPeriod( self, host, component, initialDate, endDate ):
+    """
+    Retrieves the history of logging entries for the given component during a given given time periodtime period
+    :param str host: Host where the component is installed
+    :param str component: Name of the component
+    :param str initialDate: String indicating the start of the time period, in the format 'DD/MM/YYYY hh:mm'
+    :param str endDate: String indicating the end of the time period, in the format 'DD/MM/YYYY hh:mm'
+    """
+    return DynamicMonitoringHandler.elasticDB.getLogsPeriod( host, component, initialDate, endDate )

--- a/FrameworkSystem/Service/DynamicMonitoringHandler.py
+++ b/FrameworkSystem/Service/DynamicMonitoringHandler.py
@@ -23,6 +23,7 @@ class DynamicMonitoringHandler( RequestHandler ):
     Retrieves the last logging entry for the given component
     :param str host: Host where the component is installed
     :param str component: Name of the component
+    :return S_OK/S_ERROR
     """
     return DynamicMonitoringHandler.elasticDB.getLastLog( host, component )
 
@@ -33,6 +34,7 @@ class DynamicMonitoringHandler( RequestHandler ):
     :param str host: Host where the component is installed
     :param str component: Name of the component
     :param int size: Determines how many entries should be retrieved
+    :return S_OK/S_ERROR
     """
     return DynamicMonitoringHandler.elasticDB.getLogHistory( host, component, size )
 
@@ -44,5 +46,6 @@ class DynamicMonitoringHandler( RequestHandler ):
     :param str component: Name of the component
     :param str initialDate: String indicating the start of the time period, in the format 'DD/MM/YYYY hh:mm'
     :param str endDate: String indicating the end of the time period, in the format 'DD/MM/YYYY hh:mm'
+    :return S_OK/S_ERROR
     """
     return DynamicMonitoringHandler.elasticDB.getLogsPeriod( host, component, initialDate, endDate )

--- a/FrameworkSystem/Service/DynamicMonitoringHandler.py
+++ b/FrameworkSystem/Service/DynamicMonitoringHandler.py
@@ -4,8 +4,6 @@ This Service provides functionality to read logging information from the Elastic
 
 __RCSID__ = "$Id$"
 
-import types
-from DIRAC import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.FrameworkSystem.DB.DynamicMonitoringDB import DynamicMonitoringDB
 
@@ -19,7 +17,7 @@ class DynamicMonitoringHandler( RequestHandler ):
 
     DynamicMonitoringHandler.elasticDB = DynamicMonitoringDB()
 
-  types_getLastLog = [ types.StringTypes, types.StringTypes ]
+  types_getLastLog = [ basestring, basestring ]
   def export_getLastLog( self, host, component ):
     """
     Retrieves the last logging entry for the given component
@@ -28,7 +26,7 @@ class DynamicMonitoringHandler( RequestHandler ):
     """
     return DynamicMonitoringHandler.elasticDB.getLastLog( host, component )
 
-  types_getLogHistory = [ types.StringTypes, types.StringTypes, types.IntType ]
+  types_getLogHistory = [ basestring, basestring, int ]
   def export_getLogHistory( self, host, component, size ):
     """
     Retrieves the history of logging entries for the given component
@@ -38,7 +36,7 @@ class DynamicMonitoringHandler( RequestHandler ):
     """
     return DynamicMonitoringHandler.elasticDB.getLogHistory( host, component, size )
 
-  types_getLogsPeriod = [ types.StringTypes, types.StringTypes, types.StringTypes, types.StringTypes ]
+  types_getLogsPeriod = [ basestring, basestring, basestring, basestring ]
   def export_getLogsPeriod( self, host, component, initialDate, endDate ):
     """
     Retrieves the history of logging entries for the given component during a given given time periodtime period

--- a/docs/source/AdministratorGuide/Systems/Framework/index.rst
+++ b/docs/source/AdministratorGuide/Systems/Framework/index.rst
@@ -36,3 +36,19 @@ The app allows to set a number of filters for the query. It is possible to filte
 - Date and time: It is possible to select a timespan during which the components should have been installed ( it is possible to fill just one of the two available fields )
 
 By pressing the 'Submit' button, a list with all the matching results will be shown ( or all the possible results if no filters were specified ).
+
+Dynamic Component Monitoring
+============================
+
+It shows information about running DIRAC components such as CPU, Memory, Running threads etc. The information can be accessed from the 'dirac-admin-sysadmin-cli' using 
+'show profile'. The following parameters can be used::
+
+ - <system>: The name of the system for example: DataManagementSystem 
+ - <component>: The component name for example: FileCatalog 
+ - -s <size>: number of elements to be shown 
+ - h <host>: name of the host where a specific component is running 
+ - id <initial date DD/MM/YYYY> the date where from we are interested for the log of a specific component
+ - it <initial time hh:mm> the time where from we are interested for the log of a specific component
+ - ed <end date DD/MM/YYYY>: the date before we are interested for   the log of a specific component
+ - et <end time hh:mm>: the time before we are interested for   the log of a specific component 
+ - show <size>: log lines of profiling information for a component in the machine <host>

--- a/docs/source/DeveloperGuide/Systems/Framework/index.rst
+++ b/docs/source/DeveloperGuide/Systems/Framework/index.rst
@@ -1,9 +1,9 @@
 .. contents:: Table of contents
    :depth: 3
 
-================================
+==================
 Framework Overview
-================================
+==================
 
 Information regarding use of the DIRAC Framework to build new components
 
@@ -106,3 +106,17 @@ The MonitoringUtilities module provides the functionality needed to store or del
   result = MonitoringUtilities.monitorInstallation( 'service', 'Framework', 'SystemAdministrator' )
   if not result[ 'OK' ]:
     print 'Something went wrong'
+
+Dynamic Component Monitoring
+============================
+
+This system takes care of managing monitoring information of DIRAC component. It is based on ElasticSearch database. The queries made is the following way::
+
+
+result = self.query( indexName, { 'query': { 'filtered': {
+             'query': { 'bool' : { 'must': [ { 'match': { 'host': host } }, { 'match': { 'component': component } } ] } }, \
+             'filter': { 'range': { 'timestamp': { 'from': initialDateFormatted, 'to': endDateFormatted } } } } }, \
+             'sort': { 'timestamp': { 'order': 'desc' } }, 'size': nDocs } )
+
+
+If you want to modify or add new functionality use ElasticSerachDSL instead. 

--- a/tests/Integration/Framework/Test_DynamicMonitoring.py
+++ b/tests/Integration/Framework/Test_DynamicMonitoring.py
@@ -44,8 +44,5 @@ class DynamicMonitoringClientChain( TestDynamicMonitoringClient ):
 
 if __name__ == '__main__':
   
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase \
-                                              ( TestDynamicMonitoringClient )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase \
-                                            ( DynamicMonitoringClientChain ) )
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase( DynamicMonitoringClientChain ) 
   testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )

--- a/tests/Integration/Framework/Test_DynamicMonitoring.py
+++ b/tests/Integration/Framework/Test_DynamicMonitoring.py
@@ -1,0 +1,56 @@
+"""
+Tests the DynamicMonitoring Service and db.
+This program assumes that the service Framework/DynamicMonitoring service is running
+"""
+
+from DIRAC.Core.Base.Script import parseCommandLine
+parseCommandLine()
+
+import unittest
+import datetime
+
+from DIRAC.FrameworkSystem.Client.DynamicMonitoringClient import DynamicMonitoringClient
+
+class TestDynamicMonitoringClient( unittest.TestCase ):
+  """
+  TestCase-inheriting class with setUp and tearDown methods
+  """
+
+  def setUp( self ):
+    """
+    Initialize the client on every test
+    """
+    self.client = DynamicMonitoringClient()
+
+  def tearDown( self ):
+    """
+    Nothing is done on termination
+    """
+    pass
+  
+class DynamicMonitoringClientChain( TestDynamicMonitoringClient ):
+  """
+  Contains methods for testing of separate elements
+  """
+
+  def test_getLastLog( self ):
+    result = self.client.getLastLog( 'localhost', 'Framework/SystemAdministrator' )
+    self.assert_( result[ 'OK' ] )
+
+  def test_getLogHistory( self ):
+    result = self.client.getLogHistory( 'localhost', 'SystemAdministrator', 2 )
+    self.assert_( result[ 'OK' ] )
+
+  def test_getLogsPeriod( self ):
+    start = datetime.datetime.now() - datetime.timedelta( days = 1 ).strftime( "%Y/%m/%d %H:%M" )
+    end = datetime.datetime.now().strftime( "%Y/%m/%d %H:%M" ) 
+    result = self.client.getLogsPeriod( 'localhost', 'SystemAdministrator', start, end )
+    self.assert_( result[ 'OK' ] )
+
+if __name__ == '__main__':
+  
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase \
+                                              ( TestDynamicMonitoringClient )
+  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase \
+                                            ( DynamicMonitoringClientChain ) )
+  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )

--- a/tests/Integration/Framework/Test_DynamicMonitoring.py
+++ b/tests/Integration/Framework/Test_DynamicMonitoring.py
@@ -22,11 +22,6 @@ class TestDynamicMonitoringClient( unittest.TestCase ):
     """
     self.client = DynamicMonitoringClient()
 
-  def tearDown( self ):
-    """
-    Nothing is done on termination
-    """
-    pass
   
 class DynamicMonitoringClientChain( TestDynamicMonitoringClient ):
   """


### PR DESCRIPTION
Added a new DynamicMonitoring service used to retrieve logging information from the ElasticSearch DB. This is the service from which the CLI/WebApp should get the logging information, since it is read only.
Requires PR #2973 to be merged before.