### PR TITLE
[v6r15] HTCondor: more resilient status checking

### DIFF
--- a/Resources/Computing/BatchSystems/Condor.py
+++ b/Resources/Computing/BatchSystems/Condor.py
@@ -14,6 +14,44 @@ __RCSID__ = "$Id$"
 
 import re, tempfile, commands, os
 
+def parseCondorStatus( lines, jobID ):
+  """parse the condor_q or condor_history output for the job status
+
+  :param list lines: list of lines from the output of the condor commands, each line is a pair of jobID and statusID
+  :param str jobID: jobID of condor job, e.g.: 123.53
+  :returns: Status as known by DIRAC
+  """
+  jobID = str(jobID)
+  for line in lines:
+    l = line.strip().split()
+    status = int( l[1] )
+    if l[0] == jobID:
+      return { 1: 'Waiting',
+               2: 'Running',
+               3: 'Aborted',
+               4: 'Done',
+               5: 'HELD'
+             }.get( status, 'Unknown' )
+  return 'Unknown'
+
+def treatCondorHistory( condorHistCall, qList ):
+  """concatenate clusterID and processID to get the same output as condor_q
+  until we can expect condor version 8.5.3 everywhere
+
+  :param str condorHistCall: condor_history command to run
+  :param list qList: list of jobID and status from condor_q output, will be modified in this function
+  :returns: None
+  """
+  status_history,stdout_history_temp = commands.getstatusoutput( condorHistCall )
+
+  ## Join the ClusterId and the ProcId and add to existing list of statuses
+  if status_history==0:
+    for line in stdout_history_temp.split('\n'):
+      values = line.strip().split()
+      if len(values) == 3:
+        qList.append( "%s.%s %s" % tuple(values) )
+
+
 class Condor( object ):
 
   def submitJob( self, **kwargs ):
@@ -152,35 +190,29 @@ class Condor( object ):
       resultDict['Message'] = 'No user name'
       return resultDict
     
-    status,stdout_q = commands.getstatusoutput( 'condor_q -submitter %s' % user )
+    status,stdout_q = commands.getstatusoutput( 'condor_q -submitter %s -af:j JobStatus  ' % user )
     
     if status != 0:
       resultDict['Status'] = status
       resultDict['Message'] = stdout_q
       return resultDict
-      
-    status_history, stdout_history = commands.getstatusoutput( 'condor_history | grep %s' % user )  
-    
-    stdout = stdout_q
-    if status_history == 0:
-      stdout = '\n'.join( [stdout_q,stdout_history] )
+
+    qList = stdout_q.strip().split('\n')
+
+    ##FIXME: condor_history does only support j for autoformat from 8.5.3,
+    ## format adds whitespace for each field This will return a list of 1245 75 3
+    ## needs to cocatenate the first two with a dot
+    condorHistCall = 'condor_history -af ClusterId ProcId JobStatus -submitter %s' % user
+    treatCondorHistory( condorHistCall, qList )
   
     statusDict = {}
-    if len( stdout ):
-      lines = stdout.split( '\n' )
-      for line in lines:
-        l = line.strip()
-        for job in jobIDList:
-          if l.startswith( job ):
-            if " I " in line:
-              statusDict[job] = 'Waiting'
-            elif " R " in line:
-              statusDict[job] = 'Running'
-            elif " C " in line:
-              statusDict[job] = 'Done'
-            elif " X " in line:
-              statusDict[job] = 'Aborted'    
-  
+    if len( qList ):
+      for job in jobIDList:
+        job = str(job)
+        statusDict[job] = parseCondorStatus( qList, job )
+        if statusDict[job] == 'HELD':
+          statusDict[job] = 'Unknown'
+
     if len( statusDict ) != len( jobIDList ):
       for job in jobIDList:
         if not job in statusDict:

--- a/Resources/Computing/BatchSystems/Condor.py
+++ b/Resources/Computing/BatchSystems/Condor.py
@@ -213,11 +213,6 @@ class Condor( object ):
         if statusDict[job] == 'HELD':
           statusDict[job] = 'Unknown'
 
-    if len( statusDict ) != len( jobIDList ):
-      for job in jobIDList:
-        if not job in statusDict:
-          statusDict[job] = 'Unknown'
-          
     # Final output
     status = 0
     resultDict['Status'] = 0

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -250,11 +250,6 @@ Queue %(nJobs)s
 
       resultDict[job] = pilotStatus
 
