### PR TITLE
[v6r15] Add possibility for multiple operations in Data Operation Transformations

### DIFF
--- a/RequestManagementSystem/Client/Operation.py
+++ b/RequestManagementSystem/Client/Operation.py
@@ -54,6 +54,10 @@ class Operation( object ):
   ALL_STATES = ( "Queued", "Waiting", "Scheduled", "Assigned", "Failed", "Done", "Canceled" )
   # # final states
   FINAL_STATES = ( "Failed", "Done", "Canceled" )
+  # # valid attributes
+  ATTRIBUTE_NAMES = ['OperationID', 'RequestID', "Type", "Status", "Arguments",
+                     "Order", "SourceSE", "TargetSE", "Catalog", "Error",
+                     "CreationTime", "SubmitTime", "LastUpdate"]
 
   _datetimeFormat = '%Y-%m-%d %H:%M:%S'
 
@@ -328,12 +332,9 @@ class Operation( object ):
   def _getJSONData( self ):
     """ Returns the data that have to be serialized by JSON """
 
-    attrNames = ['OperationID', 'RequestID', "Type", "Status", "Arguments",
-                 "Order", "SourceSE", "TargetSE", "Catalog", "Error",
-                  "CreationTime", "SubmitTime", "LastUpdate"]
     jsonData = {}
 
-    for attrName in attrNames :
+    for attrName in Operation.ATTRIBUTE_NAMES:
 
       # RequestID and OperationID might not be set since they are managed by SQLAlchemy
       if not hasattr( self, attrName ):

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -193,7 +193,7 @@ class RequestTasks( TaskBase ):
 
         oRequest.addOperation( op )
 
-      self._addOrPop( oRequest, taskDict, transID, taskID, ownerDN, ownerGroup )
+      self._assignRequestToTask( oRequest, taskDict, transID, taskID, ownerDN, ownerGroup )
 
   def _singleOperationsBody(self, transBody, taskDict, ownerDN, ownerGroup ):
     """ deal with a Request that has just one operation, as it was sofar
@@ -236,9 +236,9 @@ class RequestTasks( TaskBase ):
           transfer.addFile( trFile )
 
       oRequest.addOperation( transfer )
-      self._addOrPop( oRequest, taskDict, transID, taskID, ownerDN, ownerGroup )
+      self._assignRequestToTask( oRequest, taskDict, transID, taskID, ownerDN, ownerGroup )
 
-  def _addOrPop( self, oRequest, taskDict, transID, taskID, ownerDN, ownerGroup ):
+  def _assignRequestToTask( self, oRequest, taskDict, transID, taskID, ownerDN, ownerGroup ):
     """set ownerDN and group to request, and add the request to taskDict if it is
     valid, otherwise remove the task from the taskDict
 

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -166,7 +166,8 @@ class RequestTasks( TaskBase ):
 
     for taskID in sorted( taskDict ):
       paramDict = taskDict[taskID]
-      if not paramDict['InputData']:
+      if not paramDict.get('InputData'):
+        self.log.error( "Error creating request for task", "%s, No input data" % taskID )
         taskDict.pop( taskID )
         continue
       files = []
@@ -223,7 +224,7 @@ class RequestTasks( TaskBase ):
       transfer.TargetSE = paramDict['TargetSE']
 
       # If there are input files
