### PR TITLE
[v6r15] changed so it works on empty but existing options in config system

### DIFF
--- a/ConfigurationSystem/Client/CSAPI.py
+++ b/ConfigurationSystem/Client/CSAPI.py
@@ -640,7 +640,7 @@ class CSAPI( object ):
     if not self.__initialized[ 'OK' ]:
       return self.__initialized
     prevVal = self.__csMod.getValue( optionPath )
-    if not prevVal:
+    if prevVal is None:
       return S_ERROR( 'Trying to set %s to %s but option does not exist' % ( optionPath, newValue ) )
     gLogger.verbose( "Changing %s from \n%s \nto \n%s" % ( optionPath, prevVal, newValue ) )
     self.__csMod.setOptionValue( optionPath, newValue )


### PR DESCRIPTION
We noticed that we couldn't modify a value that exists in the CS but was empty. This patch fixes this (and shouldn't break anything else).