### PR TITLE
[v6r17] LocalComputingElement to use the original jobIDs in getJobStatus

### DIFF
--- a/Resources/Computing/LocalComputingElement.py
+++ b/Resources/Computing/LocalComputingElement.py
@@ -208,7 +208,11 @@ class LocalComputingElement( ComputingElement ):
   def getJobStatus( self, jobIDList ):
     """ Get the status information for the given list of jobs
     """
-    batchDict = { 'JobIDList': jobIDList,
+    stampList = []
+    for job in jobIDList:
+      stamp = os.path.basename( urlparse( job ).path )
+      stampList.append(stamp)
+    batchDict = { 'JobIDList': stampList,
                   'User': self.userName }
     resultGet = self.batch.getJobStatus( **batchDict )
     if resultGet['Status'] == 0:


### PR DESCRIPTION
jobIDs to be passed to `batch.getJobStatus` should be the original IDs, not the ones cooked into the DIRAC convention

BEGINRELEASENOTES

*Resources
FIX: LocalComputingElement to use the original jobIDs in getJobStatus

ENDRELEASENOTES