### PR TITLE
[v6r17] pylint, doc and test for rfc proxies

### DIFF
--- a/FrameworkSystem/Client/ProxyGeneration.py
+++ b/FrameworkSystem/Client/ProxyGeneration.py
@@ -1,9 +1,7 @@
 ########################################################################
-# $HeadURL$
-# File :   dirac-proxy-init.py
+# File :   ProxyGeneration.py
 # Author : Adrian Casajus
 ########################################################################
-__RCSID__ = "$Id$"
 
 import sys
 import getpass
@@ -11,8 +9,10 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Base import Script
 from DIRAC.Core.Utilities.NTP import getClockDeviation
 
+__RCSID__ = "$Id$"
 
-class CLIParams:
+
+class CLIParams(object):
 
   proxyLifeTime = 86400
   diracGroup = False
@@ -39,9 +39,9 @@ class CLIParams:
       return S_ERROR( "Can't parse time argument" )
     return S_OK()
 
-  def setRFC( self, arg ):
-      self.rfc = True
-      return S_OK()
+  def setRFC( self, _arg ):
+    self.rfc = True
+    return S_OK()
 
   def setProxyRemainingSecs( self, arg ):
     self.proxyLifeTime = int( arg )
@@ -70,11 +70,11 @@ class CLIParams:
       return S_ERROR( "Can't parse strength argument" )
     return S_OK()
 
-  def setProxyLimited( self, arg ):
+  def setProxyLimited( self, _arg ):
     self.limitedProxy = True
     return S_OK()
 
-  def setSummary( self, arg ):
+  def setSummary( self, _arg ):
     gLogger.info( "Enabling summary output" )
     self.summary = True
     return S_OK()
@@ -91,24 +91,24 @@ class CLIParams:
     self.proxyLoc = arg
     return S_OK()
 
-  def setDisableCSCheck( self, arg ):
+  def setDisableCSCheck( self, _arg ):
     self.checkWithCS = False
     return S_OK()
 
-  def setStdinPasswd( self, arg ):
+  def setStdinPasswd( self, _arg ):
     self.stdinPasswd = True
     return S_OK()
 
-  def setStrict( self, arg ):
+  def setStrict( self, _arg ):
     self.strict = True
     return S_OK()
 
-  def showVersion( self, arg ):
+  def showVersion( self, _arg ):
     gLogger.always( "Version: %s" % __RCSID__ )
     sys.exit( 0 )
     return S_OK()
 
-  def disableClockCheck( self, arg ):
+  def disableClockCheck( self, _arg ):
     self.checkClock = False
     return S_OK()
 
@@ -263,4 +263,3 @@ def generateProxy( params ):
     gLogger.warn( retVal[ 'Message' ] )
     return S_ERROR( "Couldn't generate proxy: %s" % retVal[ 'Message' ] )
   return S_OK( proxyLoc )
-

--- a/FrameworkSystem/Client/ProxyUpload.py
+++ b/FrameworkSystem/Client/ProxyUpload.py
@@ -1,16 +1,16 @@
 ########################################################################
-# $HeadURL$
 # File :    dirac-proxy-init.py
 # Author :  Adrian Casajus
 ###########################################################from DIRAC.Core.Base import Script#############
-__RCSID__ = "$Id$"
 
 import sys
 import getpass
 import DIRAC
 from DIRAC.Core.Base import Script
 
-class CLIParams:
+__RCSID__ = "$Id$"
+
+class CLIParams(object):
 
   proxyLifeTime = 2592000
   diracGroup = False

--- a/FrameworkSystem/DB/ProxyDB.py
+++ b/FrameworkSystem/DB/ProxyDB.py
@@ -83,9 +83,9 @@ class ProxyDB( DB ):
                                                         'VOMSAttr' : 'VARCHAR(255) NOT NULL',
                                                         'Pem' : 'BLOB',
                                                         'ExpirationTime' : 'DATETIME',
-                                                  },
+                                                      },
                                            'PrimaryKey' : [ 'UserDN', 'UserGroup', 'vomsAttr'  ]
-                                     }
+                                         }
 
     if 'ProxyDB_Log' not in tablesInDB:
       tablesD[ 'ProxyDB_Log' ] = { 'Fields' : { 'ID': 'BIGINT NOT NULL AUTO_INCREMENT',
@@ -96,9 +96,9 @@ class ProxyDB( DB ):
                                                 'Action' : 'VARCHAR(128) NOT NULL',
                                                 'Timestamp' : 'DATETIME',
                                               },
-                                    'PrimaryKey': 'ID',
-                                    'Indexes' : { 'Timestamp' : [ 'Timestamp' ]}
-                                  }
+                                   'PrimaryKey': 'ID',
+                                   'Indexes' : { 'Timestamp' : [ 'Timestamp' ]}
+                                 }
 
     if 'ProxyDB_Tokens' not in tablesInDB:
       tablesD[ 'ProxyDB_Tokens' ] = { 'Fields' : { 'Token' : 'VARCHAR(64) NOT NULL',
@@ -108,7 +108,7 @@ class ProxyDB( DB ):
                                                    'UsesLeft' : 'SMALLINT UNSIGNED DEFAULT 1',
                                                  },
                                       'PrimaryKey' : 'Token'
-                                  }
+                                    }
 
     if 'ProxyDB_ExpNotifs' not in tablesInDB:
       tablesD[ 'ProxyDB_ExpNotifs' ] = { 'Fields' : { 'UserDN' : 'VARCHAR(255) NOT NULL',
@@ -191,8 +191,8 @@ class ProxyDB( DB ):
       return S_ERROR( "Cannot escape DN" )
     cmd = "INSERT INTO `ProxyDB_Requests` ( Id, UserDN, Pem, ExpirationTime )"
     cmd += " VALUES ( 0, %s, %s, TIMESTAMPADD( SECOND, %d, UTC_TIMESTAMP() ) )" % ( sUserDN,
-                                                                              sAllStr,
-                                                                              int( self.__defaultRequestLifetime ) )
+                                                                                    sAllStr,
+                                                                                    int( self.__defaultRequestLifetime ) )
     retVal = self._update( cmd, conn = connObj )
     if not retVal[ 'OK' ]:
       return retVal
@@ -223,8 +223,7 @@ class ProxyDB( DB ):
       sUserDN = self._escapeString( userDN )[ 'Value' ]
     except KeyError:
       return S_ERROR( "Cannot escape DN" )
-    cmd = "SELECT Pem FROM `ProxyDB_Requests` WHERE Id = %s AND UserDN = %s" % ( requestId,
-                                                                                   sUserDN )
+    cmd = "SELECT Pem FROM `ProxyDB_Requests` WHERE Id = %s AND UserDN = %s" % ( requestId, sUserDN )
     retVal = self._query( cmd )
     if not retVal[ 'OK' ]:
       return retVal
@@ -495,10 +494,10 @@ class ProxyDB( DB ):
     #If we have a chain that's 0.8 of max mplifetime don't ask to mp
     if originChainLifeTime > maxMyProxyLifeTime * 0.8:
       self.log.error( "Skipping myproxy download",
-                     "user %s %s  chain has %s secs and requested %s secs" % ( userDN,
-                                                                               userGroup,
-                                                                               originChainLifeTime,
-                                                                               maxMyProxyLifeTime ) )
+                      "user %s %s  chain has %s secs and requested %s secs" % ( userDN,
+                                                                                userGroup,
+                                                                                originChainLifeTime,
+                                                                                maxMyProxyLifeTime ) )
       return S_OK( chain )
 
     lifeTime *= 1.3
