### PR TITLE
[v6r15] Fix ARC held jobs

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -56,13 +56,13 @@ class ARCComputingElement( ComputingElement ):
                        'Preparing'  : 'Scheduled',
                        'Submitting' : 'Scheduled',
                        'Queuing'    : 'Scheduled',
-                       'Hold'       : 'Scheduled',
                        'Undefined'  : 'Unknown',
                        'Running'    : 'Running',
                        'Finishing'  : 'Running',
                        'Deleted' : 'Killed',
                        'Killed'  : 'Killed',
                        'Failed'  : 'Failed',
+                       'Hold'    : 'Failed',
                        'Finished': 'Done',
                        'Other'   : 'Done'
       }
@@ -375,6 +375,9 @@ class ARCComputingElement( ComputingElement ):
           if job.ProxyExpirationTime < nextHour:
             job.Renew()
             gLogger.debug("Renewing proxy for job %s whose proxy expires at %s" % (jobID, job.ProxyExpirationTime))
+        if arcState == "Hold":
+          # Cancel held jobs so they don't sit in the queue forever
+          self.killJob(jobID)
       else:
         resultDict[jobID] = 'Unknown'
       # If done - is it really done? Check the exit code


### PR DESCRIPTION
Hi,

This patch changes the mapping of pilots in the hold state on the ARC-CE so they get mapped to Failed and correctly removed from the queue (up to now, they'd sit in the hold state for ever preventing any further jobs from being submitted). It also removes the JobSupervisor object from the killJob function as this didn't seem to work correctly (or at all) in my tests, whereas cancelling the jobs individually does seem to work.

Regards,
Simon
