### PR TITLE
[v6r15] Ensure the newest sandbox is returned to the client

### DIFF
--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -254,7 +254,7 @@ class SandboxStoreClient( object ):
     if sbType not in sbDict:
       return S_ERROR( "No %s sandbox registered for job %s" % ( sbType, jobId ) )
 
-    # If inMemory, enausre we return the mewest sandbox only
+    # If inMemory, ensure we return the newest sandbox only
     if inMemory:
       sbLocation = sbDict[ sbType ][ -1 ]
       result = self.downloadSandbox( sbLocation, destinationPath, inMemory )

--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -253,11 +253,16 @@ class SandboxStoreClient( object ):
     sbDict = result[ 'Value' ]
     if sbType not in sbDict:
       return S_ERROR( "No %s sandbox registered for job %s" % ( sbType, jobId ) )
+
+    # If inMemory, enausre we return the mewest sandbox only
+    if inMemory:
+      sbLocation = sbDict[ sbType ][ -1 ]
+      result = self.downloadSandbox( sbLocation, destinationPath, inMemory )
+      return result
+
     for sbLocation in sbDict[ sbType ]:
       result = self.downloadSandbox( sbLocation, destinationPath, inMemory )
       if not result[ 'OK' ]:
-        return result
-      if inMemory:
         return result
     return S_OK()
 


### PR DESCRIPTION
Hi,

We found that the web/webapp interface would still return the original output sandbox after a job had been reset. This was being caused by the inMemory = True flag (which is only set by the web interface, all other clients seem to use inMemory = False) causing the loop in downloadSandboxForJob to return after one iteration. This patch moves the inMemory case, making it only return the newest sandbox, fixing the problem.

Regards,
Simon
