### PR TITLE
[v6r18] Add script to get release notes from pull requests

### DIFF
--- a/docs/Tools/GetReleaseNotes.py
+++ b/docs/Tools/GetReleaseNotes.py
@@ -59,10 +59,6 @@ def curl2Json( *commands, **kwargs ):
   commands.insert( 1, '-s' )
   if kwargs.get("checkStatusOnly", False):
     commands.insert( 1, '-I' )
-  cleanedCommands = list(commands)
-  ## replace the github token with Xs
-  if '-H' in cleanedCommands:
-    cleanedCommands[commands.index('-H')+1] = cleanedCommands[commands.index('-H')+1].rsplit(" ", 1)[0] + " "+ "X"*len(cleanedCommands[commands.index('-H')+1].rsplit(" ", 1)[1])
   jsonText = subprocess.check_output( commands )
   try:
     jsonList = json.loads( jsonText )
@@ -149,9 +145,6 @@ def collateReleaseNotes( prs ):
 
 class GithubInterface( object ):
   """ object to make calls to github API
-
-  :param list branches: list of branches to get releases notes for
-
   """
 
   def __init__( self, owner='DiracGrid', repo='Dirac'):
@@ -220,7 +213,7 @@ class GithubInterface( object ):
 
 
   def getNotesFromPRs( self, prs ):
-    """ Loop over prs, get base branch, get PR comment and collate into dict of branch:dict( #PRID, comment ) """
+    """ Loop over prs, get base branch, get PR comment and collate into dict of branch:dict( #PRID, dict(comment, mergeDate) ) """
 
     rawReleaseNotes = defaultdict( dict )
 

--- a/docs/Tools/GetReleaseNotes.py
+++ b/docs/Tools/GetReleaseNotes.py
@@ -73,6 +73,34 @@ def curl2Json( *commands, **kwargs ):
   return jsonList
 
 
+def getFullSystemName( name ):
+  name = {
+    'API': 'Interfaces',
+    'AS': 'AccountingSystem',
+    'CS': 'ConfigurationSystem',
+    'Config': 'ConfigurationSystem',
+    'Configuration': 'ConfigurationSystem',
+    'DMS': 'DataManagementSystem',
+    'DataManagement': 'DataManagementSystem',
+    'FS': 'FrameworkSystem',
+    'Framework': 'FrameworkSystem',
+    'MS': 'MonitoringSystem',
+    'Monitoring': 'MonitoringSystem',
+    'RMS': 'RequestManagementSystem',
+    'RequestManagement': 'RequestManagementSystem',
+    'RSS': 'ResourceStatusSystem',
+    'ResourceStatus': 'ResourceStatusSystem',
+    'SMS': 'StorageManagamentSystem',
+    'StorageManagement': 'StorageManagamentSystem',
+    'TS': 'TransformationSystem',
+    'TMS': 'TransformationSystem',
+    'Transformation': 'TransformationSystem',
+    'WMS': 'WorkloadManagementSystem',
+    'Workload': 'WorkloadManagementSystem',
+  }.get( name, name )
+
+  return name
+
 def parseForReleaseNotes( commentBody ):
   """ will look for "BEGINRELEASENOTES / ENDRELEASENOTES" and extend releaseNoteList if there are entries """
 
@@ -101,7 +129,7 @@ def collateReleaseNotes( prs ):
       system = ''
       for line in notes.splitlines():
         if line.strip().startswith("*"):
-          system = line.strip().strip("*:")
+          system = getFullSystemName( line.strip("*:").strip() )
         elif line.strip():
           systemChangesDict[system].append( line.strip() )
 

