### PR TITLE
[v6r17] Fix TS

### DIFF
--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -157,7 +157,12 @@ class DMSHelpers( object ):
         siteSEMapping[DOWNLOAD].setdefault( site, set() ).update( ses )
 
     self.siteSEMapping = siteSEMapping
-    self.storageElementSet = storageElementSet
+    # Add storage elements that may not be associated with a site
+    result = gConfig.getSections( '/Resources/StorageElements' )
+    if not result['OK']:
+      gLogger.warn( 'Problem retrieving /Resources/StorageElements section', result['Message'] )
+      return result
+    self.storageElementSet = storageElementSet | set( result['Value'] )
     self.siteSet = siteSet
     return S_OK( siteSEMapping )
 

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -449,7 +449,7 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
     cachedReplicaSets = self.replicaCache.get( transID, {} )
     cachedReplicas = {}
     # Merge all sets of replicas
-    for replicas in cachedReplicaSets.values():
+    for replicas in cachedReplicaSets.itervalues():
       cachedReplicas.update( replicas )
     self._logInfo( "Number of cached replicas: %d" % len( cachedReplicas ), method = method, transID = transID )
     setCached = set( cachedReplicas )
@@ -560,7 +560,7 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
     """ Remove cached replicas that are not in a list
     """
     cachedReplicas = set()
-    for replicas in self.replicaCache.get( transID, {} ).values():
+    for replicas in self.replicaCache.get( transID, {} ).itervalues():
       cachedReplicas.update( replicas )
     toRemove = cachedReplicas - set( lfns )
     if toRemove:
@@ -630,7 +630,7 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
 
   def __filesInCache( self, transID ):
     cache = self.replicaCache.get( transID, {} )
-    return sum( len( lfns ) for lfns in cache.values() )
+    return sum( len( lfns ) for lfns in cache.itervalues() )
 
   @gSynchro
   def __writeCache( self, transID = None ):

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -247,9 +247,10 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
     plugin = transDict.get( 'Plugin', 'Standard' )
     # Limit the number of LFNs to be considered for replication or removal as they are treated individually
     if not forJobs:
+      maxFiles = operations.getValue( 'TransformationPlugins/%s/MaxFilesToProcess' % plugin, 0 )
       # Get plugin-specific limit in number of files (0 means no limit)
       totLfns = len( unusedLfns )
-      lfnsToProcess = self.__applyReduction( unusedLfns )
+      lfnsToProcess = self.__applyReduction( unusedLfns, maxFiles = maxFiles )
       if len( lfnsToProcess ) != totLfns:
         self._logInfo( "Reduced number of files from %d to %d" % ( totLfns, len( lfnsToProcess ) ),
                        method = method, transID = transID )
@@ -410,12 +411,14 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
         self.__removeFilesFromCache( transID, notUnused )
     return S_OK( transFiles )
 
-  def __applyReduction( self, lfns ):
+  def __applyReduction( self, lfns, maxFiles = None ):
     """ eventually remove the number of files to be considered
     """
-    if len( lfns ) <= self.maxFiles:
+    if maxFiles is None:
+      maxFiles = self.maxFiles
+    if not maxFiles or len( lfns ) <= maxFiles:
       return lfns
-    return randomize( lfns )[:self.maxFiles]
+    return randomize( lfns )[:maxFiles]
 
   def __getDataReplicas( self, transDict, lfns, clients, forJobs = True ):
     """ Get the replicas for the LFNs and check their statuses. It first looks within the cache.

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -248,9 +248,8 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
     # Limit the number of LFNs to be considered for replication or removal as they are treated individually
     if not forJobs:
       # Get plugin-specific limit in number of files (0 means no limit)
-      maxFiles = Operations().getValue( '/TransformationPlugins/%s/MaxFilesToProcess' % plugin, self.maxFiles )
       totLfns = len( unusedLfns )
-      lfnsToProcess = self.__applyReduction( unusedLfns, maxFiles = maxFiles )
+      lfnsToProcess = self.__applyReduction( unusedLfns )
       if len( lfnsToProcess ) != totLfns:
         self._logInfo( "Reduced number of files from %d to %d" % ( totLfns, len( lfnsToProcess ) ),
                        method = method, transID = transID )
@@ -336,7 +335,7 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
     # Check if files should be sorted and limited in number
     operations = Operations()
     sortedBy = operations.getValue( 'TransformationPlugins/%s/SortedBy' % plugin, None )
-    maxFiles = operations.getValue( 'TransformationPlugins/%s/MaxFiles' % plugin, 0 )
+    maxFiles = operations.getValue( 'TransformationPlugins/%s/MaxFilesToProcess' % plugin, 0 )
     noUnusedDelay = 0 if self.pluginTimeout.get( transID, False ) else operations.getValue( 'TransformationPlugins/%s/NoUnusedDelay' % plugin,
                                                                                             self.noUnusedDelay )
     method = '_getTransformationFiles'
@@ -407,14 +406,12 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
         self.__removeFilesFromCache( transID, notUnused )
     return S_OK( transFiles )
 
-  def __applyReduction( self, lfns, maxFiles = None ):
+  def __applyReduction( self, lfns ):
     """ eventually remove the number of files to be considered
     """
-    if maxFiles is None:
-      maxFiles = self.maxFiles
-    if not maxFiles or len( lfns ) <= maxFiles:
+    if len( lfns ) <= self.maxFiles:
       return lfns
-    return randomize( lfns )[:maxFiles]
+    return randomize( lfns )[:self.maxFiles]
 
   def __getDataReplicas( self, transDict, lfns, clients, forJobs = True ):
     """ Get the replicas for the LFNs and check their statuses. It first looks within the cache.

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -247,7 +247,7 @@ class TransformationAgent( AgentModule, TransformationAgentsUtilities ):
     plugin = transDict.get( 'Plugin', 'Standard' )
     # Limit the number of LFNs to be considered for replication or removal as they are treated individually
     if not forJobs:
