### PR TITLE
[v6r15] Service authorization rules per VO and group

### DIFF
--- a/Core/DISET/AuthManager.py
+++ b/Core/DISET/AuthManager.py
@@ -52,15 +52,20 @@ class AuthManager( object ):
     if self.KW_EXTRA_CREDENTIALS in credDict:
       userString += " extraCredentials=%s" % str( credDict[ self.KW_EXTRA_CREDENTIALS ] )
     self.__authLogger.verbose( "Trying to authenticate %s" % userString )
-    #Get properties
+    # Get properties
     requiredProperties = self.getValidPropertiesForMethod( methodQuery, defaultProperties )
+    # Extract valid groups
+    validGroups = self.getValidGroups( requiredProperties )
     lowerCaseProperties = [ prop.lower() for prop in requiredProperties ]
+    if not lowerCaseProperties:
+      lowerCaseProperties = ['any']
+
     allowAll = "any" in lowerCaseProperties or "all" in lowerCaseProperties
     #Set no properties by default
     credDict[ self.KW_PROPERTIES ] = []
     #Check non secure backends
     if self.KW_DN not in credDict or not credDict[ self.KW_DN ]:
-      if allowAll:
+      if allowAll and not validGroups:
         self.__authLogger.verbose( "Accepted request from unsecure transport" )
         return True
       else:
@@ -84,12 +89,12 @@ class AuthManager( object ):
       credDict[ self.KW_GROUP ] = credDict[ self.KW_EXTRA_CREDENTIALS ]
     #HACK TO MAINTAIN COMPATIBILITY
     else:
-      if self.KW_EXTRA_CREDENTIALS in credDict and not self.KW_GROUP in credDict:
+      if self.KW_EXTRA_CREDENTIALS in credDict and self.KW_GROUP not in credDict:
         credDict[ self.KW_GROUP ] = credDict[ self.KW_EXTRA_CREDENTIALS ]
     #END OF HACK
     #Get the username
     if self.KW_DN in credDict and credDict[ self.KW_DN ]:
-      if not self.KW_GROUP in credDict:
+      if self.KW_GROUP not in credDict:
         result = CS.findDefaultGroupForDN( credDict[ self.KW_DN ] )
         if not result['OK']:
           return False
@@ -113,14 +118,19 @@ class AuthManager( object ):
           credDict[ self.KW_USERNAME ] = "anonymous"
           credDict[ self.KW_GROUP ] = "visitor"
     #If any or all in the props, allow
-    if allowAll:
+    allowGroup = not validGroups or credDict[ self.KW_GROUP ] in validGroups
+    if allowAll and allowGroup:
       return True
     #Check authorized groups
-    if "authenticated" in lowerCaseProperties:
+    if "authenticated" in lowerCaseProperties and allowGroup:
       return True
     if not self.matchProperties( credDict, requiredProperties ):
       self.__authLogger.warn( "Client is not authorized\nValid properties: %s\nClient: %s" %
                                ( requiredProperties, credDict ) )
+      return False
+    elif not allowGroup:
+      self.__authLogger.warn( "Client is not authorized\nValid groups: %s\nClient: %s" %
+                               ( validGroups, credDict ) )
       return False
     return True
 
@@ -133,9 +143,9 @@ class AuthManager( object ):
     :param credDict: Credentials to ckeck
     :return: Boolean specifying whether the nickname was found
     """
-    if not self.KW_DN in credDict:
+    if self.KW_DN not in credDict:
       return True
-    if not self.KW_GROUP in credDict:
+    if self.KW_GROUP not in credDict:
       return False
     retVal = CS.getHostnameForDN( credDict[ self.KW_DN ] )
     if not retVal[ 'OK' ]:
@@ -168,6 +178,28 @@ class AuthManager( object ):
       return authProps
     self.__authLogger.verbose( "Method %s has no authorization rules defined. Allowing no properties" % method )
     return []
+
+  def getValidGroups( self, rawProperties ):
+    """  Get valid groups as specified in the method authorization rules
+
+    :param list rawProperties: all method properties
+    :return: list of allowed groups or []
+    """
+    validGroups = []
+    for prop in list( rawProperties ):
+      if prop.startswith( 'group:' ):
+        rawProperties.remove( prop )
+        prop = prop.replace( 'group:', '' )
+        validGroups.append( prop )
+      elif prop.startswith( 'vo:' ):
+        rawProperties.remove( prop )
+        vo = prop.replace( 'vo:', '' )
+        result = getGroupsForVO( vo )
+        if result['OK']:
+          validGroups.extend( result['Value'] )
+
+    validGroups = list( set( validGroups ) )
+    return validGroups
 
   def forwardedCredentials( self, credDict ):
     """