--- a/docs/Tools/GetReleaseNotes.py
+++ b/docs/Tools/GetReleaseNotes.py
@@ -1,0 +1,207 @@
+#!/bin/env python
+""" script to obtain release notes from DIRAC PRs
+"""
+
+import json
+import subprocess
+
+from pprint import pprint
+
+from collections import defaultdict
+
+try:
+  from GitTokens import GITHUBTOKEN
+except ImportError:
+  raise ImportError("""Failed to import GITHUBTOKEN please point the pythonpath to your GitTokens.py file which contains your "Personal Access Token" for Github
+
+                    I.e.:
+                    Filename: GitTokens.py
+                    Content:
+                    ```
+                    GITHUBTOKEN = "e0b83063396fc632646603f113437de9"
+                    ```
+                    (without the triple quotes)
+                    """
+                   )
+
+
+def getCommands( *args ):
+  """ create a flat list
+
+  :param *args: list of strings or tuples/lists
+  :returns: flattened list of strings
+  """
+  comList = []
+  for arg in args:
+    if isinstance( arg, (tuple, list) ):
+      comList.extend( getCommands( *arg ) )
+    else:
+      comList.append(arg)
+  return comList
+
+
+def ghHeaders( ):
+  """ return authorization header for github as used by curl
+
+  :returns: tuple to be used in commands list
+  """
+  return '-H','Authorization: token %s' % GITHUBTOKEN
+
+
+def curl2Json( *commands, **kwargs ):
+  """ return the json object from calling curl with the given commands
+
+  :param *commands: list of strings or tuples/lists, will be passed to `getCommands` to be flattend
+  :returns: json object returned from the github or gitlab API
+  """
+  commands = getCommands( *commands )
+  commands.insert( 0, 'curl' )
+  commands.insert( 1, '-s' )
+  if kwargs.get("checkStatusOnly", False):
+    commands.insert( 1, '-I' )
+  cleanedCommands = list(commands)
+  ## replace the github token with Xs
+  if '-H' in cleanedCommands:
+    cleanedCommands[commands.index('-H')+1] = cleanedCommands[commands.index('-H')+1].rsplit(" ", 1)[0] + " "+ "X"*len(cleanedCommands[commands.index('-H')+1].rsplit(" ", 1)[1])
+  jsonText = subprocess.check_output( commands )
+  try:
+    jsonList = json.loads( jsonText )
+  except ValueError:
+    if kwargs.get("checkStatusOnly", False):
+      return jsonText
+    raise
+  return jsonList
+
+
+def parseForReleaseNotes( commentBody ):
+  """ will look for "BEGINRELEASENOTES / ENDRELEASENOTES" and extend releaseNoteList if there are entries """
+
+  relNotes = ''
+  if not all( tag in commentBody for tag in ("BEGINRELEASENOTES", "ENDRELEASENOTES") ):
+    return relNotes
+
+  releaseNotes=commentBody.split("BEGINRELEASENOTES")[1].split("ENDRELEASENOTES")[0]
+  relNotes = releaseNotes
+
+  return relNotes
+
+def collateReleaseNotes( prs ):
+  """put the release notes in the proper order
+
+  FIXME: Tag numbers could be obtained by getting the last tag with a name similar to
+  the branch, will print out just the base branch for now.
+
+  """
+  releaseNotes = ""
+  for baseBranch, pr in prs.iteritems():
+    releaseNotes += "[%s]\n\n" % baseBranch[len("DiracGrid:"):]
+    systemChangesDict = defaultdict( list )
+    for _prid, content in pr.iteritems():
+      notes = content['comment']
+      system = ''
+      for line in notes.splitlines():
+        if line.strip().startswith("*"):
+          system = line.strip().strip("*:")
+        elif line.strip():
+          systemChangesDict[system].append( line.strip() )
+
+    pprint(systemChangesDict)
+    for system, changes in systemChangesDict.iteritems():
+      if not system:
+        continue
+      releaseNotes += "*%s\n\n" % system
+      releaseNotes += "\n".join( changes )
+      releaseNotes += "\n\n"
+    releaseNotes += "\n"
+
+  return releaseNotes
+
+class GithubInterface( object ):
+  """ object to make calls to github API
+
+  :param list branches: list of branches to get releases notes for
+
+  """
+
+  def __init__( self, startDate, owner='DiracGrid', repo='Dirac', branches=None):
+    self.startDate = startDate
+    self.owner = owner
+    self.repo = repo
+    if branches is None:
+      branches = ['Integration', 'rel-v6r17', 'rel-v6r18']
+    self.branches = branches
+    self._options = dict( owner=self.owner, repo=self.repo  )
+    self._releaseNotes = None
+
+
+  def _github( self, action ):
+    """ return the url to perform actions on github
+
+    :param str action: command to use in the gitlab API, see documentation there
+    :returns: url to be used by curl
+    """
+    options = dict(self._options)
+    options["action"] = action
+    ghURL = "https://api.github.com/repos/%(owner)s/%(repo)s/%(action)s" % options
+    return ghURL
+
+
+  def getGithubPRs( self, state="open", mergedOnly=False, perPage=100):
+    """ get all PullRequests from github
+
+    :param str state: state of the PRs, open/closed/all, default open
+    :param bool merged: if PR has to be merged, only sensible for state=closed
+    :returns: list of githubPRs
+    """
+    url = self._github( "pulls?state=%s&per_page=%s" % (state, perPage) )
+    prs = curl2Json( ghHeaders(), url )
+    #pprint(prs)
+    if not mergedOnly:
+      return prs
+
+    ## only merged PRs
+    prsToReturn = []
+    for pr in prs:
+      if pr.get( 'merged_at', None ) is not None:
+        prsToReturn.append(pr)
+
+    return prsToReturn
+
+
+  def getNotesFromPRs( self, prs ):
+    """ Loop over prs, get base branch, get PR comment and collate into dict of branch:dict( #PRID, comment ) """
+
+    rawReleaseNotes = defaultdict( dict )
+
+    for pr in prs:
+      baseBranch = pr['base']['label']
+      comment = parseForReleaseNotes( pr['body'] )
+      prID = pr['number']
+      mergeDate = pr.get('merged_at', None)
+      mergeDate = mergeDate if mergeDate is not None else '9999-99-99'
+      if mergeDate[:10] < self.startDate:
+        continue
+
+      rawReleaseNotes[baseBranch].update( {prID: dict(comment=comment, mergeDate=mergeDate)} )
+
+    return rawReleaseNotes
+
+
+  def getReleaseNotes( self ):
+
+    ## FIXME: use state closed and mergedOnly=True
+    prs = self.getGithubPRs( state='open', mergedOnly=False)
+    prs = self.getNotesFromPRs( prs )
+    releaseNotes = collateReleaseNotes( prs )
+    print releaseNotes
+
+
+if __name__ == "__main__":
+  ## FIXME: get start date from command line
+
+  RUNNER = GithubInterface( startDate='2017-07-01')
+
+  try:
+    RUNNER.getReleaseNotes()
+  except RuntimeError as e:
+    exit(1)

