### PR TITLE
[v6r15] LSFTimeLeft accept 2 "word" output from bqueues

### DIFF
--- a/Core/Utilities/TimeLeft/LSFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/LSFTimeLeft.py
@@ -50,6 +50,9 @@ class LSFTimeLeft( object ):
         if len( info ) >= 4:
           self.cpuLimit = float( info[0] ) * 60
           self.cpuRef = info[3]
+        elif len( info ) == 2 and info[1] == "min":
+          self.cpuLimit = float( info[0] ) * 60
+          self.cpuRef = None
         else:
           self.log.warn( 'Problem parsing "%s" for CPU limit' % lines[i + 1] )
           self.cpuLimit = -1

--- a/Core/Utilities/TimeLeft/test/Test_LSFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/test/Test_LSFTimeLeft.py
@@ -6,7 +6,7 @@ import os
 import unittest
 from mock import MagicMock, patch
 
-from DIRAC import gLogger, S_OK
+from DIRAC import gLogger, S_OK, S_ERROR
 
 from DIRAC.Core.Utilities.TimeLeft.LSFTimeLeft import LSFTimeLeft
 
@@ -20,6 +20,23 @@ LSF_KEK_BQUEUES = """   CPULIMIT
 LSF_LSHOSTS = """ HOST_NAME                       type       model  cpuf ncpus maxmem maxswp server RESOURCES
 b6688e710f                   SLC6_64 i6_16_63f2h24_266   2.5    16 29999M 19999M    Yes (intel share aishare cvmfs wan exe lcg wigner slot15)
   """
+
+LSF_CERN_BQUEUES = """   CPULIMIT
+  10080.0 min of KSI2K
+
+  RUNLIMIT
+  30240.0 min of KSI2K
+"""
+
+#returns with S_ERROR
+LSF_CERN_LSHOSTS_1= """KSI2K: unknown host name.
+"""
+
+##shortened
+LSF_CERN_LSINFO= """MODEL_NAME      CPU_FACTOR      ARCHITECTURE
+i6_12_62d7h20_266      3.06
+ai_intel_8            2.44
+"""
 
 class LSFTimeLeftTest( unittest.TestCase ):
   """ test LSFTimeLeft """
@@ -38,3 +55,24 @@ class LSFTimeLeftTest( unittest.TestCase ):
       lsfTimeLeft = LSFTimeLeft()
       self.assertEqual( lsfTimeLeft.cpuLimit, 720 * 60 / 2.5 )
       self.assertEqual( lsfTimeLeft.wallClockLimit, 1440 * 60 / 2.5 )
+
+
+  def test_init_cern( self ):
+
+    rcMock = MagicMock()
+    retValues = ( S_OK(LSF_CERN_BQUEUES), S_ERROR(LSF_CERN_LSHOSTS_1), S_OK(LSF_CERN_LSINFO), S_OK(LSF_LSHOSTS) )
+    rcMock.side_effect = retValues
+    sourceMock = MagicMock( return_value=S_ERROR( "no lsf.sh" ) )
+
+    with patch( "DIRAC.Core.Utilities.TimeLeft.LSFTimeLeft.runCommand", new=rcMock ), \
+         patch.dict( os.environ, {'LSB_HOSTS': 'b6688e710f', 'LSF_ENVDIR': "/dev/null"} ), \
+         patch( "os.path.isfile", new=MagicMock( return_value=True ) ), \
+         patch( "DIRAC.Core.Utilities.TimeLeft.LSFTimeLeft.sourceEnv", new=sourceMock ):
+      lsfTimeLeft = LSFTimeLeft()
+      normrefExpected = 1.0
+      hostnormExpected = 2.5
+      self.assertEqual( lsfTimeLeft.cpuLimit, 10080 * 60 / hostnormExpected / normrefExpected  )
+      self.assertEqual( lsfTimeLeft.wallClockLimit, 30240 * 60 / hostnormExpected / normrefExpected )
+      self.assertEqual( lsfTimeLeft.cpuRef, "KSI2K" )
+      self.assertEqual( lsfTimeLeft.normRef, normrefExpected )
+      self.assertEqual( lsfTimeLeft.hostNorm, hostnormExpected )

--- a/Core/Utilities/TimeLeft/test/Test_LSFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/test/Test_LSFTimeLeft.py
@@ -1,0 +1,40 @@
+""" Test class for LSFTimeLeft utility
+
+"""
+
+import os
+import unittest
+from mock import MagicMock, patch
+
+from DIRAC import gLogger, S_OK
+
+from DIRAC.Core.Utilities.TimeLeft.LSFTimeLeft import LSFTimeLeft
+
+LSF_KEK_BQUEUES = """   CPULIMIT
+  720.0 min
+
+  RUNLIMIT
+  1440.0 min
+"""
+
+LSF_LSHOSTS = """ HOST_NAME                       type       model  cpuf ncpus maxmem maxswp server RESOURCES
+b6688e710f                   SLC6_64 i6_16_63f2h24_266   2.5    16 29999M 19999M    Yes (intel share aishare cvmfs wan exe lcg wigner slot15)
+  """
+
+class LSFTimeLeftTest( unittest.TestCase ):
+  """ test LSFTimeLeft """
+
+  def setUp( self ):
+    gLogger.setLevel( 'DEBUG' )
+
+  def test_init( self ):
+
+    rcMock = MagicMock()
+    retValues = ( LSF_KEK_BQUEUES, LSF_LSHOSTS )
+    rcMock.side_effect = ( S_OK( retValue ) for retValue in retValues )
+
+    with patch( "DIRAC.Core.Utilities.TimeLeft.LSFTimeLeft.runCommand", new=rcMock ), \
+         patch.dict( os.environ, {'LSB_HOSTS': 'b6688e710f'} ):
+      lsfTimeLeft = LSFTimeLeft()
+      self.assertEqual( lsfTimeLeft.cpuLimit, 720 * 60 / 2.5 )
+      self.assertEqual( lsfTimeLeft.wallClockLimit, 1440 * 60 / 2.5 )

--- a/Core/Utilities/TimeLeft/test/Test_TimeLeft.py
+++ b/Core/Utilities/TimeLeft/test/Test_TimeLeft.py
@@ -7,7 +7,7 @@
 
 # imports
 import unittest, importlib
-from mock import MagicMock
+from mock import MagicMock, patch
 
 from DIRAC import gLogger, S_OK
 
@@ -143,8 +143,9 @@ class TimeLeftSuccess( TimeLeftTestCase ):
       tl.batchPlugin.cpuLimit = 1000
       tl.batchPlugin.wallClockLimit = 1000
 
-      res = tl.getTimeLeft()
-      self.assertEqual( res['OK'], True )
+      with patch( "DIRAC.Core.Utilities.TimeLeft.LSFTimeLeft.runCommand", new=rcMock ):
+        res = tl.getTimeLeft()
+        self.assertEqual( res['OK'], True, res.get('Message', '') )
 
     for batch, retValue in [( 'SGE', SGE_ReturnValue )]:
       self.tl = importlib.import_module( "DIRAC.Core.Utilities.TimeLeft.TimeLeft" )

--- a/WorkloadManagementSystem/Client/CPUNormalization.py
+++ b/WorkloadManagementSystem/Client/CPUNormalization.py
@@ -212,7 +212,7 @@ def getCPUTime( cpuNormalizationFactor ):
     if result['OK']:
       cpuWorkLeft = result['Value']
 
-  if cpuWorkLeft:
+  if cpuWorkLeft > 0:
     # This is in HS06sseconds
     # We need to convert in real seconds
     if not cpuNormalizationFactor:  # if cpuNormalizationFactor passed in is 0, try get it from the local cfg


### PR DESCRIPTION
Pilot matching with KEK fails because the CPUTime returns -1, which results in a negative remaining time...
At the moment the LSFTimeLeft only accepts 4 "words" in the bqueues output, however at KEK there are just two pieces
I.e. KEK gives this
```
2016-09-13 16:11:50 UTC WorkloadManagement/JobAgent/LSFTimeLeft DEBUG:  CPULIMIT
2016-09-13 16:11:50 UTC WorkloadManagement/JobAgent/LSFTimeLeft DEBUG:  720.0 min
```
While at CERN (don't have any other LSF based systems).
```
CPULIMIT
15.0 min of KSI2K
```