### PR TITLE
[v6r15] FIX FTS: specify checksum type at submission

### DIFF
--- a/DataManagementSystem/Client/FTSJob.py
+++ b/DataManagementSystem/Client/FTSJob.py
@@ -595,7 +595,7 @@ class FTSJob( object ):
     for ftsFile in self:
       trans = fts3.new_transfer( ftsFile.SourceSURL,
                                 ftsFile.TargetSURL,
-                                checksum = ftsFile.Checksum,
+                                checksum = 'ADLER32:%s'%ftsFile.Checksum,
                                 filesize = ftsFile.Size )
       transfers.append( trans )
 


### PR DESCRIPTION
From FTS server 3.5, the behavior changed with respect to the checksum type. To avoid that, always specify it 