### PR TITLE
[v6r15] Fix StageClient and WMS monitoring

### DIFF
--- a/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/StorageManagementSystem/Client/StorageManagerClient.py
@@ -64,12 +64,12 @@ def getFilesToStage( lfnList ):
     return S_ERROR( "Could not get metadata for files" )
   offlineLFNs = set( lfnList ) - onlineLFNs
 
-
   for offlineLFN in offlineLFNs:
     ses = lfnListReplicas['Value']['Successful'][offlineLFN].keys()
-    random.shuffle( ses )
-    se = ses[0]
-    offlineLFNsDict.setdefault( se, list() ).append( offlineLFN )
+    if ses:
+      random.shuffle( ses )
+      se = ses[0]
+      offlineLFNsDict.setdefault( se, list() ).append( offlineLFN )
 
   return S_OK( {'onlineLFNs':list( onlineLFNs ), 'offlineLFNs': offlineLFNsDict} )
 

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -277,8 +277,10 @@ class JobDB( DB ):
         if not ret['OK']:
           return ret
         paramNameList.append( ret['Value'] )
-      paramNames = ','.join( paramNameList )
-      cmd = "SELECT Name, Value from JobParameters WHERE JobID=%s and Name in (%s)" % ( e_jobID, paramNames )
+      if len( paramNameList ) == 1:
+        cmd = "SELECT Name, Value from JobParameters WHERE JobID=%s and Name=%s" % ( e_jobID, paramNameList[0] )
+      else:
+        cmd = "SELECT Name, Value from JobParameters WHERE JobID=%s and Name in (%s)" % ( e_jobID, ','.join( paramNameList ) )
       result = self._query( cmd )
       if result['OK']:
         if result['Value']:
@@ -1311,7 +1313,7 @@ class JobDB( DB ):
       return S_ERROR( 'Job ' + str( jobID ) + ' not found in the system' )
 
     if not resultDict['VerifiedFlag']:
-      return S_ERROR( 'Job %s not Verified: Status = %s, MinorStatus = %s' % (
+      return S_ERROR( 'Job %s not Verified: Status = %s, MinorStatus = %s' % ( 
                                                                              jobID,
                                                                              resultDict['Status'],
                                                                              resultDict['MinorStatus'] ) )


### PR DESCRIPTION
* In the stageClient (used by Optimizers), there was an exception when there was no active replica of a file
* getJobParameter with one single parameter was using a 'Name in (%s)' %paramList while more efficient 'Name=paramList[0]' 