### PR TITLE
[v6r17] Return directly status in se.getStatus()

### DIFF
--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -522,7 +522,7 @@ class FTSAgent( AgentModule ):
       now = datetime.datetime.utcnow()
       jobsToMonitor = [job for job in ftsJobs if
                        ( now - job.LastUpdate ).seconds >
-                       ( self.MONITORING_INTERVAL * ( 3. if StorageElement( job.SourceSE ).getStatus().get( 'Value', {} ).get( 'TapeSE' ) else 1. ) )
+                       ( self.MONITORING_INTERVAL * ( 3. if StorageElement( job.SourceSE ).getStatus()['TapeSE'] else 1. ) )
                        ]
       if jobsToMonitor:
         log.info( "==> found %s FTSJobs to monitor" % len( jobsToMonitor ) )
@@ -874,7 +874,7 @@ class FTSAgent( AgentModule ):
         if not sourceToken["OK"]:
           log.error( "unable to get sourceSE parameters:", "(%s) %s" % ( source, sourceToken["Message"] ) )
           continue
-        seStatus = sourceSE.getStatus()['Value']
+        seStatus = sourceSE.getStatus()
 
         targetSE = StorageElement( target )
         targetToken = targetSE.getStorageParameters( protocol = 'srm' )

--- a/DataManagementSystem/Agent/FTSAgent.py
+++ b/DataManagementSystem/Agent/FTSAgent.py
@@ -522,7 +522,7 @@ class FTSAgent( AgentModule ):
       now = datetime.datetime.utcnow()
       jobsToMonitor = [job for job in ftsJobs if
                        ( now - job.LastUpdate ).seconds >
-                       ( self.MONITORING_INTERVAL * ( 3. if StorageElement( job.SourceSE ).getStatus()['TapeSE'] else 1. ) )
+                       ( self.MONITORING_INTERVAL * ( 3. if StorageElement( job.SourceSE ).status()['TapeSE'] else 1. ) )
                        ]
       if jobsToMonitor:
         log.info( "==> found %s FTSJobs to monitor" % len( jobsToMonitor ) )
@@ -874,7 +874,7 @@ class FTSAgent( AgentModule ):
         if not sourceToken["OK"]:
           log.error( "unable to get sourceSE parameters:", "(%s) %s" % ( source, sourceToken["Message"] ) )
           continue
-        seStatus = sourceSE.getStatus()
+        seStatus = sourceSE.status()
 
         targetSE = StorageElement( target )
         targetToken = targetSE.getStorageParameters( protocol = 'srm' )

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -520,7 +520,7 @@ class DataManager( object ):
 
     ###########################################################
     # Perform the registration here
-    destinationSE = storageElement.getStorageElementName()['Value']
+    destinationSE = storageElement.storageElementName()
     res = returnSingleResult( storageElement.getURL( lfn, protocol = self.registrationProtocol ) )
     if not res['OK']:
       errStr = "Failed to generate destination PFN."
@@ -692,7 +692,7 @@ class DataManager( object ):
       return S_ERROR( "%s %s" % ( errStr, res['Message'] ) )
 
     # Get the real name of the SE
-    destSEName = destStorageElement.getStorageElementName()['Value']
+    destSEName = destStorageElement.storageElementName()
 
     ###########################################################
     # Check whether the destination storage element is banned
@@ -1034,7 +1034,7 @@ class DataManager( object ):
         for lfn, url in replicaTuple:
           failed[lfn] = errStr
       else:
-        storageElementName = destStorageElement.getStorageElementName()['Value']
+        storageElementName = destStorageElement.storageElementName()
         for lfn, url in replicaTuple:
           res = returnSingleResult( destStorageElement.getURL( lfn, protocol = self.registrationProtocol ) )
           if not res['OK']:

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -698,7 +698,7 @@ class DataManager( object ):
     # Check whether the destination storage element is banned
     log.verbose( "Determining whether %s ( destination ) is Write-banned." % destSEName )
 
-    if not destStorageElement.getStatus()['Write']:
+    if not destStorageElement.status()['Write']:
       infoStr = "Supplied destination Storage Element is not currently allowed for Write."
       log.debug( infoStr, destSEName )
       return S_ERROR( infoStr )
@@ -1601,7 +1601,7 @@ class DataManager( object ):
 
   def __checkSEStatus( self, se, status = 'Read' ):
     """ returns the value of a certain SE status flag (access or other) """
-    return StorageElement( se, vo = self.vo ).getStatus().get( status, False )
+    return StorageElement( se, vo = self.vo ).status().get( status, False )
 
   def getReplicas( self, lfns, allStatus = True, getUrl = True, diskOnly = False, preferDisk = False, active = False ):
     """ get replicas from catalogue and filter if requested

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -698,7 +698,7 @@ class DataManager( object ):
     # Check whether the destination storage element is banned
     log.verbose( "Determining whether %s ( destination ) is Write-banned." % destSEName )
 
-    if not destStorageElement.getStatus().get( 'Value', {} ).get( 'Write', False ):
+    if not destStorageElement.getStatus()['Write']:
       infoStr = "Supplied destination Storage Element is not currently allowed for Write."
       log.debug( infoStr, destSEName )
       return S_ERROR( infoStr )
@@ -1601,7 +1601,7 @@ class DataManager( object ):
 
   def __checkSEStatus( self, se, status = 'Read' ):
     """ returns the value of a certain SE status flag (access or other) """
-    return StorageElement( se, vo = self.vo ).getStatus().get( 'Value', {} ).get( status, False )
+    return StorageElement( se, vo = self.vo ).getStatus().get( status, False )
 
   def getReplicas( self, lfns, allStatus = True, getUrl = True, diskOnly = False, preferDisk = False, active = False ):
     """ get replicas from catalogue and filter if requested

--- a/DataManagementSystem/Client/FTSRequest.py
+++ b/DataManagementSystem/Client/FTSRequest.py
@@ -162,18 +162,14 @@ class FTSRequest( object ):
       return S_ERROR( "SourceSE does not support FTS transfers" )
 
     if self.__cksmTest:
-      res = self.oSourceSE.getChecksumType()
-      if not res["OK"]:
-        self.log.error( "Unable to get checksum type for SourceSE",
-                        "%s: %s" % ( self.sourceSE, res["Message"] ) )
-        cksmType = res["Value"]
-        if cksmType in ( "NONE", "NULL" ):
-          self.log.warn( "Checksum type set to %s at SourceSE %s, disabling checksum test" % ( cksmType,
-                                                                                              self.sourceSE ) )
-          self.__cksmTest = False
-        elif cksmType != self.__cksmType:
-          self.log.warn( "Checksum type mismatch, disabling checksum test" )
-          self.__cksmTest = False
+      cksmType = self.oSourceSE.checksumType()
+      if cksmType in ( "NONE", "NULL" ):
+        self.log.warn( "Checksum type set to %s at SourceSE %s, disabling checksum test" % ( cksmType,
+                                                                                            self.sourceSE ) )
+        self.__cksmTest = False
+      elif cksmType != self.__cksmType:
+        self.log.warn( "Checksum type mismatch, disabling checksum test" )
+        self.__cksmTest = False
 
     self.sourceToken = res['Value']
     self.sourceValid = True
@@ -217,18 +213,14 @@ class FTSRequest( object ):
 
     # # check checksum types
     if self.__cksmTest:
-      res = self.oTargetSE.getChecksumType()
-      if not res["OK"]:
-        self.log.error( "Unable to get checksum type for TargetSE",
-                        "%s: %s" % ( self.targetSE, res["Message"] ) )
-        cksmType = res["Value"]
-        if cksmType in ( "NONE", "NULL" ):
-          self.log.warn( "Checksum type set to %s at TargetSE %s, disabling checksum test" % ( cksmType,
-                                                                                              self.targetSE ) )
-          self.__cksmTest = False
-        elif cksmType != self.__cksmType:
-          self.log.warn( "Checksum type mismatch, disabling checksum test" )
-          self.__cksmTest = False
+      cksmType = self.oTargetSE.checksumType()
+      if cksmType in ( "NONE", "NULL" ):
+        self.log.warn( "Checksum type set to %s at TargetSE %s, disabling checksum test" % ( cksmType,
+                                                                                            self.targetSE ) )
+        self.__cksmTest = False
+      elif cksmType != self.__cksmType:
+        self.log.warn( "Checksum type mismatch, disabling checksum test" )
+        self.__cksmTest = False
 
     self.targetToken = res['Value']
     self.targetValid = True

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1178,7 +1178,7 @@ class Dirac( API ):
       :type access: string in ('Read', 'Write', 'Remove', 'Check')
       : returns: True or False
     """
-    return StorageElement( se, vo = self.vo ).getStatus().get( 'Value', {} ).get( access, False )
+    return StorageElement( se, vo = self.vo ).getStatus().get( access, False )
 
   #############################################################################
   def splitInputData( self, lfns, maxFilesPerJob = 20, printOutput = False ):

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1178,7 +1178,7 @@ class Dirac( API ):
       :type access: string in ('Read', 'Write', 'Remove', 'Check')
       : returns: True or False
     """
-    return StorageElement( se, vo = self.vo ).getStatus().get( access, False )
+    return StorageElement( se, vo = self.vo ).status().get( access, False )
 
   #############################################################################
   def splitInputData( self, lfns, maxFilesPerJob = 20, printOutput = False ):

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -330,7 +330,7 @@ class SRM2Storage( StorageBase ):
           failed[url] = 'getTransportURL: Failed to obtain turls.'
       return S_OK( {'Successful' : successful, 'Failed' : failed} )
 
-    if not self.se.getStatus().get( 'Value', {} ).get( 'Read' ):
+    if not self.se.getStatus()['Read']:
       return S_ERROR( "SRM2Storage.getTransportURL: Read access not currently permitted." )
 
     # Here we must go out to the SRM service

--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -330,7 +330,7 @@ class SRM2Storage( StorageBase ):
           failed[url] = 'getTransportURL: Failed to obtain turls.'
       return S_OK( {'Successful' : successful, 'Failed' : failed} )
 
-    if not self.se.getStatus()['Read']:
+    if not self.se.status()['Read']:
       return S_ERROR( "SRM2Storage.getTransportURL: Read access not currently permitted." )
 
     # Here we must go out to the SRM service

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -313,7 +313,7 @@ class StorageElementItem( object ):
       retDict['TapeSE'] = False
       retDict['TotalCapacityTB'] = -1
       retDict['DiskCacheTB'] = -1
-      return S_OK( retDict )
+      return retDict
 
     # If nothing is defined in the CS Access is allowed
     # If something is defined, then it must be set to Active
@@ -342,7 +342,7 @@ class StorageElementItem( object ):
     except Exception:
       retDict['DiskCacheTB'] = -1
 
-    return S_OK( retDict )
+    return retDict
 
   def isValid( self, operation = '' ):
     """ check CS/RSS statuses for :operation:
@@ -365,14 +365,11 @@ class StorageElementItem( object ):
       return S_OK()
 
     # Determine whether the StorageElement is valid for checking, reading, writing
-    res = self.getStatus()
-    if not res[ 'OK' ]:
-      log.debug( "Could not call getStatus", res['Message'] )
-      return S_ERROR( "SE.isValid could not call the getStatus method" )
-    checking = res[ 'Value' ][ 'Check' ]
-    reading = res[ 'Value' ][ 'Read' ]
-    writing = res[ 'Value' ][ 'Write' ]
-    removing = res[ 'Value' ][ 'Remove' ]
+    status = self.getStatus()
+    checking = status[ 'Check' ]
+    reading = status[ 'Read' ]
+    writing = status[ 'Write' ]
+    removing = status[ 'Remove' ]
 
     # Determine whether the requested operation can be fulfilled
     if ( not operation ) and ( not reading ) and ( not writing ) and ( not checking ):

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -271,18 +271,26 @@ class StorageElementItem( object ):
   # These are the basic get functions for storage configuration
   #
 
+  def getStorageElementName( self ):
+    """ SE name getter for backward compatibility """
+    return S_OK( self.storageElementName() )
+
   def storageElementName( self ):
     """ SE name getter """
     self.log.getSubLogger( 'storageElementName' ).verbose( "The Storage Element name is %s." % self.name )
     return self.name
 
+  def getChecksumType( self ):
+    """ Checksum type getter for backward compatibility """
+    return S_OK( self.checksumType() )
+
   def checksumType( self ):
-    """ get local /Resources/StorageElements/SEName/ChecksumType option if defined, otherwise
+    """ get specific /Resources/StorageElements/<SEName>/ChecksumType option if defined, otherwise
         global /Resources/StorageElements/ChecksumType
     """
     self.log.getSubLogger( 'checksumType' ).verbose( "get checksum type for %s." % self.name )