-    if len( resultDict ) != len( jobIDList ):
-      for jobRef in jobIDList:
-        job = jobRef.split( ":::" )[0]
-        if job not in resultDict:
-          resultDict[job] = 'Unknown'
     self.log.verbose( "Pilot Statuses: %s " % resultDict )
     return S_OK( resultDict )
 

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -24,6 +24,8 @@ from DIRAC.WorkloadManagementSystem.Agent.SiteDirector   import WAITING_PILOT_ST
 from DIRAC.Core.Utilities.File                           import makeGuid
 from DIRAC.Core.Utilities.Subprocess                     import Subprocess
 
+from DIRAC.Resources.Computing.BatchSystems.Condor import parseCondorStatus, treatCondorHistory
+
 __RCSID__ = "$Id$"
 
 CE_NAME = 'HTCondorCE'
@@ -35,22 +37,6 @@ def condorIDFromJobRef( jobRef ):
   jobURL = jobRef.split(":::")[0]
   condorID = jobURL.split("/")[-1]
   return jobURL,condorID
-
-def parseCondorStatus( lines, jobID ):
-  """parse the condor_q or condor_history output for the job status"""
-  for line in lines:
-    if line.strip().startswith( jobID ):
-      if " I " in line:
-        return 'Waiting'
-      elif " R " in line:
-        return 'Running'
-      elif " C " in line:
-        return 'Done'
-      elif " X " in line:
-        return 'Aborted'
-      elif " H " in line:
-        return 'HELD'
-  return 'Unknown'
 
 def findFile( workingDir, fileName ):
   """ find a pilot out, err, log file """
@@ -240,19 +226,22 @@ Queue %(nJobs)s
       job,jobID = condorIDFromJobRef( jobRef )
       condorIDs[job] = jobID
 
-    status,stdout_q = commands.getstatusoutput( 'condor_q %s' % ' '.join(condorIDs.values()) )
+    ##This will return a list of 1245.75 3
+    status,stdout_q = commands.getstatusoutput( 'condor_q -af:j JobStatus %s' % ' '.join(condorIDs.values()) )
     if status != 0:
       return S_ERROR( stdout_q )
+    qList = stdout_q.strip().split('\n')
 
-    status_history,stdout_history = commands.getstatusoutput( 'condor_history %s ' % ' '.join(condorIDs.values()) )
-    if status_history == 0:
-      stdout_q = '\n'.join( [stdout_q,stdout_history] )
+    ##FIXME: condor_history does only support j for autoformat from 8.5.3,
+    ## format adds whitespace for each field This will return a list of 1245 75 3
+    ## needs to cocatenate the first two with a dot
+    condorHistCall = 'condor_history -af ClusterId ProcId JobStatus %s' % ' '.join( condorIDs.values() )
 
-    lines = stdout_q.split( '\n' )
+    treatCondorHistory( condorHistCall, qList )
 
     for job,jobID in condorIDs.iteritems():
 
-      pilotStatus = parseCondorStatus( lines, jobID )
+      pilotStatus = parseCondorStatus( qList, jobID )
       if pilotStatus == 'HELD':
         #make sure the pilot stays dead and gets taken out of the condor_q
         _rmStat, _rmOut = commands.getstatusoutput( 'condor_rm %s ' % jobID )