-      if paramDict['InputData']:
+      if paramDict.get('InputData'):
         if isinstance( paramDict['InputData'], list ):
           files = paramDict['InputData']
         elif isinstance( paramDict['InputData'], basestring ):

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -2,6 +2,7 @@
 """
 import time
 import StringIO
+import json
 
 from DIRAC                                                      import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Security.ProxyInfo                              import getProxyInfo
@@ -138,6 +139,64 @@ class RequestTasks( TaskBase ):
         return res
       ownerDN = res['Value'][0]
 
+    try:
+      transJson = json.loads(transBody)
+      self._multiOperationsBody( transJson, taskDict, ownerDN, ownerGroup )
+    except ValueError: ##json couldn't load
+      self._singleOperationsBody( transBody, taskDict, ownerDN, ownerGroup )
+
+    return S_OK( taskDict )
+
+  def _multiOperationsBody( self, transJson, taskDict, ownerDN, ownerGroup ):
+    """ deal with a Request that has multiple operations
+
+    :param transJson: list of tuples of string and dictionaries
+    :param dict taskDict: dictionary of tasks, modified in this function
+    :param str ownerDN: certificate DN used for the requests
+    :param str onwerGroup: dirac group used for the requests
+    :returns: None
+    """
+
+    for taskID in sorted( taskDict ):
+      paramDict = taskDict[taskID]
+      if not paramDict['InputData']:
+        taskDict.pop( taskID )
+        continue
+      files = []
+
+      transID = paramDict['TransformationID']
+      oRequest = Request()
+      if isinstance( paramDict['InputData'], list ):
+        files = paramDict['InputData']
+      elif isinstance( paramDict['InputData'], basestring ):
+        files = paramDict['InputData'].split( ';' )
+
+      # create the operations from the json structure
+      for operationTuple in transJson:
+        op = Operation()
+        op.Type = operationTuple[0]
+        for parameter, value in operationTuple[1].iteritems():
+          setattr( op, parameter, value )
+
+        for lfn in files:
+          opFile = File()
+          opFile.LFN = lfn
+          op.addFile( opFile )
+
+        oRequest.addOperation( op )
+
+      self._addOrPop( oRequest, taskDict, transID, taskID, ownerDN, ownerGroup )
+
+  def _singleOperationsBody(self, transBody, taskDict, ownerDN, ownerGroup ):
+    """ deal with a Request that has just one operation, as it was sofar
+
+    :param transBody: string, can be an empty string
+    :param dict taskDict: dictionary of tasks, modified in this function
+    :param str ownerDN: certificate DN used for the requests
+    :param str onwerGroup: dirac group used for the requests
+    :returns: None
+    """
+
     requestOperation = 'ReplicateAndRegister'
     if transBody:
       try:
@@ -169,20 +228,34 @@ class RequestTasks( TaskBase ):
           transfer.addFile( trFile )
 
       oRequest.addOperation( transfer )
-      oRequest.RequestName = _requestName( transID, taskID )
-      oRequest.OwnerDN = ownerDN
-      oRequest.OwnerGroup = ownerGroup
+      self._addOrPop( oRequest, taskDict, transID, taskID, ownerDN, ownerGroup )
 
-      isValid = self.requestValidator.validate( oRequest )
-      if not isValid['OK']:
-        self.log.error( "Error creating request for task", "%s %s" % ( taskID, isValid ) )
-        # This works because we loop over a copy of the keys !
-        taskDict.pop( taskID )
-        continue
+  def _addOrPop( self, oRequest, taskDict, transID, taskID, ownerDN, ownerGroup ):
+    """set ownerDN and group to request, and add the request to taskDict if it is
+    valid, otherwise remove the task from the taskDict
 
-      taskDict[taskID]['TaskObject'] = oRequest
+    :param oRequest: Request
+    :param dict taskDict: dictionary of tasks, modified in this function
+    :param int transID: Transformation ID
+    :param int taskID: Task ID
+    :param str ownerDN: certificate DN used for the requests
+    :param str onwerGroup: dirac group used for the requests
+    :returns: None
+    """
 
-    return S_OK( taskDict )
+    oRequest.RequestName = _requestName( transID, taskID )
+    oRequest.OwnerDN = ownerDN
+    oRequest.OwnerGroup = ownerGroup
+
+    isValid = self.requestValidator.validate( oRequest )
+    if not isValid['OK']:
+      self.log.error( "Error creating request for task", "%s %s" % ( taskID, isValid ) )
+      # This works because we loop over a copy of the keys !
+      taskDict.pop( taskID )
+      return
+    taskDict[taskID]['TaskObject'] = oRequest
+    return
+
 
   def submitTransformationTasks( self, taskDict ):
     """ Submit requests one by one

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -150,7 +150,14 @@ class RequestTasks( TaskBase ):
   def _multiOperationsBody( self, transJson, taskDict, ownerDN, ownerGroup ):
     """ deal with a Request that has multiple operations
 
-    :param transJson: list of tuples of string and dictionaries
+    :param transJson: list of lists of string and dictionaries, e.g.:
+
+      .. code :: python
+
+        body = [ ( "ReplicateAndRegister", { "SourceSE":"FOO-SRM", "TargetSE":"BAR-SRM" }),
+                 ( "RemoveReplica", { "TargetSE":"FOO-SRM" } ),
+               ]
+
     :param dict taskDict: dictionary of tasks, modified in this function
     :param str ownerDN: certificate DN used for the requests
     :param str onwerGroup: dirac group used for the requests

--- a/TransformationSystem/Client/Transformation.py
+++ b/TransformationSystem/Client/Transformation.py
@@ -2,6 +2,7 @@
 """
 
 import types
