### PR TITLE
[v6r15] Fix proxy renewal (for ARC-CE)

### DIFF
--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -88,7 +88,7 @@ class ComputingElement(object):
         os.environ['X509_USER_PROXY'] = result['Value']['path']
         return S_OK()
     else:
-      result = gProxyManager.dumpProxyToFile( self.proxy )
+      result = gProxyManager.dumpProxyToFile( self.proxy, requiredTimeLeft=self.minProxyTime )
       if not result['OK']:
         return result
       os.environ['X509_USER_PROXY'] = result['Value']

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -531,7 +531,7 @@ class SiteDirector( AgentModule ):
       if not result['OK']:
         return result
       self.proxy = result['Value']
-      ce.setProxy( self.proxy, cpuTime - 60 )
+      ce.setProxy( self.proxy, self.proxy.getRemainingSecs()['Value'] )
 
       # Get the number of available slots on the target site/queue
       totalSlots = self.getQueueSlots( queue, manyWaitingPilotsFlag )

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -941,7 +941,10 @@ EOF
           stampedPilotRefs = list( pilotRefs )
           break
 
-      result = ce.isProxyValid()
+      # This proxy is used for checking the pilot status and renewals
+      # We really need at least a few hours otherwise the renewed
+      # proxy may expire before we check again...
+      result = ce.isProxyValid( 3*3600 )
       if not result['OK']:
         result = gProxyManager.getPilotProxyFromDIRACGroup( self.pilotDN, self.pilotGroup, 23400 )
         if not result['OK']:

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -531,7 +531,12 @@ class SiteDirector( AgentModule ):
       if not result['OK']:
         return result
       self.proxy = result['Value']
-      ce.setProxy( self.proxy, self.proxy.getRemainingSecs()['Value'] )
+      # Check returned proxy lifetime
+      result = self.proxy.getRemainingSecs()
+      if not result['OK']:
+        return result
+      lifetime_secs = result['Value']
+      ce.setProxy( self.proxy, lifetime_secs )
 
       # Get the number of available slots on the target site/queue
       totalSlots = self.getQueueSlots( queue, manyWaitingPilotsFlag )


### PR DESCRIPTION
This patch ensures that a proxy of at least 3 hours is available to the updatePilotStatus function so that if it renews any proxies (via ce.getJobStatus), it's not renewing them with a very short proxy (which causes expiry problems on the ARC-CE).