### PR TITLE
[v6r17] Split CREAM proxy renewal into chunks for improved reliability

### DIFF
--- a/Resources/Computing/CREAMComputingElement.py
+++ b/Resources/Computing/CREAMComputingElement.py
@@ -249,15 +249,19 @@ class CREAMComputingElement( ComputingElement ):
             if delegationID not in delegationIDs:
               delegationIDs.append( delegationID )
         if delegationIDs:
-          cmd = ['glite-ce-proxy-renew', '-e', self.ceName ]
-          cmd.extend( delegationIDs )
-          self.log.info( 'Refreshing proxy for:', ' '.join( delegationIDs ) )
-          result = executeGridCommand( self.proxy, cmd, self.gridEnv )
-          if result['OK']:
-            status, output, error = result['Value']
-            if status:
-              self.log.error( "Failed to renew proxy delegation",
-                              'Output:\n' + output + '\nError:\n' + error )
+          # Renew proxies in batches to avoid timeouts
+          chunkSize = 10
+          for i in xrange(0, len( delegationIDs ), chunkSize):
+            chunk = delegationIDs[ i:i+chunkSize ]
+            cmd = ['glite-ce-proxy-renew', '-e', self.ceName ]
+            cmd.extend( chunk )
+            self.log.info( 'Refreshing proxy for:', ' '.join( chunk ) )
+            result = executeGridCommand( self.proxy, cmd, self.gridEnv )
+            if result['OK']:
+              status, output, error = result['Value']
+              if status:
+                self.log.error( "Failed to renew proxy delegation",
+                                'Output:\n' + output + '\nError:\n' + error )
 
     workingDirectory = self.ceParameters['WorkingDirectory']
     fd, idFileName = tempfile.mkstemp( suffix = '.ids', prefix = 'CREAM_', dir = workingDirectory )


### PR DESCRIPTION
Hi,

We found that when a large number of pilot jobs have been submitted to a single CREAM-CE (O(10k-40k)), the proxy renewal can start to fail silently. It appears the problem is caused by a timeout on the server if the list of proxies to be renewed is too long... It works through the list of delegation IDs in sequence and then just gives up part way through resulting in a large number of pilots getting killed. This patch splits the renewals into chunks to avoid the problem. We've picked 10 as a modest chunkSize and tested it extensively: The glite-ce-proxy-renew doesn't seem to have very much overhead, so relatively small chunks are still fairly efficient.

Regards,
Simon