--- a/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -1,0 +1,113 @@
+#!/bin/env python
+"""
+tests for HTCondorCECompulintElement module
+"""
+
+import sys
+import unittest
+from mock import MagicMock as Mock, patch
+import mock
+
+from DIRAC.Resources.Computing import HTCondorCEComputingElement as HTCE
+from DIRAC.Resources.Computing.BatchSystems import Condor
+MODNAME = "DIRAC.Resources.Computing.HTCondorCEComputingElement"
+
+STATUS_LINES = """
+123.2 5
+123.1 3
+""".strip().split('\n')
+
+HISTORY_LINES ="""
+123 0 4
+""".strip().split('\n')
+
+class HTCondorCETests( unittest.TestCase ):
+
+  def setUp( self ):
+    pass
+
+  def tearDown( self ):
+    pass
+
+
+  def test_parseCondorStatus( self ):
+    statusLines = """
+    104097.9 2
+    104098.0 1
+    104098.1 4
+    104098.2 3
+    104098.3 5
+    104098.4 7
+    """.strip().split('\n')
+
+    expectedResults = {
+      "104097.9": "Running",
+      "104098.0": "Waiting",
+      "104098.1": "Done",
+      "104098.2": "Aborted",
+      "104098.3": "HELD",
+      "104098.4": "Unknown",
+    }
+    for jobID, expected in expectedResults.iteritems():
+      self.assertEqual( HTCE.parseCondorStatus( statusLines, jobID ), expected )
+
+  def test_getJobStatus( self ):
+
+    htce = HTCE.HTCondorCEComputingElement( 12345 )
+
+    with patch( MODNAME+".commands.getstatusoutput", new=Mock(
+      side_effect=( [ (0, "\n".join(STATUS_LINES) ), # condor_q
+                      (0, "\n".join(HISTORY_LINES)), # condor_history
+                      (0, 0), # condor_rm, ignored in any case
+                    ] ))), \
+      patch( MODNAME+".HTCondorCEComputingElement._HTCondorCEComputingElement__cleanup", new=Mock() ) \
+      :
+      ret = htce.getJobStatus( ["htcondorce://condorce.foo.arg/123.0:::abc321",
+                                "htcondorce://condorce.foo.arg/123.1:::c3b2a1",
+                                "htcondorce://condorce.foo.arg/123.2:::c3b2a2",
+                                "htcondorce://condorce.foo.arg/333.3:::c3b2a3",
+                               ]
+                             )
+
+    expectedResults = { "htcondorce://condorce.foo.arg/123.0":"Done",
+                        "htcondorce://condorce.foo.arg/123.1":"Aborted",
+                        "htcondorce://condorce.foo.arg/123.2":"Aborted",
+                        "htcondorce://condorce.foo.arg/333.3":"Unknown",
+                      }
+
+    self.assertTrue( ret['OK'] , ret.get('Message', '') )
+    self.assertEqual( expectedResults, ret['Value'] )
+    
+
+
+
+
+class BatchCondorTest( unittest.TestCase ):
+  """ tests for the plain batchSystem Condor Module """
+
+  def test_getJobStatus( self ):
+
+    with patch( MODNAME+".commands.getstatusoutput", new=Mock(
+      side_effect=( [ (0, "\n".join(STATUS_LINES) ), # condor_q
+                      (0, "\n".join(HISTORY_LINES)), # condor_history
+                    ] ))):
+      ret = Condor.Condor().getJobStatus( JobIDList = [ "123.0",
+                                                        "123.1",
+                                                        "123.2",
+                                                        "333.3",
+                                                      ]
+                                        )
+
+    expectedResults = { "123.0":"Done",
+                        "123.1":"Aborted",
+                        "123.2":"Unknown", ##HELD is treated as Unknown
+                        "333.3":"Unknown",
+                      }
+
+    self.assertEqual( ret['Status'] , 0 )
+    self.assertEqual( expectedResults, ret['Jobs'] )
+
+if __name__ == '__main__':
+  SUITE = unittest.defaultTestLoader.loadTestsFromTestCase( HTCondorCETests )
+  SUITE.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( BatchCondorTest ) )
+  unittest.TextTestRunner( verbosity = 2 ).run( SUITE )

--- a/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -1,12 +1,10 @@
 #!/bin/env python
 """
-tests for HTCondorCECompulintElement module
+tests for HTCondorCEComputingElement module
 """
 
-import sys
 import unittest
 from mock import MagicMock as Mock, patch
-import mock
 
 from DIRAC.Resources.Computing import HTCondorCEComputingElement as HTCE
 from DIRAC.Resources.Computing.BatchSystems import Condor
@@ -22,6 +20,7 @@ HISTORY_LINES ="""
 """.strip().split('\n')
 
 class HTCondorCETests( unittest.TestCase ):
+  """ tests for the HTCondorCE Module """
 
   def setUp( self ):
     pass


### PR DESCRIPTION
The output from condor_q/history is not guaranteed to be stable. (as far as I remember it was supposed to change in 8.5, but I don't see any signifcant difference in 8.5.5)
In any case I added "autoformat" calls to condor_q and condor_history to have a guaranteed output from these calls.

Moved parseCondorStatus to BatchSystems/Condor so it can ge re-used.

Also added tests for the getJobStatus functions

Is this needed for v6r14 as well?