### PR TITLE
[v6r15] ValidateOutputDataAgent: use the shifter proxy

### DIFF
--- a/TransformationSystem/Agent/ValidateOutputDataAgent.py
+++ b/TransformationSystem/Agent/ValidateOutputDataAgent.py
@@ -47,6 +47,12 @@ class ValidateOutputDataAgent( AgentModule ):
   def initialize( self ):
     """ Sets defaults
     """
+
+    # This sets the Default Proxy to used as that defined under
+    # /Operations/Shifter/DataManager
+    # the shifterProxy option in the Configuration can be used to change this default.
+    self.am_setOption( 'shifterProxy', 'DataManager' )
+
     gLogger.info( "Will treat the following transformation types: %s" % str( self.transformationTypes ) )
     gLogger.info( "Will search for directories in the following locations: %s" % str( self.directoryLocations ) )
     gLogger.info( "Will check the following storage elements: %s" % str( self.activeStorages ) )


### PR DESCRIPTION
Gone for almost 2 years.. this agent really needs to be reviewed because it does nothing