### PR TITLE
[v6r18][please merge quickly] Document Low level client classes

### DIFF
--- a/Core/Base/Client.py
+++ b/Core/Base/Client.py
@@ -7,24 +7,44 @@ from DIRAC.Core.DISET.RPCClient                     import RPCClient
 class Client( object ):
   """ Simple class to redirect unknown actions directly to the server. Arguments
       to the constructor are passed to the RPCClient constructor as they are.
+      Some of them can however be overwritten at each call (url and timeout).
+      This class is not thread safe !
 
       - The self.serverURL member should be set by the inheriting class
   """
   def __init__( self, **kwargs ):
+    """ C'tor.
+
+        :param kwargs: just stored as an attribute and passed when creating
+                      the RPCClient
+    """
     self.serverURL = None
-    self.call = None
+    self.call = None # I suppose it is initialized here to make pylint happy
     self.__kwargs = kwargs
 
   def setServer( self, url ):
+    """ Set the server URL used by default
+
+        :param url: url of the service
+    """
     self.serverURL = url
 
   def setTimeout( self, timeout ):
+    """ Specify the timeout of the call. Forwarded to RPCClient
+
+        :param timeout: guess...
+    """
     self.__kwargs['timeout'] = timeout
 
   def getServer( self ):
+    """ Getter for the server url. Useful ?
+    """
     return self.serverURL
 
   def __getattr__( self, name ):
+    """ Store the attribute asked and call executeRPC.
+        This means that Client should not be shared between threads !
+    """
     # This allows the dir() method to work as well as tab completion in ipython
     if name == '__dir__':
       return super( Client, self ).__getattr__() #pylint: disable=no-member
@@ -32,6 +52,15 @@ class Client( object ):
     return self.executeRPC
 
   def executeRPC( self, *parms, **kws ):
+    """ This method extracts some parameters from kwargs that
+        are used as parameter of the constructor or RPCClient.
+        Unfortunately, only a few of all the available
+        parameters of BaseClient are exposed.
+
+        :param rpc: if an RPC client is passed, use that one
+        :param timeout: we can change the timeout on a per call bases. Default 120 s
+        :param url: We can specify which url to use
+    """
     toExecute = self.call
     # Check whether 'rpc' keyword is specified
     rpc = False
@@ -56,7 +85,11 @@ class Client( object ):
     # return eval( evalString )
 
   def _getRPC( self, rpc = None, url = '', timeout = 600 ):
-    """ Return RPCClient object to url
+    """ Return an RPCClient object constructed following the attributes.
+
+        :param rpc: if set, returns this object
+        :param url: url of the service. If not set, use self.serverURL
+        :param timeout: timeout of the call
     """
     if not rpc:
       if not url:

--- a/Core/DISET/RPCClient.py
+++ b/Core/DISET/RPCClient.py
@@ -3,41 +3,100 @@
 
 __RCSID__ = "$Id$"
 
+
 from DIRAC.Core.DISET.private.InnerRPCClient import InnerRPCClient
 
 class _MagicMethod( object ):
+  """ This object allows to bundle together a function calling
+      an RPC and the remote function name.
+      When this object is called (__call__), the call is performed.
+  """
+
 
   def __init__( self, doRPCFunc, remoteFuncName ):
+    """ Constructor
+
+        :param doRPCFunc: the function actually performing the RPC call
+        :param remoteFuncName: name of the remote function
+    """
     self.__doRPCFunc = doRPCFunc
     self.__remoteFuncName = remoteFuncName
 
   def __getattr__( self, remoteFuncName ):
-    return _MagicMethod( self.__doRPCFunc, "%s.%s" % ( self.__remoteFuncName, remoteFuncName ) )
+    """ I really do not understand when this would be called.
+        I can only imagine it being called by dir, or things like that.
+        In any case, it recursively return a MagicMethod object
+        where the new remote function name is the old one to which
+        we append the new called attribute.
+    """
+    return  _MagicMethod( self.__doRPCFunc, "%s.%s" % ( self.__remoteFuncName, remoteFuncName ) )
+
+
 
   def __call__(self, *args ):
+    """ Triggers the call.
+        it uses the RPC calling function given by RPCClient,
+        and gives as argument the remote function name and whatever
+        arguments given.
+    """
+
     return self.__doRPCFunc( self.__remoteFuncName, args )
 
   def __str__( self ):
     return "<RPCClient method %s>" % self.__remoteFuncName
 
 class RPCClient( object ):
+  """ This class contains the mechanism to convert normal calls to RPC calls.
+      When instanciated, it creates a :any:`~DIRAC.Core.DISET.private.InnerRPCClient.InnerRPCClient` as an attribute.
+      Any attribute which is accessed is then either redirected to InnerRPCClient if it has it,
+      or creates a MagicMethod object otherwise. If the attribute is a function, MagicMethod will
+      trigger the RPC call, using the InnerRPCClient.
+
+      The typical workflow looks like this:
+
+
+      rpc = RPCClient('DataManagement/FileCatalog')
+
+      # Here, func is the ping function, which we call remotely.
+      # We go through RPCClient.__getattr__ which returns us a MagicMethod object
+      func = rpc.ping
+
+      # Here we call the method __call__ of the MagicMethod
+      func()
+
+  """
+
 
   def __init__( self, *args, **kwargs ):
     """
