### PR TITLE
[v6r18] Network plots

### DIFF
--- a/AccountingSystem/Agent/NetworkAgent.py
+++ b/AccountingSystem/Agent/NetworkAgent.py
@@ -1,0 +1,242 @@
+__RCSID__ = "$Id: $"
+import time
+import ssl
+import stomp
+import socket
+import json
+
+from DIRAC import S_OK, S_ERROR
+from DIRAC.Core.Base.AgentModule                  import AgentModule
+from DIRAC.Core.Security                          import Locations
+from DIRAC.AccountingSystem.Client.Types.Network  import Network
+from DIRAC.ConfigurationSystem.Client.Config      import gConfig
+from DIRAC.ConfigurationSystem.Client.CSAPI       import CSAPI
+
+from messaging.stomppy import MessageListener
+from datetime import datetime
+
+# required by stomp.py
+import logging
+logging.basicConfig()
+
+
+class NetworkAgent ( AgentModule ):
+  """
+  Class to retrieve messages containing perfSONAR data.
+  """
+
+  # supported messages
+  MESSAGE_TYPES = [
+                    'packet-loss-rate',
+                    # 'packet-count-sent',
+                    # 'packet-count-lost',
+                    # 'packet-trace',
+                    # 'throughput',
+                    'histogram-owdelay'
+                  ]
+
+  HostToDiracNameDict = {}  # one dictionary for all message listeners
+
+  def initialize( self ):
+
+    # API initialization is required to get the up-to-date configuration from CS
+    self.csAPI = CSAPI()
+    self.csAPI.initialize()
+
+    # get paths to the key and certificate
+    paths = Locations.getHostCertificateAndKeyLocation()
+    if not paths:
+      self.log.error( "getHostCertificateAndKeyLocation() returned 'False'" )
+      return S_ERROR( 'Could not find a certificate!' )
+    else:
+      self.hostCertPath = paths[0]
+      self.hostKeyPath = paths[1]
+
+    self.brokerName = self.am_getOption( 'MQBrokerName', None )  # FQDN of the broker
+    self.brokerPort = int( self.am_getOption( 'MQBrokerPort', None ) )  # port at which broker is listening
+
+    self.brokerConnections = {}  # holds connections that were established
+
+    return S_OK()
+
+  def execute( self ):
+    '''
+    During each cycle update the internal site name dictionary,
+    check connections and show statistics.
+    '''
+
+    self.updateNameDictionary()
+    self.checkConnections()
+
+    for ip, connection in self.brokerConnections.iteritems():
+      listener = connection.get_listener( ip )
+      self.log.info( "Broker IP: %s" % ip )
+      self.log.info( "\tReceived messages:           %s" % listener.messagesCount )
+      self.log.info( "\tPacket-loss-rate datapoints: %s" % listener.PLREventsCount )
+      self.log.info( "\tOne-way-delay datapoints:    %s" % listener.OWDEventsCount )
+
+    return S_OK()
+
+  def checkConnections ( self ):
+    '''
+    Check if all required connections are OK (try to reconnect if needed).
+    '''
+
+    if self.brokerName is not None and self.brokerPort is not None:
+
+      # get IP addresses of the brokers and connect to them
+      brokers = socket.gethostbyname_ex( self.brokerName )
+      self.log.info( 'Broker name resolves to %s IP(s)' % len( brokers[2] ) )
+
+      for ip in brokers[2]:
+        try:
+          connection = self.brokerConnections[ip]
+        except KeyError:
+          connection = None
+
+        # (re)connect to the brokers
+        if connection is None or not connection.is_connected():
+          new_connection = self.connectToBroker( ip )
+          if new_connection is not None:
+            self.brokerConnections[ip] = new_connection
+          elif connection is None:
+            del self.brokerConnections[ip]
+
+    else:
+      self.log.warn( 'Broker name and port are not set in the configuration!' )
+
+
+  def connectToBroker( self, ip ):
+    '''
+    Connect to a message broker at given IP and subscribe required topics.
+    '''
+
+    connection = stomp.Connection( 
+                                  [( ip, self.brokerPort )],
+                                  use_ssl = True,
+                                  ssl_version = ssl.PROTOCOL_TLSv1,
+                                  ssl_key_file = self.hostKeyPath,
+                                  ssl_cert_file = self.hostCertPath,
+                                  reconnect_sleep_initial = 10,
+                                  reconnect_attempts_max = 1
+                                 )
+
+    self.log.debug( "Setting up the message listener (%s)." % ip )
+    connection.set_listener( ip, self.NetworkMessagesListener( self.log ) )
+
+    self.log.debug( "Starting the connection (%s)." % ip )
+    connection.start()
+
+    self.log.debug( "Connecting to the broker (%s)." % ip )
+    connection.connect()
+    time.sleep( 1 )
+
+    if connection.is_connected():
+      self.log.info( "Connected to %s:%s" % ( ip, self.brokerPort ) )
+      self.log.debug( "Subscribing topics" )
+      for eventType in self.MESSAGE_TYPES:
+        connection.subscribe( destination = '/topic/perfsonar.' + eventType, ack = 'auto' )
+
+      return connection
+
+    else:
+      self.log.error( "Could not connect to %s:%s" % ( ip, self.brokerPort ) )
+      return None
+
+  def updateNameDictionary( self ):
+    '''
+    Update the internal host-to-dirac name dictionary.
+    '''
+
+    result = gConfig.getConfigurationTree( '/Resources/Sites', 'Network/', '/Enabled' )
+    if not result['OK']:
+      self.log.error( "getConfigurationTree() failed with message: %s" % result['Message'] )
+      return S_ERROR( 'Unable to fetch perfSONAR endpoints from CS.' )
+
+    tmpDict = {}
+    for path, value in result['Value'].iteritems():
+      if value == 'True':
+        elements = path.split( '/' )
+        diracName = elements[4]
+        hostName = elements[6]
+        tmpDict[hostName] = diracName
+
+    NetworkAgent.HostToDiracNameDict = tmpDict
+
+
+  class NetworkMessagesListener( MessageListener ):
+    '''
+    Internal message listener class that handle messages with perfSONAR data.
+    '''
+
+    def __init__( self, log ):
+      self.net = Network()
+
+      # counters
+      self.messagesCount = 0
+      self.PLREventsCount = 0  # packet-loss-rate events
+      self.OWDEventsCount = 0  # one-way-delay events
+
+      self.log = log.getSubLogger( 'NetworkMessagesListener' )
+
+    def error( self, message ):
+      '''
+      Log message errors if they appear.
+      '''
+
+      self.log.warn( "Message error: %s" % message )
+
+    def message( self, message ):
+      self.messagesCount += 1
+
+      # prepare DB entity
+      body = json.loads( message.get_body() )
+
+      meta_data = {
+              'SourceIP': body['meta']['source'],
+              'SourceHostName': body['meta']['input_source'],
+              'DestinationIP': body['meta']['destination'],
+              'DestinationHostName': body['meta']['input_destination'],
+             }
+
+      # skip data from unknown source or destination
+      try:
+        meta_data['Source'] = NetworkAgent.HostToDiracNameDict[body['meta']['input_source']]
+      except KeyError:
+        self.log.debug( "Unknown source: %s (message skipped)" % body['meta']['input_source'] )
+        return
+
+      try:
+        meta_data['Destination'] = NetworkAgent.HostToDiracNameDict[body['meta']['input_destination']]
+      except KeyError:
+        self.log.debug( "Unknown destination: %s (message skipped)" % body['meta']['input_destination'] )
+        return
+
+      self.net.setValuesFromDict( meta_data )
+
+      if body.has_key( 'summaries' ):
+        for summary in body['summaries']:
+
+          # we are interested in 5 minutes summaries only
+          if summary['summary_window'] == '300':
+            for data in summary['summary_data']:
+
+                # look for supported event types
+                if summary['event_type'] == 'packet-loss-rate':
+                  self.PLREventsCount += 1
+                  self.net.setValueByKey( 'PacketLossRate', data[1] * 100 )
+
+
+                elif summary['event_type'] == 'histogram-owdelay' and summary['summary_type'] == 'statistics':
+                  self.OWDEventsCount += 1
+
+                  # approximate jitter value as OWDMax - OWDMin
+                  self.net.setValueByKey( 'Jitter', data[1]['maximum'] - data[1]['minimum'] )
+                  self.net.setValueByKey( 'OneWayDelay', data[1]['mean'] )
+                else:
+                  continue
+
+                # set the time and commit data to the database
+                self.net.setStartTime( datetime.utcfromtimestamp( float( data[0] ) ) )
+                self.net.setEndTime( datetime.utcfromtimestamp( float( data[0] ) + 300 ) )
+                self.net.delayedCommit()

