### PR TITLE
[v6r15] Add agent watchdog option

### DIFF
--- a/Core/Base/AgentModule.py
+++ b/Core/Base/AgentModule.py
@@ -208,7 +208,7 @@ class AgentModule( object ):
       self.log.notice( " Cycles: %s" % self.am_getMaxCycles() )
     else:
       self.log.notice( " Cycles: unlimited" )
-    if self.am_getOption( 'WatchdogTime' ) > 0:
+    if self.am_getWatchdogTime() > 0:
       self.log.notice( " Watchdog interval: %s" % self.am_getWatchdogTime() )
     else:
       self.log.notice( " Watchdog interval: disabled " )
@@ -275,7 +275,7 @@ class AgentModule( object ):
     return self.am_getOption( "MaxCycles" )
 
   def am_getWatchdogTime( self ):
-    return self.am_getOption( "WatchdogTime" )
+    return int( self.am_getOption( "WatchdogTime" ) )
 
   def am_getCyclesDone( self ):
     return self.am_getModuleParam( 'cyclesDone' )

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/Configuration/Agents/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/Configuration/Agents/index.rst
@@ -34,6 +34,10 @@ Common options for all the agents:
 | *DryRun*            | If True, the agent won't change       | DryRun = False               |
 |                     | the CS                                |                              |
 +---------------------+---------------------------------------+------------------------------+
+| *WatchdogTime*      | If > 0 will kill the agent if the     | | WatchdogTime = 3600        |
+|                     | cycle exceeds WatchdogTime in seconds | | (default is 0)             |
+|                     | to force a restart of the agent       |                              |
++---------------------+---------------------------------------+------------------------------+
 
 
 


### PR DESCRIPTION
This patch adds a simple SIGALRM based watchdog option to the base agent code. This allows a hard timelimit to be set on each run so that it should be impossible for a module (such as the site director) to get stuck forever if there is a bug (if the watchdog time expires, the process is killed and then restarted by runit). The watchdog time limit is configurable in the same way MaxCycles etc. are and we've left the default as 0 (meaning disabled) so that no behaviour is changed by this patch automatically.

The main reason for this is as a workaround for a bug in the ARC code where sometimes contacting an ARC CE causes a infinite hang in the site director, but it should also catch any other future problems like this. We'll send a more specific e-mail about the ARC problem separately next week.