### PR TITLE
[v6r17] New feature in FTSAgent

### DIFF
--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -431,7 +431,7 @@ class FTSAgent( AgentModule ):
       self.__ftsPlacementValidStamp = now + datetime.timedelta( seconds = self.FTSPLACEMENT_REFRESH )
 
     # To be sure we have enough requests, ask for several times as much
-    requestIDs = self.requestClient().getRequestIDsList( statusList = [ "Scheduled" ], limit = self.__factorOnMaxRequest * self.MAX_REQUESTS, getJobID = True )
+    requestIDs = self.requestClient().getRequestIDsList( statusList = [ "Scheduled" ], limit = int( self.__factorOnMaxRequest * self.MAX_REQUESTS ), getJobID = True )
     if not requestIDs["OK"]:
       log.error( "unable to read scheduled request ids" , requestIDs["Message"] )
       return requestIDs

--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -428,8 +428,8 @@ class FTSAgent( AgentModule ):
         return resetFTSPlacement
       self.__ftsPlacementValidStamp = now + datetime.timedelta( seconds = self.FTSPLACEMENT_REFRESH )
 
-    # To be sure we have enough requests, ask for twice as much
-    requestIDs = self.requestClient().getRequestIDsList( statusList = [ "Scheduled" ], limit = 2 * self.MAX_REQUESTS, getJobID = True )
+    # To be sure we have enough requests, ask for 3 times as much
+    requestIDs = self.requestClient().getRequestIDsList( statusList = [ "Scheduled" ], limit = 3 * self.MAX_REQUESTS, getJobID = True )
     if not requestIDs["OK"]:
       log.error( "unable to read scheduled request ids" , requestIDs["Message"] )
       return requestIDs

--- a/DataManagementSystem/Client/FTSClient.py
+++ b/DataManagementSystem/Client/FTSClient.py
@@ -25,8 +25,6 @@ FTS client
 # # imports
 from DIRAC import gLogger, S_OK, S_ERROR
 
-from DIRAC.Core.DISET.RPCClient           import RPCClient
-from DIRAC.ConfigurationSystem.Client     import PathFinder
 from DIRAC.Core.Base.Client               import Client
 # # from DMS
 from DIRAC.DataManagementSystem.Client.FTSJob             import FTSJob
@@ -46,31 +44,26 @@ class FTSClient( Client ):
 
   """
 
-  def __init__( self, useCertificates = False ):
+  def __init__( self, url = None, useCertificates = False, **kwargs ):
     """c'tor
 
     :param self: self reference
     :param bool useCertificates: flag to enable/disable certificates
     """
-    Client.__init__( self )
+    super( FTSClient, self ).__init__( **kwargs )
     self.log = gLogger.getSubLogger( "DataManagement/FTSClient" )
-    self.setServer( "DataManagement/FTSManager" )
+    self.serverURL = 'DataManagement/FTSManager' if not url else url
 
     # getting other clients
     self.ftsValidator = FTSValidator()
     self.dataManager = DataManager()
     self.storageFactory = StorageFactory()
 
-    url = PathFinder.getServiceURL( "DataManagement/FTSManager" )
-    if not url:
-      raise RuntimeError( "CS option DataManagement/FTSManager URL is not set!" )
-    self.ftsManager = RPCClient( url )
-
   def getFTSFileList( self, statusList = None, limit = None ):
     """ get list of FTSFiles with status in statusList """
     statusList = statusList if statusList else [ "Waiting" ]
     limit = limit if limit else 1000
-    getFTSFileList = self.ftsManager.getFTSFileList( statusList, limit )
+    getFTSFileList = self._getRPC().getFTSFileList( statusList, limit )
     if not getFTSFileList['OK']:
       self.log.error( "Failed getFTSFileList", "%s" % getFTSFileList['Message'] )
       return getFTSFileList
@@ -81,7 +74,7 @@ class FTSClient( Client ):
     """ get FTSJobs wit statues in :statusList: """
     statusList = statusList if statusList else list( FTSJob.INITSTATES + FTSJob.TRANSSTATES )
     limit = limit if limit else 500
-    getFTSJobList = self.ftsManager.getFTSJobList( statusList, limit )
+    getFTSJobList = self._getRPC().getFTSJobList( statusList, limit )
     if not getFTSJobList['OK']:
       self.log.error( "Failed getFTSJobList", "%s" % getFTSJobList['Message'] )
       return getFTSJobList
@@ -95,7 +88,7 @@ class FTSClient( Client ):
     :param statusList: List of statuses (default: Waiting)
     :type statusList: python:list
     """
