### PR TITLE
[v6r15]  fix dirac-install

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -667,6 +667,8 @@ class ReleaseConfig( object ):
       return False
 
   def getLCGVersion( self, lcgVersion = "" ):
+    if lcgVersion:
+      return lcgVersion
     for objName in self.__projectsLoadedBy:
       try:
         return self.__prjRelCFG[ self.__projectName ][ cliParams.release ].get( "Releases/%s/LcgVer" % cliParams.release, lcgVersion )


### PR DESCRIPTION
Take into account the command line specified version of LcgBundle in dirac install