### PR TITLE
[v6r18] More RSS fixes to facilitate Sites/CEs synchronization

### DIFF
--- a/Core/scripts/dirac-install-client.py
+++ b/Core/scripts/dirac-install-client.py
@@ -388,6 +388,8 @@ if __name__ == "__main__":
   #############################################
 
   globusDir = os.path.expandvars( "$HOME/.globus" )
+  if not os.path.isdir( globusDir ):
+    os.mkdir( globusDir )
   globusFiles = os.listdir( globusDir )
 
   if "usercert.pem" not in globusFiles or "userkey.pem" not in globusFiles:

--- a/ResourceStatusSystem/Utilities/Synchronizer.py
+++ b/ResourceStatusSystem/Utilities/Synchronizer.py
@@ -29,7 +29,7 @@ class Synchronizer( object ):
 
   '''
 
-  def __init__( self, rStatus = None, rManagement = None ):
+  def __init__( self, rStatus = None, rManagement = None, defaultStatus = "Unknown" ):
 
     # Warm up local CS
     CSHelpers.warmUp()
@@ -38,6 +38,7 @@ class Synchronizer( object ):
       self.rStatus     = ResourceStatusClient.ResourceStatusClient()
     if rManagement is None:
       self.rManagement = ResourceManagementClient()
+    self.defaultStatus = defaultStatus
 
     self.rssConfig = RssConfiguration()
     self.tokenOwner = "rs_svc"
@@ -137,7 +138,7 @@ class Synchronizer( object ):
         query = self.rStatus.addIfNotThereStatusElement( 'Site', 'Status',
                                                          name = siteTuple[ 0 ],
                                                          statusType = siteTuple[ 1 ],
-                                                         status = 'Unknown',
+                                                         status = self.defaultStatus,
                                                          elementType = domainName,
                                                          tokenOwner = self.tokenOwner,
                                                          reason = 'Synchronized' )
@@ -292,7 +293,7 @@ class Synchronizer( object ):
 
       _name            = ceTuple[ 0 ]
       _statusType      = ceTuple[ 1 ]
-      _status          = 'Unknown'
+      _status          = self.defaultStatus
       _reason          = 'Synchronized'
       _elementType     = 'ComputingElement'
 
@@ -359,7 +360,7 @@ class Synchronizer( object ):
 
       _name            = catalogTuple[ 0 ]
       _statusType      = catalogTuple[ 1 ]
-      _status          = 'Unknown'
+      _status          = self.defaultStatus
       _reason          = 'Synchronized'
       _elementType     = 'Catalog'
 
@@ -426,7 +427,7 @@ class Synchronizer( object ):
 
       _name            = ftsTuple[ 0 ]
       _statusType      = ftsTuple[ 1 ]
-      _status          = 'Unknown'
+      _status          = self.defaultStatus
       _reason          = 'Synchronized'
       _elementType     = 'FTS'
 
@@ -493,7 +494,7 @@ class Synchronizer( object ):
 
       _name            = seTuple[ 0 ]
       _statusType      = seTuple[ 1 ]
-      _status          = 'Unknown'
+      _status          = self.defaultStatus
       _reason          = 'Synchronized'
       _elementType     = 'StorageElement'
 
@@ -563,7 +564,7 @@ class Synchronizer( object ):
 
       _name            = queueTuple[ 0 ]
       _statusType      = queueTuple[ 1 ]
-      _status          = 'Unknown'
+      _status          = self.defaultStatus
       _reason          = 'Synchronized'
       _elementType     = 'Queue'
 

--- a/ResourceStatusSystem/scripts/dirac-rss-sync.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-sync.py
@@ -112,8 +112,8 @@ def synchronize():
     Given the element switch, adds rows to the <element>Status tables with Status
     `Unknown` and Reason `Synchronized`.
   '''
-
-  synchronizer = Synchronizer.Synchronizer()
+  global DEFAULT_STATUS
+  synchronizer = Synchronizer.Synchronizer( defaultStatus = DEFAULT_STATUS )
 
   if switchDict[ 'element' ] in ( 'Site', 'all' ):
     subLogger.info( 'Synchronizing Sites' )

