### PR TITLE
[v6r17] Fixes in Stager and DataManager

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1499,11 +1499,11 @@ class DataManager( object ):
   # File catalog methods
   #
 
-  def getActiveReplicas( self, lfns, getUrl = True, diskOnly = False, preferDisk = False, forJobs = False ):
+  def getActiveReplicas( self, lfns, getUrl = True, diskOnly = False, preferDisk = False ):
     """ Get all the replicas for the SEs which are in Active status for reading.
     """
     return self.getReplicas( lfns, allStatus = False, getUrl = getUrl, diskOnly = diskOnly,
-                             preferDisk = preferDisk, forJobs = forJobs, active = True )
+                             preferDisk = preferDisk, active = True )
 
   def __filterTapeReplicas( self, replicaDict, diskOnly = False ):
     """

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1603,7 +1603,7 @@ class DataManager( object ):
     """ returns the value of a certain SE status flag (access or other) """
     return StorageElement( se, vo = self.vo ).getStatus().get( 'Value', {} ).get( status, False )
 
-  def getReplicas( self, lfns, allStatus = True, getUrl = True, diskOnly = False, preferDisk = False, active = False, forJobs = False ):
+  def getReplicas( self, lfns, allStatus = True, getUrl = True, diskOnly = False, preferDisk = False, active = False ):
     """ get replicas from catalogue and filter if requested
     Warning: all filters are independent, hence active and preferDisk should be set if using forJobs
     """
@@ -1640,13 +1640,12 @@ class DataManager( object ):
       self.__filterActiveReplicas( result )
     if diskOnly or preferDisk:
       self.__filterTapeReplicas( result, diskOnly = diskOnly )
-    if forJobs:
-      self.__filterReplicasForJobs( result )
     return S_OK( result )
 
-  def getReplicasForJobs( self, lfns, allStatus = False, getUrl = True ):
+  def getReplicasForJobs( self, lfns, allStatus = False, getUrl = True, diskOnly = False ):
     """ get replicas useful for jobs
     """
+    # Call getReplicas with no filter and enforce filters in this method
     result = self.getReplicas( lfns, allStatus = allStatus, getUrl = getUrl )
     if not result['OK']:
       return result
@@ -1654,7 +1653,7 @@ class DataManager( object ):
     # For jobs replicas must be active
     self.__filterActiveReplicas( replicaDict )
     # For jobs, give preference to disk replicas but not only
-    self.__filterTapeReplicas( replicaDict, diskOnly = False )
+    self.__filterTapeReplicas( replicaDict, diskOnly = diskOnly )
     # don't use SEs excluded for jobs (e.g. Failover)
     self.__filterReplicasForJobs( replicaDict )
     return S_OK( replicaDict )

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1603,7 +1603,7 @@ class DataManager( object ):
     """ returns the value of a certain SE status flag (access or other) """
     return StorageElement( se, vo = self.vo ).getStatus().get( 'Value', {} ).get( status, False )
 
-  def getReplicas( self, lfns, allStatus = True, getUrl = True, diskOnly = False, preferDisk = False, forJobs = False, active = False ):
+  def getReplicas( self, lfns, allStatus = True, getUrl = True, diskOnly = False, preferDisk = False, active = False, forJobs = False ):
     """ get replicas from catalogue and filter if requested
     Warning: all filters are independent, hence active and preferDisk should be set if using forJobs
     """

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1022,7 +1022,7 @@ class Dirac( API ):
   #       print self.pPrint.pformat( metaDict )
 
   #############################################################################
-  def getReplicas( self, lfns, active = True, preferDisk = False, diskOnly = False, forJobs = False, printOutput = False ):
+  def getReplicas( self, lfns, active = True, preferDisk = False, diskOnly = False, printOutput = False, forJobs = False ):
     """Obtain replica information from file catalogue client. Input LFN(s) can be string or list.
 
        Example usage:

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -666,7 +666,7 @@ class Dirac( API ):
 
     self.log.info( 'Attempting to resolve data for %s' % siteName )
     self.log.verbose( '%s' % ( '\n'.join( lfns ) ) )
-    replicaDict = self.getReplicas( lfns )
+    replicaDict = self.getReplicas( lfns, forJobs = True, active = True, preferDisk = True )
     if not replicaDict['OK']:
       return replicaDict
     catalogFailed = replicaDict['Value'].get( 'Failed', {} )
@@ -735,7 +735,7 @@ class Dirac( API ):
 
     self.log.info( 'Job has input data requirement, will attempt to resolve data for %s' % DIRAC.siteName() )
     self.log.verbose( '\n'.join( inputData ) )
-    replicaDict = self.getReplicas( inputData )
+    replicaDict = self.getReplicas( inputData, active = True, forJobs = True, preferDisk = True )
     if not replicaDict['OK']:
       return replicaDict
     catalogFailed = replicaDict['Value'].get( 'Failed', {} )
@@ -823,7 +823,7 @@ class Dirac( API ):
 
       self.log.info( 'Job has input data requirement, will attempt to resolve data for %s' % DIRAC.siteName() )
       self.log.verbose( '\n'.join( inputData ) )
-      replicaDict = self.getReplicas( inputData )
+      replicaDict = self.getReplicas( inputData, active = True, forJobs = True, preferDisk = True )
       if not replicaDict['OK']:
         return replicaDict
       guidDict = self.getMetadata( inputData )
@@ -1022,7 +1022,7 @@ class Dirac( API ):
   #       print self.pPrint.pformat( metaDict )
 
   #############################################################################
-  def getReplicas( self, lfns, active = True, preferDisk = False, diskOnly = False, printOutput = False ):
+  def getReplicas( self, lfns, active = True, preferDisk = False, diskOnly = False, forJobs = False, printOutput = False ):
     """Obtain replica information from file catalogue client. Input LFN(s) can be string or list.
 
        Example usage:
@@ -1046,10 +1046,7 @@ class Dirac( API ):
 
     start = time.time()
     dm = DataManager()
-    if active:
-      repsResult = dm.getActiveReplicas( lfns, diskOnly = diskOnly, preferDisk = preferDisk )
-    else:
-      repsResult = dm.getReplicas( lfns )
+    repsResult = dm.getReplicas( lfns, active = active, preferDisk = preferDisk, diskOnly = diskOnly, forJobs = forJobs )
     timing = time.time() - start
     self.log.info( 'Replica Lookup Time: %.2f seconds ' % ( timing ) )
     self.log.debug( repsResult )
@@ -1161,7 +1158,7 @@ class Dirac( API ):
       except Exception as x:
         return self._errorReport( str( x ), 'Expected integer for maxFilesPerJob' )
 
-    replicaDict = self.getReplicas( lfns, active = True, preferDisk = True )
+    replicaDict = self.getReplicas( lfns, active = True, preferDisk = True, forJobs = True )
     if not replicaDict['OK']:
       return replicaDict
     if len( replicaDict['Value']['Successful'] ) == 0:

--- a/StorageManagementSystem/Agent/StageMonitorAgent.py
+++ b/StorageManagementSystem/Agent/StageMonitorAgent.py
@@ -31,9 +31,7 @@ class StageMonitorAgent( AgentModule ):
       return res
     self.proxyInfoDict = res['Value']
 
-    res = self.monitorStageRequests()
-
-    return res
+    return self.monitorStageRequests()
 
   def monitorStageRequests( self ):
     """ This is the third logical task manages the StageSubmitted->Staged transition of the Replicas
@@ -48,7 +46,7 @@ class StageMonitorAgent( AgentModule ):
     seReplicas = res['Value']['SEReplicas']
     replicaIDs = res['Value']['ReplicaIDs']
     gLogger.info( "StageMonitor.monitorStageRequests: Obtained %s StageSubmitted replicas for monitoring." % len( replicaIDs ) )
-    for storageElement, seReplicaIDs in seReplicas.items():
+    for storageElement, seReplicaIDs in seReplicas.iteritems():
       self.__monitorStorageElementStageRequests( storageElement, seReplicaIDs, replicaIDs )
 
     gDataStoreClient.commit()
@@ -62,20 +60,20 @@ class StageMonitorAgent( AgentModule ):
 
     # Since we are in a given SE, the LFN is a unique key
     lfnRepIDs = {}
-    lfnReqIDs = {}
     for replicaID in seReplicaIDs:
       lfn = replicaIDs[replicaID]['LFN']
       lfnRepIDs[lfn] = replicaID
-      requestID = replicaIDs[replicaID].get( 'RequestID', None )
-      if requestID:
-        lfnReqIDs[lfn] = replicaIDs[replicaID]['RequestID']
 
-    gLogger.info( "StageMonitor.__monitorStorageElementStageRequests: Monitoring %s stage requests for %s." % ( len( lfnRepIDs ),
-                                                                                                                storageElement ) )
+    if lfnRepIDs:
+      gLogger.info( "StageMonitor.__monitorStorageElementStageRequests: Monitoring %s stage requests for %s." % ( len( lfnRepIDs ),
+                                                                                                                  storageElement ) )
+    else:
+      gLogger.warn( "StageMonitor.__monitorStorageElementStageRequests: No requests to monitor for %s." % storageElement )
+      return
     oAccounting = DataOperation()
     oAccounting.setStartTime()
 
-    res = StorageElement( storageElement ).getFileMetadata( lfnReqIDs )
+    res = StorageElement( storageElement ).getFileMetadata( lfnRepIDs )
     if not res['OK']:
       gLogger.error( "StageMonitor.__monitorStorageElementStageRequests: Completely failed to monitor stage requests for replicas.", res['Message'] )
       return
@@ -83,19 +81,22 @@ class StageMonitorAgent( AgentModule ):
 
     accountingDict = self.__newAccountingDict( storageElement )
 
-    for lfn, reason in prestageStatus['Failed'].items():
+    for lfn, reason in prestageStatus['Failed'].iteritems():
       accountingDict['TransferTotal'] += 1
       if re.search( 'File does not exist', reason ):
         gLogger.error( "StageMonitor.__monitorStorageElementStageRequests: LFN did not exist in the StorageElement", lfn )
         terminalReplicaIDs[lfnRepIDs[lfn]] = 'LFN did not exist in the StorageElement'
-    for lfn, staged in prestageStatus['Successful'].items():
-      if staged and 'Cached' in staged and staged['Cached']:
+    for lfn, metadata in prestageStatus['Successful'].iteritems():
+      if not metadata:
+        continue
+      staged = metadata.get( 'Cached' )
+      if staged:
         accountingDict['TransferTotal'] += 1
         accountingDict['TransferOK'] += 1
-        accountingDict['TransferSize'] += staged['Size']
+        accountingDict['TransferSize'] += metadata['Size']
         stagedReplicas.append( lfnRepIDs[lfn] )