-      maxFiles = operations.getValue( 'TransformationPlugins/%s/MaxFilesToProcess' % plugin, 0 )
+      maxFiles = Operations().getValue( 'TransformationPlugins/%s/MaxFilesToProcess' % plugin, 0 )
       # Get plugin-specific limit in number of files (0 means no limit)
       totLfns = len( unusedLfns )
       lfnsToProcess = self.__applyReduction( unusedLfns, maxFiles = maxFiles )

--- a/TransformationSystem/Client/Utilities.py
+++ b/TransformationSystem/Client/Utilities.py
@@ -173,7 +173,8 @@ class PluginUtilities( object ):
     if not self.groupSize:
       self.groupSize = float( self.getPluginParam( 'GroupSize', 1. ) ) * 1000 * 1000 * 1000  # input size in GB converted to bytes
     if not self.maxFiles:
-      self.maxFiles = self.getPluginParam( 'MaxFiles', 100 )
+      # FIXME: prepare for chaging the name of the ambiguoug  CS option
+      self.maxFiles = self.getPluginParam( 'MaxFilesPerTask', self.getPluginParam( 'MaxFiles', 100 ) )
     lfns = sorted( lfns, key = fileSizes.get )
     for lfn in lfns:
       size = fileSizes.get( lfn, 0 )

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/Transformation/Agents/transformationagent.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/Transformation/Agents/transformationagent.rst
@@ -3,35 +3,44 @@ Systems / Transformation / <INSTANCE> / Agents / TransformationAgent - Sub-subse
 
 The TransformationAgent processes transformations found in the transformation database.
 
+Specific options defined in this sub-sections are:
+* TransformationTypes : list of transformation types handled by this specific agent
+* transformationStatus : list of statues considered by the agent
+* MaxFilesToProcess : maximum number of files passed to the plugin. This can be overwritten for individual plugins (see below)
+* ReplicaCacheValidity : validity of hte replica cache (in days)
+* maxThreadsInPool : maximum number of threads to be used
+* NoUnusedDelay : number of hours until the plugin is called again in case there is no new Unused files since last time
+
++------------------------------+------------------------------------------------------------+
+| **Name**                     | **Example**                                                |
++------------------------------+------------------------------------------------------------+
+| PluginLocation               | DIRAC.TransformationSystem.Agent.TransformationPlugin      |
++------------------------------+------------------------------------------------------------+
+| transformationStatus         | Active, Completing, Flush                                  |
++------------------------------+------------------------------------------------------------+
+| MaxFilesToProcess            | 5000                                                       |
++------------------------------+------------------------------------------------------------+
+| TransformationTypes          | Replication                                                |
++------------------------------+------------------------------------------------------------+
+| ReplicaCacheValidity         | 2                                                          |
++------------------------------+------------------------------------------------------------+
+| maxThreadsInPool             | 1                                                          |
++------------------------------+------------------------------------------------------------+
+| NoUnusedDelay                | 6                                                          |
++------------------------------+------------------------------------------------------------+
+| Transformation               | All                                                        |
++------------------------------+------------------------------------------------------------+
+  
 This Agent also reads some options from :ref:`operations_transformations`:
 
 * DataProcessing
 * DataManipulation
 
-And from :ref:`operations_transformationplugins` , depending on the Plugin used
+And from :ref:`operations_transformationplugins` , depending on the plugin used
 for the Transformation.
 
 * SortedBy
-* MaxFiles
-* NoUnusedDelay
+* MaxFilesToProcess: supersede the agent's setting
+* NoUnusedDelay: supersede the agent's setting
 
-+------------------------------+-------------------------------+------------------------------------------------------------+
-| **Name**                     | **Description**               | **Example**                                                |
-+------------------------------+-------------------------------+------------------------------------------------------------+
-| PluginLocation               |                               | DIRAC.TransformationSystem.Agent.TransformationPlugin      |
-+------------------------------+-------------------------------+------------------------------------------------------------+
-| transformationStatus         |                               | Active, Completing, Flush                                  |
-+------------------------------+-------------------------------+------------------------------------------------------------+
-| MaxFiles                     |                               | 5000                                                       |
-+------------------------------+-------------------------------+------------------------------------------------------------+
-| TransformationTypes          |                               |                                                            |
-+------------------------------+-------------------------------+------------------------------------------------------------+
-| ReplicaCacheValidity         |                               | 2                                                          |
-+------------------------------+-------------------------------+------------------------------------------------------------+
-| maxThreadsInPool             |                               | 1                                                          |
-+------------------------------+-------------------------------+------------------------------------------------------------+
-| NoUnusedDelay                |                               | 6                                                          |
-+------------------------------+-------------------------------+------------------------------------------------------------+
-| Transformation               |                               | All                                                        |
-+------------------------------+-------------------------------+------------------------------------------------------------+
   


### PR DESCRIPTION
* Prepare for changing the name of some CS parameters for TransformationAgent: MaxFiles is used for 2 things:
1. Maximum number of files to be considered by the TSAgent -> MaxFilesToProcess
Add possibility to define it for each plugin as well. Can still use old name MaxFiles if not set
2. Maximum number of files in a task -> MaxFilesPerTask
Only in Operations section TransformationPlugins. Can still use old name MaxFiles if not set

* In the case when the plugin adds files to the transformation (LHCb has a use case), only consider the initial files in the tasks for defining the number of Unused files.