### PR TITLE
[v6r16] Various fixes

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-find-lfns.py
+++ b/DataManagementSystem/scripts/dirac-dms-find-lfns.py
@@ -33,11 +33,6 @@ if __name__ == "__main__":
     if opt == 'Path':
       path = val
 
-  if len( args ) < 1:
-    print "Error: No argument provided\n%s:" % Script.scriptName
-    Script.showHelp()
-    DIRAC.exit( -1 )
-
   fc = FileCatalog()
   result = fc.getMetadataFields()
   if not result['OK']:
@@ -47,8 +42,13 @@ if __name__ == "__main__":
   typeDict.update( result['Value']['DirectoryMetaFields'] )
   # Special meta tags
   typeDict.update( FILE_STANDARD_METAKEYS )
-  
-  gLogger.info( "MetaDataDictionary: %s" % metaDict )
+
+  if len( args ) < 1:
+    print "Error: No argument provided\n%s:" % Script.scriptName
+    Script.showHelp()
+    gLogger.notice( "MetaDataDictionary: \n%s" % str( typeDict ) )
+    DIRAC.exit( -1 )
+
 
   mq = MetaQuery( typeDict = typeDict )
   result = mq.setMetaQuery( args )
@@ -62,7 +62,6 @@ if __name__ == "__main__":
   if not result['OK']:
     gLogger.error( 'Can not access File Catalog:', result['Message'] )
     DIRAC.exit( -1 )
-  lfnList = result['Value']
+  lfnList = sorted( result['Value'] )
 
-  for lfn in lfnList:
-    print lfn
+  gLogger.notice( '\n'.join( lfn for lfn in lfnList ) )

--- a/FrameworkSystem/private/logging/Message.py
+++ b/FrameworkSystem/private/logging/Message.py
@@ -46,7 +46,11 @@ class Message:
     return self.time
 
   def getMessage( self ):
-    return "%s %s" % ( self.getFixedMessage(), self.getVariableMessage() )
+    msg = self.getFixedMessage()
+    varMsg = self.getVariableMessage()
+    if varMsg:
+      msg += ' ' + varMsg
+    return msg
 
   def getFixedMessage( self ):
     return self.msgText


### PR DESCRIPTION
* dirac-dms-find-lfns was not working: make it partly work. However the quoted example doesn't work (filter CreationDate<2015-05-15 doesn't work)

* StalledJobAgent: send a kill signal to the job before setting it Failed. This should prevent jobs to continue running after they have been found Stalled and then Failed.
https://its.cern.ch/jira/browse/LHCBDIRAC-554

* Avoid space at the end of a gLogger message when the variable message is void