### PR TITLE
[v6r17] Corrected setting of pilot environment

### DIFF
--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -249,7 +249,7 @@ class InstallDIRAC( CommandBase ):
     if retCode:
       self.log.error( "Could not parse the bashrc file [ERROR %d]" % retCode )
       self.exitWithError( retCode )
-    for line in output:
+    for line in output.split('\n'):
       try:
         var = line.split( '=' )[0].strip()
         value = line.split( '=' )[1].strip()


### PR DESCRIPTION
That was not using the bashrc from dirac-install. This is probably the cause of the failure in using GFAL2 up to now.