-    Constructor
+      Constructor
+      The arguments are just passed on to InnerRPCClient.
+      In practice:
+        * args: has to be the service name or URL
+        * kwargs: all the arguments InnerRPCClient and BaseClient accept as configuration
     """
     self.__innerRPCClient = InnerRPCClient( *args, **kwargs )
 
+
   def __doRPC( self, sFunctionName, args ):
     """
-    Execute the RPC action
+      Execute the RPC action. This is given as an attribute
+      to MagicMethod
+
+      :param sFunctionName: name of the remote function
+      :param args: arguments to pass to the function
     """
     return self.__innerRPCClient.executeRPC( sFunctionName, args )
+
+
 
   def __getattr__( self, attrName ):
     """ Function for emulating the existance of functions.
 
-	In literature this is usually called a "stub function".
+	       In literature this is usually called a "stub function".
+         If the attribute exists in InnerRPCClient, return it,
+         otherwise we create a _MagicMethod instance
+
     """
     if attrName in dir( self.__innerRPCClient ):
       return getattr( self.__innerRPCClient, attrName )

--- a/Core/DISET/RPCClient.py
+++ b/Core/DISET/RPCClient.py
@@ -52,17 +52,16 @@ class RPCClient( object ):
       or creates a MagicMethod object otherwise. If the attribute is a function, MagicMethod will
       trigger the RPC call, using the InnerRPCClient.
 
-      The typical workflow looks like this:
+      The typical workflow looks like this::
 
+        rpc = RPCClient('DataManagement/FileCatalog')
 
-      rpc = RPCClient('DataManagement/FileCatalog')
+        # Here, func is the ping function, which we call remotely.
+        # We go through RPCClient.__getattr__ which returns us a MagicMethod object
+        func = rpc.ping
 
-      # Here, func is the ping function, which we call remotely.
-      # We go through RPCClient.__getattr__ which returns us a MagicMethod object
-      func = rpc.ping
-
-      # Here we call the method __call__ of the MagicMethod
-      func()
+        # Here we call the method __call__ of the MagicMethod
+        func()
 
   """
 

--- a/Core/DISET/ThreadConfig.py
+++ b/Core/DISET/ThreadConfig.py
@@ -4,9 +4,17 @@ import functools
 from DIRAC.Core.Utilities.DIRACSingleton import DIRACSingleton
 
 class ThreadConfig( threading.local ):
-   # What the hell does it mean to have an object thread local but singleton ?!?!?!
-   # We do not even call the parent __init__ !
-   # This class seems useless to me, I could not see it used anywhere
+  """ This class allows to contain extra information when a call is done on behalf of
+      somebody else. Typically, when a host performs the request on behalf of a user.
+      It is not used inside DIRAC, but is used in WebAppDIRAC for example
+
+      Note that the class is a singleton, meaning that you share the same object in the whole process,
+      however the attributes are thread locals (because of the threading.local inheritance).
+
+      Also, this class has to be populated manually, no Client class will do it for you.
+
+  """
+
   __metaclass__ = DIRACSingleton
 
 

--- a/Core/DISET/ThreadConfig.py
+++ b/Core/DISET/ThreadConfig.py
@@ -4,7 +4,11 @@ import functools
 from DIRAC.Core.Utilities.DIRACSingleton import DIRACSingleton
 
 class ThreadConfig( threading.local ):
+   # What the hell does it mean to have an object thread local but singleton ?!?!?!
+   # We do not even call the parent __init__ !
+   # This class seems useless to me, I could not see it used anywhere
   __metaclass__ = DIRACSingleton
+
 
   def __init__( self ):
     self.reset()

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -43,6 +43,7 @@ class BaseClient(object):
 
   def __init__( self, serviceName, **kwargs ):
     """
+      :param serviceName: URL of the service (proper uri or just System/Component)
       :param useCertificates: If set to True, use the server certificate
       :param extraCredentials:
       :param timeout: Timeout of the call (default 600 s)
@@ -375,7 +376,7 @@ class BaseClient(object):
 
   def __checkThreadID( self ):
     """
