### PR TITLE
[v6r17] Fix BDII subcluster discovery for some ARC-CEs

### DIFF
--- a/Core/Utilities/Grid.py
+++ b/Core/Utilities/Grid.py
@@ -191,7 +191,7 @@ It contains by the way host information for ce.
 Each cluster is dictionary which contains attributes of ce.
 For example result['Value'][0]['GlueHostBenchmarkSI00']
   """
-  filt = '(GlueSubClusterUniqueID=%s)' % ce
+  filt = '(GlueChunkKey=GlueClusterUniqueID=%s)' % ce
 
   result = ldapsearchBDII( filt, attr, host )
 


### PR DESCRIPTION
Hi,

Some ARC-CEs have SubClusters where the name isn't set to the hostname of the machine, while this configuration is unusual, there are a few UK CEs that have this quirk. This patch changes the LDAP filter to find the SubClusters based on the ClusterUniqueID (which is always set to the CE hostname) rather than directly on the SubCluster name. As far as I can tell, this doesn't slow down the LDAP search compared to the original filter.

Regards,
Simon