-    ftsFiles = self.ftsManager.getFTSFilesForRequest( requestID, statusList )
+    ftsFiles = self._getRPC().getFTSFilesForRequest( requestID, statusList )
     if not ftsFiles['OK']:
       self.log.error( "Failed getFTSFilesForRequest", "%s" % ftsFiles['Message'] )
       return ftsFiles
@@ -106,7 +99,7 @@ class FTSClient( Client ):
 
     :param int requestID: ReqDB.Request.RequestID
     """
-    ftsFiles = self.ftsManager.getAllFTSFilesForRequest( requestID )
+    ftsFiles = self._getRPC().getAllFTSFilesForRequest( requestID )
     if not ftsFiles['OK']:
       self.log.error( "Failed getFTSFilesForRequest", "%s" % ftsFiles['Message'] )
       return ftsFiles
@@ -122,7 +115,7 @@ class FTSClient( Client ):
     :return: [ FTSJob, FTSJob, ... ]
     """
     statusList = statusList if statusList else list( FTSJob.INITSTATES + FTSJob.TRANSSTATES )
-    getJobs = self.ftsManager.getFTSJobsForRequest( requestID, statusList )
+    getJobs = self._getRPC().getFTSJobsForRequest( requestID, statusList )
     if not getJobs['OK']:
       self.log.error( "Failed getFTSJobsForRequest", "%s" % getJobs['Message'] )
       return getJobs
@@ -133,7 +126,7 @@ class FTSClient( Client ):
 
     :param int ftsFileID: FTSFileID
     """
-    getFile = self.ftsManager.getFTSFile( ftsFileID )
+    getFile = self._getRPC().getFTSFile( ftsFileID )
     if not getFile['OK']:
       self.log.error( 'Failed to get FTS file', getFile['Message'] )
     # # de-serialize
@@ -154,18 +147,18 @@ class FTSClient( Client ):
     if not isValid['OK']:
       self.log.error( "Failed to validate FTS job", "%s %s" % ( isValid['Message'], str( ftsJobJSON['Value'] ) ) )
       return isValid
-    return self.ftsManager.putFTSJob( ftsJobJSON['Value'] )
+    return self._getRPC().putFTSJob( ftsJobJSON['Value'] )
 
   def getFTSJob( self, ftsJobID ):
     """ get FTS job, change its status to 'Assigned'
 
     :param int ftsJobID: FTSJobID
     """
-    getJob = self.ftsManager.getFTSJob( ftsJobID )
+    getJob = self._getRPC().getFTSJob( ftsJobID )
     if not getJob['OK']:
       self.log.error( 'Failed to get FTS job', getJob['Message'] )
       return getJob
-    setStatus = self.ftsManager.setFTSJobStatus( ftsJobID, 'Assigned' )
+    setStatus = self._getRPC().setFTSJobStatus( ftsJobID, 'Assigned' )
     if not setStatus['OK']:
       self.log.error( 'Failed to set status of FTS job', setStatus['Message'] )
     # # de-serialize
@@ -178,7 +171,7 @@ class FTSClient( Client ):
 
     :param int ftsJobID: FTSJobID
     """
-    getJob = self.ftsManager.getFTSJob( ftsJobID )
+    getJob = self._getRPC().getFTSJob( ftsJobID )
     if not getJob['OK']:
       self.log.error( 'Failed to get FTS job', getJob['Message'] )
       return getJob
