### PR TITLE
[v6r15] FCConditionParser: ProxyPlugin handles the case of having no proxy

### DIFF
--- a/Resources/Catalog/ConditionPlugins/ProxyPlugin.py
+++ b/Resources/Catalog/ConditionPlugins/ProxyPlugin.py
@@ -34,7 +34,10 @@ class ProxyPlugin( FCConditionBasePlugin ):
 
 
         If the conditions does not follow the form 'attribute.predicate(value)', an exception
-        is thrown, and will lead to be evaluated to False
+        is thrown, and will lead to all the expression be evaluated to False
+
+        If there is no proxy, all conditions are evaluated to False
+
     """
     super( ProxyPlugin, self ).__init__( conditions )
 
@@ -49,10 +52,10 @@ class ProxyPlugin( FCConditionBasePlugin ):
     self.value = self.value.replace( "'", "" ).replace( '"', '' ).replace( ' ', '' )
 
     self._checkCondition()
-    self.proxyInfo = getProxyInfo()['Value']
+    self.proxyInfo = getProxyInfo().get( 'Value' )
 
 
-  def _checkCondition(self):
+  def _checkCondition( self ):
     """ Checks that the actual condition makes sense
         if not, raises a RuntimeError exception
     """
@@ -74,10 +77,12 @@ class ProxyPlugin( FCConditionBasePlugin ):
     """ evaluate the parameters.
     """
 
+    if not self.proxyInfo:
+      return False
 
     valueToLookFor = None
     listToLookInto = []
-    
+
     if self.attr in ['username', 'group']:
       valueToLookFor = self.proxyInfo.get( self.attr )
       listToLookInto = self.value.split( ',' )

--- a/Resources/Catalog/ConditionPlugins/test/Test_ProxyPlugin.py
+++ b/Resources/Catalog/ConditionPlugins/test/Test_ProxyPlugin.py
@@ -3,7 +3,7 @@
 
 import unittest
 import mock
-from DIRAC import S_OK
+from DIRAC import S_OK, S_ERROR
 from DIRAC.Resources.Catalog.ConditionPlugins.ProxyPlugin import ProxyPlugin
 
 __RCSID__ = "$Id $"
@@ -26,6 +26,9 @@ def mock_getProxyInfo():
             'username': 'chaen',
             'validDN': True,
             'validGroup': True} )
+
+def mock_getNoProxyInfo():
+  return S_ERROR( "No proxy" )
 
 class TestProxyPlugin( unittest.TestCase ):
   """ Test the FilenamePlugin class"""
@@ -115,7 +118,14 @@ class TestProxyPlugin( unittest.TestCase ):
     with self.assertRaises( AttributeError ):
       ProxyPlugin( 'cannotbeparsed' ).eval()
 
+  @mock.patch( 'DIRAC.Resources.Catalog.ConditionPlugins.ProxyPlugin.getProxyInfo', side_effect = mock_getNoProxyInfo )
+  def test_05_withoutProxy( self, _mockProxyInfo ):
+    """ Testing without proxy, everything should be False"""
 
+    # A priori, not both of them can give the same result
+    # but since there is no proxy, it should !
+    self.assertFalse( ProxyPlugin( 'username.in(toto)' ).eval() )
+    self.assertFalse( ProxyPlugin( 'username.not_in(toto)' ).eval() )
 
 
 if __name__ == '__main__':

--- a/Resources/Catalog/FCConditionParser.py
+++ b/Resources/Catalog/FCConditionParser.py
@@ -309,7 +309,7 @@ class FCConditionParser(object):
         try:
           evaluatedLfns[lfn] = self.__evaluateCondition( conditionStr, lfn = lfn, **kwargs )
         except Exception as e:
-          self.log.error( e )
+          self.log.exception( "Exception while evaluation conditions", lException = e )
           evaluatedLfns[lfn] = False
     else:
       evaluatedLfns = dict.fromkeys( lfns, True )


### PR DESCRIPTION
If there is no proxy when the condition is evaluated, return False