### PR TITLE
[v6r15] Fix TransformationAgent, DataManager and IDR by protocol

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1503,9 +1503,11 @@ class DataManager( object ):
     # Build the SE status cache if not existing
     if seStatus is None:
       seStatus = dict( ( se,
-                         ( self.__checkSEStatus( se, status = 'diskSE' ),
-                          self.__checkSEStatus( se, status = 'tapeSE' ) ) ) for se in replicas )
+                         ( self.__checkSEStatus( se, status = 'DiskSE' ),
+                          self.__checkSEStatus( se, status = 'TapeSE' ) ) ) for se in replicas )
 
+    print seStatus
+    print replicas
     for se in replicas:  #  There is a del below but we then return!
       # First find a disk replica, otherwise do nothing unless diskOnly is set
       if diskOnly or seStatus[se][0]:
@@ -1514,6 +1516,7 @@ class DataManager( object ):
           if seStatus[se][1]:
             replicas.pop( se )
         return
+    print replicas
     return
 
   def checkActiveReplicas( self, replicaDict ):
@@ -1589,6 +1592,7 @@ class DataManager( object ):
     result = {'Successful':catalogReplicas, 'Failed':failed}
     if active:
       self.__checkActiveReplicas( result )
+    print catalogReplicas
     if diskOnly or preferDisk:
       self.__filterTapeReplicas( result, diskOnly = diskOnly )
     return S_OK( result )

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1506,8 +1506,6 @@ class DataManager( object ):
                          ( self.__checkSEStatus( se, status = 'DiskSE' ),
                           self.__checkSEStatus( se, status = 'TapeSE' ) ) ) for se in replicas )
 
-    print seStatus
-    print replicas
     for se in replicas:  #  There is a del below but we then return!
       # First find a disk replica, otherwise do nothing unless diskOnly is set
       if diskOnly or seStatus[se][0]:
@@ -1516,7 +1514,6 @@ class DataManager( object ):
           if seStatus[se][1]:
             replicas.pop( se )
         return
-    print replicas
     return
 
   def checkActiveReplicas( self, replicaDict ):

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1486,8 +1486,8 @@ class DataManager( object ):
     seList = set( se for ses in replicaDict['Successful'].itervalues() for se in ses )
     # Get a cache of SE statuses for long list of replicas
     seStatus = dict( ( se,
-                       ( self.__checkSEStatus( se, status = 'diskSE' ),
-                        self.__checkSEStatus( se, status = 'tapeSE' ) ) ) for se in seList )
+                       ( self.__checkSEStatus( se, status = 'DiskSE' ),
+                        self.__checkSEStatus( se, status = 'TapeSE' ) ) ) for se in seList )
     for lfn, replicas in replicaDict['Successful'].items():  # Beware, there is a del below
       self.__filterTapeSEs( replicas, diskOnly = diskOnly, seStatus = seStatus )
       # If diskOnly, one may not have any replica in the end, set Failed

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1589,7 +1589,6 @@ class DataManager( object ):
     result = {'Successful':catalogReplicas, 'Failed':failed}
     if active:
       self.__checkActiveReplicas( result )
-    print catalogReplicas
     if diskOnly or preferDisk:
       self.__filterTapeReplicas( result, diskOnly = diskOnly )
     return S_OK( result )

--- a/WorkloadManagementSystem/Client/InputDataByProtocol.py
+++ b/WorkloadManagementSystem/Client/InputDataByProtocol.py
@@ -73,6 +73,7 @@ class InputDataByProtocol( object ):
         bestReplica[lfn] = success[lfn][0]
       return S_OK( {'Successful': bestReplica, 'Failed':result['Value']['Failed']} )
 
+    # Keep the failed LFNs from local SEs
     failed = set( result['Value']['Failed'] )
     # If all replicas are requested, get results for other SEs
     seList = set()

--- a/WorkloadManagementSystem/Client/InputDataByProtocol.py
+++ b/WorkloadManagementSystem/Client/InputDataByProtocol.py
@@ -117,7 +117,7 @@ class InputDataByProtocol( object ):
     # Problematic files will be returned and can be handled by another module
     failedReplicas = set()
     newReplicasDict = {}
-    for lfn, reps in replicas.items():
+    for lfn, reps in replicas.iteritems():
       if lfn in self.inputData:
         # Check that all replicas are on a valid local SE
         if not [se for se in reps if se in diskSEs.union( tapeSEs )]:
@@ -142,11 +142,11 @@ class InputDataByProtocol( object ):
     # IMPORTANT, only add replicas for input data that is requested
     # since this module could have been executed after another.
     seFilesDict = {}
-    for lfn, seList in newReplicasDict.items():
+    for lfn, seList in newReplicasDict.iteritems():
       for seName in seList:
         seFilesDict.setdefault( seName, [] ).append( lfn )
 
-    sortedSEs = sorted( [ ( len( lfns ), seName ) for seName, lfns in seFilesDict.items() ], reverse = True )
+    sortedSEs = sorted( ( ( len( lfns ), seName ) for seName, lfns in seFilesDict.iteritems() ), reverse = True )
 
     trackLFNs = {}
     for _len, seName in sortedSEs:
@@ -181,7 +181,7 @@ class InputDataByProtocol( object ):
           if type( failed ) == type( {} ):
             self.log.error( failed[ lfn ], lfn )
           failedReps.add( lfn )
-      for lfn, metadata in result['Value']['Successful'].items():
+      for lfn, metadata in result['Value']['Successful'].iteritems():
         if metadata['Lost']:
           error = "File has been Lost by the StorageElement %s" % seName
         elif metadata['Unavailable']:
@@ -213,7 +213,7 @@ class InputDataByProtocol( object ):
       badTURLs = []
       seResult = result['Value']
 
-      for lfn, cause in seResult['Failed'].items():
+      for lfn, cause in seResult['Failed'].iteritems():
         badTURLCount += 1
         badTURLs.append( 'Failed to obtain TURL for %s: %s' % ( lfn, cause ) )
         failedReps.add( lfn )


### PR DESCRIPTION
* DataManager: was extremely slow when checking active replicas and filtering tape replicas. Probably due to changes in the cached information from RSS?
* TransformationAgent: no need to get replicas URLs back, and use iterators when possible

* IDR: the failed resolution for local SEs was not considered correctly if there were other SEs that were ignored (e.g. because on tape). This the catalogs were incomplete