### PR TITLE
[v6r14] Allow staging from an SE accessible by Protocol

### DIFF
--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -65,11 +65,11 @@ def _getConnectionIndex( connectionLevel, default = None ):
 
 class DMSHelpers( object ):
 
-  def __init__( self ):
+  def __init__( self, vo = False ):
     self.siteSEMapping = {}
     self.storageElementSet = set()
     self.siteSet = set()
-    self.__opsHelper = Operations()
+    self.__opsHelper = Operations( vo = vo )
 
 
   def getSiteSEMapping( self ):

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -355,11 +355,6 @@ class JobScheduling( OptimizerExecutor ):
 
   def __preRequestStaging( self, jobState, stageSite, opData ):
     from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
-    # Allow staging from SEs accessible by protocol
-    result = DMSHelpers().getSEsForSite( stageSite, connectionLevel = 'PROTOCOL' )
-    if not result['OK']:
-      return S_ERROR( 'Could not determine SEs for site %s' % stageSite )
-    siteSEs = result['Value']
 
     tapeSEs = []
     diskSEs = []
@@ -368,6 +363,14 @@ class JobScheduling( OptimizerExecutor ):
       return result
     manifest = result['Value']
     vo = manifest.getOption( 'VirtualOrganization' )
+    inputDataPolicy = manifest.getOption( 'InputDataPolicy', 'Protocol' )
+    connectionLevel = 'DOWNLOAD' if 'download' in inputDataPolicy.lower() else 'PROTOCOL'
+    # Allow staging from SEs accessible by protocol
+    result = DMSHelpers( vo = vo ).getSEsForSite( stageSite, connectionLevel = connectionLevel )
+    if not result['OK']:
+      return S_ERROR( 'Could not determine SEs for site %s' % stageSite )
+    siteSEs = result['Value']
+
     for seName in siteSEs:
       se = StorageElement( seName, vo = vo )
       result = se.getStatus()

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -354,7 +354,9 @@ class JobScheduling( OptimizerExecutor ):
     return ( True, bestSites )
 
   def __preRequestStaging( self, jobState, stageSite, opData ):
-    result = getSEsForSite( stageSite )
+    from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
+    # Allow staging from SEs accessible by protocol
+    result = DMSHelpers().getSEsForSite( stageSite, connectionLevel = 'PROTOCOL' )
     if not result['OK']:
       return S_ERROR( 'Could not determine SEs for site %s' % stageSite )
     siteSEs = result['Value']


### PR DESCRIPTION
Allow staging to take place at an SE accessible by protocol, while until now it was only local. This was preventing a job at NIKHEF to stage at SARA.
After discussion with the reviewer, try and get both the VO and the InputDataPolicy from the job manifest in order to do it more correctly. As the agent is not running with a proxy, Operations() cannot deduce the VO and it should be picked up in the job for multi-VO installations.