### PR TITLE
[v6r17] Improve pretty printing of tables

### DIFF
--- a/Core/Utilities/PrettyPrint.py
+++ b/Core/Utilities/PrettyPrint.py
@@ -79,8 +79,8 @@ def printTable( fields, records, sortField = '', numbering = True,
     if n != ( nFields - 1 ) or columnSeparator != ' ':
       field = field.ljust( l + separatorWidth )
     stringBuffer.write( field )
-    topLength += len( f )
-  stringBuffer.write( '\n' + ' ' * topLength + '\n' )
+    topLength += len( field )
+  stringBuffer.write( '\n' + '=' * topLength + '\n' )
 
   for count, r in enumerate( recordList ):
     total = ( count == len( recordList ) - 1 and recordList[-1][0] == "Total" )


### PR DESCRIPTION
The problem was that if a field is too long, all lines would be padded with the same length of blanks. Now the last field may wrap lines and no screw up the table.

Try for example 
dirac-admin-show-task-queues --task 22215364 -v

see pictures below