+import json
 
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR
 from DIRAC.Core.Utilities.PromptUser import promptUser
@@ -90,6 +91,43 @@ class Transformation( API ):
 
   def setSourceSE( self, seList ):
     return self.__setSE( 'SourceSE', seList )
+
+  def setBody( self, body ):
+    """ check that the body is a string, or using the proper syntax for multiple operations
+
+    :param body: transformation body, for example
+
+      .. code :: python
+
+        body = [ ( "ReplicateAndRegister", { "SourceSE":"FOO-SRM", "TargetSE":"BAR-SRM" }),
+                 ( "RemoveReplica", { "TargetSE":"FOO-SRM" } ),
+               ]
+
+    :type body: string or list of tuples (or lists) of string and dictionaries
+    :raises TypeError: If the structure is not as expected
+    :returns: S_OK, S_ERROR
+    """
+    self.item_called = "Body"
+    if isinstance( body, basestring ):
+      return self.__setParam( body )
+    if not isinstance( body, list ):
+      raise TypeError( "Expected list or string, but %r is %s" % ( body, type( body ) ) )
+
+    for tup in body:
+      if not isinstance( tup, (tuple, list) ):
+        raise TypeError( "Expected tuple or list, but %r is %s" % ( tup, type( tup ) ) )
+      if len(tup) != 2:
+        raise TypeError( "Expected 2-tuple, but %r is length %d" % ( tup, len( tup ) ) )
+      if not isinstance( tup[0], basestring ):
+        raise TypeError( "Expected string, but first entry in tuple %r is %s" % ( tup, type( tup[0] ) ) )
+      if not isinstance( tup[1], dict ):
+        raise TypeError( "Expected dictionary, but second entry in tuple %r is %s" % ( tup, type( tup[0] ) ) )
+      for par, val in tup[1].iteritems():
+        if not isinstance( par, basestring ):
+          raise TypeError( "Expected string, but key in dictionary %r is %s" % ( par, type( par ) ) )
+        if not isinstance( val, ( basestring, int, long, float, list, tuple, dict ) ):
+          raise TypeError( "Cannot encode %r, in json" % ( val ) )
+      return self.__setParam( json.dumps( body ) )
 
   def __setSE( self, seParam, seList ):
     if isinstance( seList, basestring ):

--- a/TransformationSystem/Client/Transformation.py
+++ b/TransformationSystem/Client/Transformation.py
@@ -110,7 +110,7 @@ class Transformation( API ):
     self.item_called = "Body"
     if isinstance( body, basestring ):
       return self.__setParam( body )
-    if not isinstance( body, list ):
+    if not isinstance( body, (list, tuple) ):
       raise TypeError( "Expected list or string, but %r is %s" % ( body, type( body ) ) )
 
     for tup in body:

--- a/TransformationSystem/Client/Transformation.py
+++ b/TransformationSystem/Client/Transformation.py
@@ -10,6 +10,7 @@ from DIRAC.Core.Base.API import API
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
+from DIRAC.RequestManagementSystem.Client.Operation import Operation
 
 COMPONENT_NAME = 'Transformation'
 
@@ -105,6 +106,7 @@ class Transformation( API ):
 
     :type body: string or list of tuples (or lists) of string and dictionaries
     :raises TypeError: If the structure is not as expected
