### PR TITLE
[v6r15] Reduce the default length of the payload proxy 

### DIFF
--- a/FrameworkSystem/Client/ProxyManagerClient.py
+++ b/FrameworkSystem/Client/ProxyManagerClient.py
@@ -184,7 +184,7 @@ class ProxyManagerClient:
 
   @gProxiesSync
   def downloadProxy( self, userDN, userGroup, limited = False, requiredTimeLeft = 1200,
-                     cacheTime = 43200, proxyToConnect = False, token = False ):
+                     cacheTime = 14400, proxyToConnect = False, token = False ):
     """
     Get a proxy Chain from the proxy management
     """
@@ -213,7 +213,7 @@ class ProxyManagerClient:
     return S_OK( chain )
 
   def downloadProxyToFile( self, userDN, userGroup, limited = False, requiredTimeLeft = 1200,
-                           cacheTime = 43200, filePath = False, proxyToConnect = False, token = False ):
+                           cacheTime = 14400, filePath = False, proxyToConnect = False, token = False ):
     """
     Get a proxy Chain from the proxy management and write it to file
     """
@@ -229,7 +229,13 @@ class ProxyManagerClient:
 
   @gVOMSProxiesSync
   def downloadVOMSProxy( self, userDN, userGroup, limited = False, requiredTimeLeft = 1200,
-                         cacheTime = 43200, requiredVOMSAttribute = False, proxyToConnect = False, token = False ):
+                         cacheTime = 14400, requiredVOMSAttribute = False,
+
+
+
+
+
+                         proxyToConnect = False, token = False ):
     """
     Download a proxy if needed and transform it into a VOMS one
     """
@@ -259,8 +265,9 @@ class ProxyManagerClient:
     self.__vomsProxiesCache.add( cacheKey, chain.getRemainingSecs()['Value'], chain )
     return S_OK( chain )
 
-  def downloadVOMSProxyToFile( self, userDN, userGroup, limited = False, requiredTimeLeft = 1200, cacheTime = 43200,
-                               requiredVOMSAttribute = False, filePath = False, proxyToConnect = False, token = False ):
+  def downloadVOMSProxyToFile( self, userDN, userGroup, limited = False, requiredTimeLeft = 1200,
+                               cacheTime = 14400, requiredVOMSAttribute = False, filePath = False,
+                               proxyToConnect = False, token = False ):
     """
     Download a proxy if needed, transform it into a VOMS one and write it to file
     """

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -66,7 +66,7 @@ class ComputingElement(object):
     self.batchSystem = None
 
     self.minProxyTime = gConfig.getValue( '/Registry/MinProxyLifeTime', 10800 ) #secs
-    self.defaultProxyTime = gConfig.getValue( '/Registry/DefaultProxyLifeTime', 86400 ) #secs
+    self.defaultProxyTime = gConfig.getValue( '/Registry/DefaultProxyLifeTime', 43200 ) #secs
     self.proxyCheckPeriod = gConfig.getValue( '/Registry/ProxyCheckingPeriod', 3600 ) #secs
 
     self.initializeParameters()


### PR DESCRIPTION
Reduce the default length of the payload proxy which is renewed by the pilot to 12 hours. This is the setting which is defined by the /Registry/DefaultProxyLength option. The previous default was set to 1 day which is equal or even longer than VOMS extension length for some VOs. This prevented the use of the proxy cache in the ProxyManager not letting of any length margin. The length in the proxy cache in the ProxyManagerClient is reduced to just 4 hours ( from 12 hours ), to have garanteered caching even in case of shortened by VOMS proxies.