### PR TITLE
[v6r17] Return error when pilot output is missing

### DIFF
--- a/Resources/Computing/CREAMComputingElement.py
+++ b/Resources/Computing/CREAMComputingElement.py
@@ -372,6 +372,7 @@ class CREAMComputingElement( ComputingElement ):
         output = "Standard Output is not available on the CREAM service"
         if os.path.exists( outFileName ):
           os.unlink( outFileName )
+        return S_ERROR( output )
       else:
         error = '\n'.join( result['Value'][1:] )
         return S_ERROR( error )
@@ -391,6 +392,7 @@ class CREAMComputingElement( ComputingElement ):
       error = "Standard Error is not available on the CREAM service"
       if os.path.exists( errFileName ):
         os.unlink( errFileName )
+      return S_ERROR( error )
     else:
       return S_ERROR( 'Failed to retrieve error for %s' % jobID )
 


### PR DESCRIPTION
Hi,

When the pilot output is missing from the CREAM service for any reason (normally if the admin requests it immediately after a job finishes, before the CE has had a chance to copy it back to the head node), the text "Standard Output is not available on the CREAM service" gets permanently cached as the output (and there is then no way of getting the pilot output, even if it becomes available on the CE).

This patch changes this behaviour so that the missing output is returned as a proper error; preventing it from being cached. Later attempts at fetching the pilot output then actually try to fetch it from the CE again.

Regards,
Simon
