### PR TITLE
[v6r18] Allow for FailoverURLs and for MainServers

### DIFF
--- a/ConfigurationSystem/Client/PathFinder.py
+++ b/ConfigurationSystem/Client/PathFinder.py
@@ -3,6 +3,8 @@
 
 __RCSID__ = "$Id$"
 
+import urlparse
+
 from DIRAC.Core.Utilities import List
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 
@@ -78,6 +80,43 @@ def getServiceURL( serviceName, serviceTuple = False, setup = False ):
     serviceTuple = divideFullName( serviceName )
   systemSection = getSystemSection( serviceName, serviceTuple, setup = setup )
   url = gConfigurationData.extractOptionFromCFG( "%s/URLs/%s" % ( systemSection, serviceTuple[1] ) )
+  if not url:
+    return ""
+
+
+  # Trying if we are refering to the list of main servers
+  # which would be like dips://$MAINSERVERS$:1234/System/Component
+  # This can only happen if there is only one server defined
+  if ',' not in url:
+
+    urlParse = urlparse.urlparse(url)
+    server, port = urlParse.netloc.split(':')
+    mainUrlsList = []
+
+    if server == '$MAINSERVERS$':
+
+      # Operations cannot be imported at the beginning because of a bootstrap problem
+      from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+      mainServers = Operations().getValue('MainServers',[])
+      if not mainServers:
+        raise Exception("No Main servers defined")
+
+
+      for srv in mainServers:
+        mainUrlsList.append(urlparse.ParseResult( scheme = urlParse.scheme, netloc = ':'.join([srv, port]),
+                              path = urlParse.path, params = '', query = '', fragment = '').geturl())
+      return ','.join(mainUrlsList)
+
+
+  if len( url.split( "/" ) ) < 5:
+    url = "%s/%s" % ( url, serviceName )
+  return url
+
+def getServiceFailoverURL( serviceName, serviceTuple = False, setup = False ):
+  if not serviceTuple:
+    serviceTuple = divideFullName( serviceName )
+  systemSection = getSystemSection( serviceName, serviceTuple, setup = setup )
+  url = gConfigurationData.extractOptionFromCFG( "%s/FailoverURLs/%s" % ( systemSection, serviceTuple[1] ) )
   if not url:
     return ""
   if len( url.split( "/" ) ) < 5:

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -12,7 +12,7 @@ from DIRAC.FrameworkSystem.Client.Logger import gLogger
 from DIRAC.Core.Utilities import List, Network
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
-from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURL
+from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURL, getServiceFailoverURL
 from DIRAC.Core.Security import CS
 from DIRAC.Core.DISET.private.TransportPool import getGlobalTransportPool
 from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
@@ -305,15 +305,25 @@ class BaseClient(object):
     if not urls:
       return S_ERROR( "URL for service %s not found" % self._destinationSrv )
 
+    failoverUrls = []
+    # Try if there are some failover URLs to use as last resort
+    try:
+      failoverUrlsStr = getServiceFailoverURL( self._destinationSrv, setup = self.setup )
+      if failoverUrlsStr:
+        failoverUrls = failoverUrlsStr.split(',')
+    except Exception as e:
+      pass
+
+
     # We randomize the list, and add at the end the failover URLs (System/FailoverURLs/Component)
-    urlsList = List.fromChar( urls, "," )
+    urlsList = List.randomize(List.fromChar( urls, "," ) ) + failoverUrls
     self.__nbOfUrls = len( urlsList )
     self.__nbOfRetry = 2 if self.__nbOfUrls > 2 else 3 # we retry 2 times all services, if we run more than 2 services
     if self.__nbOfUrls == len( self.__bannedUrls ):
       self.__bannedUrls = []  # retry all urls
       gLogger.debug( "Retrying again all URLs" )
 
-    if len( self.__bannedUrls ) > 0 and len( urlsList ) > 1 :
+    if len( self.__bannedUrls ) > 0 and len(urlsList) > 1 :
       # we have host which is not accessible. We remove that host from the list.
       # We only remove if we have more than one instance
       for i in self.__bannedUrls:
@@ -321,8 +331,9 @@ class BaseClient(object):
         urlsList.remove( i )
 
     # Take the first URL from the list
-    randUrls = List.randomize( urlsList )
-    sURL = randUrls[0]
+    #randUrls = List.randomize( urlsList ) + failoverUrls
+
+    sURL = urlsList[0]
 
     # If we have banned URLs, and several URLs at disposals, we make sure that the selected sURL
     # is not on a host which is banned. If it is, we take the next one in the list using __selectUrl
@@ -346,7 +357,7 @@ class BaseClient(object):
             found = True
             break
         if found:
-          nexturl = self.__selectUrl( nexturl, randUrls[1:] )
+          nexturl = self.__selectUrl( nexturl, urlsList[1:] )
           if nexturl:  # an url found which is in different host
             sURL = nexturl
     gLogger.debug( "Discovering URL for service", "%s -> %s" % ( self._destinationSrv, sURL ) )

--- a/FrameworkSystem/Client/ComponentInstaller.py
+++ b/FrameworkSystem/Client/ComponentInstaller.py
@@ -622,7 +622,12 @@ class ComponentInstaller( object ):
         if not isRenamed and cType == 'service':
           result = self._removeOptionFromCS( cfgPath( 'Systems', system, compInstance, 'URLs', component ) )
           if not result[ 'OK' ]:
-            return result
+            # It is maybe in the FailoverURLs ?
+            result = self._removeOptionFromCS( cfgPath( 'Systems', system, compInstance, 'FailoverURLs', component ) )
+            if not result['OK']:
+              return result
+
+
 
       if removeMain:
         result = self._removeSectionFromCS( cfgPath( 'Systems', system,
@@ -635,7 +640,10 @@ class ComponentInstaller( object ):
         if cType == 'service':
           result = self._removeOptionFromCS( cfgPath( 'Systems', system, compInstance, 'URLs', installation[ 'Component' ][ 'Module' ] ) )
           if not result[ 'OK' ]:
-            return result
+            # it is maybe in the FailoverURLs ?
+            result = self._removeOptionFromCS( cfgPath( 'Systems', system, compInstance, 'FailoverURLs', installation[ 'Component' ][ 'Module' ] ) )
+            if not result['OK']:
+              return result
 
       return S_OK( 'Successfully removed entries from CS' )
     return S_OK( 'Instances of this component still exist. It won\'t be completely removed' )
@@ -801,6 +809,8 @@ class ComponentInstaller( object ):
       if port and self.host:
         urlsPath = cfgPath( 'Systems', system, compInstance, 'URLs' )
         cfg.createNewSection( urlsPath )
+        failoverUrlsPath = cfgPath( 'Systems', system, compInstance, 'FailoverURLs' )
+        cfg.createNewSection( failoverUrlsPath )
         cfg.setOption( cfgPath( urlsPath, component ),
                        'dips://%s:%d/%s/%s' % ( self.host, port, system, component ) )
 

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Operations/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Operations/index.rst
@@ -17,7 +17,7 @@ In the short term, most of this schema will be moved into [vo]/[setup] dependent
 
 .. toctree::
    :maxdepth: 2
-   
+
    Email/index
    DataManagement/index
    InputDataPolicy/index
@@ -27,3 +27,9 @@ In the short term, most of this schema will be moved into [vo]/[setup] dependent
    Shifter/index
    VOs/index
    Transformations/index
+
+
+List of options
+===============
+
+* `MainServers`: List of server names (no protocol, no port) to be used as MainServer

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/index.rst
@@ -7,7 +7,7 @@ Each DIRAC system has its corresponding section in the Configuration namespace.
 
 .. toctree::
    :maxdepth: 1
-   
+
    Accounting/index
    Configuration/index
    DataManagement/index
@@ -16,4 +16,73 @@ Each DIRAC system has its corresponding section in the Configuration namespace.
    Framework/index
    StorageManagement/index
    Transformation/index
-   
+
+
+Default structure
+=================
+
+In each system, per setup, you normally find the following sections:
+
+* Agents: definition of each agent
+* Services: definition of each service
+* Databases: definition of each db
+* URLs: Resolution of the URL of a given Service (like 'DataManagement/FileCatalog') to a list of real urls (like 'dips://<host>:<port>/DataManagement/FileCatalog'). They are tried in a random order.
+* FailoverURLs: Like URLs, but they are only tried if no server in URLs was successfully contacted.
+
+
+Main Servers
+============
+
+There might be setup in which all services are installed behind one or several dns alias(es) or gateways (typically orchestrator like Mesos/Kubernetes). When this is the case, it can be bothering to redefine the very same URL everywhere, especially the day the machine name changes.
+
+For this reason, there is the possibility to define a entry in the Operation section which contains the list of servers:
+
+.. code-block:: python
+
+  Operations/<Setup>/MainServers = server1, server2
+
+
+There should be no port, no protocol. In the system configuration, one can then write:
+
+.. code-block:: python
+
+  System
+  {
+    URLs
+    {
+      Service = dips://$MAINSERVERS$:1234/System/Service
+    }
+  }
+
+This will resolve in the following 2 urls:
+
+.. code-block:: python
+
+  dips://server1:1234/System/Service, dips://server2:1234/System/Service
+
+
+Using together the FailoverURLs section, it can be interesting for orchestrator's setup, where there is a risk for the whole cluster to go down:
+
+.. code-block:: python
+
+  System
+  {
+    URLs
+    {
+      Service = dips://$MAINSERVERS$:1234/System/Service
+    }
+    FailoverURLs
+    {
+      Service = dips://failover1:1234/System/Service,dips://failover2:1234/System/Service
+    }
+  }
+  Operations
+  {
+    Defaults
+    {
+      MainServers = gateway1, gateway2
+    }
+  }
+
+
+This results in all calls going to gateway1 and gateway2, which could be frontend to your orchestrator, and only if none of them answers, then do we use failover1 and failover2, which can be installed on separate machines, independent from the orchestrator

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/index.rst
@@ -44,7 +44,7 @@ For this reason, there is the possibility to define a entry in the Operation sec
 
 There should be no port, no protocol. In the system configuration, one can then write:
 
-.. code-block:: python
+.. code-block:: guess
 
   System
   {

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/index.rst
@@ -37,7 +37,7 @@ There might be setup in which all services are installed behind one or several d
 
 For this reason, there is the possibility to define a entry in the Operation section which contains the list of servers:
 
-.. code-block:: python
+.. code-block:: guess
 
   Operations/<Setup>/MainServers = server1, server2
 
@@ -56,14 +56,14 @@ There should be no port, no protocol. In the system configuration, one can then 
 
 This will resolve in the following 2 urls:
 
-.. code-block:: python
+.. code-block:: guess
 
   dips://server1:1234/System/Service, dips://server2:1234/System/Service
 
 
 Using together the FailoverURLs section, it can be interesting for orchestrator's setup, where there is a risk for the whole cluster to go down:
 
-.. code-block:: python
+.. code-block:: guess
 
   System
   {


### PR DESCRIPTION
BEGINRELEASENOTES
*ConfigurationSystem
NEW: Allow to define FailoverURLs and to reference MainServers in the URLs
ENDRELEASENOTES


@andresailer  @petricm  : Can I put more explanation here outside of the two marks ? I will do, and remove if needed.
Basically, this is what was agreed to simplify the management of the orchestrators, and its behavior (copy/paste of the doc) is illustrated by this example:

```
  System
  {
    URLs
    {
      Service = dips://$MAINSERVERS$:1234/System/Service
    }
    FailoverURLs
    {
      Service = dips://failover1:1234/System/Service,dips://failover2:1234/System/Service
    }
  }
  Operations
  {
    Defaults
    {
      MainServers = gateway1, gateway2
    }
  }
```
This results in all calls going to ```dips://gateway1:1234/System/Service, dips://gateway2:1234/System/Service ``` and if it fails, it will try to go to ``` dips://failover1:1234/System/Service,dips://failover2:1234/System/Service```