### PR TITLE
[v6r14] Soap with suds-jurko: add imports somehow needed

### DIFF
--- a/Core/Utilities/SOAPFactory.py
+++ b/Core/Utilities/SOAPFactory.py
@@ -2,6 +2,8 @@
 __RCSID__ = "$Id$"
 
 import suds
+import suds.client
+import suds.transport
 import urllib2
 from DIRAC.Core.DISET.HTTPDISETConnection import HTTPDISETConnection
 


### PR DESCRIPTION
For some reason in the suds-jurko implementation the extra imports are needed.
Otherwise an AttributeError is thrown.
See: https://github.com/DIRACGrid/Externals/pull/12
With suds
```
In [1]: import suds

In [2]: suds.transport
Out[2]: <module 'suds.transport' from '/home/sailer/software/DIRAC/DiracDevV6r13/Linux_x86_64_glibc-2.12/lib/python2.7/site-packages/suds/transport/__init__.pyo'>

In [3]: suds.__version__
Out[3]: '0.4'

In [4]: import suds.transport

In [5]: suds.transport
Out[5]: <module 'suds.transport' from '/home/sailer/software/DIRAC/DiracDevV6r13/Linux_x86_64_glibc-2.12/lib/python2.7/site-packages/suds/transport/__init__.pyo'>

```
Additional import doesn't matter, so this is backwards compatible.

with suds-jurko
```
In [1]: import suds

In [2]: suds.__version__
Out[2]: '0.6'

In [3]: suds.transport
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-7348255a7f4b> in <module>()
----> 1 suds.transport

AttributeError: 'module' object has no attribute 'transport'
In [4]: import suds.transport

In [5]: suds.transport
Out[5]: <module 'suds.transport' from '/home/sailer/software/DIRAC/DiracDevV6r13/Linux_x86_64_glibc-2.12/lib/python2.7/site-packages/suds/transport/__init__.pyo'>
```