### PR TITLE
[r6v15] Correctly handle invalid sites in JobSchduling

### DIFF
--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1444,6 +1444,27 @@ class JobDB( DB ):
     return retVal
 
 #############################################################################
+  def getUserSitesTuple( self, sites ):
+    """Returns tuple of active/banned/invalid sties from a user provided list."""
+    ret = self._escapeValues( sites )
+    if not ret['OK']:
+      return ret
+
+    sites = set(sites)
+    sites_sql = ret['Value']
+    sites_sql[0] = 'SELECT %s AS Site' % sites_sql[0]
+    sites_sql = ' UNION SELECT '.join(sites_sql)
+    cmd = "SELECT Site FROM (%s) AS tmptable WHERE Site NOT IN (SELECT Site FROM SiteMask WHERE Status='Active')" % sites_sql
+    result = self._query( cmd )
+    if not result['OK']:
+      return result
+    nonActiveSites = set(x[0] for x in result['Value'])
+    activeSites = sites.difference(nonActiveSites)
+    bannedSites = nonActiveSites.intersection(set(self.getSiteMask( 'Banned' )))
+    invalidSites = nonActiveSites.difference(bannedSites)
+    return S_OK( (activeSites, bannedSites, invalidSites) )
+
+#############################################################################
   def getSiteMask( self, siteState = 'Active' ):
     """ Get the currently active site list
     """

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1450,19 +1450,19 @@ class JobDB( DB ):
     if not ret['OK']:
       return ret
 
-    sites = set(sites)
-    sites_sql = ret['Value']
-    sites_sql[0] = 'SELECT %s AS Site' % sites_sql[0]
-    sites_sql = ' UNION SELECT '.join(sites_sql)
-    cmd = "SELECT Site FROM (%s) AS tmptable WHERE Site NOT IN (SELECT Site FROM SiteMask WHERE Status='Active')" % sites_sql
+    sites = set( sites )
+    sitesSql = ret['Value']
+    sitesSql[0] = 'SELECT %s AS Site' % sitesSql[0]
+    sitesSql = ' UNION SELECT '.join( sitesSql )
+    cmd = "SELECT Site FROM (%s) AS tmptable WHERE Site NOT IN (SELECT Site FROM SiteMask WHERE Status='Active')" % sitesSql
     result = self._query( cmd )
     if not result['OK']:
       return result
-    nonActiveSites = set(x[0] for x in result['Value'])
-    activeSites = sites.difference(nonActiveSites)
-    bannedSites = nonActiveSites.intersection(set(self.getSiteMask( 'Banned' )))
-    invalidSites = nonActiveSites.difference(bannedSites)
-    return S_OK( (activeSites, bannedSites, invalidSites) )
+    nonActiveSites = set( x[0] for x in result['Value'] )
+    activeSites = sites.difference( nonActiveSites )
+    bannedSites = nonActiveSites.intersection( set( self.getSiteMask( 'Banned' ) ) )
+    invalidSites = nonActiveSites.difference( bannedSites )
+    return S_OK( ( activeSites, bannedSites, invalidSites ) )
 
 #############################################################################
   def getSiteMask( self, siteState = 'Active' ):

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -90,15 +90,15 @@ class JobScheduling( OptimizerExecutor ):
         if not result[ 'OK' ]:
           return S_ERROR( "Problem checking userSites for tuple of active/banned/invalid sites" )
 
-        userSites, banned_sites, invalid_sites = result['Value']
-        if invalid_sites:
-          self.jobLog.debug( "Invalid site(s) requested: %s" % ','.join( invalid_sites ) )
+        userSites, bannedSites, invalidSites = result['Value']
+        if invalidSites:
+          self.jobLog.debug( "Invalid site(s) requested: %s" % ','.join( invalidSites ) )
           if not self.ex_getOption( 'AllowInvalidSites', True ):
-            return self.__holdJob( jobState, "Requested site(s) %s are invalid" % ",".join( invalid_sites ) )
-        if banned_sites:
-          self.jobLog.debug( "Banned site(s) %s ignored" % ",".join( banned_sites ) )
+            return self.__holdJob( jobState, "Requested site(s) %s are invalid" % ",".join( invalidSites ) )
+        if bannedSites:
+          self.jobLog.debug( "Banned site(s) %s ignored" % ",".join( bannedSites ) )
           if not userSites:
-            return self.__holdJob( jobState, "Requested site(s) %s are inactive" % ",".join( banned_sites ) )
+            return self.__holdJob( jobState, "Requested site(s) %s are inactive" % ",".join( bannedSites ) )
 
         if not userSites:
           return self.__holdJob( jobState, "No requested site(s) are active/valid" )

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Executors/JobScheduling/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Executors/JobScheduling/index.rst
@@ -8,27 +8,30 @@ All issues preventing the successful resolution of a site candidate are discover
 here where all information is available.
 This Executor will fail affected jobs meaningfully.
 
