### PR TITLE
[v6r17] Fix scripts deployment for MacOS

### DIFF
--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -86,7 +86,7 @@ if len( sys.argv ) == 2:
 wrapperTemplate = wrapperTemplate.replace( '$PYTHONLOCATION$', pythonLocation )
 
 # On the newest MacOS the DYLD_LIBRARY_PATH variable is not passed to the shell of
-# the os.system() - bug or feature ?
+# the os.system() due to System Integrity Protection feature
 if platform.system() == "Darwin":
   wrapperTemplate += """
 sys.exit( os.system( 'DYLD_LIBRARY_PATH=%s python "%s"%s' % ( DiracLibraryPath, DiracScript, args )  ) / 256 )

--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -13,8 +13,8 @@ import os
 import shutil
 import stat
 import re
-import time
 import sys
+import platform
 
 DEBUG = False
 
@@ -23,7 +23,7 @@ gDefaultPerms = stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat
 excludeMask = [ '__init__.py' ]
 simpleCopyMask = [ os.path.basename( __file__ ), 'dirac-compile-externals.py', 'dirac-install.py', 'dirac-platform.py' ]
 
-wrapperTemplate = """#!/usr/bin/env python
+wrapperTemplate = """#!$PYTHONLOCATION$
 #
 import os,sys,imp
 #
@@ -77,9 +77,24 @@ if sys.argv[1:]:
   args = ' "%s"' % '" "'.join( sys.argv[1:] )
 else:
   args = ''
-sys.exit( os.system('python "%s"%s' % ( DiracScript, args )  ) / 256 )
 """
 
+# Python interpreter location can be specified as an argument
+pythonLocation = "/usr/bin/env python"
+if len( sys.argv ) == 2:
+  pythonLocation = os.path.join( sys.argv[1], 'bin', 'python' )
+wrapperTemplate = wrapperTemplate.replace( '$PYTHONLOCATION$', pythonLocation )
+
+# On the newest MacOS the DYLD_LIBRARY_PATH variable is not passed to the shell of
+# the os.system() - bug or feature ?
+if platform.system() == "Darwin":
+  wrapperTemplate += """
+sys.exit( os.system( 'DYLD_LIBRARY_PATH=%s python "%s"%s' % ( DiracLibraryPath, DiracScript, args )  ) / 256 )
+"""
+else:
+  wrapperTemplate += """
+sys.exit( os.system('python "%s"%s' % ( DiracLibraryPath, DiracScript, args )  ) / 256 )
+"""
 
 def lookForScriptsInPath( basePath, rootModule ):
   isScriptsDir = os.path.split( rootModule )[1] == "scripts"

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1219,6 +1219,18 @@ def compileExternals( extVersion ):
     return False
   return True
 
+def getPlatform():
+  platformPath = os.path.join( cliParams.targetPath, "DIRAC", "Core", "Utilities", "Platform.py" )
+  try:
+    platFD = open( platformPath, "r" )
+  except IOError:
+    logERROR( "Cannot open Platform.py. Is DIRAC installed?" )
+    return ''
+
+  Platform = imp.load_module( "Platform", platFD, platformPath, ( "", "r", imp.PY_SOURCE ) )
+  platFD.close()
+  return Platform.getPlatformString()
+
 def installExternals( releaseConfig ):
   externalsVersion = releaseConfig.getExtenalsVersion()
   if not externalsVersion:
@@ -1226,16 +1238,9 @@ def installExternals( releaseConfig ):
     return False
 
   if not cliParams.platform:
-    platformPath = os.path.join( cliParams.targetPath, "DIRAC", "Core", "Utilities", "Platform.py" )
-    try:
-      platFD = open( platformPath, "r" )
-    except IOError:
-      logERROR( "Cannot open Platform.py. Is DIRAC installed?" )
-      return False
-
-    Platform = imp.load_module( "Platform", platFD, platformPath, ( "", "r", imp.PY_SOURCE ) )
-    platFD.close()
-    cliParams.platform = Platform.getPlatformString()
+    cliParams.platform = getPlatform()
+  if not cliParams.platform:
+    return False
 
   if cliParams.installSource:
     tarsURL = cliParams.installSource
@@ -1524,7 +1529,16 @@ if __name__ == "__main__":
     logNOTICE( "Deploying scripts..." )
     ddeLocation = os.path.join( cliParams.targetPath, "DIRAC", "Core", "scripts", "dirac-deploy-scripts.py" )
     if os.path.isfile( ddeLocation ):
-      os.system( ddeLocation )
+      cmd = ddeLocation
+      # In MacOS /usr/bin/env does not find python in the $PATH, passing binary path
+      # as an argument to the dirac-deploy-scripts
+      if not cliParams.platform:
+        cliParams.platform = getPlatform()
+      if "Darwin" in cliParams.platform:
+        binaryPath = os.path.join( cliParams.targetPath, cliParams.platform )
+        logNOTICE( "For MacOS (Darwin) use explicit binary path %s" % binaryPath )
+        cmd += ' %s' % binaryPath
+      os.system( cmd )
     else:
       logDEBUG( "No dirac-deploy-scripts found. This doesn't look good" )
   else:


### PR DESCRIPTION
1. It turns out that on recent MacOS ( Darwin version > 10.10 ), the behavior of "/usr/bin/env python" changed preventing finding the python interpreter in the $PATH. As a result the native python is picked up which is compiled differently, e.g. using UCS2 Unicode string treatment. The PR defines explicitely the python interpreter to be used in the DIRAC commands.
2. os.system() normally uses the environment from the calling shell. However DYLD_LIBRARY_PATH, for some obscure reason is not passed from the calling shell to the subshell of the os.system() command in Darwin > 10.10. In the PR DYLD_LIBRARY_PATH is set right in the os.system() command.

The changes should not affect non-MacOS environments.