--- a/AccountingSystem/Agent/__init__.py
+++ b/AccountingSystem/Agent/__init__.py
@@ -1,0 +1,1 @@
+__package__ = "DIRAC.AccountingSystem.Agent"

--- a/AccountingSystem/Agent/test/Test_NetworkAgent.py
+++ b/AccountingSystem/Agent/test/Test_NetworkAgent.py
@@ -1,0 +1,109 @@
+""" Contains unit tests of NetworkAgent module
+"""
+
+import DIRAC.AccountingSystem.Agent.NetworkAgent as module
+import unittest
+
+from mock.mock import MagicMock
+
+__RCSID__ = "$Id$"
+
+MQURI1 = 'mq.dirac.net::Topic::perfsonar.summary.packet-loss-rate'
+MQURI2 = 'mq.dirac.net::Queue::perfsonar.summary.histogram-owdelay'
+
+ROOT_PATH = '/Resources/Sites'
+SITE1 = 'LCG.Dirac.net'
+SITE2 = 'LCG.DiracToRemove.net'
+SITE3 = 'VAC.DiracToAdd.org'
+SITE1_HOST1 = 'perfsonar.diracold.net'
+SITE1_HOST2 = 'perfsonar-to-disable.diracold.net'
+SITE2_HOST1 = 'perfsonar.diractoremove.net'
+SITE3_HOST1 = 'perfsonar.diractoadd.org'
+
+INITIAL_CONFIG = \
+{
+  '%s/LCG/%s/Network/%s/Enabled' % ( ROOT_PATH, SITE1, SITE1_HOST1 ): 'True',
+  '%s/LCG/%s/Network/%s/Enabled' % ( ROOT_PATH, SITE1, SITE1_HOST2 ): 'True',
+  '%s/LCG/%s/Network/%s/Enabled' % ( ROOT_PATH, SITE2, SITE2_HOST1 ): 'True'
+}
+
+UPDATED_CONFIG = \
+{
+  '%s/LCG/%s/Network/%s/Enabled' % ( ROOT_PATH, SITE1, SITE1_HOST1 ): 'True',
+  '%s/LCG/%s/Network/%s/Enabled' % ( ROOT_PATH, SITE1, SITE1_HOST2 ): 'False',
+  '%s/LCG/%s/Network/%s/Enabled' % ( ROOT_PATH, SITE3, SITE3_HOST1 ): 'True'
+}
+
+
+
+class NetworkAgentSuccessTestCase( unittest.TestCase ):
+  """ Test class to check success scenarios.
+  """
+
+  def setUp( self ):
+
+    # external dependencies
+    module.datetime = MagicMock()
+
+    # internal dependencies
+    module.S_ERROR = MagicMock()
+    module.S_OK = MagicMock()
+    module.gLogger = MagicMock()
+    module.AgentModule = MagicMock()
+    module.Network = MagicMock()
+    module.gConfig = MagicMock()
+    module.CSAPI = MagicMock()
+    module.createConsumer = MagicMock()
+
+    # prepare test object
+    module.NetworkAgent.__init__ = MagicMock( return_value = None )
+    module.NetworkAgent.am_getOption = MagicMock( return_value = 100 )  # buffer timeout
+
+    self.agent = module.NetworkAgent()
+    self.agent.initialize()
+
+  def test_updateNameDictionary( self ):
+
+    module.gConfig.getConfigurationTree.side_effect = [
+                                                        {'OK': True, 'Value': INITIAL_CONFIG },
+                                                        {'OK': True, 'Value': UPDATED_CONFIG },
+                                                      ]
+
+    # check if name dictionary is empty
+    self.assertFalse( self.agent.nameDictionary )
+
+    self.agent.updateNameDictionary()
+    self.assertEqual( self.agent.nameDictionary[SITE1_HOST1], SITE1 )
+    self.assertEqual( self.agent.nameDictionary[SITE1_HOST2], SITE1 )
+    self.assertEqual( self.agent.nameDictionary[SITE2_HOST1], SITE2 )
+
+    self.agent.updateNameDictionary()
+    self.assertEqual( self.agent.nameDictionary[SITE1_HOST1], SITE1 )
+    self.assertEqual( self.agent.nameDictionary[SITE3_HOST1], SITE3 )
+
+    # check if hosts were removed form dictionary
+    self.assertRaises( KeyError, lambda: self.agent.nameDictionary[SITE1_HOST2] )
+    self.assertRaises( KeyError, lambda: self.agent.nameDictionary[SITE2_HOST1] )
+
+  def test_agentExecute( self ):
+
+    module.NetworkAgent.am_getOption.return_value = '%s, %s' % ( MQURI1, MQURI2 )
+    module.gConfig.getConfigurationTree.return_value = {'OK': True, 'Value': INITIAL_CONFIG }
+
+    # first run
+    result = self.agent.execute()
+    self.assertTrue( result['OK'] )
+
+    # second run (simulate new messages)
+    self.agent.messagesCount += 10
+    result = self.agent.execute()
+    self.assertTrue( result['OK'] )
+
+    # third run (no new messages - restart consumers)
+    result = self.agent.execute()
+    self.assertTrue( result['OK'] )
+
+
+if __name__ == '__main__':
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase( NetworkAgentSuccessTestCase )
+  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )

