### PR TITLE
[v6r17] Fix JobScheduling

### DIFF
--- a/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/StorageManagementSystem/Client/StorageManagerClient.py
@@ -92,7 +92,9 @@ def _checkFilesToStage( seToLFNs, onlineLFNs, offlineLFNs, absentLFNs,
                         executionLock = None ):
   """
   Checks on SEs whether the file is NEARLINE or ONLINE
-  onlineLFNs is modified to contain the files found online
+  onlineLFNs, offlineLFNs and absentLFNs are modified to contain the files found online
+  If checkOnlyTapeSEs is True, disk replicas are not checked
+  As soon as a replica is found Online for a file, no further check is made
   """
   # Only check on storage if it is a tape SE
   if jobLog is None:

--- a/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
+++ b/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
@@ -57,7 +57,7 @@ class StorageManagerSuccess( ClientsTestCase ):
   def test_getFilesToStage_withFilesToStage( self, _patch, _patched ):
     """ Test where the StorageElement mock will return files offline
     """
-    res = getFilesToStage( ['/a/lfn/1.txt'] )
+    res = getFilesToStage( ['/a/lfn/1.txt'], checkOnlyTapeSEs = False )
     self.assertTrue( res['OK'] )
     self.assertEqual( res['Value']['onlineLFNs'], [] )
     self.assertIn( res['Value']['offlineLFNs'], [{'SE1':['/a/lfn/1.txt']},
@@ -70,7 +70,7 @@ class StorageManagerSuccess( ClientsTestCase ):
   def test_getFilesToStage_noFilesToStage( self, _patch, _patched ):
     """ Test where the StorageElement mock will return files online
     """
-    res = getFilesToStage( ['/a/lfn/2.txt'] )
+    res = getFilesToStage( ['/a/lfn/2.txt'], checkOnlyTapeSEs = False )
     self.assertTrue( res['OK'] )
     self.assertEqual( res['Value']['onlineLFNs'], ['/a/lfn/2.txt'] )
     self.assertEqual( res['Value']['offlineLFNs'], {} )
@@ -82,7 +82,7 @@ class StorageManagerSuccess( ClientsTestCase ):
   def test_getFilesToStage_seErrors( self, _patch, _patched ):
     """ Test where the StorageElement will return failure
     """
-    res = getFilesToStage( ['/a/lfn/2.txt'] )
+    res = getFilesToStage( ['/a/lfn/2.txt'], checkOnlyTapeSEs = False )
     self.assertTrue( res['OK'] )
     self.assertEqual( res['Value']['onlineLFNs'], [] )
     self.assertEqual( res['Value']['offlineLFNs'], {} )
@@ -94,7 +94,7 @@ class StorageManagerSuccess( ClientsTestCase ):
   def test_getFilesToStage_noSuchFile( self, _patch, _patched ):
     """ Test where the StorageElement will return file is absent
     """
-    res = getFilesToStage( ['/a/lfn/2.txt'] )
+    res = getFilesToStage( ['/a/lfn/2.txt'], checkOnlyTapeSEs = False )
     self.assertTrue( res['OK'] )
     self.assertEqual( res['Value']['onlineLFNs'], [] )
     self.assertEqual( res['Value']['offlineLFNs'], {} )
@@ -106,7 +106,7 @@ class StorageManagerSuccess( ClientsTestCase ):
   def test_getFilesToStage_fileInaccessibleAtDisk( self, _patch, _patched ):
     """ Test where the StorageElement will return file is unavailable at a Disk SE
     """
-    res = getFilesToStage( ['/a/lfn/1.txt'] )
+    res = getFilesToStage( ['/a/lfn/1.txt'], checkOnlyTapeSEs = False )
     self.assertTrue( res['OK'] )
     self.assertEqual( res['Value']['onlineLFNs'], [] )
     self.assertEqual( res['Value']['offlineLFNs'], {} )

--- a/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
+++ b/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
@@ -98,7 +98,7 @@ class StorageManagerSuccess( ClientsTestCase ):
     self.assertTrue( res['OK'] )
     self.assertEqual( res['Value']['onlineLFNs'], [] )
     self.assertEqual( res['Value']['offlineLFNs'], {} )
-    self.assertEqual( res['Value']['absentLFNs'], {'/a/lfn/2.txt':['SE2']} )
+    self.assertEqual( res['Value']['absentLFNs'], {'/a/lfn/2.txt': 'No such file or directory ( 2 : File not at SE2)'} )
     self.assertEqual( res['Value']['failedLFNs'], [] )
 
   @patch( "DIRAC.StorageManagementSystem.Client.StorageManagerClient.DataManager", return_value = dm_mock )

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -121,7 +121,7 @@ class JobScheduling( OptimizerExecutor ):
     if jobType in Operations().getValue( 'Transformations/DataProcessing', [] ):
       self.jobLog.info( "Production job: sending to TQ, but first checking if staging is requested" )
 
-      res = getFilesToStage( inputData, jobState = jobState )
+      res = getFilesToStage( inputData, jobState = jobState, checkOnlyTapeSEs = self.ex_getOption( 'CheckOnlyTapeSEs', True ), jobLog = jobLog )
 
       if not res['OK']:
         return self.__holdJob( jobState, res['Message'] )

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -121,7 +121,7 @@ class JobScheduling( OptimizerExecutor ):
     if jobType in Operations().getValue( 'Transformations/DataProcessing', [] ):
       self.jobLog.info( "Production job: sending to TQ, but first checking if staging is requested" )
 
-      res = getFilesToStage( inputData, jobState = jobState, checkOnlyTapeSEs = self.ex_getOption( 'CheckOnlyTapeSEs', True ), jobLog = jobLog )
+      res = getFilesToStage( inputData, jobState = jobState, checkOnlyTapeSEs = self.ex_getOption( 'CheckOnlyTapeSEs', True ), jobLog = self.jobLog )
 
       if not res['OK']:
         return self.__holdJob( jobState, res['Message'] )

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -137,8 +137,7 @@ class JobScheduling( OptimizerExecutor ):
           # Some files are missing in the FC or in SEs, fail the job
           self.jobLog.error( reason, ','.join( lfns ) )
         error = ','.join( reasons )
-        jobState.setStatus( 'Failed', appStatus = error )
-        return S_ERROR( errno.ENOENT, error )
+        return S_ERROR( error )
 
       if res['Value']['failedLFNs']:
         return self.__holdJob( jobState, "Couldn't get storage metadata of some files" )

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Executors/JobScheduling/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Executors/JobScheduling/index.rst
@@ -35,3 +35,6 @@ This Executor will fail affected jobs meaningfully.
 | *AllowInvalidSites*     | If set to False, jobs will be held if   | AllowInvalidSites = False                  |
 |                         | any of the Sites specified are invalid. | (default value is True)                    |
 +-------------------------+-----------------------------------------+--------------------------------------------+
+| *CheckOnlyTapeSEs*      | If set to False, the optimizer will     | CheckOnlyTapeSEs = False                   |
+|                         | check the presence of all replicas      | (default value is True)                    |
++-------------------------+-----------------------------------------+--------------------------------------------+


### PR DESCRIPTION
* Add a CS flag to decide whether to check only replicas at tape SEs or all replicas. Default is to test only at Tape SEs
* If any file is not in the FC, make the job Failed instead of looping infinitely
* Avoid checking files if one replica was already found Online
* restrict usage of decorator to strict minimum, i.e. calling the SE.getFileMetadata