### PR TITLE
[integration] Add PR template and contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+
+# Contribution Guidelines for DIRAC
+
+
+## Pull Requests
+
+When making a `Pull Request` please explain what and why things were
+changed. Please include a short description in the
+BEGINRELEASENOTES/ENDRELEASENOTES block, which will appear in the
+doc/ReleaseNotes.md, once a new tag is made.
+
+We are happy if you create pull-requests also if you feature is not ready, yet.
+Please mark them as such by adding `[WIP]` to the start of the title. The purpose
+of this is, for example, that you want to let other people know you are working
+on a given issue. For these work-in-progress pull-request, we propose to have a
+check list of things that still need to be done.
+
+## Issue tracking
+
+Use the GitHub issue tracker. Reference the issues that you are working on.
+If you notice an issue, consider first creating an issue and then refering to it
+in your pull-request and commit messages with `#[issue-id]`.
+
+## Coding Conventions
+
+ * Your code should not introduce any new pylint warnings, and fix as many existing warnings as possible
+
+## Git workflow
+
+For an explanation of the git(hub) workflow please see
+[here](https://github.com/andresailer/tutorial#working-updating-pushing).  We
+basically follow the ["No Switch
+Yard"](https://root.cern.ch/suggested-work-flow-distributed-projects-nosy)
+workflow
+
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,5 +29,4 @@ in your pull-request and commit messages with `#[issue-id]`.
 
 ## Git workflow
 
-For an explanation of the git(hub) workflow please see
-[here](https://github.com/andresailer/tutorial#working-updating-pushing). The DIRAC Development Model is in detail describe in the [documentation](https://dirac.readthedocs.io/en/latest/DeveloperGuide/DevelopmentModel/index.html).
+ The DIRAC Development Model is described in the [documentation](https://dirac.readthedocs.io/en/latest/DeveloperGuide/DevelopmentModel/index.html) with detailed instructions on the git workflow listed [here](https://dirac.readthedocs.io/en/latest/DeveloperGuide/DevelopmentModel/ContributingCode/index.html). For additional help on the git(hub) workflow please see this [tutorial](https://github.com/andresailer/tutorial#working-updating-pushing).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,9 @@
 When making a `Pull Request` please explain what and why things were
 changed. Please include a short description in the
 BEGINRELEASENOTES/ENDRELEASENOTES block, which will appear in the
-doc/ReleaseNotes.md, once a new tag is made.
+relase.notes, once a new tag is made.
+
+Please prepend the title of your pull request with `[targetReleaseBranch]`.
 
 We are happy if you create pull-requests also if you feature is not ready, yet.
 Please mark them as such by adding `[WIP]` to the start of the title. The purpose
@@ -22,15 +24,10 @@ If you notice an issue, consider first creating an issue and then refering to it
 in your pull-request and commit messages with `#[issue-id]`.
 
 ## Coding Conventions
-
+ * You should follow the [DIRAC Coding Conventions](https://dirac.readthedocs.io/en/latest/DeveloperGuide/CodingConvention/index.html)
  * Your code should not introduce any new pylint warnings, and fix as many existing warnings as possible
 
 ## Git workflow
 
 For an explanation of the git(hub) workflow please see
-[here](https://github.com/andresailer/tutorial#working-updating-pushing).  We
-basically follow the ["No Switch
-Yard"](https://root.cern.ch/suggested-work-flow-distributed-projects-nosy)
-workflow
-
-
+[here](https://github.com/andresailer/tutorial#working-updating-pushing). The DIRAC Development Model is in detail describe in the [documentation](https://dirac.readthedocs.io/en/latest/DeveloperGuide/DevelopmentModel/index.html).

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,8 @@
+
+
+BEGINRELEASENOTES
+- Thank you for writing the text to appear in the release notes. It will show up
+  exactly as it appears between the two bold lines
+- ...
+
+ENDRELEASENOTES

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,8 +1,13 @@
 
 
 BEGINRELEASENOTES
-- Thank you for writing the text to appear in the release notes. It will show up
-  exactly as it appears between the two bold lines
-- ...
+Thank you for writing the text to appear in the release notes. It will show up
+exactly as it appears between the two bold lines
+
+Please follow the template:
+*Subsystem
+NEW/CHANGE/FIX: explanation
+
+For examples look into release.notes
 
 ENDRELEASENOTES


### PR DESCRIPTION
As discussed today this is the PR template that is the basis for the auto generation of release notes.
This will appear in all future PRs, users only need to fill it out.

I have also added some basic contributing guidelines. A link to this .md file will appear when you want to start a new PR. 