--- a/AccountingSystem/Client/DataStoreClient.py
+++ b/AccountingSystem/Client/DataStoreClient.py
@@ -115,6 +115,18 @@ class DataStoreClient(object):
       self.__registersList.extend(registersList)
 
     return S_OK( sent )
+  
+  def delayedCommit( self ):
+    """
+    If needed start a timer that will run the commit later
+    allowing to send more registers at once (reduces overheads).
+    """
+    
+    if not self.__commitTimer.isAlive():
+      self.__commitTimer = threading.Timer(5, self.commit)
+      self.__commitTimer.start()
+    
+    return S_OK()
 
   def remove( self, register ):
     """

--- a/AccountingSystem/Client/Types/BaseAccountingType.py
+++ b/AccountingSystem/Client/Types/BaseAccountingType.py
@@ -186,6 +186,17 @@ class BaseAccountingType:
     if not retVal[ 'OK' ]:
       return retVal
     return gDataStoreClient.commit()
+  
+  def delayedCommit( self ):
+    """
+    Commit register to the server. Delayed commit allows to speed up
+    the operation as more registers will be sent at once.
+    """
+    
+    retVal = gDataStoreClient.addRegister( self )
+    if not retVal[ 'OK' ]:
+      return retVal
+    return gDataStoreClient.delayedCommit()
 
   def remove( self ):
     """