+    :raises ValueError: If unknown attribute for the :class:`~DIRAC.RequestManagementSystem.Client.Operation.Operation` is used
     :returns: S_OK, S_ERROR
     """
     self.item_called = "Body"
@@ -125,6 +127,8 @@ class Transformation( API ):
       for par, val in tup[1].iteritems():
         if not isinstance( par, basestring ):
           raise TypeError( "Expected string, but key in dictionary %r is %s" % ( par, type( par ) ) )
+        if not par in Operation.ATTRIBUTE_NAMES:
+          raise ValueError( "Unknown attribute for Operation: %s" % par )
         if not isinstance( val, ( basestring, int, long, float, list, tuple, dict ) ):
           raise TypeError( "Cannot encode %r, in json" % ( val ) )
       return self.__setParam( json.dumps( body ) )

--- a/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -213,6 +213,15 @@ class RequestTasksSuccess( ClientsTestCase ):
       except IndexError:
         self.assertEqual( task['TaskObject'][0].Status, 'Waiting' )
 
+    ## test another (single) OperationType
+    res = self.requestTasks.prepareTransformationTasks( 'someType;LogUpload', taskDict, 'owner', 'ownerGroup', '/bih/boh/DN' )
+    self.assert_( res['OK'] )
+    # We should "lose" one of the task in the preparation
+    self.assertEqual( len( taskDict ), 2 )
+    for task in res['Value'].values():
+      self.assert_( isinstance( task['TaskObject'], Request ) )
+      self.assertEqual( task['TaskObject'][0].Type, 'LogUpload' )
+
     ### Multiple operations
     transBody = [ ("ReplicateAndRegister", { "SourceSE":"FOO-SRM", "TargetSE":"BAR-SRM" }),
                   ("RemoveReplica", { "TargetSE":"FOO-SRM" } ),

--- a/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -386,7 +386,7 @@ class TransformationSuccess( ClientsTestCase ):
     self.assertEqual( json.loads( self.transformation.paramValues[ "Body" ] ), transBody )
 
     with self.assertRaisesRegexp( TypeError, "Expected list" ):
-      self.transformation.setBody( ( "ReplicateAndRegister", "RemoveReplica" ) )
+      self.transformation.setBody( {"ReplicateAndRegister":{"foo":"bar"} } )
     with self.assertRaisesRegexp( TypeError, "Expected tuple" ):
       self.transformation.setBody( [ "ReplicateAndRegister", "RemoveReplica" ] )
     with self.assertRaisesRegexp( TypeError, "Expected 2-tuple" ):

--- a/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -397,8 +397,10 @@ class TransformationSuccess( ClientsTestCase ):
       self.transformation.setBody( [ ("ReplicateAndRegister", "parameter=foo") ] )
     with self.assertRaisesRegexp( TypeError, "Expected string" ):
       self.transformation.setBody( [ ("ReplicateAndRegister", { 123: "foo" } ) ] )
+    with self.assertRaisesRegexp( ValueError, "Unknown attribute" ):
+      self.transformation.setBody( [ ("ReplicateAndRegister", { "Request": Request() } ) ] )
     with self.assertRaisesRegexp( TypeError, "Cannot encode" ):
-      self.transformation.setBody( [ ("ReplicateAndRegister", { "Request":  Request() } ) ] )
+      self.transformation.setBody( [ ("ReplicateAndRegister", { "Arguments": Request() } ) ] )
 
   def test_SetGetReset( self ):
     """ Testing of the set, get and reset methods.

--- a/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -5,6 +5,7 @@
 
 import unittest
 import types
+import json
 
 from mock import MagicMock
 from DIRAC import gLogger
@@ -212,6 +213,41 @@ class RequestTasksSuccess( ClientsTestCase ):
       except IndexError:
         self.assertEqual( task['TaskObject'][0].Status, 'Waiting' )
 
