### PR TITLE
[v6r15] enable google style docstrings

### DIFF
--- a/Core/Security/X509Chain.py
+++ b/Core/Security/X509Chain.py
@@ -214,11 +214,13 @@ class X509Chain( object ):
   def generateProxyToString( self, lifeTime, diracGroup = False, strength = 1024, limited = False, rfc = False, proxyKey = False ):
     """
     Generate a proxy and get it as a string
-      Args:
-        - lifeTime : expected lifetime in seconds of proxy
-        - diracGroup : diracGroup to add to the certificate
-        - strength : length in bits of the pair
-        - limited : Create a limited proxy
+
+    Args:
+        lifeTime (int): expected lifetime in seconds of proxy
+        diracGroup (str): diracGroup to add to the certificate
+        strength (int): length in bits of the pair
+        limited (bool): Create a limited proxy
+
     """
     if not self.__loadedChain:
       return S_ERROR( DErrno.ENOCHAIN )
@@ -271,12 +273,13 @@ class X509Chain( object ):
   def generateProxyToFile( self, filePath, lifeTime, diracGroup = False, strength = 1024, limited = False, rfc = False ):
     """
     Generate a proxy and put it into a file
-      Args:
-        - filePath : file to write
-        - lifeTime : expected lifetime in seconds of proxy
-        - diracGroup : diracGroup to add to the certificate
-        - strength : length in bits of the pair
-        - limited : Create a limited proxy
+
+    Args:
+        filePath: file to write
+        lifeTime: expected lifetime in seconds of proxy
+        diracGroup: diracGroup to add to the certificate
+        strength: length in bits of the pair
+        limited: Create a limited proxy
     """
     retVal = self.generateProxyToString( lifeTime, diracGroup, strength, limited, rfc )
     if not retVal[ 'OK' ]:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,6 +97,7 @@ if os.environ.get('READTHEDOCS') == 'True':
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary',
               'sphinx.ext.intersphinx',
+              'sphinx.ext.napoleon',
              ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
As asked in https://github.com/DIRACGrid/DIRAC/pull/2976#discussion_r66408006
Need to enable this extension: http://www.sphinx-doc.org/en/stable/ext/napoleon.html
Also changed some docstrings to make that work (I am guessing on the types, correct me if they are wrong).
Cf.:
Before:
http://diracsailer.readthedocs.io/en/rel-v6r15/CodeDocumentation/Core/Security/X509Chain.html#DIRAC.Core.Security.X509Chain.X509Chain.generateProxyToFile
After:
http://diracsailer.readthedocs.io/en/docgoogledoc/CodeDocumentation/Core/Security/X509Chain.html#DIRAC.Core.Security.X509Chain.X509Chain.generateProxyToFile