### PR TITLE
[v6r15] HostLogging: Bring back version and setup information

### DIFF
--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -551,6 +551,7 @@ class SystemAdministratorHandler( RequestHandler ):
 
     infoResult = gComponentInstaller.getInfo( getCSExtensions() )
     if infoResult['OK']:
+      result.update( infoResult['Value'] )
       # the infoResult value is {"Extensions":{'a1':'v1',a2:'v2'}; we convert to a string
       result.update( {"Extensions":";".join( ["%s:%s" % ( key, value ) for ( key, value ) in infoResult["Value"].get( 'Extensions' ).iteritems()] )} )
 


### PR DESCRIPTION
The `infoResult['Value']` contains the DIRAC version and Setup information which needs to be passed forward as well