### PR TITLE
[v6r14] Make sure transferClient connects to the same ProxyStorage instance

### DIFF
--- a/Resources/Storage/ProxyStorage.py
+++ b/Resources/Storage/ProxyStorage.py
@@ -33,6 +33,8 @@ class ProxyStorage( StorageBase ):
     failed = {}
     successful = {}
     client = RPCClient( self.url )
+    # Make sure transferClient uses the same ProxyStorage instance.
+    # Only the this one holds the file we want to transfer.
     transferClient = TransferClient( client.serviceURL )
     for src_url in urls.keys():
       res = client.prepareFile( self.name, src_url )
@@ -79,6 +81,7 @@ class ProxyStorage( StorageBase ):
     urls = res['Value']
     failed = {}
     successful = {}
+    # make sure transferClient uses the same ProxyStorage instance we uploaded the file to
     transferClient = TransferClient( client.serviceURL )
     for dest_url, src_file in urls.items():
       fileName = os.path.basename( dest_url )

--- a/Resources/Storage/ProxyStorage.py
+++ b/Resources/Storage/ProxyStorage.py
@@ -33,7 +33,7 @@ class ProxyStorage( StorageBase ):
     failed = {}
     successful = {}
     client = RPCClient( self.url )
-    transferClient = TransferClient( self.url )
+    transferClient = TransferClient( client.serviceURL )
     for src_url in urls.keys():
       res = client.prepareFile( self.name, src_url )
       if not res['OK']:
@@ -79,8 +79,7 @@ class ProxyStorage( StorageBase ):
     urls = res['Value']
     failed = {}
     successful = {}
-    client = RPCClient( self.url )
-    transferClient = TransferClient( self.url )
+    transferClient = TransferClient( client.serviceURL )
     for dest_url, src_file in urls.items():
       fileName = os.path.basename( dest_url )
       res = transferClient.sendFile( src_file, 'putFile/%s' % fileName )


### PR DESCRIPTION
Make sure transferClient connects to the same ProxyStorage instance to which the uploaded/downloaded file has been cached before.

In setups with multiple ProxyStorage instances two independent sURL lookups led to "file not found" errors in case they returned different results.

Should fix: #3020