-      CAUTION: just guessing....
+      ..warning:: just guessing....
       This seems to check that we are not creating a client and then using it
       in a multithreaded environment.
       However, it is triggered only if self.__enableThreadCheck is to True, but it is
@@ -475,6 +476,7 @@ and this is thread %s
 
   def _disconnect( self, trid ):
     """ Disconnect the connection.
+
         :param trid: Transport ID in the transportPool
     """
     getGlobalTransportPool().close( trid )

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -17,6 +17,7 @@ from DIRAC.Core.Security import CS
 from DIRAC.Core.DISET.private.TransportPool import getGlobalTransportPool
 from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
 
+
 class BaseClient(object):
   """ Glues together stubs with threading, credentials, and URLs discovery (by DIRAC vo and setup).
       Basically what needs to be done to enable RPC calls, and transfer, to find a URL.
@@ -41,6 +42,23 @@ class BaseClient(object):
   __threadConfig = ThreadConfig()
 
   def __init__( self, serviceName, **kwargs ):
+    """
+      :param useCertificates: If set to True, use the server certificate
+      :param extraCredentials:
+      :param timeout: Timeout of the call (default 600 s)
+      :param setup: Specify the Setup
+      :param VO: Specify the VO
+      :param delegatedDN: Not clear what it can be used for.
+      :param delegatedGroup: Not clear what it can be used for.
+      :param ignoreGateways: Ignore the DIRAC Gatways settings
+      :param proxyLocation: Specify the location of the proxy
+      :param proxyString: Specify the proxy string
+      :param proxyChain: Specify the proxy chain
+      :param skipCACheck: Do not check the CA
+      :param keepAliveLapse: Duration for keepAliveLapse (heartbeat like)
+    """
+
+
     if not isinstance( serviceName, basestring ):
       raise TypeError( "Service name expected to be a string. Received %s type %s" %
                        ( str( serviceName ), type( serviceName ) ) )
@@ -83,7 +101,13 @@ class BaseClient(object):
     return self._serviceName
 
   def __discoverSetup( self ):
-    #Which setup to use?
+    """ Discover which setup to use and stores it in self.setup
+        The setup is looked for:
+           * kwargs of the constructor (see KW_SETUP)
+           * the ThreadConfig
+           * in the CS /DIRAC/Setup
+           * default to 'Test'
+    """
     if self.KW_SETUP in self.kwargs and self.kwargs[ self.KW_SETUP ]:
       self.setup = str( self.kwargs[ self.KW_SETUP ] )
     else:
@@ -93,7 +117,12 @@ class BaseClient(object):
     return S_OK()
 
   def __discoverVO( self ):
-    #Which vo to use?
+    """ Discover which VO to use and stores it in self.vo
+        The VO is looked for:
+           * kwargs of the constructor (see KW_VO)
+           * in the CS /DIRAC/VirtualOrganization
+           * default to 'unknown'
+    """
     if self.KW_VO in self.kwargs and self.kwargs[ self.KW_VO ]:
       self.vo = str( self.kwargs[ self.KW_VO ] )
     else:
@@ -101,6 +130,13 @@ class BaseClient(object):
     return S_OK()
 
   def __discoverURL( self ):
+    """ Calculate the final URL. It is called at initialization and in connect in case of issue
+
+        It sets:
+          * self.serviceURL: the url (dips) selected as target using __findServiceURL
+          * self.__URLTuple: a split of serviceURL obtained by Network.splitURL
+          * self._serviceName: the last part of URLTuple (typically System/Component)
+    """
     #Calculate final URL
     try:
       result = self.__findServiceURL()
@@ -123,6 +159,12 @@ class BaseClient(object):
     return S_OK()
 
   def __discoverTimeout( self ):
+    """ Discover which timeout to use and stores it in self.timeout
+        The timeout can be specified kwargs of the constructor (see KW_TIMEOUT),
+        with a minimum of 120 seconds.
+        If unspecified, the timeout will be 600 seconds.
+        The value is set in self.timeout, as well as in self.kwargs[KW_TIMEOUT]
+    """
     if self.KW_TIMEOUT in self.kwargs:
       self.timeout = self.kwargs[ self.KW_TIMEOUT ]
     else:
@@ -135,6 +177,17 @@ class BaseClient(object):
     return S_OK()
 
   def __discoverCredentialsToUse( self ):
+    """ Discovers which credentials to use for connection.
+        * Server certificate:
+          -> If KW_USE_CERTIFICATES in kwargs, sets it in self.__useCertificates
+          ->If not, check gConfig.useServerCertificate(), and sets it in self.__useCertificates and kwargs[KW_USE_CERTIFICATES]
+        * Certification Authorities check:
+           -> if KW_SKIP_CA_CHECK is not in kwargs and we are using the certificates, set KW_SKIP_CA_CHECK to false in kwargs
+           -> if KW_SKIP_CA_CHECK is not in kwargs and we are not using the certificate, check the CS.skipCACheck
+        * Proxy Chain
+           -> if KW_PROXY_CHAIN in kwargs, we remove it and dump its string form into kwargs[KW_PROXY_STRING]
+
+    """
     #Use certificates?
     if self.KW_USE_CERTIFICATES in self.kwargs:
       self.__useCertificates = self.kwargs[ self.KW_USE_CERTIFICATES ]
@@ -155,6 +208,18 @@ class BaseClient(object):
     return S_OK()
 
   def __discoverExtraCredentials( self ):
+    """ Add extra credentials informations.
+        * self.__extraCredentials
+          -> if KW_EXTRA_CREDENTIALS in kwargs, we set it
+          -> Otherwise, if we use the server certificate, we set it to VAL_EXTRA_CREDENTIALS_HOST
+          -> If we have a delegation (see bellow), we set it to (delegatedDN, delegatedGroup)
+          -> otherwise it is an empty string
+        * delegation:
+          -> if KW_DELEGATED_DN in kwargs, or delegatedDN in threadConfig, put in in self.kwargs
+          -> if KW_DELEGATED_GROUP in kwargs or delegatedGroup in threadConfig, put it in self.kwargs
+          -> If we have a delegated DN but not group, we find the corresponding group in the CS
+
+    """
     #Wich extra credentials to use?
     if self.__useCertificates:
       self.__extraCredentials = self.VAL_EXTRA_CREDENTIALS_HOST
@@ -178,12 +243,34 @@ class BaseClient(object):
         if not result['OK']:
           return result
       self.__extraCredentials = ( delegatedDN, delegatedGroup )
-
     return S_OK()
 
   def __findServiceURL( self ):
+    """
+        Discovers the URL of a service, taking into account gateways, multiple URLs, banned URLs
+
+
+        If the site on which we run is configured to use gateways (/DIRAC/Gateways/<siteName>),
+        these URLs will be used. To ignore the gateway, it is possible to set KW_IGNORE_GATEWAYS
+        to False in kwargs.
+
+        If self._destinationSrv (given as constructor attribute) is a properly formed URL,
+        we just return this one. If we have to use a gateway, we just replace the server name in the url.
+
+        The list of URLs defined in the CS (<System>/URLs/<Component>) is randomized
+
+        This method also sets some attributes:
+          * self.__nbOfUrls = number of URLs
+          * self.__nbOfRetry = 2 if we have more than 2 urls, otherwise 3
+          * self.__bannedUrls is reinitialized if all the URLs are banned
+
+        :return: the selected URL
+
+    """
     if not self.__initStatus[ 'OK' ]:
       return self.__initStatus
+
+    # Load the Gateways URLs for the current site Name
     gatewayURL = False
     if self.KW_IGNORE_GATEWAYS not in self.kwargs or not self.kwargs[ self.KW_IGNORE_GATEWAYS ]:
       dRetVal = gConfig.getOption( "/DIRAC/Gateways/%s" % DIRAC.siteName() )
@@ -191,6 +278,9 @@ class BaseClient(object):
         rawGatewayURL = List.randomize( List.fromChar( dRetVal[ 'Value'], "," ) )[0]
         gatewayURL = "/".join( rawGatewayURL.split( "/" )[:3] )
 
+    # If what was given as constructor attribute is a properly formed URL,
+    # we just return this one.
+    # If we have to use a gateway, we just replace the server name in it
     for protocol in gProtocolDict:
       if self._destinationSrv.find( "%s://" % protocol ) == 0:
         gLogger.debug( "Already given a valid url", self._destinationSrv )
@@ -206,6 +296,7 @@ class BaseClient(object):
       gLogger.debug( "Using gateway", gatewayURL )
       return S_OK( "%s/%s" % ( gatewayURL, self._destinationSrv ) )
 
+    # We extract the list of URLs from the CS (System/URLs/Component)
     try:
       urls = getServiceURL( self._destinationSrv, setup = self.setup )
     except Exception as e:
@@ -213,10 +304,11 @@ class BaseClient(object):
     if not urls:
       return S_ERROR( "URL for service %s not found" % self._destinationSrv )
 
+    # We randomize the list, and add at the end the failover URLs (System/FailoverURLs/Component)
     urlsList = List.fromChar( urls, "," )
     self.__nbOfUrls = len( urlsList )
     self.__nbOfRetry = 2 if self.__nbOfUrls > 2 else 3 # we retry 2 times all services, if we run more than 2 services
-    if len( urlsList ) == len( self.__bannedUrls ):
+    if self.__nbOfUrls == len( self.__bannedUrls ):
       self.__bannedUrls = []  # retry all urls
       gLogger.debug( "Retrying again all URLs" )
 
@@ -227,12 +319,15 @@ class BaseClient(object):
         gLogger.debug( "Removing banned URL", "%s" % i )
         urlsList.remove( i )
 
+    # Take the first URL from the list
     randUrls = List.randomize( urlsList )
     sURL = randUrls[0]
 
+    # If we have banned URLs, and several URLs at disposals, we make sure that the selected sURL
+    # is not on a host which is banned. If it is, we take the next one in the list using __selectUrl
+
     if len( self.__bannedUrls ) > 0 and self.__nbOfUrls > 2:  # when we have multiple services then we can have a situation
       # when two service are running on the same machine with different port...
-
       retVal = Network.splitURL( sURL )
       nexturl = None
       if retVal['OK']:
@@ -245,7 +340,7 @@ class BaseClient(object):
             bannedurl = retVal['Value']
           else:
             break
-
+          # We found a banned URL on the same host as the one we are running on
           if nexturl[1] == bannedurl[1]:
             found = True
             break
@@ -256,11 +351,16 @@ class BaseClient(object):
     gLogger.debug( "Discovering URL for service", "%s -> %s" % ( self._destinationSrv, sURL ) )
     return S_OK( sURL )
 
+
   def __selectUrl( self, notselect, urls ):
     """In case when multiple services are running in the same host, a new url has to be in a different host
     Note: If we do not have different host we will use the selected url...