--- a/AccountingSystem/Client/Types/Network.py
+++ b/AccountingSystem/Client/Types/Network.py
@@ -1,0 +1,34 @@
+__RCSID__ = "$Id$"
+
+from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
+
+class Network( BaseAccountingType ):
+  '''
+  Accounting type to stores network statistics gathered by perfSONARs.
+  '''
+
+  def __init__( self ):
+    BaseAccountingType.__init__( self )
+    
+    # IPv6 address has up to 45 chars
+    self.definitionKeyFields = [
+                                 ( 'SourceIP', 'VARCHAR(50)' ),
+                                 ( 'DestinationIP', 'VARCHAR(50)' ),
+                                 ( 'SourceHostName', 'VARCHAR(50)' ),
+                                 ( 'DestinationHostName', 'VARCHAR(50)' ),
+                                 ( 'Source', 'VARCHAR(50)' ),
+                                 ( 'Destination', 'VARCHAR(50)' )
+                               ]
+    
+    self.definitionAccountingFields = [
+                                        ( 'Jitter',         'FLOAT'),
+                                        ( 'OneWayDelay',    'FLOAT'),
+                                        ( 'PacketLossRate', 'TINYINT UNSIGNED' ),
+                                      ]
+    self.bucketsLength = [ 
+                           ( 86400 * 3, 900 ),   #<3d = 15m
+                           ( 86400 * 8, 3600 ),  #<1w+1d = 1h
+                           ( 15552000, 86400 ),  #>1w+1d <6m = 1d
+                           ( 31104000, 604800 ), #>6m = 1w
+                         ]
+    self.checkType()

--- a/AccountingSystem/Client/Types/Network.py
+++ b/AccountingSystem/Client/Types/Network.py
@@ -4,7 +4,7 @@ from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountin
 
 class Network( BaseAccountingType ):
   '''
-  Accounting type to stores network statistics gathered by perfSONARs.
+  Accounting type to stores network metrics gathered by perfSONARs.
   '''
 
   def __init__( self ):

--- a/AccountingSystem/Client/Types/Network.py
+++ b/AccountingSystem/Client/Types/Network.py
@@ -1,3 +1,6 @@
+'''
+Accounting class to stores network metrics gathered by perfSONARs.
+'''
 __RCSID__ = "$Id$"
 
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType

--- a/AccountingSystem/ConfigTemplate.cfg
+++ b/AccountingSystem/ConfigTemplate.cfg
@@ -32,8 +32,7 @@ Agents
   {
     MaxCycles = 0
     PollingTime = 60
-    MQBrokerName = 
-    MQBrokerPort = 
+    MessageQueueURI =
   }
 }
 

--- a/AccountingSystem/ConfigTemplate.cfg
+++ b/AccountingSystem/ConfigTemplate.cfg
@@ -26,3 +26,14 @@ Services
     }
   }
 }
+Agents
+{
+  NetworkAgent
+  {
+    MaxCycles = 0
+    PollingTime = 60
+    MQBrokerName = 
+    MQBrokerPort = 
+  }
+}
+

--- a/AccountingSystem/private/Plotters/NetworkPlotter.py
+++ b/AccountingSystem/private/Plotters/NetworkPlotter.py
@@ -1,3 +1,9 @@
+'''
+A reporter class to prepare reports and network accounting plots.
+Supports: packet loss rate (standard and magnified),
+          one-way delay, jitter, jitter over one-way delay
+'''
+
 __RCSID__ = "$Id: $"
 
 from DIRAC import S_OK

