### PR TITLE
[v6r17] LocalComputingElement jobIDs to start with ssh

### DIFF
--- a/Resources/Computing/LocalComputingElement.py
+++ b/Resources/Computing/LocalComputingElement.py
@@ -166,7 +166,11 @@ class LocalComputingElement( ComputingElement ):
 
     if resultSubmit['Status'] == 0:
       self.submittedJobs += len( resultSubmit['Jobs'] )
-      jobIDs = [ self.ceType.lower()+'://'+self.ceName+'/'+_id for _id in resultSubmit['Jobs'] ]  
+      # jobIDs = [ self.ceType.lower()+'://'+self.ceName+'/'+_id for _id in resultSubmit['Jobs'] ]  
+      # FIXME: It would be more proper to fix pilotCommands.__setFlavour where 'ssh' is hardcoded than
+      # making this illogical fix, but there is no good way for pilotCommands to know its origin ceType.
+      # So, the jobIDs here need to start with 'ssh', not ceType, to accomodate them to those hardcoded in pilotCommands.__setFlavour
+      jobIDs = [ 'ssh'+self.batchSystem.lower()+'://'+self.ceName+'/'+_id for _id in resultSubmit['Jobs'] ] 
       result = S_OK( jobIDs )
     else:
       result = S_ERROR( resultSubmit['Message'] )


### PR DESCRIPTION
jobIDs need to start with ssh even for LocalComputingElement because of hardcoding in `pilotCommands.__setFlavour` (https://github.com/DIRACGrid/DIRAC/issues/3392)

BEGINRELEASENOTES

*Resources
FIX: jobIDs for LocalComputingElement adapted to what are set by pilotCommands

ENDRELEASENOTES
