### PR TITLE
[v6r15] fix for Watchdog factory, tweak for dirac-admin-get-CAs

### DIFF
--- a/FrameworkSystem/scripts/dirac-admin-get-CAs.py
+++ b/FrameworkSystem/scripts/dirac-admin-get-CAs.py
@@ -20,17 +20,17 @@ if not result[ 'OK' ]:
   DIRAC.gLogger.error( "Error while updating CAs", result[ 'Message' ] )
   DIRAC.exit( 1 )
 elif result[ 'Value' ]:
-  DIRAC.gLogger.info( "CAs got updated" )
+  DIRAC.gLogger.notice( "CAs got updated" )
 else:
-  DIRAC.gLogger.info( "CAs are already synchronized" )
+  DIRAC.gLogger.notice( "CAs are already synchronized" )
 
 result = bdc.syncCRLs()
 if not result[ 'OK' ]:
   DIRAC.gLogger.error( "Error while updating CRLs", result[ 'Message' ] )
   DIRAC.exit( 1 )
 elif result[ 'Value' ]:
-  DIRAC.gLogger.info( "CRLs got updated" )
+  DIRAC.gLogger.notice( "CRLs got updated" )
 else:
-  DIRAC.gLogger.info( "CRLs are already synchronized" )
+  DIRAC.gLogger.notice( "CRLs are already synchronized" )
 
 DIRAC.exit( 0 )

--- a/WorkloadManagementSystem/JobWrapper/WatchdogFactory.py
+++ b/WorkloadManagementSystem/JobWrapper/WatchdogFactory.py
@@ -36,13 +36,13 @@ class WatchdogFactory( object ):
 
     try:
       wdModule = __import__( self.watchDogsLocation + '.%s' % subClassName, globals(), locals(), [subClassName] )
-    except ImportError, e:
-      self.log.exception( "Failed to import module" + self.watchDogsLocation + '.%s' % subClassName + '.%s' % subClassName + ': ' + e )
+    except ImportError as e:
+      self.log.exception( "Failed to import module" + self.watchDogsLocation + '.%s' % subClassName + '.%s' % subClassName + ': ' + str(e) )
       return S_ERROR( "Failed to import module" )
     try:
       wd_o = getattr( wdModule, subClassName )( pid, thread, spObject, jobcputime, memoryLimit )
       return S_OK( wd_o )
-    except AttributeError, e:
+    except AttributeError as e:
       self.log.exception( "Failed to create %s(): %s." % ( subClassName, e ) )
       return S_ERROR( "Failed to create object" )
 


### PR DESCRIPTION
dirac-admin-get-CAs: log with notice, so information is printed by default
Otherwise the script is silent and a bit confusing for users, or is someone using this in a cronjob and wants it to be quiet except for errors?

Watchdog: FIX exception: Cannot concatenate string and exception objects
(Not sure why the subClassName is twice in that string in line 40)