### PR TITLE
[v6r15] CREAMComputingElement: Fix parsing of return value

### DIFF
--- a/Resources/Computing/CREAMComputingElement.py
+++ b/Resources/Computing/CREAMComputingElement.py
@@ -120,7 +120,8 @@ class CREAMComputingElement( ComputingElement ):
       if result['OK']:
         if result['Value'][0]:
           # We have got a non-zero status code
-          return S_ERROR( 'Pilot submission failed with error: %s ' % result['Value'][2].strip() )
+          errorString = '\n'.join( result['Value'][1:] ).strip()
+          return S_ERROR( 'Pilot submission failed with error: %s ' % errorString )
         pilotJobReference = result['Value'][1].strip()
         if not pilotJobReference:
           return S_ERROR( 'No pilot reference returned from the glite job submission command' )
@@ -171,7 +172,8 @@ class CREAMComputingElement( ComputingElement ):
     if not result['OK']:
       return result
     if result['Value'][0] != 0:
-      return S_ERROR( 'Failed kill job: %s' % result['Value'][0][1] )
+      errorString = '\n'.join( result['Value'][1:] ).strip()
+      return S_ERROR( 'Failed kill job: %s' % errorString )
 
     return S_OK()
 


### PR DESCRIPTION
 printout stdout and stderr for failed calls. (Not entirely sure what is in [1] and what is in [2], or where the commands even put the output on errors, so print both just in case).

first change: the error string is more often in item 1 of `result['Value']`
e.g.:
```
ERROR:  Pilot submission failed with error: 1: 2016-07-26 15:36:56,585 FATAL - Received NULL fault; the error is due to another cause: FaultString=[connection error] - FaultCo
de=[SOAP-ENV:Client] - FaultSubCode=[SOAP-ENV:Client] - FaultDetail=[Connection timed out], 2:
``` 
(added `1:`, `2:` during debugging session)

second change: this was a bug, causing exception.
The 0 item is an int, instead at least 1 should be there