### PR TITLE
[v6r19] Fix the import logging issue

### DIFF
--- a/FrameworkSystem/private/standardLogging/Logging.py
+++ b/FrameworkSystem/private/standardLogging/Logging.py
@@ -11,6 +11,7 @@ from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
 from DIRAC.Core.Utilities.LockRing import LockRing
 from DIRAC.Resources.LogBackends.AbstractBackend import AbstractBackend
 
+
 class Logging(object):
   """
   Logging is a wrapper of the logger object from the standard "logging" library which integrate
@@ -35,7 +36,7 @@ class Logging(object):
   # it can be composed by the system name and the component name. For instance: "Monitoring/Atom"
   _componentName = "Framework"
   # use the lockRing singleton to save the Logging object
-  _lockRing = LockRing() 
+  _lockRing = LockRing()
   # lock the configuration of the Logging
   _lockConfig = _lockRing.getLock("config")
 
@@ -154,7 +155,6 @@ class Logging(object):
     """
     for backendName in desiredBackends:
       self.registerBackend(backendName, backendOptions)
-      
 
   def registerBackend(self, desiredBackend, backendOptions=None):
     """
@@ -202,7 +202,7 @@ class Logging(object):
 
     # lock to prevent that the level change before adding the new backend in the backendsList
     # and to prevent a change of the backendsList during the reading of the list
-    self._lockLevel.acquire() 
+    self._lockLevel.acquire()
     self._lockOptions.acquire()
     try:
       # update the level of the new backend to respect the Logging level
@@ -249,7 +249,7 @@ class Logging(object):
 
       # update Logging level
       self._level = level
-      
+
       # lock to prevent a modification of the backendsList
       self._lockOptions.acquire()
       try:
@@ -454,7 +454,6 @@ class Logging(object):
       return childLogging
     finally:
       self._lockInit.release()
-
 
   def initialized(self):
     """

--- a/FrameworkSystem/private/standardLogging/LoggingRoot.py
+++ b/FrameworkSystem/private/standardLogging/LoggingRoot.py
@@ -49,6 +49,9 @@ class LoggingRoot(Logging):
     # initialize the root logger
     # actually a child of the root logger to avoid conflicts with other libraries which used 'logging'
     self._logger = logging.getLogger('dirac')
+    # prevent propagation to the root logger to avoid conflicts with external libraries
+    # which want to use the root logger
+    self._logger.propagate = False
 
     # here we redefine the custom name to the empty string to remove the "\" in the display
     self._customName = ""
@@ -174,7 +177,7 @@ class LoggingRoot(Logging):
     retDictRessources = getBackendConfig(backend)
     if retDictRessources['OK']:
       backendOptions = retDictRessources['Value']
-    
+
     # Search backends config in the component to update some options
     retDictConfig = gConfig.getOptionsDict("%s/%s/%s" % (cfgPath, 'BackendsConfig', backend))
     if retDictConfig['OK']:
@@ -210,3 +213,23 @@ class LoggingRoot(Logging):
       self._setLevel(LogLevels.DEBUG)
       self.showHeaders(True)
       self.showThreadIDs(True)
+
+  def enableLogsFromExternalLibs(self, isEnabled=True):
+    """
+    Configure the root logger from 'logging' for an external library use. 
+    By default the root logger is configured with:
+    - debug level,
+    - stderr output
+    - custom format close to the DIRAC format 
+
+    :params isEnabled: boolean value. True allows the logs in the external lib,
+                       False do not.
+    """
+    rootLogger = logging.getLogger()
+    rootLogger.handlers = []
+    if isEnabled:
+      logging.basicConfig(level=logging.DEBUG,
+                          format='%(asctime)s UTC ExternalLibrary/%(name)s %(levelname)s: %(message)s',
+                          datefmt='%Y-%m-%d %H:%M:%S')
+    else: 
+      rootLogger.addHandler(logging.NullHandler())

--- a/FrameworkSystem/private/standardLogging/LoggingRoot.py
+++ b/FrameworkSystem/private/standardLogging/LoggingRoot.py
@@ -214,7 +214,20 @@ class LoggingRoot(Logging):
       self.showHeaders(True)
       self.showThreadIDs(True)
 
