### PR TITLE
[v6r15] JobCleaningAgent: Option for removing Jobs in other states

### DIFF
--- a/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -179,7 +179,7 @@ Agents
   }
   JobCleaningAgent
   {
-    PollingTime = 120
+    PollingTime = 3600
   }
   InputDataAgent
   {

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Agents/JobCleaningAgent/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Agents/JobCleaningAgent/index.rst
@@ -3,22 +3,35 @@ Systems / WorkloadManagement / <INSTANCE> / Agents / JobCleaningAgent - Sub-subs
 
 The Job Cleaning Agent controls removing jobs from the WMS in the end of their life cycle. The attributes are showed in the following table.
 
-+--------------------+----------------------------------------+---------------------------------------+
-| **Name**           | **Description**                        | **Example**                           |
-+--------------------+----------------------------------------+---------------------------------------+
-| *JobByJob*         | Boolean than express if job by job     | JobByJob = True                       |
-|                    | must be processed                      |                                       |
-+--------------------+----------------------------------------+---------------------------------------+
-| *MaxJobsAtOnce*    | Maximum number of jobs to be processed | MaxJobsAtOnce = 200                   |
-|                    | at the same time                       |                                       |
-+--------------------+----------------------------------------+---------------------------------------+
-| *ProductionTypes*  | Production types                       | ProductionTypes  = DataReconstruction |
-|                    |                                        | ProductionTypes += DataStripping      |
-|                    |                                        | ProductionTypes += MCSimulation       |
-|                    |                                        | ProductionTypes += Merge              |
-|                    |                                        | ProductionTypes += production         |
-+--------------------+----------------------------------------+---------------------------------------+
-| *ThrottlingPeriod* |                                        | ThrottlingPeriod = 0                  |
-+--------------------+----------------------------------------+---------------------------------------+
++-----------------------------+----------------------------------------+--------------------------------------------+
+| **Name**                    | **Description**                        | **Example**                                |
++-----------------------------+----------------------------------------+--------------------------------------------+
+| *JobByJob*                  | Boolean: If True jobs are deleted      | | JobByJob = True                          |
+|                             | individually not in batches            | | (default is False)                       |
++-----------------------------+----------------------------------------+--------------------------------------------+
+| *MaxJobsAtOnce*             | Int: Maximum number of jobs to be      | | MaxJobsAtOnce = 100                      |
+|                             | processed at the same time             | | (default is 500)                         |
++-----------------------------+----------------------------------------+--------------------------------------------+
+| *ProductionTypes*           | Production types                       | | ProductionTypes  = DataReconstruction    |
+|                             |                                        | | ProductionTypes += DataStripping         |
+|                             |                                        | | ProductionTypes += MCSimulation          |
+|                             |                                        | | ProductionTypes += Merge                 |
+|                             |                                        | | ProductionTypes += production            |
++-----------------------------+----------------------------------------+--------------------------------------------+
+| *ThrottlingPeriod*          | Float: Seconds to wait between jobs if | | ThrottlingPeriod = 1.0                   |
+|                             | JobByJob is True.                      | | (default is 0.)                          |
++-----------------------------+----------------------------------------+--------------------------------------------+
+| *RemoveStatusDelay/Done*    | Int: Number of days after which to     | | RemoveStatusDelay/Done = 14              |
+|                             | remove jobs in the Done state.         | | (default is 7)                           |
++-----------------------------+----------------------------------------+--------------------------------------------+
+| *RemoveStatusDelay/Killed*  | Int: Number of days after which to     | | RemoveStatusDelay/Killed = 14            |
+|                             | remove jobs in the Killed state.       | | (default is 7)                           |
++-----------------------------+----------------------------------------+--------------------------------------------+
+| *RemoveStatusDelay/Failed*  | Int: Number of days after which to     | | RemoveStatusDelay/Failed = 14            |
+|                             | remove jobs in the Failed state.       | | (default is 7)                           |
++-----------------------------+----------------------------------------+--------------------------------------------+
+| *RemoveStatusDelay/Any*     | Int: Number of days after which to     | | RemoveStatusDelay/Any = 60               |
+|                             | remove any job, irrespective of state. | | (default is -1, to disable this feature) |
++-----------------------------+----------------------------------------+--------------------------------------------+
 
 And also the common options for all the agents.


### PR DESCRIPTION
This update adds an option (disabled by default) to remove Jobs from the dirac server irrespective of their state.
We found this useful for cleaning a large backlog of jobs that had been in the Waiting state for 3+ months.
Also updated the default polling time for this agent, as Job ages are given in days and a default polling time of 120 s seems excessive.
Updated the documentation to list all options for this agent.