### PR TITLE
[v6r17] Add info on failed downloads in job parameters

### DIFF
--- a/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -212,7 +212,8 @@ for the agent restart
     if not result['OK']:
       return result
     if not result['Value']:
-      return S_ERROR( 'Failed to get the pilot reference' )
+      # There is no pilot reference, hence its status is unknown
+      return S_OK( 'NoPilot' )
 
     pilotReference = result['Value']
     wmsAdminClient = RPCClient( 'WorkloadManagement/WMSAdministrator' )
@@ -221,7 +222,8 @@ for the agent restart
       if "No pilots found" in result['Message']:
         self.log.warn( result['Message'] )
         return S_OK( 'NoPilot' )
-      self.log.error( 'Failed to get pilot information', result['Message'] )
+      self.log.error( 'Failed to get pilot information',
+                      'for job %d: ' % jobID + result['Message'] )
       return S_ERROR( 'Failed to get the pilot status' )
     pilotStatus = result['Value'][pilotReference]['Status']
 

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -221,16 +221,20 @@ class DownloadInputData:
 
     # Report datasets that could not be downloaded
     report = ''
-    if failedReplicas:
-      self.log.warn( 'The following LFN(s) could not be downloaded to the WN:\n%s' % 'n'.join( sorted( failedReplicas ) ) )
-
     if resolvedData:
-      report = 'Successfully downloaded LFN(s):\n'
-      report += '\n'.join( sorted( resolvedData ) )
-      report += '\nDownloaded %d / %d files from local Storage Elements on first attempt.' % ( localSECount, len( resolvedData ) )
+      report += 'Successfully downloaded %d LFN(s)' % len( resolvedData )
+      if localSECount != len( resolvedData ):
+        report += ' (%d from local SEs)' % localSECount
+      report += ':\n' + '\n'.join( sorted( resolvedData ) )
+    failedReplicas = sorted( failedReplicas.difference( resolvedData ) )
+    if failedReplicas:
+      self.log.warn( 'The following LFN(s) could not be downloaded to the WN:\n%s' % 'n'.join( failedReplicas ) )
+      report += '\nFailed to download %d LFN(s):\n' % len( failedReplicas )
+      report += '\n'.join( failedReplicas )
+
+    if report:
       self.__setJobParam( COMPONENT_NAME, report )
 
-    failedReplicas = [lfn for lfn in sorted( failedReplicas ) if lfn not in resolvedData]
     return S_OK( {'Successful': resolvedData, 'Failed':failedReplicas} )
 
   #############################################################################

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -68,7 +68,7 @@ class DownloadInputData:
       self.log.verbose( 'Data to resolve passed directly to DownloadInputData module' )
       self.inputData = dataToResolve  # e.g. list supplied by another module
 
-    self.inputData = sorted( [x.replace( 'LFN:', '' ) for x in self.inputData] )
+    self.inputData = sorted( lfn.replace( 'LFN:', '' ) for lfn in self.inputData )
     self.log.info( 'InputData to be downloaded is:\n%s' % '\n'.join( self.inputData ) )
 
     replicas = self.fileCatalogResult['Value']['Successful']

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -224,8 +224,10 @@ class DownloadInputData:
     if resolvedData:
       report += 'Successfully downloaded %d LFN(s)' % len( resolvedData )
       if localSECount != len( resolvedData ):
-        report += ' (%d from local SEs)' % localSECount
-      report += ':\n' + '\n'.join( sorted( resolvedData ) )
+        report += ' (%d from local SEs):\n' % localSECount
+      else:
+        report += ' from local SEs:\n'
+      report += '\n'.join( sorted( resolvedData ) )
     failedReplicas = sorted( failedReplicas.difference( resolvedData ) )
     if failedReplicas:
       self.log.warn( 'The following LFN(s) could not be downloaded to the WN:\n%s' % 'n'.join( failedReplicas ) )


### PR DESCRIPTION
BEGINRELEASENOTES
*WMS
CHANGE: Job parameters report successful downloads but not failed ones! Add them
CHANGE: If no PilotReference found in jobs parameters, do as if there would be no pilot information, i.e. set Stalled job Failed immediately
ENDRELEASENOTES
