### PR TITLE
[v6r17] Improvement in getFilesToStage, JobScheduling snd TS

### DIFF
--- a/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/StorageManagementSystem/Client/StorageManagerClient.py
@@ -9,13 +9,16 @@ from DIRAC.Core.Base.Client                         import Client
 from DIRAC.Core.Utilities.Proxy                     import executeWithUserProxy
 from DIRAC.DataManagementSystem.Client.DataManager  import DataManager
 from DIRAC.Resources.Storage.StorageElement         import StorageElement
+from DIRAC.Core.Utilities.DErrno                    import cmpError
+
+import errno
 
 def getFilesToStage( lfnList, jobState = None ):
   """ Utility that returns out of a list of LFNs those files that are offline,
       and those for which at least one copy is online
   """
   if not lfnList:
-    return S_OK( {'onlineLFNs':[], 'offlineLFNs': {}} )
+    return S_OK( {'onlineLFNs':[], 'offlineLFNs': {}, 'failedLFNs':[], 'absentLFNs':{}} )
 
   dm = DataManager()
 
@@ -27,26 +30,18 @@ def getFilesToStage( lfnList, jobState = None ):
     return S_ERROR( "Failures in getting replicas" )
 
   lfnListReplicas = lfnListReplicas['Value']['Successful']
-  # Check whether there is any file that is only at a tape SE
   # If a file is reported here at a tape SE, it is not at a disk SE as we use disk in priority
+  # We shall check all file anyway in order to make sure they exist
   seToLFNs = dict()
-  onlineLFNs = set()
-  for lfn, ld in lfnListReplicas.iteritems():
-    for se in ld:
-      status = StorageElement( se ).getStatus()
-      if not status['OK']:
-        gLogger.error( "Could not get SE status", "%s - %s" % ( se, status['Message'] ) )
-        return status
-      if status['Value']['DiskSE']:
-        # File is at a disk SE, no need to stage
-        onlineLFNs.add( lfn )
-        break
-      else:
-        seToLFNs.setdefault( se, list() ).append( lfn )
+  for lfn, ses in lfnListReplicas.iteritems():
+    for se in ses:
+      seToLFNs.setdefault( se, list() ).append( lfn )
 
   offlineLFNsDict = {}
+  onlineLFNs = set()
+  offlineLFNs = {}
+  absentLFNs = {}
   if seToLFNs:
-    # If some files are on Tape SEs, check whether they are online or offline
     if jobState:
       # Get user name and group from the job state
       userName = jobState.getAttribute( 'Owner' )
@@ -61,23 +56,25 @@ def getFilesToStage( lfnList, jobState = None ):
     else:
       userName = None
       userGroup = None
