### PR TITLE
[v6r20] FTS3: add a default ServerPolicy type in the agent

### DIFF
--- a/DataManagementSystem/Agent/FTS3Agent.py
+++ b/DataManagementSystem/Agent/FTS3Agent.py
@@ -56,7 +56,7 @@ class FTS3Agent(AgentModule):
       return res
 
     srvList = res['Value']
-    serverPolicyType = opHelper().getValue('DataManagement/FTSPlacement/FTS3/ServerPolicy')
+    serverPolicyType = opHelper().getValue('DataManagement/FTSPlacement/FTS3/ServerPolicy', 'Random')
 
     self._serverPolicy = FTS3Utilities.FTS3ServerPolicy(srvList, serverPolicy = serverPolicyType)
 


### PR DESCRIPTION
When the policy was not defined in the CS, it crashed:
```
Traceback (most recent call last):
  File "/scratch/workspace/DIRAC_v6r20_INTEGRATION/ServerInstallDIR/DIRAC/Core/Base/AgentReactor.py", line 83, in loadAgentModules
    result = instanceObj.am_initialize()
  File "/scratch/workspace/DIRAC_v6r20_INTEGRATION/ServerInstallDIR/DIRAC/Core/Base/AgentModule.py", line 174, in am_initialize
    result = self.initialize( *initArgs )
  File "/scratch/workspace/DIRAC_v6r20_INTEGRATION/ServerInstallDIR/DIRAC/DataManagementSystem/Agent/FTS3Agent.py", line 61, in initialize
    self._serverPolicy = FTS3Utilities.FTS3ServerPolicy(srvList, serverPolicy = serverPolicyType)
  File "/scratch/workspace/DIRAC_v6r20_INTEGRATION/ServerInstallDIR/DIRAC/DataManagementSystem/private/FTS3Utilities.py", line 275, in __init__
    methName = "_%sServerPolicy"%serverPolicy.lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```

BEGINRELEASENOTES
*DMS
FIX: add a default ServerPolicy in the FTS3Agent
ENDRELEASENOTES