@@ -207,9 +239,9 @@ class AuthManager( object ):
     :param credDict: Credentials to ckeck
     :return: Boolean specifying whether the username was found
     """
-    if not self.KW_DN in credDict:
+    if self.KW_DN not in credDict:
       return True
-    if not self.KW_GROUP in credDict:
+    if self.KW_GROUP not in credDict:
       result = CS.findDefaultGroupForDN( credDict[ self.KW_DN ] )
       if not result['OK']:
         return False
@@ -233,23 +265,6 @@ class AuthManager( object ):
     :param validProps: List of valid properties
     :return: Boolean specifying whether any property has matched the valid ones
     """
-
-    # Prepare and check the valid group list
-    validGroups = []
-    for property in list( validProps ):
-      if property.startswith( 'group:' ):
-        validProps.remove( property )
-        property = property.replace( 'group:', '' )
-        validGroups.append( property )
-      elif property.startswith( 'vo:' ):
-        validProps.remove( property )
-        vo = property.replace( 'vo:', '' )
-        result = getGroupsForVO( vo )
-        if result['OK']:
-          validGroups.extend( result['Value'] )
-
-    if validGroups and not credDict[ self.KW_GROUP ] in validGroups:
-      return []
 
     #HACK: Map lower case properties to properties to make the check in lowercase but return the proper case
     if not caseSensitive:

--- a/Core/DISET/AuthManager.py
+++ b/Core/DISET/AuthManager.py
@@ -142,6 +142,7 @@ class AuthManager( object ):
       return False
     credDict[ self.KW_USERNAME ] = retVal[ 'Value' ]
     credDict[ self.KW_PROPERTIES ] = CS.getPropertiesForHost( credDict[ self.KW_USERNAME ], [] )
+    credDict[ self.KW_PROPERTIES ].append( 'Host' )
     return True
 
   def getValidPropertiesForMethod( self, method, defaultProperties = False ):

