### PR TITLE
[v6r17] StorageManagerClient: fix logic for checking files on tapeSEs

### DIFF
--- a/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/StorageManagementSystem/Client/StorageManagerClient.py
@@ -146,7 +146,7 @@ def _checkFilesToStage( seToLFNs, onlineLFNs, offlineLFNs, absentLFNs,
       diskIsOK = checkOnlyTapeSEs or ( lfn in onlineLFNs )
       if diskIsOK and diskSE:
         onlineLFNs.setdefault( lfn, [] ).append( se )
-      elif not diskIsOK:
+      elif not diskIsOK or ( tapeSE and ( lfn not in onlineLFNs ) ):
         filesToCheck.append( lfn )
     if not filesToCheck:
       continue

--- a/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
+++ b/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
@@ -136,18 +136,20 @@ class StorageManagerSuccess( ClientsTestCase ):
     self.assertEqual( res['Value']['absentLFNs'], {} )
     self.assertEqual( res['Value']['failedLFNs'], [] )
 
+
   @patch( "DIRAC.StorageManagementSystem.Client.StorageManagerClient.DataManager", return_value = dm_mock )
   @patch( "DIRAC.StorageManagementSystem.Client.StorageManagerClient.StorageElement", return_value = mockObjectSE6 )
   def test_getFilesToStage_tapeSEOnly_2( self, _patch, _patched ):
     """ Test where the StorageElement will return file is at offline at tape
     """
-    res = getFilesToStage( ['/a/lfn/2.txt'], checkOnlyTapeSEs = True )
+
+    with patch( "DIRAC.StorageManagementSystem.Client.StorageManagerClient.random.choice", new=MagicMock( return_value='SERandom' )):
+      res = getFilesToStage( ['/a/lfn/2.txt'], checkOnlyTapeSEs = True )
     self.assertTrue( res['OK'] )
     self.assertEqual( res['Value']['onlineLFNs'], [] )
-    self.assertEqual( res['Value']['offlineLFNs'], {'SE1': ['/a/lfn/2.txt']} )
+    self.assertEqual( res['Value']['offlineLFNs'], {'SERandom': ['/a/lfn/2.txt']} )
     self.assertEqual( res['Value']['absentLFNs'], {} )
     self.assertEqual( res['Value']['failedLFNs'], [] )
-
 
 
 if __name__ == '__main__':

--- a/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
+++ b/StorageManagementSystem/Client/test/Test_Client_StorageManagementSystem.py
@@ -37,6 +37,12 @@ mockObjectSE5.getFileMetadata.return_value = S_OK( {'Successful':{'/a/lfn/1.txt'
                                                     'Failed':{}} )
 mockObjectSE5.getStatus.return_value = S_OK( {'DiskSE': True, 'TapeSE':False} )
 
+mockObjectSE6 = MagicMock()
+mockObjectSE6.getFileMetadata.return_value = S_OK( {'Successful':{'/a/lfn/2.txt':{'Cached':0, 'Accessible':False}},
+                                                    'Failed':{}} )
+mockObjectSE6.getStatus.return_value = S_OK( {'DiskSE': False, 'TapeSE':True} )
+
+
 mockObjectDMSHelper = MagicMock()
 mockObjectDMSHelper.getLocalSiteForSE.return_value = S_OK( 'mySite' )
 mockObjectDMSHelper.getSitesForSE.return_value = S_OK( ['mySite'] )
@@ -116,6 +122,32 @@ class StorageManagerSuccess( ClientsTestCase ):
     self.assertEqual( res['Value']['offlineLFNs'], {} )
     self.assertEqual( res['Value']['absentLFNs'], {} )
     self.assertEqual( res['Value']['failedLFNs'], ['/a/lfn/1.txt'] )
+
+
+  @patch( "DIRAC.StorageManagementSystem.Client.StorageManagerClient.DataManager", return_value = dm_mock )
+  @patch( "DIRAC.StorageManagementSystem.Client.StorageManagerClient.StorageElement", return_value = mockObjectSE2 )
+  def test_getFilesToStage_tapeSEOnly_1( self, _patch, _patched ):
+    """ Test where the StorageElement will return file is available
+    """
+    res = getFilesToStage( ['/a/lfn/2.txt'], checkOnlyTapeSEs = True )
+    self.assertTrue( res['OK'] )
+    self.assertEqual( res['Value']['onlineLFNs'], ['/a/lfn/2.txt'] )
+    self.assertEqual( res['Value']['offlineLFNs'], {} )
+    self.assertEqual( res['Value']['absentLFNs'], {} )
+    self.assertEqual( res['Value']['failedLFNs'], [] )
+
+  @patch( "DIRAC.StorageManagementSystem.Client.StorageManagerClient.DataManager", return_value = dm_mock )
+  @patch( "DIRAC.StorageManagementSystem.Client.StorageManagerClient.StorageElement", return_value = mockObjectSE6 )
+  def test_getFilesToStage_tapeSEOnly_2( self, _patch, _patched ):
+    """ Test where the StorageElement will return file is at offline at tape
+    """
+    res = getFilesToStage( ['/a/lfn/2.txt'], checkOnlyTapeSEs = True )
+    self.assertTrue( res['OK'] )
+    self.assertEqual( res['Value']['onlineLFNs'], [] )
+    self.assertEqual( res['Value']['offlineLFNs'], {'SE1': ['/a/lfn/2.txt']} )
+    self.assertEqual( res['Value']['absentLFNs'], {} )
+    self.assertEqual( res['Value']['failedLFNs'], [] )
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
BEGINRELEASENOTES

*SMS
FIX: Fix logic for JobScheduling executor when CheckOnlyTapeSEs is its default `true` and the lfn is only on a tapeSE

ENDRELEASENOTES

In The StorageManagerClient getFilesToStage:
There is a bug in this code deciding if files are online or offline. Our JobScheduling doesn't work for files that have a single replica that is on a TapeSE. And we have `checkOnlyTapeSEs` at the default value (True).

https://github.com/DIRACGrid/DIRAC/blob/e42de42d462007eb21ff8bde2790e8790b52f078/StorageManagementSystem/Client/StorageManagerClient.py#L143-L152

At the moment our LFN is simply ignored, because `checkOnlyTapeSEs` is true, but `diskSE` is false, so the lfn is neither in `onlineLFNs` nor in `filesToCheck`

These are all the possible combinations, assuming `diskIsOK = checkOnlyTapeSEs
or lfn in onlineLFNs` and tapeSE = not diskSE

 checkOnlyTapeSEs | lfn in online | diskSE | diskIsOK | tapeSE |   | inOnline | inFilesToCheck | neither 
----------------- | ------------- | ------ | -------- | ------ | - | -------- | -------------- | ------- 
 True             | True          | True   | True     | False  |   | True     |                |         
 True             | False         | True   | True     | False  |   | True     |                |         
 True             | True          | False  | True     | True   |   | True     |                |         
 True             | False         | False  | True     | True   |   |          |                | True    
 False            | False         | True   | False    | False  |   |          | True           |         
 False            | False         | False  | False    | True   |   |          | True           |         
 False            | True          | True   | True     | False  |   | True     |                |         
 False            | True          | False  | True     | True   |   | True     |                |         

I think this covers all cases and the expected outcome, except for the fourth
case, where the LFN should be in filesToCheck, so this could be fixed by adding
the or statement in this PR
