### PR TITLE
[v6r15] Small fix

### DIFF
--- a/TransformationSystem/Client/Utilities.py
+++ b/TransformationSystem/Client/Utilities.py
@@ -98,7 +98,7 @@ class PluginUtilities( object ):
 
 
 
-  @timeThis
+  # @timeThis
   def groupByReplicas( self, files, status ):
     """
     Generates tasks based on the location of the input data
@@ -194,7 +194,7 @@ class PluginUtilities( object ):
     return tasks
 
 
-  @timeThis
+  # @timeThis
   def groupBySize( self, files, status ):
     """
     Generate a task for a given amount of data
@@ -273,7 +273,7 @@ class PluginUtilities( object ):
       usageDict = self._normaliseShares( usageDict )
     return S_OK( usageDict )
 
-  @timeThis
+  # @timeThis
   def _getFileSize( self, lfns ):
     """ Get file size from a cache, if not from the catalog
     #FIXME: have to fill the cachedLFNSize!
@@ -294,7 +294,7 @@ class PluginUtilities( object ):
       fileSizes = fileSizes['Value']
     return S_OK( fileSizes )
 
-  @timeThis
+  # @timeThis
   def _getFileSizeFromCatalog( self, lfns, fileSizes ):
     """
     Get file size from the catalog


### PR DESCRIPTION
Stop using @timeThis decorator in TS as it spoils the logs (should be limited by VERBOSE gLogger level)