### PR TITLE
[v6r18] Fix RSS statusType if it isn't a list.

### DIFF
--- a/ResourceStatusSystem/Client/ResourceStatus.py
+++ b/ResourceStatusSystem/Client/ResourceStatus.py
@@ -206,6 +206,9 @@ class ResourceStatus( object ):
     if not isinstance( elementName, list ):
       elementName = [ elementName ]
 
+    if not isinstance( statusType, list ):
+      statusType = [ statusType ]
+
     result = {}
     for element in elementName:
 


### PR DESCRIPTION
Hi,

It seems the patch in #3367 didn't actually fix the problem I was having... When I started testing it, I was still getting the "WriteAccess" key error, due to a bad return from the RSS:
```
x = ResourceStatus()
x.getElementStatus("UKI-LT2-IC-HEP-disk", "StorageElement", "WriteAccess")              
{'OK': True, 'Value': {'UKI-LT2-IC-HEP-disk': {'A': 'Active', 'c': 'Active', 'e': 'Active', 'i': 'Active', 's': 'Active', 'r': 'Active', 't': 'Active', 'W': 'Active'}}}
```

This patch checks the statusType type and changes it to a list if needed, which then gives the expected output:
```
x = ResourceStatus()
x.getElementStatus("UKI-LT2-IC-HEP-disk", "StorageElement", "WriteAccess")
{'OK': True, 'Value': {'UKI-LT2-IC-HEP-disk': {'WriteAccess': 'Active'}}}
```

Regards,
Simon