-    """
 
+    :param notselect: URL that should NOT be selected
+    :param urls: list of potential URLs
+
+    :return: selected URL
+    """
     url = None
     for i in urls:
       retVal = Network.splitURL( i )
@@ -274,6 +374,13 @@ class BaseClient(object):
 
 
   def __checkThreadID( self ):
+    """
+      CAUTION: just guessing....
+      This seems to check that we are not creating a client and then using it
+      in a multithreaded environment.
+      However, it is triggered only if self.__enableThreadCheck is to True, but it is
+      hardcoded to False, and does not seem to be modified anywhere in the code.
+    """
     if not self.__initStatus[ 'OK' ]:
       return self.__initStatus
     cThID = thread.get_ident()
@@ -293,8 +400,17 @@ and this is thread %s
 
 
   def _connect( self ):
+    """ Establish the connection.
+        It uses the URL discovered in __discoverURL.
+        In case the connection cannot be established, __discoverURL
+        is called again, and _connect calls itself.
+        We stop after trying self.__nbOfRetry * self.__nbOfUrls
 
+    """
     # Check if the useServerCertificate configuration changed
+    # Note: I am not really sure that  all this block makes
+    # any sense at all since all these variables are
+    # evaluated in __discoverCredentialsToUse
     if gConfig.useServerCertificate() != self.__useCertificates:
       if self.__forceUseCertificates is None:
         self.__useCertificates = gConfig.useServerCertificate()
