### PR TITLE
[v6r15] printTable: Right align numbers, left align other things

### DIFF
--- a/Core/Utilities/PrettyPrint.py
+++ b/Core/Utilities/PrettyPrint.py
@@ -94,7 +94,12 @@ def printTable( fields, records, sortField='', numbering=True,
         stringBuffer.write( str(count).rjust(numberWidth)+columnSeparator )
 
     for i in range( nFields ):
-      stringBuffer.write( r[i].ljust( lengths[i] )+columnSeparator )
+      #try casting to int and then align to the right, if it fails align to the left
+      try:
+        _val = int( "".join( r[i].split(",") ) )
+        stringBuffer.write( r[i].rjust( lengths[i] )+columnSeparator )
+      except ValueError:
+        stringBuffer.write( r[i].ljust( lengths[i] )+columnSeparator )
 
     stringBuffer.write( '\n' )
     if count == len( recordList )-1 and recordList[-1][0] == "Total":


### PR DESCRIPTION
Makes tables look like this:
```
    StorageElement         Size                  Replicas
==========================================================
  1 KEK-SRM                  326,232,223,288,747  1086987
  2 PNNL-SRM                  16,360,823,970,918    65734
  3 gw38.hep.ph.ic.ac.uk               9,953,385        5
  4 polgrid4.in2p3.fr            144,026,824,484     2589
  5 CERN-DST-EOS             160,052,209,973,062  3732108
```