### PR TITLE
[v6r18] generateCertificates accepts validity as parameters

### DIFF
--- a/docs/source/DeveloperGuide/DevelopmentEnvironment/DeveloperInstallation/stuffThatRun.rst
+++ b/docs/source/DeveloperGuide/DevelopmentEnvironment/DeveloperInstallation/stuffThatRun.rst
@@ -176,7 +176,7 @@ The following commands should do the trick for you, by creating a fake CA, a fak
    cd $DEVROOT/DIRAC
    git checkout release/integration
    source tests/Jenkins/utilities.sh
-   generateCertificates
+   generateCertificates 365
    generateUserCredentials
    mkdir -p ~/.globus/
    cp $DEVROOT/user/*.{pem,key} ~/.globus/

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ matplotlib>=1.5.0
 mock>=1.0.1
 MySQL-python>=1.2.5
 jinja2
-ipython
+ipython==5.3.0
 numpy>=1.10.1
 pexpect>=4.0.1
 psutil>=4.2.0

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -450,6 +450,13 @@ function prepareForServer(){
 function generateCertificates(){
   echo '==> [generateCertificates]'
 
+  if [ -z ${1} ];
+  then
+    nDays=1;
+  else:
+    nDays=$1;
+  fi
+
   mkdir -p $SERVERINSTALLDIR/etc/grid-security/certificates
   cd $SERVERINSTALLDIR/etc/grid-security
   if [ $? -ne 0 ]
@@ -468,8 +475,8 @@ function generateCertificates(){
   sed -i "s/#hostname#/$fqdn/g" openssl_config
 
   # Generate X509 Certificate based on the private key and the OpenSSL configuration
-  # file, valid for one day.
-  openssl req -new -x509 -key hostkey.pem -out hostcert.pem -days 1 -config openssl_config
+  # file, valid for nDays days (default 1).
+  openssl req -new -x509 -key hostkey.pem -out hostcert.pem -days $nDays -config openssl_config
 
   # Copy hostcert, hostkey to certificates ( CA dir )
   cp host{cert,key}.pem certificates/


### PR DESCRIPTION
Allwo to choose how long a host certificate will be valid in the jenkins functions