--- a/ResourceStatusSystem/scripts/dirac-rss-sync.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-sync.py
@@ -149,17 +149,18 @@ def initSites():
     DIRACExit( 1 )
 
   for site, elements in sites['Value'].iteritems():
+    elementType = site.split( '.' )[0]
     parameters = { 'status': elements[0],
                    'reason': 'Synchronized',
                    'name': site,
                    'dateEffective': elements[1],
                    'tokenExpiration': Datetime,
-                   'elementType': 'Site',
+                   'elementType': elementType,
                    'statusType': 'all',
                    'lastCheckTime': None,
                    'tokenOwner': elements[2] }
 
-    result = rssClient.addIfNotThereStatusElement( "Site", "Status", **parameters )
+    result = rssClient.updateStatusElement( "Site", "Status", **parameters )
 
     if not result[ 'OK' ]:
       subLogger.error( result[ 'Message' ] )
@@ -262,15 +263,17 @@ def run():
 
   if 'init' in switchDict:
 
-    result = initSites()
-    if not result[ 'OK' ]:
-      subLogger.error( result[ 'Message' ] )
-      DIRACExit( 1 )
+    if switchDict.get( 'element' ) == "Site":
+      result = initSites()
+      if not result[ 'OK' ]:
+        subLogger.error( result[ 'Message' ] )
+        DIRACExit( 1 )
 
-    result = initSEs()
-    if not result[ 'OK' ]:
-      subLogger.error( result[ 'Message' ] )
-      DIRACExit( 1 )
+    if switchDict.get( 'element' ) == "Resource":
+      result = initSEs()
+      if not result[ 'OK' ]:
+        subLogger.error( result[ 'Message' ] )
+        DIRACExit( 1 )
 
 #...............................................................................
 

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -451,8 +451,7 @@ class ComputingElement(object):
     if result['OK']:
       if 'AvailableProcessors' in result:
         cores = result['AvailableProcessors']
-        if cores > 1:
-          ceDict['NumberOfProcessors'] = cores
+        ceDict['NumberOfProcessors'] = cores
 
     return S_OK( ceDict )
 

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -601,7 +601,10 @@ class SiteDirector( AgentModule ):
         jobExecDir = self.queueDict[queue]['ParametersDict'].get( 'JobExecDir', jobExecDir )
         httpProxy = self.queueDict[queue]['ParametersDict'].get( 'HttpProxy', '' )
 
-        result = self.getExecutable( queue, pilotsToSubmit, bundleProxy, httpProxy, jobExecDir )
+        result = self.getExecutable( queue, pilotsToSubmit,
+                                     bundleProxy = bundleProxy,
+                                     httpProxy = httpProxy,
+                                     jobExecDir = jobExecDir )
         if not result['OK']:
           return result
 
@@ -723,14 +726,14 @@ class SiteDirector( AgentModule ):
       return totalSlots
 
 #####################################################################################
-  def getExecutable( self, queue, pilotsToSubmit, bundleProxy = True, httpProxy = '', jobExecDir = '', processors = 1 ):
+  def getExecutable( self, queue, pilotsToSubmit, bundleProxy = True, httpProxy = '', jobExecDir = '' ):
     """ Prepare the full executable for queue
     """
 
     proxy = None
     if bundleProxy:
       proxy = self.proxy
-    pilotOptions, pilotsToSubmit = self._getPilotOptions( queue, pilotsToSubmit, processors )
+    pilotOptions, pilotsToSubmit = self._getPilotOptions( queue, pilotsToSubmit )
     if pilotOptions is None:
       self.log.error( "Pilot options empty, error in compilation" )
       return S_ERROR( "Errors in compiling pilot options" )
@@ -739,7 +742,7 @@ class SiteDirector( AgentModule ):
     return S_OK( [ executable, pilotsToSubmit ] )
 
 #####################################################################################
-  def _getPilotOptions( self, queue, pilotsToSubmit, processors = 1 ):
+  def _getPilotOptions( self, queue, pilotsToSubmit ):
     """ Prepare pilot options
     """
 