--- a/AccountingSystem/private/Plotters/NetworkPlotter.py
+++ b/AccountingSystem/private/Plotters/NetworkPlotter.py
@@ -1,0 +1,215 @@
+__RCSID__ = "$Id: $"
+
+from DIRAC import S_OK
+from DIRAC.AccountingSystem.Client.Types.Network import Network
+from DIRAC.AccountingSystem.private.Plotters.BaseReporter import BaseReporter
+import numpy as np
+
+class NetworkPlotter( BaseReporter ):
+
+  _typeName = "Network"
+  _typeKeyFields = [ dF[0] for dF in Network().definitionKeyFields ]
+
+  _reportPacketLossRateName = "Packet loss rate"
+  def _reportPacketLossRate( self, reportRequest ):
+
+    selectFields = ( self._getSelectStringForGrouping( reportRequest[ 'groupingFields' ] ) + ", %s, %s, 100 - SUM(%s)/SUM(%s), 100",
+                     reportRequest[ 'groupingFields' ][1] + [ 'startTime', 'bucketLength', 'PacketLossRate', 'entriesInBucket' ]
+                   )
+    retVal = self._getTimedData( reportRequest[ 'startTime' ],
+                                 reportRequest[ 'endTime' ],
+                                 selectFields,
+                                 reportRequest[ 'condDict' ],
+                                 reportRequest[ 'groupingFields' ],
+                                 { 'convertToGranularity' : 'average' }
+                               )
+    if not retVal[ 'OK' ]:
+      return retVal
+
+    dataDict, granularity = retVal[ 'Value' ]
+    self.stripDataField( dataDict, 0 )
+
+    selectFields = ( "'Total', %s, %s, 100 - SUM(%s)/SUM(%s), 100",
+                     [ 'startTime', 'bucketLength', 'PacketLossRate', 'entriesInBucket']
+                   )
+    retVal = self._getTimedData( reportRequest[ 'startTime' ],
+                                 reportRequest[ 'endTime' ],
+                                 selectFields,
+                                 reportRequest[ 'condDict' ],
+                                 reportRequest[ 'groupingFields' ],
+                                 { 'convertToGranularity' : 'average' }
+                               )
+    if not retVal[ 'OK' ]:
+      return retVal
+    totalDict = retVal[ 'Value' ][0]
+
+    self.stripDataField( totalDict, 0 )
+    for key in totalDict:
+      dataDict[ key ] = totalDict[ key ]
+
+    return S_OK( { 'data' : dataDict, 'granularity' : granularity } )
+
+  def _plotPacketLossRate( self, reportRequest, plotInfo, filename ):
+
+    # prepare custom scale (10,20,...,100)
+    scale_data = dict( zip( range( 0, 101 ), range( 100, -1, -1 ) ) )
+    scale_ticks = range( 0, 101, 10 )
+
+    metadata = { 'title' : 'Packet loss rate by %s' % reportRequest[ 'grouping' ] ,
+                 'starttime' : reportRequest[ 'startTime' ],
+                 'endtime' : reportRequest[ 'endTime' ],
+                 'span' : plotInfo[ 'granularity' ],
+                 'graph_size' : 'large',
+                 'reverse_labels' : True,
+                 'scale_data' : scale_data,
+                 'scale_ticks' : scale_ticks }
+    return self._generateQualityPlot( filename, plotInfo[ 'data' ], metadata )
+
+
+  _reportMagnifiedPacketLossRateName = "Packet loss rate (magnified)"
+  def _reportMagnifiedPacketLossRate( self, reportRequest ):
+
+    selectFields = ( self._getSelectStringForGrouping( reportRequest[ 'groupingFields' ] ) + ", %s, %s, 100 - IF(SUM(PacketLossRate)/SUM(entriesInBucket)*10 > 100, 100, SUM(PacketLossRate)/SUM(entriesInBucket)*10), 100",
+                     reportRequest[ 'groupingFields' ][1] + [ 'startTime', 'bucketLength' ]
+                   )
+    retVal = self._getTimedData( reportRequest[ 'startTime' ],
+                                 reportRequest[ 'endTime' ],
+                                 selectFields,
+                                 reportRequest[ 'condDict' ],
+                                 reportRequest[ 'groupingFields' ],
+                                 { 'convertToGranularity' : 'average' }
+                               )
+    if not retVal[ 'OK' ]:
+      return retVal
+
+    dataDict, granularity = retVal[ 'Value' ]
+    self.stripDataField( dataDict, 0 )
+
+    return S_OK( { 'data' : dataDict, 'granularity' : granularity } )
+
+  def _plotMagnifiedPacketLossRate( self, reportRequest, plotInfo, filename ):
+
+    # prepare custom scale (1..10, 100)
+    boundaries = list( np.arange( 0, 10, 0.1 ) )
+    boundaries.extend( range( 10, 110, 10 ) )
+    values = list( np.arange( 100, 0, -1 ) )
+    values.extend( [0] * 10 )
+
+    scale_data = dict( zip( boundaries, values ) )
+    scale_ticks = range( 0, 11 )
+    scale_ticks.append( 100 )
+
+    metadata = { 'title' : 'Magnified packet loss rate by %s' % reportRequest[ 'grouping' ] ,
+                 'starttime' : reportRequest[ 'startTime' ],
+                 'endtime' : reportRequest[ 'endTime' ],
+                 'span' : plotInfo[ 'granularity' ],
+                 'reverse_labels' : True,
+                 'graph_size' : 'large',
+                 'scale_data' : scale_data,
+                 'scale_ticks' : scale_ticks }
+    return self._generateQualityPlot( filename, plotInfo[ 'data' ], metadata )
+
+
+  _reportAverageOneWayDelayName = "One-way delay (average)"
+  def _reportAverageOneWayDelay( self, reportRequest ):
+
+    selectFields = ( self._getSelectStringForGrouping( reportRequest[ 'groupingFields' ] ) + ", %s, %s, SUM(%s)/SUM(%s)",
+                     reportRequest[ 'groupingFields' ][1] + [ 'startTime', 'bucketLength', 'OneWayDelay', 'entriesInBucket' ]
+                   )
+    retVal = self._getTimedData( reportRequest[ 'startTime' ],
+                                 reportRequest[ 'endTime' ],
+                                 selectFields,
+                                 reportRequest[ 'condDict' ],
+                                 reportRequest[ 'groupingFields' ],
+                                 { 'convertToGranularity' : 'average' }
+                               )
+    if not retVal[ 'OK' ]:
+      return retVal
+
+    dataDict, granularity = retVal[ 'Value' ]
+    self.stripDataField( dataDict, 0 )
+    dataDict = self._fillWithZero( granularity, reportRequest[ 'startTime' ], reportRequest[ 'endTime' ], dataDict )
+
+    return S_OK( { 'data' : dataDict, 'granularity' : granularity, 'unit' : 'ms' } )
+
+  def _plotAverageOneWayDelay( self, reportRequest, plotInfo, filename ):
+    metadata = { 'title' : 'One-way delay by %s' % reportRequest[ 'grouping' ] ,
+                 'ylabel' : plotInfo[ 'unit' ],
+                 'starttime' : reportRequest[ 'startTime' ],
+                 'endtime' : reportRequest[ 'endTime' ],
+                 'graph_size' : 'large',
+                 'span' : plotInfo[ 'granularity' ],
+                 'sort_labels': 'avg_nozeros',
+                 'legend_unit': plotInfo[ 'unit' ]
+               }
+    return self._generateStackedLinePlot( filename, plotInfo[ 'data' ], metadata )
+
+  _reportJitterName = "Jitter"
+  def _reportJitter( self, reportRequest ):
+
+    selectFields = ( self._getSelectStringForGrouping( reportRequest[ 'groupingFields' ] ) + ", %s, %s, SUM(%s)/SUM(%s)",
+                     reportRequest[ 'groupingFields' ][1] + [ 'startTime', 'bucketLength', 'Jitter', 'entriesInBucket' ]
+                   )
+    retVal = self._getTimedData( reportRequest[ 'startTime' ],
+                                 reportRequest[ 'endTime' ],
+                                 selectFields,
+                                 reportRequest[ 'condDict' ],
+                                 reportRequest[ 'groupingFields' ],
+                                 { 'convertToGranularity' : 'average' }
+                               )
+    if not retVal[ 'OK' ]:
+      return retVal
+
+    dataDict, granularity = retVal[ 'Value' ]
+    self.stripDataField( dataDict, 0 )
+    dataDict = self._fillWithZero( granularity, reportRequest[ 'startTime' ], reportRequest[ 'endTime' ], dataDict )
+
+    return S_OK( { 'data' : dataDict, 'granularity' : granularity, 'unit' : 'ms' } )
+
+  def _plotJitter( self, reportRequest, plotInfo, filename ):
+    metadata = { 'title' : 'Jitter by %s' % reportRequest[ 'grouping' ] ,
+                 'ylabel' : plotInfo[ 'unit' ],
+                 'starttime' : reportRequest[ 'startTime' ],
+                 'endtime' : reportRequest[ 'endTime' ],
+                 'graph_size' : 'large',
+                 'span' : plotInfo[ 'granularity' ],
+                 'sort_labels': 'avg_nozeros',
+                 'legend_unit': plotInfo[ 'unit' ] }
+    return self._generateStackedLinePlot( filename, plotInfo[ 'data' ], metadata )
+
+
+  _reportJitterDelayRatioName = "Jitter/Delay"
+  def _reportJitterDelayRatio( self, reportRequest ):
+
+    selectFields = ( self._getSelectStringForGrouping( reportRequest[ 'groupingFields' ] ) + ", %s, %s, SUM(%s)/SUM(%s)",
+                     reportRequest[ 'groupingFields' ][1] + [ 'startTime', 'bucketLength', 'Jitter', 'OneWayDelay' ]
+                   )
+    retVal = self._getTimedData( reportRequest[ 'startTime' ],
+                                 reportRequest[ 'endTime' ],
+                                 selectFields,
+                                 reportRequest[ 'condDict' ],
+                                 reportRequest[ 'groupingFields' ],
+                                 { 'convertToGranularity' : 'average' }
+                               )
+    if not retVal[ 'OK' ]:
+      return retVal
+
+    dataDict, granularity = retVal[ 'Value' ]
+    self.stripDataField( dataDict, 0 )
+    dataDict = self._fillWithZero( granularity, reportRequest[ 'startTime' ], reportRequest[ 'endTime' ], dataDict )
+
+    return S_OK( { 'data' : dataDict, 'granularity' : granularity } )
+
+
+  def _plotJitterDelayRatio( self, reportRequest, plotInfo, filename ):
+    metadata = { 'title' : 'Jitter over one-way delay by %s' % reportRequest[ 'grouping' ],
+                 'ylabel' : '',
+                 'starttime' : reportRequest[ 'startTime' ],
+                 'endtime' : reportRequest[ 'endTime' ],
+                 'graph_size' : 'large',
+                 'span' : plotInfo[ 'granularity' ],
+                 'sort_labels': 'avg_nozeros',
+                 'legend_unit': ''
+               }
+    return self._generateStackedLinePlot( filename, plotInfo[ 'data' ], metadata )
+

