### PR TITLE
[v6r14] Bug fix to extract output and error files

### DIFF
--- a/Resources/Computing/BatchSystems/Torque.py
+++ b/Resources/Computing/BatchSystems/Torque.py
@@ -41,9 +41,9 @@ class Torque( object ):
       cmd = "qsub -o %(OutputDir)s -e %(ErrorDir)s -q %(Queue)s -N DIRACPilot %(SubmitOptions)s %(Executable)s" % kwargs
       status,output = commands.getstatusoutput(cmd)
       if status == 0:
-        jobIDs.append(output)
+        jobIDs.append(output.split('.')[0])
       else:
-        break                                                         
+        break
   
     if jobIDs:
       resultDict['Status'] = 0
@@ -76,7 +76,7 @@ class Torque( object ):
     for job in jobIDList:
       if not job:
         continue
-      jobNumber = job.split( '.' )[0]
+      jobNumber = job
       jobDict[jobNumber] = job
 
     cmd = 'qstat ' + ' '.join( jobIDList )
@@ -98,9 +98,9 @@ class Torque( object ):
             statusDict[jobDict[job]] = 'Unknown'
           else:
             torqueStatus = line.split()[4]
-            if torqueStatus in ['E', 'C']:
+            if torqueStatus in ['E']:
               statusDict[jobDict[job]] = 'Done'
-            elif torqueStatus in ['R']:
+            elif torqueStatus in ['R', 'C']:
               statusDict[jobDict[job]] = 'Running'
             elif torqueStatus in ['S', 'W', 'Q', 'H', 'T']:
               statusDict[jobDict[job]] = 'Waiting'

--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -602,7 +602,14 @@ class SSHComputingElement( ComputingElement ):
     if 'OutputTemplate' in self.ceParameters:
       self.outputTemplate = self.ceParameters['OutputTemplate']
       self.errorTemplate = self.ceParameters['ErrorTemplate']
-    
+
+    if self.batchSystem == 'Torque':
+      output = self.outputTemplate % jobStamp.split('.')[0]
+      error = self.errorTemplate % jobStamp.split('.')[0]
+    else:
+      output = self.outputTemplate % jobStamp
+      error = self.errorTemplate % jobStamp
+      
     if self.outputTemplate:
       output = self.outputTemplate % jobStamp
       error = self.errorTemplate % jobStamp
@@ -656,14 +663,14 @@ class SSHComputingElement( ComputingElement ):
     result = ssh.scpCall( 30, localOutputFile, outputFile, upload = False )
     if not result['OK']:
       return result
-    output = result['Value']
+    output = result['Value'][1]
     if localDir:
       output = localOutputFile
 
     result = ssh.scpCall( 30, localErrorFile, errorFile, upload = False )
     if not result['OK']:
       return result
-    error = result['Value']
+    error = result['Value'][1]
     if localDir:
       error = localErrorFile
       

--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -602,13 +602,6 @@ class SSHComputingElement( ComputingElement ):
     if 'OutputTemplate' in self.ceParameters:
       self.outputTemplate = self.ceParameters['OutputTemplate']
       self.errorTemplate = self.ceParameters['ErrorTemplate']
-
-    if self.batchSystem == 'Torque':
-      output = self.outputTemplate % jobStamp.split('.')[0]
-      error = self.errorTemplate % jobStamp.split('.')[0]
-    else:
-      output = self.outputTemplate % jobStamp
-      error = self.errorTemplate % jobStamp
       
     if self.outputTemplate:
       output = self.outputTemplate % jobStamp

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -561,7 +561,7 @@ class ConfigureSite( CommandBase ):
     # Take the reference from the Torque batch system
     if 'PBS_JOBID' in os.environ:
       self.pp.flavour = 'SSHTorque'
-      pilotRef = 'sshtorque://' + self.pp.ceName + '/' + os.environ['PBS_JOBID']
+      pilotRef = 'sshtorque://' + self.pp.ceName + '/' + os.environ['PBS_JOBID'].split('.')[0]
 
     # Take the reference from the OAR batch system
     if 'OAR_JOBID' in os.environ:


### PR DESCRIPTION
Modifications in L659 and 666 is necessary to extract output and error files
for all the batch systems.  Result['Value'] is tuple but string is expected to be returned.

Modification in L605 is related to SSHTorque.
The jobStamp of Torque includes hostname of the head node.
But name of output file does not include it. So somehow tricky treatment is necessary.

We confirmed this code is working under Belle II environment. 


