### PR TITLE
[v6r17] Restrict ipython version to 5.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ matplotlib>=1.5.0
 mock>=1.0.1
 MySQL-python>=1.2.5
 jinja2
-ipython
+ipython==5.3.0
 numpy>=1.10.1
 pexpect>=4.0.1
 psutil>=4.2.0


### PR DESCRIPTION
Otherwise the new 6.0 is taken by default, and not compatible with python < 3.3