### PR TITLE
[v6r17] add force overwrite option to dirac-dms-add-file

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -420,7 +420,7 @@ class DataManager( object ):
         'diracSE' is the Storage Element to which to put the file
         'guid' is the guid with which the file is to be registered (if not provided will be generated)
         'path' is the path on the storage where the file will be put (if not provided the LFN will be used)
-        'overwrite' removes entry from the file catalogue before attempting upload
+        'overwrite' removes file from the file catalogue and SE before attempting upload
     """
 
     res = self.__hasAccess( 'addFile', lfn )

--- a/DataManagementSystem/scripts/dirac-dms-add-file.py
+++ b/DataManagementSystem/scripts/dirac-dms-add-file.py
@@ -10,6 +10,7 @@
 __RCSID__ = "$Id$"
 
 from DIRAC.Core.Base import Script
+from DIRAC import S_OK
 import os
 Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
                                      'Usage:',
@@ -29,7 +30,13 @@ Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
                                      '  lfn1 localfile1 SE [GUID1]',
                                      '  lfn2 localfile2 SE [GUID2]'] )
                         )
+overwrite = False
+def setOverwrite( arg ):
+  global overwrite
+  overwrite = True
+  return S_OK()
 
+Script.registerSwitch( "f", "force", "Force overwrite of existing file", setOverwrite )
 Script.parseCommandLine( ignoreErrors = True )
 args = Script.getPositionalArgs()
 if len( args ) < 1 or len( args ) > 4:
@@ -80,7 +87,7 @@ for lfn in lfns:
     continue
 
   gLogger.notice( "\nUploading %s" % lfn['lfn'] )
-  res = dm.putAndRegister( lfn['lfn'], lfn['localfile'], lfn['SE'], lfn['guid'] )
+  res = dm.putAndRegister( lfn['lfn'], lfn['localfile'], lfn['SE'], lfn['guid'], overwrite = overwrite )
   if not res['OK']:
     exitCode = 3
     gLogger.error( 'Error: failed to upload %s to %s' % ( lfn['lfn'], lfn['SE'] ) )


### PR DESCRIPTION
Based on a user request. Default behaviour is unchanged.
BEGINRELEASENOTES

*DataManagementSystem
NEW:  Added option (-f) to force an overwrite of an existing file in dirac-dms-add-file

ENDRELEASENOTES
