### PR TITLE
[v6r15] fixes for condor log/out files location and dirac-dms-remove-replicas

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-remove-replicas.py
+++ b/DataManagementSystem/scripts/dirac-dms-remove-replicas.py
@@ -40,7 +40,7 @@ Usage:
     inputFile.close()
   else:
     lfns = [inputFileName]
-  for lfnList in breakListIntoChunks( sorted( lfns, True ), 500 ):
+  for lfnList in breakListIntoChunks( sorted( lfns, reverse=True ), 500 ):
     for storageElementName in storageElementNames:
       res = dm.removeReplica( storageElementName, lfnList )
       if not res['OK']:

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -101,15 +101,14 @@ class HTCondorCEComputingElement( ComputingElement ):
 
     """
 
-    initialDir = os.path.dirname( self.workingDirectory )
     self.log.debug( "Working directory: %s " % self.workingDirectory )
     ##We randomize the location of the pilotoutput and log, because there are just too many of them
     pre1 = makeGuid()[:3]
     pre2 = makeGuid()[:3]
-    mkDir( os.path.join( initialDir, pre1, pre2 ) )
+    mkDir( os.path.join( self.workingDirectory, pre1, pre2 ) )
     initialDirPrefix = "%s/%s" %( pre1, pre2 )
 
-    self.log.debug( "InitialDir: %s" % os.path.join(initialDir,initialDirPrefix) )
+    self.log.debug( "InitialDir: %s" % os.path.join( self.workingDirectory, initialDirPrefix ) )
 
     fd, name = tempfile.mkstemp( suffix = '.sub', prefix = 'HTCondorCE_', dir = self.workingDirectory )
     subFile = os.fdopen( fd, 'w' )
@@ -138,7 +137,7 @@ Queue %(nJobs)s
             nJobs=nJobs,
             ceName=self.ceName,
             extraString=self.extraSubmitString,
-            initialDir=os.path.join(initialDir,initialDirPrefix),
+            initialDir=os.path.join( self.workingDirectory, initialDirPrefix ),
           )
     subFile.write( sub )
     subFile.close()


### PR DESCRIPTION
HTCondorCE: If the WorkingDirectory does not end with a slash the location is changed

dirac-dms-remove-replicas: correct sorted arguments