### PR TITLE
[v6r19] SEFactory backward compatibility fix

### DIFF
--- a/Resources/Storage/StorageFactory.py
+++ b/Resources/Storage/StorageFactory.py
@@ -145,6 +145,7 @@ class StorageFactory( object ):
     for protocolSection, protocolDetails in self.protocols.iteritems():
       pluginName = protocolDetails.get( 'PluginName' )
       if pluginName is None:
+        gLogger.warn( "No MANDATORY PluginName option is found in the SE protocol section" )
         # Try ProtocolName/protocolSection for backward compatibility
         pluginName = protocolDetails.get( 'ProtocolName', protocolSection )
       if pluginList and pluginName not in pluginList:

--- a/Resources/Storage/StorageFactory.py
+++ b/Resources/Storage/StorageFactory.py
@@ -143,7 +143,10 @@ class StorageFactory( object ):
     turlProtocols = []
     # Generate the protocol specific plug-ins
     for protocolSection, protocolDetails in self.protocols.iteritems():
-      pluginName = protocolDetails.get('PluginName', protocolSection) 
+      pluginName = protocolDetails.get( 'PluginName' )
+      if pluginName is None:
+        # Try ProtocolName/protocolSection for backward compatibility
+        pluginName = protocolDetails.get( 'ProtocolName', protocolSection )
       if pluginList and pluginName not in pluginList:
         continue
       protocol = protocolDetails['Protocol']

--- a/Resources/Storage/StorageFactory.py
+++ b/Resources/Storage/StorageFactory.py
@@ -146,8 +146,8 @@ class StorageFactory( object ):
       pluginName = protocolDetails.get( 'PluginName' )
       if pluginName is None:
         gLogger.warn( "No MANDATORY PluginName option is found in the SE protocol section" )
-        # Try ProtocolName/protocolSection for backward compatibility
-        pluginName = protocolDetails.get( 'ProtocolName', protocolSection )
+        # Try protocolSection for backward compatibility. This is to be dropped as deprecated
+        pluginName = protocolSection
       if pluginList and pluginName not in pluginList:
         continue
       protocol = protocolDetails['Protocol']


### PR DESCRIPTION
BEGINRELEASENOTES
*Resources
FIX: StorageElementFactory - preserve backward compatibility with respect to using protocol section name as the name of plugin in the absence of PluginName option 
ENDRELEASENOTES