--- a/AccountingSystem/private/Plotters/NetworkPlotter.py
+++ b/AccountingSystem/private/Plotters/NetworkPlotter.py
@@ -29,24 +29,6 @@ class NetworkPlotter( BaseReporter ):
     dataDict, granularity = retVal[ 'Value' ]
     self.stripDataField( dataDict, 0 )
 
-    selectFields = ( "'Total', %s, %s, 100 - SUM(%s)/SUM(%s), 100",
-                     [ 'startTime', 'bucketLength', 'PacketLossRate', 'entriesInBucket']
-                   )
-    retVal = self._getTimedData( reportRequest[ 'startTime' ],
-                                 reportRequest[ 'endTime' ],
-                                 selectFields,
-                                 reportRequest[ 'condDict' ],
-                                 reportRequest[ 'groupingFields' ],
-                                 { 'convertToGranularity' : 'average' }
-                               )
-    if not retVal[ 'OK' ]:
-      return retVal
-    totalDict = retVal[ 'Value' ][0]
-
-    self.stripDataField( totalDict, 0 )
-    for key in totalDict:
-      dataDict[ key ] = totalDict[ key ]
-
     return S_OK( { 'data' : dataDict, 'granularity' : granularity } )
 
   def _plotPacketLossRate( self, reportRequest, plotInfo, filename ):

--- a/ConfigurationSystem/ConfigTemplate.cfg
+++ b/ConfigurationSystem/ConfigTemplate.cfg
@@ -47,6 +47,7 @@ Agents
   }
   GOCDB2CSAgent
   {
+    Cycles = 0
     PollingTime = 14400
     DryRun = True
   }

--- a/Core/Utilities/Graphs/GraphData.py
+++ b/Core/Utilities/Graphs/GraphData.py
@@ -129,6 +129,7 @@ class GraphData:
           max_value - by max value of the subplot
           sum - by the sum of values of the subplot
           last_value - by the last value in the subplot
