### PR TITLE
[v6r15] Hosts are presenting Host property

### DIFF
--- a/Core/DISET/AuthManager.py
+++ b/Core/DISET/AuthManager.py
@@ -142,6 +142,7 @@ class AuthManager( object ):
       return False
     credDict[ self.KW_USERNAME ] = retVal[ 'Value' ]
     credDict[ self.KW_PROPERTIES ] = CS.getPropertiesForHost( credDict[ self.KW_USERNAME ], [] )
+    credDict[ self.KW_PROPERTIES ].append( 'Host' )
     return True
 
   def getValidPropertiesForMethod( self, method, defaultProperties = False ):


### PR DESCRIPTION
Added a Host group property presented by host certificates that can be used for authorization. Some service methods are meant only to be called by hosts, e.g. host status update for monitoring and logging.