### PR TITLE
[v6r15] Html aggregated notifications in RSS

### DIFF
--- a/Core/Utilities/Mail.py
+++ b/Core/Utilities/Mail.py
@@ -16,6 +16,7 @@ class Mail( object ):
     self._subject = ''
     self._message = ''
     self._mailAddress = ''
+    self._html = False
     self._fromAddress = getuser() + '@' + socket.getfqdn()
     self.esmtp_features = {}
 
@@ -31,7 +32,11 @@ class Mail( object ):
         gLogger.warn( "Subject and body empty. Mail not sent" )
         return S_ERROR ( "Subject and body empty. Mail not sent" )
 
-    mail = MIMEText( self._message , "plain" )
+    if self._html:
+      mail = MIMEText( self._message , "html" )
+    else:
+      mail = MIMEText( self._message , "plain" )
+
     addresses = self._mailAddress
     if not type( self._mailAddress ) == type( [] ):
       addresses = [self._mailAddress]

--- a/FrameworkSystem/Client/NotificationClient.py
+++ b/FrameworkSystem/Client/NotificationClient.py
@@ -26,7 +26,7 @@ class NotificationClient:
     return self.__rpcFunctor( "Framework/Notification", **kwargs )
 
   #############################################################################
-  def sendMail( self, address, subject, body, fromAddress = None, localAttempt = True ):
+  def sendMail( self, address, subject, body, fromAddress = None, localAttempt = True, html = False ):
     """ Send an e-mail with subject and body to the specified address. Try to send
         from local area before central service by default.
     """
@@ -38,6 +38,7 @@ class NotificationClient:
         m._subject = subject
         m._message = body
         m._mailAddress = address
+        m._html = html
         if fromAddress:
           m._fromAddress = fromAddress
         result = m._send()

--- a/Interfaces/API/DiracAdmin.py
+++ b/Interfaces/API/DiracAdmin.py
@@ -1039,12 +1039,12 @@ class DiracAdmin( API ):
     return self.csAPI.commitChanges( sortUsers = False )
 
   #############################################################################
-  def sendMail( self, address, subject, body, fromAddress = None, localAttempt = True ):
+  def sendMail( self, address, subject, body, fromAddress = None, localAttempt = True, html = False ):
     """
     Send mail to specified address with body.
     """
     notification = NotificationClient()
-    return notification.sendMail( address, subject, body, fromAddress, localAttempt )
+    return notification.sendMail( address, subject, body, fromAddress, localAttempt, html )
 
   #############################################################################
   def sendSMS( self, userName, body, fromAddress = None ):

--- a/ResourceStatusSystem/Agent/EmailAgent.py
+++ b/ResourceStatusSystem/Agent/EmailAgent.py
@@ -1,11 +1,8 @@
 ''' EmailAgent
-
-  This agent reads a cache file ( cache.json ) which contains the aggregated information
+  This agent reads a cache file ( cache.db ) which contains the aggregated information
   of what happened to the elements of each site. After reading the cache file
   ( by default every 30 minutes ) it sends an email for every site and then clears it.
-
 '''
-
 
 import os
 import sqlite3

--- a/ResourceStatusSystem/Agent/EmailAgent.py
+++ b/ResourceStatusSystem/Agent/EmailAgent.py
@@ -48,23 +48,67 @@ class EmailAgent( AgentModule ):
         for site in result:
           cursor = conn.execute("SELECT StatusType, ResourceName, Status, Time, PreviousStatus from ResourceStatusCache WHERE SiteName='"+ site[0] +"';")
 
+          email = ""
+          html_body = ""
+          html_elements = ""
+
           if gConfig.getValue('/DIRAC/Setup'):
-            email_body = "(" + gConfig.getValue('/DIRAC/Setup') + ")\n\n"
+            setup = "(" + gConfig.getValue('/DIRAC/Setup') + ")\n\n"
           else:
-            email_body = ""
-            
+            setup = ""
+
+          html_header = """\
+          <!DOCTYPE html>
+          <html>
+          <head>
+          <meta charset='UTF-8'>
+            <style>
+              table{color:#333;font-family:Helvetica,Arial,sans-serif;width:640px;border-collapse:collapse;border-spacing:0}
+              td,th{border:1px solid transparent;height:30px;transition:all .3s}th{background:#DFDFDF;font-weight:700}
+              td{background:#FAFAFA;text-align:center}.setup{font-size:150%;color:grey}.Banned{color:red}.Error{color:#8b0000}
+              .Degraded{color:gray}.Probing{color:#00f}.Active{color:green}tr:nth-child(even) td{background:#F1F1F1}tr:nth-child(odd)
+              td{background:#FEFEFE}tr td:hover{background:#666;color:#FFF}
+            </style>
+          </head>
+          <body>
+            <p class="setup">{setup}</p>
+          """.format(setup=setup)
+
           for StatusType, ResourceName, Status, Time, PreviousStatus in cursor:
-            email_body += StatusType + " of " + ResourceName + " has been " + Status + " since " + Time + " (Previous status: " + PreviousStatus + ")\n"
+            html_elements += "<tr>" + \
+                             "<td>" + StatusType + "</td>" + \
+                             "<td>" + ResourceName + "</td>" + \
+                             "<td>" + Status + "</td>" + \
+                             "<td>" + Time + "</td>" + \
+                             "<td>" + PreviousStatus + "</td>" + \
+                             "</tr>"
+
+          html_body = """\
+          <table>
+            <tr>
+                <th>Status Type</th>
+                <th>Resource Name</th>
+                <th>Status</th>
+                <th>Time</th>
+                <th>Previous Status</th>
+            </tr>
+            {html_elements}
+          </table>
+          </body>
+          </html>
+          """.format(html_elements=html_elements)
+
+          email = html_header + html_body
 
           subject = "RSS actions taken for " + site[0] + "\n"