-    result = _checkFilesToStage( seToLFNs, onlineLFNs,  # pylint: disable=unexpected-keyword-arg
+    # Check whether files are Online or Offline, or missing at SE
+    result = _checkFilesToStage( seToLFNs, onlineLFNs, offlineLFNs, absentLFNs,  # pylint: disable=unexpected-keyword-arg
                                  proxyUserName = userName,
                                  proxyUserGroup = userGroup,
                                  executionLock = True )
+
     if not result['OK']:
       return result
-    offlineLFNs = set( lfnList ) - onlineLFNs
+    failedLFNs = set( lfnList ) - onlineLFNs - set( offlineLFNs ) - set( absentLFNs )
 
-    for offlineLFN in offlineLFNs:
-      ses = lfnListReplicas[offlineLFN].keys()
+    for lfn in offlineLFNs:
+      ses = offlineLFNs[lfn]
       if ses:
-        offlineLFNsDict.setdefault( random.choice( ses ), list() ).append( offlineLFN )
+        offlineLFNsDict.setdefault( random.choice( ses ), list() ).append( lfn )
 
-  return S_OK( {'onlineLFNs':list( onlineLFNs ), 'offlineLFNs': offlineLFNsDict} )
+  return S_OK( {'onlineLFNs':list( onlineLFNs ), 'offlineLFNs': offlineLFNsDict, 'failedLFNs':list( failedLFNs ), 'absentLFNs':absentLFNs} )
 
 @executeWithUserProxy
-def _checkFilesToStage( seToLFNs, onlineLFNs ):
+def _checkFilesToStage( seToLFNs, onlineLFNs, offlineLFNs, absentLFNs ):
   """
   Checks on SEs whether the file is NEARLINE or ONLINE
   onlineLFNs is modified to contain the files found online
@@ -85,7 +82,14 @@ def _checkFilesToStage( seToLFNs, onlineLFNs ):
   # Only check on storage if it is a tape SE
   failed = {}
   for se, lfnsInSEList in seToLFNs.iteritems():
-    fileMetadata = StorageElement( se ).getFileMetadata( lfnsInSEList )
+    seObj = StorageElement( se )
+    status = seObj.getStatus()
+    if not status['OK']:
+      gLogger.error( "Could not get SE status", "%s - %s" % ( se, status['Message'] ) )
+      return status
+    tapeSE = status['Value']['TapeSE']
+        # File is at a disk SE, no need to stage
+    fileMetadata = seObj.getFileMetadata( lfnsInSEList )
     if not fileMetadata['OK']:
       failed[se] = dict.fromkeys( lfnsInSEList, fileMetadata['Message'] )
     else:
@@ -96,6 +100,16 @@ def _checkFilesToStage( seToLFNs, onlineLFNs ):
         # SRM returns Cached, but others may only return Accessible
         if mDict.get( 'Cached', mDict['Accessible'] ):
           onlineLFNs.add( lfn )
+        elif tapeSE:
+          # A file can be staged only at Tape SE
+          offlineLFNs.setdefault( lfn, [] ).append( se )
+        else:
+          # File not available at a diskSE... we shall retry later
+          pass
+
+  # Doesn't matter if some files are Offline if they are also online
+  for lfn in set( offlineLFNs ) & onlineLFNs:
+    offlineLFNs.pop( lfn )
 
   # If the file was found staged, ignore possible errors, but print out errors
   for se, failedLfns in failed.items():
@@ -105,12 +119,15 @@ def _checkFilesToStage( seToLFNs, onlineLFNs ):
         gLogger.info( '%s: %s, but there is an online replica' % ( lfn, reason ) )
         failed[se].pop( lfn )
       else:
-        gLogger.info( '%s: %s, no online replicas' % ( lfn, reason ) )
+        gLogger.error( '%s: %s, no online replicas' % ( lfn, reason ) )
+        if cmpError( reason, errno.ENOENT ):
+          absentLFNs.setdefault( lfn, [] ).append( se )
+          failed[se].pop( lfn )
     if not failed[se]:
       failed.pop( se )
+  # Find the files that do not exist at SE
   if failed:
-    gLogger.error( "Could not get metadata", "for %d files" % len( set( lfn for lfnList in failed.itervalues() for lfn in lfnList ) ) )
-    return S_ERROR( "Could not get metadata for files" )
+    gLogger.error( "Error getting metadata", "for %d files" % len( set( lfn for lfnList in failed.itervalues() for lfn in lfnList ) ) )
 
   return S_OK()
 

--- a/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
+++ b/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
@@ -6,7 +6,7 @@
 import unittest
 from mock import MagicMock, patch
 
-from DIRAC import S_OK
+from DIRAC import S_OK, S_ERROR
 from DIRAC.StorageManagementSystem.Client.StorageManagerClient import getFilesToStage
 from DIRAC.DataManagementSystem.Client.test.mock_DM import dm_mock
 import errno
@@ -29,7 +29,7 @@ mockObjectSE3.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
 mockObjectSE4 = MagicMock()
 mockObjectSE4.getFileMetadata.return_value = S_OK( {'Successful':{},
                                                     'Failed':{'/a/lfn/2.txt':
-                                                              "No such file or directory ( 2 : [SE][Ls][SRM_INVALID_PATH] No such file or directory, 2))"}} )
+                                                              S_ERROR( errno.ENOENT, '' )['Message']}} )
 mockObjectSE4.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
 
 mockObjectSE5 = MagicMock()
@@ -60,7 +60,8 @@ class StorageManagerSuccess( ClientsTestCase ):
     res = getFilesToStage( ['/a/lfn/1.txt'] )
     self.assertTrue( res['OK'] )
     self.assertEqual( res['Value']['onlineLFNs'], [] )
-    self.assert_( res['Value']['offlineLFNs'], ['SE1'] or ['SE2'] )
+    self.assertIn( res['Value']['offlineLFNs'], [{'SE1':['/a/lfn/1.txt']},
+                                                 {'SE2':['/a/lfn/1.txt']}] )
     self.assertEqual( res['Value']['absentLFNs'], {} )
     self.assertEqual( res['Value']['failedLFNs'], [] )
 

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -125,6 +125,14 @@ class JobScheduling( OptimizerExecutor ):
 
       if not res['OK']:
         return self.__holdJob( jobState, res['Message'] )
+      if res['Value']['absentLFNs']:
+        # Some files do not exist at all... set the job Failed
+        error = 'Some files do not exist at SE'
+        self.jobLog.error( error, ':' + ','.join( res['Value']['absentLFNs'] ) )
+        jobState.setStatus( 'Failed', appStatus = error )
+        return S_ERROR( error )
+      if res['Value']['failedLFNs']:
+        return self.__holdJob( jobState, "Couldn't get storage metadata of some files" )
       stageLFNs = res['Value']['offlineLFNs']
       if stageLFNs:
         res = self.__checkStageAllowed( jobState )


### PR DESCRIPTION
* getFilesToStage was only returning online files
* JobScheduling was assuming all non-online files required staging
* Improvements include:
   * return explicitly offline files and only stage those if at TpeSE
   * return also absent files (i.e. not at SE): in this case make the job Failed
* Improvements in TaskManager: process tasks in chunks of 100 in order to update faster the TS (tasks and files)