### PR TITLE
[v6r17] Do not evaluate GUID in LcgFileCatalogClient if it is not a string

### DIFF
--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -303,7 +303,7 @@ class LcgFileCatalogClient( FileCatalogClientBase ):
         failed[lfn] = res['Message']
       elif res['Value']:
         successful[lfn] = lfn
-      elif not isinstance( guid, str ):
+      elif not isinstance( guid, basestring ):
         successful[lfn] = False
       else:
         res = existsGuid( guid )

--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -303,7 +303,7 @@ class LcgFileCatalogClient( FileCatalogClientBase ):
         failed[lfn] = res['Message']
       elif res['Value']:
         successful[lfn] = lfn
-      elif not guid:
+      elif not isinstance( guid, str ):
         successful[lfn] = False
       else:
         res = existsGuid( guid )


### PR DESCRIPTION
Prior to v6r15, LcgFileCatalogClient.exists() worked with [{lfn: False}] given by checkArgumentFormat.
Because checkCatalogArguments, which has been introduced since v6r15, gives [{lfn: True}], exists() attempts to evaluate the boolean as GUID and results in crash.
We should avoid the evaluation if GUID is given by non-string. 