### PR TITLE
[v6r15] HTCondorCE: Make better configurable

### DIFF
--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -65,7 +65,7 @@ def getCondorLogFile( pilotRef ):
   #FIXME: This gets called from the WMSAdministrator, so we don't have the same
   #working directory as for the SiteDirector unless we force it, there is also
   #no CE instantiated when this function is called so we can only pick this option up from one place
-  workingDirectory = gConfig.getValue( "Resources/Computing/CEDefaults/HTCondorCE/WorkingDirectory",
+  workingDirectory = gConfig.getValue( "Resources/Computing/HTCondorCE/WorkingDirectory",
                                        DEFAULT_WORKINGDIRECTORY )
   resLog = findFile( workingDirectory, '%s.log' % condorID )
   return resLog
@@ -91,7 +91,7 @@ class HTCondorCEComputingElement( ComputingElement ):
     self.extraSubmitString = self.ceParameters.get('ExtraSubmitString', '').decode('string_escape')
 
     ## see note on getCondorLogFile, why we can only use the global setting
-    self.workingDirectory = gConfig.getValue( "Resources/Computing/CEDefaults/HTCondorCE/WorkingDirectory",
+    self.workingDirectory = gConfig.getValue( "Resources/Computing/HTCondorCE/WorkingDirectory",
                                               DEFAULT_WORKINGDIRECTORY )
     self.daysToKeepLogs = self.ceParameters.get( "DaysToKeepLogs", DEFAULT_DAYSTOKEEPLOGS )
 

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
@@ -4,39 +4,73 @@ Resources / Computing
 In this section options for ComputingElements can be set
 
 
-Resources / Computing / CEDefaults
-==================================
+Location for Parameters
+-----------------------
+
+Options for computing elements can be set at different levels, from lowest to
+highest prority
+
+  /Resources/Computing/CEDefaults
+	For all computing elements
+  /Resources/Computing/<CEType>
+	 For CEs of a given type, e.g., HTCondorCE or ARC
+  /Resources/Sites/<grid>/<site>/CEs
+	 For all CEs at a given site
+  /Resources/Sites/<grid>/<site>/CEs/<CEName>
+	 For the specific CE
+
+Values are overwritten.
 
 
+General Parameters
+------------------
+
+These parameters are valid for all types of computing elements
 
 +---------------------------------+------------------------------------------------+-----------------------------------+
 | **Name**                        | **Description**                                | **Example**                       |
 +---------------------------------+------------------------------------------------+-----------------------------------+
 | GridEnv                         |Default environment file sourced before calling | /opt/dirac/gridenv                |
-|                                 |grid commands, without extension                |                                   |
-+---------------------------------+------------------------------------------------+-----------------------------------+
-| XRSLExtraString                 | Default additional string for ARC submit files |                                   |
+|                                 |grid commands, without extension '.sh'.         | (when the file is gridenv.sh)     |
 +---------------------------------+------------------------------------------------+-----------------------------------+
 
-	     
 
-Resources / Computing / CEDefaults / HTCondorCE
-===============================================
+
+
+ARC CE Parameters
+-----------------
+
++---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
+| **Name**                        | **Description**                                   | **Example**                                                 |
++---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
+| XRSLExtraString                 |  Default additional string for ARC submit files   |                                                             |
++---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
+| Host                            | The host for the ARC CE, used to overwrite the    |                                                             |
+|                                 | ce name                                           |                                                             |
++---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
+| WorkingDirectory                | Directory where the pilot log files are stored    |   /opt/dirac/pro/runit/WorkloadManagement/SiteDirectorArc   |
+|                                 | locally.                                          |                                                             |
++---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
+
+
+.. _res-comp-htcondor:
+
+HTCondorCE Parameters
+---------------------
 
 Options for the HTCondorCEs
-
 
 +---------------------+----------------------------------------------------+-----------------------------------------------------------+
 | **Name**            | **Description**                                    | **Example**                                               |
 +---------------------+----------------------------------------------------+-----------------------------------------------------------+
-| ExtraSubmitstring   | Default additional string for the condor submit    | request_cpus = 8 \n periodic_remove = ...                 |
-|                     | file. Separate entries with "\n".                  |                                                           |
+| ExtraSubmitString   | Additional string for the condor submit            | request_cpus = 8 \\n periodic_remove = ...                |
+|                     | file. Separate entries with "\\n".                 |                                                           |
 +---------------------+----------------------------------------------------+-----------------------------------------------------------+
 | WorkingDirectory    | Directory where the pilot log files are stored     | /opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT    |
-|                     | locallly. Also temproray files like condor submit  |                                                           |
-|                     | files are kept here.                               |                                                           |
+|                     | locally. Also temproray files like condor submit   |                                                           |
+|                     | files are kept here. This option is only read from |                                                           |
+|                     | the global CEDefaults/HTCondorCE location.         |                                                           |
 +---------------------+----------------------------------------------------+-----------------------------------------------------------+
 | DaysToKeepLogFiles  | How many days pilot log files are kept on the disk | 15                                                        |
 |                     | before they are removed                            |                                                           |
 +---------------------+----------------------------------------------------+-----------------------------------------------------------+
-

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
@@ -1,0 +1,42 @@
+Resources / Computing
+=====================
+
+In this section options for ComputingElements can be set
+
+
+Resources / Computing / CEDefaults
+==================================
+
+
+
++---------------------------------+------------------------------------------------+-----------------------------------+
+| **Name**                        | **Description**                                | **Example**                       |
++---------------------------------+------------------------------------------------+-----------------------------------+
+| GridEnv                         |Default environment file sourced before calling | /opt/dirac/gridenv                |
+|                                 |grid commands, without extension                |                                   |
++---------------------------------+------------------------------------------------+-----------------------------------+
+| XRSLExtraString                 | Default additional string for ARC submit files |                                   |
++---------------------------------+------------------------------------------------+-----------------------------------+
+
+	     
+
+Resources / Computing / CEDefaults / HTCondorCE
+===============================================
+
+Options for the HTCondorCEs
+
+
++---------------------+----------------------------------------------------+-----------------------------------------------------------+
+| **Name**            | **Description**                                    | **Example**                                               |
++---------------------+----------------------------------------------------+-----------------------------------------------------------+
+| ExtraSubmitstring   | Default additional string for the condor submit    | request_cpus = 8 \n periodic_remove = ...                 |
+|                     | file. Separate entries with "\n".                  |                                                           |
++---------------------+----------------------------------------------------+-----------------------------------------------------------+
+| WorkingDirectory    | Directory where the pilot log files are stored     | /opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT    |
+|                     | locallly. Also temproray files like condor submit  |                                                           |
+|                     | files are kept here.                               |                                                           |
++---------------------+----------------------------------------------------+-----------------------------------------------------------+
+| DaysToKeepLogFiles  | How many days pilot log files are kept on the disk | 15                                                        |
+|                     | before they are removed                            |                                                           |
++---------------------+----------------------------------------------------+-----------------------------------------------------------+
+

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
@@ -60,17 +60,17 @@ HTCondorCE Parameters
 
 Options for the HTCondorCEs
 
-+---------------------+----------------------------------------------------+-----------------------------------------------------------+
-| **Name**            | **Description**                                    | **Example**                                               |
-+---------------------+----------------------------------------------------+-----------------------------------------------------------+
-| ExtraSubmitString   | Additional string for the condor submit            | request_cpus = 8 \\n periodic_remove = ...                |
-|                     | file. Separate entries with "\\n".                 |                                                           |
-+---------------------+----------------------------------------------------+-----------------------------------------------------------+
-| WorkingDirectory    | Directory where the pilot log files are stored     | /opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT    |
-|                     | locally. Also temproray files like condor submit   |                                                           |
-|                     | files are kept here. This option is only read from |                                                           |
-|                     | the global CEDefaults/HTCondorCE location.         |                                                           |
-+---------------------+----------------------------------------------------+-----------------------------------------------------------+
-| DaysToKeepLogFiles  | How many days pilot log files are kept on the disk | 15                                                        |
-|                     | before they are removed                            |                                                           |
-+---------------------+----------------------------------------------------+-----------------------------------------------------------+
++---------------------+-----------------------------------------------------+-----------------------------------------------------------+
+| **Name**            | **Description**                                     | **Example**                                               |
++---------------------+-----------------------------------------------------+-----------------------------------------------------------+
+| ExtraSubmitString   | Additional string for the condor submit             | request_cpus = 8 \\n periodic_remove = ...                |
+|                     | file. Separate entries with "\\n".                  |                                                           |
++---------------------+-----------------------------------------------------+-----------------------------------------------------------+
+| WorkingDirectory    | Directory where the pilot log files are stored      | /opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT    |
+|                     | locally. Also temproray files like condor submit    |                                                           |
+|                     | files are kept here. This option is only read from  |                                                           |
+|                     | the global Resources/Computing/HTCondorCE location. |                                                           |
++---------------------+-----------------------------------------------------+-----------------------------------------------------------+
+| DaysToKeepLogFiles  | How many days pilot log files are kept on the disk  | 15                                                        |
+|                     | before they are removed                             |                                                           |
++---------------------+-----------------------------------------------------+-----------------------------------------------------------+

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/index.rst
@@ -13,3 +13,4 @@ In this section all the physical resources than can be used by DIRAC users are d
    Sites/index
    StorageElements/index
    StorageElementsGroups/index
+   Computing/index


### PR DESCRIPTION


Add CS options:
   * add extraOption string to the submission file, based on the ARCCE implementation.
   * set working directory where the pilot logs etc. are kept
   * make the time to keep logs configurable

I place this for now in Computing/CEDefaults, because the ARC extraString was there too, but maybe this should go to Operations somewhere?


Add documentation page for CEDefaults