### PR TITLE
[v6r19] Fix RequiredTag and multi-processor Tags

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -415,7 +415,7 @@ class SiteDirector( AgentModule ):
     # Get a union of all tags
     tags = []
     for queue in self.queueDict:
-      tags += self.queueDict[queue]['ParametersDict'].get( 'Tags', [] )
+      tags += self.queueDict[queue]['ParametersDict'].get( 'Tag', [] )
     tqDict['Tag'] = list( set( tags ) )
 
     # Add overall max values for all queues

--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -386,7 +386,7 @@ class JobScheduling( OptimizerExecutor ):
       if nProcessors:
         tagList.append( "%dProcessors" % nProcessors )
     if "WholeNode" in jobManifest:
-      if jobManifest.getOption( "WholeNode", "" ).lower() in ["1", "yes", "false"]:
+      if jobManifest.getOption( "WholeNode", "" ).lower() in ["1", "yes", "true"]:
         tagList.append( "WholeNode" )
     if "Tags" in jobManifest:
       tagList.extend( jobManifest.getOption( "Tags", [] ) )

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -392,8 +392,10 @@ class CheckCECapabilities( CommandBase ):
     self.cfg = []
 
   def execute( self ):
-    """ Setup CE/Queue Tags
+    """ Main execution method
     """
+    if self.pp.debugFlag:
+      self.cfg.append( '-ddd' )
 
     # Get the resource description as defined in its configuration
     checkCmd = 'dirac-resource-get-parameters -S %s -N %s -Q %s %s' % ( self.pp.site,
@@ -450,6 +452,9 @@ class CheckWNCapabilities( CommandBase ):
   def execute( self ):
     """ Discover NumberOfProcessors and RAM
     """
+
+    if self.pp.debugFlag:
+      self.cfg.append( '-ddd' )
 
     # Get the worker node parameters
     checkCmd = 'dirac-wms-get-wn-parameters -S %s -N %s -Q %s %s' % ( self.pp.site, self.pp.ceName, self.pp.queueName,

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -422,12 +422,6 @@ class CheckCECapabilities( CommandBase ):
       self.pp.tags += resourceDict['Tag']
       self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
 
-    # Add some operational parameters if they are defined
-    if self.pp.useServerCertificate:
-      self.cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
-    if self.debugFlag:
-        self.cfg.append( '-ddd' )
-
     # If there is anything to be added to the local configuration, let's do it
     if self.cfg:
       self.cfg.append( '-FDMH' )

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -474,11 +474,11 @@ class CheckWNCapabilities( CommandBase ):
 
     # If NumberOfProcessors or MaxRAM are defined in the resource configuration, these
     # values are preferred
-    if numberOfProcessors and "NumberOfProcessors" not in self.queueParameters:
+    if numberOfProcessors and "NumberOfProcessors" not in self.pp.queueParameters:
       self.cfg.append( '-o "/Resources/Computing/CEDefaults/NumberOfProcessors=%d"' % numberOfProcessors )
     else:
       self.log.warn( "Could not retrieve number of processors" )
-    if maxRAM and "MaxRAM" not in self.queueParameters:
+    if maxRAM and "MaxRAM" not in self.pp.queueParameters:
       self.cfg.append( '-o "/Resources/Computing/CEDefaults/MaxRAM=%d"' % maxRAM )
     else:
       self.log.warn( "Could not retrieve MaxRAM" )

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -394,14 +394,14 @@ class CheckCECapabilities( CommandBase ):
   def execute( self ):
     """ Main execution method
     """
-    if self.pp.debugFlag:
-      self.cfg.append( '-ddd' )
+    debugCfg = '-ddd' if self.pp.debugFlag else ''
 
     # Get the resource description as defined in its configuration
     checkCmd = 'dirac-resource-get-parameters -S %s -N %s -Q %s %s' % ( self.pp.site,
                                                                         self.pp.ceName,
                                                                         self.pp.queueName,
-                                                                        " ".join( self.cfg ) )
+                                                                        debugCfg )
+
     retCode, resourceDict = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
     if retCode:
       self.log.error( "Could not get resource parameters [ERROR %d]" % retCode )
@@ -422,6 +422,7 @@ class CheckCECapabilities( CommandBase ):
     # Tags must be added to already defined tags if any
     if resourceDict.get( 'Tag' ):
       self.pp.tags += resourceDict['Tag']
+    if self.tags:
       self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
 
     # If there is anything to be added to the local configuration, let's do it
@@ -453,12 +454,13 @@ class CheckWNCapabilities( CommandBase ):
     """ Discover NumberOfProcessors and RAM
     """
 
-    if self.pp.debugFlag:
-      self.cfg.append( '-ddd' )
+    debugCfg = '-ddd' if self.pp.debugFlag else ''
 
     # Get the worker node parameters
-    checkCmd = 'dirac-wms-get-wn-parameters -S %s -N %s -Q %s %s' % ( self.pp.site, self.pp.ceName, self.pp.queueName,
-                                                                      " ".join( self.cfg ) )
+    checkCmd = 'dirac-wms-get-wn-parameters -S %s -N %s -Q %s %s' % ( self.pp.site,
+                                                                      self.pp.ceName,
+                                                                      self.pp.queueName,
+                                                                      debugCfg )
     retCode, result = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
     if retCode:
       self.log.error( "Could not get resource parameters [ERROR %d]" % retCode )

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -381,7 +381,7 @@ class ConfigureBasics( CommandBase ):
       self.cfg.append( "-o /DIRAC/Security/KeyFile=%s/hostkey.pem" % self.pp.certsLocation )
 
 class CheckCECapabilities( CommandBase ):
-  """ Used to get  CE tags.
+  """ Used to get CE tags and other relevant parameters
   """
   def __init__( self, pilotParams ):
     """ c'tor
@@ -395,12 +395,7 @@ class CheckCECapabilities( CommandBase ):
     """ Setup CE/Queue Tags
     """
 
-    if self.pp.useServerCertificate:
-      self.cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
-    if self.pp.localConfigFile:
-      self.cfg.append( self.pp.localConfigFile )  # this file is as input
-
-
+    # Get the resource description as defined in its configuration
     checkCmd = 'dirac-resource-get-parameters -S %s -N %s -Q %s %s' % ( self.pp.site,
                                                                         self.pp.ceName,
                                                                         self.pp.queueName,
@@ -415,23 +410,31 @@ class CheckCECapabilities( CommandBase ):
     except ValueError:
       self.log.error( "The pilot command output is not json compatible." )
       sys.exit( 1 )
-    if resourceDict.get( 'WholeNode' ):
-      self.pp.tags.append( "WholeNode" )
+    self.pp.queueParameters = resourceDict
+
+    # Pick up all the relevant resource parameters that will be used in the job matching
+    for ceParam in [ "WholeNode", "NumberOfProcessors", "RequiredTag" ]:
+      if resourceDict.get( ceParam ):
+        self.cfg.append( '-o  /Resources/Computing/CEDefaults/%s=%s' % ( ceParam, resourceDict[ ceParam ] ) )
+
+    # Tags must be added to already defined tags if any
     if resourceDict.get( 'Tag' ):
       self.pp.tags += resourceDict['Tag']
-      self.cfg.append( '-FDMH' )
+      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
 
-      if self.pp.useServerCertificate:
-        self.cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
+    # Add some operational parameters if they are defined
+    if self.pp.useServerCertificate:
+      self.cfg.append( '-o  /DIRAC/Security/UseServerCertificate=yes' )
+    if self.debugFlag:
+        self.cfg.append( '-ddd' )
+
+    # If there is anything to be added to the local configuration, let's do it
+    if self.cfg:
+      self.cfg.append( '-FDMH' )
 
       if self.pp.localConfigFile:
         self.cfg.append( '-O %s' % self.pp.localConfigFile )  # this file is as output
         self.cfg.append( self.pp.localConfigFile )  # this file is as input
-
-      if self.debugFlag:
-        self.cfg.append( '-ddd' )
-
-      self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
 
       configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
       retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )
@@ -440,7 +443,8 @@ class CheckCECapabilities( CommandBase ):
         self.exitWithError( retCode )
 
 class CheckWNCapabilities( CommandBase ):
-  """ Used to get capabilities specific to the Worker Node.
+  """ Used to get capabilities specific to the Worker Node. This command must be called
+      after the CheckCECapabilities command
   """
 
   def __init__( self, pilotParams ):
