### PR TITLE
[v6r16] Change ExtraModule to Extensions

### DIFF
--- a/Core/scripts/dirac-configure.py
+++ b/Core/scripts/dirac-configure.py
@@ -88,6 +88,7 @@ vo = None
 update = False
 outputFile = ''
 skipVOMSDownload = False
+extensions = ''
 
 def setGateway( optionValue ):
   global gatewayServer
@@ -198,9 +199,17 @@ def forceUpdate( optionValue ):
   update = True
   return DIRAC.S_OK()
 
+def setExtensions( optionValue ):
+  global extensions
+  extensions = optionValue
+  DIRAC.gConfig.setOptionValue( '/DIRAC/Extensions', extensions )
+  DIRAC.gConfig.setOptionValue( cfgInstallPath( 'Extensions' ), extensions )
+  return DIRAC.S_OK()
+
 Script.disableCS()
 
 Script.registerSwitch( "S:", "Setup=", "Set <setup> as DIRAC setup", setSetup )
+Script.registerSwitch( "E:", "Extensions=", "Set <extensions> as DIRAC extensions", setExtensions )
 Script.registerSwitch( "C:", "ConfigurationServer=", "Set <server> as DIRAC configuration server", setServer )
 Script.registerSwitch( "I", "IncludeAllServers", "include all Configuration Servers", setAllServers )
 Script.registerSwitch( "n:", "SiteName=", "Set <sitename> as DIRAC Site Name", setSiteName )
@@ -302,6 +311,11 @@ if not vo:
   if newVO:
     setVO( newVO )
 
+if not extensions:
+  newExtensions = DIRAC.gConfig.getValue( cfgInstallPath( 'Extensions' ), '' )
+  if newExtensions:
+    setExtensions( newExtensions )
+    
 DIRAC.gLogger.notice( 'Executing: %s ' % ( ' '.join( sys.argv ) ) )
 DIRAC.gLogger.notice( 'Checking DIRAC installation at "%s"' % DIRAC.rootPath )
 

--- a/Core/scripts/dirac-configure.py
+++ b/Core/scripts/dirac-configure.py
@@ -209,7 +209,7 @@ def setExtensions( optionValue ):
 Script.disableCS()
 
 Script.registerSwitch( "S:", "Setup=", "Set <setup> as DIRAC setup", setSetup )
-Script.registerSwitch( "E:", "Extensions=", "Set <extensions> as DIRAC extensions", setExtensions )
+Script.registerSwitch( "e:", "Extensions=", "Set <extensions> as DIRAC extensions", setExtensions )
 Script.registerSwitch( "C:", "ConfigurationServer=", "Set <server> as DIRAC configuration server", setServer )
 Script.registerSwitch( "I", "IncludeAllServers", "include all Configuration Servers", setAllServers )
 Script.registerSwitch( "n:", "SiteName=", "Set <sitename> as DIRAC Site Name", setSiteName )
@@ -312,7 +312,14 @@ if not vo:
     setVO( newVO )
 
 if not extensions:
-  newExtensions = DIRAC.gConfig.getValue( cfgInstallPath( 'Extensions' ), '' )
+  newExtensions = None
+  extraModules = cfgInstallPath( 'ExtraModules' )
+  if extraModules:
+    DIRAC.gLogger.warn( "extraModules is deprecated please use extensions instead!" )
+    newExtensions = DIRAC.gConfig.getValue( extraModules, '' )
+  else:
+    newExtensions = DIRAC.gConfig.getValue( cfgInstallPath( 'Extensions' ), '' )
+  
   if newExtensions:
     setExtensions( newExtensions )
     

--- a/Core/scripts/dirac-configure.py
+++ b/Core/scripts/dirac-configure.py
@@ -312,11 +312,9 @@ if not vo:
     setVO( newVO )
 
 if not extensions:
-  newExtensions = None
-  extraModules = cfgInstallPath( 'ExtraModules' )
-  if extraModules:
+  newExtensions = DIRAC.gConfig.getValue( cfgInstallPath( 'ExtraModules' ) )
+  if newExtensions:
     DIRAC.gLogger.warn( "extraModules is deprecated please use extensions instead!" )
