### PR TITLE
[v6r20] FTS3Manager fix type exception

### DIFF
--- a/DataManagementSystem/Client/FTSRequest.py
+++ b/DataManagementSystem/Client/FTSRequest.py
@@ -959,7 +959,8 @@ class FTSRequest( object ):
       sourceURL = self.__getFileParameter( lfn, 'Source' )
       if not sourceURL['OK']:
         self.__setFileParameter( lfn, 'Source', ftsFile.SourceSURL )
-      self.transferTime += int( ftsFile._duration )
+      if ftsFile._duration:
+        self.transferTime += int( ftsFile._duration )
     return S_OK()
 
   ####################################################################

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -77,7 +77,7 @@ class FTS3ManagerHandler( RequestHandler ):
     return S_OK( opJSON )
 
 
-  types_getActiveJobs = [ ( long, int ), [None ] + list( basestring ), basestring ]
+  types_getActiveJobs = [ ( long, int ), [None ] + [ basestring ], basestring ]
   @classmethod
   def export_getActiveJobs( cls, limit, lastMonitor, jobAssignmentTag ):
     """ Get all the FTSJobs that are not in a final state


### PR DESCRIPTION
We get this exception while trying to install FTS3Manager

```2017-10-11 12:56:07 UTC Framework/SystemAdministrator ERROR: Uncaught exception when serving RPC Function setupComponent
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/DISET/RequestHandler.py", line 256, in __RPCCallFunction
    uReturnValue = oMethod( *args )
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py", line 132, in export_setupComponent
    result = gComponentInstaller.setupComponent( componentType, system, component, getCSExtensions(), componentModule )
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Client/ComponentInstaller.py", line 1911, in setupComponent
    result = self.installComponent( componentType, system, component, extensions, componentModule, checkModule )
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Client/ComponentInstaller.py", line 1808, in installComponent
    result = self.checkComponentModule( componentType, system, cModule )
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Client/ComponentInstaller.py", line 1358, in checkComponentModule
    return loader.loadModule( "%s/%s" % ( system, module ) )
  File "/opt/dirac/pro/DIRAC/Core/Base/private/ModuleLoader.py", line 164, in loadModule
    result = self.__recurseImport( importString, hideExceptions = hideExceptions )
  File "/opt/dirac/pro/DIRAC/Core/Base/private/ModuleLoader.py", line 223, in __recurseImport
    return self.__recurseImport( modName[1:], impModule )
  File "/opt/dirac/pro/DIRAC/Core/Base/private/ModuleLoader.py", line 223, in __recurseImport
    return self.__recurseImport( modName[1:], impModule )
  File "/opt/dirac/pro/DIRAC/Core/Base/private/ModuleLoader.py", line 223, in __recurseImport
    return self.__recurseImport( modName[1:], impModule )
  File "/opt/dirac/pro/DIRAC/Core/Base/private/ModuleLoader.py", line 210, in __recurseImport
    impModule = imp.load_module( modName[0], *impData )
  File "/opt/dirac/pro/DIRAC/DataManagementSystem/Service/FTS3ManagerHandler.py", line 23, in <module>
    class FTS3ManagerHandler( RequestHandler ):
  File "/opt/dirac/pro/DIRAC/DataManagementSystem/Service/FTS3ManagerHandler.py", line 80, in FTS3ManagerHandler
    types_getActiveJobs = [ ( long, int ), [None ] + list( basestring ), basestring ]
TypeError: 'type' object is not iterable
```