@@ -450,14 +454,10 @@ class CheckWNCapabilities( CommandBase ):
     self.cfg = []
 
   def execute( self ):
-    """ Discover #Processors and memory
+    """ Discover NumberOfProcessors and RAM
     """
 
-    if self.pp.useServerCertificate:
-      self.cfg.append( '-o /DIRAC/Security/UseServerCertificate=yes' )
-    if self.pp.localConfigFile:
-      self.cfg.append( self.pp.localConfigFile )  # this file is as input
-
+    # Get the worker node parameters
     checkCmd = 'dirac-wms-get-wn-parameters -S %s -N %s -Q %s %s' % ( self.pp.site, self.pp.ceName, self.pp.queueName,
                                                                       " ".join( self.cfg ) )
     retCode, result = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
@@ -466,31 +466,30 @@ class CheckWNCapabilities( CommandBase ):
       self.exitWithError( retCode )
     try:
       result = result.split( ' ' )
-      numberOfProcessor = int( result[0] )
+      numberOfProcessors = int( result[0] )
       maxRAM = int( result[1] )
     except ValueError:
       self.log.error( "Wrong Command output %s" % result )
       sys.exit( 1 )
-    if numberOfProcessor or maxRAM:
+
+    # If NumberOfProcessors or MaxRAM are defined in the resource configuration, these
+    # values are preferred
+    if numberOfProcessors and "NumberOfProcessors" not in self.queueParameters:
+      self.cfg.append( '-o "/Resources/Computing/CEDefaults/NumberOfProcessors=%d"' % numberOfProcessors )
+    else:
+      self.log.warn( "Could not retrieve number of processors" )
+    if maxRAM and "MaxRAM" not in self.queueParameters:
+      self.cfg.append( '-o "/Resources/Computing/CEDefaults/MaxRAM=%d"' % maxRAM )
+    else:
+      self.log.warn( "Could not retrieve MaxRAM" )
+
+    if self.cfg:
       self.cfg.append( '-FDMH' )
 
-      if self.pp.useServerCertificate:
-        self.cfg.append( '-o /DIRAC/Security/UseServerCertificate=yes' )
       if self.pp.localConfigFile:
         self.cfg.append( '-O %s' % self.pp.localConfigFile )  # this file is as output
         self.cfg.append( self.pp.localConfigFile )  # this file is as input
 
-      if self.debugFlag:
-        self.cfg.append( '-ddd' )
-
-      if numberOfProcessor:
-        self.cfg.append( '-o "/Resources/Computing/CEDefaults/NumberOfProcessors=%d"' % numberOfProcessor )
-      else:
-        self.log.warn( "Could not retrieve number of processors" )
-      if maxRAM:
-        self.cfg.append( '-o "/Resources/Computing/CEDefaults/MaxRAM=%d"' % maxRAM )
-      else:
-        self.log.warn( "Could not retrieve MaxRAM" )
       configureCmd = "%s %s" % ( self.pp.configureScript, " ".join( self.cfg ) )
       retCode, _configureOutData = self.executeAndGetOutput( configureCmd, self.pp.installEnv )
       if retCode:

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -438,6 +438,8 @@ class CheckCECapabilities( CommandBase ):
       if retCode:
         self.log.error( "Could not configure DIRAC [ERROR %d]" % retCode )
         self.exitWithError( retCode )
+    else:
+      self.log.debug( 'No Tags defined for this Queue' )
 
 class CheckWNCapabilities( CommandBase ):
   """ Used to get capabilities specific to the Worker Node. This command must be called

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -394,14 +394,10 @@ class CheckCECapabilities( CommandBase ):
   def execute( self ):
     """ Main execution method
     """