+    ### Multiple operations
+    transBody = [ ("ReplicateAndRegister", { "SourceSE":"FOO-SRM", "TargetSE":"BAR-SRM" }),
+                  ("RemoveReplica", { "TargetSE":"FOO-SRM" } ),
+                ]
+    jsonBody = json.dumps(transBody)
+
+    taskDict = {1:{'TransformationID':1, 'TargetSE':'SE1', 'b1':'bb1', 'Site':'MySite',
+                   'InputData':['/this/is/a1.lfn', '/this/is/a2.lfn']},
+                2:{'TransformationID':1, 'TargetSE':'SE2', 'b2':'bb2', 'InputData':"/this/is/a1.lfn;/this/is/a2.lfn"},
+                3:{'TransformationID':2, 'TargetSE':'SE3', 'b3':'bb3', 'InputData':''}}
+
+    res = self.requestTasks.prepareTransformationTasks( jsonBody, taskDict, 'owner', 'ownerGroup', '/bih/boh/DN' )
+    self.assert_( res['OK'] )
+    # We should "lose" one of the task in the preparation
+    self.assertEqual( len( taskDict ), 2 )
+    for task in res['Value'].values():
+      self.assert_( isinstance( task['TaskObject'], Request ) )
+      self.assertEqual( task['TaskObject'][0].Type, 'ReplicateAndRegister' )
+      self.assertEqual( task['TaskObject'][1].Type, 'RemoveReplica' )
+      try:
+        self.assertEqual( task['TaskObject'][0][0].LFN, '/this/is/a1.lfn' )
+        self.assertEqual( task['TaskObject'][1][0].LFN, '/this/is/a1.lfn' )
+      except IndexError:
+        self.assertEqual( task['TaskObject'][0].Status, 'Waiting' )
+        self.assertEqual( task['TaskObject'][1].Status, 'Waiting' )
+      try:
+        self.assertEqual( task['TaskObject'][0][1].LFN, '/this/is/a2.lfn' )
+        self.assertEqual( task['TaskObject'][1][1].LFN, '/this/is/a2.lfn' )
+      except IndexError:
+        self.assertEqual( task['TaskObject'][0].Status, 'Waiting' )
+        self.assertEqual( task['TaskObject'][1].Status, 'Waiting' )
+
+      self.assertEqual( task['TaskObject'][0].SourceSE, 'FOO-SRM' )
+      self.assertEqual( task['TaskObject'][0].TargetSE, 'BAR-SRM' )
+      self.assertEqual( task['TaskObject'][1].TargetSE, 'FOO-SRM' )
 
 #############################################################################
 
@@ -317,6 +353,43 @@ class TransformationSuccess( ClientsTestCase ):
     self.assert_( res['OK'] )
     res = self.transformation.setPlugin( 'aPlugin' )
     self.assertTrue( res['OK'] )