-    return gConfig.getValue( "/Resources/StorageElements/ChecksumType", "ADLER32" ).upper() \
-      if "ChecksumType" not in self.options else str( self.options["ChecksumType"] ).upper()
+    return self.options["ChecksumType"].upper() \
+      if "ChecksumType" in self.options else gConfig.getValue( "/Resources/StorageElements/ChecksumType", "ADLER32" ).upper()
 
   def getStatus( self ):
     """

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -313,6 +313,8 @@ class StorageElementItem( object ):
       retDict['TapeSE'] = False
       retDict['TotalCapacityTB'] = -1
       retDict['DiskCacheTB'] = -1
+      # FIXME: once the interface change is known, remove this line
+      retDict.update( S_OK( retDict.copy() ) )
       return retDict
 
     # If nothing is defined in the CS Access is allowed
@@ -342,6 +344,8 @@ class StorageElementItem( object ):
     except Exception:
       retDict['DiskCacheTB'] = -1
 
+    # FIXME: once the interface change is known, remove this line
+    retDict.update( S_OK( retDict.copy() ) )
     return retDict
 
   def isValid( self, operation = '' ):

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -239,7 +239,7 @@ class StorageElementItem( object ):
     self.okMethods = [ 'getLocalProtocols',
                        'getProtocols',
                        'getRemoteProtocols',
-                       'getStorageElementName',
+                       'storageElementName',
                        'getStorageParameters',
                        'getTransportURL',
                        'isLocalSE' ]
@@ -271,18 +271,18 @@ class StorageElementItem( object ):
   # These are the basic get functions for storage configuration
   #
 
-  def getStorageElementName( self ):
+  def storageElementName( self ):
     """ SE name getter """
-    self.log.getSubLogger( 'getStorageElementName' ).verbose( "The Storage Element name is %s." % self.name )
-    return S_OK( self.name )
+    self.log.getSubLogger( 'storageElementName' ).verbose( "The Storage Element name is %s." % self.name )
+    return self.name
 
-  def getChecksumType( self ):
+  def checksumType( self ):
     """ get local /Resources/StorageElements/SEName/ChecksumType option if defined, otherwise
         global /Resources/StorageElements/ChecksumType
     """
-    self.log.getSubLogger( 'getChecksumType' ).verbose( "get checksum type for %s." % self.name )
-    return S_OK( str( gConfig.getValue( "/Resources/StorageElements/ChecksumType", "ADLER32" ) ).upper()
-                 if "ChecksumType" not in self.options else str( self.options["ChecksumType"] ).upper() )
+    self.log.getSubLogger( 'checksumType' ).verbose( "get checksum type for %s." % self.name )
+    return gConfig.getValue( "/Resources/StorageElements/ChecksumType", "ADLER32" ).upper() \
+      if "ChecksumType" not in self.options else str( self.options["ChecksumType"] ).upper()
 
   def getStatus( self ):
     """