@@ -304,57 +420,101 @@ and this is thread %s
         if not result['OK']:
           return result
 
+    # Take all the extra credentials
     self.__discoverExtraCredentials()
     if not self.__initStatus[ 'OK' ]:
       return self.__initStatus
     if self.__enableThreadCheck:
       self.__checkThreadID()
+
     gLogger.debug( "Connecting to: %s" % self.serviceURL )
     try:
+      # Calls the transport method of the apropriate protocol.
+      # self.__URLTuple[1:3] = [server name, port, System/Component]
       transport = gProtocolDict[ self.__URLTuple[0] ][ 'transport' ]( self.__URLTuple[1:3], **self.kwargs )
       #the socket timeout is the default value which is 1.
       #later we increase to 5
       retVal = transport.initAsClient()
+      # If we have an issue connecting
       if not retVal[ 'OK' ]:
+        # We try at most __nbOfRetry each URLs
         if self.__retry < self.__nbOfRetry * self.__nbOfUrls - 1:
+          # Recompose the URL (why not using self.serviceURL ? )
           url = "%s://%s:%d/%s" % ( self.__URLTuple[0], self.__URLTuple[1], int( self.__URLTuple[2] ), self.__URLTuple[3] )
+          # Add the url to the list of banned URLs if it is not already there. (Can it happen ? I don't think so)
           if url not in self.__bannedUrls:
             self.__bannedUrls += [url]
+            # Why only printing in this case ?
             if len( self.__bannedUrls ) < self.__nbOfUrls:
               gLogger.notice( "Non-responding URL temporarily banned", "%s" % url )
+          # Increment the retry couunter
           self.__retry += 1
