### PR TITLE
[v6r17] Minor change in gLogger and mesh processing

### DIFF
--- a/FrameworkSystem/private/logging/Logger.py
+++ b/FrameworkSystem/private/logging/Logger.py
@@ -174,6 +174,7 @@ class Logger( object ):
       return self._sendMessage( self._logLevels.debug,
                                 sMsg,
                                 sVarMsg )
+    return False
 
   def warn( self, sMsg, sVarMsg = '' ):
     return self._sendMessage( self._logLevels.warn,
@@ -194,6 +195,7 @@ class Logger( object ):
       return self._sendMessage( self._logLevels.exception,
                                 sMsg,
                                 sVarMsg )
+    return False
 
   def fatal( self, sMsg, sVarMsg = '' ):
     return self._sendMessage( self._logLevels.fatal,
@@ -211,15 +213,16 @@ class Logger( object ):
                                msgText,
                                variableText,
                                self.__discoverCallingFrame() )
-      self.processMessage( messageObject )
-    return True
+      return self.processMessage( messageObject )
+    return False
 
   def processMessage( self, messageObject ):
     if self.__testLevel( messageObject.getLevel() ):
       if not messageObject.getName():
         messageObject.setName( self._systemName )
       self._processMessage( messageObject )
-    return True
+      return True
+    return False
 
   def __testLevel( self, sLevel ):
     return abs( self._logLevels.getLevelValue( sLevel ) ) >= self._minLevel

--- a/TransformationSystem/Client/TaskManagerPlugin.py
+++ b/TransformationSystem/Client/TaskManagerPlugin.py
@@ -120,8 +120,9 @@ class TaskManagerPlugin( PluginBase ):
       # Add all sites with storage, such that jobs can run wherever data is
       autoAddedSites.remove( 'WithStorage' )
       autoAddedSites |= set( DMSHelpers().getTiers( withStorage = True, tier = ( 0, 1, 2 ) ) )
-    excludedSites |= autoAddedSites
-    gLogger.debug( "Full list of excluded sites for %s task: %s" % ( jobType, ','.join( excludedSites ) ) )
+    # If there are explicitly excluded sites, they should not be autoadded
+    autoAddedSites -= excludedSites
+    gLogger.debug( "Auto-added sites for %s task: %s" % ( jobType, ','.join( autoAddedSites ) ) )
 
     # 3. removing sites in Exclude
     if not excludedSites:

--- a/TransformationSystem/Client/TaskManagerPlugin.py
+++ b/TransformationSystem/Client/TaskManagerPlugin.py
@@ -115,14 +115,11 @@ class TaskManagerPlugin( PluginBase ):
       raise RuntimeError( "No jobType specified" )
     excludedSites = set( self.opsH.getValue( 'JobTypeMapping/%s/Exclude' % jobType, [] ) )
     gLogger.debug( "Explicitly excluded sites for %s task: %s" % ( jobType, ','.join( excludedSites ) ) )
-    autoAddedSites = set( self.opsH.getValue( 'JobTypeMapping/AutoAddedSites', [] ) )
+    autoAddedSites = self.opsH.getValue( 'JobTypeMapping/AutoAddedSites', [] )
     if 'WithStorage' in autoAddedSites:
       # Add all sites with storage, such that jobs can run wherever data is
       autoAddedSites.remove( 'WithStorage' )
-      autoAddedSites |= set( DMSHelpers().getTiers( withStorage = True, tier = ( 0, 1, 2 ) ) )
-    # If there are explicitly excluded sites, they should not be autoadded
-    autoAddedSites -= excludedSites
-    gLogger.debug( "Auto-added sites for %s task: %s" % ( jobType, ','.join( autoAddedSites ) ) )
+      autoAddedSites += DMSHelpers().getTiers( withStorage = True, tier = ( 0, 1, 2 ) )
 
     # 3. removing sites in Exclude
     if not excludedSites:
@@ -140,6 +137,8 @@ class TaskManagerPlugin( PluginBase ):
     else:
       allowed = dict( ( site, set( fromChar( fromSites ) ) ) for site, fromSites in res['Value'].iteritems() )
 
+    autoAddedSites = set( self.opsH.getValue( 'JobTypeMapping/%s/AutoAddedSites' % jobType, autoAddedSites ) )
+    gLogger.debug( "Auto-added sites for %s task: %s" % ( jobType, ','.join( autoAddedSites ) ) )
     # 5. add autoAddedSites, if requested
     for autoAddedSite in autoAddedSites:
       allowed.setdefault( autoAddedSite, set() ).add( autoAddedSite )

--- a/TransformationSystem/Client/test/Test_Client_TaskManagerPlugin.py
+++ b/TransformationSystem/Client/test/Test_Client_TaskManagerPlugin.py
@@ -7,15 +7,17 @@ import unittest
 import importlib
 from mock import MagicMock
 
-from DIRAC import S_OK
+from DIRAC import S_OK, gLogger
 from DIRAC.TransformationSystem.Client.TaskManagerPlugin      import TaskManagerPlugin
 
 class opsHelperFakeUser( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ['CERN', 'IN2P3']
-    # The only option requested that is not /AutoAddedSites is /JobTypeMapping/<type>/Exclude
-    # Therefore this returned value is for the Exclded sites
+    # This is for 'JobTypeMapping/<jobType>/AutoAddedSites
+    elif foo.endswith( 'AutoAddedSites' ):
+      return bar
+    # and this is for 'JobTypeMapping/<jobType>/Exclude
     return ['PAK', 'Ferrara', 'Bologna', 'Paris', 'Hospital']
   def getOptionsDict( self, foo = '' ):
     # The only call to this method is for /JobTypeMapping/<type>/Allow
@@ -25,6 +27,10 @@ class opsHelperFakeUser2( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ''
+    # This is for 'JobTypeMapping/<jobType>/AutoAddedSites
+    elif foo.endswith( 'AutoAddedSites' ):
+      return bar
+    # and this is for 'JobTypeMapping/<jobType>/Exclude
     return ['PAK', 'Ferrara', 'Bologna', 'Paris', 'CERN', 'IN2P3', 'Hospital']
   def getOptionsDict( self, foo = '' ):
     return {'OK': True, 'Value': {'Paris': 'IN2P3', 'CERN': 'CERN', 'IN2P3':'IN2P3'}}
@@ -33,6 +39,10 @@ class opsHelperFakeDataReco( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ['CERN', 'IN2P3']
+    # This is for 'JobTypeMapping/<jobType>/AutoAddedSites
+    elif foo.endswith( 'AutoAddedSites' ):
+      return bar
+    # and this is for 'JobTypeMapping/<jobType>/Exclude
     return ['PAK', 'Ferrara', 'CERN', 'IN2P3', 'Hospital']
   def getOptionsDict( self, foo = '' ):
     return {'OK': True, 'Value': {'Ferrara': 'CERN', 'IN2P3': 'IN2P3, CERN'}}
@@ -41,7 +51,11 @@ class opsHelperFakeHospital( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ['CERN', 'IN2P3']
-    return ['ALL', 'CERN', 'IN2P3']
+    # This is for 'JobTypeMapping/<jobType>/AutoAddedSites
+    elif foo.endswith( 'AutoAddedSites' ):
+      return []
+    # and this is for 'JobTypeMapping/<jobType>/Exclude
+    return ['ALL']
   def getOptionsDict( self, foo = '' ):
     return {'OK': True, 'Value': {'Hospital': 'CERN, IN2P3'}}
 
@@ -49,6 +63,10 @@ class opsHelperFakeMerge( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ['CERN', 'IN2P3', 'Hospital']
+    # This is for 'JobTypeMapping/<jobType>/AutoAddedSites
+    elif foo.endswith( 'AutoAddedSites' ):
+      return bar
+    # and this is for 'JobTypeMapping/<jobType>/Exclude
     return ['ALL']
   def getOptionsDict( self, foo = '' ):
     return {'OK': False, 'Message': 'JobTypeMapping/MCSimulation/Allow in Operations does not exist'}
@@ -57,6 +75,10 @@ class opsHelperFakeMerge2( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ''
+    # This is for 'JobTypeMapping/<jobType>/AutoAddedSites
+    elif foo.endswith( 'AutoAddedSites' ):
+      return bar
+    # and this is for 'JobTypeMapping/<jobType>/Exclude
     return ['ALL']
   def getOptionsDict( self, foo = '' ):
     return {'OK': True, 'Value': {'CERN': 'CERN', 'IN2P3': 'IN2P3'}}
@@ -65,6 +87,10 @@ class opsHelperFakeMC( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ['CERN', 'IN2P3']
+    # This is for 'JobTypeMapping/<jobType>/AutoAddedSites
+    elif foo.endswith( 'AutoAddedSites' ):
+      return bar
+    # and this is for 'JobTypeMapping/<jobType>/Exclude
     return ['']
   def getOptionsDict( self, foo = '' ):
     return {'OK': False, 'Message': 'JobTypeMapping/MCSimulation/Allow in Operations does not exist'}
@@ -90,7 +116,6 @@ class ClientsTestCase( unittest.TestCase ):
   """
   def setUp( self ):
 
-    from DIRAC import gLogger
     gLogger.setLevel( 'DEBUG' )
 
     self.mockTransClient = MagicMock()
@@ -201,7 +226,7 @@ class TaskManagerPluginSuccess( ClientsTestCase ):
 
     p_o.params = {'Site':'', 'TargetSE':'CERN-DST', 'JobType':'DataReconstruction'}
     res = p_o.run()
-    self.assertEqual( res, set( ['Bologna', 'Ferrara', 'Paris', 'CSCS', 'IN2P3'] ) )
+    self.assertEqual( res, set( ['Bologna', 'Ferrara', 'Paris', 'CSCS', 'IN2P3', 'CERN'] ) )
 
     p_o.params = {'Site':'', 'TargetSE':'IN2P3-DST', 'JobType':'DataReconstruction'}
     res = p_o.run()

--- a/TransformationSystem/Client/test/Test_Client_TaskManagerPlugin.py
+++ b/TransformationSystem/Client/test/Test_Client_TaskManagerPlugin.py
@@ -1,7 +1,7 @@
 """ unit tests for Transformation Clients
 """
 
-#pylint: disable=missing-docstring,blacklisted-name,invalid-name
+# pylint: disable=missing-docstring,blacklisted-name,invalid-name
 
 import unittest
 import importlib
@@ -14,15 +14,18 @@ class opsHelperFakeUser( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ['CERN', 'IN2P3']
-    return ['PAK', 'Ferrara', 'Bologna', 'Paris']
+    # The only option requested that is not /AutoAddedSites is /JobTypeMapping/<type>/Exclude
+    # Therefore this returned value is for the Exclded sites
+    return ['PAK', 'Ferrara', 'Bologna', 'Paris', 'Hospital']
   def getOptionsDict( self, foo = '' ):
+    # The only call to this method is for /JobTypeMapping/<type>/Allow
     return {'OK': True, 'Value': {'Paris': 'IN2P3'}}
 
 class opsHelperFakeUser2( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ''
-    return ['PAK', 'Ferrara', 'Bologna', 'Paris', 'CERN', 'IN2P3']
+    return ['PAK', 'Ferrara', 'Bologna', 'Paris', 'CERN', 'IN2P3', 'Hospital']
   def getOptionsDict( self, foo = '' ):
     return {'OK': True, 'Value': {'Paris': 'IN2P3', 'CERN': 'CERN', 'IN2P3':'IN2P3'}}
 
@@ -30,14 +33,22 @@ class opsHelperFakeDataReco( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
       return ['CERN', 'IN2P3']
-    return ['PAK', 'Ferrara', 'CERN', 'IN2P3']
-  def getOptionsDict(self, foo = ''):
+    return ['PAK', 'Ferrara', 'CERN', 'IN2P3', 'Hospital']
+  def getOptionsDict( self, foo = '' ):
     return {'OK': True, 'Value': {'Ferrara': 'CERN', 'IN2P3': 'IN2P3, CERN'}}
+
+class opsHelperFakeHospital( object ):
+  def getValue( self, foo = '', bar = '' ):
+    if foo == 'JobTypeMapping/AutoAddedSites':
+      return ['CERN', 'IN2P3']
+    return ['ALL', 'CERN', 'IN2P3']
+  def getOptionsDict( self, foo = '' ):
+    return {'OK': True, 'Value': {'Hospital': 'CERN, IN2P3'}}
 
 class opsHelperFakeMerge( object ):
   def getValue( self, foo = '', bar = '' ):
     if foo == 'JobTypeMapping/AutoAddedSites':
-      return ['CERN', 'IN2P3']
+      return ['CERN', 'IN2P3', 'Hospital']
     return ['ALL']
   def getOptionsDict( self, foo = '' ):
     return {'OK': False, 'Message': 'JobTypeMapping/MCSimulation/Allow in Operations does not exist'}
@@ -60,7 +71,7 @@ class opsHelperFakeMC( object ):
 
 
 def getSitesFake():
-  return S_OK( ['Ferrara', 'Bologna', 'Paris', 'CSCS', 'PAK', 'CERN', 'IN2P3'] )
+  return S_OK( ['Ferrara', 'Bologna', 'Paris', 'CSCS', 'PAK', 'CERN', 'IN2P3', 'Hospital'] )
 
 def getSitesForSE( ses ):
   if ses == ['CERN-DST'] or ses == 'CERN-DST':
@@ -108,7 +119,7 @@ class ClientsTestCase( unittest.TestCase ):
 
 #############################################################################
 
-class TaskManagerPluginSuccess(ClientsTestCase):
+class TaskManagerPluginSuccess( ClientsTestCase ):
 
   def test__BySE( self ):
 
@@ -160,15 +171,15 @@ class TaskManagerPluginSuccess(ClientsTestCase):
 
     p_o.params = {'Site':'', 'TargetSE':'CERN-DST', 'JobType':'User'}
     res = p_o.run()
-    self.assertEqual( res, set( ['CERN', 'CSCS'] ) )
+    self.assertEqual( res, set( ['CERN', 'CSCS', 'IN2P3'] ) )
 
     p_o.params = {'Site':'', 'TargetSE':'IN2P3-DST', 'JobType':'User'}
     res = p_o.run()
-    self.assertEqual( res, set( ['IN2P3', 'Paris', 'CSCS'] ) )
+    self.assertEqual( res, set( ['IN2P3', 'Paris', 'CSCS', 'CERN'] ) )
 
     p_o.params = {'Site':'', 'TargetSE':['CERN-DST', 'CSCS-DST'], 'JobType':'User'}
     res = p_o.run()
-    self.assertEqual( res, set( ['CERN', 'CSCS'] ) )
+    self.assertEqual( res, set( ['CERN', 'CSCS', 'IN2P3'] ) )
 
     # "User" case - 2
     p_o = TaskManagerPlugin( 'ByJobType', operationsHelper = opsHelperFakeUser2() )
@@ -190,11 +201,22 @@ class TaskManagerPluginSuccess(ClientsTestCase):
 
     p_o.params = {'Site':'', 'TargetSE':'CERN-DST', 'JobType':'DataReconstruction'}
     res = p_o.run()
-    self.assertEqual( res, set( ['Bologna', 'Ferrara', 'Paris', 'CSCS', 'CERN', 'IN2P3'] ) )
+    self.assertEqual( res, set( ['Bologna', 'Ferrara', 'Paris', 'CSCS', 'IN2P3'] ) )
 
     p_o.params = {'Site':'', 'TargetSE':'IN2P3-DST', 'JobType':'DataReconstruction'}
     res = p_o.run()
     self.assertEqual( res, set( ['Bologna', 'Paris', 'CSCS', 'IN2P3'] ) )
+
+    # "Hospital" case: all sites go to hospital only
+    p_o = TaskManagerPlugin( 'ByJobType', operationsHelper = opsHelperFakeHospital() )
+
+    p_o.params = {'Site':'', 'TargetSE':'CERN-DST', 'JobType':'DataReconstruction'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['Hospital'] ) )
+
+    p_o.params = {'Site':'', 'TargetSE':'IN2P3-DST', 'JobType':'DataReconstruction'}
+    res = p_o.run()
+    self.assertEqual( res, set( ['Hospital'] ) )
 
 
     # "Merge" case - 1
@@ -224,11 +246,11 @@ class TaskManagerPluginSuccess(ClientsTestCase):
 
     p_o.params = {'Site':'', 'TargetSE':'', 'JobType':'MC'}
     res = p_o.run()
-    self.assertEqual( res, set( ['CERN', 'IN2P3', 'Bologna', 'Ferrara', 'Paris', 'CSCS', 'PAK'] ) )
+    self.assertEqual( res, set( ['CERN', 'IN2P3', 'Bologna', 'Ferrara', 'Paris', 'CSCS', 'PAK', 'Hospital'] ) )
 
     p_o.params = {'Site':'', 'TargetSE':'', 'JobType':'MC'}
     res = p_o.run()
-    self.assertEqual( res, set( ['CERN', 'IN2P3', 'Bologna', 'Ferrara', 'Paris', 'CSCS', 'PAK'] ) )
+    self.assertEqual( res, set( ['CERN', 'IN2P3', 'Bologna', 'Ferrara', 'Paris', 'CSCS', 'PAK', 'Hospital'] ) )
 
 
 #############################################################################

--- a/docs/source/AdministratorGuide/Systems/Transformation/index.rst
+++ b/docs/source/AdministratorGuide/Systems/Transformation/index.rst
@@ -220,8 +220,11 @@ TransformationAgent plugins
 TaskManager plugins
 -------------------
 
-By default the standard plugin (BySE) sets job's destination depending on the location of its input data. Starting from v6r13 a new **ByJobType**
-TaskManager plugin has been introduced, so that different rules for site destinations can be specified for each JobType.
+By default the standard plugin (BySE) sets job's destination depending on the location of its input data. 
+
+Starting from v6r13 a new **ByJobType**
+TaskManager plugin has been introduced, so that different rules for site destinations can be specified for each JobType. This plugin allows so-called "mesh processing",
+i.e. depending on the job type, some sites may become eligible for "helping" other sites to run jobs that normally would only be running at the site where data is located.
 In order to use the ByJobType plugin, one has to:
 
 * Set CS section Operations/Transformations/DestinationPlugin = ByJobType
@@ -254,6 +257,15 @@ In order to use the ByJobType plugin, one has to:
           AutoAddedSites += LCG.RAL.uk
           AutoAddedSites += LCG.SARA.nl
           AutoAddedSites += LCG.RRCKI.ru
+          DataReconstruction
+          {
+            Exclude = ALL
+            Exclude += LCG.CERN.cern
+            Allow
+            {
+              CLOUD.CERN.cern = LCG.CERN.cern
+            }
+          }
           DataReprocessing
           {
             Exclude = ALL
@@ -282,16 +294,21 @@ In order to use the ByJobType plugin, one has to:
 
 
   * By default, all sites are allowed to do every job
-  * "AutoAddedSites" contains the list of sites allowed to run jobs with files in their local SEs
+  * "AutoAddedSites" contains the list of sites allowed to run jobs with files in their local SEs.
+  If it contains 'WithStorage', all sites with an associated local storage will be added automatically.
   * Sections under "JobTypeMapping" correspond to the different JobTypes one may want to define, *e.g.*: DataReprocessing, Merge, etc.
   * For each JobType one has to define:
 
-    * "Exclude": the list of sites that will be removed as destination sites ("ALL" for all sites)
-    * "Allow": the list of 'helpers', specifying sites helping another site
+    * "Exclude": the list of sites that will be removed as destination sites ("ALL" for all sites). 
+    If a site is explicitly excluded, it is removed from the AutoAddedSites. This is an easy way to disallow jobs to run at the site
+    holding their input data.
+    * "Allow": the list of 'helpers', specifying sites helping another site.
+    For each "helper" one specifies a list of sites that it helps, i.e. if the input data is at one of these sites, the job is eligible to the helper site.
 
   * In the example above all sites in "AutoAddedSites" are allowed to run jobs with input files in their local SEs.
-  These sites won't be excluded, even if set in the Exclude list.
+  These sites won't be excluded, unless they are set in the Exclude list.
   For DataReprocessing jobs, jobs having input files at LCG.SARA.nl local SEs can run both at LCG.SARA.nl and at LCG.NIKHEF.nl, etc.
+  For DataReconstruction jobs, jobs will run at the Tier1 where the input data is, except when the data is at CERN, where they will run exclusively at CLOUD.CERN.cern.
 
 ---------
 Use-cases

--- a/docs/source/AdministratorGuide/Systems/Transformation/index.rst
+++ b/docs/source/AdministratorGuide/Systems/Transformation/index.rst
@@ -249,7 +249,7 @@ In order to use the ByJobType plugin, one has to:
 
         JobTypeMapping
         {
-          AutoAddedSites = LCG.CERN.ch
+          AutoAddedSites = LCG.CERN.cern
           AutoAddedSites += LCG.IN2P3.fr
           AutoAddedSites += LCG.CNAF.it
           AutoAddedSites += LCG.PIC.es
@@ -260,10 +260,15 @@ In order to use the ByJobType plugin, one has to:
           DataReconstruction
           {
             Exclude = ALL
-            Exclude += LCG.CERN.cern
+            AutoAddedSites = LCG.IN2P3.fr
+            AutoAddedSites += LCG.CNAF.it
+            AutoAddedSites += LCG.PIC.es
+            AutoAddedSites += LCG.GRIDKA.de
+            AutoAddedSites += LCG.RAL.uk
+            AutoAddedSites += LCG.RRCKI.ru
             Allow
             {
-              CLOUD.CERN.cern = LCG.CERN.cern
+              CLOUD.CERN.cern = LCG.CERN.cern, LCG.SARA.nl
             }
           }
           DataReprocessing
@@ -275,10 +280,10 @@ In order to use the ByJobType plugin, one has to:
               LCG.UKI-LT2-QMUL.uk = LCG.RAL.uk
               LCG.CPPM.fr = LCG.SARA.nl
               LCG.USC.es = LCG.PIC.es
-              LCG.LAL.fr = LCG.CERN.ch
+              LCG.LAL.fr = LCG.CERN.cern
               LCG.LAL.fr += LCG.IN2P3.fr
               LCG.BariRECAS.it = LCG.CNAF.it
-              LCG.CBPF.br = LCG.CERN.ch
+              LCG.CBPF.br = LCG.CERN.cern
               VAC.Manchester.uk = LCG.RAL.uk
             }
           }
@@ -300,15 +305,13 @@ In order to use the ByJobType plugin, one has to:
   * For each JobType one has to define:
 
     * "Exclude": the list of sites that will be removed as destination sites ("ALL" for all sites). 
-    If a site is explicitly excluded, it is removed from the AutoAddedSites. This is an easy way to disallow jobs to run at the site
-    holding their input data.
+    * Optionally one may redefine the "AutoAddedSites" (including setting it empty)
     * "Allow": the list of 'helpers', specifying sites helping another site.
     For each "helper" one specifies a list of sites that it helps, i.e. if the input data is at one of these sites, the job is eligible to the helper site.
 
   * In the example above all sites in "AutoAddedSites" are allowed to run jobs with input files in their local SEs.
-  These sites won't be excluded, unless they are set in the Exclude list.
   For DataReprocessing jobs, jobs having input files at LCG.SARA.nl local SEs can run both at LCG.SARA.nl and at LCG.NIKHEF.nl, etc.
-  For DataReconstruction jobs, jobs will run at the Tier1 where the input data is, except when the data is at CERN, where they will run exclusively at CLOUD.CERN.cern.
+  For DataReconstruction jobs, jobs will run at the Tier1 where the input data is, except when the data is at CERN or SARA, where they will run exclusively at CLOUD.CERN.cern.
 
 ---------
 Use-cases


### PR DESCRIPTION
* In gLogger.<into|warn|...>: return True if the message was printed, False if not
Useful to make differentiate printout according to print level
* In mesh processing, allow to redefine the AutoAddedSites for each type (in particular set it empty)