### PR TITLE
[v6r17] Lower security log gzip memory usage

### DIFF
--- a/FrameworkSystem/private/SecurityFileLog.py
+++ b/FrameworkSystem/private/SecurityFileLog.py
@@ -74,11 +74,11 @@ class SecurityFileLog( threading.Thread ):
       gLogger.info( "Compressing file %s" % filePath )
       fd = gzip.open( "%s.gz" % filePath, "w" )
       fO = file( filePath )
-      bS = 1048576
-      buf = fO.read(2**31-1)
+      bS = 1048576 # 1MiB
+      buf = fO.read( bS )
       while buf:
         fd.write( buf )
-        buf = fO.read(2**31-1)
+        buf = fO.read( bS )
       fd.close()
       fO.close()
     except Exception as e:


### PR DESCRIPTION
Hi,

When the security logs are rotated, the buffer size used is ~2GiB... This seems excessive and on our installation causes the gzip to fail most of the time; any buffer larger than the compression block size should be just as good (>64KiB). This patch lowers the buffer size to 1MiB,

Regards,
Simon