-          self._sendMail(subject, email_body)
+          self._sendMail(subject, email, html = True)
 
         conn.execute("DELETE FROM ResourceStatusCache;")
         conn.execute("VACUUM;")
 
     return S_OK()
 
-  def _sendMail( self, subject, body ):
+  def _sendMail( self, subject, body, html = False ):
 
     userEmails = self._getUserEmails()
     if not userEmails[ 'OK' ]:
@@ -77,7 +121,7 @@ class EmailAgent( AgentModule ):
 
       #FIXME: should not I get the info from the RSS User cache ?
 
-      resEmail = self.diracAdmin.sendMail( user, subject, body, fromAddress = fromAddress )
+      resEmail = self.diracAdmin.sendMail( user, subject, body, fromAddress = fromAddress, html = html )
       if not resEmail[ 'OK' ]:
         return S_ERROR( 'Cannot send email to user "%s"' % user )
 

--- a/ResourceStatusSystem/Agent/EmailAgent.py
+++ b/ResourceStatusSystem/Agent/EmailAgent.py
@@ -63,7 +63,7 @@ class EmailAgent( AgentModule ):
           <head>
           <meta charset='UTF-8'>
             <style>
-              table{{color:#333;font-family:Helvetica,Arial,sans-serif;width:640px;border-collapse:collapse;border-spacing:0}}
+              table{{color:#333;font-family:Helvetica,Arial,sans-serif;min-width:700px;border-collapse:collapse;border-spacing:0}}
               td,th{{border:1px solid transparent;height:30px;transition:all .3s}}th{{background:#DFDFDF;font-weight:700}}
               td{{background:#FAFAFA;text-align:center}}.setup{{font-size:150%;color:grey}}.Banned{{color:red}}.Error{{color:#8b0000}}
               .Degraded{{color:gray}}.Probing{{color:#00f}}.Active{{color:green}}tr:nth-child(even) td{{background:#F1F1F1}}tr:nth-child(odd)

--- a/ResourceStatusSystem/Agent/EmailAgent.py
+++ b/ResourceStatusSystem/Agent/EmailAgent.py
@@ -63,11 +63,11 @@ class EmailAgent( AgentModule ):
           <head>
           <meta charset='UTF-8'>
             <style>
-              table{color:#333;font-family:Helvetica,Arial,sans-serif;width:640px;border-collapse:collapse;border-spacing:0}
-              td,th{border:1px solid transparent;height:30px;transition:all .3s}th{background:#DFDFDF;font-weight:700}
-              td{background:#FAFAFA;text-align:center}.setup{font-size:150%;color:grey}.Banned{color:red}.Error{color:#8b0000}
-              .Degraded{color:gray}.Probing{color:#00f}.Active{color:green}tr:nth-child(even) td{background:#F1F1F1}tr:nth-child(odd)
-              td{background:#FEFEFE}tr td:hover{background:#666;color:#FFF}
+              table{{color:#333;font-family:Helvetica,Arial,sans-serif;width:640px;border-collapse:collapse;border-spacing:0}}
+              td,th{{border:1px solid transparent;height:30px;transition:all .3s}}th{{background:#DFDFDF;font-weight:700}}
+              td{{background:#FAFAFA;text-align:center}}.setup{{font-size:150%;color:grey}}.Banned{{color:red}}.Error{{color:#8b0000}}
+              .Degraded{{color:gray}}.Probing{{color:#00f}}.Active{{color:green}}tr:nth-child(even) td{{background:#F1F1F1}}tr:nth-child(odd)
+              td{{background:#FEFEFE}}tr td:hover{{background:#666;color:#FFF}}
             </style>
           </head>
           <body>
@@ -78,22 +78,22 @@ class EmailAgent( AgentModule ):
             html_elements += "<tr>" + \
                              "<td>" + StatusType + "</td>" + \
                              "<td>" + ResourceName + "</td>" + \
-                             "<td>" + Status + "</td>" + \
+                             "<td class='" + Status + "'>" + Status + "</td>" + \
                              "<td>" + Time + "</td>" + \
-                             "<td>" + PreviousStatus + "</td>" + \
+                             "<td class='" + PreviousStatus + "'>" + PreviousStatus + "</td>" + \
                              "</tr>"
 
           html_body = """\
-          <table>
-            <tr>
-                <th>Status Type</th>
-                <th>Resource Name</th>
-                <th>Status</th>
-                <th>Time</th>
-                <th>Previous Status</th>
-            </tr>
-            {html_elements}
-          </table>
+            <table>
+              <tr>
+                  <th>Status Type</th>
+                  <th>Resource Name</th>
+                  <th>Status</th>
+                  <th>Time</th>
+                  <th>Previous Status</th>
+              </tr>
+              {html_elements}
+            </table>
           </body>
           </html>
           """.format(html_elements=html_elements)


### PR DESCRIPTION
I added an optional parameter to `Mail.py` and now we can set the MIME type of the email to HTML.
I have also hardcoded the HTML and CSS code in order to send emails that are more readable.

This is how an email should look like now:
![html_email](https://cloud.githubusercontent.com/assets/8127545/16338048/4f8f6f16-3a1a-11e6-969b-f234534244ce.jpg)