+          # If it is our last attempt for each URL, we increase the timeout
           if self.__retryCounter == self.__nbOfRetry - 1:
             transport.setSocketTimeout( 5 ) # we increase the socket timeout in case the network is not good
           gLogger.info( "Retry connection: ", "%d" % self.__retry )
+          # If we tried all the URL, we increase the global counter (__retryCounter), and sleep
           if len(self.__bannedUrls) == self.__nbOfUrls:
             self.__retryCounter += 1
             self.__retryDelay = 3. / self.__nbOfUrls  if self.__nbOfUrls > 1 else 2  # we run only one service! In that case we increase the retry delay.
             gLogger.info( "Waiting %f seconds before retry all service(s)" % self.__retryDelay )
             time.sleep( self.__retryDelay )
+          # rediscover the URL
           self.__discoverURL()
+          # try to reconnect
           return self._connect()
         else:
           return retVal
     except Exception as e:
       gLogger.exception(lException = True, lExcInfo = True)
       return S_ERROR( "Can't connect to %s: %s" % ( self.serviceURL, repr( e ) ) )
+    # We add the connection to the transport pool
     trid = getGlobalTransportPool().add( transport )
+
     return S_OK( ( trid, transport ) )
 
   def _disconnect( self, trid ):
+    """ Disconnect the connection.
+        :param trid: Transport ID in the transportPool
+    """
     getGlobalTransportPool().close( trid )
 
+
   def _proposeAction( self, transport, action ):
+    """ Proposes an action by sending a tuple containing
+
+          * System/Component
+          * Setup
+          * VO
+          * action
+          * extraCredentials
+
+        It is kind of a handshake.
+
+        The server might ask for a delegation, in which case it is done here.
+        The result of the delegation is then returned.
+
+        :param transport: the Transport object returned by _connect
+        :param action: tuple (<action type>, <action name>). It depends on the
+                       subclasses of BaseClient. <action type> can be for example
+                       'RPC' or 'FileTransfer'
+
+       :return: whatever the server sent back
+
+    """
     if not self.__initStatus[ 'OK' ]:
       return self.__initStatus
     stConnectionInfo = ( ( self.__URLTuple[3], self.setup, self.vo ),
                          action,
                          self.__extraCredentials )
+
+    # Send the connection info and get the answer back
     retVal = transport.sendData( S_OK( stConnectionInfo ) )
     if not retVal[ 'OK' ]:
       return retVal
     serverReturn = transport.receiveData()
-    #TODO: Check if delegation is required
+
+    #TODO: Check if delegation is required. This seems to be used only for the GatewayService
     if serverReturn[ 'OK' ] and 'Value' in serverReturn and isinstance( serverReturn[ 'Value' ], dict ):
       gLogger.debug( "There is a server requirement" )
       serverRequirements = serverReturn[ 'Value' ]
@@ -363,7 +523,12 @@ and this is thread %s
         serverReturn = self.__delegateCredentials( transport, serverRequirements[ 'delegate' ] )
     return serverReturn
 
+
   def __delegateCredentials( self, transport, delegationRequest ):
+    """ Perform a credential delegation. This seems to be used only for the GatewayService.
+        It calls the delegation mechanism of the Transport class. Note that it is not used when
+        delegating credentials to the ProxyDB
+    """
     retVal = gProtocolDict[ self.__URLTuple[0] ][ 'delegation' ]( delegationRequest, self.kwargs )
     if not retVal[ 'OK' ]:
       return retVal
@@ -373,6 +538,12 @@ and this is thread %s
     return transport.receiveData()
 
   def __checkTransportSanity( self ):
+    """ Calls the sanity check of the underlying Transport object
+        and stores the result in self.__idDict.
+        It is checked at the creation of the BaseClient, and when connecting
+        if the use of the certificate has changed.
+
+    """
     if not self.__initStatus[ 'OK' ]:
       return self.__initStatus
     retVal = gProtocolDict[ self.__URLTuple[0] ][ 'sanity' ]( self.__URLTuple[1:3], self.kwargs )
@@ -384,10 +555,14 @@ and this is thread %s
     return S_OK()
 
   def __setKeepAliveLapse( self ):
+    """ Select the maximum Keep alive lapse between
+        150 seconds and what is specifind in kwargs[KW_KEEP_ALIVE_LAPSE],
+        and sets it in kwargs[KW_KEEP_ALIVE_LAPSE]
+    """
     kaa = 1
     if self.KW_KEEP_ALIVE_LAPSE in self.kwargs:
       try:
-        kaa = max( 0, int( self.kwargs ) )
+        kaa = max( 0, int( self.kwargs[ self.KW_KEEP_ALIVE_LAPSE ] ) )
       except:
         pass
     if kaa:
@@ -396,6 +571,19 @@ and this is thread %s
     return S_OK()
 
   def _getBaseStub( self ):
+    """ Returns a tuple with (self._destinationSrv, newKwargs)
+        self._destinationSrv is what was given as first parameter of the init serviceName
+
+        newKwargs is an updated copy of kwargs:
+          * kwargs has already been updated by all the initialization functions
+          * if a delegated DN is not set, but is found in __threadConfig or in the info returned by the protocol
+            sanitiy check, then we replace it (KW_DELEGATED_DN)
+          * Same goes for the delegated group KW_DELEGATED_GROUP. In the case of a host,
+            the value is the same as for VAL_EXTRA_CREDENTIALS_HOST
+          * if set, we remove the useCertificates (KW_USE_CERTIFICATES) in newKwargs (not sure to know why)
+
+        This method is just used to return information in case of error in the InnerRPCClient
+    """
     newKwargs = dict( self.kwargs )
     #Set DN
     tDN, tGroup = self.__threadConfig.getID()
@@ -419,6 +607,7 @@ and this is thread %s
           if CS.getHostnameForDN( newKwargs[ self.KW_DELEGATED_DN ] )[ 'OK' ]:
             newKwargs[ self.KW_DELEGATED_GROUP ] = self.VAL_EXTRA_CREDENTIALS_HOST
 
+    # Not sure why one would want to remove that...
     if 'useCertificates' in newKwargs:
       del newKwargs[ 'useCertificates' ]
     return ( self._destinationSrv, newKwargs )

--- a/Core/DISET/private/InnerRPCClient.py
+++ b/Core/DISET/private/InnerRPCClient.py
@@ -8,17 +8,41 @@ from DIRAC.Core.Utilities.ReturnValues import S_OK
 from DIRAC.Core.Utilities.DErrno import cmpError, ENOAUTH
 
 class InnerRPCClient( BaseClient ):
+  """ This class instruments the BaseClient to perform RPC calls.
+      At every RPC call, this class:
+        * connects
+        * proposes the action
+        * sends the method parameters
+        * retrieve the result
+        * disconnect
+  """
 
+  # Number of times we retry the call.
+  # The connection retry is handled by BaseClient
   __retry = 0
 
   def executeRPC( self, functionName, args ):
+    """ Perform the RPC call, connect before and disconnect after.
+
+        :param functionName: name of the function
+        :param args: arguments to the function
+
+        :return: in case of success, the return of the server call. In any case
+                we add the connection stub to it.
+
+
+    """
     retVal = self._connect()
+
+    # Generate the stub which contains all the connection and call options
     stub = ( self._getBaseStub(), functionName, args )
     if not retVal[ 'OK' ]:
       retVal[ 'rpcStub' ] = stub
       return retVal
+    # Get the transport connection ID as well as the Transport object
     trid, transport = retVal[ 'Value' ]
     try:
+      # Handshake to perform the RPC call for functionName
       retVal = self._proposeAction( transport, ( "RPC", functionName ) )
       if not retVal['OK']:
         if cmpError( retVal, ENOAUTH ):  # This query is unauthorized
@@ -32,9 +56,12 @@ class InnerRPCClient( BaseClient ):
             retVal[ 'rpcStub' ] = stub
             return retVal
 
+      # Send the arguments to the function
       retVal = transport.sendData( S_OK( args ) )
       if not retVal[ 'OK' ]:
         return retVal
+
+      # Get the result of the call and append the stub to it
       receivedData = transport.receiveData()
       if isinstance( receivedData, dict ):
         receivedData[ 'rpcStub' ] = stub