-  def enableLogsFromExternalLibs(self, isEnabled=True):
+  def enableLogsFromExternalLibs(self):
+    """
+    Enable the display of the logs coming from external libraries
+    """
+    self.__enableLogsFromExternalLibs()
+
+  def disableLogsFromExternalLibs(self):
+    """
+    Disable the display of the logs coming from external libraries
+    """
+    self.__enableLogsFromExternalLibs(False)
+
+  @staticmethod
+  def __enableLogsFromExternalLibs(isEnabled=True):
     """
     Configure the root logger from 'logging' for an external library use. 
     By default the root logger is configured with:

--- a/FrameworkSystem/test/testLogging/Test_ConfigForExternalLibs.py
+++ b/FrameworkSystem/test/testLogging/Test_ConfigForExternalLibs.py
@@ -30,7 +30,7 @@ class Test_ConfigForExternalLibs(Test_Logging):
     self.assertEqual(1, len(handlers))
     self.assertIsInstance(handlers[0], logging.StreamHandler)
 
-    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.disableLogsFromExternalLibs()
     handlers = logging.getLogger().handlers
 
     self.assertEqual(logging.getLogger().getEffectiveLevel(), logging.DEBUG)
@@ -63,7 +63,7 @@ class Test_ConfigForExternalLibs(Test_Logging):
     bufferRoot.truncate(0)
 
     # Disabled
-    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.disableLogsFromExternalLibs()
 
     logging.getLogger().info("message")
     # this is a direct child of root, as the logger in DIRAC
@@ -99,27 +99,27 @@ class Test_ConfigForExternalLibs(Test_Logging):
     self.assertEqual(1, len(handlers))
     self.assertIsInstance(handlers[0], logging.StreamHandler)
 
-    gLogger.enableLogsFromExternalLibs(False)
-    gLogger.enableLogsFromExternalLibs(False)
-    gLogger.enableLogsFromExternalLibs(False)
-    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.disableLogsFromExternalLibs()
+    gLogger.disableLogsFromExternalLibs()
+    gLogger.disableLogsFromExternalLibs()
+    gLogger.disableLogsFromExternalLibs()
     handlers = logging.getLogger().handlers
 
     self.assertEqual(1, len(handlers))
     self.assertIsInstance(handlers[0], logging.NullHandler)
 
     gLogger.enableLogsFromExternalLibs()
-    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.disableLogsFromExternalLibs()
     gLogger.enableLogsFromExternalLibs()
-    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.disableLogsFromExternalLibs()
     handlers = logging.getLogger().handlers
 
     self.assertEqual(1, len(handlers))
     self.assertIsInstance(handlers[0], logging.NullHandler)
 
-    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.disableLogsFromExternalLibs()
     gLogger.enableLogsFromExternalLibs()
-    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.disableLogsFromExternalLibs()
     gLogger.enableLogsFromExternalLibs()
     handlers = logging.getLogger().handlers
 

--- a/FrameworkSystem/test/testLogging/Test_ConfigForExternalLibs.py
+++ b/FrameworkSystem/test/testLogging/Test_ConfigForExternalLibs.py
@@ -1,0 +1,132 @@
+"""
+Test Config for External Libraries
+"""
+
+__RCSID__ = "$Id$"
+
+
+import unittest
+import logging
+from StringIO import StringIO
+
+from DIRAC.FrameworkSystem.test.testLogging.Test_Logging import Test_Logging, gLogger, cleaningLog
+
+
+class Test_ConfigForExternalLibs(Test_Logging):
+  """
+  Test enableLogsFromExternalLibs method of LoggingRoot.
+  logging.getLogger() returns the root logger which is used in external libraries
+  """
+
+  def test_00rootLoggerConfiguration(self):
+    """
+    Test the good configuration of the root logger
+    """
+    gLogger.enableLogsFromExternalLibs()
+    handlers = logging.getLogger().handlers
+
+    self.assertEqual(logging.getLogger().getEffectiveLevel(), logging.DEBUG)
+
+    self.assertEqual(1, len(handlers))
+    self.assertIsInstance(handlers[0], logging.StreamHandler)
+
+    gLogger.enableLogsFromExternalLibs(False)
+    handlers = logging.getLogger().handlers
+
+    self.assertEqual(logging.getLogger().getEffectiveLevel(), logging.DEBUG)
+
+    self.assertEqual(1, len(handlers))
+    self.assertIsInstance(handlers[0], logging.NullHandler)
+
+  def test_01displayLogs(self):
+    """
+    Test the display of the logs according to the value of the boolean in the method.
+    """
+    # Enabled
+    gLogger.enableLogsFromExternalLibs()
+
+    # modify the output to capture logs of the root logger
+    bufferRoot = StringIO()
+    logging.getLogger().handlers[0].stream = bufferRoot
+
+    logging.getLogger().info("message")
+    logstring1 = cleaningLog(bufferRoot.getvalue())
+
+    self.assertEqual("UTCExternalLibrary/rootINFO:message\n", logstring1)
+    bufferRoot.truncate(0)
+
+    # this is a direct child of root, as the logger in DIRAC
+    logging.getLogger("sublog").info("message")
+    logstring1 = cleaningLog(bufferRoot.getvalue())
+
+    self.assertEqual("UTCExternalLibrary/sublogINFO:message\n", logstring1)
+    bufferRoot.truncate(0)
+
+    # Disabled
+    gLogger.enableLogsFromExternalLibs(False)
+
+    logging.getLogger().info("message")
+    # this is a direct child of root, as the logger in DIRAC
+    logging.getLogger("sublog").info("message")
+
+    self.assertEqual("", bufferRoot.getvalue())
+
+  def test_02propagation(self):
+    """
+    Test the no propagation of the logs from the Logging objects to the root logger of 'logging' 
+    """
+    gLogger.enableLogsFromExternalLibs()
+    # modify the output to capture logs of the root logger
+    bufferRoot = StringIO()
+    logging.getLogger().handlers[0].stream = bufferRoot
+
+    gLogger.debug('message')
+
+    self.assertNotEqual(self.buffer.getvalue(), "")
+    self.assertEqual(bufferRoot.getvalue(), "")
+    self.buffer.truncate(0)
+
+  def test_03multipleCalls(self):
+    """
+    Test the multiple calls to the method to see if we have no duplication of the logs
+    """
+    gLogger.enableLogsFromExternalLibs()
+    gLogger.enableLogsFromExternalLibs()
+    gLogger.enableLogsFromExternalLibs()
+    gLogger.enableLogsFromExternalLibs()
+    handlers = logging.getLogger().handlers
+
+    self.assertEqual(1, len(handlers))
+    self.assertIsInstance(handlers[0], logging.StreamHandler)
+
+    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.enableLogsFromExternalLibs(False)
+    handlers = logging.getLogger().handlers
+
+    self.assertEqual(1, len(handlers))
+    self.assertIsInstance(handlers[0], logging.NullHandler)
+
+    gLogger.enableLogsFromExternalLibs()
+    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.enableLogsFromExternalLibs()
+    gLogger.enableLogsFromExternalLibs(False)
+    handlers = logging.getLogger().handlers
+
+    self.assertEqual(1, len(handlers))
+    self.assertIsInstance(handlers[0], logging.NullHandler)
+
+    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.enableLogsFromExternalLibs()
+    gLogger.enableLogsFromExternalLibs(False)
+    gLogger.enableLogsFromExternalLibs()
+    handlers = logging.getLogger().handlers
+
+    self.assertEqual(1, len(handlers))
+    self.assertIsInstance(handlers[0], logging.StreamHandler)
+
+
+if __name__ == '__main__':
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(Test_ConfigForExternalLibs)
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/FrameworkSystem/test/testLogging/Test_DisplayOptions.py
+++ b/FrameworkSystem/test/testLogging/Test_DisplayOptions.py
@@ -7,8 +7,8 @@ __RCSID__ = "$Id$"
 import unittest
 import thread
 
-from DIRAC.FrameworkSystem.test.testLogging.tests.Test_Logging import Test_Logging, cleaningLog
-from DIRAC.FrameworkSystem.test.testLogging.tests.Test_Logging import gLogger, oldgLogger
+from DIRAC.FrameworkSystem.test.testLogging.Test_Logging import Test_Logging, cleaningLog
+from DIRAC.FrameworkSystem.test.testLogging.Test_Logging import gLogger, oldgLogger
 
 
 class Test_DisplayOptions(Test_Logging):

--- a/FrameworkSystem/test/testLogging/Test_Levels.py
+++ b/FrameworkSystem/test/testLogging/Test_Levels.py
@@ -8,7 +8,7 @@ __RCSID__ = "$Id$"
 
 import unittest
 
-from DIRAC.FrameworkSystem.test.testLogging.tests.Test_Logging import Test_Logging, gLogger, oldgLogger
+from DIRAC.FrameworkSystem.test.testLogging.Test_Logging import Test_Logging, gLogger, oldgLogger
 
 
 class Test_Levels(Test_Logging):

--- a/FrameworkSystem/test/testLogging/Test_LogRecordCreation.py
+++ b/FrameworkSystem/test/testLogging/Test_LogRecordCreation.py
@@ -8,8 +8,8 @@ __RCSID__ = "$Id$"
 
 import unittest
 
-from DIRAC.FrameworkSystem.test.testLogging.tests.Test_Logging import Test_Logging, cleaningLog
-from DIRAC.FrameworkSystem.test.testLogging.tests.Test_Logging import gLogger, oldgLogger
+from DIRAC.FrameworkSystem.test.testLogging.Test_Logging import Test_Logging, cleaningLog
+from DIRAC.FrameworkSystem.test.testLogging.Test_Logging import gLogger, oldgLogger
 
 
 class Test_LogRecordCreation(Test_Logging):

--- a/FrameworkSystem/test/testLogging/Test_Logging.py
+++ b/FrameworkSystem/test/testLogging/Test_Logging.py
@@ -67,14 +67,16 @@ class Test_Logging(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  from DIRAC.FrameworkSystem.test.testLogging.tests.Test_DisplayOptions import Test_DisplayOptions
-  from DIRAC.FrameworkSystem.test.testLogging.tests.Test_Levels import Test_Levels
-  from DIRAC.FrameworkSystem.test.testLogging.tests.Test_LogRecordCreation import Test_LogRecordCreation
-  from DIRAC.FrameworkSystem.test.testLogging.tests.Test_SubLogger import Test_SubLogger
+  from DIRAC.FrameworkSystem.test.testLogging.Test_DisplayOptions import Test_DisplayOptions
+  from DIRAC.FrameworkSystem.test.testLogging.Test_Levels import Test_Levels
+  from DIRAC.FrameworkSystem.test.testLogging.Test_LogRecordCreation import Test_LogRecordCreation
+  from DIRAC.FrameworkSystem.test.testLogging.Test_SubLogger import Test_SubLogger
+  from DIRAC.FrameworkSystem.test.testLogging.Test_ConfigForExternalLibs import Test_ConfigForExternalLibs
 
   suite = unittest.defaultTestLoader.loadTestsFromTestCase(Test_Logging)
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_DisplayOptions))
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_Levels))
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_LogRecordCreation))
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_SubLogger))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_ConfigForExternalLibs))
   testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/FrameworkSystem/test/testLogging/Test_SubLogger.py
+++ b/FrameworkSystem/test/testLogging/Test_SubLogger.py
@@ -8,7 +8,7 @@ __RCSID__ = "$Id$"
 
 import unittest
 
-from DIRAC.FrameworkSystem.test.testLogging.tests.Test_Logging import Test_Logging, gLogger
+from DIRAC.FrameworkSystem.test.testLogging.Test_Logging import Test_Logging, gLogger
 
 
 class Test_SubLogger(Test_Logging):

--- a/Resources/Computing/BOINCComputingElement.py
+++ b/Resources/Computing/BOINCComputingElement.py
@@ -16,7 +16,7 @@ import tempfile
 from urlparse import urlparse
 
 from DIRAC.Resources.Computing.ComputingElement          import ComputingElement
-from DIRAC                                               import S_OK, S_ERROR
+from DIRAC                                               import S_OK, S_ERROR, gLogger
 
 CE_NAME = 'BOINC'
 
@@ -55,8 +55,8 @@ class BOINCComputingElement( ComputingElement ):
     if not self.BOINCClient:
       try:
         from suds.client import Client
-        import logging
-        logging.basicConfig(format="%(asctime)-15s %(message)s")
+        if self.log.getLevel() == 'DEBUG':
+          gLogger.enableLogsFromExternalLibs()
         self.BOINCClient = Client(self.wsdl)
       except Exception,x:
         self.log.error( 'Creation of the soap client failed', '%s' % str( x ) )

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -13,9 +13,6 @@ from DIRAC.Core.Security import Locations
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities.DErrno import EMQUKN, EMQCONN
 
-# needed by stomp.py (without import there is an exception when it tries to log something)
-import logging
-logging.basicConfig()
 
 class StompMQConnector( MQConnector ):
   """
