### PR TITLE
[6r15] HTCondor: protect against non-standard line in 'job status' list

### DIFF
--- a/Resources/Computing/BatchSystems/Condor.py
+++ b/Resources/Computing/BatchSystems/Condor.py
@@ -24,7 +24,10 @@ def parseCondorStatus( lines, jobID ):
   jobID = str(jobID)
   for line in lines:
     l = line.strip().split()
-    status = int( l[1] )
+    try:
+      status = int( l[1] )
+    except (ValueError, IndexError):
+      continue
     if l[0] == jobID:
       return { 1: 'Waiting',
                2: 'Running',

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -227,7 +227,7 @@ Queue %(nJobs)s
       condorIDs[job] = jobID
 
     ##This will return a list of 1245.75 3
-    status,stdout_q = commands.getstatusoutput( 'condor_q -af:j JobStatus %s' % ' '.join(condorIDs.values()) )
+    status,stdout_q = commands.getstatusoutput( 'condor_q %s -af:j JobStatus ' % ' '.join(condorIDs.values()) )
     if status != 0:
       return S_ERROR( stdout_q )
     qList = stdout_q.strip().split('\n')
@@ -235,7 +235,7 @@ Queue %(nJobs)s
     ##FIXME: condor_history does only support j for autoformat from 8.5.3,
     ## format adds whitespace for each field This will return a list of 1245 75 3
     ## needs to cocatenate the first two with a dot
-    condorHistCall = 'condor_history -af ClusterId ProcId JobStatus %s' % ' '.join( condorIDs.values() )
+    condorHistCall = 'condor_history %s -af ClusterId ProcId JobStatus' % ' '.join( condorIDs.values() )
 
     treatCondorHistory( condorHistCall, qList )
 

--- a/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -34,10 +34,13 @@ class HTCondorCETests( unittest.TestCase ):
     104097.9 2
     104098.0 1
     104098.1 4
+
+    foo bar
     104098.2 3
     104098.3 5
     104098.4 7
     """.strip().split('\n')
+    ## force there to be an empty line
 
     expectedResults = {
       "104097.9": "Running",


### PR DESCRIPTION
Can happen if condor_q returns nothing because there are active jobs at the moment.
