### PR TITLE
[v6r17] allow to run multiple DataStore

### DIFF
--- a/AccountingSystem/Service/DataStoreHandler.py
+++ b/AccountingSystem/Service/DataStoreHandler.py
@@ -150,7 +150,10 @@ class DataStoreHandler( RequestHandler ):
     """
     Compact the db by grouping buckets
     """
-    if self.runBucketing:
+    #if we are running slaves (not only one service) we can redirect the request to the master
+    #For more information please read the Administrative guide Accounting part!
+    #ADVICE: If you want to trigger the bucketing, please make sure the bucketing is not running!!!!
+    if self.runBucketing:  
       return self.__acDB.compactBuckets() #pylint: disable=no-member
     else:
       return RPCClient('Accounting/DataStoreMaster').compactDB()

--- a/docs/source/AdministratorGuide/Systems/Accounting/index.rst
+++ b/docs/source/AdministratorGuide/Systems/Accounting/index.rst
@@ -42,8 +42,7 @@ With the previous configuration all accounting data will be stored and retrieved
 
 DataStore Helpers
 ======================
-From DIRAC v8r17p14 we are able to run multiple services. The master will creates the proper buckets and the helpers only insert the records to the 'in' table.
-When you install the DataStore helper service you have to set RunBucketing parameter False.
+From DIRAC v6r17p14 there is the possibility to to run multiple 'DataStore' services, where one need to be called 'master', while all the others may be called slaves. The master will creates the proper buckets and the helpers only insert the records to the 'in' table.
 For example:
 install service Accounting DataStoreHelper -m DataStore -p RunBucketing=True -p Port=1966
 In the CS you have to define DataStoreMaster. For example::

--- a/docs/source/AdministratorGuide/Systems/Accounting/index.rst
+++ b/docs/source/AdministratorGuide/Systems/Accounting/index.rst
@@ -39,3 +39,22 @@ Since v6r12 each accounting type can be stored in a different DB. By default all
     }
     
 With the previous configuration all accounting data will be stored and retrieved from the usual database except for the _WMSHistory_ type that will be stored and retrieved from the _Acc2_ database.
+
+DataStore Helpers
+======================
+From DIRAC v8r17p14 we are able to run multiple services. The master will creates the proper buckets and the helpers only insert the records to the 'in' table.
+When you install the DataStore helper service you have to set RunBucketing parameter False.
+For example:
+install service Accounting DataStoreHelper -m DataStore -p RunBucketing=True -p Port=1966
+In the CS you have to define DataStoreMaster. For example::
+     
+	URLs
+	{
+        DataStore = dips://lbvobox105.cern.ch:9133/Accounting/DataStore
+        DataStore += dips://lbvobox105.cern.ch:9166/Accounting/DataStoreHelper
+        DataStore += dips://lbvobox102.cern.ch:9166/Accounting/DataStoreHelper
+        ReportGenerator = dips://lbvobox106.cern.ch:9134/Accounting/ReportGenerator
+        DataStoreHelper = dips://lbvobox105.cern.ch:9166/Accounting/DataStoreHelper
+        DataStoreHelper += dips://lbvobox102.cern.ch:9166/Accounting/DataStoreHelper
+        DataStoreMaster = dips://lbvobox105.cern.ch:9133/Accounting/DataStore
+       }


### PR DESCRIPTION
In case when one DataStore can not scope with the load, we can install multiple helper DataStore services. These services are only inserting the records to the appropriate table. The master service will do the bucketing.