@@ -30,6 +27,9 @@ class StompMQConnector( MQConnector ):
     self.log = gLogger.getSubLogger( self.__class__.__name__ )
     self.parameters = parameters.copy()
     self.connections = {}
+
+    if self.log.getLevel() == 'DEBUG':
+      gLogger.enableLogsFromExternalLibs()
 
   def setupConnection( self, parameters = None ):
     #"""

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -14,7 +14,6 @@ import os
 import sys
 import datetime
 import errno
-import logging
 from stat import S_ISREG, S_ISDIR, S_IXUSR, S_IRUSR, S_IWUSR, \
   S_IRWXG, S_IRWXU, S_IRWXO
 
@@ -66,7 +65,7 @@ class GFAL2_StorageBase( StorageBase ):
 
     dlevel = self.log.getLevel()
     if dlevel == 'DEBUG':
-      logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+      gLogger.enableLogsFromExternalLibs()
       gfal2.set_verbose( gfal2.verbose_level.trace )
 
     self.isok = True

--- a/docs/source/DeveloperGuide/AddingNewComponents/Utilities/gLogger/gLogger/Basics/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/Utilities/gLogger/gLogger/Basics/index.rst
@@ -749,6 +749,18 @@ Multiple threads
 *gLogger* is completely thread-safe, there is no conflict possible especially in the case when two threads 
 try to write on a same file at the same time. 
 
