### PR TITLE
[v6r17] Implement PlatformCheck code in JobScheduling module.

### DIFF
--- a/WorkloadManagementSystem/Executor/JobSanity.py
+++ b/WorkloadManagementSystem/Executor/JobSanity.py
@@ -65,14 +65,6 @@ class JobSanity( OptimizerExecutor ):
       finalMsg.append( "%s LFNs" % result[ 'Value' ] )
       self.jobLog.info( "%s LFNs" % result[ 'Value' ] )
 
-    #Platform check # disabled
-    if self.ex_getOption( 'PlatformCheck', False ):
-      result = self.checkPlatformSupported( jobState )
-      if not result[ 'OK' ]:
-        return result
-      finalMsg.append( "Platform OK" )
-      self.jobLog.info( "Platform OK" )
-
     #Output data exists check # disabled
     if self.ex_getOption( 'OutputDataCheck', False ):
       if jobType != 'user':
@@ -139,15 +131,6 @@ class JobSanity( OptimizerExecutor ):
        data manager. To be tidied for DIRAC3...
     """
     # FIXME: To implement checkOutputDataExists
-    return S_OK()
-
-  #############################################################################
-  def checkPlatformSupported( self, jobState ):
-    """This method queries the CS for available platforms
-       supported by DIRAC and will check these against what
-       the job requests.
-    """
-    # FIXME: To implement checkPlatformSupported
     return S_OK()
 
   #############################################################################

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -123,7 +123,8 @@ class JobScheduling( OptimizerExecutor ):
         return S_ERROR( "Unable to get OSCompatibility list" )
       allPlatforms = result[ 'Value' ]
       if not jobPlatform in allPlatforms:
-        return self.__holdJob( jobState, "Platform %s is not supported" % jobPlatform )
+        self.jobLog.error( "Platform %s is not supported" % jobPlatform )
+        return S_ERROR( "Platform %s is not supported" % jobPlatform )
 
     # Filter the userSites by the platform selection (if there is one)
     if checkPlatform and userSites:
@@ -135,7 +136,8 @@ class JobScheduling( OptimizerExecutor ):
         userSites = result[ 'Value' ]
         if not userSites:
           # No sites left after filtering -> Invalid platform/sites combination
-          return self.__holdJob( jobState, "No selected sites match platform '%s'" % jobPlatform )
+          self.jobLog.error( "No selected sites match platform '%s'" % jobPlatform )
+          return S_ERROR( "No selected sites match platform '%s'" % jobPlatform )
 
     # Check if there is input data
     result = jobState.getInputData()

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Executors/JobSanity/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Executors/JobSanity/index.rst
@@ -20,9 +20,6 @@ The JobSanity executor screens jobs for the following problems
 | *InputSandboxCheck* | Check for input sandbox files         | InputSandboxCheck = True                   |
 |                     |                                       |                                            |
 +---------------------+---------------------------------------+--------------------------------------------+
-| *PlatformCheck*     | Check if platform is supported        | PlatformCheck = False                      |
-|                     | Not Implemented                       |                                            |
-+---------------------+---------------------------------------+--------------------------------------------+
 | *OutputDataCheck*   | Check if output data exists           | OutputDataCheck = True                     |
 |                     | Not Implemented                       |                                            |
 +---------------------+---------------------------------------+--------------------------------------------+

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Executors/JobScheduling/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Executors/JobScheduling/index.rst
@@ -38,3 +38,7 @@ This Executor will fail affected jobs meaningfully.
 | *CheckOnlyTapeSEs*      | If set to False, the optimizer will     | CheckOnlyTapeSEs = False                   |
 |                         | check the presence of all replicas      | (default value is True)                    |
 +-------------------------+-----------------------------------------+--------------------------------------------+
+| *CheckPlatform*         | If set to True, the optimizer will      | CheckPlatform = True                       |
+|                         | verify the job JDL Platform setting.    | (default value is False)                   |
++-------------------------+-----------------------------------------+--------------------------------------------+
+


### PR DESCRIPTION
Hi,

This code enhances the JobScheduling executor to check the platform specified by the user is actually available at a subset of the sites they've picked. The new tests are only enabled if CheckPlatform = True (default is False) in the CS, so backwards compatibility is maintained. I've removed the old "PlatformCheck" stub from the JobSanity module as this was never implemented and it makes more sense to do it in the JobScheduling module after the list of active sites for the job has been retrieved.

At the same time I've also adjusted the code so that the job manifest is only fetched once, which simplifies some of the other functions slightly.

Regards,
Simon