### PR TITLE
[v6r17] Fixes in ProcessPool, DownloadInputData in JobScheduling

### DIFF
--- a/Core/Utilities/ProcessPool.py
+++ b/Core/Utilities/ProcessPool.py
@@ -879,8 +879,11 @@ class ProcessPool( object ):
         log.debug( "__spawnNeededWorkingProcesses", 't=%.2f' % ( time.time() - start ) )
       time.sleep( 0.1 )
       if self.__resultsQueue.empty():
+        if self.__resultsQueue.qsize():
+          log.warn( "Results queue is empty but has non zero size: %d" % self.__resultsQueue.qsize() )
+          return -1
         if processed == 0:
-          log.info( "Process results, but queue is empty..." )
+          log.verbose( "Process results, but queue is empty..." )
         break
       # # get task
       task = self.__resultsQueue.get()
@@ -896,7 +899,8 @@ class ProcessPool( object ):
           if self.__poolCallback and task.taskResults():
             self.__poolCallback( task.getTaskID(), task.taskResults() )
             log.debug( "__poolCallback", 't=%.2f' % ( time.time() - start ) )
-      except Exception, error:
+      except Exception as error:
+        log.exception( "Exception in callback", lException = error )
         pass
       processed += 1
     if processed:

--- a/Core/Utilities/ProcessPool.py
+++ b/Core/Utilities/ProcessPool.py
@@ -3,7 +3,7 @@
 #################################################################
 """
 .. module:: Pfn
-  
+
 :synopsis: ProcessPool and related classes
 
 ProcessPool
@@ -41,7 +41,7 @@ or alternatively by using ProcessTask instance:::
                       kwargs = { "kwarg1" : value1, .. },
                       callback = callbackDef,
                       exceptionCallback = exceptionCallbackDef )
-                      
+
   pool.queueTask( task )
 
 where parameters are:
@@ -135,18 +135,18 @@ class WorkingProcess( multiprocessing.Process ):
 
   WorkingProcess is a class that represents activity that runs in a separate process.
 
-  It is running main thread (process) in daemon mode, reading tasks from :pendingQueue:, executing 
-  them and pushing back tasks with results to the :resultsQueue:. If task has got a timeout value 
-  defined a separate threading.Timer thread is started killing execution (and destroying worker) 
+  It is running main thread (process) in daemon mode, reading tasks from :pendingQueue:, executing
+  them and pushing back tasks with results to the :resultsQueue:. If task has got a timeout value
+  defined a separate threading.Timer thread is started killing execution (and destroying worker)
   after :ProcessTask.__timeOut: seconds.
 
   Main execution could also terminate in a few different ways:
-    
+
     * on every failed read attempt (from empty  :pendingQueue:), the  idle loop counter is increased,
       worker is terminated when counter is reaching a value of 10;
     * when stopEvent is set (so ProcessPool is in draining mode),
     * when parent process PID is set to 1 (init process, parent process with ProcessPool is dead).
-  
+
   """
 
   def __init__( self, pendingQueue, resultsQueue, stopEvent, keepRunning ):
@@ -161,50 +161,50 @@ class WorkingProcess( multiprocessing.Process ):
     :type stopEvent: multiprocessing.Event
     """
     multiprocessing.Process.__init__( self )
-    ## daemonize
+    # # daemonize
     self.daemon = True
-    ## flag to see if task is being treated
+    # # flag to see if task is being treated
     self.__working = multiprocessing.Value( 'i', 0 )
-    ## task counter
+    # # task counter
     self.__taskCounter = multiprocessing.Value( 'i', 0 )
-    ## task queue
+    # # task queue
     self.__pendingQueue = pendingQueue
-    ## results queue
+    # # results queue
     self.__resultsQueue = resultsQueue
-    ## stop event
+    # # stop event
     self.__stopEvent = stopEvent
-    ## keep process running until stop event
+    # # keep process running until stop event
     self.__keepRunning = keepRunning
-    ## placeholder for watchdog thread
+    # # placeholder for watchdog thread
     self.__watchdogThread = None
-    ## placeholder for process thread
+    # # placeholder for process thread
     self.__processThread = None
-    ## placeholder for current task
+    # # placeholder for current task
     self.task = None
-    ## start yourself at least    
+    # # start yourself at least
     self.start()
 
   def __watchdog( self ):
-    """ 
+    """
     Watchdog thread target
 
     Terminating/killing WorkingProcess when parent process is dead
 
     :param self: self reference
     """
-    while True:      
-      ## parent is dead,  commit suicide
+    while True:
+      # # parent is dead,  commit suicide
       if os.getppid() == 1:
         os.kill( self.pid, signal.SIGTERM )
-        ## wait for half a minute and if worker is still alive use REAL silencer
-        time.sleep(30)
-        ## now you're dead
+        # # wait for half a minute and if worker is still alive use REAL silencer
+        time.sleep( 30 )
+        # # now you're dead
         os.kill( self.pid, signal.SIGKILL )
-      ## wake me up in 5 seconds
-      time.sleep(5)
+      # # wake me up in 5 seconds
+      time.sleep( 5 )
 
   def isWorking( self ):
