### PR TITLE
[v6r17] Framework Monitoring - Set username to unknown if CS not fully initialised yet.

### DIFF
--- a/FrameworkSystem/Utilities/MonitoringUtilities.py
+++ b/FrameworkSystem/Utilities/MonitoringUtilities.py
@@ -18,9 +18,12 @@ def monitorInstallation( componentType, system, component, module = None, cpu = 
     module = component
 
   # Retrieve user installing the component
+  user = None
   result = getProxyInfo()
   if result[ 'OK' ]:
-    user = result[ 'Value' ][ 'username' ]
+    proxyInfo = result[ 'Value' ]
+    if 'username' in proxyInfo:
+      user = proxyInfo[ 'username' ]
   else:
     return result
   if not user:
@@ -70,9 +73,12 @@ def monitorUninstallation( system, component, cpu = None, hostname = None ):
   monitoringClient = ComponentMonitoringClient()
 
   # Retrieve user uninstalling the component
+  user = None
   result = getProxyInfo()
   if result[ 'OK' ]:
-    user = result[ 'Value' ][ 'username' ]
+    proxyInfo = result[ 'Value' ]
+    if 'username' in proxyInfo:
+      user = proxyInfo[ 'username' ]
   else:
     return result
   if not user:


### PR DESCRIPTION
Hi,

When installing DIRAC from scratch, the CS isn't initialised fully when running dirac-setup-site (which currently causes a crash on unknown key 'username'). This patch sets a suitable "unknown" username if that is the case, which is enough to get things to bootstrap correctly.

Regards,
Simon