--- a/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/StorageManagementSystem/Client/StorageManagerClient.py
@@ -136,12 +136,9 @@ def _checkFilesToStage( seToLFNs, onlineLFNs, offlineLFNs, absentLFNs,
       continue
 
     vo = getVOForGroup( proxyUserGroup )
-    seObj = StorageElement( se, vo=vo )
+    seObj = StorageElement( se, vo = vo )
     status = seObj.getStatus()
-    if not status['OK']:
-      logger.error( "Could not get SE status", "%s - %s" % ( se, status['Message'] ) )
-      return status
-    tapeSE = status['Value']['TapeSE']
+    tapeSE = status['TapeSE']
     # If requested to check only Tape SEs and  the file is at a diskSE, we guess it is Online...
     if checkOnlyTapeSEs and not tapeSE:
       for lfn in lfnsInSEList:

--- a/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/StorageManagementSystem/Client/StorageManagerClient.py
@@ -138,7 +138,9 @@ def _checkFilesToStage( seToLFNs, onlineLFNs, offlineLFNs, absentLFNs,
     vo = getVOForGroup( proxyUserGroup )
     seObj = StorageElement( se, vo = vo )
     status = seObj.getStatus()
-    tapeSE = status['TapeSE']
+    if not status['OK']:
+      return status
+    tapeSE = status['Value']['TapeSE']
     # If requested to check only Tape SEs and  the file is at a diskSE, we guess it is Online...
     if checkOnlyTapeSEs and not tapeSE:
       for lfn in lfnsInSEList:

--- a/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
+++ b/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
@@ -14,28 +14,28 @@ import errno
 mockObjectSE1 = MagicMock()
 mockObjectSE1.getFileMetadata.return_value = S_OK( {'Successful':{'/a/lfn/1.txt':{'Accessible':False}},
                                                     'Failed':{}} )
-mockObjectSE1.getStatus.return_value = {'DiskSE': False, 'TapeSE':True}
+mockObjectSE1.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
 
 mockObjectSE2 = MagicMock()
 mockObjectSE2.getFileMetadata.return_value = S_OK( {'Successful':{'/a/lfn/2.txt':{'Cached':1, 'Accessible':True}},
                                                     'Failed':{}} )
-mockObjectSE2.getStatus.return_value = {'DiskSE': False, 'TapeSE':True}
+mockObjectSE2.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
 
 mockObjectSE3 = MagicMock()
 mockObjectSE3.getFileMetadata.return_value = S_OK( {'Successful':{},
                                                     'Failed':{'/a/lfn/2.txt': 'error'}} )
-mockObjectSE3.getStatus.return_value = {'DiskSE': False, 'TapeSE':True}
+mockObjectSE3.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
 
 mockObjectSE4 = MagicMock()
 mockObjectSE4.getFileMetadata.return_value = S_OK( {'Successful':{},
                                                     'Failed':{'/a/lfn/2.txt':
                                                               S_ERROR( errno.ENOENT, '' )['Message']}} )
-mockObjectSE4.getStatus.return_value = {'DiskSE': False, 'TapeSE':True}
+mockObjectSE4.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
 
 mockObjectSE5 = MagicMock()
 mockObjectSE5.getFileMetadata.return_value = S_OK( {'Successful':{'/a/lfn/1.txt':{'Accessible':False}},
                                                     'Failed':{}} )
-mockObjectSE5.getStatus.return_value = {'DiskSE': True, 'TapeSE':False}
+mockObjectSE5.getStatus.return_value = S_OK( {'DiskSE': True, 'TapeSE':False} )
 
 mockObjectDMSHelper = MagicMock()
 mockObjectDMSHelper.getLocalSiteForSE.return_value = S_OK( 'mySite' )

--- a/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
+++ b/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
@@ -14,28 +14,28 @@ import errno
 mockObjectSE1 = MagicMock()
 mockObjectSE1.getFileMetadata.return_value = S_OK( {'Successful':{'/a/lfn/1.txt':{'Accessible':False}},
                                                     'Failed':{}} )
-mockObjectSE1.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
+mockObjectSE1.getStatus.return_value = {'DiskSE': False, 'TapeSE':True}
 
 mockObjectSE2 = MagicMock()
 mockObjectSE2.getFileMetadata.return_value = S_OK( {'Successful':{'/a/lfn/2.txt':{'Cached':1, 'Accessible':True}},
                                                     'Failed':{}} )
-mockObjectSE2.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
+mockObjectSE2.getStatus.return_value = {'DiskSE': False, 'TapeSE':True}
 
 mockObjectSE3 = MagicMock()
 mockObjectSE3.getFileMetadata.return_value = S_OK( {'Successful':{},
                                                     'Failed':{'/a/lfn/2.txt': 'error'}} )
-mockObjectSE3.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
+mockObjectSE3.getStatus.return_value = {'DiskSE': False, 'TapeSE':True}
 
 mockObjectSE4 = MagicMock()
 mockObjectSE4.getFileMetadata.return_value = S_OK( {'Successful':{},
                                                     'Failed':{'/a/lfn/2.txt':
                                                               S_ERROR( errno.ENOENT, '' )['Message']}} )
-mockObjectSE4.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
+mockObjectSE4.getStatus.return_value = {'DiskSE': False, 'TapeSE':True}
 
 mockObjectSE5 = MagicMock()
 mockObjectSE5.getFileMetadata.return_value = S_OK( {'Successful':{'/a/lfn/1.txt':{'Accessible':False}},
                                                     'Failed':{}} )
-mockObjectSE5.getStatus.return_value = S_OK( {'DiskSE': True, 'TapeSE':False} )
+mockObjectSE5.getStatus.return_value = {'DiskSE': True, 'TapeSE':False}
 
 mockObjectDMSHelper = MagicMock()
 mockObjectDMSHelper.getLocalSiteForSE.return_value = S_OK( 'mySite' )

--- a/TransformationSystem/Client/TransformationCLI.py
+++ b/TransformationSystem/Client/TransformationCLI.py
@@ -33,7 +33,7 @@ def printDict( dictionary ):
 class TransformationCLI( CLI, API ):
 
   def __init__( self ):
-    self.server = TransformationClient()
+    self.transClient = TransformationClient()
     self.indentSpace = 4
     CLI.__init__( self )
     API.__init__( self )
@@ -99,7 +99,7 @@ class TransformationCLI( CLI, API ):
   def check_id_or_name( self, id_or_name ):
     """resolve name or Id by converting type of argument """
     if id_or_name.isdigit():
-      return long( id_or_name ) # its look like id
+      return long( id_or_name )  # its look like id
     return id_or_name
 
   ####################################################################
@@ -122,7 +122,7 @@ The first argument is the authorDN or username. The authorDN
 is preferred: it need to be inside quotes because contains
 white spaces. Only authorDN should be quoted.
 
-When the username is provided instead, 
+When the username is provided instead,
 the authorDN is retrieved from the uploaded proxy,
 so that the retrieved transformations are those created by
 the user who uploaded that proxy: that user could be different
@@ -144,12 +144,12 @@ that the username provided to the function.
       print "AuthorDN need to be quoted (just quote that argument)"
       return
 
-    if argss[0][0] in ["'", '"']: # authorDN given
+    if argss[0][0] in ["'", '"']:  # authorDN given
       author = argss[0]
       status_idx = 1
       for arg in argss[1:]:
         author += ' ' + arg
-        status_idx +=1
+        status_idx += 1
         if arg[-1] in ["'", '"']:
           break
       # At this point we should have something like 'author'
@@ -157,10 +157,10 @@ that the username provided to the function.
         print "AuthorDN need to be quoted (just quote that argument)"
         return
       else:
-        author = author[1:-1] # throw away the quotes
+        author = author[1:-1]  # throw away the quotes
       # the rest are the requested status
       status = argss[ status_idx: ]
-    else: # username given
+    else:  # username given
       username = argss[0]
       status = argss[ 1: ]
 
@@ -193,7 +193,7 @@ that the username provided to the function.
       print "no transformation supplied"
       return
     for transName in argss:
-      res = self.server.getTransformation( transName )
+      res = self.transClient.getTransformation( transName )
       if not res['OK']:
         print "Getting status of %s failed: %s" % ( transName, res['Message'] )
       else:
@@ -212,7 +212,7 @@ that the username provided to the function.
     status = argss[0]
     transNames = argss[1:]
     for transName in transNames:
-      res = self.server.setTransformationParameter( transName, 'Status', status )
+      res = self.transClient.setTransformationParameter( transName, 'Status', status )
       if not res['OK']:
         print "Setting status of %s failed: %s" % ( transName, res['Message'] )
       else:
@@ -228,11 +228,11 @@ that the username provided to the function.
       print "no transformation supplied"
       return
     for transName in argss:
-      res = self.server.setTransformationParameter( transName, 'Status', 'Active' )
+      res = self.transClient.setTransformationParameter( transName, 'Status', 'Active' )
       if not res['OK']:
         print "Setting Status of %s failed: %s" % ( transName, res['Message'] )
       else:
-        res = self.server.setTransformationParameter( transName, 'AgentType', 'Automatic' )
+        res = self.transClient.setTransformationParameter( transName, 'AgentType', 'Automatic' )
         if not res['OK']:
           print "Setting AgentType of %s failed: %s" % ( transName, res['Message'] )
         else:
@@ -251,7 +251,7 @@ that the username provided to the function.
       print "no transformation supplied"
       return
     for transName in argss:
-      res = self.server.setTransformationParameter( transName, 'AgentType', 'Manual' )
+      res = self.transClient.setTransformationParameter( transName, 'AgentType', 'Manual' )
       if not res['OK']:
         print "Stopping of %s failed: %s" % ( transName, res['Message'] )
       else:
@@ -267,7 +267,7 @@ that the username provided to the function.
       print "no transformation supplied"
       return
     for transName in argss:
-      res = self.server.setTransformationParameter( transName, 'Status', 'Flush' )
+      res = self.transClient.setTransformationParameter( transName, 'Status', 'Flush' )
       if not res['OK']:
         print "Flushing of %s failed: %s" % ( transName, res['Message'] )
       else:
@@ -283,7 +283,7 @@ that the username provided to the function.
       print "no transformation supplied"
       return
     transName = argss[0]
-    res = self.server.getTransformation( transName )
+    res = self.transClient.getTransformation( transName )
     if not res['OK']:
       print "Failed to get %s: %s" % ( transName, res['Message'] )
     else:
@@ -300,7 +300,7 @@ that the username provided to the function.
       print "no transformation supplied"
       return
     transName = argss[0]
-    res = self.server.getTransformation( transName )
+    res = self.transClient.getTransformation( transName )
     if not res['OK']:
       print "Failed to get %s: %s" % ( transName, res['Message'] )
     else:
@@ -316,7 +316,7 @@ that the username provided to the function.
       print "no transformation supplied"
       return
     transName = argss[0]
-    res = self.server.getTransformationStats( transName )
+    res = self.transClient.getTransformationStats( transName )
     if not res['OK']:
       print "Failed to get statistics for %s: %s" % ( transName, res['Message'] )
     else:
@@ -335,7 +335,7 @@ that the username provided to the function.
     mask = argss[0]
     transNames = argss[1:]
     for transName in transNames:
-      res = self.server.setTransformationParameter( transName, "FileMask", mask )
+      res = self.transClient.setTransformationParameter( transName, "FileMask", mask )
       if not res['OK']:
         print "Failed to modify input file mask for %s: %s" % ( transName, res['Message'] )
       else:
@@ -352,14 +352,14 @@ that the username provided to the function.
       return
     transName = argss[0]
     status = argss[1:]
-    res = self.server.getTransformation( transName )
+    res = self.transClient.getTransformation( transName )
     if not res['OK']:
       print "Failed to get transformation information: %s" % res['Message']
     else:
       selectDict = {'TransformationID':res['Value']['TransformationID']}
       if status:
         selectDict['Status'] = status
-      res = self.server.getTransformationFiles( condDict = selectDict )
+      res = self.transClient.getTransformationFiles( condDict = selectDict )
       if not res['OK']:
         print "Failed to get transformation files: %s" % res['Message']
       elif res['Value']:
@@ -380,12 +380,12 @@ that the username provided to the function.
     transName = argss[0]
     lfns = argss[1:]
 
-    res = self.server.getTransformation( transName )
+    res = self.transClient.getTransformation( transName )
     if not res['OK']:
       print "Failed to get transformation information: %s" % res['Message']
     else:
       selectDict = {'TransformationID':res['Value']['TransformationID']}
-      res = self.server.getTransformationFiles( condDict = selectDict )
+      res = self.transClient.getTransformationFiles( condDict = selectDict )
       if not res['OK']:
         print "Failed to get transformation files: %s" % res['Message']
       elif res['Value']:
@@ -411,7 +411,7 @@ that the username provided to the function.
       print "no transformation supplied"
       return
     transName = argss[0]
-    res = self.server.getTransformation( transName )
+    res = self.transClient.getTransformation( transName )
     if not res['OK']:
       print "Failed to get transformation information: %s" % res['Message']
     else:
@@ -423,7 +423,7 @@ that the username provided to the function.
         print res['Message']
         return
       if not len( res['Value'] ) > 0:
-        print 'No output files yet for transformation %d' %int(transName)
+        print 'No output files yet for transformation %d' % int( transName )
         return
       else:
         for lfn in res['Value']:
@@ -439,7 +439,7 @@ that the username provided to the function.
       print "no transformation supplied"
       return
     transName = argss[0]
-    res = self.server.getTransformationInputDataQuery( transName )
+    res = self.transClient.getTransformationInputDataQuery( transName )
     if not res['OK']:
       print "Failed to get transformation input data query: %s" % res['Message']
     else:
@@ -457,7 +457,7 @@ that the username provided to the function.
     transName = argss[0]
     lfn = argss[1]
     status = argss[2]
-    res = self.server.setFileStatusForTransformation( transName, status, [lfn] )
+    res = self.transClient.setFileStatusForTransformation( transName, status, [lfn] )
     if not res['OK']:
       print "Failed to update file status: %s" % res['Message']
     else:
@@ -474,7 +474,7 @@ that the username provided to the function.
       return
     transName = argss[0]
     lfns = argss[1:]
-    res = self.server.setFileStatusForTransformation( transName, 'Unused', lfns )
+    res = self.transClient.setFileStatusForTransformation( transName, 'Unused', lfns )
     if not res['OK']:
       print "Failed to reset file status: %s" % res['Message']
     else:
@@ -489,14 +489,14 @@ that the username provided to the function.
     """ Reset file status for the given transformation
         usage: resetFile <transName|ID> <lfn>
     """
-    argss = args.split() 
-    
+    argss = args.split()
+
     if not len( argss ) > 1:
       print "transformation and file(s) not supplied"
       return
     transName = argss[0]
     lfns = argss[1:]
-    res = self.server.setFileStatusForTransformation( transName, 'Unused', lfns, force = True )
+    res = self.transClient.setFileStatusForTransformation( transName, 'Unused', lfns, force = True )
     if not res['OK']:
       print "Failed to reset file status: %s" % res['Message']
     else:
@@ -522,7 +522,7 @@ that the username provided to the function.
       print "no directory supplied"
       return
     for directory in argss:
-      res = self.server.addDirectory( directory, force = True )
+      res = self.transClient.addDirectory( directory, force = True )
       if not res['OK']:
         print 'failed to add directory %s: %s' % ( directory, res['Message'] )
       else:
@@ -537,7 +537,7 @@ that the username provided to the function.
     if not len( argss ) > 0:
       print "no files supplied"
       return
-    res = self.server.getReplicas( argss )
+    res = self.transClient.getReplicas( argss )
     if not res['OK']:
       print "failed to get any replica information: %s" % res['Message']
       return
@@ -564,7 +564,7 @@ that the username provided to the function.
     for lfn in argss:
       lfnDict[lfn] = {'PFN':'IGNORED-PFN', 'SE':'IGNORED-SE', 'Size':0, 'GUID':'IGNORED-GUID',
                       'Checksum':'IGNORED-CHECKSUM'}
-    res = self.server.addFile( lfnDict, force = True )
+    res = self.transClient.addFile( lfnDict, force = True )
     if not res['OK']:
       print "failed to add any files: %s" % res['Message']
       return
@@ -583,7 +583,7 @@ that the username provided to the function.
     if not len( argss ) > 0:
       print "no files supplied"
       return
-    res = self.server.removeFile( argss )
+    res = self.transClient.removeFile( argss )
     if not res['OK']:
       print "failed to remove any files: %s" % res['Message']
       return
@@ -606,7 +606,7 @@ that the username provided to the function.
     se = argss[1]
     lfnDict = {}
     lfnDict[lfn] = {'PFN':'IGNORED-PFN', 'SE':se, 'Size':0, 'GUID':'IGNORED-GUID', 'Checksum':'IGNORED-CHECKSUM'}
-    res = self.server.addReplica( lfnDict, force = True )
+    res = self.transClient.addReplica( lfnDict, force = True )
     if not res['OK']:
       print "failed to add replica: %s" % res['Message']
       return
@@ -629,7 +629,7 @@ that the username provided to the function.
     se = argss[1]
     lfnDict = {}
     lfnDict[lfn] = {'PFN':'IGNORED-PFN', 'SE':se, 'Size':0, 'GUID':'IGNORED-GUID', 'Checksum':'IGNORED-CHECKSUM'}
-    res = self.server.removeReplica( lfnDict )
+    res = self.transClient.removeReplica( lfnDict )
     if not res['OK']:
       print "failed to remove replica: %s" % res['Message']
       return
@@ -653,7 +653,7 @@ that the username provided to the function.
     se = argss[2]
     lfnDict = {}
     lfnDict[lfn] = {'Status':status, 'PFN':'IGNORED-PFN', 'SE':se, 'Size':0, 'GUID':'IGNORED-GUID', 'Checksum':'IGNORED-CHECKSUM'}
-    res = self.server.setReplicaStatus( lfnDict )
+    res = self.transClient.setReplicaStatus( lfnDict )
     if not res['OK']:
       print "failed to set replica status: %s" % res['Message']
       return

--- a/TransformationSystem/Client/Utilities.py
+++ b/TransformationSystem/Client/Utilities.py
@@ -457,7 +457,7 @@ def sortSEs( ses ):
     if len( se.split( ',' ) ) != 1:
       return sorted( ses )
     if se not in seSvcClass:
-      seSvcClass[se] = StorageElement( se ).getStatus()['Value']['DiskSE']
+      seSvcClass[se] = StorageElement( se ).getStatus()['DiskSE']
   diskSEs = [se for se in ses if seSvcClass[se]]
   tapeSEs = [se for se in ses if se not in diskSEs]
   return sorted( diskSEs ) + sorted( tapeSEs )
@@ -491,4 +491,4 @@ def isFailover( se ):
 def getActiveSEs( seList, access = 'Write' ):
   """ Utility function - uses the StorageElement cached status
   """
-  return [ se for se in seList if StorageElement( se ).getStatus().get( 'Value', {} ).get( access, False )]
+  return [ se for se in seList if StorageElement( se ).getStatus().get( access, False )]

--- a/TransformationSystem/Client/Utilities.py
+++ b/TransformationSystem/Client/Utilities.py
@@ -457,7 +457,7 @@ def sortSEs( ses ):
     if len( se.split( ',' ) ) != 1:
       return sorted( ses )
     if se not in seSvcClass:
-      seSvcClass[se] = StorageElement( se ).getStatus()['DiskSE']
+      seSvcClass[se] = StorageElement( se ).status()['DiskSE']
   diskSEs = [se for se in ses if seSvcClass[se]]
   tapeSEs = [se for se in ses if se not in diskSEs]
   return sorted( diskSEs ) + sorted( tapeSEs )
@@ -491,4 +491,4 @@ def isFailover( se ):
 def getActiveSEs( seList, access = 'Write' ):
   """ Utility function - uses the StorageElement cached status
   """
-  return [ se for se in seList if StorageElement( se ).getStatus().get( access, False )]
+  return [ se for se in seList if StorageElement( se ).status().get( access, False )]

--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -896,11 +896,10 @@ class TransformationDB( DB ):
       return res
     connection = res['Value']['Connection']
     transID = res['Value']['TransformationID']
-    # Set ID first such that we can't end up with status OK and no ID
-    res = self.__setTaskParameterValue( transID, taskID, 'ExternalID', taskWmsID, connection = connection )
+    res = self.__setTaskParameterValue( transID, taskID, 'ExternalStatus', status, connection = connection )
     if not res['OK']:
       return res
-    return self.__setTaskParameterValue( transID, taskID, 'ExternalStatus', status, connection = connection )
+    return self.__setTaskParameterValue( transID, taskID, 'ExternalID', taskWmsID, connection = connection )
 
   def setTaskStatus( self, transName, taskID, status, connection = False ):
     """ Set status for job with taskID in production with transformationID """

--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -497,7 +497,7 @@ class TransformationDB( DB ):
 
   def addFilesToTransformation( self, transName, lfns, connection = False ):
     """ Add a list of LFNs to the transformation directly """
-    gLogger.info( "TransformationDB.addFilesToTransformation: Attempting to add %s files to transformations: %s" % ( len(lfns), transName ) )
+    gLogger.info( "TransformationDB.addFilesToTransformation: Attempting to add %s files to transformations: %s" % ( len( lfns ), transName ) )
     if not lfns:
       return S_ERROR( 'Zero length LFN list' )
     res = self._getConnectionTransID( connection, transName )
@@ -896,10 +896,11 @@ class TransformationDB( DB ):
       return res
     connection = res['Value']['Connection']
     transID = res['Value']['TransformationID']
-    res = self.__setTaskParameterValue( transID, taskID, 'ExternalStatus', status, connection = connection )
+    # Set ID first such that we can't end up with status OK and no ID
+    res = self.__setTaskParameterValue( transID, taskID, 'ExternalID', taskWmsID, connection = connection )
     if not res['OK']:
       return res
-    return self.__setTaskParameterValue( transID, taskID, 'ExternalID', taskWmsID, connection = connection )
+    return self.__setTaskParameterValue( transID, taskID, 'ExternalStatus', status, connection = connection )
 
   def setTaskStatus( self, transName, taskID, status, connection = False ):
     """ Set status for job with taskID in production with transformationID """
@@ -1438,7 +1439,7 @@ class TransformationDB( DB ):
         metadatadict = res['Value']
       gLogger.info( 'Filter file with metadata', metadatadict )
       transIDs = self._filterFileByMetadata( metadatadict )
-      gLogger.info('Transformations passing the filter: %s' % transIDs)
+      gLogger.info( 'Transformations passing the filter: %s' % transIDs )
       if not ( transIDs or force ):  # not clear how force should be used for
         successful[lfn] = False  # True -> False bug fix: otherwise it is set to True even if transIDs is empty.
       else:
@@ -1529,7 +1530,7 @@ class TransformationDB( DB ):
     """ It can be applied to a file or to a directory (path). For a file, add the file to Transformations if the updated metadata dictionary passes the filter.
         For a directory, add the files contained in the directory to the Transformations if the the updated metadata dictionary passes the filter.
     """
-    gLogger.info( "setMetadata: Attempting to set metadata %s to: %s" % (usermetadatadict, path) )
+    gLogger.info( "setMetadata: Attempting to set metadata %s to: %s" % ( usermetadatadict, path ) )
     transFiles = {}
     filesToAdd = []
 
@@ -1560,7 +1561,7 @@ class TransformationDB( DB ):
     metadatadict.update( usermetadatadict )
     gLogger.info( 'Filter file with metadata:', metadatadict )
     transIDs = self._filterFileByMetadata( metadatadict )
-    gLogger.info('Transformations passing the filter: %s' % transIDs)
+    gLogger.info( 'Transformations passing the filter: %s' % transIDs )
     if not transIDs:
       return S_OK()
     elif isFile:
@@ -1605,7 +1606,7 @@ class TransformationDB( DB ):
     for transID, query in queries:
       mq = MetaQuery( query, typeDict )
       gLogger.info( "Apply query %s to metadata %s" % ( mq.getMetaQuery(), metadatadict ) )
-      res = mq.applyQuery(metadatadict)
+      res = mq.applyQuery( metadatadict )
       if not res['OK']:
         gLogger.error( "Error in applying query: %s" % res['Message'] )
         return res

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -83,6 +83,9 @@ class DownloadInputData:
     tapeSEs = set()
     for localSE in [se for se in localSEList if se]:
       seStatus = StorageElement( localSE ).getStatus()
+      if not seStatus['OK']:
+        return seStatus
+      seStatus = seStatus['Value']
       if seStatus['Read'] and seStatus['DiskSE']:
         diskSEs.add( localSE )
       elif seStatus['Read'] and seStatus['TapeSE']:
@@ -269,7 +272,7 @@ class DownloadInputData:
     diskSEs = set()
     tapeSEs = set()
     for seName in reps:
-      seStatus = StorageElement( seName ).getStatus()
+      seStatus = StorageElement( seName ).status()
       # FIXME: This is simply terrible - this notion of "DiskSE" vs "TapeSE" should NOT be used here!
       if seStatus['Read'] and seStatus['DiskSE']:
         diskSEs.add( seName )

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -82,7 +82,7 @@ class DownloadInputData:
     diskSEs = set()
     tapeSEs = set()
     for localSE in [se for se in localSEList if se]:
-      seStatus = StorageElement( localSE ).getStatus()['Value']
+      seStatus = StorageElement( localSE ).getStatus()
       if seStatus['Read'] and seStatus['DiskSE']:
         diskSEs.add( localSE )
       elif seStatus['Read'] and seStatus['TapeSE']:
@@ -269,7 +269,7 @@ class DownloadInputData:
     diskSEs = set()
     tapeSEs = set()
     for seName in reps:
-      seStatus = StorageElement( seName ).getStatus()['Value']
+      seStatus = StorageElement( seName ).getStatus()
       # FIXME: This is simply terrible - this notion of "DiskSE" vs "TapeSE" should NOT be used here!
       if seStatus['Read'] and seStatus['DiskSE']:
         diskSEs.add( seName )

--- a/WorkloadManagementSystem/Client/InputDataByProtocol.py
+++ b/WorkloadManagementSystem/Client/InputDataByProtocol.py
@@ -106,7 +106,7 @@ class InputDataByProtocol( object ):
       return S_OK( {'Successful': {}, 'Failed': []} )
 
     for localSE in seList:
-      seStatus = StorageElement( localSE ).getStatus()['Value']
+      seStatus = StorageElement( localSE ).getStatus()
       if seStatus['Read'] and seStatus['DiskSE']:
         diskSEs.add( localSE )
       elif seStatus['Read'] and seStatus['TapeSE']:

--- a/WorkloadManagementSystem/Client/InputDataByProtocol.py
+++ b/WorkloadManagementSystem/Client/InputDataByProtocol.py
@@ -106,7 +106,7 @@ class InputDataByProtocol( object ):
       return S_OK( {'Successful': {}, 'Failed': []} )
 
     for localSE in seList:
-      seStatus = StorageElement( localSE ).getStatus()
+      seStatus = StorageElement( localSE ).status()
       if seStatus['Read'] and seStatus['DiskSE']:
         diskSEs.add( localSE )
       elif seStatus['Read'] and seStatus['TapeSE']:

--- a/WorkloadManagementSystem/Executor/InputData.py
+++ b/WorkloadManagementSystem/Executor/InputData.py
@@ -349,6 +349,8 @@ class InputData( OptimizerExecutor ):
           siteList = result[ 'Value' ]
           seObj = StorageElement( seName, vo = vo )
           seStatus = seObj.getStatus()
+          if not seStatus['OK']:
+            return seStatus
           seDict[ seName ] = { 'Sites': siteList, 'Status': seStatus }
         # Get SE info from the dict
         seData = seDict[ seName ]

--- a/WorkloadManagementSystem/Executor/InputData.py
+++ b/WorkloadManagementSystem/Executor/InputData.py
@@ -234,53 +234,6 @@ class InputData( OptimizerExecutor ):
     return self.__getSiteCandidates( okReplicas, vo )
 
   #############################################################################
-  def __checkActiveSEs( self, jobState, replicaDict ):
-    """
-    Check active SE and replicas and identify possible Site candidates for
-    the execution of the job
-    """
-    # Now let's check if some replicas might not be available due to banned SE's
-    self.jobLog.info( "Checking active replicas" )
-    startTime = time.time()
-    result = jobState.getManifest()
-    if not result['OK']:
-      return result
-    manifest = result['Value']
-    vo = manifest.getOption( 'VirtualOrganization' )
-    dm = self.__getDataManager( vo )
-    if dm is None:
-      return S_ERROR( 'Failed to instantiate DataManager for vo %s' % vo )
-    else:
-      result = dm.checkActiveReplicas( replicaDict )
-    self.jobLog.info( "Active replica check took %.2f secs" % ( time.time() - startTime ) )
-    if not result['OK']:
-      # due to banned SE's input data might no be available
-      msg = "On Hold: Input data not Available for SE"
-      self.jobLog.warn( result['Message'] )
-      return S_ERROR( result['Message'] )
-
-    activeReplicaDict = result['Value']
-
-    result = self.__checkReplicas( jobState, activeReplicaDict, vo )
-
-    if not result['OK']:
-      # due to a banned SE's input data is not available at a single site
-      msg = "On Hold: Input data not Available due to banned SE"
-      self.jobLog.warn( result['Message'] )
-      return S_ERROR( msg )
-
-    resolvedData = {}
-    # THIS IS ONE OF THE MOST HORRIBLE HACKS. I hate the creator of the Value of Value of Successful of crap...
-    resolvedData['Value'] = S_OK( activeReplicaDict )
-    resolvedData['SiteCandidates'] = result['Value']
-    result = self.storeOptimizerParam( self.ex_getProperty( 'optimizerName' ), resolvedData )
-    if not result['OK']:
-      self.log.warn( result['Message'] )
-      return result
-    return S_OK( resolvedData )
-
-
-  #############################################################################
   def __getSitesForSE( self, seName ):
     """ Returns a list of sites having the given SE as a local one.
         Uses the local cache of the site-se information

--- a/WorkloadManagementSystem/Executor/InputData.py
+++ b/WorkloadManagementSystem/Executor/InputData.py
@@ -348,11 +348,7 @@ class InputData( OptimizerExecutor ):
             continue
           siteList = result[ 'Value' ]
           seObj = StorageElement( seName, vo = vo )
-          result = seObj.getStatus()
-          if not result[ 'OK' ]:
-            self.jobLog.error( "Could not retrieve status for SE %s: %s" % ( seName, result[ 'Message' ] ) )
-            continue
-          seStatus = result[ 'Value' ]
+          seStatus = seObj.getStatus()
           seDict[ seName ] = { 'Sites': siteList, 'Status': seStatus }
         # Get SE info from the dict
         seData = seDict[ seName ]

--- a/WorkloadManagementSystem/Executor/InputData.py
+++ b/WorkloadManagementSystem/Executor/InputData.py
@@ -351,7 +351,7 @@ class InputData( OptimizerExecutor ):
           seStatus = seObj.getStatus()
           if not seStatus['OK']:
             return seStatus
-          seDict[ seName ] = { 'Sites': siteList, 'Status': seStatus }
+          seDict[ seName ] = { 'Sites': siteList, 'Status': seStatus['Value'] }
         # Get SE info from the dict
         seData = seDict[ seName ]
         siteList = seData[ 'Sites' ]

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -449,11 +449,7 @@ class JobScheduling( OptimizerExecutor ):
 
     for seName in siteSEs:
       se = StorageElement( seName, vo = vo )
-      result = se.getStatus()
-      if not result[ 'OK' ]:
-        self.jobLog.error( "Cannot retrieve SE %s status: %s" % ( seName, result[ 'Message' ] ) )
-        return S_ERROR( "Cannot retrieve SE status" )
-      seStatus = result[ 'Value' ]
+      seStatus = se.getStatus()
       if seStatus[ 'Read' ] and seStatus[ 'TapeSE' ]:
         tapeSEs.append( seName )
       if seStatus[ 'Read' ] and seStatus[ 'DiskSE' ]:
@@ -566,11 +562,8 @@ class JobScheduling( OptimizerExecutor ):
         # If we don't have the SE status get it and store it
         if seName not in seStatus:
           seObj = StorageElement( seName, vo = vo )
-          result = seObj.getStatus()
-          if not result['OK' ]:
-            self.jobLog.error( "Cannot retrieve SE %s status: %s" % ( seName, result[ 'Message' ] ) )
-            continue
-          seStatus[ seName ] = result[ 'Value' ]
+          status = seObj.getStatus()
+          seStatus[ seName ] = status
         # get the SE status from mem and add it if its disk
         status = seStatus[ seName ]
         if status['Read'] and status['DiskSE']:

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -450,6 +450,9 @@ class JobScheduling( OptimizerExecutor ):
     for seName in siteSEs:
       se = StorageElement( seName, vo = vo )
       seStatus = se.getStatus()
+      if not seStatus['OK']:
+        return seStatus
+      seStatus = seStatus['Value']
       if seStatus[ 'Read' ] and seStatus[ 'TapeSE' ]:
         tapeSEs.append( seName )
       if seStatus[ 'Read' ] and seStatus[ 'DiskSE' ]:
@@ -561,7 +564,7 @@ class JobScheduling( OptimizerExecutor ):
       for seName in closeSEs:
         # If we don't have the SE status get it and store it
         if seName not in seStatus:
-          seStatus[ seName ] = StorageElement( seName, vo = vo ).getStatus()
+          seStatus[ seName ] = StorageElement( seName, vo = vo )status()
         # get the SE status from mem and add it if its disk
         status = seStatus[ seName ]
         if status['Read'] and status['DiskSE']:
@@ -590,9 +593,6 @@ class JobScheduling( OptimizerExecutor ):
             self.jobLog.verbose( "Setting LFN to disk for %s" % ( seName ) )
             siteData[ 'disk' ] += 1
             siteData[ 'tape' ] -= 1
-
-    return S_OK()
-
 
   def __setJobSite( self, jobState, siteList, onlineSites = None ):
     """ Set the site attribute

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -561,9 +561,7 @@ class JobScheduling( OptimizerExecutor ):
       for seName in closeSEs:
         # If we don't have the SE status get it and store it
         if seName not in seStatus:
-          seObj = StorageElement( seName, vo = vo )
-          status = seObj.getStatus()
-          seStatus[ seName ] = status
+          seStatus[ seName ] = StorageElement( seName, vo = vo ).getStatus()
         # get the SE status from mem and add it if its disk
         status = seStatus[ seName ]
         if status['Read'] and status['DiskSE']:

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -564,7 +564,7 @@ class JobScheduling( OptimizerExecutor ):
       for seName in closeSEs:
         # If we don't have the SE status get it and store it
         if seName not in seStatus:
-          seStatus[ seName ] = StorageElement( seName, vo = vo )status()
+          seStatus[ seName ] = StorageElement( seName, vo = vo ).status()
         # get the SE status from mem and add it if its disk
         status = seStatus[ seName ]
         if status['Read'] and status['DiskSE']:


### PR DESCRIPTION
BEGINRELEASENOTES
* DMS
CHANGE: as se.getStatus() always returns S_OK, return directly the values. Remove the checks of OK everywhere
* TS
FIX TransformationDB.py: set the ExternalID before the ExternalStatus in order to avoid inconsistent tasks if setting the ExternalID fails
* StorageManagementSystem
FIX StorageManagementClient.py: return the full list of onlineSites while it was previously happy with only one

ENDRELEASENOTES