@@ -517,7 +516,7 @@ class ProxyDB( DB ):
     mpChainSecsLeft = retVal['Value']
     if mpChainSecsLeft < originChainLifeTime:
       self.log.info( "Chain downloaded from myproxy has less lifetime than the one stored in the db",
-                    "\n Downloaded from myproxy: %s secs\n Stored in DB: %s secs" % ( mpChainSecsLeft, originChainLifeTime ) )
+                     "\n Downloaded from myproxy: %s secs\n Stored in DB: %s secs" % ( mpChainSecsLeft, originChainLifeTime ) )
       return S_OK( chain )
     retVal = mpChain.getDIRACGroup()
     if not retVal[ 'OK' ]:
@@ -845,8 +844,8 @@ class ProxyDB( DB ):
       cmd += "( %s, %s, '', UTC_TIMESTAMP(), 'True' )" % ( sUserDN, sUserGroup )
     else:
       cmd = "UPDATE `ProxyDB_Proxies` SET PersistentFlag='%s' WHERE UserDN=%s AND UserGroup=%s" % ( sqlFlag,
-                                                                                            sUserDN,
-                                                                                            sUserGroup )
+                                                                                                    sUserDN,
+                                                                                                    sUserGroup )
 
     retVal = self._update( cmd )
     if not retVal[ 'OK' ]:
@@ -948,10 +947,10 @@ class ProxyDB( DB ):
       qr = []
       if 'beforeDate' in selDict:
         qr.append( "Timestamp < %s" % self._escapeString( selDict[ 'beforeDate' ] )[ 'Value' ] )
-        del( selDict[ 'beforeDate' ] )
+        del selDict[ 'beforeDate' ]
       if 'afterDate' in selDict:
         qr.append( "Timestamp > %s" % self._escapeString( selDict[ 'afterDate' ] )[ 'Value' ] )
-        del( selDict[ 'afterDate' ] )
+        del selDict[ 'afterDate' ]
       for field in selDict:
         qr.append( "(%s)" % " OR ".join( [ "%s=%s" % ( field, self._escapeString( str( value ) )[ 'Value' ] ) for value in selDict[field] ] ) )
       whereStr = " WHERE %s" % " AND ".join( qr )
@@ -988,10 +987,10 @@ class ProxyDB( DB ):
     token = m.hexdigest()
     fieldsSQL = ", ".join( ( "Token", "RequesterDN", "RequesterGroup", "ExpirationTime", "UsesLeft" ) )
     valuesSQL = ", ".join( ( self._escapeString( token )['Value'],
-                              self._escapeString( requesterDN )['Value'],
-                              self._escapeString( requesterGroup )['Value'],
-                            "TIMESTAMPADD( SECOND, %d, UTC_TIMESTAMP() )" % int( lifeTime ),
-                            str( numUses ) ) )
+                             self._escapeString( requesterDN )['Value'],
+                             self._escapeString( requesterGroup )['Value'],
+                             "TIMESTAMPADD( SECOND, %d, UTC_TIMESTAMP() )" % int( lifeTime ),
+                             str( numUses ) ) )
 
     insertSQL = "INSERT INTO `ProxyDB_Tokens` ( %s ) VALUES ( %s )" % ( fieldsSQL, valuesSQL )
     result = self._update( insertSQL )
@@ -1105,7 +1104,7 @@ Dear %s,
   If you plan on keep using this credentials please upload a newer proxy to
   DIRAC by executing:
 
-  $ dirac-proxy-init -UP -g %s
+  $ dirac-proxy-init -P -g %s --rfc
 
   If you have been issued different certificate, please make sure you have a
   proxy uploaded with that certificate.

--- a/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -229,11 +229,7 @@ class ProxyManagerHandler( RequestHandler ):
     if not retVal[ 'OK' ]:
       return retVal
     credDict = self.getRemoteCredentials()
-    self.__proxyDB.logAction( "set persistency to %s" % bool( persistentFlag ),
-                                                  credDict[ 'DN' ],
-                                                  credDict[ 'group' ],
-                                                  userDN,
-                                                  userGroup )
+    self.__proxyDB.logAction( "set persistency to %s" % bool( persistentFlag ), credDict[ 'DN' ], credDict[ 'group' ], userDN, userGroup )
     return S_OK()
 
   types_deleteProxyBundle = [ ( list, tuple ) ]
@@ -267,12 +263,10 @@ class ProxyManagerHandler( RequestHandler ):
     retVal = self.__proxyDB.deleteProxy( userDN, userGroup )
     if not retVal[ 'OK' ]:
       return retVal
-    self.__proxyDB.logAction( "delete proxy", credDict[ 'DN' ], credDict[ 'group' ],
-                                        userDN, userGroup )
+    self.__proxyDB.logAction( "delete proxy", credDict[ 'DN' ], credDict[ 'group' ], userDN, userGroup )
     return S_OK()
 