-+-------------------------+---------------------------------------+--------------------------------------------+
-| **Name**                | **Description**                       | **Example**                                |
-+-------------------------+---------------------------------------+--------------------------------------------+
-| *RescheduleDelays*      | How long to hold job after            | RescheduleDelays=60, 180, 300, 600         |
-|                         | rescheduling                          |                                            |
-+-------------------------+---------------------------------------+--------------------------------------------+
-| *ExcludedOnHoldJobTypes*| List of job types to exclude from     |                                            |
-|                         | holding after rescheduling            |                                            |
-+-------------------------+---------------------------------------+--------------------------------------------+
-| *InputDataAgent*        | Name of the InputData executor        | InputDataAgent = InputData                 |
-|                         | instance                              |                                            |
-+-------------------------+---------------------------------------+--------------------------------------------+
-| *RestrictDataStage*     | Are users restricted from staging     |  RestrictDataStage = False                 |
-|                         |                                       |                                            |
-+-------------------------+---------------------------------------+--------------------------------------------+
-| *HoldTime*              | How long jobs are held for            | HoldTime = 300                             |
-|                         |                                       |                                            |
-+-------------------------+---------------------------------------+--------------------------------------------+
-| *StagingStatus*         | Status when staging                   | StagingStatus = Staging                    |
-|                         |                                       |                                            |
-+-------------------------+---------------------------------------+--------------------------------------------+
-| *StagingMinorStatus*    | Minor status when staging             | StagingMinorStatus = "Request To Be Sent"  |
-|                         |                                       |                                            |
-+-------------------------+---------------------------------------+--------------------------------------------+
++-------------------------+-----------------------------------------+--------------------------------------------+
+| **Name**                | **Description**                         | **Example**                                |
++-------------------------+-----------------------------------------+--------------------------------------------+
+| *RescheduleDelays*      | How long to hold job after              | RescheduleDelays=60, 180, 300, 600         |
+|                         | rescheduling                            |                                            |
++-------------------------+-----------------------------------------+--------------------------------------------+
+| *ExcludedOnHoldJobTypes*| List of job types to exclude from       |                                            |
+|                         | holding after rescheduling              |                                            |
++-------------------------+-----------------------------------------+--------------------------------------------+
+| *InputDataAgent*        | Name of the InputData executor          | InputDataAgent = InputData                 |
+|                         | instance                                |                                            |
++-------------------------+-----------------------------------------+--------------------------------------------+
+| *RestrictDataStage*     | Are users restricted from staging       |  RestrictDataStage = False                 |
+|                         |                                         |                                            |
++-------------------------+-----------------------------------------+--------------------------------------------+
+| *HoldTime*              | How long jobs are held for              | HoldTime = 300                             |
+|                         |                                         |                                            |
++-------------------------+-----------------------------------------+--------------------------------------------+
+| *StagingStatus*         | Status when staging                     | StagingStatus = Staging                    |
+|                         |                                         |                                            |
++-------------------------+-----------------------------------------+--------------------------------------------+
+| *StagingMinorStatus*    | Minor status when staging               | StagingMinorStatus = "Request To Be Sent"  |
+|                         |                                         |                                            |
++-------------------------+-----------------------------------------+--------------------------------------------+
+| *AllowInvalidSites*     | If set to False, jobs will be held if   | AllowInvalidSites = False                  |
+|                         | any of the Sites specified are invalid. | (default value is True)                    |
++-------------------------+-----------------------------------------+--------------------------------------------+


### PR DESCRIPTION
Commit ac6bff55380a2edddcf0ad4f3952d5a8c8c834fc tidied up the JobScheduling code but also changed the behaviour. The original behaviour was that if only an unknown site was specified in the JDL (i.e. the site wasn't banned or active) the job would be held with a "no active sites" style message. The new behaviour is that unknown sites in the JDL are accepted into the waiting state, which can lead to jobs being left waiting for a site that doesn't exist indefinitely.

This patch returns the original behaviour: It's slightly longer than the original code as it distinguishes between all of the possible failure modes (wrong site names / banned sites) while also avoiding getting the (potentially long) list of all active sites.

The patch also adds a new config option "AllowInvalidSites" defaulting to true. If this is set to false then if any of the sites specified in the JDL don't exist an error is flagged (so that the user will know that there is a problem with their site list immediately, rather than potentially being surprised later).