### PR TITLE
[v6r15] Add getFileDescendents/Ancestors to READ methods for FileCatalog

### DIFF
--- a/Resources/Catalog/FileCatalogClient.py
+++ b/Resources/Catalog/FileCatalogClient.py
@@ -23,6 +23,7 @@ class FileCatalogClient( FileCatalogClientBase ):
                    'getLFNForPFN', 'getLFNForGUID', 'findFilesByMetadata','getMetadataFields',
                    'findDirectoriesByMetadata','getReplicasByMetadata','findFilesByMetadataDetailed',
                    'findFilesByMetadataWeb','getCompatibleMetadata','getMetadataSet', 'getDatasets',
+                   'getFileDescendents', 'getFileAncestors',
                    'checkDataset', 'getDatasetParameters', 'getDatasetFiles', 'getDatasetAnnotation']
 
   WRITE_METHODS = ['createLink', 'removeLink', 'addFile', 'setFileStatus', 'addReplica', 'removeReplica',


### PR DESCRIPTION
There should be some way to ensure that all functions are in the lists...
( This is not part of #3095, https://github.com/DIRACGrid/DIRAC/pull/3095/files#diff-38faa43f37e89cea3917fb128720076dR33 )
