### PR TITLE
[v6r19] SiteDirector - give default values to MaxTotal|WaitingJobs

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -758,8 +758,8 @@ class SiteDirector( AgentModule ):
             self.queueSlots[queue]['AvailableSlots'] = totalSlots
             waitingJobs = ceInfoDict['WaitingJobs']
         else:
-          maxWaitingJobs = int( self.queueDict[queue]['ParametersDict']['MaxWaitingJobs'] )
-          maxTotalJobs = int( self.queueDict[queue]['ParametersDict']['MaxTotalJobs'] )
+          maxWaitingJobs = int( self.queueDict[queue]['ParametersDict'].get( 'MaxWaitingJobs', 10 ) )
+          maxTotalJobs = int( self.queueDict[queue]['ParametersDict'].get( 'MaxTotalJobs', 10 ) )
           waitingJobs = 0
           totalJobs = 0
           if jobIDList:

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -95,8 +95,7 @@ class SiteDirector( AgentModule ):
     self.rssClient = None
     self.rssFlag = None
 
-    self.globalParameters = { "WholeNode": False,
-                              "NumberOfProcessors": 1,
+    self.globalParameters = { "NumberOfProcessors": 1,
                               "MaxRAM": 2048 }
 
   def initialize( self ):

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1374,8 +1374,6 @@ class JobDB( DB ):
     if not self._update( cmd )['OK']:
       return S_ERROR( 'JobDB.removeJobOptParameter: operation failed.' )
 
-    # the JobManager needs to know if there is InputData ??? to decide which optimizer to call
-    # proposal: - use the getInputData method
     res = self.getJobJDL( jobID, original = True )
     if not res['OK']:
       return res

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1214,6 +1214,8 @@ class JobDB( DB ):
       cpuTime = classAdJob.getAttributeInt( 'MaxCPUTime' )
       if cpuTime is not None:
         classAdJob.insertAttributeInt( 'CPUTime', cpuTime )
+      else:
+        cpuTime = 0
     classAdReq.insertAttributeInt( 'UserPriority', priority )
     classAdReq.insertAttributeInt( 'CPUTime', cpuTime )
 

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -51,6 +51,7 @@ from DIRAC.Core.Utilities.ReturnValues                       import S_OK, S_ERRO
 from DIRAC.Core.Utilities                                    import Time
 from DIRAC.ConfigurationSystem.Client.Config                 import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry       import getVOForGroup, getVOOption, getGroupOption
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations     import Operations
 from DIRAC.Core.Base.DB                                      import DB
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources      import getDIRACPlatform
 from DIRAC.WorkloadManagementSystem.Client.JobState.JobManifest   import JobManifest
@@ -1215,7 +1216,9 @@ class JobDB( DB ):
       if cpuTime is not None:
         classAdJob.insertAttributeInt( 'CPUTime', cpuTime )
       else:
-        cpuTime = 0
+        opsHelper = Operations( group = ownerGroup,
+                                setup = diracSetup )
+        cpuTime = opsHelper.getValue( 'JobDescription/DefaultCPUTime', 86400 )
     classAdReq.insertAttributeInt( 'UserPriority', priority )
     classAdReq.insertAttributeInt( 'CPUTime', cpuTime )
 
@@ -1371,7 +1374,7 @@ class JobDB( DB ):
     if not self._update( cmd )['OK']:
       return S_ERROR( 'JobDB.removeJobOptParameter: operation failed.' )
 
-    # the Jobreceiver needs to know if there is InputData ??? to decide which optimizer to call
+    # the JobManager needs to know if there is InputData ??? to decide which optimizer to call
     # proposal: - use the getInputData method
     res = self.getJobJDL( jobID, original = True )
     if not res['OK']:

--- a/WorkloadManagementSystem/Service/MatcherHandler.py
+++ b/WorkloadManagementSystem/Service/MatcherHandler.py
@@ -117,7 +117,10 @@ class MatcherHandler( RequestHandler ):
       negativeCond = self.limiter.getNegativeCondForSite( resourceDict[ 'Site' ] )
     else:
       negativeCond = self.limiter.getNegativeCond()
-    matcher = Matcher()
+    matcher = Matcher( pilotAgentsDB = pilotAgentsDB,
+                       jobDB = gJobDB,
+                       tqDB = gTaskQueueDB,
+                       jlDB = jlDB )
     resourceDescriptionDict = matcher._processResourceDescription( resourceDict )
     return gTaskQueueDB.retrieveTaskQueuesThatMatch( resourceDescriptionDict, negativeCond = negativeCond )
 

--- a/WorkloadManagementSystem/Service/MatcherHandler.py
+++ b/WorkloadManagementSystem/Service/MatcherHandler.py
@@ -117,7 +117,9 @@ class MatcherHandler( RequestHandler ):
       negativeCond = self.limiter.getNegativeCondForSite( resourceDict[ 'Site' ] )
     else:
       negativeCond = self.limiter.getNegativeCond()
-    return gTaskQueueDB.retrieveTaskQueuesThatMatch( resourceDict, negativeCond = negativeCond )
+    matcher = Matcher()
+    resourceDescriptionDict = matcher._processResourceDescription( resourceDict )
+    return gTaskQueueDB.retrieveTaskQueuesThatMatch( resourceDescriptionDict, negativeCond = negativeCond )
 
 ##############################################################################
   types_matchAndGetTaskQueue = [ dict ]


### PR DESCRIPTION
  This prevents SiteDirector cycle interruption in case some queue does not have MaxTotal|WaitingJobs options defined

BEGINRELEASENOTES
*WMS
FIX: SiteDirector - if MaxWaitingJobs or MaxTotalJobs not defined for a queue, assume a default value of 10
FIX: MatcherHandler - preprocess resource description in getMatchingTaskQueues()
FIX: JobDB - set CPUTime to a default value if not defined when rescheduling jobs
ENDRELEASENOTES