-    """ 
+    """
     Check if process is being executed
 
     :param self: self reference
@@ -212,15 +212,15 @@ class WorkingProcess( multiprocessing.Process ):
     return self.__working.value == 1
 
   def taskProcessed( self ):
-    """ 
+    """
     Tell how many tasks have been processed so far
 
     :param self: self reference
     """
     return self.__taskCounter
-    
+
   def __processTask( self ):
-    """ 
+    """
     processThread target
 
     :param self: self reference
@@ -229,7 +229,7 @@ class WorkingProcess( multiprocessing.Process ):
       self.task.process()
 
   def run( self ):
-    """ 
+    """
     Task execution
 
     Reads and executes ProcessTask :task: out of pending queue and then pushes it
@@ -237,93 +237,93 @@ class WorkingProcess( multiprocessing.Process ):
 
     :param self: self reference
     """
-    ## start watchdog thread
+    # # start watchdog thread
     self.__watchdogThread = threading.Thread( target = self.__watchdog )
     self.__watchdogThread.daemon = True
     self.__watchdogThread.start()
 
-    ## http://cdn.memegenerator.net/instances/400x/19450565.jpg
+    # # http://cdn.memegenerator.net/instances/400x/19450565.jpg
     if LockRing:
       # Reset all locks
       lr = LockRing()
       lr._openAll()
       lr._setAllEvents()
 
-    ## zero processed task counter
+    # # zero processed task counter
     taskCounter = 0
-    ## zero idle loop counter
+    # # zero idle loop counter
     idleLoopCount = 0
 
-    ## main loop
+    # # main loop
     while True:
 
-      ## draining, stopEvent is set, exiting 
+      # # draining, stopEvent is set, exiting
       if self.__stopEvent.is_set():
         return
 
-      ## clear task
+      # # clear task
       self.task = None
 
-      ## read from queue
+      # # read from queue
       try:
-        task = self.__pendingQueue.get( block = True, timeout = 10 )   
+        task = self.__pendingQueue.get( block = True, timeout = 10 )
       except Queue.Empty:
-        ## idle loop?
+        # # idle loop?
         idleLoopCount += 1
-        ## 10th idle loop - exit, nothing to do 
+        # # 10th idle loop - exit, nothing to do
         if idleLoopCount == 10 and not self.__keepRunning:
-          return 
+          return
         continue
 
-      ## toggle __working flag
+      # # toggle __working flag
       self.__working.value = 1
-      ## save task
+      # # save task
       self.task = task
-      ## reset idle loop counter
+      # # reset idle loop counter
       idleLoopCount = 0
 
-      ## process task in a separate thread
+      # # process task in a separate thread
       self.__processThread = threading.Thread( target = self.__processTask )
       self.__processThread.start()
 
       timeout = False
       noResults = False
-      ## join processThread with or without timeout
+      # # join processThread with or without timeout
       if self.task.getTimeOut():
-        self.__processThread.join( self.task.getTimeOut()+10 )
+        self.__processThread.join( self.task.getTimeOut() + 10 )
       else:
         self.__processThread.join()
 
-      ## processThread is still alive? stop it!
+      # # processThread is still alive? stop it!
       if self.__processThread.is_alive():
         self.__processThread._Thread__stop()
         self.task.setResult( S_ERROR( errno.ETIME, "Timed out" ) )
         timeout = True
-      # if the task finished with no results, something bad happened, e.g. 
-      # undetected timeout  
+      # if the task finished with no results, something bad happened, e.g.
+      # undetected timeout
       if not self.task.taskResults() and not self.task.taskException():
-        self.task.setResult( S_ERROR("Task produced no results") )  
+        self.task.setResult( S_ERROR( "Task produced no results" ) )
         noResults = True
-      
-      ## check results and callbacks presence, put task to results queue
+
+      # # check results and callbacks presence, put task to results queue
       if self.task.hasCallback() or self.task.hasPoolCallback():
         self.__resultsQueue.put( task )
-      if timeout or noResults:  
-        # The task execution timed out, stop the process to prevent it from running 
+      if timeout or noResults:
+        # The task execution timed out, stop the process to prevent it from running
         # in the background
         time.sleep( 1 )
         os.kill( self.pid, signal.SIGKILL )
-        return   
-      ## increase task counter
+        return
+      # # increase task counter
       taskCounter += 1
-      self.__taskCounter = taskCounter 
-      ## toggle __working flag
+      self.__taskCounter = taskCounter
+      # # toggle __working flag
       self.__working.value = 0
-   
+
 class ProcessTask( object ):
   """ Defines task to be executed in WorkingProcess together with its callbacks.
   """
