### PR TITLE
[v6r15][IMPORTANT] FTS: use requests library

### DIFF
--- a/DataManagementSystem/Client/FTSJob.py
+++ b/DataManagementSystem/Client/FTSJob.py
@@ -33,7 +33,13 @@ from DIRAC.DataManagementSystem.Client.FTSFile import FTSFile
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.Resources.Catalog.FileCatalog     import FileCatalog
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
+
 import fts3.rest.client.easy as fts3
+# Because of a bug in fts-rest, we can't use Request
+# This ftsSSLWrapper has the fix. we need to wait for 
+# the next fts release to get rid of it
+#from fts3.rest.client.request import Request
+from DIRAC.DataManagementSystem.Client.ftsSSLWrapper import Request as ftsSSLRequest
 
 ########################################################################
 class FTSJob( object ):
@@ -604,7 +610,7 @@ class FTSJob( object ):
 
     try:
       if not self._fts3context:
-        self._fts3context = fts3.Context( endpoint = self.FTSServer )
+        self._fts3context = fts3.Context( endpoint = self.FTSServer, request_class = ftsSSLRequest, verify = False )
       context = self._fts3context
       self.FTSGUID = fts3.submit( context, job )
 
@@ -626,7 +632,7 @@ class FTSJob( object ):
     jobStatusDict = None
     try:
       if not self._fts3context:
-        self._fts3context = fts3.Context( endpoint = self.FTSServer )
+        self._fts3context = fts3.Context( endpoint = self.FTSServer, request_class = ftsSSLRequest, verify = False )
       context = self._fts3context
       jobStatusDict = fts3.get_job_status( context, self.FTSGUID, list_files = True )
     except Exception as e:

--- a/DataManagementSystem/Client/ftsSSLWrapper.py
+++ b/DataManagementSystem/Client/ftsSSLWrapper.py
@@ -1,0 +1,108 @@
+
+# This is a temporary file that should go away as soon as this PR is merged and released
+# https://gitlab.cern.ch/fts/fts-rest/merge_requests/9
+
+
+
+#
+#   See www.eu-emi.eu for details on the copyright holders
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+try:
+    import simplejson as json
+except:
+    import json
+import logging
+import requests
+import tempfile
+from exceptions import *
+import os
+
+class Request(object):
+
+    def __init__(self, ucert, ukey, capath=None, passwd=None, verify=False, access_token=None, connectTimeout=30, timeout=30):
+        self.ucert = ucert
+        self.ukey  = ukey
+        self.passwd = passwd
+        self.access_token = access_token
+        self.verify = verify
+        # Disable the warnings
+        if not verify:
+          requests.packages.urllib3.disable_warnings()
+
+        self.connectTimeout = connectTimeout
+        self.timeout = timeout
+
+        self.session = requests.Session()
+        
+
+    def _handle_error(self, url, code, response_body=None):
+        # Try parsing the response, maybe we can get the error message
+        message = None
+        response = None
+        if response_body:
+            try:
+                response = json.loads(response_body)
+                if 'message' in response:
+                    message = response['message']
+                else:
+                    message = response_body
+            except:
+                message = response_body
+
+        if code == 207:
+            try:
+                raise ClientError('\n'.join(map(lambda m: m['http_message'], response)))
+            except (KeyError, TypeError):
+                raise ClientError(message)
+        elif code == 400:
+            if message:
+                raise ClientError('Bad request: ' + message)
+            else:
+                raise ClientError('Bad request')
+        elif 401 <= code <= 403:
+            raise Unauthorized()
+        elif code == 404:
+            raise NotFound(url, message)
+        elif code == 419:
+            raise NeedDelegation('Need delegation')
+        elif code == 424:
+            raise FailedDependency('Failed dependency')
+        elif 404 < code < 500:
+            raise ClientError(str(code))
+        elif code == 503:
+            raise TryAgain(str(code))
+        elif code >= 500:
+            raise ServerError(str(code))
+
+    def method(self, method, url, body=None, headers=None):   
+        _headers = {'Accept': 'application/json'}
+        if headers:
+            _headers.update(headers)
+        if self.access_token:
+            _headers['Authorization'] = 'Bearer ' + self.access_token
+        
+        response = self.session.request(method=method, url=str(url), 
+                             data=body, headers=_headers, verify = self.verify, 
+                             timeout=(self.connectTimeout, self.timeout), 
+                             cert=(self.ucert, self.ukey))
+        
+       
+        #log.debug(response.text)
+
+        self._handle_error(url, response.status_code, response.text)
+
+        return response.text
+
+
+__all__ = ['Request']

--- a/DataManagementSystem/Client/ftsSSLWrapper.py
+++ b/DataManagementSystem/Client/ftsSSLWrapper.py
@@ -25,7 +25,7 @@ except:
 import logging
 import requests
 import tempfile
-from exceptions import *
+from fts3.rest.client.exceptions import *
 import os
 
 class Request(object):
@@ -102,7 +102,7 @@ class Request(object):
 
         self._handle_error(url, response.status_code, response.text)
 
-        return response.text
+        return str( response.text )
 
 
 __all__ = ['Request']


### PR DESCRIPTION
use requests with no server verification, and add temporary fix for fts-rest

The use of requests is needed because of the memory leak and on top of this we are now for some reason hit by another curl bug (https://curl.haxx.se/mail/lib-2008-09/0197.html)

There is however a bug in the fts-rest library which does not propagate the server verification flag. I have made a PR, but until they merge it and release it (3.5.2, a month from now) I have added the fix in DIRAC (ftsSSLWrapper). As soon as we have the proper release in the bundle, we can remove this file.

This is an important PR, it should be in the next patch, it runs as hotfix in LHCb