@@ -189,7 +182,7 @@ class FTSClient( Client ):
 
     :param int ftsJob: FTSJobID
     """
-    deleteJob = self.ftsManager.deleteFTSJob( ftsJobID )
+    deleteJob = self._getRPC().deleteFTSJob( ftsJobID )
     if not deleteJob['OK']:
       self.log.error( 'Failed to delete FTS job', deleteJob['Message'] )
     return deleteJob
@@ -197,7 +190,7 @@ class FTSClient( Client ):
   def getFTSJobIDs( self, statusList = None ):
     """ get list of FTSJobIDs for a given status list """
     statusList = statusList if statusList else [ "Submitted", "Ready", "Active" ]
-    ftsJobIDs = self.ftsManager.getFTSJobIDs( statusList )
+    ftsJobIDs = self._getRPC().getFTSJobIDs( statusList )
     if not ftsJobIDs['OK']:
       self.log.error( 'Failed to get FTS job IDs', ftsJobIDs['Message'] )
     return ftsJobIDs
@@ -205,14 +198,14 @@ class FTSClient( Client ):
   def getFTSFileIDs( self, statusList = None ):
     """ get list of FTSFileIDs for a given status list """
     statusList = statusList if statusList else [ "Waiting" ]
-    ftsFileIDs = self.ftsManager.getFTSFileIDs( statusList )
+    ftsFileIDs = self._getRPC().getFTSFileIDs( statusList )
     if not ftsFileIDs['OK']:
       self.log.error( 'Failed to get FTS file IDs', ftsFileIDs['Message'] )
     return ftsFileIDs
 
   def getFTSHistory( self ):
     """ get FTS history snapshot """
-    getFTSHistory = self.ftsManager.getFTSHistory()
+    getFTSHistory = self._getRPC().getFTSHistory()
     if not getFTSHistory['OK']:
       self.log.error( 'Failed to get FTS history', getFTSHistory['Message'] )
       return getFTSHistory
@@ -221,7 +214,7 @@ class FTSClient( Client ):
 
   def getDBSummary( self ):
     """ get FTDB summary """
-    dbSummary = self.ftsManager.getDBSummary()
+    dbSummary = self._getRPC().getDBSummary()
     if not dbSummary['OK']:
       self.log.error( "Failed getDBSummary", "%s" % dbSummary['Message'] )
     return dbSummary
@@ -233,7 +226,7 @@ class FTSClient( Client ):
     :param str sourceSE: source SE name
     :param opFileIDList: [ ReqDB.File.FileID, ... ]
     """
-    return self.ftsManager.setFTSFilesWaiting( operationID, sourceSE, opFileIDList )
+    return self._getRPC().setFTSFilesWaiting( operationID, sourceSE, opFileIDList )
 
   def deleteFTSFiles( self, operationID, opFileIDList = None ):
     """ delete FTSFiles for rescheduling
@@ -242,7 +235,7 @@ class FTSClient( Client ):
     :param opFileIDList: [ ReqDB.File.FileID, ... ]
     :type opFileIDList: python:list
     """