--- a/docs/source/DeveloperGuide/Internals/Core/index.rst
+++ b/docs/source/DeveloperGuide/Internals/Core/index.rst
@@ -1,0 +1,68 @@
+===========================
+Client Service Interactions
+===========================
+
+*******
+Clients
+*******
+
+The client can interact with services using RPC calls. DIRAC provides an abstraction which allows to easily add new clients.
+
+
+.. graphviz::
+
+   digraph {
+   YourClient -> Client [label=inherit];
+   Client -> RPCClient [label=use];
+   RPCClient -> InnerRPCClient [label=use];
+   TransferClient -> BaseClient [label=inherit];
+   InnerRPCClient -> BaseClient [label=inherit];
+   BaseClient -> Transports [label=use];
+
+   YourClient  [shape=polygon,sides=4];
+   Client  [shape=polygon,sides=4, label = "DIRAC.Core.Base.Client"];
+   RPCClient  [shape=polygon,sides=4, label = "DIRAC.Core.DISET.RPCClient"];
+   InnerRPCClient  [shape=polygon,sides=4, label = "DIRAC.Core.DISET.private.InnerRPCClient"];
+   TransferClient  [shape=polygon,sides=4, label = "DIRAC.Core.DISET.private.TransferClient"];
+   BaseClient [shape=polygon,sides=4, label = "DIRAC.Core.DISET.private.BaseClient"] ;
+   Transports [shape=polygon,sides=4];
+   }
+
+
+
+
+The BaseClient class contains the low level logic to discover the URLs from System/Component, the connection retry and failover mechanism, the discovery of the credentials to use, and the mechanism to initialize actions with the server. It relies on a Transport class to actually perform the communication.
+
+InnerRPCClient inherits from BaseClient, and just contain the logic to perform an RPC call: it proposes to the server an RPC action. TransferClient implements the FileTransfer logic.
+
+RPCClient translates non existing methods into RPC calls. It does this by using an InnerRPCClient.
+
+the Client class contains a similar logic to emulate methods, but parses specific arguments at each call (url, rpc and timeout) to instantiate an RPCClient. All parameters given to it at initialization will be passed to RPCClient, and propagated down to BaseClient.
+
+Refer to the code documentation of each class for more details. It is good to know however that many connection details can be specified at the creation of the client, and are not necessarily taken from the environment, like the proxy to use.
+
+Here is a rough overview of what is happening when you are calling a method from a client.
+
+.. code-block:: python
+
+   from DIRAC.Core.Base.Cliet import Client
+
+   c = Client()
+   c.serverURL('DataManagement/FileCatalog') # The subclient would have to define it themselves as well
+
+   # This returns a function pointing to Client.executeRPC
+   pingMethod = c.ping
+   # Calling <class 'DIRAC.Core.Base.Client.Client'>.__getattr__(('ping',))
+
+   # When performing the executiong, the whole chain happens
+   pingMethod()
+
+
+   # Calling <class 'DIRAC.Core.Base.Client.Client'>.executeRPC(): this parses the specific arguments URL and  timeout
+   #   if given in the call parameters
+   # Calling <class 'DIRAC.Core.Base.Client.Client'>._getRPC(False, '', 120): we generate an RPCClient
+   # Calling <class 'DIRAC.Core.DISET.RPCClient.RPCClient'>.__getattr__('ping'): we forward the call to the RPCClient
+   # Calling <class 'DIRAC.Core.DISET.RPCClient.RPCClient'>.__doRPC('ping',()): the RPCClient emulates the existance of the
+   #   function and forwards it to the InnerRPCClient
+   # Calling <class 'DIRAC.Core.DISET.private.InnerRPCClient.InnerRPCClient'>.executeRPC('ping', ()): the RPC call is finally
+   #   executed

--- a/docs/source/DeveloperGuide/Internals/index.rst
+++ b/docs/source/DeveloperGuide/Internals/index.rst
@@ -6,3 +6,4 @@ How DIRAC works underneath
    :maxdepth: 2
 
    ../../AdministratorGuide/Systems/WorkloadManagement/JobPriorities/index
+   Core/index

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,6 +98,7 @@ if os.environ.get('READTHEDOCS') == 'True':
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary',
               'sphinx.ext.intersphinx',
               'sphinx.ext.napoleon',
+              'sphinx.ext.graphviz',
              ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
"Always code as if the person who ends up maintaining your code is a violent psychopath who knows where you live." Luckily, I do not know the address ... :-)

This is just pure documentation of how the client side works when you perform an RPC call. probably more will come.
I also introduce a change in the config of sphinx to add the graphviz module. I've checked, and it is supported by readthedoc (http://docs.readthedocs.io/en/latest/builds.html#packages-installed-in-the-build-environment)

As a general note: we have a problem with the images we put in the doc. They are PNG, and once they are in, no one has anymore the original file to modify it. If we use a descriptive language like dot directly inside the documentation, anyone can modify it very easily. So I propose we use that when making class diagrams for example. 

Finally, it turned out to be extremely instructive to document that ! And I do have a few questions:
* What the hell is this ThreadConfig class ? It has the very strange concept to me of being a threading.local and yet a singleton !! That does not mean anything to me :-) Moreover, I cannot see it used anywhere. 
* What are the DIRAC Gateways ? Are they used at all ? I seem to have understood that it is a way to forward calls. 
* I am under the very strong impression that ```DIRAC.Core.Base.Client``` is not thread safe nor reentrant ! 
* There actually is a hell lot of options one can pass when constructing the client ! :-) So to perform a call with a server certificate or with another proxy does not require to change the environment ! That is a discovery to me ! :-) 

Can you please merge it quickly ? I would like to modify slightly the behavior of it, and I don't want to have merge conflicts. This PR contains only documentation 
