### PR TITLE
[v6r15] print request id for replicate and register requests

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-replicate-and-register-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-replicate-and-register-request.py
@@ -58,6 +58,7 @@ if __name__ == "__main__":
   count = 0
   reqClient = ReqClient()
   fc = FileCatalog()
+  requestIDs = []
   for lfnChunk in lfnChunks:
     metaDatas = fc.getFileMetadata( lfnChunk )
     if not metaDatas["OK"]:
@@ -106,13 +107,15 @@ if __name__ == "__main__":
       gLogger.error( "unable to put request '%s': %s" % ( request.RequestName, putRequest["Message"] ) )
       error = -1
       continue
-
+    requestIDs.append( str( putRequest["Value"] ) )
     if not multiRequests:
       gLogger.always( "Request '%s' has been put to ReqDB for execution." % request.RequestName )
 
   if multiRequests:
     gLogger.always( "%d requests have been put to ReqDB for execution, with name %s_<num>" % ( count, requestName ) )
-  gLogger.always( "You can monitor requests' status using command: 'dirac-rms-show-request <requestName>'" )
+  if len(requestIDs) > 0:
+    gLogger.always( "RequestID(s): %s" % " ".join( requestIDs ) )
+  gLogger.always( "You can monitor requests' status using command: 'dirac-rms-show-request <requestName/ID>'" )
   DIRAC.exit( error )
 
 

--- a/DataManagementSystem/scripts/dirac-dms-replicate-and-register-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-replicate-and-register-request.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
 
   if multiRequests:
     gLogger.always( "%d requests have been put to ReqDB for execution, with name %s_<num>" % ( count, requestName ) )
-  if len(requestIDs) > 0:
+  if requestIDs:
     gLogger.always( "RequestID(s): %s" % " ".join( requestIDs ) )
   gLogger.always( "You can monitor requests' status using command: 'dirac-rms-show-request <requestName/ID>'" )
   DIRAC.exit( error )


### PR DESCRIPTION
We have users who, especially for one off requests, use the dirac-dms-replicate-and-register-request command directly. Right now this command only prints the request name, which doesn't make allowances for duplicate request names. This patch now also prints the requestid(s), giving the user a chance to monitor their request(s).