### PR TITLE
[v617] executionLock optional argument to executeWithUserProxy()

### DIFF
--- a/Core/Utilities/Proxy.py
+++ b/Core/Utilities/Proxy.py
@@ -23,6 +23,7 @@ from DIRAC                                               import gConfig, gLogger
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient     import gProxyManager
 from DIRAC.ConfigurationSystem.Client.ConfigurationData  import gConfigurationData
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry   import getVOMSAttributeForGroup, getDNForUsername
+from DIRAC.Core.Utilities.LockRing                       import LockRing
 
 __RCSID__ = "$Id$"
 
@@ -41,6 +42,8 @@ def executeWithUserProxy( fcn ):
   :param str proxyUserDN: the user DN of the proxy to be used
   :param str proxyWithVOMS: optional flag to dress or not the user proxy with VOMS extension ( default True )
   :param str proxyFilePath: optional file location for the temporary proxy
+  :param str or object executionLock: optional lock object for execution of the original function;
+                                      if string, then named LockRing lock will be created
   """
 
   def wrapped_fcn( *args, **kwargs ):
@@ -51,6 +54,8 @@ def executeWithUserProxy( fcn ):
     vomsFlag = kwargs.pop( 'proxyWithVOMS', True )
     proxyFilePath = kwargs.pop( 'proxyFilePath', False )
     executionLock = kwargs.pop( 'executionLock', False )
+    if isinstance( executionLock, basestring ):
+      executionLock = LockRing().getLock( executionLock )
 
     if ( userName or userDN ) and userGroup:
 

--- a/Core/Utilities/Proxy.py
+++ b/Core/Utilities/Proxy.py
@@ -50,6 +50,7 @@ def executeWithUserProxy( fcn ):
     userGroup = kwargs.pop( 'proxyUserGroup', '' )
     vomsFlag = kwargs.pop( 'proxyWithVOMS', True )
     proxyFilePath = kwargs.pop( 'proxyFilePath', False )
+    executionLock = kwargs.pop( 'executionLock', False )
 
     if ( userName or userDN ) and userGroup:
 
@@ -70,6 +71,9 @@ def executeWithUserProxy( fcn ):
 
       if not result['OK']:
         return result
+
+      if executionLock:
+          executionLock.acquire()
 
       proxyFile = result['Value']
       os.environ['X509_USER_PROXY'] = proxyFile
@@ -93,6 +97,8 @@ def executeWithUserProxy( fcn ):
           os.environ['X509_USER_PROXY'] = originalUserProxy
         else:
           os.environ.pop( 'X509_USER_PROXY' )
+        if executionLock:
+          executionLock.release()
 
     else:
       # No proxy substitution requested

--- a/Core/Utilities/Proxy.py
+++ b/Core/Utilities/Proxy.py
@@ -56,7 +56,7 @@ def executeWithUserProxy( fcn ):
     proxyFilePath = kwargs.pop( 'proxyFilePath', False )
     executionLock = kwargs.pop( 'executionLock', False )
     if isinstance( executionLock, basestring ):
-      executionLock = LockRing().getLock( executionLock )
+      executionLock = LockRing().getLock( executionLock, recursive = True )
 
     if ( userName or userDN ) and userGroup:
 

--- a/Core/Utilities/Proxy.py
+++ b/Core/Utilities/Proxy.py
@@ -79,7 +79,7 @@ def executeWithUserProxy( fcn ):
         return result
 
       if executionLock:
-          executionLock.acquire()
+        executionLock.acquire()
 
       proxyFile = result['Value']
       os.environ['X509_USER_PROXY'] = proxyFile

--- a/Core/Utilities/Proxy.py
+++ b/Core/Utilities/Proxy.py
@@ -42,8 +42,9 @@ def executeWithUserProxy( fcn ):
   :param str proxyUserDN: the user DN of the proxy to be used
   :param str proxyWithVOMS: optional flag to dress or not the user proxy with VOMS extension ( default True )
   :param str proxyFilePath: optional file location for the temporary proxy
-  :param str or object executionLock: optional lock object for execution of the original function;
-                                      if string, then named LockRing lock will be created
+  :param executionLock: optional lock object for execution of the original function;
+                        if string, then a named LockRing lock object will be created
+  :type executionLock: str or object
   """
 
   def wrapped_fcn( *args, **kwargs ):


### PR DESCRIPTION
This change allows to pass a lock object to a function call decorated with @executeWithUserProxy. The actual function will be executed with this lock. E.g.:

    res = getFilesToStage( inputData, proxyUserName = userName, proxyUserGroup = userGroup, executionLock = lockObject  )

Or just pass it as a string, then no lock object should be created beforehand:

    res = getFilesToStage( inputData, proxyUserName = userName, proxyUserGroup = userGroup, executionLock = 'ThisParticularLock'  )