--- a/Core/test/Test_AuthManager.py
+++ b/Core/test/Test_AuthManager.py
@@ -1,0 +1,217 @@
+""" Basic unit tests for AuthManager
+"""
+
+import unittest
+
+from DIRAC import gConfig
+from DIRAC.Core.Utilities.CFG import CFG
+from DIRAC.Core.DISET.AuthManager import AuthManager
+
+__RCSID__ = "$Id$"
+
+testSystemsCFG = """
+Systems
+{
+  Service
+  {
+    Authorization
+    {
+      Method = NormalUser
+      MethodAll = Any
+      MethodAuth = Authenticated
+      MethodGroup = NormalUser,group:group_test
+      MethodAllGroup = Any,group:group_test
+      MethodAuthGroup = Authenticated,group:group_test
+      MethodVO = NormalUser,vo:testVO
+      MethodAllVO = Any,vo:testVO
+      MethodAuthVO = Authenticated,vo:testVO
+      MethodHost = group:hosts
+      MethodTrustedHost = TrustedHost,group:hosts
+    }
+  }
+}
+"""
+
+testRegistryCFG = """
+Registry
+{
+  Users
+  {
+    userA
+    {
+      DN = /User/test/DN/CN=userA
+    }
+    userB
+    {
+      DN = /User/test/DN/CN=userB
+    }
+  }
+  Hosts
+  {
+    test.hostA.ch
+    {
+      DN = /User/test/DN/CN=test.hostA.ch
+      Properties = TrustedHost
+    }
+    test.hostB.ch
+    {
+      DN = /User/test/DN/CN=test.hostB.ch
+      Properties = NoTrustedHost
+    }
+  }
+  Groups
+  {
+    group_test
+    {
+      Users = userA
+      VO = testVO
+      Properties = NormalUser
+    }
+    group_bad
+    {
+      Users = userB
+      VO = testVOBad
+      Properties = NoProperties
+    }
+  }
+}
+"""
+
+class AuthManagerTest( unittest.TestCase ):
+  """ Base class for the Modules test cases
+  """
+  def setUp( self ):
+    self.authMgr = AuthManager( '/Systems/Service/Authorization' )
+    cfg = CFG()
+    cfg.loadFromBuffer( testSystemsCFG )
+    gConfig.loadCFG( cfg )
+    cfg.loadFromBuffer( testRegistryCFG )
+    gConfig.loadCFG( cfg )
+
+    self.noAuthCredDict = { 'group': 'group_test' }
+
+    self.userCredDict = { 'DN': '/User/test/DN/CN=userA',
+                          'group': 'group_test' }
+
+    self.badUserCredDict = { 'DN': '/User/test/DN/CN=userB',
+                             'group': 'group_bad' }
+    self.hostCredDict = { 'DN': '/User/test/DN/CN=test.hostA.ch',
+                          'group': 'hosts' }
+    self.badHostCredDict = { 'DN': '/User/test/DN/CN=test.hostB.ch',
+                             'group': 'hosts' }
+
+  def tearDown( self ):
+    pass
+
+  def test_userProperties( self ):
+
+    # MethodAll accepts everybody
+    result = self.authMgr.authQuery( 'MethodAll', self.userCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodAll', self.noAuthCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodAll', self.badUserCredDict )
+    self.assertTrue( result )
+
+    # MethodAuth requires DN to be identified
+    result = self.authMgr.authQuery( 'MethodAuth', self.userCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodAuth', self.noAuthCredDict )
+    self.assertFalse( result )
+    result = self.authMgr.authQuery( 'MethodAuth', self.badUserCredDict )
+    self.assertTrue( result )
+
+    # Method requires NormalUser property
+    result = self.authMgr.authQuery( 'Method', self.userCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'Method', self.badUserCredDict )
+    self.assertFalse( result )
+    result = self.authMgr.authQuery( 'Method', self.noAuthCredDict )
+    self.assertFalse( result )
+
+  def test_userGroup( self ):
+
+    # MethodAllGroup accepts everybody from the right group
+    result = self.authMgr.authQuery( 'MethodAllGroup', self.userCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodAllGroup', self.noAuthCredDict )
+    self.assertFalse( result )
+    result = self.authMgr.authQuery( 'MethodAllGroup', self.badUserCredDict )
+    self.assertFalse( result )
+
+    # MethodAuthGroup requires DN to be identified from the right group
+    result = self.authMgr.authQuery( 'MethodAuthGroup', self.userCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodAuthGroup', self.noAuthCredDict )
+    self.assertFalse( result )
+    result = self.authMgr.authQuery( 'MethodAuthGroup', self.badUserCredDict )
+    self.assertFalse( result )
+
+    # Method requires NormalUser property and the right group
+    result = self.authMgr.authQuery( 'MethodGroup', self.userCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodGroup', self.badUserCredDict )
+    self.assertFalse( result )
+    result = self.authMgr.authQuery( 'MethodGroup', self.noAuthCredDict )
+    self.assertFalse( result )
+
+  def test_userVO( self ):
+
+    # MethodAllGroup accepts everybody from the right group
+    result = self.authMgr.authQuery( 'MethodAllVO', self.userCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodAllVO', self.noAuthCredDict )
+    self.assertFalse( result )
+    result = self.authMgr.authQuery( 'MethodAllVO', self.badUserCredDict )
+    self.assertFalse( result )
+
+    # MethodAuthGroup requires DN to be identified from the right group
+    result = self.authMgr.authQuery( 'MethodAuthVO', self.userCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodAuthVO', self.noAuthCredDict )
+    self.assertFalse( result )
+    result = self.authMgr.authQuery( 'MethodAuthVO', self.badUserCredDict )
+    self.assertFalse( result )
+
+    # Method requires NormalUser property and the right group
+    result = self.authMgr.authQuery( 'MethodVO', self.userCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodVO', self.badUserCredDict )
+    self.assertFalse( result )
+    result = self.authMgr.authQuery( 'MethodVO', self.noAuthCredDict )
+    self.assertFalse( result )
+
+  def test_hostProperties( self ):
+
+    # MethodAll accepts everybody
+    result = self.authMgr.authQuery( 'MethodAll', self.hostCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodAll', self.badHostCredDict )
+    self.assertTrue( result )
+
+    # MethodAuth requires DN to be identified
+    result = self.authMgr.authQuery( 'MethodAuth', self.hostCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodAuth', self.badHostCredDict )
+    self.assertTrue( result )
+
+    # Method requires NormalUser property
+    result = self.authMgr.authQuery( 'Method', self.hostCredDict )
+    self.assertFalse( result )
+
+    # MethodHost requires hosts group
+    result = self.authMgr.authQuery( 'MethodHost', self.hostCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodHost', self.badHostCredDict )
+    self.assertTrue( result )
+
+    # MethodTrustedHost requires hosts group and TrustedHost property
+    result = self.authMgr.authQuery( 'MethodTrustedHost', self.hostCredDict )
+    self.assertTrue( result )
+    result = self.authMgr.authQuery( 'MethodTrustedHost', self.badHostCredDict )
+    self.assertFalse( result )
+
+if __name__ == '__main__':
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase( AuthManagerTest )
+  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
+


### PR DESCRIPTION
Added a possibility to authorize access to a service method by the caller VO and/or group. The authorization rule is described as, for example:

    Authorization
    {
        myMethod = NormalUser, vo:lhcb, group:biomed_user
    }    

In the example above, the myMethod can be called by a user with a group that has NormalUser property, but in addition the user must belong either to VO lhcb or to group biomed_user. This can be useful to limit certain services to the use by a given VO or group. For example, a VO specific file catalog or service from a VO specific extension in a multi-VO environment. 

In the special case of using host certificates, the authorization can be described with group:hosts special property which means that the call must come from a host. This more general solution replaces the Host property introduced in the previously closed PR #3064  