### PR TITLE
[v6r16] MessageQueue resources

### DIFF
--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -85,6 +85,10 @@ EVOMS = 1121
 # Databases : 3X
 EDB = 1130
 EMYSQL = 1131
+# Message Queues: 4X
+EMQUKN = 1140
+EMQNOM = 1141
+EMQCONN = 1142
 
 # ## WMS/Workflow
 EWMSUKN = 1500
@@ -136,6 +140,10 @@ dErrorCode = {
                # 113X: Databases
                1130 : 'EDB',
                1131 : 'EMYSQL',
+               # 114X: Message Queues
+               1140 : 'EMQUKN',
+               1141 : 'EMQNOM',
+               1142 : 'EMQCONN',
                # WMS/Workflow
                1500 : 'EWMSUKN',
                1501 : 'EWMSJDL',
@@ -186,6 +194,10 @@ dStrError = {
               # 113X: Databases
               EDB : "Database Error",
               EMYSQL : "MySQL Error",
+              # 114X: Message Queues
+              EMQUKN : "Unknown MQ Error",
+              EMQNOM : "No messages",
+              EMQCONN : "MQ connection failure",
               # WMS/Workflow
               EWMSUKN : "Unknown WMS error",
               EWMSJDL : "Invalid JDL",

--- a/Resources/MessageQueue/MQConnection.py
+++ b/Resources/MessageQueue/MQConnection.py
@@ -1,0 +1,107 @@
+"""
+Abstract class for management of MQ connections
+"""
+
+import time
+
+from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC.Core.Utilities.DErrno import EMQUKN
+
+__RCSID__ = "$Id$"
+
+class MQConnectionError( Exception ):
+  pass
+
+class MQConnection( object ):
+  """
+  Abstract class for management of message queue connections
+  Allows to both send and receive messages from a queue
+  """
+
+  MANDATORY_PARAMETERS = [ 'Host', 'Port', 'User', 'VHost', 'MQType' ]
+
+  def __init__( self ):
+    """ Standard constructor
+    """
+
+    self.alive = False
+    self.parameters = {}
+
+  def on_error( self, headers, message ):
+    """ Default callback function called when an error happens
+    """
+    gLogger.error( message )
+
+  # Rest of functions
+
+  def setParameters( self, parameters ):
+    """ Sets the parameters attribute
+
+    :param dict parameters: dictionary with the parameters for the queue. It should include the following parameters:
+    'Host', 'Port', 'User', 'VH' and 'MQType'. Otherwise, the function will return an error
+    """
+
+    if not parameters:
+      return S_ERROR( EMQUKN, 'Queue parameters are not provided' )
+
+    missingParameters = set( self.MANDATORY_PARAMETERS ) - set( parameters )
+    if missingParameters:
+      return S_ERROR( EMQUKN, "Parameter(s) %s not provided" % ','.join( missingParameters ) )
+
+    self.parameters = parameters
+
+    return S_OK( 'Queue parameters set successfully' )
+
+  def setupConnection( self, parameters = None, receive = False, messageCallback = None ):
+    """
+    Establishes a new non-blocking connection to the message queue
+
+    :param dict parameters: dictionary with additional MQ parameters if any
+    :param bool receive: flag to enable the MQ connection for getting message
+    :param func messageCallback: function to be called when a new message is received from the queue ( only receiver mode ).
+                                If None, the defaultCallback method is used instead
+    :return: S_OK/S_ERROR
+    """
+    raise NotImplementedError( 'This method should be implemented by child class' )
+
+  def run( self, parameters = None, receive = True, messageCallback = None ):
+    """
+    Establishes a new blocking connection to the message queue
+
+    :param dict parameters: dictionary with additional MQ parameters if any
+    :param bool receive: flag to enable the MQ connection for getting message
+    :param func messageCallback: function to be called when a new message is received from the queue
+                                 ( only receiver mode ).
+    :return: S_OK/S_ERROR
+    """
+    result = self.setupConnection( parameters, receive, messageCallback )
+    if not result[ 'OK' ]:
+      return result
+
+    while self.alive:
+      time.sleep( 1 )
+
+    self.disconnect()
+
+  def put( self, message ):
+    """ Send message to a MQ server
+
+    :param message: any json encodable structure
+    :return: S_OK/S_ERROR
+    """
+
+    raise NotImplementedError( 'This method should be implemented by child class' )
+
+  def get( self ):
+    """ Get one message, if any, from the MQ server
+
+    :return: S_OK( message )/ S_ERROR if not message available or connection error
+    """
+
+    raise NotImplementedError( 'This method should be implemented by child class' )
+
+  def disconnect( self ):
+    """
+    Disconnects from the message queue server
+    """
+    raise NotImplementedError( 'This method should be implemented by child class' )

--- a/Resources/MessageQueue/MQConnectionFactory.py
+++ b/Resources/MessageQueue/MQConnectionFactory.py
@@ -1,0 +1,97 @@
+"""  The MQ Factory creates MQConnection objects
+"""
+from DIRAC                 import S_OK, S_ERROR, gLogger
+from DIRAC.Core.Utilities  import ObjectLoader
+from DIRAC.Resources.MessageQueue.Utilities import getMQueue
+from DIRAC.Core.Utilities.DErrno import EMQUKN
+
+__RCSID__ = "$Id$"
+
+class MQConnectionFactory( object ):
+
+  #############################################################################
+  def __init__(self, mqType=''):
+    """ Standard constructor
+    """
+    self.mqType = mqType
+    self.log = gLogger.getSubLogger( self.mqType )
+
+  #############################################################################
+  def __getMQConnection( self, queueName = None, parameters = None ):
+    """ This method returns the MQConnection instance corresponding to the parameters and queue
+
+       :param str queueName: name of the queue. Can be provided as just queueName or <MQServer>::<queueName>
+                             forms
+       :param dict parameters: dictionary of connection parameters
+       :return: S_OK(MQconnectionObject)/ S_ERROR
+    """
+
+    queueParameters = {}
+    if queueName is not None:
+      result = getMQueue( queueName )
+      if not result['OK']:
+        return result
+      queueParameters = result['Value']
+    if parameters is not None:
+      queueParameters.update( parameters )
+
+    mqType = queueParameters.get( 'MQType' )
+    if not mqType:
+      mqType = self.mqType
+    if not mqType:
+      return S_ERROR( EMQUKN, 'No MQType specified' )
+
+    subClassName = mqType + 'MQConnection'
+    objectLoader = ObjectLoader.ObjectLoader()
+    result = objectLoader.loadObject( 'Resources.MessageQueue.%s' % subClassName, subClassName )
+    if not result['OK']:
+      self.log.error( 'Failed to load object', '%s: %s' % ( subClassName, result['Message'] ) )
+      return result
+
+    ceClass = result['Value']
+    try:
+      mqConnection = ceClass()
+      result = mqConnection.setParameters( queueParameters )
+      if not result['OK']:
+        return result
+
+    except Exception as exc:
+      msg = 'MQConnectionFactory could not instantiate %s object: %s' % ( subClassName, repr( exc ) )
+      self.log.exception( 'Could not instantiate MQConnection object', IException = exc )
+      self.log.warn( msg )
+      return S_ERROR( EMQUKN, msg )
+
+    return S_OK( mqConnection )
+
+  def getMQListener( self, queueName = None, parameters = None ):
+    """ Get a MQConnection object in a Listener mode without connection
+        initialized
+
+    :param str queueName: queueName
+    :param dict parameters: MQ connection parameters
+    :return: S_OK( MQconnectionObject )/ S_ERROR
+    """
+    return self.__getMQConnection( queueName = queueName,
+                                   parameters = parameters )
+
+  def getMQPublisher( self, queueName = None, parameters = None ):
+    """ Get a MQConnection object in a Publisher mode
+
+    :param str queueName: queueName
+    :param dict parameters: MQ connection parameters
+    :return: S_OK( MQconnectionObject )/ S_ERROR
+    """
+
+    result = self.__getMQConnection( queueName = queueName,
+                                     parameters = parameters )
+    if not result['OK']:
+      return result
+
+    mqConnection = result['Value']
+    result = mqConnection.setupConnection()
+    if not result['OK']:
+      return result
+
+    return S_OK( mqConnection )
+
+#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#

--- a/Resources/MessageQueue/MQListener.py
+++ b/Resources/MessageQueue/MQListener.py
@@ -4,16 +4,17 @@
     The MQListener can be used in two modes:
 
     Simple mode with a default callback allows to get messages one by one by an explicit
-    get() call:
+    get() call::
 
       listener = MQListener( queueName )
       listener.get()
 
     Consumer mode with a custom callback function provided in the constructor or through
-    setCallback call:
+    setCallback call::
 
       listener = MQListener( queueName, callback = myCallback )
-      listener run()
+      listener.run()
+
 """
 
 import time

--- a/Resources/MessageQueue/MQListener.py
+++ b/Resources/MessageQueue/MQListener.py
@@ -1,0 +1,80 @@
+""" MQListener class encapsulates listener functionality fully configurable
+    by the CS options
+
+    The MQListener can be used in two modes:
+
+    Simple mode with a default callback allows to get messages one by one by an explicit
+    get() call:
+
+      listener = MQListener( queueName )
+      listener.get()
+
+    Consumer mode with a custom callback function provided in the constructor or through
+    setCallback call:
+
+      listener = MQListener( queueName, callback = myCallback )
+      listener run()
+"""
+
+import time
+from DIRAC import S_ERROR
+from DIRAC.Resources.MessageQueue.MQConnectionFactory import MQConnectionFactory
+from DIRAC.Resources.MessageQueue.MQConnection import MQConnectionError
+
+
+__RCSID__ = "$Id$"
+
+class MQListener( object ):
+
+  def __init__(self, messageQueue, callback = None ):
+
+    self.callback = callback
+    mqFactory = MQConnectionFactory()
+    result = mqFactory.getMQListener( messageQueue )
+    if not result['OK']:
+      raise MQConnectionError( 'Failed to instantiate MQService connection: %s' % result['Message'] )
+    self.mqConnection = result['Value']
+    if callback:
+      self.mqConnection.callback = callback
+
+  def get( self ):
+    """ Get one message, if any, from the MQ server
+
+    :return: S_OK( message )/ S_ERROR if not message available or connection error
+    """
+    if self.callback:
+      return S_ERROR( 'Can not do get(): the listener is configured with callback' )
+    if self.mqConnection.connection is None:
+      result = self.mqConnection.setupConnection( receive = True )
+      if not result['OK']:
+        return result
+      # Give some time for the first check for messages on the server
+      time.sleep(0.2)
+    return self.mqConnection.get()
+
+  def run( self ):
+    """ Runs the listener with a configured callback forever. It can be stopped by explicit
+        stop() call, for example in a control thread
+
+    :return: S_OK/S_ERROR
+    """
+    result = self.mqConnection.run()
+    return result
+
+  def stop( self ):
+    """ Stops consuming messages and disconnects from the MQ server
+
+    :return: S_OK/S_ERROR
+    """
+
+    result = self.mqConnection.disconnect()
+    return result
+
+  def setCallback( self, callback ):
+    """ Set the call back function in a consumer mode
+
+    :param func callback: callback function
+    :return: S_OK
+    """
+    self.mqConnection.callback = callback
+    return S_OK()

--- a/Resources/MessageQueue/MQPublisher.py
+++ b/Resources/MessageQueue/MQPublisher.py
@@ -1,0 +1,36 @@
+""" MQPublisher class encapsulates publisher functionality fully configurable
+    by the CS options
+"""
+
+from DIRAC.Resources.MessageQueue.MQConnectionFactory import MQConnectionFactory
+from DIRAC.Resources.MessageQueue.MQConnection import MQConnectionError
+
+__RCSID__ = "$Id$"
+
+class MQPublisher(object):
+
+  def __init__(self, messageQueue ):
+
+    mqFactory = MQConnectionFactory()
+    result = mqFactory.getMQPublisher( messageQueue )
+    if not result['OK']:
+      raise MQConnectionError( 'Failed to instantiate MQService connection: %s' % result['Message'] )
+    self.mqConnection = result['Value']
+
+  def put( self, message ):
+    """ Send message to a MQ server
+
+    :param message: any json encodable structure
+    :return: S_OK/S_ERROR
+    """
+    result = self.mqConnection.put( message )
+    return result
+
+  def stop( self ):
+    """ Dosconnect publisher from the MQ server
+
+    :return: S_OK/S_ERROR
+    """
+
+    result = self.mqConnection.disconnect()
+    return result

--- a/Resources/MessageQueue/StompMQConnection.py
+++ b/Resources/MessageQueue/StompMQConnection.py
@@ -1,0 +1,172 @@
+"""
+Class for management of Stomp MQ connections, e.g. RabbitMQ
+"""
+
+__RCSID__ = "$Id$"
+
+import json
+import stomp
+import threading
+
+from DIRAC.Core.Utilities.File import makeGuid
+from DIRAC.Resources.MessageQueue.MQConnection import MQConnection
+from DIRAC import S_OK, S_ERROR
+from DIRAC.Core.Utilities.DErrno import EMQNOM, EMQUKN, EMQCONN
+
+class StompMQConnection( MQConnection ):
+  """
+  Class for management of Stomp connections
+  Allows to both send and receive messages from a queue
+  The class also implements callback functions to be able to act as a listener and receive messages
+  """
+
+  MANDATORY_PARAMETERS = [ 'Host', 'MQType' ]
+
+  def __init__( self ):
+
+    super( StompMQConnection, self ).__init__()
+    self.queueName = None
+
+    self.callback = None
+    self.receiver = False
+    self.acknowledgement = False
+    self.subscriptionID = None
+    self.msgList = []
+    self.lock = threading.Lock()
+    self.connection = None
+
+  # Callback functions for message receiving mode
+
+  def on_message( self, headers, message ):
+    """
+    Callback function called upon receiving a message
+
+    :param dict headers: headers of the MQ message
+    :param json message: json string of the message
+    """
+    result = self.callback( headers, message )
+    if self.acknowledgement:
+      if result['OK']:
+        self.connection.ack( headers['message-id'], self.subscriptionID )
+      else:
+        self.connection.nack( headers['message-id'], self.subscriptionID )
+
+  def defaultCallback( self, headers, message ):
+    """
+    Default callback function called every time something is read from the queue
+
+    :param dict headers: headers of the MQ message
+    :param json message: json string of the message
+    """
+    dictionary = json.loads( message )
+    with self.lock:
+      self.msgList.append( dictionary )
+    return S_OK()
+
+  # Rest of functions
+
+  def setupConnection( self, parameters = None, receive = False, messageCallback = None ):
+    """
+    Establishes a new connection to a Stomp server, e.g. RabbitMQ
+
+    :param dict parameters: dictionary with additional MQ parameters if any
+    :param bool receive: flag to enable the MQ connection for getting message
+    :param func messageCallback: function to be called when a new message is received from the queue ( only receiver mode ).
+                                If None, the defaultCallback method is used instead
+    :return: S_OK/S_ERROR
+    """
+
+    self.receiver = receive
+    if self.receiver:
+      if messageCallback:
+        self.callback = messageCallback
+      elif not self.callback:
+        self.callback = self.defaultCallback
+
+    if parameters is not None:
+      self.parameters.update( parameters )
+
+    # Make the actual connection
+    host = self.parameters.get( 'Host' )
+    port = self.parameters.get( 'Port', 61613 )
+    vhost = self.parameters.get( 'VHost' )
+    user = self.parameters.get( 'User', 'guest' )
+    password = self.parameters.get( 'Password', 'guest' )
+    self.queueName = self.parameters.get( 'Queue' )
+    headers = {}
+    if self.parameters.get( 'Persistent', '' ).lower() in ['true', 'yes', '1']:
+      headers = { 'persistent': 'true' }
+    try:
+      self.connection = stomp.Connection( [ ( host, int( port ) ) ], vhost = vhost )
+      self.connection.start()
+      self.connection.connect( username = user, passcode = password )
+
+      if self.receiver:
+        ack = 'auto'
+        if self.parameters.get( 'Acknowledgement', '' ).lower() in ['true', 'yes', '1']:
+          self.acknowledgement = True
+          ack = 'client-individual'
+        self.subscriptionID = makeGuid()[:8]
+        self.connection.set_listener( '', self )
+        self.connection.subscribe( destination = '/queue/%s' % self.queueName,
+                                   id = self.subscriptionID,
+                                   ack = ack,
+                                   headers = headers )
+    except Exception as e:
+      return S_ERROR( EMQCONN, 'Failed to setup connection: %s' % e )
+
+    self.alive = True
+    return S_OK( 'Setup successful' )
+
+  def put( self, message ):
+    """
+    Sends a message to the queue
+    message contains the body of the message
+
+    :param str message: string or any json encodable structure
+    """
+    try:
+      if isinstance( message, ( list, set, tuple ) ):
+        for msg in message:
+          self.connection.send( body = json.dumps( msg ), destination = '/queue/%s' % self.queueName )
+      else:
+        self.connection.send( body = json.dumps( message ), destination = '/queue/%s' % self.queueName )
+    except Exception as e:
+      return S_ERROR( EMQUKN, 'Failed to send message: %s' % e )
+
+    return S_OK( 'Message sent successfully' )
+
+  def get( self ):
+    """
+    Retrieves a message from the queue ( if any ). This method is only valid
+    if the default behaviour for the message callback is being used
+
+    :return: S_OK( message )/S_ERROR if there are no messages in the queue
+
+    """
+    if not self.receiver:
+      return S_ERROR( EMQUKN, 'StompMQConnection is not configured to receive messages' )
+
+    with self.lock:
+      if self.msgList:
+        msg = self.msgList.pop( 0 )
+      else:
+        return S_ERROR( EMQNOM, 'No messages in queue' )
+
+    return S_OK( msg )
+
+  def disconnect( self ):
+    """
+    Disconnects from the Stomp server
+
+    :return: S_OK/S_ERROR
+    """
+    self.alive = False
+    try:
+      if self.subscriptionID:
+        self.connection.unsubscribe( self.subscriptionID )
+      self.connection.disconnect()
+    except Exception as e:
+      return S_ERROR( EMQUKN, 'Failed to disconnect: %s' % str( e ) )
+
+    return S_OK( 'Disconnection successful' )

--- a/Resources/MessageQueue/Utilities.py
+++ b/Resources/MessageQueue/Utilities.py
@@ -1,0 +1,63 @@
+""" Utilities for the MessageQueue package
+"""
+
+from DIRAC import S_OK, S_ERROR, gConfig
+
+__RCSID__ = "$Id$"
+
+def getMQueue( queueName ):
+  """ Get parameter of a MQ queue from the CS
+
+  :param str queueName: name of the queue either just the queue name, in this case
+                       the default MQServer will be used, or in th form <MQServer>::<queueName>
+  :return: S_OK( parameterDict )/ S_ERROR
+  """
+
+  mqService = None
+  elements = queueName.split( '::' )
+  if len( elements ) == 2:
+    mqService, queue = elements
+  else:
+    queue = queueName
+
+
+  result = gConfig.getSections( '/Resources/MQServices' )
+  if not result['OK']:
+    return result
+  sections = result['Value']
+  if mqService and not mqService in sections:
+    return S_ERROR( 'Requested MQService %s not found in the CS' % mqService )
+  elif not mqService and len( sections ) == 1:
+    mqService = sections[0]
+
+  queuePath = ''
+  servicePath = ''
+  if mqService:
+    servicePath = '/Resources/MQServices/%s' % mqService
+    result = gConfig.getSections( '/Resources/MQServices/%s/Queues' % mqService )
+    if result['OK'] and queue in result['Value']:
+      queuePath = '/Resources/MQServices/%s/Queues/%s' % ( mqService, queue )
+  else:
+    for section in sections:
+      result = gConfig.getSections( '/Resources/MQServices/%s/Queues' % section )
+      if result['OK']:
+        if queue in result['Value']:
+          if queuePath:
+            return S_ERROR( 'Ambiguous queue %s definition' % queue )
+          else:
+            servicePath = '/Resources/MQServices/%s' % section
+            queuePath = '/Resources/MQServices/%s/Queues/%s' % ( section, queue )
+
+  result = gConfig.getOptionsDict( servicePath )
+  if not result['OK']:
+    return result
+  serviceDict = result['Value']
+
+  if queuePath:
+    result = gConfig.getOptionsDict( queuePath )
+    if not result['OK']:
+      return result
+    serviceDict.update( result['Value'] )
+  serviceDict['Queue'] = queue
+
+  return S_OK( serviceDict )

--- a/Resources/MessageQueue/test/Test_MQ_test.py
+++ b/Resources/MessageQueue/test/Test_MQ_test.py
@@ -1,0 +1,182 @@
+"""
+Tests for the MQListener and MQPublisher helper classes
+"""
+
+import unittest
+import time
+import threading
+import socket
+import json
+
+from DIRAC import S_OK
+from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
+from DIRAC.Core.Utilities.CFG import CFG
+from DIRAC.Resources.MessageQueue.MQListener import MQListener
+from DIRAC.Resources.MessageQueue.MQPublisher import MQPublisher
+from DIRAC.Resources.MessageQueue.MQConnection import MQConnectionError
+from DIRAC.Core.Utilities.DErrno import cmpError, EMQCONN, EMQNOM
+
+__RCSID__ = "$Id$"
+
+TEST_CONFIG = """
+Resources
+{
+  MQServices
+  {
+    mardirac3.in2p3.fr
+    {
+      MQType = Stomp
+      Host = mardirac3.in2p3.fr
+      Port = 9165
+      User = guest
+      Password = guest
+      Queues
+      {
+        TestQueue
+        {
+          Acknowledgement = True
+        }
+      }
+    }
+  }
+}
+"""
+
+TEST_BAD_CONFIG = """
+Resources
+{
+  MQServices
+  {
+    rubbish.in2p3.fr
+    {
+      MQType = Stomp
+      Host = rubbish.in2p3.fr
+      Port = 9165
+      User = guest
+      Password = guest
+      Queues
+      {
+        TestQueueBad
+        {
+          Acknowledgement = True
+        }
+      }
+    }
+  }
+}
+"""
+
+MQ_HOST = "mardirac3.in2p3.fr"
+MQ_PORT = 9165
+
+def checkHost( host, port ):
+
+  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+  try:
+    s.connect( (host, port) )
+    result = True
+  except socket.error as e:
+    result = False
+  s.close()
+  return result
+
+class MQTestCase( unittest.TestCase ):
+  """ Base test class. Defines all the method to test
+  """
+
+  def setUp(self):
+
+    mqCFG = CFG()
+    mqCFG.loadFromBuffer( TEST_CONFIG )
+    gConfigurationData.mergeWithLocal( mqCFG )
+    mqCFG.loadFromBuffer( TEST_BAD_CONFIG )
+    gConfigurationData.mergeWithLocal( mqCFG )
+
+  @unittest.skipIf( not checkHost( MQ_HOST, MQ_PORT ), "Test MQ host is not reachable" )
+  def test_listener_publisher(self):
+    """ Test simple fully predefined queue with a simple listener
+    """
+
+    publisher = None
+    with self.assertRaises( MQConnectionError ):
+      publisher = MQPublisher( "rubbish.in2p3.fr::TestQueueBad" )
+
+    try:
+      publisher = MQPublisher( "TestQueue" )
+    except MQConnectionError as exc:
+      self.fail( "Fail to create Publisher: %s" % str( exc ) )
+
+    if publisher is None:
+      self.fail( "Unknown failure when instantiating MQPublisher" )
+
+    listener = None
+    try:
+      listener = MQListener( "TestQueue" )
+    except MQConnectionError as exc:
+      self.fail( "Fail to create Listener: %s" % str( exc ) )
+
+    if listener is None:
+      self.fail( "Unknown failure when instantiating MQListener" )
+
+    # Drain messages on the server if any
+    result = S_OK()
+    while result['OK']:
+      result = listener.get()
+
+    message = "Hello World"
+
+    result = publisher.put( message )
+    self.assertTrue( result['OK'] )
+
+    time.sleep( 1 )
+    result = listener.get()
+
+    print result
+
+    self.assertTrue( result['OK'] )
+    self.assertTrue( result['Value'] == message )
+
+    # No more messages available
+    result = listener.get()
+    self.assertTrue( not result['OK'] )
+    self.assertTrue( cmpError( result, EMQNOM ) )
+
+    result = publisher.stop()
+    self.assertTrue( result['OK'] )
+    result = listener.stop()
+    self.assertTrue( result['OK'] )
+
+  def callbackTest( self, headers, message ):
+
+    self.message = json.loads( message )
+    self.messageID = headers['message-id']
+    return S_OK()
+
+  @unittest.skipIf( not checkHost( MQ_HOST, MQ_PORT ), "Test MQ host is not reachable" )
+  #@unittest.skip
+  def test_consumer( self ):
+    """ Test listener in a consumer mode
+    """
+    self.message = ''
+
+    try:
+      publisher = MQPublisher( "TestQueue" )
+      listener = MQListener( "TestQueue", callback = self.callbackTest )
+    except MQConnectionError as exc:
+      self.fail( "Fail to create Publisher: %s" % str( exc ) )
+
+    consumerThread = threading.Thread( target = listener.run )
+    consumerThread.start()
+
+    message = 'Hello consumer'
+    publisher.put( message )
+    time.sleep(1)
+    self.assertEqual( self.message, message )
+
+    result = listener.stop()
+    self.assertTrue( result['OK'] )
+
+
+if __name__ == '__main__':
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase( MQTestCase )
+  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )

--- a/docs/source/AdministratorGuide/DIRACSites/ComputingElements/index.rst
+++ b/docs/source/AdministratorGuide/DIRACSites/ComputingElements/index.rst
@@ -1,5 +1,5 @@
 =================================
-DIRAC Computing Elements
+Computing Elements
 =================================
 
 Direct access to the site computing clusters is done by sending pilot jobs in a similar way as 

--- a/docs/source/AdministratorGuide/DIRACSites/MessageQueues/index.rst
+++ b/docs/source/AdministratorGuide/DIRACSites/MessageQueues/index.rst
@@ -1,0 +1,69 @@
+.. _configuration_message_queues:
+
+==================
+Message Queues
+==================
+
+Message Queues are services for passing messages between DIRAC components.
+These services are not part necessarily of the DIRAC software and are provided
+by third parties. Access to the services is done via logical Queues which are
+described in the *Resources* section of the DIRAC configuration.
+
+A commented example of the Message Queues configuration is provided below.
+Each option value is representing its default value::
+
+    Resources
+    {
+      # General section for all the MessageQueue service. Each subsection is
+      # dedicated to a particular MQ server
+      MQServices
+      {
+        # MQ server section. The name of the section is arbitrary, not necessarily
+        # the host name
+        mardirac3.in2p3.fr
+        {
+          # The MQ type defines the protocol by which the service is accessed.
+          # Currently only Stomp protocol is available. Mandatory option
+          MQType = Stomp
+          # The MQ server host name
+          Host = mardirac3.in2p3.fr
+          # The MQ server port number
+          Port = 9165
+          # User name to access the MQ server
+          User = guest
+          # Password to access the MQ server. This option should never be defined
+          # in the Global Configuration, only in the local one
+          Password = guest
+          # General section containing subsections per Message Queue. Multiple Message
+          # Queues can be defined by MQ server
+          Queues
+          {
+            # Message Queue section. The name of the section is defining the name
+            # of the Message Queue
+            TestQueue
+            {
+              # Option defines if messages reception is acknowledged by the listener
+              Acknowledgement = True
+              # Option defines if the Message Queue is persistent or not
+              Persistent = False
+            }
+          }
+        }
+      }
+    }
+
+Once Message Queues are defined in the configuration, they can be used in the DIRAC codes
+like described in :ref:`development_use_mq`, for example::
+
+   from DIRAC.Resources.MessageQueue.MQPublisher import MQPublisher
+   from DIRAC.Resources.MessageQueue.MQListener import MQListener
+   ...
+   publisher = MQPublisher( "TestQueue" )
+   listener = MQListener( "TestQueue" )
+   ...
+   result = publisher.put( message )
+   ...
+   result = listener.get( message )
+   if result['OK']:
+     message = result['Value']
+

--- a/docs/source/AdministratorGuide/DIRACSites/StorageElements/index.rst
+++ b/docs/source/AdministratorGuide/DIRACSites/StorageElements/index.rst
@@ -1,3 +1,4 @@
 =========================
-DIRAC Storage Elements
+Storage Elements
 =========================
+

--- a/docs/source/AdministratorGuide/DIRACSites/index.rst
+++ b/docs/source/AdministratorGuide/DIRACSites/index.rst
@@ -11,3 +11,4 @@ In this section, the procedures to give access to the site resources are describ
    
    ComputingElements/index
    StorageElements/index
+   MessageQueues/index

--- a/docs/source/DeveloperGuide/AddingNewComponents/Resources/MessageQueues/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/Resources/MessageQueues/index.rst
@@ -1,0 +1,44 @@
+.. _development_use_mq:
+
+================
+Message Queues
+================
+
+Message Queues are fully described in the DIRAC Configuration as explained in the
+:ref:`configuration_message_queues`. In the code, Message Queues can be used to publish
+messages which are arbitrary json structures. The *MQPublisher* objects are used in this case:
+
+.. code-block:: python
+
+   from DIRAC.Resources.MessageQueue.MQPublisher import MQPublisher
+
+   publisher = MQPublisher( "TestQueue" )
+   # Publish a message which is an arbitrary json structure
+   result = publisher.put( message )
+
+The Messages are received by listeners. Listeners are objects of the MQListener class.
+These objects can request messages explicitly:
+
+.. code-block:: python
+
+   from DIRAC.Resources.MessageQueue.MQListener import MQListener
+
+   listener = MQListener( "TestQueue" )
+   result = listener.get( message )
+   if result['OK']:
+     message = result['Value']
+
+Listeners can be instantiated with a callback function that will be called automatically
+when new messages will arrive:
+
+.. code-block:: python
+
+  from DIRAC.Resources.MessageQueue.MQListener import MQListener
+
+  def myCallback( headers, message ):
+    <function implementation>
+
+  listener = MQListener( "MyQueue", callback = myCallback )
+  # Blocking call
+  listener.run()
+

--- a/docs/source/DeveloperGuide/AddingNewComponents/Resources/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/Resources/index.rst
@@ -1,0 +1,18 @@
+=========================================
+DIRAC Resources
+=========================================
+
+DIRAC Resources are logical entities representing computing resources and
+services usually provided by third parties. DIRAC is providing an abstract
+layer for various types of such services, e.g. Computing or Storage Elements,
+File Catalogs, etc. For each particular kind of service an implementation
+is provided and objects representing each service is created using its logical name
+by an appropriate Factory.
+
+This section describes how Resources of different types can be used for developing
+DIRAC applications
+
+.. toctree::
+   :maxdepth: 2
+
+   MessageQueues/index

--- a/docs/source/DeveloperGuide/AddingNewComponents/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/index.rst
@@ -20,5 +20,6 @@ What starts here is a guide to develop DIRAC components. This guide is done in t
    DevelopingExecutors/index
    DevelopingCommands/index
    Utilities/index
-   DevelopingWebPages/index  
+   Resources/index
+   DevelopingWebPages/index
    CodeQuality/index


### PR DESCRIPTION
This PR replaces #2985, which was badly screwed by a faulty rebase. All the comments from #2985 are either incorporated or answered. 

This PR contains classes for managing MQ connections as DIRAC Resources. The current implementation is only for the Stomp MQ protocol which is provided by the RabbitMQ. This is a wrapper over the MQConnection classes by Sergio as in #2974, and replaces this PR.

Users are supposed to use MQListener and MQPublisher classes which can be used as simply as the following:

publisher = MQPublisher( "MyQueue" )
listener = MQListener( "MyQueue" )
publisher.put( message )
listener.get( message )

Or:
publisher = MQPublisher( "MyQueue" )
listener = MQListener( "MyQueue", callback = myCallback )
publisher.put( message )
listener.run()

Example of the MQ configuration description is the following:

Resources
{
MQServices
{
mardirac3.in2p3.fr
{
MQType = Stomp
Host = mardirac3.in2p3.fr
Port = 9165
User = guest
Password = guest
Queues
{
TestQueue
{
Acknowledgement = True
}
}
}
}
}

The queueName in the listener/publisher instantiation can be given as just the Queue name (if no ambiguities ) or fully qualified name like "mardirac3.in2p3.fr::TestQueue" to avoid ambiguities.
