### PR TITLE
[v6r15] Renew ARC pilots in the queued state.

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -369,10 +369,10 @@ class ARCComputingElement( ComputingElement ):
       gLogger.debug("ARC status for job %s is %s" % (jobID, arcState))
       if arcState: # Meaning arcState is filled. Is this good python?
         resultDict[jobID] = self.mapStates[arcState]
-        # Renew proxy only of jobs which are running - and will expire within the next hour
-        if self.mapStates[arcState] == "Running":
-          nextHour = arc.Time()+arc.Period(10000) # 2 hours, 46 minutes and 40 seconds
-          if job.ProxyExpirationTime < nextHour:
+        # Renew proxy only of jobs which are running or queuing
+        if arcState in ("Running", "Queuing"):
+          nearExpiry = arc.Time()+arc.Period(10000) # 2 hours, 46 minutes and 40 seconds
+          if job.ProxyExpirationTime < nearExpiry:
             job.Renew()
             gLogger.debug("Renewing proxy for job %s whose proxy expires at %s" % (jobID, job.ProxyExpirationTime))
       else:


### PR DESCRIPTION
This patch ensures that pilot jobs that are queued also get their proxies renewed on ARC-CE.

Regards,
Simon