+
+    ## Test DataOperation Body
+
+    res = self.transformation.setBody( "" )
+    self.assertTrue( res['OK'] )
+    self.assertEqual( self.transformation.paramValues[ "Body" ], "" )
+
+    res = self.transformation.setBody( "_requestType;RemoveReplica" )
+    self.assertTrue( res['OK'] )
+    self.assertEqual( self.transformation.paramValues[ "Body" ], "_requestType;RemoveReplica" )
+
+    ##Json will turn tuples to lists and strings to unicode
+    transBody = [ [ u"ReplicateAndRegister", { u"SourceSE":u"FOO-SRM", u"TargetSE":u"BAR-SRM" }],
+                  [ u"RemoveReplica", { u"TargetSE":u"FOO-SRM" } ],
+                ]
+    res = self.transformation.setBody( transBody )
+    self.assertTrue( res['OK'] )
+
+    self.assertEqual( self.transformation.paramValues[ "Body" ], json.dumps( transBody ) )
+
+    ## This is not true if any of the keys or values are not strings, e.g., integers
+    self.assertEqual( json.loads( self.transformation.paramValues[ "Body" ] ), transBody )
+
+    with self.assertRaisesRegexp( TypeError, "Expected list" ):
+      self.transformation.setBody( ( "ReplicateAndRegister", "RemoveReplica" ) )
+    with self.assertRaisesRegexp( TypeError, "Expected tuple" ):
+      self.transformation.setBody( [ "ReplicateAndRegister", "RemoveReplica" ] )
+    with self.assertRaisesRegexp( TypeError, "Expected 2-tuple" ):
+      self.transformation.setBody( [ ( "ReplicateAndRegister", "RemoveReplica", "LogUpload" ) ] )
+    with self.assertRaisesRegexp( TypeError, "Expected string" ):
+      self.transformation.setBody( [ ( 123, "Parameter:Value" ) ] )
+    with self.assertRaisesRegexp( TypeError, "Expected dictionary" ):
+      self.transformation.setBody( [ ("ReplicateAndRegister", "parameter=foo") ] )
+    with self.assertRaisesRegexp( TypeError, "Expected string" ):
+      self.transformation.setBody( [ ("ReplicateAndRegister", { 123: "foo" } ) ] )
+    with self.assertRaisesRegexp( TypeError, "Cannot encode" ):
+      self.transformation.setBody( [ ("ReplicateAndRegister", { "Request":  Request() } ) ] )
 
   def test_SetGetReset( self ):
     """ Testing of the set, get and reset methods.

--- a/docs/source/AdministratorGuide/Systems/Transformation/index.rst
+++ b/docs/source/AdministratorGuide/Systems/Transformation/index.rst
@@ -355,11 +355,46 @@ Generation of bulk data removal/replication requests from a fixed file list or a
 
 **Note:**
 
-* It's not needed to set a Plugin, the default is 'Standard'
-* It's mandatory to set the Body, otherwise the default operation is 'ReplicateAndRegister'
-* It's not needed to set a SourceSE nor a TargetSE
-* This script remove all replicas of each file. We should verify how to remove only a subset of replicas (SourceSE?)
-* If you add non existing files to a Transformation, you won't get any particular status, the Transformation just does not progress
+  * It's not needed to set a Plugin, the default is 'Standard'
+  * It's mandatory to set the Body, otherwise the default operation is 'ReplicateAndRegister'
+  * It's not needed to set a SourceSE nor a TargetSE
+  * This script remove all replicas of each file. We should verify how to remove only a subset of replicas (SourceSE?)
+  * If you add non existing files to a Transformation, you won't get any particular status, the Transformation just does not progress
+
+
+* Example for Multiple Operations
+
+
+  .. code:: python
+
+    from DIRAC.TransformationSystem.Client.Transformation import Transformation
+    from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
+
+    infileList = []
+    ...
+
+    t = Transformation( )
+    tc = TransformationClient( )
+    t.setTransformationName("DM_Moving") # Must be unique
+    #t.setTransformationGroup("Moving")
+    t.setType("Moving")
+    t.setPlugin("Standard") # Not needed. The default is 'Standard'
+    t.setDescription("dataset1 Moving")
+    t.setLongDescription( "Long description of dataset1 Moving" ) # Mandatory
+    t.setGroupSize(2) # Here you specify how many files should be grouped within he same request, e.g. 100
+
+    transBody = [ ( "ReplicateAndRegister", { "SourceSE":"FOO-SRM", "TargetSE":"BAR-SRM" }),
+                  ( "RemoveReplica", { "TargetSE":"FOO-SRM" } ),
+                ]
+
+    t.setBody ( transBody ) # Mandatory
+    t.addTransformation() # Transformation is created here
+    t.setStatus("Active")
+    t.setAgentType("Automatic")
+    transID = t.getTransformationID()
+    tc.addFilesToTransformation(transID['Value'],infileList) # Files are added here
+
+
 
 Data replication based on Catalog Query
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The goal is to stay backward compatible, so we need to identify when we
have a multi-operation request and when the old style is used
And arbitrary chains of requests must be supported. I describe the multiple operations as  list of tuples, where each tuple is a string and a dictionary of parameter and parameter values.
For example
```python
...
  transBody = [ ("ReplicateAndRegister", { "SourceSE":sourceSE,
"TargetSE":targetSE }),
                ("RemoveReplica", { "TargetSE":sourceSE } ),
              ]
  jsonBody = json.dumps( transBody )
  trans.setBody( jsonBody )
...
```

Currently defined productions they either have no body, or just a
string, which is not in json format(i.e. `json.loads` fails), so we can use that to differentiate
old and new.

This should allow one to chain all current and future Operations and all
parameters, as long as parameter values can be parsed by json.

Added explicit transformation.setBody function to check the proper syntax if the body structure is used if something other than a string is placed in the body of the transformation

Also including tests and documentation.