-  types_getContents = [ dict, ( list, tuple ),
-                       ( int, long ), ( int, long ) ]
+  types_getContents = [ dict, ( list, tuple ), ( int, long ), ( int, long ) ]
   def export_getContents( self, selDict, sortDict, start, limit ):
     """
     Retrieve the contents of the DB

--- a/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -82,16 +82,7 @@ class ProxyManagerHandler( RequestHandler ):
       return S_ERROR( "%s is not a valid group for user %s" % ( userGroup, userName ) )
     clientChain = credDict[ 'x509Chain' ]
     clientSecs = clientChain.getIssuerCert()[ 'Value' ].getRemainingSecs()[ 'Value' ]
-    requestedUploadTime = min( requestedUploadTime, clientSecs )
-    retVal = self.__proxyDB.getRemainingTime( userDN, userGroup )
-    if not retVal[ 'OK' ]:
-      return retVal
-    remainingSecs = retVal[ 'Value' ]
-    # If we have a proxy longer than the one uploading it's not needed
-    # ten minute margin to compensate just in case
-    if remainingSecs >= requestedUploadTime - 600:
-      gLogger.info( "Upload request not necessary by %s:%s" % ( userName, userGroup ) )
-      return self.__addKnownUserProxiesInfo( S_OK() )
+    requestedUploadTime = min( requestedUploadTime, clientSecs ) #FIXME: this is useless now...
     result = self.__proxyDB.generateDelegationRequest( credDict[ 'x509Chain' ], userDN )
     if result[ 'OK' ]:
       gLogger.info( "Upload request by %s:%s given id %s" % ( userName, userGroup, result['Value']['id'] ) )
@@ -204,9 +195,9 @@ class ProxyManagerHandler( RequestHandler ):
 
   def __getVOMSProxy( self, userDN, userGroup, requestPem, requiredLifetime, vomsAttribute, forceLimited ):
     retVal = self.__proxyDB.getVOMSProxy( userDN,
-                                    userGroup,
-                                    requiredLifeTime = requiredLifetime,
-                                    requestedVOMSAttr = vomsAttribute )
+                                          userGroup,
+                                          requiredLifeTime = requiredLifetime,
+                                          requestedVOMSAttr = vomsAttribute )
     if not retVal[ 'OK' ]:
       return retVal
     chain, secsLeft = retVal[ 'Value' ]
@@ -276,8 +267,7 @@ class ProxyManagerHandler( RequestHandler ):
       selDict[ 'UserName' ] = credDict[ 'username' ]
     return self.__proxyDB.getProxiesContent( selDict, sortDict, start, limit )
 
-  types_getLogContents = [ dict, ( list, tuple ),
-                       ( int, long ), ( int, long ) ]
+  types_getLogContents = [ dict, ( list, tuple ), ( int, long ), ( int, long ) ]
   def export_getLogContents( self, selDict, sortDict, start, limit ):
     """
     Retrieve the contents of the DB

--- a/FrameworkSystem/scripts/dirac-admin-proxy-upload.py
+++ b/FrameworkSystem/scripts/dirac-admin-proxy-upload.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 ########################################################################
-# File :    dirac-proxy-init.py
+# File :    dirac-admin-proxy-upload.py
 # Author :  Adrian Casajus
 ###########################################################from DIRAC.Core.Base import Script#############
-__RCSID__ = "$Id$"
 
 import sys
 from DIRAC.Core.Base import Script
 from DIRAC.FrameworkSystem.Client.ProxyUpload import CLIParams, uploadProxy
+
+__RCSID__ = "$Id$"
 
 if __name__ == "__main__":
   cliParams = CLIParams()

--- a/FrameworkSystem/scripts/dirac-proxy-init.py
+++ b/FrameworkSystem/scripts/dirac-proxy-init.py
@@ -66,7 +66,7 @@ class ProxyInit:
   def certLifeTimeCheck( self ):
     minLife = Registry.getGroupOption( self.__piParams.diracGroup, "SafeCertificateLifeTime", 2592000 )
     issuerCert = self.getIssuerCert()
-    result = issuerCert.getRemainingSecs()
+    result = issuerCert.getRemainingSecs() #pylint: disable=no-member
     if not result[ 'OK' ]:
       gLogger.error( "Could not retrieve certificate expiration time", result[ 'Message' ] )
       return
@@ -89,7 +89,7 @@ class ProxyInit:
         return uploadGroups
 
     issuerCert = self.getIssuerCert()
-    userDN = issuerCert.getSubjectDN()[ 'Value' ]
+    userDN = issuerCert.getSubjectDN()[ 'Value' ] #pylint: disable=no-member
 
     result = Registry.getGroupsForDN( userDN )
     if not result[ 'OK' ]:
@@ -133,7 +133,7 @@ class ProxyInit:
 
   def uploadProxy( self, userGroup = False ):
     issuerCert = self.getIssuerCert()
-    userDN = issuerCert.getSubjectDN()[ 'Value' ]
+    userDN = issuerCert.getSubjectDN()[ 'Value' ] #pylint: disable=no-member
     if not userGroup:
       userGroup = self.__piParams.diracGroup
     gLogger.notice( "Uploading proxy for %s..." % userGroup )
@@ -143,13 +143,13 @@ class ProxyInit:
     if userDN in self.__uploadedInfo:
       expiry = self.__uploadedInfo[ userDN ].get( userGroup )
       if expiry:
-        if issuerCert.getNotAfterDate()[ 'Value' ] - datetime.timedelta( minutes = 10 ) < expiry:
+        if issuerCert.getNotAfterDate()[ 'Value' ] - datetime.timedelta( minutes = 10 ) < expiry: #pylint: disable=no-member
           gLogger.info( "SKipping upload for group %s. Already uploaded" % userGroup )
           return S_OK()
     gLogger.info( "Uploading %s proxy to ProxyManager..." % self.__piParams.diracGroup )
     upParams = ProxyUpload.CLIParams()
     upParams.onTheFly = True
-    upParams.proxyLifeTime = issuerCert.getRemainingSecs()[ 'Value' ] - 300
+    upParams.proxyLifeTime = issuerCert.getRemainingSecs()[ 'Value' ] - 300 #pylint: disable=no-member
     upParams.rfcIfPossible = self.__piParams.rfc
     upParams.diracGroup = userGroup
     for k in ( 'certLoc', 'keyLoc', 'userPasswd' ):
@@ -182,8 +182,8 @@ class ProxyInit:
       for userDN in self.__uploadedInfo:
         for group in self.__uploadedInfo[ userDN ]:
           gLogger.notice( " %s | %s | %s" % ( userDN.ljust( maxDNLen ),
-                                                  group.ljust( maxGroupLen ),
-                                                  self.__uploadedInfo[ userDN ][ group ].strftime( "%Y/%m/%d %H:%M" ) ) )
+                                              group.ljust( maxGroupLen ),
+                                              self.__uploadedInfo[ userDN ][ group ].strftime( "%Y/%m/%d %H:%M" ) ) )
 
   def doTheMagic( self ):
     result = self.createProxy()

--- a/docs/source/AdministratorGuide/CommandReference/dirac-proxy-init.rst
+++ b/docs/source/AdministratorGuide/CommandReference/dirac-proxy-init.rst
@@ -6,47 +6,48 @@ Obtain a user proxy.
 
 Usage::
 
-  dirac-proxy-init.py (<options>|<cfgFile>)* 
- 
+  dirac-proxy-init.py (<options>|<cfgFile>)*
+
 
 Options::
 
-  -v:  --valid=          : Valid HH:MM for the proxy. By default is 24 hours 
+  -v:  --valid=          : Valid HH:MM for the proxy. By default is 24 hours
 
-  -g:  --group=          : DIRAC Group to embed in the proxy 
+  -g:  --group=          : DIRAC Group to embed in the proxy
 
-  -b:  --strength=       : Set the proxy strength in bytes 
+  -b:  --strength=       : Set the proxy strength in bytes
 
-  -l   --limited         : Generate a limited proxy 
+  -l   --limited         : Generate a limited proxy
 
