### PR TITLE
[v6r17] Fixes for parametric jobs treatment

### DIFF
--- a/Core/Utilities/ClassAd/ClassAdLight.py
+++ b/Core/Utilities/ClassAd/ClassAdLight.py
@@ -288,12 +288,12 @@ class ClassAd:
   def getAttributeInt( self, name ):
     """ Get Integer type attribute value
     """
-    value = 0
+    value = None
     if self.lookupAttribute( name ):
       try:
         value = int( self.get_expression( name ).replace( '"', '' ) )
       except Exception:
-        value = 0
+        value = None
     return value
 
   def getAttributeBool( self, name ):
@@ -313,12 +313,12 @@ class ClassAd:
   def getAttributeFloat( self, name ):
     """ Get Float type attribute value
     """
-    value = 0.0
+    value = None
     if self.lookupAttribute( name ):
       try:
         value = float( self.get_expression( name ).replace( '"', '' ) )
       except Exception:
-        value = 0.0
+        value = None
     return value
 
   def getAttributes( self ):

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1023,7 +1023,13 @@ class JobDB( DB ):
     jobAttrValues.append( diracSetup )
 
     # 2.- Check JDL and Prepare DIRAC JDL
-    classAdJob = ClassAd( jobManifest.dumpAsJDL() )
+    jobJDL = jobManifest.dumpAsJDL()
+
+    # Replace the JobID placeholder if any
+    if jobJDL.find( '%j' ) != -1:
+      jobJDL = jobJDL.replace( '%j', str( jobID ) )
+
+    classAdJob = ClassAd( jobJDL )
     classAdReq = ClassAd( '[]' )
     retVal = S_OK( jobID )
     retVal['JobID'] = jobID
@@ -1082,10 +1088,6 @@ class JobDB( DB ):
     classAdJob.insertAttributeInt( 'JobRequirements', reqJDL )
 
     jobJDL = classAdJob.asJDL()
-
-    # Replace the JobID placeholder if any
-    if jobJDL.find( '%j' ) != -1:
-      jobJDL = jobJDL.replace( '%j', str( jobID ) )
 
     result = self.setJobJDL( jobID, jobJDL )
     if not result['OK']:

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1057,6 +1057,8 @@ class JobDB( DB ):
       return result
 
     priority = classAdJob.getAttributeInt( 'Priority' )
+    if priority is None:
+      priority = 0
     jobAttrNames.append( 'UserPriority' )
     jobAttrValues.append( priority )
 
@@ -1194,15 +1196,17 @@ class JobDB( DB ):
           classAdJob.insertAttributeString( param, val )
 
     priority = classAdJob.getAttributeInt( 'Priority' )
+    if priority is None:
+      priority = 0
     platform = classAdJob.getAttributeString( 'Platform' )
     # Legacy check to suite the LHCb logic
     if not platform:
       platform = classAdJob.getAttributeString( 'SystemConfig' )
     cpuTime = classAdJob.getAttributeInt( 'CPUTime' )
-    if cpuTime == 0:
+    if cpuTime is None:
       # Just in case check for MaxCPUTime for backward compatibility
       cpuTime = classAdJob.getAttributeInt( 'MaxCPUTime' )
-      if cpuTime > 0:
+      if cpuTime is not None:
         classAdJob.insertAttributeInt( 'CPUTime', cpuTime )
     classAdReq.insertAttributeInt( 'UserPriority', priority )
     classAdReq.insertAttributeInt( 'CPUTime', cpuTime )
@@ -1384,6 +1388,8 @@ class JobDB( DB ):
       return result
 
     priority = classAdJob.getAttributeInt( 'Priority' )
+    if priority is None:
+      priority = 0
     jobAttrNames.append( 'UserPriority' )
     jobAttrValues.append( priority )
 

--- a/WorkloadManagementSystem/Utilities/ParametricJob.py
+++ b/WorkloadManagementSystem/Utilities/ParametricJob.py
@@ -41,7 +41,7 @@ def getNumberOfParameters( jobClassAd ):
     else:
       return jobClassAd.getAttributeInt( 'Parameters' )
   else:
-    return 0
+    return None
 
 def __updateAttribute( classAd, attribute, parName, parValue ):
 
@@ -79,8 +79,10 @@ def generateParametricJobs( jobClassAd ):
     return S_OK( [ jobClassAd.asJDL() ] )
 
   nParameters = getNumberOfParameters( jobClassAd )
-  if nParameters == 0:
+  if nParameters is None:
     return S_ERROR( EWMSJDL, 'Can not determine number of job parameters' )
+  if nParameters <= 0:
+    return S_ERROR( EWMSJDL, 'Illegal number of job parameters %d' % ( nParameters ) )
 
   parameterDict = {}
   attributes = jobClassAd.getAttributes()
@@ -99,12 +101,15 @@ def generateParametricJobs( jobClassAd ):
             if attribute != "Parameters":
               return S_ERROR( EWMSJDL, 'Inconsistent parametric job description' )
             nPar = jobClassAd.getAttributeInt( attribute )
+            if nPar is None:
+              value = jobClassAd.get_expression( attribute )
+              return S_ERROR( EWMSJDL, 'Inconsistent parametric job description: %s=%s' % ( attribute, value ) )
             parameterDict[seqID]['Parameters'] = nPar
         else:
           value = jobClassAd.getAttributeInt( attribute )
-          if not value:
+          if value is None:
             value = jobClassAd.getAttributeFloat( attribute )
-            if not value:
+            if value is None:
               value = jobClassAd.get_expression( attribute )
               return S_ERROR( 'Illegal value for %s JDL field: %s' % ( attribute, value ) )
           parameterDict[seqID][key] = value


### PR DESCRIPTION
  Fixes to the problems reported in the DIRAC User Forum:
https://groups.google.com/forum/?hl=en#!topic/diracgrid-forum/9iGEXrVRDQ8
https://groups.google.com/forum/?hl=en#!topic/diracgrid-forum/vwyevuhWIyA

BEGINRELEASENOTES
*Core
FIX: ClassAdLight - getAttributeInt() and getAttributeFloat() return None if the corresponding JDL attribute is not defined

*WMS
FIX: JobDB - fix the case where parametric job placeholder %j is used in the JobName attribute
FIX: JobDB - take into account that ClassAdLight methods return None if numerical attribute is not defined
FIX: ParametricJob utility - fixed bug in evaluation of the ParameterStart|Step|Factor.X job numerical attribute
ENDRELEASENOTES