+About the use of external libraries
+-----------------------------------
+
+*DIRAC* uses some external libraries which have their own loggers, mainly based on the standard logging Python library like *gLogger*. Logs providing by these libraries can be useful in debugging, but not in production. The *enableLogsFromExternalLib* method allows us to enable or disable the display of these logs thanks to a boolean parameter.
+When the boolean is *True*, the method initializes a specific logger for external libraries like this: 
+
++ a level at Debug
++ a display on the standard error output
++ a log format close to the one used in *DIRAC*
+
+We can call this method each time that we use an external library and we want to see the logs inside. 
+
 Advanced part
 ------------------------------------
 

--- a/docs/source/DeveloperGuide/AddingNewComponents/Utilities/gLogger/gLogger/Basics/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/Utilities/gLogger/gLogger/Basics/index.rst
@@ -752,14 +752,14 @@ try to write on a same file at the same time.
 About the use of external libraries
 -----------------------------------
 
-*DIRAC* uses some external libraries which have their own loggers, mainly based on the standard logging Python library like *gLogger*. Logs providing by these libraries can be useful in debugging, but not in production. The *enableLogsFromExternalLib* method allows us to enable or disable the display of these logs thanks to a boolean parameter.
-When the boolean is *True*, the method initializes a specific logger for external libraries like this: 
+*DIRAC* uses some external libraries which have their own loggers, mainly based on the standard logging Python library like *gLogger*. Logs providing by these libraries can be useful in debugging, but not in production. The *enableLogsFromExternalLib* and *disableLogsFromExternalLib* methods allow us to enable or disable the display of these logs.
+The first method initializes a specific logger for external libraries like this: 
 
 + a level at Debug
 + a display on the standard error output
 + a log format close to the one used in *DIRAC*
 
-We can call this method each time that we use an external library and we want to see the logs inside. 
+We can call these methods each time that we use an external library and we want to see the logs inside or not. 
 
 Advanced part
 ------------------------------------


### PR DESCRIPTION
This pull request mainly concerns the following code which caused a double display of each log: 
`import logging`
`logging.basicConfig(...)`

These lines are replaced by a gLogger method which enables or disables the display of the logs providing by all the external libraries. I also added a test class for this new method and updated the documentation.

By the way, I change the test path from *FrameworkSystem/test/testLogging/tests/* to *FrameworkSystem/test/testLogging/*
