### PR TITLE
[v6r15] Fixed DIRACExit Code

### DIFF
--- a/ResourceStatusSystem/scripts/dirac-rss-set-token.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-set-token.py
@@ -179,13 +179,13 @@ def main():
   user = proxyUser()
   if not user[ 'OK' ]:
     subLogger.error( user[ 'Message' ] )
-    DIRACExit( user[ 'Message' ] )
+    DIRACExit( 1 )
   user = user[ 'Value' ]
   
   res = setToken( user )
   if not res[ 'OK' ]:
     subLogger.error( res[ 'Message' ] )
-    DIRACExit( res[ 'Message' ] )
+    DIRACExit( 1 )
 
 #...............................................................................
 


### PR DESCRIPTION
The `res[ 'Message' ]` is not an integer value.