### PR TITLE
[v6r17] RequestExecutingAgent: Fix infinite loop

### DIFF
--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -307,8 +307,8 @@ class RequestExecutingAgent( AgentModule ):
             res = self.cacheRequest( request )
             if not res['OK']:
               if cmpError( res, errno.EALREADY ):
-                # The request is already in the cache, skip it
-                continue
+                # The request is already in the cache, skip it. break out of the while loop to get next request
+                break
               # There are too many requests in the cache, commit suicide
               self.log.error( res['Message'], '(%d requests): put back all requests and exit cycle' % len( self.__requestCache ) )
               self.putAllRequests()


### PR DESCRIPTION
For duplicate requests this continue was just going back to `while True` so we would just try the same `request` over and over

BEGINRELEASENOTES

*RMS
FIX: Fix infinite loop for duplicate requests in RequestExecutingAgent


ENDRELEASENOTES
