### PR TITLE
[v6r17] printTable utility enhanced

### DIFF
--- a/Core/Utilities/PrettyPrint.py
+++ b/Core/Utilities/PrettyPrint.py
@@ -188,7 +188,7 @@ def printTable( fields, records, sortField = '', numbering = True,
     # If the field has a list type value, print out one value per line
     if listMode:
       stringBuffer.write( '\n' )
-      for ll in range( 1, listMode - 1 ):
+      for ll in range( 1, listMode ):
         # Do not number continuation lines
         if numbering:
           stringBuffer.write( " "*(numberWidth + separatorWidth) )

--- a/Core/Utilities/PrettyPrint.py
+++ b/Core/Utilities/PrettyPrint.py
@@ -154,7 +154,7 @@ def printTable( fields, records, sortField = '', numbering = True,
   stringBuffer.write( ' ' * ( topLength ) )
 
   for i in range(nFields):
-    stringBuffer.write( fieldList[i].ljust(fieldWidths[i] + separatorWidth ) )
+    stringBuffer.write( fieldList[i].ljust( fieldWidths[i] + separatorWidth ) )
   stringBuffer.write( '\n' )
   stringBuffer.write( '='*totalLength + '\n' )
 

--- a/Core/Utilities/PrettyPrint.py
+++ b/Core/Utilities/PrettyPrint.py
@@ -18,19 +18,19 @@ def int_with_commas( inputValue ):
   """
   s = str( inputValue )
   news = ''
-  while len(s) > 0:
-    news = s[-3:]+","+news
+  while len( s ) > 0:
+    news = s[-3:] + "," + news
     s = s[:-3] 
   return news[:-1]
 
-def printTable( fields, records, sortField='', numbering=True, 
+def printTable( fields, records, sortField = '', numbering = True,
                 printOut = True, columnSeparator = ' ' ):
   """ Utility to pretty print tabular data
 
-  :param fields: list of column names
-  :type fields: python:list
-  :param records: list of records, each record is a list or tuple of string values
-  :type records: python:list
+  :param list fields: list of column names
+  :param list records: list of records, each record is a list or tuple of field values
+         where field value itself can be a string or a list of strings or a dictionary
+         of the structure { "Value": string_value, 'Just': 'L|R|C' } to specify justification
   :param str sortField: name of the column by which the output will be sorted
   :param bool numbering: flag for numbering rows
   :param bool printOut: flag for printing into the stdout
@@ -38,75 +38,180 @@ def printTable( fields, records, sortField='', numbering=True,
   :return: pretty table string
   """
 
-  stringBuffer = StringIO.StringIO()
+  def __writeField( buffer, value, length, columnSeparator ):
+
+    justification = None
+    if isinstance( value, dict ):
+      justification = value.get( 'Just' )
+      value = value.get( 'Value', '' )
+
+    if justification is None:
+      #try casting to int and then align to the right, if it fails align to the left
+      justification = "r"
+      try:
+        _val = int( "".join( value.split(",") ) )
+      except ValueError:
+        justification = "l"
+
+    if justification.lower() == "l":
+      buffer.write( value.ljust( length ) + columnSeparator )
+    elif justification.lower() == "r":
+      buffer.write( value.rjust( length ) + columnSeparator )
+    elif justification.lower() == "c":
+      margin = length - len( value )
+      if margin <= 1:
+        buffer.write( value.ljust( length ) + columnSeparator )
+      else:
+        m1 = margin/2
+        m2 = margin - m1
+        buffer.write( " "*m1 + value + " "*m2 + columnSeparator )
 
   if not records:
     if printOut:
       print "No output"
     return "No output"
 
-  fieldList = list( fields )
+  # Strip all strings
+  fieldList = [f.strip() for f in fields]
   recordList = []
-  for r in records:
-    recordList.append( list( r ) )
+  for record in records:
+    strippedRecord = []
+    for fieldValue in record:
+      if isinstance( fieldValue, basestring ):
+        strippedRecord.append( fieldValue.strip() )
+      elif isinstance( fieldValue, list ):
+        strippedList = []
+        for ll in fieldValue:
+          if isinstance( ll, basestring ):
+            strippedList.append( ll.strip() )
+          elif isinstance( ll, dict ):
+            ll['Value'] = ll['Value'].strip()
+            strippedList.append( ll )
+          else:
+            out = "Wrong type for field value: %s" % type( ll )
+            if printOut:
+              print out
+            return out
+        strippedRecord.append( strippedList )
+      elif isinstance( fieldValue, dict ):
+        itemValue = fieldValue['Value']
+        if isinstance( itemValue, basestring ):
+          itemValue = itemValue.strip()
+          fieldValue.update( { 'Value': itemValue } )
+          strippedRecord.append( fieldValue )
+        elif isinstance( itemValue, list ):
+          itemValue = [r.strip() for r in itemValue]
+          fieldValue.update( { 'Value': itemValue } )
+          strippedRecord.append( fieldValue )
+        else:
+          out = "Wrong type for field value: %s" % type( itemValue )
+          if printOut:
+            print out
+          return out
+    recordList.append( strippedRecord )
 
-
-  nFields = len( fieldList )
-  if nFields != len( recordList[0] ):
-    out = "Incorrect data structure to print, nFields %d, nRecords %d" % ( nFields, len( recordList[0] ) )
-    if printOut:
-      print out
-    return out
+  nFields = len( fields )
+  for rec in records:
+    if nFields != len( rec ):
+      out = "Incorrect data structure to print, nFields %d, nRecords %d" % ( nFields, len( rec ) )
+      if printOut:
+        print out
+      return out
 
   if sortField:
     recordList.sort( None, lambda x: x[fieldList.index( sortField )] )
 
-  lengths = []
+  # Compute the maximum width for each field
+  fieldWidths = []
   for i in range(nFields):
-    fieldList[i] = fieldList[i].strip()
-    lengths.append( len( fieldList[i] ) )
-    for r in recordList:
-      r[i] = r[i].strip()
-      if len( r[i] ) > lengths[i]:
-        lengths[i] = len( r[i] )
-
+    fieldWidths.append( len( fieldList[i] ) )
+    for record in recordList:
+      if isinstance( record[i], list ):
+        for item in record[i]:
+          if isinstance( item, dict ):
+            itemValue = item['Value']
+          else:
+            itemValue = item
+          fieldWidths[i] = max( len( itemValue ), fieldWidths[i] )
+      elif isinstance( record[i], dict ):
+        fieldValue = record[i]['Value']
+        if isinstance( fieldValue, list ):
+          fieldWidths[i] = max( max( len( item ) for item in fieldValue ), fieldWidths[i] )
+        else:
+          fieldWidths[i] = max( len( fieldValue ), fieldWidths[i] )
+      else:
+        fieldWidths[i] = max( len( record[i] ), fieldWidths[i] )
 
   numberWidth = len( str( len( recordList ) ) ) + 1
   separatorWidth = len( columnSeparator )
-  totalLength = 0
-  for i in lengths:
-    totalLength += i
-    totalLength += separatorWidth
-
+  totalLength = sum( fieldWidths ) + separatorWidth * nFields
   if numbering:
-    totalLength += (numberWidth + separatorWidth)
+    totalLength += ( numberWidth + separatorWidth )
 
-  if numbering:
-    stringBuffer.write( ' '*(numberWidth+separatorWidth) )
+  # Accumulate the table output in the stringBuffer now
+  stringBuffer = StringIO.StringIO()
+  topLength = ( numberWidth + separatorWidth ) if numbering else 0
+  stringBuffer.write( ' ' * ( topLength ) )
+
   for i in range(nFields):
-    stringBuffer.write( fieldList[i].ljust(lengths[i]+separatorWidth) )
+    stringBuffer.write( fieldList[i].ljust(fieldWidths[i] + separatorWidth ) )
   stringBuffer.write( '\n' )
   stringBuffer.write( '='*totalLength + '\n' )
-  count = 1
-  for r in recordList:
+
+  for count, record in enumerate( recordList ):
+    total = ( count == len( recordList ) - 1 and recordList[-1][0] == "Total" )
     if numbering:
-      if count == len( recordList ) and recordList[-1][0] == "Total":
-        stringBuffer.write( " "*(numberWidth+separatorWidth) )
+      if total:
+        # Do not number the line with the total
+        stringBuffer.write( " "*( numberWidth + separatorWidth ) )
       else:
-        stringBuffer.write( str(count).rjust(numberWidth)+columnSeparator )
+        stringBuffer.write( str( count + 1 ).rjust( numberWidth ) + columnSeparator )
 
-    for i in range( nFields ):
-      #try casting to int and then align to the right, if it fails align to the left
-      try:
-        _val = int( "".join( r[i].split(",") ) )
-        stringBuffer.write( r[i].rjust( lengths[i] )+columnSeparator )
-      except ValueError:
-        stringBuffer.write( r[i].ljust( lengths[i] )+columnSeparator )
+    listMode = 0
+    for item in record:
+      if isinstance( item, list ):
+        listMode = max( len( item ), listMode )
+      elif isinstance( item, dict ) and isinstance( item['Value'], list ):
+        listMode = max( len( item['Value'] ), listMode )
 
-    stringBuffer.write( '\n' )
-    if count == len( recordList )-1 and recordList[-1][0] == "Total":
+    for fieldValue, fieldWidth in zip( record, fieldWidths ):
+
+      value = fieldValue
+      if isinstance( fieldValue, list ):
+        value = fieldValue[0]
+      elif isinstance( fieldValue, dict ) and isinstance( fieldValue['Value'], list ):
+        value = dict( fieldValue )
+        value.update( { 'Value': value['Value'][0] } )
+
+      __writeField( stringBuffer, value, fieldWidth, columnSeparator )
+
+    # If the field has a list type value, print out one value per line
+    if listMode:
+      stringBuffer.write( '\n' )
+      for ll in range( 1, listMode - 1 ):
+        # Do not number continuation lines
+        if numbering:
+          stringBuffer.write( " "*(numberWidth + separatorWidth) )
+        for fieldValue, fieldWidth in zip( record, fieldWidths ):
+          valueList = fieldValue
+          if isinstance( valueList, list ) and ll < len( valueList ):
+            value = valueList[ll]
+          elif isinstance( valueList, dict ) and \
+               isinstance( valueList['Value'], list ) and \
+               ll < len( valueList['Value'] ):
+            value = dict( valueList )
+            value.update( { 'Value': valueList['Value'][ll] } )
+          else:
+            value = ''
+
+          __writeField( stringBuffer, value, fieldWidth, columnSeparator )
+
+        stringBuffer.write( '\n' )
+
+    if not listMode:
+      stringBuffer.write( '\n' )
+    if total:
       stringBuffer.write( '-'*totalLength + '\n' )
-    count += 1
 
   output = stringBuffer.getvalue()
   if printOut:
@@ -130,7 +235,7 @@ def printDict( dDict, printOut = False ):
     line = "%s: " % key
     line = line.ljust( keyLength + 2 )
     value = dDict[ key ]
-    if isinstance( value, (list, tuple) ):
+    if isinstance( value, ( list, tuple ) ):
       line += ','.join( list( value ) )
     else:
       line += str( value )

--- a/Core/scripts/dirac-info.py
+++ b/Core/scripts/dirac-info.py
@@ -27,7 +27,7 @@ args = Script.getPositionalArgs()
 records = []
 
 records.append( ('Setup', gConfig.getValue( '/DIRAC/Setup', 'Unknown' ) ) )
-records.append( ('ConfigurationServer', str( gConfig.getValue( '/DIRAC/Configuration/Servers', [] ) ) ) )
+records.append( ('ConfigurationServer', gConfig.getValue( '/DIRAC/Configuration/Servers', [] ) ) )
 records.append( ('Installation path', DIRAC.rootPath ) )
 
 if os.path.exists( os.path.join( DIRAC.rootPath, DIRAC.getPlatform(), 'bin', 'mysql' ) ):
@@ -40,13 +40,16 @@ records.append( ( 'Platform', DIRAC.getPlatform() ) )
 ret = getProxyInfo( disableVOMS = True )
 if ret['OK']:
   if 'group' in ret['Value']:
-    records.append( ('VirtualOrganization', getVOForGroup( ret['Value']['group'] ) ) )
+    vo = getVOForGroup( ret['Value']['group'] )
   else:
-    records.append( ('VirtualOrganization', getVOForGroup( '' ) ) )
+    vo = getVOForGroup( '' )
+  if not vo:
+    vo = "None"
+  records.append( ('VirtualOrganization', vo ) )
   if 'identity' in ret['Value']:
     records.append( ('User DN', ret['Value']['identity'] ) )
   if 'secondsLeft' in ret['Value']:
-    records.append( ('Proxy validity, secs', str( ret['Value']['secondsLeft'] ) ) )
+    records.append( ('Proxy validity, secs', { 'Value': str( ret['Value']['secondsLeft'] ), 'Just': 'L' } ) )
   
 if gConfig.getValue( '/DIRAC/Security/UseServerCertificate', True ):
   records.append( ('Use Server Certificate', 'Yes' ) )

--- a/WorkloadManagementSystem/scripts/dirac-admin-show-task-queues.py
+++ b/WorkloadManagementSystem/scripts/dirac-admin-show-task-queues.py
@@ -94,10 +94,11 @@ else:
     tqData = tqDict[ tqId ]
     for key in sorted( tqData ):
       value = tqData[ key ]
-      if type( value ) == types.ListType:
-        value = ",".join( value )
+      if isinstance( value, list ):
+        records.append( [key, { "Value": value, 'Just': 'L'} ] )
       else:
         value = str( value )
-      records.append( [key, value] )
-    printTable( fields, records )    
+        records.append( [key, { "Value": value, 'Just': 'L' } ] )
+
+    printTable( fields, records, numbering = False )
     


### PR DESCRIPTION
1. Allow to pass list of values for one field value. In this case values are printed out one per line within the table slot
2. One can pass as a value a dict where justification of the printout for this particular value can be specified ( L or R or C ), for example, { "Value": value, 'Just': 'L' }
3. dirac-info and dirac-admin-show-task-queues commands updated to make use of these features.
An example output of dirac-admin-show-task-queues command:
![screen shot 2017-03-16 at 21 49 08](https://cloud.githubusercontent.com/assets/679892/24017989/6fe01272-0a92-11e7-83d5-024695763682.png)

This PR replaces #3285 from which most of the improvements are imported.