### PR TITLE
[v6r16] DynamicMonitoring task in SysAdmin

### DIFF
--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -93,6 +93,9 @@ EMQCONN = 1142
 #Elasticsearch
 EELNOFOUND = 1146
 
+#config
+ESECTION = 1400
+
 # ## WMS/Workflow
 EWMSUKN = 1500
 EWMSJDL = 1501
@@ -109,9 +112,6 @@ ERMSUKN = 1700
 # ## TS (19XX)
 ETSUKN = 1900
 ETSDATA = 1901
-
-#config
-ESECTION = 1400
 
 # This translates the integer number into the name of the variable
 dErrorCode = {
@@ -153,6 +153,8 @@ dErrorCode = {
                1142 : 'EMQCONN',
                # Elasticsearch
                1146 : 'EELNOFOUND',
+               # Config
+               1400 : "ESECTION",
                # WMS/Workflow
                1500 : 'EWMSUKN',
                1501 : 'EWMSJDL',
@@ -167,10 +169,7 @@ dErrorCode = {
 
                # TS
                1900 : "ETSUKN",
-               1901 : "ETSDATA",
-               # Config
-               1400 : "ESECTION"
-               }
+               1901 : "ETSDATA"}
 
 
 dStrError = {
@@ -212,6 +211,8 @@ dStrError = {
               EMQCONN : "MQ connection failure",
               # 114X Elasticsearch
               EELNOFOUND: "Index not found",
+               # Config
+              ESECTION : "Section is not found",
               # WMS/Workflow
               EWMSUKN : "Unknown WMS error",
               EWMSJDL : "Invalid JDL",
@@ -224,10 +225,7 @@ dStrError = {
               ERMSUKN : "Unknown RMS error",
               # TS
               ETSUKN : "Unknown Transformation System Error",
-              ETSDATA : "Invalid Input Data definition",
-              # Config
-              ESECTION : "Section is not found"
-}
+              ETSDATA : "Invalid Input Data definition"}
 
 def strerror(code):
   """ This method wraps up os.strerror, and behave the same way.

--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -110,6 +110,9 @@ ERMSUKN = 1700
 ETSUKN = 1900
 ETSDATA = 1901
 
+#config
+ESECTION = 1400
+
 # This translates the integer number into the name of the variable
 dErrorCode = {
                # ## Generic (10XX)
@@ -165,6 +168,8 @@ dErrorCode = {
                # TS
                1900 : "ETSUKN",
                1901 : "ETSDATA",
+               # Config
+               1400 : "ESECTION"
                }
 
 
@@ -220,6 +225,8 @@ dStrError = {
               # TS
               ETSUKN : "Unknown Transformation System Error",
               ETSDATA : "Invalid Input Data definition",
+              # Config
+              ESECTION : "Section is not found"
 }
 
 def strerror(code):

--- a/Core/Utilities/ElasticSearchDB.py
+++ b/Core/Utilities/ElasticSearchDB.py
@@ -229,9 +229,9 @@ class ElasticSearchDB( object ):
       }
       body['_source'] = row
       try:
-        body['_source']['time'] = datetime.fromtimestamp( row.get( 'time', int( Time.toEpoch() ) ) )
+        body['_source']['timestamp'] = datetime.fromtimestamp( row.get( 'timestamp', int( Time.toEpoch() ) ) )
       except TypeError as e:
-        body['_source']['time'] = row.get( 'time' )
+        body['_source']['timestamp'] = row.get( 'timestamp' )
       docs += [body]
     try:
       res = helpers.bulk( self.__client, docs, chunk_size = self.__chunk_size )

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -26,6 +26,7 @@ from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.FrameworkSystem.Client.SystemAdministratorClient import SystemAdministratorClient
 from DIRAC.Core.Utilities.RabbitMQ import RabbitConnection
 from DIRAC.Core.Utilities import Profiler
+from DIRAC.Core.Utilities import DErrno
 
 __RCSID__ = "$Id$"
 
@@ -61,12 +62,12 @@ class SystemAdministratorHandler( RequestHandler ):
       result = gConfig.getOption( 'DIRAC/Setups/%s/%s' % ( setup, system ) )
       if not result[ 'OK' ]:
         gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
-        return result
+        return S_ERROR( DErrno.ESECTION, result )
       sysSetup = result[ 'Value' ]
       result = gConfig.getOptionsDict( 'Systems/%s/%s/MessageQueueing/%s' % ( system, sysSetup, queueName ) )
       if not result[ 'OK' ]:
         gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
-        return result
+        return S_ERROR( DErrno.ESECTION, result )
       parameters = result[ 'Value' ]
 
       # Setup the RabbitMQ connection with the retrieved parameters

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -51,9 +51,26 @@ class SystemAdministratorHandler( RequestHandler ):
 
     if dynamicMonitoring:
       client = SystemAdministratorClient( 'localhost' )
-      result = SystemAdministratorHandler.rabbitMQ.setupConnection( 'Framework', 'ComponentMonitoring', False )
+
+      # Get the RabbitMQ parameters from the CS
+      result = gConfig.getOption( 'DIRAC/Setup' )
+      if not result[ 'OK' ]:
+        return result
+      setup = result[ 'Value' ]
+      result = gConfig.getOption( 'DIRAC/Setups/%s/%s' % ( setup, system ) )
+      if not result[ 'OK' ]:
+        return result
+      sysSetup = result[ 'Value' ]
+      result = gConfig.getOptionsDict( 'Systems/%s/%s/MessageQueueing/%s' % ( system, sysSetup, queueName ) )
+      if not result[ 'OK' ]:
+        return result
+      parameters = result[ 'Value' ]
+
+      # Setup the RabbitMQ connection with the retrieved parameters
+      result = SystemAdministratorHandler.rabbitMQ.setupConnection( 'Framework', 'ComponentMonitoring', parameters, False )
       if not result[ 'OK' ]:
         gLogger.error( result[ 'Message' ] )
+
       gThreadScheduler.addPeriodicTask( 120, client.storeProfiling )
 
     return S_OK( 'Initialization went well' )

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -55,21 +55,25 @@ class SystemAdministratorHandler( RequestHandler ):
       # Get the RabbitMQ parameters from the CS
       result = gConfig.getOption( 'DIRAC/Setup' )
       if not result[ 'OK' ]:
+        gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
         return result
       setup = result[ 'Value' ]
       result = gConfig.getOption( 'DIRAC/Setups/%s/%s' % ( setup, system ) )
       if not result[ 'OK' ]:
+        gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
         return result
       sysSetup = result[ 'Value' ]
       result = gConfig.getOptionsDict( 'Systems/%s/%s/MessageQueueing/%s' % ( system, sysSetup, queueName ) )
       if not result[ 'OK' ]:
+        gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
         return result
       parameters = result[ 'Value' ]
 
       # Setup the RabbitMQ connection with the retrieved parameters
       result = SystemAdministratorHandler.rabbitMQ.setupConnection( 'Framework', 'ComponentMonitoring', parameters, False )
       if not result[ 'OK' ]:
-        gLogger.error( result[ 'Message' ] )
+        gLogger.error( 'DynamicMonitoring couldn\'t be enabled: %s' % result[ 'Message' ] )
+        return result
 
       gThreadScheduler.addPeriodicTask( 120, client.storeProfiling )
 

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -24,6 +24,8 @@ from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
 from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient import ComponentMonitoringClient
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.FrameworkSystem.Client.SystemAdministratorClient import SystemAdministratorClient
+from DIRAC.Core.Utilities.RabbitMQ import RabbitConnection
+from DIRAC.Core.Utilities import Profiler
 
 __RCSID__ = "$Id$"
 
@@ -43,6 +45,16 @@ class SystemAdministratorHandler( RequestHandler ):
     if hostMonitoring:
       gThreadScheduler.addPeriodicTask( 60, cls.__storeHostInfo )
       #the SystemAdministrator service does not has to use the client to report data about the host.
+
+    # Check the flag for dynamic monitoring
+    dynamicMonitoring = cls.srv_getCSOption( 'DynamicMonitoring', False )
+
+    if dynamicMonitoring:
+      client = SystemAdministratorClient( 'localhost' )
+      result = SystemAdministratorHandler.rabbitMQ.setupConnection( 'Framework', 'ComponentMonitoring', False )
+      if not result[ 'OK' ]:
+        gLogger.error( result[ 'Message' ] )
+      gThreadScheduler.addPeriodicTask( 120, client.storeProfiling )
 
     return S_OK( 'Initialization went well' )
 
@@ -654,5 +666,44 @@ class SystemAdministratorHandler( RequestHandler ):
     if not result[ 'OK' ]:
       gLogger.error( result[ 'Message' ] )
       return result
+
+    return S_OK( 'Profiling information logged correctly' )
+
+  types_storeProfiling = []
+  def export_storeProfiling( self ):
+    """
+    Retrieves and stores into ElasticSearch profiling information about the components on the host
+    """
+    result = ComponentInstaller.getStartupComponentStatus( [] )
+    if not result[ 'OK' ]:
+      gLogger.error( result[ 'Message' ] )
+      return S_ERROR( result[ 'Message' ] )
+    startupComps = result[ 'Value' ]
+
+    result = ComponentInstaller.getSetupComponents()
+    if not result[ 'OK' ]:
+      gLogger.error( result[ 'Message' ] )
+      return S_ERROR( result[ 'Message' ] )
+    setupComps = result[ 'Value' ]
+
+    # Get the profiling information for every running component and send it to RabbitMQ
+    for cType in setupComps:
+      for system in setupComps[ cType ]:
+        for comp in setupComps[ cType ][ system ]:
+          pid = startupComps[ '%s_%s' % ( system, comp ) ][ 'PID' ]
+          profiler = Profiler.Profiler( pid )
+          result = profiler.getAllProcessData()
+          if result[ 'OK' ]:
+            log = result[ 'Value' ][ 'stats' ]
+            log[ 'host' ] = socket.getfqdn()
+            log[ 'component' ] = '%s_%s' % ( system, comp )
+            log[ 'timestamp' ] = result[ 'Value' ][ 'datetime' ].isoformat()
+            result = SystemAdministratorHandler.rabbitMQ.put( log )
+            if not result[ 'OK' ]:
+              gLogger.error( result[ 'Message' ] )
+              return result
+          else:
+            gLogger.error( result[ 'Message' ] )
+            return result
 
     return S_OK( 'Profiling information logged correctly' )

--- a/MonitoringSystem/Client/Types/BaseType.py
+++ b/MonitoringSystem/Client/Types/BaseType.py
@@ -61,7 +61,7 @@ class BaseType( object ):
     index = ''
     if self.__index == None:
       fullName = self.__class__.__name__
-      index = "%s-index" % fullName
+      index = "%s-index" % fullName.lower()
     else:
       index = self.__index
     return index

--- a/MonitoringSystem/Client/Types/ComponentMonitoring.py
+++ b/MonitoringSystem/Client/Types/ComponentMonitoring.py
@@ -1,0 +1,39 @@
+"""
+ComponentMonitoring type used to monitor DIRAC components.
+"""
+
+from DIRAC.MonitoringSystem.Client.Types.BaseType import BaseType
+
+__RCSID__ = "$Id $"
+
+########################################################################
+class ComponentMonitoring( BaseType ):
+
+  
+  """
+  .. class:: ComponentMonitoring
+  """
+  ########################################################################
+  def __init__( self ):
+    super( ComponentMonitoring, self ).__init__()
+    
+    """ c'tor
+    :param self: self reference
+    """
+    
+    self.setKeyFields( [ 'host', 'component', 'pid', 'status'] )
+    
+    self.setMonitoringFields( [ 'runningTime', 'memoryUsage', 'threads', 'cpuUsage' ] )
+    
+    self.setIndex( 'wmshistory_index' )  # overwrite the index name
+    
+    self.setDocType( "WMSHistory" )
+    
+    self.setMapping( {'host_type': {'_all': {'enabled': 'false'}, 'properties': {'host': {'index': 'not_analyzed', 'type': 'string'}}},
+                      'component_type':{'_all': {'enabled': 'false'}, 'properties': {'component': {'index': 'not_analyzed', 'type': 'string'}}},
+                      'status_type':{'_all': {'enabled': 'false'}, 'properties': {'status': {'index': 'not_analyzed', 'type': 'string'}}}} )
+    
+    self.setDataToKeep ( 86400 * 30 )#we need to define...
+    
+    self.checkType()
+    

--- a/MonitoringSystem/Client/Types/ComponentMonitoring.py
+++ b/MonitoringSystem/Client/Types/ComponentMonitoring.py
@@ -25,9 +25,9 @@ class ComponentMonitoring( BaseType ):
     
     self.setMonitoringFields( [ 'runningTime', 'memoryUsage', 'threads', 'cpuUsage' ] )
     
-    self.setIndex( 'wmshistory_index' )  # overwrite the index name
+    #self.setIndex( 'wmshistory_index' )  # overwrite the index name
     
-    self.setDocType( "WMSHistory" )
+    self.setDocType( "ComponentMonitoring" )
     
     self.setMapping( {'host_type': {'_all': {'enabled': 'false'}, 'properties': {'host': {'index': 'not_analyzed', 'type': 'string'}}},
                       'component_type':{'_all': {'enabled': 'false'}, 'properties': {'component': {'index': 'not_analyzed', 'type': 'string'}}},

--- a/MonitoringSystem/DB/MonitoringDB.py
+++ b/MonitoringSystem/DB/MonitoringDB.py
@@ -143,7 +143,7 @@ class MonitoringDB( ElasticDB ):
     
     indexName = "%s*" % ( retVal['Value'] )
     q = [self._Q( 'range',
-                  time = {'lte':endTime * 1000,
+                  timestamp = {'lte':endTime * 1000,
                           'gte': startTime * 1000} )]
     for cond in condDict:
       kwargs = {cond: condDict[cond][0]}
@@ -151,11 +151,11 @@ class MonitoringDB( ElasticDB ):
       q += [query] 
     
     a1 = self._A( 'terms', field = grouping, size = 0 )
-    a2 = self._A( 'terms', field = 'time' )
+    a2 = self._A( 'terms', field = 'timestamp' )
     a2.metric( 'total_jobs', 'sum', field = selectFields[0] )
     a1.bucket( 'end_data',
                'date_histogram',
-               field = 'time',
+               field = 'timestamp',
                interval = interval ).metric( 'tt', a2 ).pipeline( 'avg_monthly_sales',
                                                                   'avg_bucket',
                                                                   buckets_path = 'tt>total_jobs',
@@ -169,7 +169,7 @@ class MonitoringDB( ElasticDB ):
     s = self._Search( indexName )
     s = s.filter( 'bool', must = q )
     s.aggs.bucket( '2', a1 )
-    s.fields( ['time'] + selectFields )
+    s.fields( ['timestamp'] + selectFields )
     gLogger.debug( 'Query:', s.to_dict() )
     retVal = s.execute()
     

--- a/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
+++ b/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
@@ -109,7 +109,7 @@ class StatesMonitoringAgent( AgentModule ):
         record = record[ len( self.__summaryKeyFieldsMapping ): ]
         for iP in range( len( self.__summaryValueFieldsMapping ) ):
           rD[ self.__summaryValueFieldsMapping[iP] ] = int( record[iP] )
-        rD['time'] = int( Time.toEpoch( now ) )       
+        rD['timestamp'] = int( Time.toEpoch( now ) )       
         documents += [rD]
       res = self.sendRecords( documents, 'WMSHistory' )
       if res['OK']:


### PR DESCRIPTION
Added a periodic task to the SysAdmin service (can be enabled from CS by setting a flag, just like the pseudostatic monitoring) that retrieves profiling information from running components and sends it to a RabbitMQ queue for later storage in ElasticSearch.
Requires PR's #2924 and #3106 to be merged before.