### PR TITLE
[v6r19] Matcher - process resource description getMatchingTaskQueues

### DIFF
--- a/WorkloadManagementSystem/Service/MatcherHandler.py
+++ b/WorkloadManagementSystem/Service/MatcherHandler.py
@@ -117,7 +117,9 @@ class MatcherHandler( RequestHandler ):
       negativeCond = self.limiter.getNegativeCondForSite( resourceDict[ 'Site' ] )
     else:
       negativeCond = self.limiter.getNegativeCond()
-    return gTaskQueueDB.retrieveTaskQueuesThatMatch( resourceDict, negativeCond = negativeCond )
+    matcher = Matcher()
+    resourceDescriptionDict = matcher._processResourceDescription( resourceDict )
+    return gTaskQueueDB.retrieveTaskQueuesThatMatch( resourceDescriptionDict, negativeCond = negativeCond )
 
 ##############################################################################
   types_matchAndGetTaskQueue = [ dict ]


### PR DESCRIPTION
  The resources description was not preprocessed to get internal tag-based representation of multi-processor parameters in getMatchingTaskQueues() service interface. This PR fixes it.

BEGINRELEASENOTES
*WMS
FIX: MatcherHandler - preprocess resource description in getMatchingTaskQueues()
ENDRELEASENOTES