-  -t   --strict          : Fail on each error. Treat warnings as errors. 
+  -t   --strict          : Fail on each error. Treat warnings as errors.
 
-  -S   --summary         : Enable summary output when generating proxy 
+  -S   --summary         : Enable summary output when generating proxy
 
-  -C:  --Cert=           : File to use as user certificate 
+  -C:  --Cert=           : File to use as user certificate
 
-  -K:  --Key=            : File to use as user key 
+  -K:  --Key=            : File to use as user key
 
-  -u:  --out=            : File to write as proxy 
+  -u:  --out=            : File to write as proxy
 
-  -x   --nocs            : Disable CS check 
+  -x   --nocs            : Disable CS check
 
-  -p   --pwstdin         : Get passwd from stdin 
+  -p   --pwstdin         : Get passwd from stdin
 
-  -i   --version         : Print version 
+  -i   --version         : Print version
 
-  -j   --noclockcheck    : Disable checking if time is ok 
+  -j   --noclockcheck    : Disable checking if time is ok
 
-  -U   --upload          : Upload a long lived proxy to the ProxyManager 
+  -U   --upload          : Upload a long lived proxy to the ProxyManager
 
-  -P   --uploadPilot     : Upload a long lived pilot proxy to the ProxyManager 
+  -P   --uploadPilot     : Upload a long lived pilot proxy to the ProxyManager
 
