### PR TITLE
[v6r17] Fix GFAL2 space tokens for some SEs

### DIFF
--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -352,7 +352,8 @@ class GFAL2_StorageBase( StorageBase ):
     else:
       params.nbstreams = 1
     params.overwrite = True  # old gfal removed old file first, gfal2 can just overwrite it with this flag set to True
-    params.dst_spacetoken = self.spaceToken
+    if self.spaceToken:
+      params.dst_spacetoken = self.spaceToken
 
 
     # Params set, copying file now
@@ -477,7 +478,8 @@ class GFAL2_StorageBase( StorageBase ):
     else:
       params.nbstreams = 1
     params.overwrite = True  # old gfal removed old file first, gfal2 can just overwrite it with this flag set to True
-    params.src_spacetoken = self.spaceToken
+    if self.spaceToken:
+      params.src_spacetoken = self.spaceToken
 
     params.checksum_check = bool( self.checksumType and not disableChecksum )
 


### PR DESCRIPTION
Hi,

If the space token is set to an empty string in GFAL2, some SEs (dCache at least) return a "space token not found" error. This patch simply only sets the space token if there is one, which fixes the problem.

Regards,
Simon