### PR TITLE
[v6r17] When no MQ is used then do not try to close the connection

### DIFF
--- a/MonitoringSystem/Client/MonitoringReporter.py
+++ b/MonitoringSystem/Client/MonitoringReporter.py
@@ -147,7 +147,8 @@ class MonitoringReporter( object ):
       gLogger.exception( "Error committing", lException = e )
       return S_ERROR( "Error committing %s" % repr( e ).replace( ',)', ')' ) )
     finally:
-      mqProducer.close()
+      if mqProducer:
+        mqProducer.close()
       self.__documents.extend( documents )
 
     return S_OK( recordSent )


### PR DESCRIPTION
BEGINRELEASENOTES

Please follow the template:
*MonitoringSystem

FIX: When MQ is not used, then do not try to close the connection

ENDRELEASENOTES
