### PR TITLE
[v6r18] Only check RSS bannedSEs in DMS if RSS is enabled.

### DIFF
--- a/DataManagementSystem/Agent/RequestOperations/DMSRequestOperationsBase.py
+++ b/DataManagementSystem/Agent/RequestOperations/DMSRequestOperationsBase.py
@@ -30,10 +30,10 @@ class DMSRequestOperationsBase( OperationHandlerBase ):
 
         :param checkSEs: SEs to check, by default the operation target list is used.
         :param access: The type of access to check for ('WriteAccess' or 'ReadAccess').
-        :type checkSEs: list
+        :type checkSEs: python:list
         :type access: str
         :return: A list of banned SE names
-        :rtype: list
+        :rtype: python:list
     """
     # Only do these checks if RSS is enabled, otherwise return an empty list
     # (to indicate no SEs have been banned by RSS)

--- a/DataManagementSystem/Agent/RequestOperations/DMSRequestOperationsBase.py
+++ b/DataManagementSystem/Agent/RequestOperations/DMSRequestOperationsBase.py
@@ -13,19 +13,33 @@ from DIRAC.RequestManagementSystem.Client.Operation             import Operation
 from DIRAC.RequestManagementSystem.Client.File                  import File
 from DIRAC.Resources.Storage.StorageElement                     import StorageElement
 from DIRAC.RequestManagementSystem.private.OperationHandlerBase import OperationHandlerBase
-from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
+from DIRAC.DataManagementSystem.Utilities.DMSHelpers            import DMSHelpers
+from DIRAC.ResourceStatusSystem.Client.ResourceStatus           import ResourceStatus
 
 class DMSRequestOperationsBase( OperationHandlerBase ):
 
   def __init__( self, operation = None, csPath = None ):
     OperationHandlerBase.__init__( self, operation, csPath )
     self.registrationProtocols = DMSHelpers().getRegistrationProtocols()
+    self.rssFlag = ResourceStatus().rssFlag
 
 
   def checkSEsRSS( self, checkSEs = None, access = 'WriteAccess' ):
-    """ check SEs.
+    """ check SEs, returning a list of banned SEs.
         By default, we check the SEs for WriteAccess, but it is configurable
+
+        :param checkSEs: SEs to check, by default the operation target list is used.
+        :param access: The type of access to check for ('WriteAccess' or 'ReadAccess').
+        :type checkSEs: list
+        :type access: str
+        :return: A list of banned SE names
+        :rtype: list
     """
+    # Only do these checks if RSS is enabled, otherwise return an empty list
+    # (to indicate no SEs have been banned by RSS)
+    if not self.rssFlag:
+      return S_OK( [] )
+
     if not checkSEs:
       checkSEs = self.operation.targetSEList
     elif type( checkSEs ) == str:


### PR DESCRIPTION
Hi,

This patches a bug we were seeing where transfers in the RequestManagementSystem would fail with a KeyError if the RSS was disabled. For completeness, the full traceback of the bug is:
```python
Traceback (most recent call last):
  File "/opt/dirac/DIRAC/RequestManagementSystem/private/RequestTask.py", line 308, in __call__
    exe = handler()
  File "/opt/dirac/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py", line 182, in __call__
    return self.dmTransfer()
  File "/opt/dirac/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py", line 373, in dmTransfer
    bannedTargets = self.checkSEsRSS()
  File "/opt/dirac/DIRAC/DataManagementSystem/Agent/RequestOperations/DMSRequestOperationsBase.py", line 41, in checkSEsRSS
    seStatus = self.rssSEStatus( checkSE, access, retries = 5 )
  File "/opt/dirac/DIRAC/RequestManagementSystem/private/OperationHandlerBase.py", line 222, in rssSEStatus
    return S_OK( rssStatus["Value"][se][status] != "Banned" )
KeyError: 'WriteAccess'
```

Regards,
Simon