-      if staged and 'Cached' in staged and not staged['Cached']:
-        oldRequests.append( lfnRepIDs[lfn] );  # only ReplicaIDs
+      elif staged is not None:
+        oldRequests.append( lfnRepIDs[lfn] )  # only ReplicaIDs
 
     oAccounting.setValuesFromDict( accountingDict )
     oAccounting.setEndTime()
@@ -157,11 +158,9 @@ class StageMonitorAgent( AgentModule ):
 
     seReplicas = {}
     replicaIDs = res['Value']
-    for replicaID, info in replicaIDs.items():
+    for replicaID, info in replicaIDs.iteritems():
       storageElement = info['SE']
-      if not seReplicas.has_key( storageElement ):
-        seReplicas[storageElement] = []
-      seReplicas[storageElement].append( replicaID )
+      seReplicas.setdefault( storageElement, [] ).append( replicaID )
 
     # RequestID was missing from replicaIDs dictionary BUGGY?
     res = self.stagerClient.getStageRequests( {'ReplicaID':replicaIDs.keys()} )
@@ -170,9 +169,8 @@ class StageMonitorAgent( AgentModule ):
     if not res['Value']:
       return S_ERROR( 'Could not obtain request IDs for replicas %s from StageRequests table' % ( replicaIDs.keys() ) )
 
-    for replicaID, info in res['Value'].items():
-      reqID = info['RequestID']
-      replicaIDs[replicaID]['RequestID'] = reqID
+    for replicaID, info in res['Value'].iteritems():
+      replicaIDs[replicaID]['RequestID'] = info['RequestID']
 
     return S_OK( {'SEReplicas':seReplicas, 'ReplicaIDs':replicaIDs} )
 

--- a/StorageManagementSystem/Agent/StageRequestAgent.py
+++ b/StorageManagementSystem/Agent/StageRequestAgent.py
@@ -15,7 +15,7 @@ class StageRequestAgent( AgentModule ):
 
   def initialize( self ):
     self.stagerClient = StorageManagerClient()
-    #self.storageDB = StorageManagementDB()
+    # self.storageDB = StorageManagementDB()
     # pin lifetime = 1 day
     self.pinLifetime = self.am_getOption( 'PinLifetime', THROTTLING_TIME )
 
@@ -65,7 +65,7 @@ class StageRequestAgent( AgentModule ):
         * Waiting -> StageSubmitted (if the file is found Cached)
         * Offline -> StageSubmitted (if there are not more Waiting replicas)
     """
-    # Retry Replicas that have not been Staged in a previous attempt 
+    # Retry Replicas that have not been Staged in a previous attempt
     res = self._getMissingReplicas()
     if not res['OK']:
       gLogger.fatal( "StageRequest.submitStageRequests: Failed to get replicas from StorageManagementDB.", res['Message'] )
@@ -75,7 +75,7 @@ class StageRequestAgent( AgentModule ):
 
     if seReplicas:
       gLogger.info( "StageRequest.submitStageRequests: Completing partially Staged Tasks" )
-    for storageElement, seReplicaIDs in seReplicas.items():
+    for storageElement, seReplicaIDs in seReplicas.iteritems():
       gLogger.debug( 'Staging at %s:' % storageElement, seReplicaIDs )
       self._issuePrestageRequests( storageElement, seReplicaIDs, allReplicaInfo )
 
@@ -95,19 +95,14 @@ class StageRequestAgent( AgentModule ):
       return res
 
     # Merge info from both results
-    for storageElement, seReplicaIDs in res['Value']['SEReplicas'].items():
-      if storageElement not in seReplicas:
-        seReplicas[storageElement] = seReplicaIDs
-      else:
-        for replicaID in seReplicaIDs:
-          if replicaID not in seReplicas[storageElement]:
-            seReplicas[storageElement].append( replicaID )
+    for storageElement, seReplicaIDs in res['Value']['SEReplicas'].iteritems():
+      seReplicas.setdefault( storageElement, set() ).update( seReplicaIDs )
     allReplicaInfo.update( res['Value']['AllReplicaInfo'] )
 
     gLogger.info( "StageRequest.submitStageRequests: Obtained %s replicas for staging." % len( allReplicaInfo ) )
-    for storageElement, seReplicaIDs in seReplicas.items():
+    for storageElement, seReplicaIDs in seReplicas.iteritems():
       gLogger.debug( 'Staging at %s:' % storageElement, seReplicaIDs )
-      self._issuePrestageRequests( storageElement, seReplicaIDs, allReplicaInfo )
+      self._issuePrestageRequests( storageElement, list( seReplicaIDs ), allReplicaInfo )
     return S_OK()
 
   def _getMissingReplicas( self ):
@@ -115,7 +110,7 @@ class StageRequestAgent( AgentModule ):
         while other Replicas of the same task are already Staged. If left behind they can produce a deadlock.
         All SEs are considered, even if their Cache is full
     """
-    # Get Replicas that are in Staged/StageSubmitted 
+    # Get Replicas that are in Staged/StageSubmitted
     gLogger.info( 'StageRequest._getMissingReplicas: Checking Staged Replicas' )
 
     res = self.__getStagedReplicas()
@@ -126,9 +121,9 @@ class StageRequestAgent( AgentModule ):
 
     allReplicaInfo = res['Value']['AllReplicaInfo']
     replicasToStage = []
-    for _storageElement, seReplicaIDs in res['Value']['SEReplicas'].items():
+    for seReplicaIDs in res['Value']['SEReplicas'].itervalues():
       # Consider all SEs
-      replicasToStage.extend( seReplicaIDs )
+      replicasToStage += seReplicaIDs
 
     # Get Replicas from the same Tasks as those selected
     res = self.__addAssociatedReplicas( replicasToStage, seReplicas, allReplicaInfo )
@@ -157,7 +152,7 @@ class StageRequestAgent( AgentModule ):
       return res
     gLogger.info( "StageRequest._getOnlineReplicas: Obtained %s replicas Waiting for staging." % len( allReplicaInfo ) )
     replicasToStage = []
-    for storageElement, seReplicaIDs in res['Value']['SEReplicas'].items():
+    for storageElement, seReplicaIDs in res['Value']['SEReplicas'].iteritems():
       if not self.__usage( storageElement ) < self.__cache( storageElement ):
         gLogger.info( 'StageRequest._getOnlineReplicas: Skipping %s, current usage above limit ( %s GB )' % ( storageElement, self.__cache( storageElement ) ) )
         # Do not consider those SE that have the Cache full
@@ -169,7 +164,7 @@ class StageRequestAgent( AgentModule ):
       else:
         # keep only Online Replicas
         seReplicas[storageElement] = res['Value']['Online']
-        replicasToStage.extend( res['Value']['Online'] )
+        replicasToStage += res['Value']['Online']
 
     # Get Replicas from the same Tasks as those selected
     res = self.__addAssociatedReplicas( replicasToStage, seReplicas, allReplicaInfo )
@@ -197,8 +192,7 @@ class StageRequestAgent( AgentModule ):
       return res
     gLogger.info( "StageRequest._getOfflineReplicas: Obtained %s replicas Offline for staging." % len( allReplicaInfo ) )
     replicasToStage = []
-
-    for storageElement, seReplicaIDs in res['Value']['SEReplicas'].items():
+    for storageElement, seReplicaIDs in res['Value']['SEReplicas'].iteritems():
       if not self.__usage( storageElement ) < self.__cache( storageElement ):
         gLogger.info( 'StageRequest._getOfflineReplicas: Skipping %s, current usage above limit ( %s GB )' % ( storageElement, self.__cache( storageElement ) ) )
         # Do not consider those SE that have the Cache full
@@ -222,23 +216,23 @@ class StageRequestAgent( AgentModule ):
   def __usage( self, storageElement ):
     """ Retrieve current usage of SE
     """
-    if not storageElement in self.storageElementUsage:
-      self.storageElementUsage[storageElement] = {'TotalSize': 0.}
+    # Set it if not yet done
+    self.storageElementUsage.setdefault( storageElement, {'TotalSize': 0.} )
     return self.storageElementUsage[storageElement]['TotalSize']
 
   def __cache( self, storageElement ):
     """ Retrieve cache size for SE
     """
-    if not storageElement in self.storageElementCache:
-      self.storageElementCache[storageElement] = gConfig.getValue( "/Resources/StorageElements/%s/DiskCacheTB" % storageElement, 1. ) * 1000. / THROTTLING_STEPS
+    self.storageElementCache.setdefault( storageElement,
+                                        gConfig.getValue( "/Resources/StorageElements/%s/DiskCacheTB" % storageElement,
+                                                           1. ) * 1000. / THROTTLING_STEPS )
     return self.storageElementCache[storageElement]
 
   def __add( self, storageElement, size ):
     """ Add size (in bytes) to current usage of storageElement (in GB)
     """
-    if not storageElement in self.storageElementUsage:
-      self.storageElementUsage[storageElement] = {'TotalSize': 0.}
-    size = size / ( 1000 * 1000 * 1000.0 )
+    self.storageElementUsage.setdefault( storageElement, {'TotalSize': 0.} )
+    size /= 1000. * 1000. * 1000.
     self.storageElementUsage[storageElement]['TotalSize'] += size
     return size
 
@@ -258,17 +252,15 @@ class StageRequestAgent( AgentModule ):
       gLogger.info( "StageRequest._issuePrestageRequests: Submitting %s stage requests for %s." % ( len( lfnRepIDs ), storageElement ) )
       res = StorageElement( storageElement ).prestageFile( lfnRepIDs, lifetime = self.pinLifetime )
       gLogger.debug( "StageRequest._issuePrestageRequests: StorageElement.prestageStorageFile: res=", res )
-      #Daniela: fishy result from ReplicaManager!!! Should NOT return OK
-      #res= {'OK': True, 'Value': {'Successful': {}, 'Failed': {'srm://srm-lhcb.cern.ch/castor/cern.ch/grid/lhcb/data/2010/RAW/EXPRESS/LHCb/COLLISION10/71476/071476_0000000241.raw': ' SRM2Storage.__gfal_exec: Failed to perform gfal_prestage.[SE][BringOnline][SRM_INVALID_REQUEST] httpg://srm-lhcb.cern.ch:8443/srm/managerv2: User not able to access specified space token\n'}}}
-      #res= {'OK': True, 'Value': {'Successful': {'srm://gridka-dCache.fzk.de/pnfs/gridka.de/lhcb/data/2009/RAW/FULL/LHCb/COLLISION09/63495/063495_0000000001.raw': '-2083846379'}, 'Failed': {}}}
+      # Daniela: fishy result from ReplicaManager!!! Should NOT return OK
+      # res= {'OK': True, 'Value': {'Successful': {}, 'Failed': {'srm://srm-lhcb.cern.ch/castor/cern.ch/grid/lhcb/data/2010/RAW/EXPRESS/LHCb/COLLISION10/71476/071476_0000000241.raw': ' SRM2Storage.__gfal_exec: Failed to perform gfal_prestage.[SE][BringOnline][SRM_INVALID_REQUEST] httpg://srm-lhcb.cern.ch:8443/srm/managerv2: User not able to access specified space token\n'}}}
+      # res= {'OK': True, 'Value': {'Successful': {'srm://gridka-dCache.fzk.de/pnfs/gridka.de/lhcb/data/2009/RAW/FULL/LHCb/COLLISION09/63495/063495_0000000001.raw': '-2083846379'}, 'Failed': {}}}
 
       if not res['OK']:
         gLogger.error( "StageRequest._issuePrestageRequests: Completely failed to submit stage requests for replicas.", res['Message'] )
       else:
