### PR TITLE
[v6r15] RMS TimeOut and FTS Canceled request

### DIFF
--- a/Core/Utilities/ProcessPool.py
+++ b/Core/Utilities/ProcessPool.py
@@ -106,6 +106,7 @@ import threading
 import os
 import signal
 import Queue
+import errno
 from types import FunctionType, TypeType, ClassType
 
 try:
@@ -296,7 +297,7 @@ class WorkingProcess( multiprocessing.Process ):
       ## processThread is still alive? stop it!
       if self.__processThread.is_alive():
         self.__processThread._Thread__stop()
-        self.task.setResult( S_ERROR("Timed out") )  
+        self.task.setResult( S_ERROR( errno.ETIME, "Timed out" ) )
         timeout = True
       # if the task finished with no results, something bad happened, e.g. 
       # undetected timeout  

--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -172,6 +172,17 @@ class FTSAgent( AgentModule ):
   @classmethod
   def getRequest( cls, reqID ):
     """ get Requests systematically and refresh cache """
+
+    # Make sure the request is Scheduled
+    res = cls.requestClient().getRequestStatus( reqID )
+    if not res['OK']:
+      cls.__reqCache.pop( reqID, None )
+      return res
+    status = res['Value']
+    if status != 'Scheduled':
+      cls.__reqCache.pop( reqID, None )
+      return S_ERROR( "Request with id %s is not Scheduled:%s" % ( reqID, status ) )
+
     getRequest = cls.requestClient().getRequest( reqID )
     if not getRequest["OK"]:
       cls.__reqCache.pop( reqID, None )

--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -32,6 +32,8 @@ from DIRAC.Core.Utilities.ProcessPool import ProcessPool
 from DIRAC.RequestManagementSystem.Client.ReqClient import ReqClient
 from DIRAC.RequestManagementSystem.private.RequestTask import RequestTask
 
+from DIRAC.Core.Utilities.DErrno import cmpError
+import errno
 # # agent name
 AGENT_NAME = "RequestManagement/RequestExecutingAgent"
 
@@ -207,7 +209,7 @@ class RequestExecutingAgent( AgentModule ):
       if taskResult and taskResult['OK']:
         request = taskResult['Value']
       # In case of timeout, we need to increment ourselves all the attempts
-      elif taskResult and not taskResult['OK'] and taskResult['Message'] == 'Timed out':
+      elif taskResult and not taskResult['OK'] and cmpError( taskResult, errno.ETIME ):
         waitingOp = request.getWaiting()
         for rmsFile in waitingOp.get( 'Value', [] ):
           rmsFile.Attempt += 1

--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -206,6 +206,11 @@ class RequestExecutingAgent( AgentModule ):
       request = self.__requestCache.pop( requestID )
       if taskResult and taskResult['OK']:
         request = taskResult['Value']
+      # In case of timeout, we need to increment ourselves all the attempts
+      elif taskResult and not taskResult['OK'] and taskResult['Message'] == 'Timed out':
+        waitingOp = request.getWaiting()
+        for rmsFile in waitingOp.get( 'Value', [] ):
+          rmsFile.Attempt += 1
 
       reset = self.requestClient().putRequest( request, useFailoverProxy = False, retryMainService = 2 )
       if not reset["OK"]:

--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -206,13 +206,14 @@ class RequestExecutingAgent( AgentModule ):
     """
     if requestID in self.__requestCache:
       request = self.__requestCache.pop( requestID )
-      if taskResult and taskResult['OK']:
-        request = taskResult['Value']
-      # In case of timeout, we need to increment ourselves all the attempts
-      elif taskResult and not taskResult['OK'] and cmpError( taskResult, errno.ETIME ):
-        waitingOp = request.getWaiting()
-        for rmsFile in waitingOp.get( 'Value', [] ):
-          rmsFile.Attempt += 1
+      if taskResult:
+        if taskResult['OK']:
+          request = taskResult['Value']
+        # In case of timeout, we need to increment ourselves all the attempts
+        elif cmpError( taskResult, errno.ETIME ):
+          waitingOp = request.getWaiting()
+          for rmsFile in waitingOp.get( 'Value', [] ):
+            rmsFile.Attempt += 1
 
       reset = self.requestClient().putRequest( request, useFailoverProxy = False, retryMainService = 2 )
       if not reset["OK"]:


### PR DESCRIPTION
* When the processing of an operation times out, there was no increment of the attempts done. Now yes.
* Avoid FTS to fetch a request that was canceled (https://groups.google.com/forum/#!topic/diracgrid-forum/J8FOcskLxBU)

This is WIP because I would like @phicharp to double check the fix for FTS, since it is a very tricky system...