### PR TITLE
[v6r18] Add option to clear PYTHONPATH on pilot start

### DIFF
--- a/WorkloadManagementSystem/PilotAgent/dirac-pilot.py
+++ b/WorkloadManagementSystem/PilotAgent/dirac-pilot.py
@@ -27,14 +27,14 @@ from pilotTools import Logger, pythonPathCheck, PilotParams, getCommand
 
 if __name__ == "__main__":
 
-  pythonPathCheck()
-
   log = Logger( 'Pilot' )
 
   pilotParams = PilotParams()
   if pilotParams.debugFlag:
     log.setDebug()
-  if pilotParams.clearPythonPath:
+  if pilotParams.keepPythonPath:
+    pythonPathCheck()
+  else:
     log.info( "Clearing PYTHONPATH for child processes." )
     if "PYTHONPATH" in os.environ:
       os.environ["PYTHONPATH_SAVE"] = os.environ["PYTHONPATH"]

--- a/WorkloadManagementSystem/PilotAgent/dirac-pilot.py
+++ b/WorkloadManagementSystem/PilotAgent/dirac-pilot.py
@@ -34,6 +34,12 @@ if __name__ == "__main__":
   pilotParams = PilotParams()
   if pilotParams.debugFlag:
     log.setDebug()
+  if pilotParams.clearPythonPath:
+    log.info( "Clearing PYTHONPATH for child processes." )
+    if "PYTHONPATH" in os.environ:
+      os.environ["PYTHONPATH_SAVE"] = os.environ["PYTHONPATH"]
+      os.environ["PYTHONPATH"] = ""
+
 
   pilotParams.pilotRootPath = os.getcwd()
   pilotParams.pilotScript = os.path.realpath( sys.argv[0] )

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -348,7 +348,7 @@ class PilotParams( object ):
     self.workingDir = os.getcwd()
 
     self.optList = {}
-    self.clearPythonPath = False
+    self.keepPythonPath = False
     self.debugFlag = False
     self.local = False
     self.commandExtensions = []
@@ -396,7 +396,6 @@ class PilotParams( object ):
 
     # Pilot command options
     self.cmdOpts = ( ( 'b', 'build', 'Force local compilation' ),
-                     ( 'c', 'clearpp', 'Clear PYTHONPATH on start' ),
                      ( 'd', 'debug', 'Set debug flag' ),
                      ( 'e:', 'extraPackages=', 'Extra packages to install (comma separated)' ),
                      ( 'E:', 'commandExtensions=', 'Python module with extra commands' ),
@@ -404,6 +403,7 @@ class PilotParams( object ):
                      ( 'g:', 'grid=', 'lcg tools package version' ),
                      ( 'h', 'help', 'Show this help' ),
                      ( 'i:', 'python=', 'Use python<26|27> interpreter' ),
+                     ( 'k', 'keepPP', 'Do not clear PYTHONPATH on start' ),
                      ( 'l:', 'project=', 'Project to install' ),
                      ( 'p:', 'platform=', 'Use <platform> instead of local one' ),
                      ( 'u:', 'url=', 'Use <url> to download tarballs' ),
@@ -458,8 +458,8 @@ class PilotParams( object ):
         self.queueName = v
       elif o == '-R' or o == '--reference':
         self.pilotReference = v
-      elif o == '-c' or o == '--clearpp':
-        self.clearPythonPath = True
+      elif o == '-k' or o == '--keepPP':
+        self.keepPythonPath = True
       elif o == '-d' or o == '--debug':
         self.debugFlag = True
       elif o in ( '-S', '--setup' ):

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -348,6 +348,7 @@ class PilotParams( object ):
     self.workingDir = os.getcwd()
 
     self.optList = {}
+    self.clearPythonPath = False
     self.debugFlag = False
     self.local = False
     self.commandExtensions = []
@@ -395,6 +396,7 @@ class PilotParams( object ):
 
     # Pilot command options
     self.cmdOpts = ( ( 'b', 'build', 'Force local compilation' ),
+                     ( 'c', 'clearpp', 'Clear PYTHONPATH on start' ),
                      ( 'd', 'debug', 'Set debug flag' ),
                      ( 'e:', 'extraPackages=', 'Extra packages to install (comma separated)' ),
                      ( 'E:', 'commandExtensions=', 'Python module with extra commands' ),
@@ -456,6 +458,8 @@ class PilotParams( object ):
         self.queueName = v
       elif o == '-R' or o == '--reference':
         self.pilotReference = v
+      elif o == '-c' or o == '--clearpp':
+        self.clearPythonPath = True
       elif o == '-d' or o == '--debug':
         self.debugFlag = True
       elif o in ( '-S', '--setup' ):


### PR DESCRIPTION
Hi,

While testing GFAL2, we've found that the PYTHONPATH setting from the base worker-node software (at some sites, mainly ones that use it from CVMFS) causes DIRAC to load the wrong gfal2 library at runtime and segfault (when instantiating the GFAL2_SRM2 plugin for example). This patch adds an option to the pilot to clear the PYTOHNPATH at the start of the dirac-pilot.py which fixes this problem. (I wonder if this should actually be the default behaviour: It seems unlikely that the PYTHONPATH from the WN will ever have anything useful to DIRAC on it).

Regards,
Simon