-  ## taskID
+  # # taskID
   taskID = 0
 
   def __init__( self,
@@ -373,7 +373,7 @@ class ProcessTask( object ):
     self.__resultCallback = callback
     self.__exceptionCallback = exceptionCallback
     self.__timeOut = 0
-    ## set time out
+    # # set time out
     self.setTimeOut( timeOut )
     self.__done = False
     self.__exceptionRaised = False
@@ -382,7 +382,7 @@ class ProcessTask( object ):
     self.__usePoolCallbacks = usePoolCallbacks
 
   def taskResults( self ):
-    """ 
+    """
     Get task results
 
     :param self: self reference
@@ -390,7 +390,7 @@ class ProcessTask( object ):
     return self.__taskResult
 
   def taskException( self ):
-    """ 
+    """
     Get task exception
 
     :param self: self reference
@@ -398,19 +398,19 @@ class ProcessTask( object ):
     return self.__taskException
 
   def enablePoolCallbacks( self ):
-    """ 
-    (re)enable use of ProcessPool callbacks 
+    """
+    (re)enable use of ProcessPool callbacks
     """
     self.__usePoolCallbacks = True
 
   def disablePoolCallbacks( self ):
-    """ 
-    Disable execution of ProcessPool callbacks 
+    """
+    Disable execution of ProcessPool callbacks
     """
     self.__usePoolCallbacks = False
 
   def usePoolCallbacks( self ):
-    """ 
+    """
     Check if results should be processed by callbacks defined in the :ProcessPool:
 
     :param self: self reference
@@ -418,7 +418,7 @@ class ProcessTask( object ):
     return self.__usePoolCallbacks
 
   def hasPoolCallback( self ):
-    """ 
+    """
     Check if asked to execute :ProcessPool: callbacks
 
     :param self: self reference
@@ -426,7 +426,7 @@ class ProcessTask( object ):
     return self.__usePoolCallbacks
 
   def setTimeOut( self, timeOut ):
-    """ 
+    """
     Set time out (in seconds)
 
     :param self: selt reference
@@ -435,11 +435,11 @@ class ProcessTask( object ):
     try:
       self.__timeOut = int( timeOut )
       return S_OK( self.__timeOut )
-    except (TypeError, ValueError), error:
-      return S_ERROR( str(error) )
+    except ( TypeError, ValueError ), error:
+      return S_ERROR( str( error ) )
 
   def getTimeOut( self ):
-    """ 
+    """
     Get timeOut value
 
     :param self: self reference
@@ -447,7 +447,7 @@ class ProcessTask( object ):
     return self.__timeOut
 
   def hasTimeOutSet( self ):
-    """ 
+    """
     Check if timeout is set
 
     :param self: self reference
@@ -455,7 +455,7 @@ class ProcessTask( object ):
     return bool( self.__timeOut != 0 )
 
   def getTaskID( self ):
-    """ 
+    """
     TaskID getter
 
     :param self: self reference
@@ -463,7 +463,7 @@ class ProcessTask( object ):
     return self.__taskID
 
   def hasCallback( self ):
-    """ 
+    """
     Callback existence checking
 
     :param self: self reference
@@ -472,7 +472,7 @@ class ProcessTask( object ):
     return self.__resultCallback or self.__exceptionCallback or self.__usePoolCallbacks
 
   def exceptionRaised( self ):
-    """ 
+    """
     Flag to determine exception in process
 
     :param self: self reference
@@ -480,7 +480,7 @@ class ProcessTask( object ):
     return self.__exceptionRaised
 
   def doExceptionCallback( self ):
-    """ 
+    """
     Execute exceptionCallback
 
     :param self: self reference
@@ -489,7 +489,7 @@ class ProcessTask( object ):
       self.__exceptionCallback( self, self.__taskException )
 
   def doCallback( self ):
-    """ 
+    """
     Execute result callback function
 
     :param self: self reference
@@ -498,30 +498,30 @@ class ProcessTask( object ):
       self.__resultCallback( self, self.__taskResult )
 
   def setResult( self, result ):
-    """ 
-    Set taskResult to result 
+    """
+    Set taskResult to result
     """
     self.__taskResult = result
 
   def process( self ):
-    """ 
+    """
     Execute task
 
     :param self: self reference
-    """ 
+    """
     self.__done = True
     try:
-      ## it's a function?
+      # # it's a function?
       if type( self.__taskFunction ) is FunctionType:
         self.__taskResult = self.__taskFunction( *self.__taskArgs, **self.__taskKwArgs )
-      ## or a class?
+      # # or a class?
       elif type( self.__taskFunction ) in ( TypeType, ClassType ):
-        ## create new instance
+        # # create new instance
         taskObj = self.__taskFunction( *self.__taskArgs, **self.__taskKwArgs )
-        ### check if it is callable, raise TypeError if not
+        # ## check if it is callable, raise TypeError if not
         if not callable( taskObj ):
           raise TypeError( "__call__ operator not defined not in %s class" % taskObj.__class__.__name__ )
-        ### call it at least
+        # ## call it at least
         self.__taskResult = taskObj()
     except Exception as x:
       self.__exceptionRaised = True
@@ -532,59 +532,59 @@ class ProcessTask( object ):
         retDict['Value'] = str( x )
         retDict['Exc_info'] = sys.exc_info()[1]
         self.__taskException = retDict
-        
+
 class ProcessPool( object ):
   """
   .. class:: ProcessPool
-  
+
   ProcessPool
-  
-  This class is managing multiprocessing execution of tasks (:ProcessTask: instances) in a separate 
+
+  This class is managing multiprocessing execution of tasks (:ProcessTask: instances) in a separate
   sub-processes (:WorkingProcess:).
-  
+
   Pool depth
 
-  The :ProcessPool: is keeping required number of active workers all the time: slave workers are only created 
-  when pendingQueue is being filled with tasks, not exceeding defined min and max limits. When pendingQueue is 
-  empty, active workers will be cleaned up by themselves, as each worker has got built in 
-  self-destroy mechanism after 10 idle loops. 
+  The :ProcessPool: is keeping required number of active workers all the time: slave workers are only created
+  when pendingQueue is being filled with tasks, not exceeding defined min and max limits. When pendingQueue is
+  empty, active workers will be cleaned up by themselves, as each worker has got built in
+  self-destroy mechanism after 10 idle loops.
 
   Processing and communication
 
-  The communication between :ProcessPool: instance and slaves is performed using two :multiprocessing.Queues: 
+  The communication between :ProcessPool: instance and slaves is performed using two :multiprocessing.Queues:
 
     * pendingQueue, used to push tasks to the workers,
     * resultsQueue for revert direction;
 
-  and one :multiprocessing.Event: instance (stopEvent), which is working as a fuse to destroy idle workers 
-  in a clean manner. 
+  and one :multiprocessing.Event: instance (stopEvent), which is working as a fuse to destroy idle workers
+  in a clean manner.
 
-  Processing of task begins with pushing it into :pendingQueue: using :ProcessPool.queueTask: or 
-  :ProcessPool.createAndQueueTask:. Every time new task is queued, :ProcessPool: is checking existance of 
-  active and idle workers and spawning new ones when required. The task is then read and processed on worker 
-  side. If results are ready and callback functions are defined, task is put back to the resultsQueue and it is 
+  Processing of task begins with pushing it into :pendingQueue: using :ProcessPool.queueTask: or
+  :ProcessPool.createAndQueueTask:. Every time new task is queued, :ProcessPool: is checking existance of
+  active and idle workers and spawning new ones when required. The task is then read and processed on worker
+  side. If results are ready and callback functions are defined, task is put back to the resultsQueue and it is
   ready to be picked up by ProcessPool again. To perform this last step one has to call :ProcessPool.processResults:,
-  or alternatively ask for daemon mode processing, when this function is called again and again in 
+  or alternatively ask for daemon mode processing, when this function is called again and again in
   separate background thread.
 
   Finalisation
 
   Finalization for task processing is done in several steps:
-  
+
     * if pool is working in daemon mode, background result processing thread is joined and stopped
     * :pendingQueue: is emptied by :ProcessPool.processAllResults: function, all enqueued tasks are executed
     * :stopEvent: is set, so all idle workers are exiting immediately
     * non-hanging workers are joined and terminated politelty
-    * the rest of workers, if any, are forcefully retained by signals: first by SIGTERM, and if is doesn't work 
+    * the rest of workers, if any, are forcefully retained by signals: first by SIGTERM, and if is doesn't work
       by SIGKILL
 
   :warn: Be carefull and choose wisely :timeout: argument to :ProcessPool.finalize:. Too short time period can
-         cause that all workers will be killed.  
-  
+         cause that all workers will be killed.
+
   """
   def __init__( self, minSize = 2, maxSize = 0, maxQueuedRequests = 10,
-                strictLimits = True, poolCallback=None, poolExceptionCallback=None,
-                keepProcessesRunning=True ):
+                strictLimits = True, poolCallback = None, poolExceptionCallback = None,
+                keepProcessesRunning = True ):
     """ c'tor
 
     :param self: self reference
@@ -595,44 +595,44 @@ class ProcessPool( object ):
     :param callable poolCallbak: results callback
     :param callable poolExceptionCallback: exception callback
     """
-    ## min workers
+    # # min workers
     self.__minSize = max( 1, minSize )
-    ## max workers 
+    # # max workers
     self.__maxSize = max( self.__minSize, maxSize )
-    ## queue size
+    # # queue size
     self.__maxQueuedRequests = maxQueuedRequests
-    ## flag to worker overcommit 
+    # # flag to worker overcommit
     self.__strictLimits = strictLimits
 
-    ## pool results callback
+    # # pool results callback
     self.__poolCallback = poolCallback
-    ## pool exception callback
+    # # pool exception callback
     self.__poolExceptionCallback = poolExceptionCallback
 
-    ## pending queue
+    # # pending queue
     self.__pendingQueue = multiprocessing.Queue( self.__maxQueuedRequests )
-    ## results queue
+    # # results queue
     self.__resultsQueue = multiprocessing.Queue( 0 )
-    ## stop event
+    # # stop event
     self.__stopEvent = multiprocessing.Event()
-    ## keep processes running flag
+    # # keep processes running flag
     self.__keepRunning = keepProcessesRunning
-    ## lock 
+    # # lock
     self.__prListLock = threading.Lock()
-    
-    ## workers dict
+
+    # # workers dict
     self.__workersDict = {}
-    
-    ## flag to trigger workers draining
+
+    # # flag to trigger workers draining
     self.__draining = False
-    ## placeholder for daemon results processing
+    # # placeholder for daemon results processing
     self.__daemonProcess = False
-    
-    ## create initial workers
+
+    # # create initial workers
     self.__spawnNeededWorkingProcesses()
 
-  def stopProcessing( self, timeout=10 ):
-    """ 
+  def stopProcessing( self, timeout = 10 ):
+    """
     Case fire
 
     :param self: self reference
@@ -640,17 +640,17 @@ class ProcessPool( object ):
     self.finalize( timeout )
 
   def startProcessing( self ):
-    """ 
-    Restart processing again 
-
-    :param self: self reference 
     """
-    self.__draining = False 
+    Restart processing again
+
+    :param self: self reference
+    """
+    self.__draining = False
     self.__stopEvent.clear()
     self.daemonize()
-    
+
   def setPoolCallback( self, callback ):
-    """ 
+    """
     Set ProcessPool callback function
 
     :param self: self reference
@@ -660,7 +660,7 @@ class ProcessPool( object ):
       self.__poolCallback = callback
 
   def setPoolExceptionCallback( self, exceptionCallback ):
-    """ 
+    """
     Set ProcessPool exception callback function
 
     :param self: self refernce
@@ -670,7 +670,7 @@ class ProcessPool( object ):
       self.__poolExceptionCallback = exceptionCallback
 
   def getMaxSize( self ):
-    """ 
+    """
     MaxSize getter
 
     :param self: self reference
@@ -678,7 +678,7 @@ class ProcessPool( object ):
     return self.__maxSize
 
   def getMinSize( self ):
-    """ 
+    """
     MinSize getter
 
     :param self: self reference
@@ -686,7 +686,7 @@ class ProcessPool( object ):
     return self.__minSize
 
   def getNumWorkingProcesses( self ):
-    """ 
+    """
     Count processes currently being executed
 
     :param self: self reference
@@ -694,13 +694,13 @@ class ProcessPool( object ):
     counter = 0
     self.__prListLock.acquire()
     try:
-      counter = len( [ pid for pid, worker in self.__workersDict.items() if worker.isWorking() ] )
+      counter = len( [ pid for pid, worker in self.__workersDict.iteritems() if worker.isWorking() ] )
     finally:
       self.__prListLock.release()
     return counter
 
   def getNumIdleProcesses( self ):
-    """ 
+    """
     Count processes being idle
 
     :param self: self reference
@@ -708,7 +708,7 @@ class ProcessPool( object ):
     counter = 0
     self.__prListLock.acquire()
     try:
-      counter = len( [ pid for pid, worker in self.__workersDict.items() if not worker.isWorking() ] )
+      counter = len( [ pid for pid, worker in self.__workersDict.iteritems() if not worker.isWorking() ] )
     finally:
       self.__prListLock.release()
     return counter
@@ -721,7 +721,7 @@ class ProcessPool( object ):
     return max( 0, self.__maxSize - self.getNumWorkingProcesses() )
 
   def __spawnWorkingProcess( self ):
-    """ 
+    """
     Create new process
 
     :param self: self reference
@@ -730,16 +730,16 @@ class ProcessPool( object ):
     try:
       worker = WorkingProcess( self.__pendingQueue, self.__resultsQueue, self.__stopEvent, self.__keepRunning )
       while worker.pid == None:
-        time.sleep(0.1)
+        time.sleep( 0.1 )
       self.__workersDict[ worker.pid ] = worker
     finally:
       self.__prListLock.release()
 
   def __cleanDeadProcesses( self ):
-    """ 
-    Delete references of dead workingProcesses from ProcessPool.__workingProcessList 
     """
-    ## check wounded processes
+    Delete references of dead workingProcesses from ProcessPool.__workingProcessList
+    """
+    # # check wounded processes
     self.__prListLock.acquire()
     try:
       for pid, worker in self.__workersDict.items():
@@ -749,19 +749,19 @@ class ProcessPool( object ):
       self.__prListLock.release()
 
   def __spawnNeededWorkingProcesses( self ):
-    """ 
-    Create N working process (at least self.__minSize, but no more 
+    """
+    Create N working process (at least self.__minSize, but no more
     than self.__maxSize)
 
     :param self: self reference
     """
     self.__cleanDeadProcesses()
-    ## if we're draining do not spawn new workers 
+    # # if we're draining do not spawn new workers
     if self.__draining or self.__stopEvent.is_set():
       return
 
     while len( self.__workersDict ) < self.__minSize:
-      if self.__draining or self.__stopEvent.is_set():  
+      if self.__draining or self.__stopEvent.is_set():
         return
       self.__spawnWorkingProcess()
 
@@ -773,8 +773,8 @@ class ProcessPool( object ):
       self.__spawnWorkingProcess()
       time.sleep( 0.1 )
 
-  def queueTask( self, task, blocking = True, usePoolCallbacks= False ):
-    """ 
+  def queueTask( self, task, blocking = True, usePoolCallbacks = False ):
+    """
     Enqueue new task into pending queue
 
     :param self: self reference
@@ -797,7 +797,7 @@ class ProcessPool( object ):
       self.__prListLock.release()
 
     self.__spawnNeededWorkingProcesses()
-    ## throttle a bit to allow task state propagation
+    # # throttle a bit to allow task state propagation
     time.sleep( 0.1 )
     return S_OK()
 
@@ -811,7 +811,7 @@ class ProcessPool( object ):
                           blocking = True,
                           usePoolCallbacks = False,
                           timeOut = 0 ):
-    """ 
+    """
     Create new processTask and enqueue it in pending task queue
 
     :param self: self reference
@@ -829,29 +829,29 @@ class ProcessPool( object ):
     return self.queueTask( task, blocking )
 
   def hasPendingTasks( self ):
-    """ 
+    """
     Check if taks are present in pending queue
 
     :param self: self reference
 
     :warning: results may be misleading if elements put into the queue are big
-    
+
     """
     return not self.__pendingQueue.empty()
 
   def isFull( self ):
-    """ 
+    """
     Check in peding queue is full
 
     :param self: self reference
 
     :warning: results may be misleading if elements put into the queue are big
-    
+
     """
     return self.__pendingQueue.full()
 
   def isWorking( self ):
-    """ 
+    """
     Check existence of working subprocesses
 
     :param self: self reference
@@ -859,99 +859,125 @@ class ProcessPool( object ):
     return not self.__pendingQueue.empty() or self.getNumWorkingProcesses()
 
   def processResults( self ):
-    """ 
+    """
     Execute tasks' callbacks removing them from results queue
 
     :param self: self reference
     """
     processed = 0
+    log = gLogger.getSubLogger( 'ProcessPool' )
     while True:
+      if ( not log.debug( "Start loop (t=0) queue size = %d, processed = %d" % ( self.__resultsQueue.qsize(), processed ) ) and
+          processed == 0 and
+          self.__resultsQueue.qsize() ):
+        log.info( "Process results, queue size = %d" % self.__resultsQueue.qsize() )
+      start = time.time()
       self.__cleanDeadProcesses()
+      log.debug( "__cleanDeadProcesses", 't=%.2f' % ( time.time() - start ) )
       if not self.__pendingQueue.empty():
         self.__spawnNeededWorkingProcesses()
+        log.debug( "__spawnNeededWorkingProcesses", 't=%.2f' % ( time.time() - start ) )
       time.sleep( 0.1 )
       if self.__resultsQueue.empty():
+        if processed == 0:
+          log.info( "Process results, but queue is empty..." )
         break
-      ## get task
+      # # get task
       task = self.__resultsQueue.get()
-      ## execute callbacks
+      log.debug( "__resultsQueue.get", 't=%.2f' % ( time.time() - start ) )
+      # # execute callbacks
       try:
         task.doExceptionCallback()
         task.doCallback()
+        log.debug( "doCallback", 't=%.2f' % ( time.time() - start ) )
         if task.usePoolCallbacks():
           if self.__poolExceptionCallback and task.exceptionRaised():
             self.__poolExceptionCallback( task.getTaskID(), task.taskException() )
           if self.__poolCallback and task.taskResults():
             self.__poolCallback( task.getTaskID(), task.taskResults() )
+            log.debug( "__poolCallback", 't=%.2f' % ( time.time() - start ) )
       except Exception, error:
         pass
       processed += 1
+    if processed:
+      log.info( "Processed %d results" % processed )
+    else:
+      log.debug( "No results processed" )
     return processed
 
-  def processAllResults( self, timeout=10 ):
-    """ 
+  def processAllResults( self, timeout = 10 ):
+    """
     Process all enqueued tasks at once
 
     :param self: self reference
     """
     start = time.time()
     while self.getNumWorkingProcesses() or not self.__pendingQueue.empty():
-      self.processResults()      
+      self.processResults()
       time.sleep( 1 )
       if time.time() - start > timeout:
         break
     self.processResults()
 
   def finalize( self, timeout = 60 ):
-    """ 
+    """
     Drain pool, shutdown processing in more or less clean way
 
     :param self: self reference
     :param timeout: seconds to wait before killing
     """
-    ## start drainig 
+    # # start drainig
     self.__draining = True
-    ## join deamon process
+    # # join deamon process
     if self.__daemonProcess:
       self.__daemonProcess.join( timeout )
-    ## process all tasks
+    # # process all tasks
     self.processAllResults( timeout )
-    ## set stop event, all idle workers should be terminated
+    # # set stop event, all idle workers should be terminated
     self.__stopEvent.set()
-    ## join idle workers
+    # # join idle workers
     start = time.time()
+    log = gLogger.getSubLogger( "ProcessPool/finalize" )
+    nWorkers = 9999999
     while self.__workersDict:
+      self.__cleanDeadProcesses()
+      if len( self.__workersDict ) != nWorkers:
+        nWorkers = len( self.__workersDict )
+        log.debug( "%d workers still active, timeout = %d" % ( nWorkers, timeout ) )
       if timeout <= 0 or time.time() - start >= timeout:
         break
       time.sleep( 0.1 )
-    self.__cleanDeadProcesses()
-    ## second clean up - join and terminate workers
+    # # second clean up - join and terminate workers
+    if self.__workersDict:
+      log.debug( "After cleaning dead processes, %d workers still active, timeout = %d" % ( len( self.__workersDict ), timeout ) )
     for worker in self.__workersDict.values():
       if worker.is_alive():
         worker.terminate()
-        worker.join(5)
+        worker.join( 5 )
     self.__cleanDeadProcesses()
     ## third clean up - kill'em all!!!
+    if self.__workersDict:
+      log.debug( "After terminating processes, %d workers still active, timeout = %d, kill them" % ( len( self.__workersDict ), timeout ) )
     self.__filicide()
 
   def __filicide( self ):
-    """ 
+    """
     Kill all workers, kill'em all!
-    
+
     :param self: self reference
     """
     while self.__workersDict:
-      pid = self.__workersDict.keys().pop(0)
+      pid = self.__workersDict.keys().pop( 0 )
       worker = self.__workersDict[pid]
       if worker.is_alive():
         os.kill( pid, signal.SIGKILL )
       del self.__workersDict[pid]
-  
+
   def daemonize( self ):
-    """ 
-    Make ProcessPool a finite being for opening and closing doors between 
+    """
+    Make ProcessPool a finite being for opening and closing doors between
     chambers.
-    Also just run it in a separate background thread to the death of 
+    Also just run it in a separate background thread to the death of
     PID 0.
 
     :param self: self reference
@@ -963,7 +989,7 @@ class ProcessPool( object ):
     self.__daemonProcess.start()
 
   def __backgroundProcess( self ):
-    """ 
+    """
     Daemon thread target
 
     :param self: self reference
@@ -975,7 +1001,7 @@ class ProcessPool( object ):
       time.sleep( 1 )
 
   def __del__( self ):
-    """ 
+    """
     Delete slot
 
     :param self: self reference

--- a/DataManagementSystem/scripts/dirac-admin-allow-se.py
+++ b/DataManagementSystem/scripts/dirac-admin-allow-se.py
@@ -48,6 +48,7 @@ for switch in Script.getUnprocessedSwitches():
 
 if not ( read or write or check or remove ):
   # No switch was specified, means we need all of them
+  gLogger.notice( "No option given, all accesses will be allowed if they were not" )
   read = True
   write = True
   check = True
@@ -113,10 +114,7 @@ if not res[ 'OK' ]:
 
 reason = 'Forced with dirac-admin-allow-se by %s' % userName
 
-for se, seOptions in res[ 'Value' ].items():
-
-  resW = resC = resR = { 'OK' : False }
-
+for se, seOptions in res[ 'Value' ].iteritems():
 
   # InActive is used on the CS model, Banned is the equivalent in RSS
   for statusType in STATUS_TYPES:
@@ -124,22 +122,19 @@ for se, seOptions in res[ 'Value' ].items():
       if seOptions.get( statusType ) == "Active":
         gLogger.notice( '%s status of %s is already Active' % ( statusType, se ) )
         continue
-      if seOptions.has_key( statusType ):
+      if statusType in seOptions:
         if not seOptions[ statusType ] in ALLOWED_STATUSES:
           gLogger.notice( '%s option for %s is %s, instead of %s' %
                           ( statusType, se, seOptions[ 'ReadAccess' ], ALLOWED_STATUSES ) )
           gLogger.notice( 'Try specifying the command switches' )
-          continue
-
-        resR = resourceStatus.setStorageElementStatus( se, statusType, 'Active', reason, userName )
-        if not resR['OK']:
-          gLogger.error( "Failed to update %s %s to Active" % ( se, statusType ) )
         else:
-          gLogger.notice( "Successfully updated %s %s to Active" % ( se, statusType ) )
-          statusAllowedDict[statusType].append( se )
-
-  if not( resR['OK'] or resW['OK'] or resC['OK'] ):
-    DIRAC.exit( -1 )
+          resR = resourceStatus.setStorageElementStatus( se, statusType, 'Active', reason, userName )
+          if not resR['OK']:
+            gLogger.fatal( "Failed to update %s %s to Active, exit -" % ( se, statusType ), resR['Message'] )
+            DIRAC.exit( -1 )
+          else:
+            gLogger.notice( "Successfully updated %s %s to Active" % ( se, statusType ) )
+            statusAllowedDict[statusType].append( se )
 
 totalAllowed = 0
 totalAllowedSEs = []

--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -190,7 +190,9 @@ class RequestExecutingAgent( AgentModule ):
     :param ~Request.Request request: Request instance
     """
     maxProcess = max( self.__minProcess, self.__maxProcess )
-    if len( self.__requestCache ) > maxProcess + 4:
+    if len( self.__requestCache ) > maxProcess + 50:
+      # For the time being we just print a warning... If the ProcessPool is working well, this is not needed
+      # We don't know how much is acceptable as it depends on many factors
       self.log.warn( "Too many requests in cache", ': %d' % len( self.__requestCache ) )
 #      return S_ERROR( "Too many requests in cache" )
     if request.RequestID in self.__requestCache:

--- a/RequestManagementSystem/private/RequestTask.py
+++ b/RequestManagementSystem/private/RequestTask.py
@@ -367,7 +367,7 @@ class RequestTask( object ):
       if self.request.JobID:
         attempts = 0
         while True:
-          finalizeRequest = self.requestClient.finalizeRequest( self.request.RequestID, self.request.JobID ) #pylint: disable=no-member
+          finalizeRequest = self.requestClient.finalizeRequest( self.request.RequestID, self.request.JobID )  # pylint: disable=no-member
           if not finalizeRequest["OK"]:
             if not attempts:
               self.log.error( "unable to finalize request %s: %s, will retry" % ( self.request.RequestName,
@@ -386,4 +386,5 @@ class RequestTask( object ):
             break
 
     # Request will be updated by the callBack method
+    self.log.verbose( "RequestTasks exiting, request %s" % self.request.Status )
     return S_OK( self.request )

--- a/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
+++ b/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
@@ -37,6 +37,10 @@ mockObjectSE5.getFileMetadata.return_value = S_OK( {'Successful':{'/a/lfn/1.txt'
                                                     'Failed':{}} )
 mockObjectSE5.getStatus.return_value = S_OK( {'DiskSE': True, 'TapeSE':False} )
 
+mockObjectDMSHelper = MagicMock()
+mockObjectDMSHelper.getLocalSiteForSE.return_value = S_OK( 'mySite' )
+mockObjectDMSHelper.getSitesForSE.return_value = S_OK( ['mySite'] )
+
 class ClientsTestCase( unittest.TestCase ):
   """ Base class for the clients test cases
   """

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -119,7 +119,7 @@ class DownloadInputData:
             downloadReplicas[lfn]['SE'].append( seName )
 
     totalSize = 0
-    self.log.verbose( 'Replicas to download are:' )
+    verbose = self.log.verbose( 'Replicas to download are:' )
     for lfn, reps in downloadReplicas.iteritems():
       self.log.verbose( lfn )
       if not reps['SE']:
@@ -132,9 +132,10 @@ class DownloadInputData:
         # get SE and pfn from tuple
         reps['SE'] = reps['SE'][0]
       totalSize += int( reps.get( 'Size', 0 ) )
-      for item, value in sorted( reps.items() ):
-        if value:
-          self.log.verbose( '\t%s %s' % ( item, value ) )
+      if verbose:
+        for item, value in sorted( reps.items() ):
+          if value:
+            self.log.verbose( '\t%s %s' % ( item, value ) )
 
     self.log.info( 'Total size of files to be downloaded is %s bytes' % ( totalSize ) )
     for lfn in failedReplicas:
@@ -264,7 +265,7 @@ class DownloadInputData:
     """ Download a local copy of a single LFN from a list of Storage Elements.
         This is used as a last resort to attempt to retrieve the file.
     """
-    self.log.verbose( "Attempting to download file from all SEs (%s):" % ','.join( reps.keys() ), lfn )
+    self.log.verbose( "Attempting to download file from all SEs (%s):" % ','.join( reps ), lfn )
     diskSEs = set()
     tapeSEs = set()
     for seName in reps:

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -119,7 +119,9 @@ class JobScheduling( OptimizerExecutor ):
     self.jobLog.verbose( "Has an input data requirement" )
     inputData = result[ 'Value' ]
 
+    # ===================================================================================
     # Production jobs are sent to TQ, but first we have to verify if staging is necessary
+    # ===================================================================================
     if jobType in Operations().getValue( 'Transformations/DataProcessing', [] ):
       self.jobLog.info( "Production job: sending to TQ, but first checking if staging is requested" )
 
@@ -151,9 +153,18 @@ class JobScheduling( OptimizerExecutor ):
         self.__requestStaging( jobState, stageLFNs )
         return S_OK()
       else:
+        # No staging required
+        onlineSites = res['Value']['onlineSites']
+        if onlineSites:
+          # Set the online site(s) first
+          userSites = set( userSites )
+          onlineSites &= userSites
+          userSites = list( onlineSites ) + list( userSites - onlineSites )
         return self.__sendToTQ( jobState, userSites, userBannedSites )
 
+    # ===================================================
     # From now on we know it's a user job with input data
+    # ===================================================
 
     idAgent = self.ex_getOption( 'InputDataAgent', 'InputData' )
     result = self.retrieveOptimizerParam( idAgent )


### PR DESCRIPTION
* ProcessPool: fix the finalization

* DownloadInputData: metadata keys were used as Storage Elements in case of failure. Make the check... This would fix JIRA issue https://its.cern.ch/jira/browse/LHCBDIRAC-663

* JobScheduling: 
   - try and select replicas for staging at the same site as online files
   - put sites holding data before others in the list of available sites