### PR TITLE
[v6r15] Site-wide and global CE parameters

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -205,7 +205,7 @@ def getQueues( siteList = None, ceList = None, ceTypeList = None, community = No
           comList = gConfig.getValue( '/Resources/Sites/%s/%s/CEs/%s/VO' % ( grid, site, ce ), [] )
           if comList and not community in comList:
             continue
-        ceOptionsDict = siteCEParameters
+        ceOptionsDict = dict( siteCEParameters )
         result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/CEs/%s' % ( grid, site, ce ) )
         if not result['OK']:
           continue

--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -183,7 +183,7 @@ def getQueues( siteList = None, ceList = None, ceTypeList = None, community = No
         if comList and not community in comList:
           continue
       siteCEParameters = {}
-      result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/CEs' )
+      result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/CEs' % ( grid, site ) )
       if result['OK']:
         siteCEParameters = result['Value']
       result = gConfig.getSections( '/Resources/Sites/%s/%s/CEs' % ( grid, site ) )

--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -69,7 +69,6 @@ def getFTS2ServersForSites( siteList = None ):
 
 def getFTS3Servers():
   """ get FTSServers for sites
-  :param list siteList: list of sites
   """
 
   csPath = cfgPath( gBaseResourcesSection, "FTSEndpoints/FTS3" )
@@ -160,7 +159,6 @@ def getQueue( site, ce, queue ):
   return S_OK( resultDict )
 
 
-
 def getQueues( siteList = None, ceList = None, ceTypeList = None, community = None, mode = None ):
   """ Get CE/queue options according to the specified selection
   """
@@ -184,6 +182,10 @@ def getQueues( siteList = None, ceList = None, ceTypeList = None, community = No
         comList = gConfig.getValue( '/Resources/Sites/%s/%s/VO' % ( grid, site ), [] )
         if comList and not community in comList:
           continue
+      siteCEParameters = {}
+      result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/CEs' )
+      if result['OK']:
+        siteCEParameters = result['Value']
       result = gConfig.getSections( '/Resources/Sites/%s/%s/CEs' % ( grid, site ) )
       if not result['OK']:
         continue
@@ -197,14 +199,17 @@ def getQueues( siteList = None, ceList = None, ceTypeList = None, community = No
           ceType = gConfig.getValue( '/Resources/Sites/%s/%s/CEs/%s/CEType' % ( grid, site, ce ), '' )
           if not ceType or not ceType in ceTypeList:
             continue
+        if ceList is not None and not ce in ceList:
+          continue
         if community:
           comList = gConfig.getValue( '/Resources/Sites/%s/%s/CEs/%s/VO' % ( grid, site, ce ), [] )
           if comList and not community in comList:
             continue
+        ceOptionsDict = siteCEParameters
         result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/CEs/%s' % ( grid, site, ce ) )
         if not result['OK']:
           continue
-        ceOptionsDict = result['Value']
+        ceOptionsDict.update( result['Value'] )
         result = gConfig.getSections( '/Resources/Sites/%s/%s/CEs/%s/Queues' % ( grid, site, ce ) )
         if not result['OK']:
           continue

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -8,7 +8,7 @@
     Using the ARC API now
 """
 
-__RCSID__ = "58c42fc (2013-07-07 22:54:57 +0200) Andrei Tsaregorodtsev <atsareg@in2p3.fr>"
+__RCSID__ = "$Id$"
 
 import os
 import stat

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -66,7 +66,7 @@ class ComputingElement(object):
     self.batchSystem = None
 
     self.minProxyTime = gConfig.getValue( '/Registry/MinProxyLifeTime', 10800 ) #secs
-    self.defaultProxyTime = gConfig.getValue( '/Registry/DefaultProxyLifeTime', 86400 ) #secs
+    self.defaultProxyTime = gConfig.getValue( '/Registry/DefaultProxyLifeTime', 43200 ) #secs
     self.proxyCheckPeriod = gConfig.getValue( '/Registry/ProxyCheckingPeriod', 3600 ) #secs
 
     self.initializeParameters()
@@ -190,8 +190,21 @@ class ComputingElement(object):
 
   def setParameters( self, ceOptions ):
     """ Add parameters from the given dictionary overriding the previous values
+
+        :param dict ceOptions: CE parameters dictionary to update already defined ones
     """
     self.ceParameters.update( ceOptions )
+
+    # At this point we can know the exact type of CE,
+    # try to get generic parameters for this type
+    ceType = self.ceParameters.get( 'CEType' )
+    if ceType:
+      result = gConfig.getOptionsDict( '/Resources/Computing/%s' % ceType )
+      if result['OK']:
+        generalCEDict = result['Value']
+        generalCEDict.update( self.ceParameters )
+        self.ceParameters = generalCEDict
+
     for key in ceOptions:
       if key in INTEGER_PARAMETERS:
         self.ceParameters[key] = int( self.ceParameters[key] )

--- a/Resources/Computing/ComputingElementFactory.py
+++ b/Resources/Computing/ComputingElementFactory.py
@@ -52,10 +52,11 @@ class ComputingElementFactory( object ):
     ceClass = result['Value']
     try:
       computingElement = ceClass( ceNameLocal )
+      # Always set the CEType parameter according to instantiated class
+      ceDict = { 'CEType': ceTypeLocal }
       if ceParametersDict:
-        computingElement.setParameters( ceParametersDict )
-      else:
-        computingElement._reset()
+        ceDict.update( ceParametersDict )
+      computingElement.setParameters( ceDict )
     except Exception as x:
       msg = 'ComputingElementFactory could not instantiate %s object: %s' % ( subClassName, str( x ) )
       self.log.exception()


### PR DESCRIPTION
This PR allows to define site-wide CE parameters in the section:

    /Resources/Sites/_grid_/_site_/CEs

CE parameters specific for a given type for the whole DIRAC installation can be defined in the section:

    /Resources/Computing/_ceType_