+          avg_nozeros - by an average that excludes all zero values
     """
     if self.plotdata:
       if self.key_type == "string":
@@ -166,6 +167,12 @@ class GraphData:
         if reverse_order:
           self.labels.reverse()  
         self.label_values = [ self.subplots[x].sum_value for x in self.labels ]
+      elif sort_type == 'avg_nozeros':
+        pairs = zip( self.subplots.keys(), self.subplots.values() )
+        reverse = not reverse_order
+        pairs.sort( key = lambda x: x[1].avg_nozeros, reverse = reverse )
+        self.labels = [ x[0] for x in pairs ]
+        self.label_values = [ x[1].avg_nozeros for x in pairs ] 
       else:
         self.labels = self.subplots.keys()
         if reverse_order:
@@ -425,13 +432,18 @@ class PlotData:
     elif self.key_type == "numeric":
       self.num_keys = [ float( key ) for key in self.keys ]
 
-
     self.min_value = float( min( self.real_values ) )
     self.max_value = float( max( self.real_values ) )
     self.min_key = self.keys[0]
     self.max_key = self.keys[-1]
     self.sum_value = float( sum( self.real_values ) )
     self.last_value = float( self.real_values[-1] )
+    
+    count = len( filter(lambda a: a != 0, self.real_values) )
+    if count != 0:
+      self.avg_nozeros = self.sum_value / float( count )
+    else:
+      self.avg_nozeros = 0
 
   def expandKeys( self, all_keys ):
     """ Fill zero values into the missing keys 

--- a/Core/Utilities/Graphs/QualityMapGraph.py
+++ b/Core/Utilities/Graphs/QualityMapGraph.py
@@ -62,6 +62,24 @@ class QualityMapGraph( PlotBase ):
       if self.gdata.key_type == "time":
         nKeys = self.gdata.getNumberOfKeys()
         self.width = ( max( self.gdata.all_keys ) - min( self.gdata.all_keys ) ) / nKeys
+    
+    # redefine the look of the scale if requested
+    if isinstance(self.prefs['scale_data'], dict):
+      self.cbBoundaries = list()
+      self.cbValues = list()
+      
+      # ColorbarBase needs sorted data
+      for boundary in sorted(self.prefs['scale_data'].keys()):
+        self.cbBoundaries.append(boundary)
+        self.cbValues.append(self.prefs['scale_data'][boundary])
+    else: 
+      self.cbBoundaries = None # set default values
+      self.cbValues = None
+      
+    if isinstance(self.prefs['scale_ticks'], list):
+      self.cbTicks = self.prefs['scale_ticks']
+    else:
+      self.cbTicks = None # set default value
 
     # Setup the colormapper to get the right colors
     self.cmap = None
@@ -152,8 +170,11 @@ class QualityMapGraph( PlotBase ):
     setp( self.ax.get_xticklines(), markersize = 0. )
     setp( self.ax.get_yticklines(), markersize = 0. )
 
-    cax, kw = make_axes( self.ax, orientation = 'vertical', fraction = 0.07 )
-    cb = ColorbarBase( cax, cmap = self.cmap, norm = self.norms ) #pylint: disable=no-member
+    cax, kw = make_axes( self.ax, orientation = 'vertical', fraction = 0.07 ) 
+    cb = ColorbarBase( cax, cmap = cm.RdYlGn, norm = self.norms,
+                                              boundaries = self.cbBoundaries,
+                                              values = self.cbValues,
+                                              ticks = self.cbTicks ) #pylint: disable=no-member
     cb.draw_all()
     #cb = self.ax.colorbar( self.mapper, format="%d%%",
     #  orientation='horizontal', fraction=0.04, pad=0.1, aspect=40  )

