### PR TITLE
[v6r15] FC: skip execution of method if empty imput

### DIFF
--- a/Resources/Catalog/FileCatalog.py
+++ b/Resources/Catalog/FileCatalog.py
@@ -230,10 +230,20 @@ class FileCatalog( object ):
             return S_ERROR( "The master catalog is not valid for some LFNS %s" % condEvals )
 
         validLFNs = dict( ( lfn, fileInfo[lfn] ) for lfn in condEvals if condEvals[lfn] )
+
+        # We can skip the execution without worry,
+        # since at this level it is for sure not a master catalog
+        if not validLFNs:
+          gLogger.debug( "No valid LFN, skipping the call" )
+          continue
+
         invalidLFNs = [lfn for lfn in condEvals if not condEvals[lfn]]
+
         if invalidLFNs:
           gLogger.debug( "Some LFNs are not valid for operation '%s' on catalog '%s' : %s" % ( self.call, catalogName,
                                                                                                invalidLFNs ) )
+
+
         result = method( validLFNs, *parms1, **kws )
 
 

--- a/Resources/Catalog/FileCatalogClient.py
+++ b/Resources/Catalog/FileCatalogClient.py
@@ -35,7 +35,7 @@ class FileCatalogClient( FileCatalogClientBase ):
   NO_LFN_METHODS = ['findFilesByMetadata','addMetadataField','deleteMetadataField','getMetadataFields','setMetadata',
                     'setMetadataBulk','removeMetadata','getDirectoryUserMetadata','findDirectoriesByMetadata',
                     'getReplicasByMetadata','findFilesByMetadataDetailed','findFilesByMetadataWeb',
-                    'getCompatibleMetadata','addMetadataSet','getMetadataSet','getFileUserMetadata']
+                    'getCompatibleMetadata', 'addMetadataSet', 'getMetadataSet', 'getFileUserMetadata', 'getLFNForGUID']
 
   ADMIN_METHODS = [ 'addUser', 'deleteUser', 'addGroup', 'deleteGroup', 'getUsers', 'getGroups',
                     'getCatalogCounters', 'repairCatalog', 'rebuildDirectoryUsage' ]
@@ -419,7 +419,6 @@ class FileCatalogClient( FileCatalogClientBase ):
     """ Get the status for the supplied replicas """
     return self._getRPC( timeout = timeout ).getFileDescendents( lfns, depths )
 
-  @checkCatalogArguments
   def getLFNForGUID( self, guids, timeout = 120 ):
     """Get the matching lfns for given guids"""
     return self._getRPC( timeout = timeout ).getLFNForGUID( guids )


### PR DESCRIPTION
Without this, the checkArgument decorator would throw an error of empty imput