### PR TITLE
[v6r15] BaseClient: proper error propagation

### DIFF
--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -96,13 +96,13 @@ class BaseClient:
     try:
       result = self.__findServiceURL()
     except Exception as e:
-      return S_ERROR( str( e ) )
+      return S_ERROR( repr( e ) )
     if not result[ 'OK' ]:
       return result
     self.serviceURL = result[ 'Value' ]
     retVal = Network.splitURL( self.serviceURL )
     if not retVal[ 'OK' ]:
-      return S_ERROR( "URL is malformed: %s" % retVal[ 'Message' ] )
+      return retVal
     self.__URLTuple = retVal[ 'Value' ]
     self._serviceName = self.__URLTuple[-1]
     res = gConfig.getOptionsDict( "/DIRAC/ConnConf/%s:%s" % self.__URLTuple[1:3] )
@@ -200,7 +200,7 @@ class BaseClient:
     try:
       urls = getServiceURL( self._destinationSrv, setup = self.setup )
     except Exception as e:
-      return S_ERROR( "Cannot get URL for %s in setup %s: %s" % ( self._destinationSrv, self.setup, str( e ) ) )
+      return S_ERROR( "Cannot get URL for %s in setup %s: %s" % ( self._destinationSrv, self.setup, repr( e ) ) )
     if not urls:
       return S_ERROR( "URL for service %s not found" % self._destinationSrv )
 
@@ -315,9 +315,9 @@ and this is thread %s
           self.__discoverURL()
           return self._connect()
         else:
-          return S_ERROR( "Can't connect to %s: %s" % ( self.serviceURL, retVal ) )
+          return retVal
     except Exception as e:
-      return S_ERROR( "Can't connect to %s: %s" % ( self.serviceURL, e ) )
+      return S_ERROR( "Can't connect to %s: %s" % ( self.serviceURL, repr( e ) ) )
     trid = getGlobalTransportPool().add( transport )
     return S_OK( ( trid, transport ) )
 
@@ -357,7 +357,7 @@ and this is thread %s
       return self.__initStatus
     retVal = gProtocolDict[ self.__URLTuple[0] ][ 'sanity' ]( self.__URLTuple[1:3], self.kwargs )
     if not retVal[ 'OK' ]:
-      return S_ERROR( "Insane environment for protocol: %s" % retVal[ 'Message' ] )
+      return retVal
     idDict = retVal[ 'Value' ]
     for key in idDict:
       self.__idDict[ key ] = idDict[ key ]


### PR DESCRIPTION
Avoid that when logging ```res['Message']```

2016-08-23 12:32:54 UTC DataManagement/FTSAgent/Monitoring  ERROR: Can't send activities marks Can't connect to dips://lbvobox23.cern.ch:9142/Framework/Monitoring: {'Errno': 0, 'Message': "Could not connect to (
'lbvobox23.cern.ch', 9142): ('128.142.154.93', 9142): Can't connect: [Errno 111] Connection refused", 'OK': False, 'CallStack': ['  File "/opt/dirac/pro/Linux_x86_64_glibc-2.12/lib/python2.7/threading.py", line
783, in __bootstrap\n    self.__bootstrap_inner()\n', '  File "/opt/dirac/pro/Linux_x86_64_glibc-2.12/lib/python2.7/threading.py", line 810, in __bootstrap_inner\n    self.run()\n', '  File "/opt/dirac/pro/Linux
_x86_64_glibc-2.12/lib/python2.7/threading.py", line 763, in run\n    self.__target(*self.__args, **self.__kwargs)\n', '  File "/opt/dirac/pro/DIRAC/Core/Utilities/ThreadScheduler.py", line 117, in __executorThr
ead\n    timeToNext = self.executeNextTask()\n', '  File "/opt/dirac/pro/DIRAC/Core/Utilities/ThreadScheduler.py", line 133, in executeNextTask\n    self.__executeTask( taskId )\n', '  File "/opt/dirac/pro/DIRAC
/Core/Utilities/ThreadScheduler.py", line 186, in __executeTask\n    task[ \'func\' ]( *task[ \'args\' ] )\n', '  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Client/MonitoringClient.py", line 48, in flush\n    mc
.flush( allData )\n', '  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Client/MonitoringClient.py", line 290, in flush\n    self.__sendData()\n', '  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Client/MonitoringClien
t.py", line 325, in __sendData\n    if self.__sendMarks( rpcClient ) and maxIteration:\n', '  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Client/MonitoringClient.py", line 361, in __sendMarks\n    self.__compComm
itExtraDict )\n', '  File "/opt/dirac/pro/DIRAC/Core/DISET/RPCClient.py", line 18, in __call__\n    return self.__doRPCFunc( self.__remoteFuncName, args )\n', '  File "/opt/dirac/pro/DIRAC/Core/DISET/RPCClient.p
y", line 35, in __doRPC\n    retVal = self.__innerRPCClient.executeRPC( sFunctionName, args )\n', '  File "/opt/dirac/pro/DIRAC/Core/DISET/private/InnerRPCClient.py", line 15, in executeRPC\n    retVal = self._c
onnect()\n', '  File "/opt/dirac/pro/DIRAC/Core/DISET/private/BaseClient.py", line 316, in _connect\n    return self._connect()\n', '  File "/opt/dirac/pro/DIRAC/Core/DISET/private/BaseClient.py", line 316, in _
connect\n    return self._connect()\n', '  File "/opt/dirac/pro/DIRAC/Core/DISET/private/BaseClient.py", line 298, in _connect\n    retVal = transport.initAsClient()\n', '  File "/opt/dirac/pro/DIRAC/Core/DISET/
private/Transports/SSLTransport.py", line 52, in initAsClient\n    retVal = gSocketInfoFactory.getSocket( self.stServerAddress, **self.extraArgsDict )\n', '  File "/opt/dirac/pro/DIRAC/Core/DISET/private/Transpo
rts/SSL/SocketInfoFactory.py", line 149, in getSocket\n    return S_ERROR( "Could not connect to %s: %s" % ( hostAddress, "," .join( [ e for e in errorsList ] ) ) )\n']}
