### PR TITLE
[v6r15] Fix: FCC getDirectoryUserMetadata was not working

### DIFF
--- a/Resources/Catalog/FileCatalogClient.py
+++ b/Resources/Catalog/FileCatalogClient.py
@@ -519,7 +519,7 @@ class FileCatalogClient( FileCatalogClientBase ):
   def getDirectoryUserMetadata( self, path, timeout = 120 ):
     """ Get all the metadata valid for the given directory path
     """
-    return self._getRPC( timeout = timeout ).dmeta.getDirectoryMetadata( path )
+    return self._getRPC( timeout = timeout ).getDirectoryUserMetadata( path )
 
 
   def findDirectoriesByMetadata( self, metaDict, path = '/', timeout = 120 ):


### PR DESCRIPTION

`'Message': 'Unknown method dmeta.getDirectoryMetadata',`

Also want to get userMetadata in this function.