### PR TITLE
[v6r15] RunLocalJob: Fix download of LFNs in InputSandbox when running job lo…

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -877,7 +877,9 @@ class Dirac( API ):
       if isinstance( sandbox, basestring ):
         sandbox = [sandbox]
       for isFile in sandbox:
-        if not os.path.isabs( isFile ):
+        if isFile.lower().startswith("lfn:"): #isFile is an LFN
+          isFile = isFile[4:]
+        elif not os.path.isabs( isFile ):
           # if a relative path, it is relative to the user working directory
           isFile = os.path.join( baseDir, isFile )
 


### PR DESCRIPTION
…cally

If file in sandbox starts with "lfn:" one couldn't run the job locally.