### PR TITLE
[v6r15] Graphs - force matplotlib to use Agg backend

### DIFF
--- a/Core/Utilities/Graphs/__init__.py
+++ b/Core/Utilities/Graphs/__init__.py
@@ -7,12 +7,14 @@
 
 __RCSID__ = "$Id$"
 
+# Make sure the the Agg backend is used despite arbitrary configuration
+import matplotlib
+matplotlib.use( 'agg' )
+
 import DIRAC
 
 from DIRAC.Core.Utilities.Graphs.Graph import Graph
 from DIRAC.Core.Utilities.Graphs.GraphUtilities import evalPrefs
-
-import time
 
 common_prefs = {
   'background_color':'white',

--- a/FrameworkSystem/Client/ProxyManagerClient.py
+++ b/FrameworkSystem/Client/ProxyManagerClient.py
@@ -230,11 +230,6 @@ class ProxyManagerClient:
   @gVOMSProxiesSync
   def downloadVOMSProxy( self, userDN, userGroup, limited = False, requiredTimeLeft = 1200,
                          cacheTime = 14400, requiredVOMSAttribute = False,
-
-
-
-
-
                          proxyToConnect = False, token = False ):
     """
     Download a proxy if needed and transform it into a VOMS one


### PR DESCRIPTION
On some installations the matplotlib default configuration can point to some interactive backend which can be in the way for DIRAC ploltting services