### PR TITLE
[WIP][v6r19] Add RequiredTag to CheckCECapabilities

### DIFF
--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -431,7 +431,8 @@ class CheckCECapabilities( CommandBase ):
       if self.debugFlag:
         self.cfg.append( '-ddd' )
 
-      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
+      tags = ','.join( ( str( x ) for x in self.pp.tags ) ) 
+      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s" -o "/AgentJobRequirements/RequiredTag=%s"' % ( tags, tags ) )
 
       configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
       retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )


### PR DESCRIPTION
This reinstates the functionality of v6r15 (PR#2823) where the options were added by the SiteDirector. Otherwise payloads without the right tags still run on CEs or queues with the tag (single processor jobs in multiprocessor job slots; nonGPU jobs on GPU machines etc)

BEGINRELEASENOTES
*Pilot
FIX: reinstate one to one matching between tagged payload jobs and tagged CEs/queues. To run on a CE or queue with a tag, the payload must have that tag.
ENDRELEASENOTES
