### PR TITLE
[v6r19] InputData/JobScheduling Executor, jobDB, clean lfn strings once

### DIFF
--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -495,7 +495,12 @@ class JobDB( DB ):
     if not res['OK']:
       return res
 
-    return S_OK( [ i[0] for i in res['Value'] if i[0].strip() ] )
+    inputData = [ i[0] for i in res['Value'] if i[0].strip() ]
+    for index, lfn in enumerate( inputData ):
+      if lfn.lower().startswith( 'lfn:' ):
+        inputData[index] = lfn[4:]
+
+    return S_OK( inputData )
 
 #############################################################################
   def setInputData( self, jobID, inputData ):

--- a/WorkloadManagementSystem/DB/tests/Test_JobDB.py
+++ b/WorkloadManagementSystem/DB/tests/Test_JobDB.py
@@ -1,0 +1,36 @@
+""" tests for the JobDB module """
+
+#pylint: disable=protected-access, missing-docstring
+
+import unittest
+from mock import MagicMock, patch
+
+from DIRAC import S_OK
+
+MODULE_NAME = "DIRAC.WorkloadManagementSystem.DB.JobDB"
+
+class JobDBTest( unittest.TestCase ):
+
+  def setUp( self ):
+
+    def mockInit(self ):
+      self.log = MagicMock()
+      self.logger = MagicMock()
+      self._connected = True
+
+    from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
+    with patch( MODULE_NAME+".JobDB.__init__", new=mockInit):
+      self.jobDB = JobDB()
+    self.jobDB._query = MagicMock( name="Query" )
+    self.jobDB._escapeString = MagicMock( return_value=S_OK() )
+
+  def tearDown( self ):
+    pass
+
+
+  def test_getInputData( self ):
+    self.jobDB._query.return_value = S_OK( (( '/vo/user/lfn1',), ('LFN:/vo/user/lfn2',)) )
+    result = self.jobDB.getInputData( 1234 )
+    print result
+    self.assertTrue( result['OK'] )
+    self.assertEqual( result['Value'], [ '/vo/user/lfn1', '/vo/user/lfn2' ] )

--- a/WorkloadManagementSystem/Executor/InputData.py
+++ b/WorkloadManagementSystem/Executor/InputData.py
@@ -133,12 +133,7 @@ class InputData( OptimizerExecutor ):
   def _resolveInputData( self, jobState, inputData ):
     """ This method checks the file catalog for replica information.
     """
-    lfns = []
-    for lfn in inputData:
-      if lfn[:4].lower() == "lfn:":
-        lfns.append( lfn[4:] )
-      else:
-        lfns.append( lfn )
+    lfns = inputData
 
     result = jobState.getManifest()
     if not result['OK']:


### PR DESCRIPTION

The JobScheduling Executor doesn't do the same cleanup of "LFN:/vo/user/u/username/lfn.root" that the InputData Executor is doing

https://github.com/DIRACGrid/DIRAC/blob/9ed6247ad8d0a35e1b20b13d28b24fe98d0ce84f/WorkloadManagementSystem/Executor/JobScheduling.py#L153-L172

Which then causes problems in getFilesToStage.
Instead of adding the cleanup to the JobScheduling, I propose to do it once in the JobDB function where the inputData is coming from

BEGINRELEASENOTES

*WMS
FIX: JobDB.getInputData now returns list of cleaned LFNs strings, possible "LFN:" prefix is removed

ENDRELEASENOTES