-    return self.ftsManager.deleteFTSFiles( operationID, opFileIDList )
+    return self._getRPC().deleteFTSFiles( operationID, opFileIDList )
 
   def ftsSchedule( self, requestID, operationID, opFileList ):
     """ schedule lfn for FTS job
@@ -262,7 +255,7 @@ class FTSClient( Client ):
       else:
         self.log.warn( 'File list for FTS scheduling has duplicates, fix it:\n', fTuple )
     fileIDs = [int( fileJSON.get( 'FileID', 0 ) ) for fileJSON, _sourceSEs, _targetSEs in fList ]
-    res = self.ftsManager.cleanUpFTSFiles( requestID, fileIDs )
+    res = self._getRPC().cleanUpFTSFiles( requestID, fileIDs )
     if not res['OK']:
       self.log.error( "Failed ftsSchedule", "%s" % res['Message'] )
       return S_ERROR( "ftsSchedule: %s" % res['Message'] )
@@ -301,7 +294,7 @@ class FTSClient( Client ):
         result["Failed"][fileID] = "no active replicas found in sources"
         continue
 
-      tree = self.ftsManager.getReplicationTree( sourceSEs, targetSEs, size )
+      tree = self._getRPC().getReplicationTree( sourceSEs, targetSEs, size )
       if not tree['OK']:
         self.log.error( "Failed ftsSchedule", "%s cannot be scheduled: %s" % ( lfn, tree['Message'] ) )
         result["Failed"][fileID] = tree['Message']
@@ -355,7 +348,7 @@ class FTSClient( Client ):
       return S_OK( result )
 
     ftsFilesJSONList = [ftsFile.toJSON()['Value'] for ftsFile in ftsFiles]
-    res = self.ftsManager.putFTSFileList( ftsFilesJSONList )
+    res = self._getRPC().putFTSFileList( ftsFilesJSONList )
     if not res['OK']:
       self.log.error( "Failed ftsSchedule", "%s" % res['Message'] )
       return S_ERROR( "ftsSchedule: %s" % res['Message'] )
@@ -378,7 +371,7 @@ class FTSClient( Client ):
     res = StorageFactory().getStorages( targetSE, pluginList = ["SRM2", "GFAL2_SRM2"] )
     if not res['OK']:
       errStr = "_getSurlForLFN: Failed to create SRM2 storage for %s: %s" % ( targetSE, res['Message'] )
-      self.log.error( "_getSurlForLFN: Failed to create SRM2 storage", 
+      self.log.error( "_getSurlForLFN: Failed to create SRM2 storage",
                       "%s: %s" % ( targetSE, res['Message'] ) )
       return S_ERROR( errStr )
     storageObjects = res['Value']["StorageObjects"]

--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -194,8 +194,12 @@ class RequestExecutingAgent( AgentModule ):
     while request.RequestID in self.__requestCache:
       count -= 1
       if not count:
-        self.requestClient().putRequest( request, useFailoverProxy = False, retryMainService = 2 )
-        return S_ERROR( "Duplicate request, ignore: %s" % request.RequestID )
+        # Comment out the putRequest as we have got back the request that is still being executed. Better keep it
+        # The main reason for this is that it lasted longer than the kick time of CleanReqAgent
+        # self.requestClient().putRequest( request, useFailoverProxy = False, retryMainService = 2 )
+        # return S_ERROR( "Duplicate request, ignore: %s" % request.RequestID )
+        self.log.warn( "Duplicate request, keep it: %s" % request.RequestID )
+        break
       time.sleep( 1 )
     self.__requestCache[ request.RequestID ] = request
     return S_OK()

--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -185,14 +185,14 @@ class ReqClient( Client ):
                       "'%s' request: %s" % ( requestID, deleteRequest["Message"] ) )
     return deleteRequest
 
-  def getRequestIDsList( self, statusList = None, limit = None, since = None, until = None ):
+  def getRequestIDsList( self, statusList = None, limit = None, since = None, until = None, getJobID = False ):
     """ get at most :limit: request ids with statuses in :statusList: """
     statusList = statusList if statusList else list( Request.FINAL_STATES )
     limit = limit if limit else 100
     since = since.strftime( '%Y-%m-%d' ) if since else ""
     until = until.strftime( '%Y-%m-%d' ) if until else ""
 
-    return self._getRPC().getRequestIDsList( statusList, limit, since, until )
+    return self._getRPC().getRequestIDsList( statusList, limit, since, until, getJobID )
 
   def getScheduledRequest( self, operationID ):
     """ get scheduled request given its scheduled OperationID """

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -257,13 +257,13 @@ class ReqManagerHandler( RequestHandler ):
 
   types_getRequestIDsList = [ ListType, IntType, StringTypes ]
   @classmethod
-  def export_getRequestIDsList( cls, statusList = None, limit = None, since = None, until = None ):
+  def export_getRequestIDsList( cls, statusList = None, limit = None, since = None, until = None, getJobID = False ):
     """ get requests' IDs with status in :statusList: """
     statusList = statusList if statusList else list( Request.FINAL_STATES )
     limit = limit if limit else 100
     since = since if since else ""
     until = until if until else ""
-    reqIDsList = cls.__requestDB.getRequestIDsList( statusList, limit, since = since, until = until )
+    reqIDsList = cls.__requestDB.getRequestIDsList( statusList, limit, since = since, until = until, getJobID = getJobID )
     if not reqIDsList["OK"]:
       gLogger.error( "getRequestIDsList: %s" % reqIDsList["Message"] )
     return reqIDsList


### PR DESCRIPTION
We want to be able to run 2 FTSAgents, one for Failover requests, one for other requests (mostly DM transformations). 
This PR modifies the getRequestIDsList() method to get also the JobID in the returned tuple. 
The FTSAgent has a new CS parameter ProcessJobRequests (default None, i.e. same behavior as before). If True, it processes the Job requests only, if False it doesn't process them.
Beware that it is not possible to run 2 agents that process the same requests.
The FTSAgent is getting a list twice as large as the MaxRequests, filters out the requests that it needs and then reduces it after being filtered to MaxRequests