-    debugCfg = '-ddd' if self.pp.debugFlag else ''
-
     # Get the resource description as defined in its configuration
-    checkCmd = 'dirac-resource-get-parameters -S %s -N %s -Q %s %s' % ( self.pp.site,
+    checkCmd = 'dirac-resource-get-parameters -S %s -N %s -Q %s' % ( self.pp.site,
                                                                         self.pp.ceName,
-                                                                        self.pp.queueName,
-                                                                        debugCfg )
-
+                                                                        self.pp.queueName )
     retCode, resourceDict = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
     if retCode:
       self.log.error( "Could not get resource parameters [ERROR %d]" % retCode )
@@ -422,13 +418,15 @@ class CheckCECapabilities( CommandBase ):
     # Tags must be added to already defined tags if any
     if resourceDict.get( 'Tag' ):
       self.pp.tags += resourceDict['Tag']
-    if self.tags:
+    if self.pp.tags:
       self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
 
     # If there is anything to be added to the local configuration, let's do it
     if self.cfg:
       self.cfg.append( '-FDMH' )
 
+      if self.debugFlag:
+        self.cfg.append( '-ddd' )
       if self.pp.localConfigFile:
         self.cfg.append( '-O %s' % self.pp.localConfigFile )  # this file is as output
         self.cfg.append( self.pp.localConfigFile )  # this file is as input