-  -M   --VOMS            : Add voms extension 
+  -M   --VOMS            : Add voms extension
+
+  -r   --rfc             : Create an RFC proxy (https://www.ietf.org/rfc/rfc3820.txt)
+
 
 Example::
 
-  $ dirac-proxy-init -g dirac_user
+  $ dirac-proxy-init -g dirac_user -t --rfc
   Enter Certificate password:
-  $ 
-
-
+  $

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Registry/Groups/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Registry/Groups/index.rst
@@ -22,21 +22,21 @@ This subsection is used to describe DIRAC groups registered in the server.
 +---------------------------+------------------------------------------------+-----------------------------+
 | *JobShare*                | Just for normal users                          | JobShare = 200              |
 +---------------------------+------------------------------------------------+-----------------------------+
-| *AutoUploadProxy*         | Controls automatic Proxy upload by             | AutoUploadProxy = True      | 
+| *AutoUploadProxy*         | Controls automatic Proxy upload by             | AutoUploadProxy = True      |
 |                           | dirac-proxy-init                               |                             |
 +---------------------------+------------------------------------------------+-----------------------------+
 | *AutoUploadPilotProxy*    | Controls automatic Proxy upload by             | AutoUploadPilotProxy = True |
-|                           | dirac-proxy-init for Pilot groups              |                             |           
+|                           | dirac-proxy-init for Pilot groups              |                             |
 +---------------------------+------------------------------------------------+-----------------------------+
 | *AutoAddVOMS*             | Controls automatic addition of VOMS            | AutoAddVOMS = True          |
-|                           | extension by dirac-proxy-init                  |                             |  
+|                           | extension by dirac-proxy-init                  |                             |
 +---------------------------+------------------------------------------------+-----------------------------+
 
 
 * Default properties by group:
 
   ** dirac_admin:
-  
+
    -   Properties = AlarmsManagement
    -   Properties += ServiceAdministrator
    -   Properties += CSAdministrator
@@ -44,14 +44,13 @@ This subsection is used to describe DIRAC groups registered in the server.
    -   Properties += FullDelegation
    -   Properties += ProxyManagement
    -   Properties += Operator
-  
+
   ** dirac_pilot
-  
+
    -  Properties = GenericPilot
    -  Properties += LimitedDelegation
    -  Properties += Pilot
-   
+
   ** dirac_user
-  
+
    - Properties = NormalUser
- 

--- a/docs/source/AdministratorGuide/InstallingDIRACService/index.rst
+++ b/docs/source/AdministratorGuide/InstallingDIRACService/index.rst
@@ -4,18 +4,18 @@
 DIRAC Server Installation
 =========================
 
-The procedure described here outlines the installation of the DIRAC components on a host machine, a 
+The procedure described here outlines the installation of the DIRAC components on a host machine, a
 DIRAC server. There are two distinct cases of installations:
 
   - *Primary server installation*. This the first installation of a fresh new DIRAC system. No functioning
     Configuration Service is running yet (:ref:`install_primary_server`).
-  - *Additional server installation*. This is the installation of additional hosts connected to an already 
-    existing DIRAC system, with the Master Configuration Service already up and running on another 
+  - *Additional server installation*. This is the installation of additional hosts connected to an already
+    existing DIRAC system, with the Master Configuration Service already up and running on another
     DIRAC server (:ref:`install_additional_server`).
 
 The primary server installation should install and start at least the Configuration Service which is the
 backbone for the entire DIRAC system. The SystemAdministrator Service, once installed, allows remote
-management of the DIRAC components on the server. In multi-server installations DIRAC components are 
+management of the DIRAC components on the server. In multi-server installations DIRAC components are
 distributed among a number of servers installed using the procedure for additional host installation.
 
 For all DIRAC installations any number of client installations is possible.
@@ -27,21 +27,21 @@ Requirements
 
 *Server:*
 
-      - 9130-9200 ports should be open in the firewall for the incoming TCP/IP connections (this is the 
-        default range if predefined ports are used, the port on which services are listening can be 
+      - 9130-9200 ports should be open in the firewall for the incoming TCP/IP connections (this is the
+        default range if predefined ports are used, the port on which services are listening can be
         configured by the DIRAC administrator)::
-        
+
          iptables -I INPUT -p tcp --dport 9130:9200 -j ACCEPT
          service iptables save
-      - DIRAC extensions that need specific services which are not an extension of DIRAC used 
-        should better use ports 9201-9300 in order to avoid confusion. If this happens, 
+      - DIRAC extensions that need specific services which are not an extension of DIRAC used
+        should better use ports 9201-9300 in order to avoid confusion. If this happens,
         the procedure above should be repeated to include the new range of ports.
-      - For the server hosting the portal, ports 80 and 443 should be open and redirected to ports 
+      - For the server hosting the portal, ports 80 and 443 should be open and redirected to ports
         8080 and 8443 respectively, i.e. setting iptables appropriately::
 
          iptables -t nat -I PREROUTING -p tcp --dport 80 -j REDIRECT --to-ports 8080
          iptables -t nat -I PREROUTING -p tcp --dport 443 -j REDIRECT --to-ports 8443
-         
+
         If you have problems with NAT or iptables you can use multipurpose relay *socat*::
 
          socat TCP4-LISTEN:80,fork TCP4:localhost:8080 &
@@ -49,18 +49,18 @@ Requirements
 
       - Grid host certificates in pem format;
       - At least one of the servers of the installation must have updated CAs and CRLs files; if you want to install
-         the standard Grid CAs you can follow the instructions at https://wiki.egi.eu/wiki/EGI_IGTF_Release. They 
+         the standard Grid CAs you can follow the instructions at https://wiki.egi.eu/wiki/EGI_IGTF_Release. They
          are usally installed /etc/grid-security/certificates. You may also need to install the ``fetch-crl`` package,
          and run the ``fetch-crl`` command once installed.
-      - If gLite third party services are needed (for example, for the pilot job submission via WMS 
-        or for data transfer using FTS) gLite User Interface must be installed and the environment set up 
+      - If gLite third party services are needed (for example, for the pilot job submission via WMS
+        or for data transfer using FTS) gLite User Interface must be installed and the environment set up
         by "sourcing" the corresponding script, e.g. /etc/profile.d/grid-env.sh.
 
 *Client:*
 
-      - User certificate and private key in .pem format in the $HOME/.globus directory with correct 
+      - User certificate and private key in .pem format in the $HOME/.globus directory with correct
         permissions.
-      - User certificate loaded into the Web Browser (currently supported browsers are: Mozilla Firefox, Chrome 
+      - User certificate loaded into the Web Browser (currently supported browsers are: Mozilla Firefox, Chrome
         and Safari)
 
 .. _server_preparation:
@@ -68,7 +68,7 @@ Requirements
 Server preparation
 ------------------
 
-Any host running DIRAC server components should be prepared before the installation of DIRAC following 
+Any host running DIRAC server components should be prepared before the installation of DIRAC following
 the steps below. This procedure must be followed for the primary server and for any additional server installations.
 
  - As *root* create a *dirac* user account. This account will be used to run all the DIRAC components::
@@ -78,9 +78,9 @@ the steps below. This procedure must be followed for the primary server and for 
  - As *root*, create the directory where the DIRAC services will be installed::
 
       mkdir /opt/dirac
-      chown -R dirac:dirac /opt/dirac 
+      chown -R dirac:dirac /opt/dirac
 
- - As *root*, check that the system clock is exact. Some system components are generating user certificate proxies 
+ - As *root*, check that the system clock is exact. Some system components are generating user certificate proxies
    dynamically and their validity can be broken because of the wrong system date and time. Properly configure
    the NTP daemon if necessary.
 
@@ -88,16 +88,16 @@ the steps below. This procedure must be followed for the primary server and for 
 
       mkdir -p /opt/dirac/etc/grid-security/
       cp hostcert.pem hostkey.pem /opt/dirac/etc/grid-security
-      
+
    In case your host certificate is in the p12 format, you can convert it with::
-   
+
       openssl pkcs12 -in host.p12 -clcerts -nokeys -out hostcert.pem
       openssl pkcs12 -in host.p12 -nocerts -nodes -out hostkey.pem
-      
+
    Make sure the permissions are set right correctly, such that the hostkey.pem is only readable by the ``dirac`` user.
  - As *dirac* user, create a directory or a link pointing to the CA certificates directory, for example::
 
-      ln -s /etc/grid-security/certificates  /opt/dirac/etc/grid-security/certificates    
+      ln -s /etc/grid-security/certificates  /opt/dirac/etc/grid-security/certificates
 
    (this is only mandatory in one of the servers. Others can be synchronized from this one using DIRAC tools.)
 
@@ -110,18 +110,18 @@ the steps below. This procedure must be followed for the primary server and for 
 Server Certificates
 -------------------
 
-Server certificates are used for validating the identity of the host a given client is connecting to. By default 
-grid host certificate include host/ in the CN (common name) field. This is not a problem for DIRAC components 
-since DISET only keeps the host name after the **/** if present. 
+Server certificates are used for validating the identity of the host a given client is connecting to. By default
+grid host certificate include host/ in the CN (common name) field. This is not a problem for DIRAC components
+since DISET only keeps the host name after the **/** if present.
 
 However if the certificate is used for the Web Portal, the client validating the certificate is your browser. All browsers
 will rise a security alarm if the host name in the url does not match the CN field in the certificate presented by the server.
-In particular this means that *host/*, or other similar parts should nto be present, and that it is preferable to use 
+In particular this means that *host/*, or other similar parts should nto be present, and that it is preferable to use
 DNS aliases and request a certificate under this alias in order to be able to migrate the server to a new host without
 having to change your URLs. DIRAC will accept both real host names and any valid aliases without complains.
 
-Finally, you will have to instruct you users on the procedure to upload the public key of the CA signing the certificate 
-of the host where the Web Portal is running. This depends from CA to CA, but typically only means clicking on a certain 
+Finally, you will have to instruct you users on the procedure to upload the public key of the CA signing the certificate
+of the host where the Web Portal is running. This depends from CA to CA, but typically only means clicking on a certain
 link on the web portal of the CA.
 
 Using your own CA
@@ -136,7 +136,7 @@ you need to make sure the hash of that CA certificate is created. Make sure the 
   openssl x509 -noout -in cert.pem -hash
   ln -s cert.pem hash.0
 
-where the output of the ``openssl`` command gives you the hash of the certificate ``cert.pem``, and must be used for the 
+where the output of the ``openssl`` command gives you the hash of the certificate ``cert.pem``, and must be used for the
 ``hash.0`` link name. Make sure the ``.0`` part is present in the name, as this is looked for when starting the web server.
 
 .. _install_primary_server:
@@ -145,12 +145,12 @@ Primary server installation
 ---------------------------
 
 The installation consists of setting up a set of services, agents and databases for the
-required DIRAC functionality. The SystemAdministrator interface can be used later to complete 
+required DIRAC functionality. The SystemAdministrator interface can be used later to complete
 the installation by setting up additional components. The following steps should
 be taken:
- 
+
   - Editing the installation configuration file. This file contains all
-    the necessary information describing the installation. By editing the configuration 
+    the necessary information describing the installation. By editing the configuration
     file one can describe the complete DIRAC server or
     just a subset for the initial setup. Below is an example of a commented configuration file.
     This file corresponds to a minimal DIRAC server configuration which allows to start
@@ -164,7 +164,7 @@ be taken:
         #
         #   These are options for the installation of the DIRAC software
         #
-        #  DIRAC release version (this is an example, you should find out the current 
+        #  DIRAC release version (this is an example, you should find out the current
         #  production release)
         Release = v6r10p4
         #  Python version of the installation
@@ -179,9 +179,9 @@ be taken:
         UseVersionsDir = yes
         #  The directory of the DIRAC software installation
         TargetPath = /opt/dirac
-        #  DIRAC extra modules to be installed (Web is required if you are installing the Portal on 
+        #  DIRAC extra modules to be installed (Web is required if you are installing the Portal on
         #  this server).
-        #  Only modules not defined as default to install in their projects need to be defined here: 
+        #  Only modules not defined as default to install in their projects need to be defined here:
         #   i.e. LHCb, LHCbWeb for LHCb
         Externals = WebApp
 
@@ -189,21 +189,21 @@ be taken:
         #   These are options for the configuration of the installed DIRAC software
         #   i.e., to produce the initial dirac.cfg for the server
         #
-        #  Give a Name to your User Community, it does not need to be the same name as in EGI, 
+        #  Give a Name to your User Community, it does not need to be the same name as in EGI,
         #  it can be used to cover more than one VO in the grid sense
         VirtualOrganization = Name of your VO
-        #  Site name   
+        #  Site name
         SiteName = DIRAC.HostName.ch
         #  Setup name
         Setup = MyDIRAC-Production
-        #  Default name of system instances 
+        #  Default name of system instances
         InstanceName = Production
         #  Flag to skip download of CAs, on the first Server of your installation you need to get CAs
         #  installed by some external means
         SkipCADownload = yes
         #  Flag to use the server certificates
         UseServerCertificate = yes
-        #  Configuration Server URL (This should point to the URL of at least one valid Configuration 
+        #  Configuration Server URL (This should point to the URL of at least one valid Configuration
         #  Service in your installation, for the primary server it should not used )
         #  ConfigurationServer = dips://myprimaryserver.name:9135/Configuration/Server
         #  Configuration Name
@@ -219,7 +219,7 @@ be taken:
         #  Name of the Admin user (default: None )
         AdminUserName = adminusername
         #  DN of the Admin user certificate (default: None )
-        #  In order the find out the DN that needs to be included in the Configuration for a given 
+        #  In order the find out the DN that needs to be included in the Configuration for a given
         #  host or user certificate the following command can be used::
         #
         #          openssl x509 -noout -subject -enddate -in <certfile.pem>
@@ -228,12 +228,12 @@ be taken:
         #  Email of the Admin user (default: None )
         AdminUserEmail = adminmail@provider
         #  Name of the Admin group (default: dirac_admin )
-        AdminGroupName = dirac_admin 
+        AdminGroupName = dirac_admin
         #  DN of the host certificate (*) (default: None )
         HostDN = /DC=ch/DC=country/OU=computers/CN=computer.dn
         # Define the Configuration Server as Master for your installations
         ConfigurationMaster = yes
-        
+
         #
         #  The following options define components to be installed
         #
@@ -241,7 +241,7 @@ be taken:
         #  Used to build the URLs the services will publish
         #  For a test installation you can use 127.0.0.1
         # Host = dirac.cern.ch
-        Host = 
+        Host =
         #  List of Services to be installed
         Services  = Configuration/Server
         Services += Framework/SystemAdministrator
@@ -274,24 +274,24 @@ be taken:
     .cfg extension (CFG file)::
 
       ./install_site.sh install.cfg
-      
+
   - If the installation is successful, in the end of the script execution you will see the report
     of the status of running DIRAC services, e.g.::
-          
+
                                   Name : Runit    Uptime    PID
                   Configuration_Server : Run          41    30268
          Framework_SystemAdministrator : Run          21    30339
                              Web_httpd : Run           5    30828
                             Web_paster : Run           5    30829
-        
-Now the basic services - Configuration and SystemAdministrator - are installed. The rest of the installation can proceed using 
-the DIRAC Administrator interface, either command line (System Administrator Console) or using Web Portal (eventually, 
+
+Now the basic services - Configuration and SystemAdministrator - are installed. The rest of the installation can proceed using
+the DIRAC Administrator interface, either command line (System Administrator Console) or using Web Portal (eventually,
 not available yet).
 
 It is also possible to include any number of additional systems, services, agents and databases to be installed by "install_site.sh".
 
-**Important Notice:** after executing install_site.sh (or dirac-setup-site) a runsvdir process is kept running. This 
-is a watchdog process that takes care to keep DIRAC component running on your server. If you want to remove your 
+**Important Notice:** after executing install_site.sh (or dirac-setup-site) a runsvdir process is kept running. This
+is a watchdog process that takes care to keep DIRAC component running on your server. If you want to remove your
 installation (for instance if you are testing your install .cfg) you should first remove links from startup directory, kill the runsvdir, the runsv processes::
 
       #!/bin/bash
@@ -309,8 +309,8 @@ installation (for instance if you are testing your install .cfg) you should firs
 Additional server installation
 ------------------------------
 
-To add a new server to an already existing DIRAC Installation the procedure is similar to the one above. 
-You should perform all the preliminary steps to prepare the host for the installation. One additional 
+To add a new server to an already existing DIRAC Installation the procedure is similar to the one above.
+You should perform all the preliminary steps to prepare the host for the installation. One additional
 operation is the registration of the new host in the already functional Configuration Service.
 
   - Then you edit the installation configuration file::
@@ -323,7 +323,7 @@ operation is the registration of the new host in the already functional Configur
         #
         #   These are options for the installation of the DIRAC software
         #
-        #  DIRAC release version (this is an example, you should find out the current 
+        #  DIRAC release version (this is an example, you should find out the current
         #  production release)
         Release = v6r3p7
         #  To install the Server version of DIRAC (the default is client)
@@ -336,28 +336,28 @@ operation is the registration of the new host in the already functional Configur
         UseVersionsDir = yes
         #  The directory of the DIRAC software installation
         TargetPath = /opt/dirac
-        #  DIRAC extra packages to be installed (Web is required if you are installing the Portal on 
+        #  DIRAC extra packages to be installed (Web is required if you are installing the Portal on
         #  this server).
-        #  For each User Community their extra package might be necessary here: 
+        #  For each User Community their extra package might be necessary here:
         #   i.e. LHCb, LHCbWeb for LHCb
-        Externals = 
+        Externals =
 
         #
         #   These are options for the configuration of the previously installed DIRAC software
         #   i.e., to produce the initial dirac.cfg for the server
         #
-        #  Give a Name to your User Community, it does not need to be the same name as in EGI, 
+        #  Give a Name to your User Community, it does not need to be the same name as in EGI,
         #  it can be used to cover more than one VO in the grid sense
         VirtualOrganization = Name of your VO
-        #  Site name   
+        #  Site name
         SiteName = DIRAC.HostName2.ch
         #  Setup name
         Setup = MyDIRAC-Production
-        #  Default name of system instances 
+        #  Default name of system instances
         InstanceName = Production
         #  Flag to use the server certificates
         UseServerCertificate = yes
-        #  Configuration Server URL (This should point to the URL of at least one valid Configuration 
+        #  Configuration Server URL (This should point to the URL of at least one valid Configuration
         #  Service in your installation, for the primary server it should not used)
         ConfigurationServer = dips://myprimaryserver.name:9135/Configuration/Server
         ConfigurationServer += dips://localhost:9135/Configuration/Server
@@ -366,7 +366,7 @@ operation is the registration of the new host in the already functional Configur
 
         #
         #   These options define the DIRAC components being installed on "this" DIRAC server.
-        #   The simplest option is to install a slave of the Configuration Server and a 
+        #   The simplest option is to install a slave of the Configuration Server and a
         #   SystemAdministrator for remote management.
         #
         #  The following options defined components to be installed
@@ -374,13 +374,13 @@ operation is the registration of the new host in the already functional Configur
         #  Name of the installation host (default: the current host )
         #  Used to build the URLs the services will publish
         # Host = dirac.cern.ch
-        Host = 
+        Host =
         #  List of Services to be installed
         Services  = Configuration/Server
         Services += Framework/SystemAdministrator
 
   - Now run install_site.sh giving the edited CFG file as the argument:::
-  
+
         ./install_site.sh install.cfg
 
 If the installation is successful, the SystemAdministrator service will be up and running on the
@@ -389,9 +389,9 @@ server. You can now set up the required components as described in :ref:`setting
 Post-Installation step
 ----------------------
 
-In order to make the DIRAC components running we use the *runit* mechanism (http://smarden.org/runit/). For each component that 
-must run permanently (services and agents) there is a directory created under */opt/dirac/startup* that is 
-monitored by a *runsvdir* daemon. The installation procedures above will properly start this daemon. In order 
+In order to make the DIRAC components running we use the *runit* mechanism (http://smarden.org/runit/). For each component that
+must run permanently (services and agents) there is a directory created under */opt/dirac/startup* that is
+monitored by a *runsvdir* daemon. The installation procedures above will properly start this daemon. In order
 to ensure starting the DIRAC components at boot you need to add a hook in your boot sequence. A possible solution
 is to add an entry in the */etc/inittab*::
 
@@ -438,7 +438,7 @@ To install the DIRAC Client, follow the procedure described in the User Guide.
 
   - Start admin command line interface using administrator DIRAC group::
 
-      dirac-proxy-init -g dirac_admin
+      dirac-proxy-init -g dirac_admin --rfc
       dirac-admin-sysadmin-cli --host <HOST_NAME>
 
       where the HOST_NAME is the name of the DIRAC service host
@@ -446,12 +446,12 @@ To install the DIRAC Client, follow the procedure described in the User Guide.
   - At any time you can use the help command to get further details::
 
       dirac.pic.es >help
-      
+
       Documented commands (type help <topic>):
       ========================================
-      add   execfile  install  restart  show   stop  
+      add   execfile  install  restart  show   stop
       exec  exit      quit     set      start  update
-      
+
       Undocumented commands:
       ======================
       help
@@ -460,7 +460,7 @@ To install the DIRAC Client, follow the procedure described in the User Guide.
 
       add instance WorkloadManagement Production
 
-  - Install MySQL database. You have to enter two passwords one is the root password for MySQL itself (if not already done in the server installation) 
+  - Install MySQL database. You have to enter two passwords one is the root password for MySQL itself (if not already done in the server installation)
     and another one is the password for user who will own the DIRAC databases, in our case the user name is Dirac::
 
       install mysql
@@ -477,15 +477,15 @@ To install the DIRAC Client, follow the procedure described in the User Guide.
       ...
       install agent Configuration CE2CSAgent
 
-Note that all the necessary commands above can be collected in a text file and the whole installation can be 
+Note that all the necessary commands above can be collected in a text file and the whole installation can be
 accomplished with a single command::
 
-      execfile <command_file> 
+      execfile <command_file>
 
 Component Configuration and Monitoring
----------------------------------------- 
+----------------------------------------
 
-At this point all the services should be running with their default configuration parameters. 
+At this point all the services should be running with their default configuration parameters.
 To change the components configuration parameters
 
   - Login into web portal and choose dirac_admin group, you can change configuration file following these links::
@@ -496,8 +496,7 @@ To change the components configuration parameters
 
     $ *dirac-configuration-cli*
 
-  - In the server all the logs of the services and agents are stored and rotated in 
+  - In the server all the logs of the services and agents are stored and rotated in
     files that can be checked using the following command::
 
       tail -f  /opt/dirac/startup/<System>_<Service or Agent>/log/current
-

--- a/docs/source/UserGuide/CommandReference/Others/dirac-proxy-init.rst
+++ b/docs/source/UserGuide/CommandReference/Others/dirac-proxy-init.rst
@@ -4,47 +4,48 @@ dirac-proxy-init
 
 Usage::
 
-  dirac-proxy-init.py (<options>|<cfgFile>)* 
+  dirac-proxy-init.py (<options>|<cfgFile>)*
 
- 
+
 
 Options::
 
-  -v:  --valid=          : Valid HH:MM for the proxy. By default is 24 hours 
+  -v:  --valid=          : Valid HH:MM for the proxy. By default is 24 hours
 
-  -g:  --group=          : DIRAC Group to embed in the proxy 
+  -g:  --group=          : DIRAC Group to embed in the proxy
 
-  -b:  --strength=       : Set the proxy strength in bytes 
+  -b:  --strength=       : Set the proxy strength in bytes
 
-  -l   --limited         : Generate a limited proxy 
+  -l   --limited         : Generate a limited proxy
 
-  -t   --strict          : Fail on each error. Treat warnings as errors. 
+  -t   --strict          : Fail on each error. Treat warnings as errors.
 
-  -S   --summary         : Enable summary output when generating proxy 
+  -S   --summary         : Enable summary output when generating proxy
 
-  -C:  --Cert=           : File to use as user certificate 
+  -C:  --Cert=           : File to use as user certificate
 
-  -K:  --Key=            : File to use as user key 
+  -K:  --Key=            : File to use as user key
 
-  -u:  --out=            : File to write as proxy 
+  -u:  --out=            : File to write as proxy
 
-  -x   --nocs            : Disable CS check 
+  -x   --nocs            : Disable CS check
 
-  -p   --pwstdin         : Get passwd from stdin 
+  -p   --pwstdin         : Get passwd from stdin
 
-  -i   --version         : Print version 
+  -i   --version         : Print version
 
-  -j   --noclockcheck    : Disable checking if time is ok 
+  -j   --noclockcheck    : Disable checking if time is ok
 
-  -U   --upload          : Upload a long lived proxy to the ProxyManager 
+  -U   --upload          : Upload a long lived proxy to the ProxyManager
 
-  -P   --uploadPilot     : Upload a long lived pilot proxy to the ProxyManager 
+  -P   --uploadPilot     : Upload a long lived pilot proxy to the ProxyManager
 
-  -M   --VOMS            : Add voms extension 
+  -M   --VOMS            : Add voms extension
+
+  -r   --rfc             : Create and RFC proxy style (https://www.ietf.org/rfc/rfc3820.txt)
 
 Example::
 
-  $ dirac-proxy-init -g dirac_user
+  $ dirac-proxy-init -g dirac_user --rfc
   Enter Certificate password:
-  $ 
-
+  $

--- a/docs/source/UserGuide/Tutorials/ManagingUserCredentials/index.rst
+++ b/docs/source/UserGuide/Tutorials/ManagingUserCredentials/index.rst
@@ -33,7 +33,7 @@ This section assumes that the DIRAC client is already installed and configured.
 
   Output of this command must look like::
 
-      $ dirac-cert-convert.sh usercert.p12 
+      $ dirac-cert-convert.sh usercert.p12
       Creating globus directory
       Converting p12 key to pem format
       Enter Import Password:
@@ -43,8 +43,8 @@ This section assumes that the DIRAC client is already installed and configured.
       Converting p12 certificate to pem format
       Enter Import Password:
       MAC verified OK
-      Information about your certificate: 
-      subject= /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Vanessa Hamar 
+      Information about your certificate:
+      subject= /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Vanessa Hamar
       issuer= /C=FR/O=CNRS/CN=GRID2-FR
       Done
 
@@ -52,7 +52,7 @@ This section assumes that the DIRAC client is already installed and configured.
   It will be requested twice. The PEM pass phrase is the password associated with the created private key. This
   password will be requested each time you will create a proxy. Do not forget it !
 
-- Check that your certificate was correctly converted and placed in the $HOME/.globus directory, in PEM format 
+- Check that your certificate was correctly converted and placed in the $HOME/.globus directory, in PEM format
   and with correct permissions::
 
       $ ls -la ~/.globus
@@ -66,8 +66,8 @@ This section assumes that the DIRAC client is already installed and configured.
 
 2.2 Managing Proxies
 --------------------
- 
-Before running any command in the grid, it is mandatory to have a valid certificate proxy. The commands to create a 
+
+Before running any command in the grid, it is mandatory to have a valid certificate proxy. The commands to create a
 valid proxy using DIRAC commands are shown below.
 
 
@@ -81,44 +81,44 @@ valid proxy using DIRAC commands are shown below.
 
 - After the environment is set up, you are able to create your proxy with the following command::
 
-        dirac-proxy-init --group dirac_user -U 
+        dirac-proxy-init --group dirac_user -U --rfc
 
 
   For example, with the additional debug option the output must be like the following::
 
         $ dirac-proxy-init --debug --group dirac_user -u
-        Generating proxy... 
+        Generating proxy...
         Enter Certificate password:
-        Contacting CS... 
-        Checking DN /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev 
-        Username is atsareg 
-        Creating proxy for atsareg@dirac_user (/O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev) 
-        Uploading proxy for dirac_user... 
-        Uploading dirac_user proxy to ProxyManager... 
-        Loading user proxy 
-        Uploading proxy on-the-fly 
-        Cert file /home/andrei/.globus/usercert.pem 
-        Key file  /home/andrei/.globus/userkey.pem 
-        Loading cert and key 
-        User credentials loaded 
-         Uploading... 
-        Proxy uploaded 
-        Proxy generated: 
+        Contacting CS...
+        Checking DN /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev
+        Username is atsareg
+        Creating proxy for atsareg@dirac_user (/O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev)
+        Uploading proxy for dirac_user...
+        Uploading dirac_user proxy to ProxyManager...
+        Loading user proxy
+        Uploading proxy on-the-fly
+        Cert file /home/andrei/.globus/usercert.pem
+        Key file  /home/andrei/.globus/userkey.pem
+        Loading cert and key
+        User credentials loaded
+         Uploading...
+        Proxy uploaded
+        Proxy generated:
         subject      : /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev/CN=proxy
         issuer       : /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev
         identity     : /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev
         timeleft     : 23:59:57
         DIRAC group  : dirac_user
         path         : /tmp/x509up_u501
-        username     : atsareg 
-        
-        Proxies uploaded: 
-         DN                                                      | Group      | Until (GMT) 
+        username     : atsareg
+
+        Proxies uploaded:
+         DN                                                      | Group      | Until (GMT)
          /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev | dirac_user | 2012/02/08 13:05
 
   As a result of this command, several operations are accomplished:
-  
-  - a long user proxy ( with the length of the validity of the certificate ) is uploaded to the 
+
+  - a long user proxy ( with the length of the validity of the certificate ) is uploaded to the
     DIRAC ProxyManager service, equivalent of the gLite MyProxy service
   - a short user proxy is created with the DIRAC extension carrying the DIRAC group name and with the
     VOMS extension corresponding to the DIRAC group if the gLite UI environment is available.

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -531,7 +531,7 @@ function diracCredentials(){
   echo '==> [diracCredentials]'
 
   sed -i 's/commitNewData = CSAdministrator/commitNewData = authenticated/g' $SERVERINSTALLDIR/etc/Configuration_Server.cfg
-  dirac-proxy-init -g dirac_admin -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG
+  dirac-proxy-init -g dirac_admin -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG --rfc
   sed -i 's/commitNewData = authenticated/commitNewData = CSAdministrator/g' $SERVERINSTALLDIR/etc/Configuration_Server.cfg
 
 }
@@ -573,9 +573,9 @@ function diracProxies(){
   echo '==> [diracProxies]'
 
   # User proxy, should be uploaded anyway
-  dirac-proxy-init -U -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG
+  dirac-proxy-init -U -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key --rfc $DEBUG
   # group proxy, will be uploaded explicitly
-  dirac-proxy-init -U -g prod -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG
+  dirac-proxy-init -U -g prod -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key --rfc $DEBUG
 
 }
 
@@ -627,7 +627,7 @@ diracServices(){
 
   # group proxy, will be uploaded explicitly
   #  echo '==> getting/uploading proxy for prod'
-  #  dirac-proxy-init -U -g prod -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG
+  #  dirac-proxy-init -U -g prod -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key --rfc $DEBUG
 
   for serv in $services
   do
@@ -654,7 +654,7 @@ diracUninstallServices(){
 
   # group proxy, will be uploaded explicitly
   #  echo '==> getting/uploading proxy for prod'
-  #  dirac-proxy-init -U -g prod -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG
+  #  dirac-proxy-init -U -g prod -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key --rfc $DEBUG
 
   for serv in $services
   do


### PR DESCRIPTION
This PR as of now contains almost nothing but documentation. I originally started it with the intention of modifying the following behavior:
- suppose that user X has an uploaded "dirac-user" proxy, non "rfc", and non expiring
- user X wants to now upload an "RFC" proxy, again for "dirac-user" group.
- the ProxyManager will not upload the new proxy and will reply "Upload request not necessary by X:dirac-user"

There's no obvious way to discriminate, at DB level, between RFC and non RFC proxies, unless inspecting the actual content of the proxy uploaded. Shall we go through this path?
The (brutal) alternative is removing these lines: https://github.com/DIRACGrid/DIRAC/blob/rel-v6r17/FrameworkSystem/Service/ProxyManagerHandler.py#L90