-    newExtensions = DIRAC.gConfig.getValue( extraModules, '' )
   else:
     newExtensions = DIRAC.gConfig.getValue( cfgInstallPath( 'Extensions' ), '' )
   

--- a/Core/scripts/dirac-configure.py
+++ b/Core/scripts/dirac-configure.py
@@ -314,7 +314,7 @@ if not vo:
 if not extensions:
   newExtensions = DIRAC.gConfig.getValue( cfgInstallPath( 'ExtraModules' ) )
   if newExtensions:
-    DIRAC.gLogger.warn( "extraModules is deprecated please use extensions instead!" )
+    DIRAC.gLogger.warn( "ExtraModules option is deprecated, use Extensions option instead!" )
   else:
     newExtensions = DIRAC.gConfig.getValue( cfgInstallPath( 'Extensions' ), '' )
   

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1027,7 +1027,6 @@ def installExternalRequirements( extType ):
 
 cmdOpts = ( ( 'r:', 'release=', 'Release version to install' ),
             ( 'l:', 'project=', 'Project to install' ),
-            #( 'e:', 'extraModules=', 'Extra modules to install (comma separated)' ),
             ( 'e:', 'extensions=', 'Extensions to install (comma separated)' ),
             ( 't:', 'installType=', 'Installation type (client/server)' ),
             ( 'i:', 'pythonVersion=', 'Python version to compile (27/26)' ),

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -35,7 +35,8 @@ def S_ERROR( msg = "" ):
 class Params( object ):
 
   def __init__( self ):
-    self.extraModules = []
+    #self.extraModules = []
+    self.extensions = []
     self.project = 'DIRAC'
     self.installation = 'DIRAC'
     self.release = ""
@@ -668,9 +669,9 @@ class ReleaseConfig( object ):
         pass
     return lcgVersion
 
-  def getModulesToInstall( self, release, extraModules = False ):
-    if not extraModules:
-      extraModules = []
+  def getModulesToInstall( self, release, extensions = False ):
+    if not extensions:
+      extensions = []
     extraFound = []
     modsToInstall = {}
     modsOrder = []
@@ -687,8 +688,8 @@ class ReleaseConfig( object ):
       except KeyError:
         requiredModules = []
       for modName in requiredModules:
-        if modName not in extraModules:
-          extraModules.append( modName )
+        if modName not in extensions:
+          extensions.append( modName )
       result = self.getTarsLocation( project )
       if not result[ 'OK' ]:
         return result
@@ -703,27 +704,27 @@ class ReleaseConfig( object ):
         modNames = [ mod.strip() for mod in defaultMods.split( "," ) if mod.strip() ]
       except KeyError:
         modNames = []
-      for extraMod in extraModules:
+      for extension in extensions:
         # Check if the version of the extension module is specified in the command line
         extraVersion = None
-        if ":" in extraMod:
-          extraMod, extraVersion = extraMod.split( ":" )
-          modVersions[extraMod] = extraVersion
-        if extraMod in modVersions:
-          modNames.append( extraMod )
-          extraFound.append( extraMod )
-        if project != 'DIRAC':
-          dExtraMod = "%sDIRAC" % extraMod
-          if dExtraMod in modVersions:
-            modNames.append( dExtraMod )
-            extraFound.append( extraMod )
+        if ":" in extension:
+          extension, extraVersion = extension.split( ":" )
+          modVersions[extension] = extraVersion
+        if extension in modVersions:
+          modNames.append( extension )
+          extraFound.append( extension )
+        if 'DIRAC' not in extension:
+          dextension = "%sDIRAC" % extension
+          if dextension in modVersions:
+            modNames.append( dextension )
+            extraFound.append( extension )
       modNameVer = [ "%s:%s" % ( modName, modVersions[ modName ] ) for modName in modNames ]
       self.__dbgMsg( "Modules to be installed for %s are: %s" % ( project, ", ".join( modNameVer ) ) )
       for modName in modNames:
         modsToInstall[ modName ] = ( tarsPath, modVersions[ modName ] )
         modsOrder.insert( 0, modName )
 
-    for modName in extraModules:
+    for modName in extensions:
       if modName.split(":")[0] not in extraFound:
         return S_ERROR( "No module %s defined. You sure it's defined for this release?" % modName )
 
@@ -1027,7 +1028,8 @@ def installExternalRequirements( extType ):
 
 cmdOpts = ( ( 'r:', 'release=', 'Release version to install' ),
             ( 'l:', 'project=', 'Project to install' ),
-            ( 'e:', 'extraModules=', 'Extra modules to install (comma separated)' ),
+            #( 'e:', 'extraModules=', 'Extra modules to install (comma separated)' ),
+            ( 'e:', 'extensions=', 'Extensions to install (comma separated)' ),
             ( 't:', 'installType=', 'Installation type (client/server)' ),
             ( 'i:', 'pythonVersion=', 'Python version to compile (27/26)' ),
             ( 'p:', 'platform=', 'Platform to install' ),
@@ -1109,9 +1111,11 @@ def loadConfiguration():
       opVal = releaseConfig.getInstallationConfig( "LocalInstallation/%s" % ( opName[0].upper() + opName[1:] ) )
     except KeyError:
       continue
-    #Also react to Extensions as if they were extra modules
-    if opName == 'extensions':
-      opName = 'extraModules'
+    
+    if opName == 'extraModules':
+      logWARN( "extraModules is deprecated please use extensions instead!" )
+      opName = 'extensions'
+    
     if opName == 'installType':
       opName = 'externalsType'
     if isinstance( getattr( cliParams, opName ), basestring ):
@@ -1127,10 +1131,10 @@ def loadConfiguration():
       cliParams.release = v
     elif o in ( '-l', '--project' ):
       cliParams.project = v
-    elif o in ( '-e', '--extraModules' ):
+    elif o in ( '-e', '--extensions' ):
       for pkg in [ p.strip() for p in v.split( "," ) if p.strip() ]:
-        if pkg not in cliParams.extraModules:
-          cliParams.extraModules.append( pkg )
+        if pkg not in cliParams.extensions:
+          cliParams.extensions.append( pkg )
     elif o in ( '-t', '--installType' ):
       cliParams.externalsType = v
     elif o in ( '-i', '--pythonVersion' ):
@@ -1455,7 +1459,7 @@ if __name__ == "__main__":
     sys.exit( 1 )
   if not cliParams.externalsOnly:
     logNOTICE( "Discovering modules to install" )
-    result = releaseConfig.getModulesToInstall( cliParams.release, cliParams.extraModules )
+    result = releaseConfig.getModulesToInstall( cliParams.release, cliParams.extensions )
     if not result[ 'OK' ]:
       logERROR( result[ 'Message' ] )
       sys.exit( 1 )

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -35,7 +35,6 @@ def S_ERROR( msg = "" ):
 class Params( object ):
 
   def __init__( self ):
-    #self.extraModules = []
     self.extensions = []
     self.project = 'DIRAC'
     self.installation = 'DIRAC'

--- a/Core/scripts/install_full.cfg
+++ b/Core/scripts/install_full.cfg
@@ -22,7 +22,7 @@ LocalInstallation
    # The directory of the DIRAC software installation
    TargetPath = /opt/dirac
    # DIRAC extensions to be installed
-   ExtraModules = Web
+   Extension = WebApp
    PythonVersion = 27
 
    # Installation is of the server type

--- a/Core/scripts/install_minimal.cfg
+++ b/Core/scripts/install_minimal.cfg
@@ -24,7 +24,7 @@ LocalInstallation
    # The directory of the DIRAC software installation
    TargetPath = /opt/dirac
    # DIRAC extensions to be installed
-   ExtraModules = Web
+   Extension = WebApp
    PythonVersion = 26
 
    # Installation is of the server type

--- a/Core/scripts/install_secondary.cfg
+++ b/Core/scripts/install_secondary.cfg
@@ -25,7 +25,7 @@ LocalInstallation
    # The directory of the DIRAC software installation
    TargetPath = /opt/dirac
    # DIRAC extensions to be installed
-   #ExtraModules = Web
+   #Extension = WebApp
    PythonVersion = 26
 
    # Site name

--- a/docs/source/AdministratorGuide/CommandReference/dirac-install.rst
+++ b/docs/source/AdministratorGuide/CommandReference/dirac-install.rst
@@ -1,6 +1,6 @@
-====================
+=============
 dirac-install
-====================
+=============
 
 2013-02-06 12:30:27 UTC dirac-install [NOTICE]  Processing installation requirements
 
@@ -10,7 +10,7 @@ Usage::
 
  l:  project=             : Project to install
 
- e:  extraModules=        : Extra modules to install (comma separated)
+ e:  externals=        : Externals to install (comma separated)
 
  t:  installType=         : Installation type (client/server)
 

--- a/docs/source/AdministratorGuide/InstallingDIRACService/index.rst
+++ b/docs/source/AdministratorGuide/InstallingDIRACService/index.rst
@@ -1,8 +1,8 @@
 .. _server_installation:
 
-===================================
+=========================
 DIRAC Server Installation
-===================================
+=========================
 
 The procedure described here outlines the installation of the DIRAC components on a host machine, a 
 DIRAC server. There are two distinct cases of installations:
@@ -23,7 +23,7 @@ For all DIRAC installations any number of client installations is possible.
 .. _server_requirements:
 
 Requirements
------------------------------------------------
+------------
 
 *Server:*
 
@@ -63,7 +63,7 @@ Requirements
 .. _server_preparation:
 
 Server preparation
----------------------------------
+------------------
 
 Any host running DIRAC server components should be prepared before the installation of DIRAC following 
 the steps below. This procedure must be followed for the primary server and for any additional server installations.
@@ -105,7 +105,7 @@ the steps below. This procedure must be followed for the primary server and for 
       wget -np https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/install_site.sh --no-check-certificate
 
 Server Certificates
----------------------
+-------------------
 
 Server certificates are used for validating the identity of the host a given client is connecting to. By default 
 grid host certificate include host/ in the CN (common name) field. This is not a problem for DIRAC components 
@@ -139,7 +139,7 @@ where the output of the ``openssl`` command gives you the hash of the certificat
 .. _install_primary_server:
 
 Primary server installation
-----------------------------
+---------------------------
 
 The installation consists of setting up a set of services, agents and databases for the
 required DIRAC functionality. The SystemAdministrator interface can be used later to complete 
@@ -180,7 +180,7 @@ be taken:
         #  this server).
         #  Only modules not defined as default to install in their projects need to be defined here: 
         #   i.e. LHCb, LHCbWeb for LHCb
-        ExtraModules = Web
+        Externals = WebApp
 
         #
         #   These are options for the configuration of the installed DIRAC software
@@ -304,7 +304,7 @@ installation (for instance if you are testing your install .cfg) you should firs
 .. _install_additional_server:
 
 Additional server installation
-------------------------------------
+------------------------------
 
 To add a new server to an already existing DIRAC Installation the procedure is similar to the one above. 
 You should perform all the preliminary steps to prepare the host for the installation. One additional 
@@ -337,7 +337,7 @@ operation is the registration of the new host in the already functional Configur
         #  this server).
         #  For each User Community their extra package might be necessary here: 
         #   i.e. LHCb, LHCbWeb for LHCb
-        ExtraModules = 
+        Externals = 
 
         #
         #   These are options for the configuration of the previously installed DIRAC software
@@ -384,7 +384,7 @@ If the installation is successful, the SystemAdministrator service will be up an
 server. You can now set up the required components as described in :ref:`setting_with_CLI`
 
 Post-Installation step
----------------------------
+----------------------
 
 In order to make the DIRAC components running we use the *runit* mechanism (http://smarden.org/runit/). For each component that 
 must run permanently (services and agents) there is a directory created under */opt/dirac/startup* that is 
@@ -428,7 +428,7 @@ The same script can be used to restart all DIRAC components running on the machi
 .. _setting_with_CLI:
 
 Setting up DIRAC services and agents using the System Administrator Console
-----------------------------------------------------------------------------
+---------------------------------------------------------------------------
 
 To use the :ref:`system-admin-console`, you will need first to install the DIRAC Client software on some machine.
 To install the DIRAC Client, follow the procedure described in the User Guide.

--- a/docs/source/AdministratorGuide/InstallingWebAppDIRAC/index.rst
+++ b/docs/source/AdministratorGuide/InstallingWebAppDIRAC/index.rst
@@ -26,7 +26,7 @@ Configuration file
 ~~~~~~~~~~~~~~~~~~
 You can use a standard configuration file for example :ref:`_install_primary_server`. Please make sure that the following lines are exists in the 
 configuration file::
-   ExtraModules = WebAppDIRAC
+   Externals = WebApp
    WebApp = yes
 But you can also use the following configuration file to install the web portal.
 $installCfg::
@@ -54,7 +54,7 @@ $installCfg::
      #  this server).
      #  Only modules not defined as default to install in their projects need to be defined here:
      #   i.e. LHCb, LHCbWeb for LHCb for example: ExtraModules = WebAppDIRAC,LHCb,LHCbWeb
-     ExtraModules = WebAppDIRAC
+     Externals = WebApp
      Project = DIRAC
      WebPortal = yes
      WebApp = yes

--- a/docs/source/DeveloperGuide/DevelopmentModel/DIRACProjects/index.rst
+++ b/docs/source/DeveloperGuide/DevelopmentModel/DIRACProjects/index.rst
@@ -1,8 +1,8 @@
 .. _dirac_projects:
 
-========================
+==============
 DIRAC Projects
-========================
+==============
 
 DIRAC is used by several user communities. Some of them are creating their own modules for DIRAC. 
 These modules require a certain version of DIRAC in order to function properly. Virtual organizations 
@@ -13,7 +13,7 @@ Preparing DIRAC distribution
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ 
 
 Releases schema
--------------------
+---------------
 
 DIRAC *modules* are released and distributed in *projects*. Each project has a *releases.cfg* 
 configuration file where the releases, modules and dependencies are defined. A single *releases.cfg* 
@@ -52,7 +52,7 @@ release name. Each release can require a certain version of any other project (D
 An example with more than one module follows::
 
    DefaultModules = MyExt
-   RequiredExtraModules = Web
+   RequiredExtraModules = WebApp
    
    Sources
    {
@@ -133,7 +133,7 @@ Once generated, they have to be upload to the install project source of tarballs
 to pick them up.
 
 How to define how to make a project distribution
-----------------------------------------------------
+------------------------------------------------
 
 *dirac-distribution* needs to know where to find the *releases.cfg* file. *dirac-distribution* will load 
 some global configuration from a DIRAC web server. That configuration can instruct *dirac-distribution* 
@@ -157,7 +157,7 @@ The defaults file is defined per project and can live in any web server.
 
 
 Installation
-@@@@@@@@@@@@@@@
+@@@@@@@@@@@@
 
 When installing, *dirac-install* requires a release version and optionally a project name. If the project 
 name is given *dirac-install* will try to load the project's versioned ``release-<projectName>-<version>.cfg`` 
@@ -206,7 +206,7 @@ Reference of *releases.cfg*  schema
  #List of modules to be installed by default for the project
  DefaultModules = MyExt
  #Extra modules to be installed
- RequiredExtraModules = Web
+ RequiredExtraModules = WebApp
  
  #Section containing where to find the source code to generate releases
  Sources
@@ -242,7 +242,7 @@ Reference of *releases.cfg*  schema
  }
  
 Reference of an installation's defaults file
------------------------------------------------
+--------------------------------------------
 
 ::
 
@@ -275,7 +275,7 @@ Reference of an installation's defaults file
  
  
 Reference of global default's file
-------------------------------------
+----------------------------------
 
 Global defaults is the file that *dirac-install* will try to load to discover where the each project's 
 ``defaults.cfg`` file is. The schema is as follows::
@@ -322,7 +322,7 @@ All the values in the defined defaults file file take precedence over the global
 for DIRAC maintainers to keep track of all the projects installable via native dirac-install.
 
 Common pitfalls
-------------------
+---------------
 
 Installation will find a given *releases.cfg*  by looking up the project name. All modules defined inside 
 a *releases.cfg*  have to start with the same name as the project. For instance, if the project is *MyVO*, 


### PR DESCRIPTION
This fix the issue reported #2099. The backward compatibility is kept. But there is one exception:

dirac-install --extraModules 

I assume we are using -e instead of --extraModules.  