@@ -456,13 +454,10 @@ class CheckWNCapabilities( CommandBase ):
     """ Discover NumberOfProcessors and RAM
     """
 
-    debugCfg = '-ddd' if self.pp.debugFlag else ''
-
     # Get the worker node parameters
-    checkCmd = 'dirac-wms-get-wn-parameters -S %s -N %s -Q %s %s' % ( self.pp.site,
+    checkCmd = 'dirac-wms-get-wn-parameters -S %s -N %s -Q %s' % ( self.pp.site,
                                                                       self.pp.ceName,
-                                                                      self.pp.queueName,
-                                                                      debugCfg )
+                                                                      self.pp.queueName )
     retCode, result = self.executeAndGetOutput( checkCmd, self.pp.installEnv )
     if retCode:
       self.log.error( "Could not get resource parameters [ERROR %d]" % retCode )
@@ -489,6 +484,8 @@ class CheckWNCapabilities( CommandBase ):
     if self.cfg:
       self.cfg.append( '-FDMH' )
 
+      if self.debugFlag:
+        self.cfg.append( '-ddd' )
       if self.pp.localConfigFile:
         self.cfg.append( '-O %s' % self.pp.localConfigFile )  # this file is as output
         self.cfg.append( self.pp.localConfigFile )  # this file is as input

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -414,7 +414,7 @@ class CheckCECapabilities( CommandBase ):
 
     # Pick up all the relevant resource parameters that will be used in the job matching
     for ceParam in [ "WholeNode", "NumberOfProcessors", "RequiredTag" ]:
-      if resourceDict.get( ceParam ):
+      if ceParam in resourceDict:
         self.cfg.append( '-o  /Resources/Computing/CEDefaults/%s=%s' % ( ceParam, resourceDict[ ceParam ] ) )
 
     # Tags must be added to already defined tags if any

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -364,6 +364,7 @@ class PilotParams( object ):
     self.ceName = ""
     self.ceType = ''
     self.queueName = ""
+    self.queueParameters = {}
     self.platform = ""
     self.minDiskSpace = 2560 #MB
     self.jobCPUReq = 900


### PR DESCRIPTION
  This PR is replacing #3433 and #3398. It fixes the pilot local configuration with respect to Tags, RequiredTag and multi-processor related settings. Tags are also properly taken into account in the SiteDirector logic.

BEGINRELEASENOTES
*WMS
FIX: pilotTools,pilotCommands - pick up all the necessary settings from the site/queue configuration
       related to Tags and multi-processor
CHANGE: pilotCommands - removed debug and useServerCerticate configuration from CheckCECapabilities and CheckWNCapabilities as this is done in ConfigureBasics
FIX: SiteDirector - aggregate tags for the general job availability test
FIX: JobScheduling - bug fix in __sendToTQ()
ENDRELEASENOTES
