### PR TITLE
[v6r19] StorageElement: method to generate pairs of URLs for third party copy

### DIFF
--- a/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -5,6 +5,8 @@ import os
 import unittest
 from DIRAC.ConfigurationSystem.Client.PathFinder import getComponentSection, getServiceFailoverURL, getServiceURL
 from DIRAC.ConfigurationSystem.private.ConfigurationClient import ConfigurationClient
+from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
+from DIRAC.Core.Utilities.CFG import CFG
 
 class TestPathFinder( unittest.TestCase ):
   def setUp( self ):
@@ -57,6 +59,12 @@ class TestPathFinder( unittest.TestCase ):
       os.remove(self.testCfgFileName)
     except OSError:
       pass
+    # SUPER UGLY: one must recreate the CFG objects of gConfigurationData
+    # not to conflict with other tests that might be using a local dirac.cfg
+    gConfigurationData.localCFG=CFG()
+    gConfigurationData.remoteCFG=CFG()
+    gConfigurationData.mergedCFG=CFG()
+    gConfigurationData.generateNewVersion()
 
 class TestGetComponentSection( TestPathFinder ):
 

--- a/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/Resources/Storage/GFAL2_SRM2Storage.py
@@ -21,7 +21,7 @@ class GFAL2_SRM2Storage( GFAL2_StorageBase ):
   """ SRM2 SE class that inherits from GFAL2StorageBase
   """
 
-  _INPUT_PROTOCOLS = ['file', 'root', 'srm']
+  _INPUT_PROTOCOLS = ['file', 'root', 'srm', 'gsiftp']
   _OUTPUT_PROTOCOLS = ['file', 'root', 'dcap', 'gsidcap', 'rfio', 'srm', 'gsiftp']
 
 

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -305,12 +305,7 @@ class GFAL2_StorageBase( StorageBase ):
       return S_ERROR( errStr )
 
     # check whether the source is local or on another storage
-
-    # TODO: as soon as self.protocolParameters contains all known protocols to the SE
-    # we wont need this hard coded list below anymore but can implement a function in StorageBase
-    # similar to isNativeURL which returns true if the src_file contains a known protocol.
-    protocols = ['srm', 'root']
-    if any( src_file.startswith( protocol + ':' ) for protocol in protocols ):
+    if any( src_file.startswith( protocol + ':' ) for protocol in self.protocolParameters['InputProtocols'] ):
       src_url = src_file
       if not sourceSize:
         errStr = "For file replication the source file size in bytes must be provided."
@@ -1739,7 +1734,7 @@ class GFAL2_StorageBase( StorageBase ):
       :returns: list of successful and failed dictionaries, both indexed by the path
 
                   * In the failed, the value is the error message
-                  * In the successful the values are dictionaries: 
+                  * In the successful the values are dictionaries:
 
                       * Files : amount of files in the dir
                       * Size : summed up size of all files

--- a/Resources/Storage/test/Test_StorageElement.py
+++ b/Resources/Storage/test/Test_StorageElement.py
@@ -308,6 +308,12 @@ class TestBase( unittest.TestCase ):
       os.remove(self.testCfgFileName)
     except OSError:
       pass
+    # SUPER UGLY: one must recreate the CFG objects of gConfigurationData
+    # not to conflict with other tests that might be using a local dirac.cfg
+    gConfigurationData.localCFG=CFG()
+    gConfigurationData.remoteCFG=CFG()
+    gConfigurationData.mergedCFG=CFG()
+    gConfigurationData.generateNewVersion()
 
 
 

--- a/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -9,7 +9,7 @@ import importlib
 import os
 import shutil
 
-from mock import MagicMock
+from mock import MagicMock, patch
 
 from DIRAC import gLogger
 
@@ -19,6 +19,9 @@ from DIRAC.Resources.Catalog.test.mock_FC import fc_mock
 from DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper import JobWrapper
 from DIRAC.WorkloadManagementSystem.JobWrapper.WatchdogLinux import WatchdogLinux
 
+getSystemSectionMock = MagicMock()
+getSystemSectionMock.return_value = 'aValue'
+
 class JobWrapperTestCase( unittest.TestCase ):
   """ Base class for the JobWrapper test cases
   """
@@ -26,7 +29,11 @@ class JobWrapperTestCase( unittest.TestCase ):
     gLogger.setLevel( 'DEBUG' )
 
   def tearDown( self ):
-    pass
+    for f in ['std.out']:
+      try:
+        os.remove(f)
+      except OSError:
+        pass
 
 
 class JobWrapperTestCaseSuccess( JobWrapperTestCase ):
@@ -63,7 +70,8 @@ class JobWrapperTestCaseSuccess( JobWrapperTestCase ):
     res = wd._performChecks()
     self.assertTrue( res['OK'] )
 
-  def test_execute(self):
+  @patch( "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect = getSystemSectionMock )
+  def test_execute(self, _patch):
     jw = JobWrapper()
     jw.jobArgs = {'Executable':'/bin/ls'}
     res = jw.execute('')

--- a/docs/source/AdministratorGuide/Systems/DataManagement/index.rst
+++ b/docs/source/AdministratorGuide/Systems/DataManagement/index.rst
@@ -161,6 +161,14 @@ GFAL2_SRM2 plugins because only srm is allowed as a write plugin, but since this
 
 The WriteProtocols and AccessProtocols list can be locally overwritten in the SE definition.
 
+-----------------------
+Multi Protocol with FTS
+-----------------------
+
+CAUTION: not yet active
+
+External services like FTS requires pair of URLs to perform third party copy.
+This is implemented using the same logic as described above. There is however an extra step: once the common protocols between 2 SEs have been filtered, an extra loop filter is done to make sure that the selected protocol can be used as read from the source and as write to the destination. Finally, the URLs which are returned are not necessarily the url of the common protocol, but are the native urls of the plugin that can accept/generate the common protocol. For example, if the common protocol is gsiftp but one of the SE has only an SRM plugin, then you will get an srm URL (which is compatible with gsiftp).
 
 
 --------------------------


### PR DESCRIPTION
This implements the logic that we will need in FTS to do something else than srm to srm. 
There's a huge caveat though: even if a protocol is third party capable, it does not mean that the storage implements it. For example, dCache does not have third party for xroot. Uncool... 
The method is not used yet in FTS.

It appears like there are many changes in the tests, but it is mostly replacing the mock of the CS with an actual cfg file (just discovered that recently :-) ), and add tests for this new method at the very end. 

BEGINRELEASENOTES
Implement the logic to generate pair of URLs to do third party copy. This will be used mostly by FTS, but is not enabled as of now

Please follow the template:
*Resources

NEW: New method in the StorageElement to generate pair of URLs for third party copy

ENDRELEASENOTES