-        for lfn, requestID in res['Value']['Successful'].items():
-          if not stageRequestMetadata.has_key( requestID ):
-            stageRequestMetadata[requestID] = []
-          stageRequestMetadata[requestID].append( lfnRepIDs[lfn] )
+        for lfn, requestID in res['Value']['Successful'].iteritems():
+          stageRequestMetadata.setdefault( requestID, [] ).append( lfnRepIDs[lfn] )
           updatedLfnIDs.append( lfnRepIDs[lfn] )
     if stageRequestMetadata:
       gLogger.info( "StageRequest._issuePrestageRequests: %s stage request metadata to be updated." % len( stageRequestMetadata ) )
@@ -285,15 +277,13 @@ class StageRequestAgent( AgentModule ):
 
     seReplicas = {}
     replicaIDs = {}
-    for replicaID, info in replicaDict.items():
+    for replicaID, info in replicaDict.iteritems():
       lfn = info['LFN']
       storageElement = info['SE']
       size = info['Size']
       pfn = info['PFN']
       replicaIDs[replicaID] = {'LFN':lfn, 'PFN':pfn, 'Size':size, 'StorageElement':storageElement}
-      if not seReplicas.has_key( storageElement ):
-        seReplicas[storageElement] = []
-      seReplicas[storageElement].append( replicaID )
+      seReplicas.setdefault( storageElement, [] ).append( replicaID )
     return S_OK( {'SEReplicas':seReplicas, 'AllReplicaInfo':replicaIDs} )
 
   def __getStagedReplicas( self ):
@@ -347,18 +337,15 @@ class StageRequestAgent( AgentModule ):
       return res
     addReplicas = {'Offline': {}, 'Waiting': {}}
     replicaIDs = {}
-    for replicaID, info in res['Value'].items():
+    for replicaID, info in res['Value'].iteritems():
       lfn = info['LFN']
       storageElement = info['SE']
       size = info['Size']
       pfn = info['PFN']
       status = info['Status']
-      if status not in ['Waiting', 'Offline']:
-        continue
-      if not addReplicas[status].has_key( storageElement ):
-        addReplicas[status][storageElement] = []
-      replicaIDs[replicaID] = {'LFN':lfn, 'PFN':pfn, 'Size':size, 'StorageElement':storageElement }
-      addReplicas[status][storageElement].append( replicaID )
+      if status in ['Waiting', 'Offline']:
+        replicaIDs[replicaID] = {'LFN':lfn, 'PFN':pfn, 'Size':size, 'StorageElement':storageElement }
+        addReplicas[status].setdefault( storageElement, [] ).append( replicaID )
 
     waitingReplicas = addReplicas['Waiting']
     offlineReplicas = addReplicas['Offline']
@@ -366,7 +353,7 @@ class StageRequestAgent( AgentModule ):
     allReplicaInfo.update( newReplicaInfo )
 
     # First handle Waiting Replicas for which metadata is to be checked
-    for storageElement, seReplicaIDs in waitingReplicas.items():
+    for storageElement, seReplicaIDs in waitingReplicas.iteritems():
       for replicaID in list( seReplicaIDs ):
         if replicaID in replicasToStage:
           seReplicaIDs.remove( replicaID )
@@ -375,21 +362,17 @@ class StageRequestAgent( AgentModule ):
         gLogger.error( 'StageRequest.__addAssociatedReplicas: Failed to check Replica Metadata', '(%s): %s' % ( storageElement, res['Message'] ) )
       else:
         # keep all Replicas (Online and Offline)
-        if not storageElement in seReplicas:
-          seReplicas[storageElement] = []
-        seReplicas[storageElement].extend( res['Value']['Online'] )
+        seReplicas.setdefault( storageElement, [] ).extend( res['Value']['Online'] )
         replicasToStage.extend( res['Value']['Online'] )
         seReplicas[storageElement].extend( res['Value']['Offline'] )
         replicasToStage.extend( res['Value']['Offline'] )
 
     # Then handle Offline Replicas for which metadata is already checked
-    for storageElement, seReplicaIDs in offlineReplicas.items():
-      if not storageElement in seReplicas:
-        seReplicas[storageElement] = []
+    for storageElement, seReplicaIDs in offlineReplicas.iteritems():
       for replicaID in sorted( seReplicaIDs ):
         if replicaID in replicasToStage:
           seReplicaIDs.remove( replicaID )
-      seReplicas[storageElement].extend( seReplicaIDs )
+      seReplicas.setdefault( storageElement, [] ).extend( seReplicaIDs )
       replicasToStage.extend( seReplicaIDs )
 
     for replicaID in allReplicaInfo.keys():
@@ -433,7 +416,7 @@ class StageRequestAgent( AgentModule ):
     terminalReplicaIDs = {}
     onlineReplicaIDs = []
     offlineReplicaIDs = []
-    for lfn, metadata in res['Value']['Successful'].items():
+    for lfn, metadata in res['Value']['Successful'].iteritems():
 
       if metadata['Size'] != allReplicaInfo[lfnRepIDs[lfn]]['Size']:
         gLogger.error( "StageRequest.__checkIntegrity: LFN StorageElement size does not match FileCatalog", lfn )
@@ -454,7 +437,7 @@ class StageRequestAgent( AgentModule ):
         else:
           offlineReplicaIDs.append( lfnRepIDs[lfn] )
 
-    for lfn, reason in res['Value']['Failed'].items():
+    for lfn, reason in res['Value']['Failed'].iteritems():
       if re.search( 'File does not exist', reason ):
         gLogger.error( "StageRequest.__checkIntegrity: LFN does not exist in the StorageElement", lfn )
         terminalReplicaIDs[lfnRepIDs[lfn]] = 'LFN does not exist in the StorageElement'

--- a/StorageManagementSystem/Agent/StageRequestAgent.py
+++ b/StorageManagementSystem/Agent/StageRequestAgent.py
@@ -223,9 +223,9 @@ class StageRequestAgent( AgentModule ):
   def __cache( self, storageElement ):
     """ Retrieve cache size for SE
     """
-    self.storageElementCache.setdefault( storageElement,
-                                        gConfig.getValue( "/Resources/StorageElements/%s/DiskCacheTB" % storageElement,
-                                                           1. ) * 1000. / THROTTLING_STEPS )
+    if storageElement not in self.storageElementCache:
+      self.storageElementCache[storageElement] = gConfig.getValue( "/Resources/StorageElements/%s/DiskCacheTB" % storageElement,
+                                                                   1. ) * 1000. / THROTTLING_STEPS
     return self.storageElementCache[storageElement]
 
   def __add( self, storageElement, size ):

--- a/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/StorageManagementSystem/DB/StorageManagementDB.py
@@ -13,7 +13,6 @@
 __RCSID__ = "$Id$"
 
 import inspect
-import types
 import threading
 
 from DIRAC                                        import gLogger, S_OK, S_ERROR
@@ -80,7 +79,7 @@ class StorageManagementDB( DB ):
     reqSelect = "SELECT TaskID FROM Tasks WHERE TaskID IN (%s) AND Status != '%s';" % ( intListToString( toUpdate ), newTaskStatus )
     resSelect = self._query( reqSelect, connection )
     if not resSelect['OK']:
