### PR TITLE
Fixing checksum to be 8 char long in Core/Utilities/Adler.py

### DIFF
--- a/Core/Utilities/Adler.py
+++ b/Core/Utilities/Adler.py
@@ -22,7 +22,7 @@ def intAdlerToHex( intAdler ):
   """
   try:
     # Will always be 8 hex digits made from a positive integer
-    return hex( intAdler & 0xffffffff ).lower().replace( 'l', '' ).replace( 'x', '0' )[-8:]
+    return hex( intAdler & 0xffffffff ).lower().replace( 'l', '' ).replace( 'x', '0000' )[-8:]
   except Exception as error:
     print repr( error ).replace( ',)', ')' )
     return False


### PR DESCRIPTION
Sometimes a file can have a checksum with less than 6 char
e.g.
intAdler = 198772
hex( intAdler & 0xffffffff ).lower()
'0x30874'

Notice only 5 char after 0x

Now current code gives

hex( intAdler & 0xffffffff ).lower().replace( 'l', '' ).replace( 'x', '0' )[-8:]

0030874

i.e. 7 char instead of 8 char

This line gives desired 8 char long string by pre pending extra 0
 
hex( intAdler & 0xffffffff ).lower().replace( 'l', '' ).replace( 'x', '0000' )[-8:]
'00030874'

8 char is important because gfal-sum returns 8 char long string in this case.