--- a/docs/Tools/GetReleaseNotes.py
+++ b/docs/Tools/GetReleaseNotes.py
@@ -124,14 +124,18 @@ def collateReleaseNotes( prs ):
   for baseBranch, pr in prs.iteritems():
     releaseNotes += "[%s]\n\n" % baseBranch[len("DiracGrid:"):]
     systemChangesDict = defaultdict( list )
-    for _prid, content in pr.iteritems():
+    for prid, content in pr.iteritems():
       notes = content['comment']
       system = ''
       for line in notes.splitlines():
-        if line.strip().startswith("*"):
+        line = line.strip()
+        if line.startswith("*"):
           system = getFullSystemName( line.strip("*:").strip() )
-        elif line.strip():
-          systemChangesDict[system].append( line.strip() )
+        elif line:
+          splitline = line.split(":", 1)
+          if splitline[0] == splitline[0].upper() and len(splitline) > 1:
+            line = "%s: (#%s) %s" % (splitline[0], prid, splitline[1].strip() )
+          systemChangesDict[system].append( line )
 
     pprint(systemChangesDict)
     for system, changes in systemChangesDict.iteritems():

--- a/docs/source/DeveloperGuide/DevelopmentModel/ReleaseProcedure/index.rst
+++ b/docs/source/DeveloperGuide/DevelopmentModel/ReleaseProcedure/index.rst
@@ -68,6 +68,10 @@ correspondingly.
 
 Release notes for the given branch should be made in this branch.
 
+The release notes for a given branch can be obtained with the
+*docs/Tools/GetReleaseNotes.py* script::
+
+  python docs/Tools/GetReleaseNotes.py --branches <branch> [<branch2>...] --date <dateTheLastTagWasMade> [--openPRs]
 
 
 Working with code and tags


### PR DESCRIPTION
This script uses the github api (via curl) to get the release notes for pull requests that were merged since a given date.

You need to get your github Personal Access Token from here https://github.com/settings/tokens
And put it in the place the script expects:
```
Filename: GitTokens.py
Content:
GITHUBTOKEN = "e0b83063396fc632646603f113437de9"
```
 (this is some git sha, not my PAT)
The output from the script needs to be copied to the `release.notes` file by hand

At least two things need to be fixed:
- [x] : get the date from which to check PRs from command line argument
- [x] : change to closed and merged PRs, right now used open as otherwise there are no release notes to parse...
- [x] : get the desired branches from command line arguments
- [x] : update http://dirac.readthedocs.io/en/integration/DeveloperGuide/DevelopmentModel/ReleaseProcedure/index.html

Possibly:
- [x] : replace WMS etc. by WorkloadManagementSystem etc. ?
- [x] : add #PRID to the release notes entries


See output below. Please have a look @atsareg @fstagni 
anything else you would like the script to do?

There are no two PRs targeting the same system so the collation of changes for a single system is not tested

Right now this produces:

```
[integration]


[rel-v6r18]

*Core

FIX: dirac-distribution will by default compile for python 2.7

*tests

NEW: added submitAndMatch test for Jenkins style jobs

*WMS

NEW: The JobWrapperTemplate can reschedule a job if the payload exits with status 111

*ConfigurationSystem

NEW: Allow to define FailoverURLs and to reference MainServers in the URLs

*AccountingSystem

FIX: change the queries, which are used by the unit tests.

*Interfaces

FIX: correctly setting local PATHs for local job execution


[rel-v6r17]

* WorkloadManagementSystem

FIX: SiteDirector - unlink is also to be skipped for Local Condor batchsystem

*Core

FIX: dirac-install.py to fail when installation of lcgBundle has failed


[rel-v6r15]
```


BEGINRELEASENOTES

*Docs
NEW: Add script to collate release notes from Pull Request comments 

ENDRELEASENOTES

EDIT: updated to-do items