@@ -841,14 +844,6 @@ class SiteDirector( AgentModule ):
     # Hack
     if self.defaultSubmitPools:
       pilotOptions.append( '-o /Resources/Computing/CEDefaults/SubmitPool=%s' % self.defaultSubmitPools )
-
-    if processors != 1:
-      if processors > 1:
-        pilotOptions.append( '-o /AgentJobRequirements/RequiredTag=%sProcessors' % processors )
-        pilotOptions.append( '-o /Resources/Computing/CEDefaults/Tag=%sProcessors' % processors )
-      else:
-        pilotOptions.append( '-o /AgentJobRequirements/RequiredTag=WholeNode' )
-        pilotOptions.append( '-o /Resources/Computing/CEDefaults/Tag=WholeNode' )
 
     if self.group:
       pilotOptions.append( '-G %s' % self.group )

--- a/WorkloadManagementSystem/Client/Matcher.py
+++ b/WorkloadManagementSystem/Client/Matcher.py
@@ -209,6 +209,9 @@ class Matcher( object ):
         if paramTags:
           resourceDict.setdefault( "Tag", [] ).extend( paramTags )
 
+    if "WholeNode" in resourceDescription:
+      resourceDict.setdefault( "Tag", [] ).append( "WholeNode" )
+
     if 'Tag' in resourceDict:
       resourceDict['Tag'] = list( set( resourceDict['Tag'] ) )
 

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -366,6 +366,25 @@ class JobScheduling( OptimizerExecutor ):
     """This method sends jobs to the task queue agent and if candidate sites
        are defined, updates job JDL accordingly.
     """
+
+    # Generate Tags from specific requirements
+    tagList = []
+    if "MaxRAM" in jobManifest:
+      maxRAM = jobManifest.getOption( "MaxRAM", 0 )
+      if maxRAM:
+        tagList.append( "%dGB" % maxRAM )
+    if "NumberOfProcessors" in jobManifest:
+      nProcessors = jobManifest.getOption( "NumberOfProcessors", 0 )
+      if nProcessors:
+        tagList.append( "%dProcessors" % nProcessors )
+    if "WholeNode" in jobManifest:
+      if jobManifest.getOption( "WholeNode", "" ).lower() in ["1", "yes", "false"]:
+        tagList.append( "WholeNode" )
+    if "Tags" in jobManifest:
+      tagList.extend( jobManifest.getOption( "Tags", [] ) )
+    if tagList:
+      jobManifest.setOption( "Tags", ", ".join( tagList ) )
+
     reqSection = "JobRequirements"
 
     if reqSection in jobManifest:

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -415,6 +415,8 @@ class CheckCECapabilities( CommandBase ):
     except ValueError:
       self.log.error( "The pilot command output is not json compatible." )
       sys.exit( 1 )
+    if resourceDict.get( 'WholeNode' ):
+      self.pp.tags.append( "WholeNode" )
     if resourceDict.get( 'Tag' ):
       self.pp.tags += resourceDict['Tag']
       self.cfg.append( '-FDMH' )

--- a/__init__.py
+++ b/__init__.py
@@ -77,8 +77,8 @@ __RCSID__ = "$Id$"
 # Define Version
 
 majorVersion = 6
-minorVersion = 15
-patchLevel = 9
+minorVersion = 18
+patchLevel = 0
 preVersion = 0
 
 version = "v%sr%s" % ( majorVersion, minorVersion )


### PR DESCRIPTION
1. Few fixes to facilitate dirac-rss-sync command for Sites
2. Allow WholeNode and NumberOfProcessors job JDL parameters instead of the correponding tags 
3. One more case of using SiteMask directly corrected in the JobScheduling executor
4. Introduced QueryCEFlag that can be defined on the level of the CE CS parameters. If evaluated positively ( by default ), the SiteDirector will attempt to get the CE status from the CE itself. In the opposite case, the CE status is evaluated from the information on pilots in PilotAgentsDB. This can be used to avoid direct interrogation of the pilots status at certain CEs that are not providing exact information or otherwise vulnerable, e.g. ARC CEs 
5. Small fix for #3273 in dirac-install-client