### PR TITLE
[v6r18] Fix missing parameter in RSS getSiteMask call

### DIFF
--- a/ResourceStatusSystem/Client/SiteStatus.py
+++ b/ResourceStatusSystem/Client/SiteStatus.py
@@ -273,7 +273,7 @@ class SiteStatus( object ):
       if self.rssFlag:
         siteStatus = self.rsClient.selectStatusElement( 'Site', 'Status', status = siteState, meta = { 'columns' : [ 'Name' ] } )
       else:
-        siteStatus = self.wmsAdministrator.getSiteMask()
+        siteStatus = self.wmsAdministrator.getSiteMask( siteState )
 
     if not siteStatus['OK']:
       return siteStatus


### PR DESCRIPTION
Hi,

When testing v6r18 without the RSS, I found that if a job had InputData, then all sites were being seen as "banned" (so the job was held). I tracked it down to a missing parameter to getSiteMask, so that instead of getting banned sites, it gets all of the sites listed in the DB... This patch fixes the problem.

Regards,
Simon