--- a/Core/Utilities/Graphs/__init__.py
+++ b/Core/Utilities/Graphs/__init__.py
@@ -29,7 +29,9 @@ common_prefs = {
   'legend_position':'bottom',
   'legend_max_rows':99,
   'legend_max_columns':4,
-  'square_axis':False
+  'square_axis':False,
+  'scale_data': None,
+  'scale_ticks': None
 }
 
 graph_large_prefs = {

--- a/Resources/MessageQueue/MQConsumer.py
+++ b/Resources/MessageQueue/MQConsumer.py
@@ -21,7 +21,7 @@ class MQConsumer ( object ):
       if connector:
         result = connector.subscribe( parameters = {'messengerId':self._id, 'callback':callback, 'destination':self._destination} )
         if not result['OK']:
-          self.log.error( 'Failed to subscirbe the consumer:'+ self._id )
+          self.log.error( 'Failed to subscribe the consumer:' + self._id )
       else:
         self.log.error( 'Failed to initialize MQConsumer! No MQConnector!' )
     else:

--- a/Resources/MessageQueue/test/Test_StompMQConnection.py
+++ b/Resources/MessageQueue/test/Test_StompMQConnection.py
@@ -53,13 +53,6 @@ GETHOSTBYNAME = ( HOST, [], [IP1, IP2] )
 def testCallback():
   pass
 
-listeners = {}
-def setListener( name, listener ):
-  listeners[name] = listener
-
-def getListener( name ):
-  return listeners[name]
-
 class StompMQConnectorSuccessTestCase( unittest.TestCase ):
   """ Test class to check success scenarios.
   """

--- a/Resources/MessageQueue/test/Test_StompMQConnection.py
+++ b/Resources/MessageQueue/test/Test_StompMQConnection.py
@@ -18,6 +18,7 @@ PASSWORD = 'guest'
 QUEUE = 'TestQueue'
 TOPIC = 'TestTopic'
 ACKNOWLEDGEMENT = 'True'
+MESSENGERID = 'Producer1'
 
 PARAMETERS = \
 {
@@ -70,50 +71,61 @@ class StompMQConnectorSuccessTestCase( unittest.TestCase ):
 
     module.time = MagicMock()
     module.ssl = MagicMock()
+    module.json = MagicMock()
 
     connectionMock = MagicMock()
-    connectionMock.is_connected.return_value = False
+    connectionMock.is_connected.return_value = True
 
-    module.stomp.Connection = MagicMock()
+    module.stomp = MagicMock()
     module.stomp.Connection.return_value = connectionMock
-    module.stomp.ConnectionListener = MagicMock()
+
+    # internal dependencies
+    module.MQConnector = MagicMock()
+    module.gLogger = MagicMock()
 
     # prepare test object
     self.mqConnector = module.StompMQConnector()
-    self.mqConnector.log = MagicMock()
 
   def test_createStompListener( self ):
     connection = module.stomp.Connection()
-    messengerId = 'producer1'
-    listener = module.StompListener( testCallback, ACKNOWLEDGEMENT, connection, messengerId )
+    listener = module.StompListener( testCallback, ACKNOWLEDGEMENT, connection, MESSENGERID )
 
     self.assertEqual( listener.callback, testCallback )
     self.assertEqual( listener.ack, ACKNOWLEDGEMENT )
     self.assertEqual( listener.connection, connection )
-    self.assertEqual( listener.mId, messengerId )
+    self.assertEqual( listener.mId, MESSENGERID )
 
   def test_makeConnection( self ):
-    result = self.mqConnector.setupConnection( parameters = PARAMETERS)
+    result = self.mqConnector.setupConnection( parameters = PARAMETERS )
     self.assertTrue( result['OK'] )
 
     # check parameters
-    PARAMETERS.update({'IP':IP1})
     self.assertEqual( sorted(self.mqConnector.parameters), sorted(PARAMETERS) )
     
     # check calls
     module.stomp.Connection.assert_any_call( 
                                             [ ( IP1, int( PORT ) ) ],
-                                            vhost = VHOST
+                                            vhost = VHOST,
+                                            keepalive = True
                                            )
+
+    module.stomp.Connection.assert_any_call( 
+                                            [ ( IP2, int( PORT ) ) ],
+                                            vhost = VHOST,
+                                            keepalive = True
+                                           )
+
+    result = self.mqConnector.connect()
+    self.assertTrue( result['OK'] )
 
   def test_makeSSLConnection( self ):
 
-    result = self.mqConnector.setupConnection( SSL_PARAMETERS)
+    result = self.mqConnector.setupConnection( SSL_PARAMETERS )
     self.assertTrue( result['OK'] )
 
     ## check parameters
-    for ip in [IP1]:
-      self.assertIsNotNone( self.mqConnector.connection[ip] )
+    for ip in [IP1, IP2]:
+      self.assertIsNotNone( self.mqConnector.connections[ip] )
 
     # check calls
     module.stomp.Connection.assert_any_call( 
@@ -123,8 +135,22 @@ class StompMQConnectorSuccessTestCase( unittest.TestCase ):
                                             ssl_key_file = HOSTKEY,
                                             ssl_cert_file = HOSTCERT,
                                             vhost = VHOST,
+                                            keepalive = True
                                            )
     
+    module.stomp.Connection.assert_any_call( 
+                                            [ ( IP2, int( PORT ) ) ],
+                                            use_ssl = True,
+                                            ssl_version = module.ssl.PROTOCOL_TLSv1,
+                                            ssl_key_file = HOSTKEY,
+                                            ssl_cert_file = HOSTCERT,
+                                            vhost = VHOST,
+                                            keepalive = True
+                                           )
+
+    result = self.mqConnector.connect()
+    self.assertTrue( result['OK'] )
+
 class StompMQConnectorFailureTestCase( unittest.TestCase ):
   """ Test class to check failure scenarios.
   """
@@ -136,17 +162,21 @@ class StompMQConnectorFailureTestCase( unittest.TestCase ):
 
     module.time = MagicMock()
     module.ssl = MagicMock()
+    module.json = MagicMock()
 
     # fake connection object
     self.connectionMock = MagicMock()
     self.connectionMock.is_connected.return_value = False
 
-    module.stomp.Connection = MagicMock()
+    module.stomp = MagicMock()
     module.stomp.Connection.return_value = self.connectionMock
+
+    # internal dependencies
+    module.MQConnector = MagicMock()
+    module.gLogger = MagicMock()
 
     # prepare test object
     self.mqConnector = module.StompMQConnector()
-    self.mqConnector.log = MagicMock()
 
 
   def test_invalidSSLVersion( self ):


### PR DESCRIPTION
I am pushing a new functionality to plot the data gathered by perfSONARs. It allows to present jitter, one-way delay, packet-loss rate and some derived functions.

In the current version DataStore is supplied by NetworkAgent module which does not use the RabbitMQ client provided by DIRAC. Please treat this module (and its requirements i.e. stomp.py=3.1.6, messaging, numpy) as a temporary solution.

Some changes were also needed in the core DIRAC modules but I've tried to make them transparent, so I don't expect any troubles after integration.