-      gLogger.error( "%s.%s_DB: problem retrieving record:" % ( self._caller(), '__updateTaskStatus' ), 
+      gLogger.error( "%s.%s_DB: problem retrieving record:" % ( self._caller(), '__updateTaskStatus' ),
                      "%s. %s" % ( reqSelect, resSelect['Message'] ) )
 
     req = "UPDATE Tasks SET Status='%s',LastUpdate=UTC_TIMESTAMP() WHERE TaskID IN (%s) AND Status != '%s';" % ( newTaskStatus, intListToString( toUpdate ), newTaskStatus )
@@ -151,7 +150,7 @@ class StorageManagementDB( DB ):
     reqSelect = "SELECT ReplicaID FROM CacheReplicas WHERE ReplicaID IN (%s) AND Status != '%s';" % ( intListToString( toUpdate ), newReplicaStatus )
     resSelect = self._query( reqSelect, connection )
     if not resSelect['OK']:
-      gLogger.error( "%s.%s_DB: problem retrieving record:" % ( self._caller(), 'updateReplicaStatus' ), 
+      gLogger.error( "%s.%s_DB: problem retrieving record:" % ( self._caller(), 'updateReplicaStatus' ),
                      "%s. %s" % ( reqSelect, resSelect['Message'] ) )
 
     req = "UPDATE CacheReplicas SET Status='%s',LastUpdate=UTC_TIMESTAMP() WHERE ReplicaID IN (%s) AND Status != '%s';" % ( newReplicaStatus, intListToString( toUpdate ), newReplicaStatus )
@@ -212,7 +211,7 @@ class StorageManagementDB( DB ):
             tasksInStatus[state].append( taskId )
           break
 
-    for newStatus in tasksInStatus.keys():
+    for newStatus in tasksInStatus:
       if tasksInStatus[newStatus]:
         res = self.__updateTaskStatus( tasksInStatus[newStatus], newStatus, True, connection = connection )
         if not res['OK']:
@@ -371,7 +370,7 @@ class StorageManagementDB( DB ):
     req = "SELECT TaskID from Tasks WHERE SourceTaskID=%s;" % int( jobID )
     res = self._query( req )
     if not res['OK']:
-      gLogger.error( "%s.%s_DB: problem retrieving record:" % ( self._caller(), '_getTaskIDForJob' ), 
+      gLogger.error( "%s.%s_DB: problem retrieving record:" % ( self._caller(), '_getTaskIDForJob' ),
                      "%s. %s" % ( req, res['Message'] ) )
       return S_ERROR( 'The supplied JobID does not exist!' )
     taskID = [ row[0] for row in res['Value'] ]
@@ -409,9 +408,9 @@ class StorageManagementDB( DB ):
     connection = self.__getConnection( connection )
     req = "SELECT %s FROM Tasks" % ( intListToString( self.TASKPARAMS ) )
     if condDict or older or newer:
-      if condDict.has_key( 'ReplicaID' ):
+      if 'ReplicaID' in condDict:
         replicaIDs = condDict.pop( 'ReplicaID' )
-        if type( replicaIDs ) not in ( types.ListType, types.TupleType ):
+        if not isinstance( replicaIDs, ( list, tuple ) ):
           replicaIDs = [replicaIDs]
         res = self._getReplicaIDTasks( replicaIDs, connection = connection )
         if not res['OK']:
@@ -435,9 +434,9 @@ class StorageManagementDB( DB ):
     connection = self.__getConnection( connection )
     req = "SELECT %s FROM CacheReplicas" % ( intListToString( self.REPLICAPARAMS ) )
     if condDict or older or newer:
-      if condDict.has_key( 'TaskID' ):
+      if 'TaskID' in condDict:
         taskIDs = condDict.pop( 'TaskID' )
-        if type( taskIDs ) not in ( types.ListType, types.TupleType ):
+        if not isinstance( taskIDs, ( list, tuple ) ):
           taskIDs = [taskIDs]
         res = self._getTaskReplicaIDs( taskIDs, connection = connection )
         if not res['OK']:
@@ -465,9 +464,9 @@ class StorageManagementDB( DB ):
     connection = self.__getConnection( connection )
     req = "SELECT %s FROM StageRequests" % ( intListToString( self.STAGEPARAMS ) )
     if condDict or older or newer:
-      if condDict.has_key( 'TaskID' ):
+      if 'TaskID' in condDict:
         taskIDs = condDict.pop( 'TaskID' )
-        if type( taskIDs ) not in ( types.ListType, types.TupleType ):
+        if not isinstance( taskIDs, ( list, tuple ) ):
           taskIDs = [taskIDs]
         res = self._getTaskReplicaIDs( taskIDs, connection = connection )
         if not res['OK']:
@@ -533,8 +532,8 @@ class StorageManagementDB( DB ):
     # Get the Replicas which already exist in the CacheReplicas table
     allReplicaIDs = []
     taskStates = []
-    for se, lfns in lfnDict.items():
-      if type( lfns ) in types.StringTypes:
+    for se, lfns in lfnDict.iteritems():
+      if isinstance( lfns, basestring ):
         lfns = [lfns]
       res = self._getExistingReplicas( se, lfns, connection = connection )
       if not res['OK']:
@@ -542,7 +541,7 @@ class StorageManagementDB( DB ):
       existingReplicas = res['Value']
       # Insert the CacheReplicas that do not already exist
       for lfn in lfns:
-        if lfn in existingReplicas.keys():
+        if lfn in existingReplicas:
           gLogger.verbose( 'StorageManagementDB.setRequest: Replica already exists in CacheReplicas table %s @ %s' % ( lfn, se ) )
           existingFileState = existingReplicas[lfn][1]
           taskState = self.__getTaskStateFromReplicaState( existingFileState )
@@ -818,7 +817,7 @@ class StorageManagementDB( DB ):
 
   def insertStageRequest( self, requestDict, pinLifeTime ):
     req = "INSERT INTO StageRequests (ReplicaID,RequestID,StageRequestSubmitTime,PinLength) VALUES "
-    for requestID, replicaIDs in requestDict.items():
+    for requestID, replicaIDs in requestDict.iteritems():
       for replicaID in replicaIDs:
         replicaString = "(%s,'%s',UTC_TIMESTAMP(),%d)," % ( replicaID, requestID, pinLifeTime )
         req = "%s %s" % ( req, replicaString )
@@ -828,7 +827,7 @@ class StorageManagementDB( DB ):
       gLogger.error( 'StorageManagementDB.insertStageRequest: Failed to insert to StageRequests table.', res['Message'] )
       return res
 
-    for requestID, replicaIDs in requestDict.items():
+    for requestID, replicaIDs in requestDict.iteritems():
       for replicaID in replicaIDs:
         # fix, no individual queries
         reqSelect = "SELECT * FROM StageRequests WHERE ReplicaID = %s AND RequestID = '%s';" % ( replicaID, requestID )

--- a/StorageManagementSystem/scripts/dirac-stager-monitor-file.py
+++ b/StorageManagementSystem/scripts/dirac-stager-monitor-file.py
@@ -28,75 +28,75 @@ args = Script.getPositionalArgs()
 if len( args ) < 2:
   Script.showHelp()
 
-from DIRAC import exit as DIRACExit
+from DIRAC import exit as DIRACExit, gLogger
 
 lfn = args[0]
 se = args[1]
 
 from DIRAC.StorageManagementSystem.Client.StorageManagerClient import StorageManagerClient
 client = StorageManagerClient()
-res = client.getCacheReplicas( {'LFN':lfn,'SE':se} )
+res = client.getCacheReplicas( {'LFN':lfn, 'SE':se} )
 if not res['OK']:
-  print res['Message']
+  gLogger.error( res['Message'] )
 cacheReplicaInfo = res['Value']
 if cacheReplicaInfo:
   replicaID = cacheReplicaInfo.keys()[0]
   outStr = "\n--------------------"
-  outStr = "%s\n%s: %s" % ( outStr, 'LFN'.ljust( 8 ), cacheReplicaInfo[replicaID]['LFN'].ljust( 100 ) )
-  outStr = "%s\n%s: %s" % ( outStr, 'SE'.ljust( 8 ), cacheReplicaInfo[replicaID]['SE'].ljust( 100 ) )
-  outStr = "%s\n%s: %s" % ( outStr, 'PFN'.ljust( 8 ), cacheReplicaInfo[replicaID]['PFN'].ljust( 100 ) )
-  outStr = "%s\n%s: %s" % ( outStr, 'Status'.ljust( 8 ), cacheReplicaInfo[replicaID]['Status'].ljust( 100 ) )
-  outStr = "%s\n%s: %s" % ( outStr, 'LastUpdate'.ljust( 8 ), str(cacheReplicaInfo[replicaID]['LastUpdate']).ljust( 100 ) )
-  outStr = "%s\n%s: %s" % ( outStr, 'Reason'.ljust( 8 ), str( cacheReplicaInfo[replicaID]['Reason']).ljust( 100 ) )
-  
-  resTasks = client.getTasks({'ReplicaID':replicaID})
+  outStr += "\n%s: %s" % ( 'LFN'.ljust( 8 ), cacheReplicaInfo[replicaID]['LFN'].ljust( 100 ) )
+  outStr += "\n%s: %s" % ( 'SE'.ljust( 8 ), cacheReplicaInfo[replicaID]['SE'].ljust( 100 ) )
+  outStr += "\n%s: %s" % ( 'PFN'.ljust( 8 ), cacheReplicaInfo[replicaID]['PFN'].ljust( 100 ) )
+  outStr += "\n%s: %s" % ( 'Status'.ljust( 8 ), cacheReplicaInfo[replicaID]['Status'].ljust( 100 ) )
+  outStr += "\n%s: %s" % ( 'LastUpdate'.ljust( 8 ), str( cacheReplicaInfo[replicaID]['LastUpdate'] ).ljust( 100 ) )
+  outStr += "\n%s: %s" % ( 'Reason'.ljust( 8 ), str( cacheReplicaInfo[replicaID]['Reason'] ).ljust( 100 ) )
+
+  resTasks = client.getTasks( {'ReplicaID':replicaID} )
 
   if resTasks['OK']:
-    #print resTasks['Message']
-    outStr = '%s\nJob IDs requesting this file to be staged:'.ljust( 8) % outStr
+    # print resTasks['Message']
+    outStr += '\nJob IDs requesting this file to be staged:'.ljust( 8 )
     tasks = resTasks['Value']
     for tid in tasks.keys():
-      outStr = '%s %s ' % (outStr, tasks[tid]['SourceTaskID'])  
+      outStr += ' %s ' % ( tasks[tid]['SourceTaskID'] )
 
-  resStageRequests = client.getStageRequests({'ReplicaID':replicaID})
+  resStageRequests = client.getStageRequests( {'ReplicaID':replicaID} )
 
   if not resStageRequests['OK']:
-    print resStageRequests['Message']
+    gLogger.error( resStageRequests['Message'] )
 
   if resStageRequests['Records']:
     stageRequests = resStageRequests['Value']
-    outStr = "%s\n------SRM staging request info--------------" % outStr
-    for srid in stageRequests.keys():
-      outStr = "%s\n%s: %s" % ( outStr, 'SRM RequestID'.ljust( 8 ), stageRequests[srid]['RequestID'].ljust( 100 ) )
-      outStr = "%s\n%s: %s" % ( outStr, 'SRM StageStatus'.ljust( 8 ), stageRequests[srid]['StageStatus'].ljust( 100 ) )
-      outStr = "%s\n%s: %s" % ( outStr, 'SRM StageRequestSubmitTime'.ljust( 8 ), str(stageRequests[srid]['StageRequestSubmitTime']).ljust( 100 ) )
-      outStr = "%s\n%s: %s" % ( outStr, 'SRM StageRequestCompletedTime'.ljust( 8 ), str(stageRequests[srid]['StageRequestCompletedTime']).ljust( 100 ) )
-      outStr = "%s\n%s: %s" % ( outStr, 'SRM PinExpiryTime'.ljust( 8 ), str(stageRequests[srid]['PinExpiryTime']).ljust( 100 ) )
-      outStr = "%s\n%s: %s sec" % ( outStr, 'SRM PinLength'.ljust( 8 ), str(stageRequests[srid]['PinLength']).ljust( 100 ) )
+    outStr += "\n------SRM staging request info--------------"
+    for info in stageRequests.itervalues():
+      outStr += "\n%s: %s" % ( 'SRM RequestID'.ljust( 8 ), info['RequestID'].ljust( 100 ) )
+      outStr += "\n%s: %s" % ( 'SRM StageStatus'.ljust( 8 ), info['StageStatus'].ljust( 100 ) )
+      outStr += "\n%s: %s" % ( 'SRM StageRequestSubmitTime'.ljust( 8 ), str( info['StageRequestSubmitTime'] ).ljust( 100 ) )
+      outStr += "\n%s: %s" % ( 'SRM StageRequestCompletedTime'.ljust( 8 ), str( info['StageRequestCompletedTime'] ).ljust( 100 ) )
+      outStr += "\n%s: %s" % ( 'SRM PinExpiryTime'.ljust( 8 ), str( info['PinExpiryTime'] ).ljust( 100 ) )
+      outStr += "\n%s: %s sec" % ( 'SRM PinLength'.ljust( 8 ), str( info['PinLength'] ).ljust( 100 ) )
   else:
-    outStr = '%s\nThere are no staging requests submitted to the site yet.'.ljust( 8) % outStr
+    outStr += '\nThere are no staging requests submitted to the site yet.'.ljust( 8 )
 else:
-  outStr = "\nThere is no such file requested for staging. Check for typo's!"   
-  #Script.showHelp() 
-print outStr
+  outStr = "\nThere is no such file requested for staging. Check for typo's!"
+  # Script.showHelp()
+gLogger.notice( outStr )
 
 DIRACExit( 0 )
 
 ''' Example:
 dirac-stager-monitor-file.py /lhcb/LHCb/Collision12/FULL.DST/00020846/0005/00020846_00056603_1.full.dst GRIDKA-RDST
 --------------------
-LFN     : /lhcb/LHCb/Collision12/FULL.DST/00020846/0005/00020846_00056603_1.full.dst                          
-SE      : GRIDKA-RDST                                                                                         
+LFN     : /lhcb/LHCb/Collision12/FULL.DST/00020846/0005/00020846_00056603_1.full.dst
+SE      : GRIDKA-RDST
 PFN     : srm://gridka-dCache.fzk.de/pnfs/gridka.de/lhcb/LHCb/Collision12/FULL.DST/00020846/0005/00020846_00056603_1.full.dst
-Status  : StageSubmitted                                                                                      
-LastUpdate: 2013-06-11 18:13:40                                                                                 
-Reason  : None                                                                                                
-Jobs requesting this file to be staged: 48518896 
+Status  : StageSubmitted
+LastUpdate: 2013-06-11 18:13:40
+Reason  : None
+Jobs requesting this file to be staged: 48518896
 ------SRM staging request info--------------
-SRM RequestID: -1768636375                                                                                         
-SRM StageStatus: StageSubmitted                                                                                      
-SRM StageRequestSubmitTime: 2013-06-11 18:13:38                                                                                 
-SRM StageRequestCompletedTime: None                                                                                                
-SRM PinExpiryTime: None                                                                                                
-SRM PinLength: 43200         
+SRM RequestID: -1768636375
+SRM StageStatus: StageSubmitted
+SRM StageRequestSubmitTime: 2013-06-11 18:13:38
+SRM StageRequestCompletedTime: None
+SRM PinExpiryTime: None
+SRM PinLength: 43200
 '''

--- a/StorageManagementSystem/scripts/dirac-stager-monitor-jobs.py
+++ b/StorageManagementSystem/scripts/dirac-stager-monitor-jobs.py
@@ -23,12 +23,12 @@ args = Script.getPositionalArgs()
 if len( args ) < 1:
   Script.showHelp()
 
-from DIRAC import exit as DIRACExit
+from DIRAC import exit as DIRACExit, gLogger
 
 try:
   jobIDs = [int( arg ) for arg in args]
 except:
-  print 'DIRAC Job IDs must be integers'
+  gLogger.fatal( 'DIRAC Job IDs must be integers' )
   DIRACExit( 2 )
 
 from DIRAC.StorageManagementSystem.Client.StorageManagerClient import StorageManagerClient
@@ -38,32 +38,32 @@ outStr = "\n"
 for jobID in jobIDs:
   res = client.getTaskSummary( jobID )
   if not res['OK']:
-    print res['Message']
+    gLogger.error( res['Message'] )
     continue
   if not res['Value']:
-    print 'No info for job %s, probably gone from the stager...' % jobID
+    gLogger.notice( 'No info for job %s, probably gone from the stager...' % jobID )
     continue
   taskInfo = res['Value']['TaskInfo']
   replicaInfo = res['Value']['ReplicaInfo']
   outStr = "%s: %s" % ( 'JobID'.ljust( 20 ), jobID )
-  outStr = "%s\n%s: %s" % ( outStr, 'Status'.ljust( 20 ), taskInfo[str(jobID)]['Status'] )
-  outStr = "%s\n%s: %s" % ( outStr, 'SubmitTime'.ljust( 20 ), taskInfo[str(jobID)]['SubmitTime'] )
-  outStr = "%s\n%s: %s" % ( outStr, 'CompleteTime'.ljust( 20 ), taskInfo[str(jobID)]['CompleteTime'] )
-  outStr = "%s\nStaging files for this job:" % outStr
+  outStr += "\n%s: %s" % ( 'Status'.ljust( 20 ), taskInfo[str( jobID )]['Status'] )
+  outStr += "\n%s: %s" % ( 'SubmitTime'.ljust( 20 ), taskInfo[str( jobID )]['SubmitTime'] )
+  outStr += "\n%s: %s" % ( 'CompleteTime'.ljust( 20 ), taskInfo[str( jobID )]['CompleteTime'] )
+  outStr += "\nStaging files for this job:"
   if not res['Value']['ReplicaInfo']:
-    print 'No info on files for the job = %s, that is odd' %jobID
+    gLogger.notice( 'No info on files for the job = %s, that is odd' % jobID )
     continue
-  else:  
-    for lfn, metadata in replicaInfo.items():
-      outStr = "%s\n\t--------------------" % outStr
-      outStr = "%s\n\t%s: %s" % ( outStr, 'LFN'.ljust( 8 ), lfn.ljust( 100 ) )
-      outStr = "%s\n\t%s: %s" % ( outStr, 'SE'.ljust( 8 ), metadata['StorageElement'].ljust( 100 ) )
-      outStr = "%s\n\t%s: %s" % ( outStr, 'PFN'.ljust( 8 ), str( metadata['PFN'] ).ljust( 100 ) )
-      outStr = "%s\n\t%s: %s" % ( outStr, 'Status'.ljust( 8 ), metadata['Status'].ljust( 100 ) )
-      outStr = "%s\n\t%s: %s" % ( outStr, 'Reason'.ljust( 8 ), str( metadata['Reason'] ).ljust( 100 ) )
-      outStr = "%s\n%s: %s" % ( outStr, 'LastUpdate'.ljust( 8 ), str(metadata['LastUpdate']).ljust( 100 ) )
-    outStr = "%s\n----------------------" % outStr
-  print outStr
+  else:
+    for lfn, metadata in replicaInfo.iteritems():
+      outStr += "\n\t--------------------"
+      outStr += "\n\t%s: %s" % ( 'LFN'.ljust( 8 ), lfn.ljust( 100 ) )
+      outStr += "\n\t%s: %s" % ( 'SE'.ljust( 8 ), metadata['StorageElement'].ljust( 100 ) )
+      outStr += "\n\t%s: %s" % ( 'PFN'.ljust( 8 ), str( metadata['PFN'] ).ljust( 100 ) )
+      outStr += "\n\t%s: %s" % ( 'Status'.ljust( 8 ), metadata['Status'].ljust( 100 ) )
+      outStr += "\n\t%s: %s" % ( 'Reason'.ljust( 8 ), str( metadata['Reason'] ).ljust( 100 ) )
+      outStr += "\n%s: %s" % ( 'LastUpdate'.ljust( 8 ), str( metadata['LastUpdate'] ).ljust( 100 ) )
+    outStr += "\n----------------------"
+  gLogger.notice( outStr )
 DIRACExit( 0 )
 
 ''' Example:
@@ -75,29 +75,29 @@ SubmitTime          : 2013-06-10 15:21:03
 CompleteTime        : None
 Staging files for this job:
     --------------------
-    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00003705_1.sdst                                  
-    SE      : IN2P3-RDST                                                                                          
+    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00003705_1.sdst
+    SE      : IN2P3-RDST
     PFN     : srm://ccsrm.in2p3.fr/pnfs/in2p3.fr/data/lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00003705_1.sdst
-    Status  : Offline                                                                                             
-    Reason  : None                                                                                                
+    Status  : Offline
+    Reason  : None
     --------------------
-    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00001918_1.sdst                                  
-    SE      : IN2P3-RDST                                                                                          
+    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00001918_1.sdst
+    SE      : IN2P3-RDST
     PFN     : srm://ccsrm.in2p3.fr/pnfs/in2p3.fr/data/lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00001918_1.sdst
-    Status  : Offline                                                                                             
-    Reason  : None                                                                                                
+    Status  : Offline
+    Reason  : None
     --------------------
-    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00002347_1.sdst                                  
-    SE      : IN2P3-RDST                                                                                          
+    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00002347_1.sdst
+    SE      : IN2P3-RDST
     PFN     : srm://ccsrm.in2p3.fr/pnfs/in2p3.fr/data/lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00002347_1.sdst
-    Status  : Offline                                                                                             
-    Reason  : None                                                                                                
+    Status  : Offline
+    Reason  : None
     --------------------
-    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00003701_1.sdst                                  
-    SE      : IN2P3-RDST                                                                                          
+    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00003701_1.sdst
+    SE      : IN2P3-RDST
     PFN     : srm://ccsrm.in2p3.fr/pnfs/in2p3.fr/data/lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00003701_1.sdst
-    Status  : Offline                                                                                             
-    Reason  : None                                                                                                
+    Status  : Offline
+    Reason  : None
 ----------------------
 JobID               : 5688644
 Status              : Offline
@@ -105,35 +105,35 @@ SubmitTime          : 2013-06-10 15:21:07
 CompleteTime        : None
 Staging files for this job:
     --------------------
-    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00005873_1.sdst                                  
-    SE      : IN2P3-RDST                                                                                          
+    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00005873_1.sdst
+    SE      : IN2P3-RDST
     PFN     : srm://ccsrm.in2p3.fr/pnfs/in2p3.fr/data/lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00005873_1.sdst
-    Status  : Offline                                                                                             
-    Reason  : None                                                                                                
+    Status  : Offline
+    Reason  : None
     --------------------
-    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00004468_1.sdst                                  
-    SE      : IN2P3-RDST                                                                                          
+    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00004468_1.sdst
+    SE      : IN2P3-RDST
     PFN     : srm://ccsrm.in2p3.fr/pnfs/in2p3.fr/data/lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00004468_1.sdst
-    Status  : Offline                                                                                             
-    Reason  : None                                                                                                
+    Status  : Offline
+    Reason  : None
     --------------------
-    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00000309_1.sdst                                  
-    SE      : IN2P3-RDST                                                                                          
+    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00000309_1.sdst
+    SE      : IN2P3-RDST
     PFN     : srm://ccsrm.in2p3.fr/pnfs/in2p3.fr/data/lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00000309_1.sdst
-    Status  : Offline                                                                                             
-    Reason  : None                                                                                                
+    Status  : Offline
+    Reason  : None
     --------------------
-    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00005911_1.sdst                                  
-    SE      : IN2P3-RDST                                                                                          
+    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00005911_1.sdst
+    SE      : IN2P3-RDST
     PFN     : srm://ccsrm.in2p3.fr/pnfs/in2p3.fr/data/lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00005911_1.sdst
-    Status  : Offline                                                                                             
-    Reason  : None                                                                                                
+    Status  : Offline
+    Reason  : None
     --------------------
-    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00003296_1.sdst                                  
-    SE      : IN2P3-RDST                                                                                          
+    LFN     : /lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00003296_1.sdst
+    SE      : IN2P3-RDST
     PFN     : srm://ccsrm.in2p3.fr/pnfs/in2p3.fr/data/lhcb/LHCb/Collision10/SDST/00010270/0000/00010270_00003296_1.sdst
-    Status  : Offline                                                                                             
-    Reason  : None                                                                                                
+    Status  : Offline
+    Reason  : None
     --------------------
 
 '''

--- a/StorageManagementSystem/scripts/dirac-stager-monitor-request.py
+++ b/StorageManagementSystem/scripts/dirac-stager-monitor-request.py
@@ -23,12 +23,12 @@ args = Script.getPositionalArgs()
 if not len( args ) == 1:
   Script.showHelp()
 
-from DIRAC import exit as DIRACExit
+from DIRAC import exit as DIRACExit, gLogger
 
 try:
   taskID = int( args[0] )
 except:
-  print 'Stage requestID must be an integer'
+  gLogger.fatal( 'Stage requestID must be an integer' )
   DIRACExit( 2 )
 
 from DIRAC.StorageManagementSystem.Client.StorageManagerClient import StorageManagerClient
@@ -36,23 +36,23 @@ client = StorageManagerClient()
 
 res = client.getTaskSummary( taskID )
 if not res['OK']:
-  print res['Message']
+  gLogger.error( res['Message'] )
   DIRACExit( 2 )
 taskInfo = res['Value']['TaskInfo']
 replicaInfo = res['Value']['ReplicaInfo']
 outStr = "%s: %s" % ( 'TaskID'.ljust( 20 ), taskID )
-outStr = "%s\n%s: %s" % ( outStr, 'Status'.ljust( 20 ), taskInfo[taskID]['Status'] )
-outStr = "%s\n%s: %s" % ( outStr, 'Source'.ljust( 20 ), taskInfo[taskID]['Source'] )
-outStr = "%s\n%s: %s" % ( outStr, 'SourceTaskID'.ljust( 20 ), taskInfo[taskID]['SourceTaskID'] )
-outStr = "%s\n%s: %s" % ( outStr, 'CallBackMethod'.ljust( 20 ), taskInfo[taskID]['CallBackMethod'] )
-outStr = "%s\n%s: %s" % ( outStr, 'SubmitTime'.ljust( 20 ), taskInfo[taskID]['SubmitTime'] )
-outStr = "%s\n%s: %s" % ( outStr, 'CompleteTime'.ljust( 20 ), taskInfo[taskID]['CompleteTime'] )
-for lfn, metadata in replicaInfo.items():
-  outStr = "%s\n" % outStr
-  outStr = "%s\n\t%s: %s" % ( outStr, 'LFN'.ljust( 8 ), lfn.ljust( 100 ) )
-  outStr = "%s\n\t%s: %s" % ( outStr, 'SE'.ljust( 8 ), metadata['StorageElement'].ljust( 100 ) )
-  outStr = "%s\n\t%s: %s" % ( outStr, 'PFN'.ljust( 8 ), str( metadata['PFN'] ).ljust( 100 ) )
-  outStr = "%s\n\t%s: %s" % ( outStr, 'Size'.ljust( 8 ), str( metadata['FileSize'] ).ljust( 100 ) )
-  outStr = "%s\n\t%s: %s" % ( outStr, 'Status'.ljust( 8 ), metadata['Status'].ljust( 100 ) )
-  outStr = "%s\n\t%s: %s" % ( outStr, 'Reason'.ljust( 8 ), str( metadata['Reason'] ).ljust( 100 ) )
-print outStr
+outStr += "\n%s: %s" % ( 'Status'.ljust( 20 ), taskInfo[taskID]['Status'] )
+outStr += "\n%s: %s" % ( 'Source'.ljust( 20 ), taskInfo[taskID]['Source'] )
+outStr += "\n%s: %s" % ( 'SourceTaskID'.ljust( 20 ), taskInfo[taskID]['SourceTaskID'] )
+outStr += "\n%s: %s" % ( 'CallBackMethod'.ljust( 20 ), taskInfo[taskID]['CallBackMethod'] )
+outStr += "\n%s: %s" % ( 'SubmitTime'.ljust( 20 ), taskInfo[taskID]['SubmitTime'] )
+outStr += "\n%s: %s" % ( 'CompleteTime'.ljust( 20 ), taskInfo[taskID]['CompleteTime'] )
+for lfn, metadata in replicaInfo.iteritems():
+  outStr += "\n"
+  outStr += "\n\t%s: %s" % ( 'LFN'.ljust( 8 ), lfn.ljust( 100 ) )
+  outStr += "\n\t%s: %s" % ( 'SE'.ljust( 8 ), metadata['StorageElement'].ljust( 100 ) )
+  outStr += "\n\t%s: %s" % ( 'PFN'.ljust( 8 ), str( metadata['PFN'] ).ljust( 100 ) )
+  outStr += "\n\t%s: %s" % ( 'Size'.ljust( 8 ), str( metadata['FileSize'] ).ljust( 100 ) )
+  outStr += "\n\t%s: %s" % ( 'Status'.ljust( 8 ), metadata['Status'].ljust( 100 ) )
+  outStr += "\n\t%s: %s" % ( 'Reason'.ljust( 8 ), str( metadata['Reason'] ).ljust( 100 ) )
+gLogger.notice( outStr )

--- a/StorageManagementSystem/scripts/dirac-stager-monitor-requests.py
+++ b/StorageManagementSystem/scripts/dirac-stager-monitor-requests.py
@@ -11,7 +11,7 @@ _RCSID__ = "$Id$"
 from DIRAC.Core.Base import Script
 from DIRAC                                     import gConfig, gLogger, exit as DIRACExit, S_OK, version
 
-subLogger  = None
+subLogger = None
 
 Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
                                      'Usage:',
@@ -22,20 +22,20 @@ Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
                                      '  showJobs: whether to ALSO list the jobs asking for these files to be staged'
                                      ' WARNING: Query may be heavy, please use --limit switch!'
                                        ] ) )
