### PR TITLE
[v6r15] cshrc: protect against undefined variables

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1384,7 +1384,11 @@ def createCshrc():
 
       lines.extend( ['# Prepend the PYTHONPATH, the LD_LIBRARY_PATH, and the DYLD_LIBRARY_PATH'] )
 
-      lines.extend( ['( echo $PATH | grep -q $DIRACBIN ) || setenv PATH ${DIRACBIN}:$PATH',
+      lines.extend( ['( test $?PATH -eq 1 ) || setenv PATH ""',
+                     '( test $?LD_LIBRARY_PATH -eq 1 ) || setenv LD_LIBRARY_PATH ""',
+                     '( test $?DY_LD_LIBRARY_PATH -eq 1 ) || setenv DYLD_LIBRARY_PATH ""',
+                     '( test $?PYTHONPATH -eq 1 ) || setenv PYTHONPATH ""',
+                     '( echo $PATH | grep -q $DIRACBIN ) || setenv PATH ${DIRACBIN}:$PATH',
                      '( echo $PATH | grep -q $DIRACSCRIPTS ) || setenv PATH ${DIRACSCRIPTS}:$PATH',
                      '( echo $LD_LIBRARY_PATH | grep -q $DIRACLIB ) || setenv LD_LIBRARY_PATH ${DIRACLIB}:$LD_LIBRARY_PATH',
                      '( echo $LD_LIBRARY_PATH | grep -q $DIRACLIB/mysql ) || setenv LD_LIBRARY_PATH ${DIRACLIB}/mysql:$LD_LIBRARY_PATH',
@@ -1399,7 +1403,7 @@ def createCshrc():
       # add DIRACPLAT environment variable for client installations
       if cliParams.externalsType == 'client':
         lines.extend( ['# DIRAC platform',
-                       'test -z "$DIRACPLAT" && setenv DIRACPLAT `$DIRAC/scripts/dirac-platform`'] )
+                       'test $?DIRACPLAT -eq 1 || setenv DIRACPLAT `$DIRAC/scripts/dirac-platform`'] )
       # Add the lines required for ARC CE support
       lines.extend( ['# ARC Computing Element',
                      'setenv ARC_PLUGIN_PATH $DIRACLIB/arc'] )


### PR DESCRIPTION
if a variable is not set (t)csh aborts with an error message
```
LD_LIBRARY_PATH: Undefined variable.
LD_LIBRARY_PATH: Undefined variable.
```