-  
+
 def registerSwitches():
   '''
     Registers all switches that can be used while calling the script from the
     command line interface.
   '''
-  
-  switches = (
-    ( 'status=',     'Filter per file status=(New, Offline, Waiting, Failed, StageSubmitted, Staged). If not used, all status values will be taken into account' ),
-    ( 'se=',        'Filter per Storage Element. If not used, all storage elements will be taken into account.' ),
-    ( 'limit=',        'Limit the number of entries returned.' ),
-    (  'showJobs=', 'Whether to ALSO list the jobs asking for these files to be staged'),
+
+  switches = ( 
+    ( 'status=', 'Filter per file status=(New, Offline, Waiting, Failed, StageSubmitted, Staged). If not used, all status values will be taken into account' ),
+    ( 'se=', 'Filter per Storage Element. If not used, all storage elements will be taken into account.' ),
+    ( 'limit=', 'Limit the number of entries returned.' ),
+    ( 'showJobs=', 'Whether to ALSO list the jobs asking for these files to be staged' ),
              )
-  
+
   for switch in switches:
     Script.registerSwitch( '', switch[ 0 ], switch[ 1 ] )
 
@@ -43,7 +43,7 @@ def parseSwitches():
   '''
     Parses the arguments passed by the user
   '''
-  
+
   Script.parseCommandLine( ignoreErrors = True )
   args = Script.getPositionalArgs()
   if args:
@@ -51,131 +51,128 @@ def parseSwitches():
     subLogger.error( "Please, check documentation below" )
     Script.showHelp()
     DIRACExit( 1 )
-  
-  switches = dict( Script.getUnprocessedSwitches() )  
-  
-  for key in ( 'status', 'se','limit'):
+
+  switches = dict( Script.getUnprocessedSwitches() )
+
+  for key in ( 'status', 'se', 'limit' ):
 
     if not key in switches:
       print "You're not using switch --%s, query may take long!" % key
-      
-  if 'status' in  switches.keys():  
-    if not switches[ 'status' ] in ( 'New', 'Offline', 'Waiting','Failed','StageSubmitted','Staged' ):
+
+  if 'status' in  switches.keys():
+    if not switches[ 'status' ] in ( 'New', 'Offline', 'Waiting', 'Failed', 'StageSubmitted', 'Staged' ):
       subLogger.error( "Found \"%s\" as Status value. Incorrect value used!" % switches[ 'status' ] )
       subLogger.error( "Please, check documentation below" )
       Script.showHelp()
       DIRACExit( 1 )
-  
+
   subLogger.debug( "The switches used are:" )
   map( subLogger.debug, switches.iteritems() )
 
-  return switches  
+  return switches
 
-#...............................................................................
+# ...............................................................................
 
 def run():
-  
+
   from DIRAC.StorageManagementSystem.Client.StorageManagerClient import StorageManagerClient
   client = StorageManagerClient()
   queryDict = {}
 
-  dictKeys = switchDict.keys()
-  
-  if 'status' in dictKeys:
-    queryDict['Status'] = str(switchDict['status']) 
-  
-  
-  if 'se' in dictKeys:
-    queryDict['SE'] = str(switchDict['se']);
-  
+  if 'status' in switchDict:
+    queryDict['Status'] = str( switchDict['status'] )
+
+
+  if 'se' in switchDict:
+    queryDict['SE'] = str( switchDict['se'] );
+
   # weird: if there are no switches (dictionary is empty), then the --limit is ignored!!
   # must FIX that in StorageManagementDB.py!
   # ugly fix:
-  newer = '1903-08-02 06:24:38' # select newer than 
-  if 'limit' in dictKeys:
-    print "Query limited to %s entries" %switchDict['limit']   
-    res = client.getCacheReplicas(queryDict, None, newer, None, None, int(switchDict['limit']))
+  newer = '1903-08-02 06:24:38'  # select newer than
+  if 'limit' in switchDict:
+    print "Query limited to %s entries" % switchDict['limit']
+    res = client.getCacheReplicas( queryDict, None, newer, None, None, int( switchDict['limit'] ) )
   else:
-    res = client.getCacheReplicas(queryDict)
-  
+    res = client.getCacheReplicas( queryDict )
+
   if not res['OK']:
-    print res['Message']
-  outStr ="\n"
+    gLogger.error( res['Message'] )
+  outStr = "\n"
   if res['Records']:
     replicas = res['Value']
-    outStr = "%s %s" %(outStr, "Status".ljust(15)) 
-    outStr = "%s %s" %(outStr, "LastUpdate".ljust(20))  
-    outStr = "%s %s" %(outStr, "LFN".ljust(80))   
-    outStr = "%s %s" %(outStr, "SE".ljust(10))  
-    outStr = "%s %s" %(outStr, "Reason".ljust(10))
-    if 'showJobs' in dictKeys:  
-      outStr = "%s %s" %(outStr, "Jobs".ljust(10))  
-    outStr = "%s %s" %(outStr, "PinExpiryTime".ljust(15))  
-    outStr = "%s %s" %(outStr, "PinLength(sec)".ljust(15))  
-    outStr = "%s\n" % outStr  
-    
-    for crid in replicas.keys():
-      outStr = "%s %s" %(outStr, replicas[crid]['Status'].ljust( 15 ))
-      outStr = "%s %s" %(outStr, str(replicas[crid]['LastUpdate']).ljust( 20 ))
-      outStr = "%s %s" %(outStr, replicas[crid]['LFN'].ljust( 30 ))
-      outStr = "%s %s" %(outStr, replicas[crid]['SE'].ljust( 15 ))              
-      outStr = "%s %s" %(outStr, str(replicas[crid]['Reason']).ljust( 10 ))
- 
+    outStr += " %s" % ( "Status".ljust( 15 ) )
+    outStr += " %s" % ( "LastUpdate".ljust( 20 ) )
+    outStr += " %s" % ( "LFN".ljust( 80 ) )
+    outStr += " %s" % ( "SE".ljust( 10 ) )
+    outStr += " %s" % ( "Reason".ljust( 10 ) )
+    if 'showJobs' in switchDict:
+      outStr += " %s" % ( "Jobs".ljust( 10 ) )
+    outStr += " %s" % ( "PinExpiryTime".ljust( 15 ) )
+    outStr += " %s" % ( "PinLength(sec)".ljust( 15 ) )
+    outStr += "\n"
+
+    for info in replicas.itervalues():
+      outStr += " %s" % ( info['Status'].ljust( 15 ) )
+      outStr += " %s" % ( str( info['LastUpdate'] ).ljust( 20 ) )
+      outStr += " %s" % ( info['LFN'].ljust( 30 ) )
+      outStr += " %s" % ( info['SE'].ljust( 15 ) )
+      outStr += " %s" % ( str( info['Reason'] ).ljust( 10 ) )
+
       # Task info
-      if 'showJobs' in dictKeys:
-        resTasks = client.getTasks({'ReplicaID':crid})
+      if 'showJobs' in switchDict:
+        resTasks = client.getTasks( {'ReplicaID':crid} )
         if resTasks['OK']:
           if resTasks['Value']:
             tasks = resTasks['Value']
             jobs = []
             for tid in tasks.keys():
-              jobs.append(tasks[tid]['SourceTaskID'])      
-            outStr = '%s %s ' % (outStr, str(jobs).ljust(10))
+              jobs.append( tasks[tid]['SourceTaskID'] )
+            outStr += ' %s ' % ( str( jobs ).ljust( 10 ) )
         else:
-          outStr = '%s %s ' % (outStr, " --- ".ljust(10))     
+          outStr += ' %s ' % ( " --- ".ljust( 10 ) )
       # Stage request info
       # what if there's no request to the site yet?
-      resStageRequests = client.getStageRequests({'ReplicaID':crid})
+      resStageRequests = client.getStageRequests( {'ReplicaID':crid} )
       if not resStageRequests['OK']:
         print resStageRequests['Message']
       if resStageRequests['Records']:
-        stageRequests = resStageRequests['Value']        
-        for srid in stageRequests.keys():
-          outStr = "%s %s" %(outStr, str(stageRequests[srid]['PinExpiryTime']).ljust( 20 ))
-          outStr = "%s %s" %(outStr, str(stageRequests[srid]['PinLength']).ljust( 10 ))
-           
- 
-      outStr = "%s\n" % outStr  
-    print outStr
+        stageRequests = resStageRequests['Value']
+        for info in stageRequests.itervalues():
+          outStr += " %s" % ( str( info['PinExpiryTime'] ).ljust( 20 ) )
+          outStr += " %s" % ( str( info['PinLength'] ).ljust( 10 ) )
+      outStr += "\n"
+
+    gLogger.notice( outStr )
   else:
-    print "No entries"    
-    
+    gLogger.notice( "No entries" )
+
 if __name__ == "__main__":
-  
-  subLogger  = gLogger.getSubLogger( __file__ )
-  
+
+  subLogger = gLogger.getSubLogger( __file__ )
+
   registerSwitches()
 
   switchDict = parseSwitches()
   run()
-   
-  #Bye
+
+  # Bye
   DIRACExit( 0 )
 ''' Example:
 dirac-stager-show-requests.py --status=Staged --se=GRIDKA-RDST --limit=10 --showJobs=YES
 Query limited to 10 entries
 
- Status          LastUpdate                     LFN                                                               SE       Reason     Jobs       PinExpiryTime   PinLength      
- Staged        2013-06-05 20:10:50 /lhcb/LHCb/Collision12/FULL.DST/00020846/0005/00020846_00054816_1.full.dst GRIDKA-RDST None    ['48498752']  2013-06-05 22:10:50  86400     
- Staged        2013-06-06 15:54:29 /lhcb/LHCb/Collision12/FULL.DST/00020846/0001/00020846_00013202_1.full.dst GRIDKA-RDST None    ['48516851']  2013-06-06 16:54:29  43200     
- Staged        2013-06-07 02:35:41 /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032726_1.full.dst GRIDKA-RDST None    ['48520736']  2013-06-07 03:35:41  43200     
- Staged        2013-06-06 04:16:50 /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00030567_1.full.dst GRIDKA-RDST None    ['48510852']  2013-06-06 06:16:50  86400     
- Staged        2013-06-07 03:44:04 /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032699_1.full.dst GRIDKA-RDST None    ['48520737']  2013-06-07 04:44:04  43200     
- Staged        2013-06-05 23:37:46 /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032576_1.full.dst GRIDKA-RDST None    ['48508687']  2013-06-06 01:37:46  86400     
- Staged        2013-06-10 08:50:09 /lhcb/LHCb/Collision12/FULL.DST/00020846/0005/00020846_00056424_1.full.dst GRIDKA-RDST None    ['48518896']  2013-06-10 09:50:09  43200     
- Staged        2013-06-06 11:03:25 /lhcb/LHCb/Collision12/FULL.DST/00020846/0002/00020846_00022161_1.full.dst GRIDKA-RDST None    ['48515583']  2013-06-06 12:03:25  43200     
- Staged        2013-06-06 11:11:50 /lhcb/LHCb/Collision12/FULL.DST/00020846/0002/00020846_00029215_1.full.dst GRIDKA-RDST None    ['48515072']  2013-06-06 12:11:50  43200     
- Staged        2013-06-07 03:19:26 /lhcb/LHCb/Collision12/FULL.DST/00020846/0002/00020846_00022323_1.full.dst GRIDKA-RDST None    ['48515600']  2013-06-07 04:19:26  43200     
+ Status          LastUpdate                     LFN                                                               SE       Reason     Jobs       PinExpiryTime   PinLength
+ Staged        2013-06-05 20:10:50 /lhcb/LHCb/Collision12/FULL.DST/00020846/0005/00020846_00054816_1.full.dst GRIDKA-RDST None    ['48498752']  2013-06-05 22:10:50  86400
+ Staged        2013-06-06 15:54:29 /lhcb/LHCb/Collision12/FULL.DST/00020846/0001/00020846_00013202_1.full.dst GRIDKA-RDST None    ['48516851']  2013-06-06 16:54:29  43200
+ Staged        2013-06-07 02:35:41 /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032726_1.full.dst GRIDKA-RDST None    ['48520736']  2013-06-07 03:35:41  43200
+ Staged        2013-06-06 04:16:50 /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00030567_1.full.dst GRIDKA-RDST None    ['48510852']  2013-06-06 06:16:50  86400
+ Staged        2013-06-07 03:44:04 /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032699_1.full.dst GRIDKA-RDST None    ['48520737']  2013-06-07 04:44:04  43200
+ Staged        2013-06-05 23:37:46 /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032576_1.full.dst GRIDKA-RDST None    ['48508687']  2013-06-06 01:37:46  86400
+ Staged        2013-06-10 08:50:09 /lhcb/LHCb/Collision12/FULL.DST/00020846/0005/00020846_00056424_1.full.dst GRIDKA-RDST None    ['48518896']  2013-06-10 09:50:09  43200
+ Staged        2013-06-06 11:03:25 /lhcb/LHCb/Collision12/FULL.DST/00020846/0002/00020846_00022161_1.full.dst GRIDKA-RDST None    ['48515583']  2013-06-06 12:03:25  43200
+ Staged        2013-06-06 11:11:50 /lhcb/LHCb/Collision12/FULL.DST/00020846/0002/00020846_00029215_1.full.dst GRIDKA-RDST None    ['48515072']  2013-06-06 12:11:50  43200
+ Staged        2013-06-07 03:19:26 /lhcb/LHCb/Collision12/FULL.DST/00020846/0002/00020846_00022323_1.full.dst GRIDKA-RDST None    ['48515600']  2013-06-07 04:19:26  43200
  '''
 ################################################################################
 

--- a/StorageManagementSystem/scripts/dirac-stager-monitor-requests.py
+++ b/StorageManagementSystem/scripts/dirac-stager-monitor-requests.py
@@ -55,16 +55,14 @@ def parseSwitches():
   switches = dict( Script.getUnprocessedSwitches() )
 
   for key in ( 'status', 'se', 'limit' ):
-
-    if not key in switches:
+    if key not in switches:
       print "You're not using switch --%s, query may take long!" % key
 
-  if 'status' in  switches.keys():
-    if not switches[ 'status' ] in ( 'New', 'Offline', 'Waiting', 'Failed', 'StageSubmitted', 'Staged' ):
-      subLogger.error( "Found \"%s\" as Status value. Incorrect value used!" % switches[ 'status' ] )
-      subLogger.error( "Please, check documentation below" )
-      Script.showHelp()
-      DIRACExit( 1 )
+  if 'status' in  switches and switches[ 'status' ] not in ( 'New', 'Offline', 'Waiting', 'Failed', 'StageSubmitted', 'Staged' ):
+    subLogger.error( "Found \"%s\" as Status value. Incorrect value used!" % switches[ 'status' ] )
+    subLogger.error( "Please, check documentation below" )
+    Script.showHelp()
+    DIRACExit( 1 )
 
   subLogger.debug( "The switches used are:" )
   map( subLogger.debug, switches.iteritems() )
@@ -126,7 +124,7 @@ def run():
           if resTasks['Value']:
             tasks = resTasks['Value']
             jobs = []
-            for tid in tasks.keys():
+            for tid in tasks:
               jobs.append( tasks[tid]['SourceTaskID'] )
             outStr += ' %s ' % ( str( jobs ).ljust( 10 ) )
         else:

--- a/StorageManagementSystem/scripts/dirac-stager-monitor-requests.py
+++ b/StorageManagementSystem/scripts/dirac-stager-monitor-requests.py
@@ -110,7 +110,7 @@ def run():
     outStr += " %s" % ( "PinLength(sec)".ljust( 15 ) )
     outStr += "\n"
 
-    for info in replicas.itervalues():
+    for crid, info in replicas.iteritems():
       outStr += " %s" % ( info['Status'].ljust( 15 ) )
       outStr += " %s" % ( str( info['LastUpdate'] ).ljust( 20 ) )
       outStr += " %s" % ( info['LFN'].ljust( 30 ) )

--- a/StorageManagementSystem/scripts/dirac-stager-monitor-requests.py
+++ b/StorageManagementSystem/scripts/dirac-stager-monitor-requests.py
@@ -56,7 +56,7 @@ def parseSwitches():
 
   for key in ( 'status', 'se', 'limit' ):
     if key not in switches:
-      print "You're not using switch --%s, query may take long!" % key
+      subLogger.warn( "You're not using switch --%s, query may take long!" % key )
 
   if 'status' in  switches and switches[ 'status' ] not in ( 'New', 'Offline', 'Waiting', 'Failed', 'StageSubmitted', 'Staged' ):
     subLogger.error( "Found \"%s\" as Status value. Incorrect value used!" % switches[ 'status' ] )
@@ -89,7 +89,7 @@ def run():
   # ugly fix:
   newer = '1903-08-02 06:24:38'  # select newer than
   if 'limit' in switchDict:
-    print "Query limited to %s entries" % switchDict['limit']
+    gLogger.notice( "Query limited to %s entries" % switchDict['limit'] )
     res = client.getCacheReplicas( queryDict, None, newer, None, None, int( switchDict['limit'] ) )
   else:
     res = client.getCacheReplicas( queryDict )
@@ -133,7 +133,7 @@ def run():
       # what if there's no request to the site yet?
       resStageRequests = client.getStageRequests( {'ReplicaID':crid} )
       if not resStageRequests['OK']:
-        print resStageRequests['Message']
+        gLogger.error( resStageRequests['Message'] )
       if resStageRequests['Records']:
         stageRequests = resStageRequests['Value']
         for info in stageRequests.itervalues():

--- a/StorageManagementSystem/scripts/dirac-stager-show-stats.py
+++ b/StorageManagementSystem/scripts/dirac-stager-show-stats.py
@@ -19,48 +19,48 @@ client = StorageManagerClient()
 
 res = client.getCacheReplicasSummary()
 if not res['OK']:
-  print res['Message']
-  DIRACExit( 2 )      
+  gLogger.fatal( res['Message'] )
+  DIRACExit( 2 )
 stagerInfo = res['Value']
-outStr ="\n"
-outStr = "%s %s" %(outStr, "Status".ljust(20)) 
-outStr = "%s %s" %(outStr, "SE".ljust(20))
-outStr = "%s %s" %(outStr, "NumberOfFiles".ljust(20))  
-outStr = "%s %s" %(outStr, "Size(GB)".ljust(20))   
-outStr = "%s\n--------------------------------------------------------------------------\n" % outStr    
+outStr = "\n"
+outStr += "  %s" % ( "Status".ljust( 20 ) )
+outStr += "  %s" % ( "SE".ljust( 20 ) )
+outStr += "  %s" % ( "NumberOfFiles".ljust( 20 ) )
+outStr += "  %s" % ( "Size(GB)".ljust( 20 ) )
+outStr += " \n--------------------------------------------------------------------------\n" % outStr
 if stagerInfo:
   for sid in stagerInfo:
-    outStr = "%s %s" %(outStr, stagerInfo[sid]['Status'].ljust( 20 ))
-    outStr = "%s %s" %(outStr, stagerInfo[sid]['SE'].ljust( 20 ))
-    outStr = "%s %s" %(outStr, str(stagerInfo[sid]['NumFiles']).ljust( 20 ))
-    outStr = "%s %s\n" %(outStr, str(stagerInfo[sid]['SumFiles']).ljust( 20 ))
+    outStr += "  %s" % ( stagerInfo[sid]['Status'].ljust( 20 ) )
+    outStr += "  %s" % ( stagerInfo[sid]['SE'].ljust( 20 ) )
+    outStr += "  %s" % ( str( stagerInfo[sid]['NumFiles'] ).ljust( 20 ) )
+    outStr += "  %s\n" % ( str( stagerInfo[sid]['SumFiles'] ).ljust( 20 ) )
 else:
-  outStr ="%s %s" % (outStr, "Nothing to see here...Bye")
-outStr ="%s %s" % (outStr, "\nWARNING: the Size for files with Status=New is not yet determined at the point of selection!\n\n")
-outStr ="%s %s" %(outStr,"--------------------- current status of the SE Caches from the DB-----------")
+  outStr += "  %s" % ( "Nothing to see here...Bye" )
+outStr += "  %s" % ( "\nWARNING: the Size for files with Status=New is not yet determined at the point of selection!\n\n" )
+outStr += "  %s" % ( "--------------------- current status of the SE Caches from the DB-----------" )
 res = client.getSubmittedStagePins()
 if not res['OK']:
-  print res['Message']
-  DIRACExit(2)
+  gLogger.fatal( res['Message'] )
+  DIRACExit( 2 )
 storageElementUsage = res['Value']
 if storageElementUsage:
   for storageElement in storageElementUsage.keys():
     seDict = storageElementUsage[storageElement]
     seDict['TotalSize'] = seDict['TotalSize'] / ( 1000 * 1000 * 1000.0 )
-    outStr ="%s\n %s: %s replicas with a size of %.3f GB." % (outStr, storageElement.ljust( 15 ), str( seDict['Replicas'] ).rjust( 6 ), seDict['TotalSize'] ) 
+    outStr += " \n %s: %s replicas with a size of %.3f GB." % ( storageElement.ljust( 15 ), str( seDict['Replicas'] ).rjust( 6 ), seDict['TotalSize'] )
 else:
-  outStr ="%s %s" % (outStr, "StageRequest.getStorageUsage: No active stage/pin requests found." )    
-print outStr
+  outStr += "  %s" % ( "StageRequest.getStorageUsage: No active stage/pin requests found." )
+gLogger.notice( outStr )
 DIRACExit( 0 )
 '''Example:
-dirac-stager-show-stats.py 
+dirac-stager-show-stats.py
 
- Status               SE                   NumberOfFiles        Size(GB)            
+ Status               SE                   NumberOfFiles        Size(GB)
 --------------------------------------------------------------------------
- Staged               GRIDKA-RDST          1                    4.5535              
- StageSubmitted       GRIDKA-RDST          5                    22.586              
- Waiting              PIC-RDST             3                    13.6478             
- 
+ Staged               GRIDKA-RDST          1                    4.5535
+ StageSubmitted       GRIDKA-RDST          5                    22.586
+ Waiting              PIC-RDST             3                    13.6478
+
 WARNING: the Size for files with Status=New is not yet determined at the point of selection!
 
  --------------------- current status of the SE Caches from the DB-----------

--- a/StorageManagementSystem/scripts/dirac-stager-show-stats.py
+++ b/StorageManagementSystem/scripts/dirac-stager-show-stats.py
@@ -29,11 +29,11 @@ outStr += "  %s" % ( "NumberOfFiles".ljust( 20 ) )
 outStr += "  %s" % ( "Size(GB)".ljust( 20 ) )
 outStr += " \n--------------------------------------------------------------------------\n" % outStr
 if stagerInfo:
-  for sid in stagerInfo:
-    outStr += "  %s" % ( stagerInfo[sid]['Status'].ljust( 20 ) )
-    outStr += "  %s" % ( stagerInfo[sid]['SE'].ljust( 20 ) )
-    outStr += "  %s" % ( str( stagerInfo[sid]['NumFiles'] ).ljust( 20 ) )
-    outStr += "  %s\n" % ( str( stagerInfo[sid]['SumFiles'] ).ljust( 20 ) )
+  for info in stagerInfo.itervalues():
+    outStr += "  %s" % ( info['Status'].ljust( 20 ) )
+    outStr += "  %s" % ( info['SE'].ljust( 20 ) )
+    outStr += "  %s" % ( str( info['NumFiles'] ).ljust( 20 ) )
+    outStr += "  %s\n" % ( str( info['SumFiles'] ).ljust( 20 ) )
 else:
   outStr += "  %s" % ( "Nothing to see here...Bye" )
 outStr += "  %s" % ( "\nWARNING: the Size for files with Status=New is not yet determined at the point of selection!\n\n" )

--- a/StorageManagementSystem/scripts/dirac-stager-stage-files.py
+++ b/StorageManagementSystem/scripts/dirac-stager-stage-files.py
@@ -5,7 +5,7 @@
 # Author :  Daniela Remenska
 ########################################################################
 """
-- submit staging requests for a particular Storage Element! Default DIRAC JobID will be =0. 
+- submit staging requests for a particular Storage Element! Default DIRAC JobID will be =0.
   (not visible in the Job monitoring list though)
 
 """
@@ -44,31 +44,31 @@ if os.path.exists( fileName ):
     gLogger.exception( 'Can not open file', fileName )
     DIRACExit( -1 )
 else:
-  lfns = args[:len(args)-1]
+  lfns = args[:len( args ) - 1]
 
 stageLfns[seName] = lfns
 stagerClient = StorageManagerClient()
 
 res = stagerClient.setRequest( stageLfns, 'WorkloadManagement',
-                                      'updateJobFromStager@WorkloadManagement/JobStateUpdate',
-                                      0 ) # fake JobID = 0
+                               'updateJobFromStager@WorkloadManagement/JobStateUpdate',
+                               0 )  # fake JobID = 0
 if not res['OK']:
   gLogger.error( res['Message'] )
   DIRACExit( -1 )
 else:
-  print "Stage request submitted for LFNs:\n %s" %lfns
-  print "SE= %s" %seName
-  print "You can check their status and progress with dirac-stager-monitor-file <LFN> <SE>"
+  gLogger.notice( "Stage request submitted for LFNs:\n %s" % lfns )
+  gLogger.notice( "SE= %s" % seName )
+  gLogger.notice( "You can check their status and progress with dirac-stager-monitor-file <LFN> <SE>" )
 
 '''Example1:
-dirac-stager-stage-files.py filesToStage.txt GRIDKA-RDST 
+dirac-stager-stage-files.py filesToStage.txt GRIDKA-RDST
 Stage request submitted for LFNs:
  ['/lhcb/LHCb/Collision12/FULL.DST/00020846/0002/00020846_00023458_1.full.dst', '/lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032669_1.full.dst', '/lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032666_1.full.dst']
 SE= GRIDKA-RDST
 You can check their status and progress with dirac-stager-monitor-file <LFN> <SE>
 
 Example2:
-dirac-stager-stage-files.py /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032641_1.full.dst GRIDKA-RDST 
+dirac-stager-stage-files.py /lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032641_1.full.dst GRIDKA-RDST
 Stage request submitted for LFNs:
  ['/lhcb/LHCb/Collision12/FULL.DST/00020846/0003/00020846_00032641_1.full.dst']
 SE= GRIDKA-RDST


### PR DESCRIPTION
* Stager: mostly streamline code, but also monitor files even when there is no requestID (dCache returns none when staging a file that is already staged!)

* DataManager: add key argument forJobs (default False) in getReplicas() in order to get only replicas that can be used for jobs (as defined in  the CS)
Use this feature in the API as well (default unchanged except for splitting where it is set to True)