### PR TITLE
[v6r20] Remove deprecated aliases

### DIFF
--- a/ConfigurationSystem/Client/Helpers/test/Test_Helpers.py
+++ b/ConfigurationSystem/Client/Helpers/test/Test_Helpers.py
@@ -35,23 +35,23 @@ class ResourcesSuccess( HelpersTestCase ):
     self.assertFalse( res['OK'] )
 
     res = getDIRACPlatform( 'OS1' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], ['plat3', 'plat1'] )
 
     res = getDIRACPlatform( 'OS2' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], ['plat1'] )
 
     res = getDIRACPlatform( 'OS3' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], ['plat1'] )
 
     res = getDIRACPlatform( 'OS4' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], ['plat3', 'plat2'] )
 
     res = getDIRACPlatform( 'OS5' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], ['plat2'] )
 
     res = getDIRACPlatform( 'plat1' )
@@ -74,7 +74,7 @@ class ResourcesSuccess( HelpersTestCase ):
     self.assertEqual( res['Value'], ['plat'] )
 
     res = getCompatiblePlatforms( 'plat1' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], ['plat1', 'xOS1', 'xOS2', 'xOS3'] )
 
 

--- a/Core/LCG/test/Test_LCG.py
+++ b/Core/LCG/test/Test_LCG.py
@@ -68,12 +68,12 @@ class GOCDBClientSuccess( ClientsTestCase ):
     self.assertEqual( res, {} )
 
     res = self.GOCCli._downTimeXMLParsing( XML_nodesite_ongoing, 'Site' )
-    self.assertEquals( len( res ), 1 )
+    self.assertEqual( len( res ), 1 )
     self.assertEqual( res.keys()[0], '28490G0 GRISU-ENEA-GRID' )
     self.assertEqual( res['28490G0 GRISU-ENEA-GRID']['SITENAME'], 'GRISU-ENEA-GRID' )
 
     res = self.GOCCli._downTimeXMLParsing( XML_nodesite_ongoing, 'Resource' )
-    self.assertEquals( len( res ), 1 )
+    self.assertEqual( len( res ), 1 )
     self.assertEqual( res.keys()[0], '28490G0 egse-cresco.portici.enea.it' )
     self.assertEqual( res['28490G0 egse-cresco.portici.enea.it']['HOSTNAME'], 'egse-cresco.portici.enea.it' )
 
@@ -100,8 +100,8 @@ class GOCDBClientSuccess( ClientsTestCase ):
     self.assertEqual( res['28490G1 GRISU-ENEA-GRID']['SITENAME'], 'GRISU-ENEA-GRID' )
     res = self.GOCCli._downTimeXMLParsing( XML_site_ongoing_and_other_site_starting_in_24_hours,
                                           'Site', ['GRISU-ENEA-GRID', 'CERN-PROD'] )
-    self.assert_( '28490G1 GRISU-ENEA-GRID' in res.keys() )
-    self.assert_( '28490G0 CERN-PROD' in res.keys() )
+    self.assertTrue( '28490G1 GRISU-ENEA-GRID' in res.keys() )
+    self.assertTrue( '28490G0 CERN-PROD' in res.keys() )
     self.assertEqual( res['28490G1 GRISU-ENEA-GRID']['SITENAME'], 'GRISU-ENEA-GRID' )
     self.assertEqual( res['28490G0 CERN-PROD']['SITENAME'], 'CERN-PROD' )
     res = self.GOCCli._downTimeXMLParsing( XML_site_ongoing_and_other_site_starting_in_24_hours, 'Site', 'CERN-PROD' )
@@ -125,8 +125,8 @@ class GOCDBClientSuccess( ClientsTestCase ):
     self.assertEqual( res['28490G1 egse-cresco.portici.enea.it']['HOSTNAME'], 'egse-cresco.portici.enea.it' )
     res = self.GOCCli._downTimeXMLParsing( XML_node_ongoing_and_other_node_starting_in_24_hours,
                                            'Resource', ['egse-cresco.portici.enea.it', 'ce112.cern.ch'] )
-    self.assert_( '28490G1 egse-cresco.portici.enea.it' in res.keys() )
-    self.assert_( '28490G0 ce112.cern.ch' in res.keys() )
+    self.assertTrue( '28490G1 egse-cresco.portici.enea.it' in res.keys() )
+    self.assertTrue( '28490G0 ce112.cern.ch' in res.keys() )
     self.assertEqual( res['28490G1 egse-cresco.portici.enea.it']['HOSTNAME'], 'egse-cresco.portici.enea.it' )
     self.assertEqual( res['28490G0 ce112.cern.ch']['HOSTNAME'], 'ce112.cern.ch' )
     res = self.GOCCli._downTimeXMLParsing( XML_node_ongoing_and_other_node_starting_in_24_hours, 'Resource', 'ce112.cern.ch' )
@@ -136,7 +136,7 @@ class GOCDBClientSuccess( ClientsTestCase ):
     self.assertEqual( res, {} )
 
     res = self.GOCCli._downTimeXMLParsing( XML_node_ongoing_and_other_node_starting_in_24_hours, 'Resource', ['egse-cresco.portici.enea.it', 'ce112.cern.ch'], now )
-    self.assert_( '28490G1 egse-cresco.portici.enea.it' in res.keys() )
+    self.assertTrue( '28490G1 egse-cresco.portici.enea.it' in res.keys() )
     self.assertEqual( res['28490G1 egse-cresco.portici.enea.it']['HOSTNAME'], 'egse-cresco.portici.enea.it' )
     res = self.GOCCli._downTimeXMLParsing( XML_node_ongoing_and_other_node_starting_in_24_hours,
                                            'Resource', ['egse-cresco.portici.enea.it', 'ce112.cern.ch'], inAWeek )

--- a/Core/Utilities/TimeLeft/test/Test_TimeLeft.py
+++ b/Core/Utilities/TimeLeft/test/Test_TimeLeft.py
@@ -193,7 +193,7 @@ class TimeLeftSuccess( TimeLeftTestCase ):
       tl.batchPlugin.wallClockLimit = 1000
 
       res = tl.getTimeLeft()
-      self.assert_( res['OK'] )
+      self.assertTrue(res['OK'])
       self.assertEqual( res['Value'], 9400.0 )
 
 

--- a/Core/Utilities/test/Test_File.py
+++ b/Core/Utilities/test/Test_File.py
@@ -121,7 +121,7 @@ class FileTestCase(unittest.TestCase):
 
     md5sum = getMD5ForFiles( self.filesList )
     reMD5 = re.compile( "^[0-9a-fA-F]+$" )
-    self.assert_( reMD5.match( md5sum) != None )
+    self.assertTrue( reMD5.match( md5sum) != None )
     # OK for python 2.7
     # self.assertRegexpMatches( md5sum, reMD5, "regexp doesn't match" )
 

--- a/Core/Utilities/test/Test_StateMachine.py
+++ b/Core/Utilities/test/Test_StateMachine.py
@@ -75,7 +75,7 @@ class StateMachineTests(unittest.TestCase):
     self.assertRaises( TypeError, StateMachine, False )
 
     sm = StateMachine( self.waiting, {} )
-    self.assert_( sm )
+    self.assertTrue( sm )
 
 
 

--- a/DataManagementSystem/Agent/RequestOperations/test/Test_RequestOperations.py
+++ b/DataManagementSystem/Agent/RequestOperations/test/Test_RequestOperations.py
@@ -184,7 +184,7 @@ class ReplicateAndRegisterSuccess( ReqOpsTestCase ):
                   '/lhcb/2.dst': [file2, ['SE4'], ['SE5', 'SE6']]}
 
     res = self.rr._addMetadataToFiles( toSchedule )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     for lfn in toSchedule:
       self.assertEqual( res['Value'][lfn].LFN, lfn )

--- a/DataManagementSystem/private/test/Test_FTS3Utilities.py
+++ b/DataManagementSystem/private/test/Test_FTS3Utilities.py
@@ -47,12 +47,12 @@ class TestFTS3Serialization( unittest.TestCase ):
     obj2 = json.loads( obj.toJSON(), cls = FTS3JSONDecoder )
 
 
-    self.assert_( obj.string == obj2.string )
-    self.assert_( obj.date == obj2.date )
-    self.assert_( obj.dic == obj2.dic )
+    self.assertTrue( obj.string == obj2.string )
+    self.assertTrue( obj.date == obj2.date )
+    self.assertTrue( obj.dic == obj2.dic )
 
 
-    self.assert_( not hasattr( obj2, 'notSerialized' ) )
+    self.assertTrue( not hasattr( obj2, 'notSerialized' ) )
 
 
   def test_02_subobjects( self ):
@@ -73,7 +73,7 @@ class TestFTS3Serialization( unittest.TestCase ):
 
     obj2 = json.loads( obj.toJSON(), cls = FTS3JSONDecoder )
 
-    self.assert_( obj.sub.string == obj2.sub.string )
+    self.assertTrue( obj.sub.string == obj2.sub.string )
 
 
 
@@ -123,20 +123,20 @@ class TestFileGrouping( unittest.TestCase ):
   def test_01_groupFilesByTarget( self ):
 
     # empty input
-    self.assert_( groupFilesByTarget( [] )['Value'] == {} )
+    self.assertTrue( groupFilesByTarget( [] )['Value'] == {} )
 
 
 
     res = groupFilesByTarget( self.allFiles )
     
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     groups = res['Value']
 
-    self.assert_( self.f1 in groups['target1'] )
-    self.assert_( self.f2 in groups['target2'] )
-    self.assert_( self.f3 in groups['target1'] )
-    self.assert_( self.f4 in groups['target3'] )
+    self.assertTrue( self.f1 in groups['target1'] )
+    self.assertTrue( self.f2 in groups['target2'] )
+    self.assertTrue( self.f3 in groups['target1'] )
+    self.assertTrue( self.f4 in groups['target3'] )
 
 
   @mock.patch( 'DIRAC.DataManagementSystem.private.FTS3Utilities._checkSourceReplicas', side_effect = mock__checkSourceReplicas )
@@ -145,14 +145,14 @@ class TestFileGrouping( unittest.TestCase ):
     # We assume here that they all go to the same target
     res = generatePossibleTransfersBySources( self.allFiles )
 
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     groups = res['Value']
-    self.assert_( self.f1 in groups['Src1'] )
-    self.assert_( self.f1 in groups['Src2'] )
-    self.assert_( self.f2 in groups['Src2'] )
-    self.assert_( self.f2 in groups['Src3'] )
-    self.assert_( self.f3 in groups['Src4'] )
-    self.assert_( self.f2 in groups['Src3'] )
+    self.assertTrue( self.f1 in groups['Src1'] )
+    self.assertTrue( self.f1 in groups['Src2'] )
+    self.assertTrue( self.f2 in groups['Src2'] )
+    self.assertTrue( self.f2 in groups['Src3'] )
+    self.assertTrue( self.f3 in groups['Src4'] )
+    self.assertTrue( self.f2 in groups['Src3'] )
 
   @mock.patch( 'DIRAC.DataManagementSystem.private.FTS3Utilities._checkSourceReplicas', side_effect = mock__checkSourceReplicas )
   def test_03_selectUniqueSourceforTransfers( self, _mk_checkSourceReplicas ):
@@ -162,14 +162,14 @@ class TestFileGrouping( unittest.TestCase ):
 
     res = selectUniqueSourceforTransfers( groupBySource )
 
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     uniqueSources = res['Value']
     # Src1 and Src2 should not be here because f1 and f2 should be taken from Src2
-    self.assert_( sorted( uniqueSources.keys() ) == sorted( ['Src2', 'Src4'] ) )
-    self.assert_( self.f1 in uniqueSources['Src2'] )
-    self.assert_( self.f2 in uniqueSources['Src2'] )
-    self.assert_( self.f3 in uniqueSources['Src4'] )
+    self.assertTrue( sorted( uniqueSources.keys() ) == sorted( ['Src2', 'Src4'] ) )
+    self.assertTrue( self.f1 in uniqueSources['Src2'] )
+    self.assertTrue( self.f2 in uniqueSources['Src2'] )
+    self.assertTrue( self.f3 in uniqueSources['Src4'] )
 
 
 

--- a/RequestManagementSystem/DB/test/TestRequestDB.py
+++ b/RequestManagementSystem/DB/test/TestRequestDB.py
@@ -27,9 +27,9 @@
 #     requestType = 'transfer'
 #     requestStatus = 'waiting'
 #     result = self.requestDB.setRequest(requestType,self.requestName,requestStatus,requestString)
-#     self.assert_(result['OK'])
+#     self.assertTrue(result['OK'])
 #     result = self.requestDB.getRequest('transfer')
-#     self.assert_(result['OK'])
+#     self.assertTrue(result['OK'])
 #     request = DataManagementRequest(request=result['Value']['RequestString'])
 #     res = request.getNumSubRequests(requestType)
 #     for ind in range (res['Value']):
@@ -41,13 +41,13 @@
 #     res = request.toXML()
 #     requestString = res['Value']
 #     result = self.requestDB.updateRequest(self.requestName, requestString)
-#     self.assert_(result['OK'])
+#     self.assertTrue(result['OK'])
 #     requestStatus = 'done'
 #     result = self.requestDB.setRequestStatus(requestType,self.requestName,requestStatus)
 #     #there is some transient error here where it fails to retrieve the requestID
-#     self.assert_( result['OK'])
+#     self.assertTrue( result['OK'])
 #     result = self.requestDB.deleteRequest(self.requestName)
-#     self.assert_(result['OK'])
+#     self.assertTrue(result['OK'])
 #
 # if __name__ == '__main__':
 #

--- a/ResourceStatusSystem/Command/test/Test_RSS_Command_GOCDBStatusCommand.py
+++ b/ResourceStatusSystem/Command/test/Test_RSS_Command_GOCDBStatusCommand.py
@@ -106,10 +106,10 @@ class GOCDBStatusCommand_Success( GOCDBStatusCommand_TestCase ):
     command = DowntimeCommand( self.args, {'ResourceManagementClient':self.mock_GOCDBClient} )
     self.getStorageElementOptionsMock.return_value = {'OK':True, 'Value': {'TapeSE':True, 'DiskSE': False}}
     res = command.doCache()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.getStorageElementOptionsMock.return_value = {'OK':True, 'Value': {'TapeSE':False, 'DiskSE': True}}
     res = command.doCache()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
 
     #CASE01: get ongoing DT from 2 DTs where one ongoing the other in the future
@@ -142,14 +142,14 @@ class GOCDBStatusCommand_Success( GOCDBStatusCommand_TestCase ):
     self.mock_GOCDBClient.selectDowntimeCache.return_value = resFromDB
     command = DowntimeCommand( self.args, {'ResourceManagementClient':self.mock_GOCDBClient} )
     res = command.doCache()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['DowntimeID'], '1 aRealName' )
 
     self.mock_GOCDBClient.selectDowntimeCache.return_value = resFromDB
     self.args.update( {'hours':2} )
     command = DowntimeCommand( self.args, {'ResourceManagementClient':self.mock_GOCDBClient} )
     res = command.doCache()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['DowntimeID'], '1 aRealName' )
 
     #CASE02: get future DT from 2 DTs where one ongoing the other in the future
@@ -182,7 +182,7 @@ class GOCDBStatusCommand_Success( GOCDBStatusCommand_TestCase ):
     self.args.update( {'hours':3} )
     command = DowntimeCommand( self.args, {'ResourceManagementClient':self.mock_GOCDBClient} )
     res = command.doCache()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['DowntimeID'], '2 aRealName' )
 
     #CASE03: get DT from 2 overlapping OUTAGE DTs, one ongoing the other starting in the future
@@ -215,7 +215,7 @@ class GOCDBStatusCommand_Success( GOCDBStatusCommand_TestCase ):
     self.args.update( {'hours':0} )
     command = DowntimeCommand( self.args, {'ResourceManagementClient':self.mock_GOCDBClient} )
     res = command.doCache()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['DowntimeID'], '1 aRealName' )
 
 
@@ -251,7 +251,7 @@ class GOCDBStatusCommand_Success( GOCDBStatusCommand_TestCase ):
     self.args.update( {'hours':0} )
     command = DowntimeCommand( self.args, {'ResourceManagementClient':self.mock_GOCDBClient} )
     res = command.doCache()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['DowntimeID'], '1 aRealName' )
 
     #CASE05: get DT from 2 overlapping future DTs, the first WARNING the other OUTAGE
@@ -286,7 +286,7 @@ class GOCDBStatusCommand_Success( GOCDBStatusCommand_TestCase ):
     self.args.update( {'hours':10} )
     command = DowntimeCommand( self.args, {'ResourceManagementClient':self.mock_GOCDBClient} )
     res = command.doCache()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['DowntimeID'], '2 aRealName' )
 
 

--- a/ResourceStatusSystem/Policy/test/Test_RSS_Policy_DTPolicy.py
+++ b/ResourceStatusSystem/Policy/test/Test_RSS_Policy_DTPolicy.py
@@ -50,7 +50,7 @@ class DTPolicy_Success( DTPolicy_TestCase ):
     self.DTCommand.doCommand.return_value = { 'OK' : False, 'Message' : 'Grumpy command' }
     policy.setCommand( self.DTCommand )
     res = policy.evaluate()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( 'Grumpy command', res['Value']['Reason'] )
     self.assertEqual( 'Error', res['Value']['Status'] )
 
@@ -62,11 +62,11 @@ class DTPolicy_Success( DTPolicy_TestCase ):
     self.assertEqual( 'Error', res['Value']['Status'] )
 
     res = policy.evaluate()
-    self.assert_( res[ 'OK' ] )
+    self.assertTrue( res[ 'OK' ] )
     # command result empty
     self.DTCommand.doCommand.return_value = {'OK': True, 'Value': None}
     res = policy.evaluate()
-    self.assert_( res[ 'OK' ] )
+    self.assertTrue( res[ 'OK' ] )
     self.assertEqual( 'Active', res[ 'Value' ][ 'Status' ] )
     self.assertEqual( 'No DownTime announced', res[ 'Value' ][ 'Reason' ] )
 

--- a/ResourceStatusSystem/PolicySystem/test/Test_PolicySystem.py
+++ b/ResourceStatusSystem/PolicySystem/test/Test_PolicySystem.py
@@ -33,11 +33,11 @@ class PEPSuccess(PolicySystemTestCase):
     pep = PEP( {'ResourceStatusClient':self.RSMock, 'ResourceManagementClient': self.RMMock, 'SiteStatus': self.RMMock} )
     pep.pdp = self.mockPDP
     res = pep.enforce( None )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     decisionParams = {}
     res = pep.enforce( decisionParams )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     decisionParams = {'element':'Site', 'name': 'Site1'}
     decParamsPDP = dict(decisionParams)
@@ -56,11 +56,11 @@ class PEPSuccess(PolicySystemTestCase):
                                                                                 'EndDate': '2010-02-16 15:00:00'}],
                                                        'decisionParams':decParamsPDP}}
     res = pep.enforce( decisionParams )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     decisionParams = {'element':'Resource', 'name': 'StorageElement', 'statusType': 'ReadAccess'}
     res = pep.enforce( decisionParams )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
 # class PDPSuccess(PolicySystemTestCase):
 #
@@ -77,15 +77,15 @@ class PEPSuccess(PolicySystemTestCase):
 #           pdp = PDP(self.VO, granularity, 'XX', oldStatus, None, 'XX')
 #           res = pdp.takeDecision(policyIn = self.mock_p)
 #           res = res['PolicyCombinedResult']
-#           self.assert_(res['Action'])
+#           self.assertTrue(res['Action'])
 #
 #           res = pdp.takeDecision(policyIn = self.mock_p, argsIn = ())
 #           res = res['PolicyCombinedResult']
-#           self.assert_(res['Action'])
+#           self.assertTrue(res['Action'])
 #
 #           res = pdp.takeDecision(policyIn = self.mock_p, knownInfo={})
 #           res = res['PolicyCombinedResult']
-#           self.assert_(res['Action'])
+#           self.assertTrue(res['Action'])
 #
 #   def test__policyCombination(self):
 #
@@ -153,8 +153,8 @@ class PEPSuccess(PolicySystemTestCase):
 #           if status == oldStatus:
 #             continue
 #           pdp = PDP(self.VO, granularity, 'XX', status, oldStatus, 'XX')
-#           self.failUnlessRaises(Exception, pdp.takeDecision, self.mock_pdp, self.mock_rsDB)
-#           self.failUnlessRaises(Exception, pdp.takeDecision, self.mock_pdp, self.mock_rsDB, knownInfo={'DT':'AT_RISK'})
+#           self.assertRaises(Exception, pdp.takeDecision, self.mock_pdp, self.mock_rsDB)
+#           self.assertRaises(Exception, pdp.takeDecision, self.mock_pdp, self.mock_rsDB, knownInfo={'DT':'AT_RISK'})
 #
 # #############################################################################
 #
@@ -264,7 +264,7 @@ class PEPSuccess(PolicySystemTestCase):
 #
 # #   def test_policyFail(self):
 # #     for granularity in ValidRes:
-# #       self.failUnlessRaises(Exception, self.pi.evaluatePolicy)
+# #       self.assertRaises(Exception, self.pi.evaluatePolicy)
 
 #############################################################################
 

--- a/Resources/Catalog/ConditionPlugins/test/Test_FilenamePlugin.py
+++ b/Resources/Catalog/ConditionPlugins/test/Test_FilenamePlugin.py
@@ -16,16 +16,16 @@ class TestfilenamePlugin( unittest.TestCase ):
 
     fnp = FilenamePlugin("endswith('n')")
 
-    self.assert_( not fnp.eval( lfn = '/lhcb/lfn1' ) )
-    self.assert_( fnp.eval( lfn = '/lhcb/lfn' ) )
+    self.assertTrue( not fnp.eval( lfn = '/lhcb/lfn1' ) )
+    self.assertTrue( fnp.eval( lfn = '/lhcb/lfn' ) )
 
   def test_02_find( self ):
     """ Testing special case of find"""
 
     fnp = FilenamePlugin( "find('lfn')" )
 
-    self.assert_( fnp.eval( lfn = '/lhcb/lfn1' ) )
-    self.assert_( not fnp.eval( lfn = '/lhcb/l0f0n' ) )
+    self.assertTrue( fnp.eval( lfn = '/lhcb/lfn1' ) )
+    self.assertTrue( not fnp.eval( lfn = '/lhcb/l0f0n' ) )
 
 
   def test_03_isalnum( self ):
@@ -33,16 +33,16 @@ class TestfilenamePlugin( unittest.TestCase ):
 
     fnp = FilenamePlugin( "isalnum()" )
 
-    self.assert_( fnp.eval( lfn = 'lhcblfn1' ) )
-    self.assert_( not fnp.eval( lfn = '/lhcb/lf_n' ) )
+    self.assertTrue( fnp.eval( lfn = 'lhcblfn1' ) )
+    self.assertTrue( not fnp.eval( lfn = '/lhcb/lf_n' ) )
 
   def test_04_nonExisting( self ):
     """ Testing non existing string method"""
 
     fnp = FilenamePlugin( "nonexisting()" )
 
-    self.assert_( not fnp.eval( lfn = 'lhcblfn1' ) )
-    self.assert_( not fnp.eval( lfn = '/lhcb/lf_n' ) )
+    self.assertTrue( not fnp.eval( lfn = 'lhcblfn1' ) )
+    self.assertTrue( not fnp.eval( lfn = '/lhcb/lf_n' ) )
 
 
 

--- a/Resources/Catalog/ConditionPlugins/test/Test_ProxyPlugin.py
+++ b/Resources/Catalog/ConditionPlugins/test/Test_ProxyPlugin.py
@@ -39,17 +39,17 @@ class TestProxyPlugin( unittest.TestCase ):
     """ Testing username attribute"""
 
     # the username is chaen
-    self.assert_( not ProxyPlugin( 'username.in(toto)' ).eval() )
-    self.assert_( ProxyPlugin( 'username.not_in(toto)' ).eval() )
-    self.assert_( ProxyPlugin( 'username.in(toto, chaen)' ).eval() )
-    self.assert_( not ProxyPlugin( 'username.not_in(toto, chaen)' ).eval() )
+    self.assertTrue( not ProxyPlugin( 'username.in(toto)' ).eval() )
+    self.assertTrue( ProxyPlugin( 'username.not_in(toto)' ).eval() )
+    self.assertTrue( ProxyPlugin( 'username.in(toto, chaen)' ).eval() )
+    self.assertTrue( not ProxyPlugin( 'username.not_in(toto, chaen)' ).eval() )
 
     # Testing some more formating with spaces and quotes
 
-    self.assert_( not ProxyPlugin( 'username.in( toto )' ).eval() )
-    self.assert_( ProxyPlugin( 'username.not_in("toto")' ).eval() )
-    self.assert_( ProxyPlugin( 'username.in(toto,"chaen")' ).eval() )
-    self.assert_( not ProxyPlugin( "username.not_in('toto' ,chaen)" ).eval() )
+    self.assertTrue( not ProxyPlugin( 'username.in( toto )' ).eval() )
+    self.assertTrue( ProxyPlugin( 'username.not_in("toto")' ).eval() )
+    self.assertTrue( ProxyPlugin( 'username.in(toto,"chaen")' ).eval() )
+    self.assertTrue( not ProxyPlugin( "username.not_in('toto' ,chaen)" ).eval() )
 
 
   @mock.patch( 'DIRAC.Resources.Catalog.ConditionPlugins.ProxyPlugin.getProxyInfo', side_effect = mock_getProxyInfo )
@@ -57,17 +57,17 @@ class TestProxyPlugin( unittest.TestCase ):
     """ Testing group attribute"""
 
     # the group is lhcb_user
-    self.assert_( not ProxyPlugin( 'group.in(toto)' ).eval() )
-    self.assert_( ProxyPlugin( 'group.not_in(toto)' ).eval() )
-    self.assert_( ProxyPlugin( 'group.in(toto, lhcb_user)' ).eval() )
-    self.assert_( not ProxyPlugin( 'group.not_in(toto, lhcb_user)' ).eval() )
+    self.assertTrue( not ProxyPlugin( 'group.in(toto)' ).eval() )
+    self.assertTrue( ProxyPlugin( 'group.not_in(toto)' ).eval() )
+    self.assertTrue( ProxyPlugin( 'group.in(toto, lhcb_user)' ).eval() )
+    self.assertTrue( not ProxyPlugin( 'group.not_in(toto, lhcb_user)' ).eval() )
 
     # Testing some more formating with spaces and quotes
 
-    self.assert_( not ProxyPlugin( 'group.in( toto )' ).eval() )
-    self.assert_( ProxyPlugin( 'group.not_in("toto")' ).eval() )
-    self.assert_( ProxyPlugin( 'group.in(toto,"lhcb_user")' ).eval() )
-    self.assert_( not ProxyPlugin( "group.not_in('toto' ,lhcb_user)" ).eval() )
+    self.assertTrue( not ProxyPlugin( 'group.in( toto )' ).eval() )
+    self.assertTrue( ProxyPlugin( 'group.not_in("toto")' ).eval() )
+    self.assertTrue( ProxyPlugin( 'group.in(toto,"lhcb_user")' ).eval() )
+    self.assertTrue( not ProxyPlugin( "group.not_in('toto' ,lhcb_user)" ).eval() )
 
 
   @mock.patch( 'DIRAC.Resources.Catalog.ConditionPlugins.ProxyPlugin.getProxyInfo', side_effect = mock_getProxyInfo )
@@ -75,20 +75,20 @@ class TestProxyPlugin( unittest.TestCase ):
     """ Testing property attribute"""
 
     # the properties are 'NormalUser', 'SuperProperty'
-    self.assert_( not ProxyPlugin( 'property.has(toto)' ).eval() )
-    self.assert_( ProxyPlugin( 'property.has_not(toto)' ).eval() )
-    self.assert_( ProxyPlugin( 'property.has(SuperProperty)' ).eval() )
-    self.assert_( not ProxyPlugin( 'property.has_not(SuperProperty)' ).eval() )
+    self.assertTrue( not ProxyPlugin( 'property.has(toto)' ).eval() )
+    self.assertTrue( ProxyPlugin( 'property.has_not(toto)' ).eval() )
+    self.assertTrue( ProxyPlugin( 'property.has(SuperProperty)' ).eval() )
+    self.assertTrue( not ProxyPlugin( 'property.has_not(SuperProperty)' ).eval() )
 
   @mock.patch( 'DIRAC.Resources.Catalog.ConditionPlugins.ProxyPlugin.getProxyInfo', side_effect = mock_getProxyInfo )
   def test_04_voms( self, _mockProxyInfo ):
     """ Testing voms attribute"""
 
     # the voms role is /lhcb/Role=user
-    self.assert_( not ProxyPlugin( 'voms.has(toto)' ).eval() )
-    self.assert_( ProxyPlugin( 'voms.has_not(toto)' ).eval() )
-    self.assert_( ProxyPlugin( 'voms.has(/lhcb/Role->user)' ).eval() )
-    self.assert_( not ProxyPlugin( 'voms.has_not(/lhcb/Role->user)' ).eval() )
+    self.assertTrue( not ProxyPlugin( 'voms.has(toto)' ).eval() )
+    self.assertTrue( ProxyPlugin( 'voms.has_not(toto)' ).eval() )
+    self.assertTrue( ProxyPlugin( 'voms.has(/lhcb/Role->user)' ).eval() )
+    self.assertTrue( not ProxyPlugin( 'voms.has_not(/lhcb/Role->user)' ).eval() )
 
 
   @mock.patch( 'DIRAC.Resources.Catalog.ConditionPlugins.ProxyPlugin.getProxyInfo', side_effect = mock_getProxyInfo )

--- a/Resources/Catalog/test/Test_FCConditionParser.py
+++ b/Resources/Catalog/test/Test_FCConditionParser.py
@@ -21,17 +21,17 @@ class TestLogicEvaluation( unittest.TestCase ):
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "Dummy=False" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
   def test_02_notLogic( self ):
     """Testing the ! operator"""
@@ -39,17 +39,17 @@ class TestLogicEvaluation( unittest.TestCase ):
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "!Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "!Dummy=False" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
   def test_03_andLogic( self ):
     """Testing the & operator"""
@@ -57,25 +57,25 @@ class TestLogicEvaluation( unittest.TestCase ):
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "Dummy=True & Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "Dummy=False & Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "Dummy=True & Dummy=False" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
   def test_04_orLogic( self ):
     """Testing the | operator"""
@@ -83,24 +83,24 @@ class TestLogicEvaluation( unittest.TestCase ):
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "Dummy=True | Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "Dummy=False | Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "Dummy=False | Dummy=False" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
 
   def test_05_priority( self ):
@@ -109,105 +109,105 @@ class TestLogicEvaluation( unittest.TestCase ):
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "!Dummy=False & Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "!Dummy=True | Dummy=False" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns ,
                      condition = "Dummy=True & Dummy=False | Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns ,
                      condition = "Dummy=True | Dummy=False & Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns ,
                      condition = "!Dummy=True | Dummy=False & Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns ,
                      condition = "!Dummy=True | !Dummy=False & Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns ,
                      condition = "!Dummy=True | !Dummy=False & !Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "[!Dummy=False] & Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "![Dummy=False] & Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "![Dummy=False & Dummy=True]" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns ,
                      condition = "[Dummy=True | Dummy=False] & Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns ,
                      condition = "Dummy=True | [Dummy=False & Dummy=True]" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     res = self.fcp( 'catalogName', 'operationName', self.lfns ,
                      condition = "Dummy=False | [Dummy=False & Dummy=True]" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
   def test_06_errors( self ):
     """Testing different error situation"""
@@ -215,26 +215,26 @@ class TestLogicEvaluation( unittest.TestCase ):
     # Error in the plugin
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "Dummy=CantParse" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
     # Non existing plugin
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "NonExistingPlugin=something" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
     # Error in the grammar
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "[Dummy=True" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to False
     for lfn in self.lfns:
-      self.assert_( not res['Value']['Successful'][lfn], res )
+      self.assertTrue( not res['Value']['Successful'][lfn], res )
 
 
 
@@ -244,19 +244,19 @@ class TestLogicEvaluation( unittest.TestCase ):
     # Non condition given
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = "" )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
     # Can't retrive conditions
     # It so happen that it will all be True
     res = self.fcp( 'catalogName', 'operationName', self.lfns , condition = None )
 
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     # We expect all the lfn to be to True
     for lfn in self.lfns:
-      self.assert_( res['Value']['Successful'][lfn], res )
+      self.assertTrue( res['Value']['Successful'][lfn], res )
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestLogicEvaluation )

--- a/Resources/Catalog/test/Test_FileCatalog.py
+++ b/Resources/Catalog/test/Test_FileCatalog.py
@@ -176,11 +176,11 @@ class TestInitialization( unittest.TestCase ):
 
     # We should not be able to have 2 masters
     twoMastersFc = FileCatalog( catalogs = ['c1_True_True_True_5_2_2_0', 'c2_True_True_True_5_2_2_0'] )
-    self.assert_( not twoMastersFc.isOK() )
+    self.assertTrue( not twoMastersFc.isOK() )
 
     # One master should be ok
     oneMasterFc = FileCatalog( catalogs = ['c1_True_True_True_2_0_2_2', 'c2_False_True_True_3_1_4_2'] )
-    self.assert_( oneMasterFc.isOK() )
+    self.assertTrue( oneMasterFc.isOK() )
 
     # With a master, the write method should be the method of the master
     self.assertEqual( sorted( oneMasterFc.write_methods ), writeList( 2 ) )
@@ -194,7 +194,7 @@ class TestInitialization( unittest.TestCase ):
 
     # No master should be ok
     noMasterFc = FileCatalog( catalogs = ['c1_False_True_True_2_0_2_0', 'c2_False_True_True_3_0_4_0'] )
-    self.assert_( oneMasterFc.isOK() )
+    self.assertTrue( oneMasterFc.isOK() )
     # With no master, the write method should be from all catalogs
     self.assertEqual( sorted( noMasterFc.write_methods ), writeList( 4 ) )
     # The read methods and no_lfn should be from all catalogs
@@ -222,39 +222,39 @@ class TestWrite(unittest.TestCase):
     # Test a write method which works for everybody
     lfn = '/lhcb/toto'
     res = fc.write1( lfn )
-    self.assert_( res['OK'] )
-    self.assert_( lfn in res['Value']['Successful'] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( lfn in res['Value']['Successful'] )
     self.assertEqual( sorted( ['c1', 'c2'] ), sorted( res['Value']['Successful'][lfn].keys() ) )
-    self.assert_( not res['Value']['Failed'] )
+    self.assertTrue( not res['Value']['Failed'] )
 
 
     # Test a write method that only the master has
     lfn = '/lhcb/toto'
     res = fc.write2( lfn )
-    self.assert_( res['OK'] )
-    self.assert_( lfn in res['Value']['Successful'] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( lfn in res['Value']['Successful'] )
     self.assertEqual( ['c1'], res['Value']['Successful'][lfn].keys() )
-    self.assert_( not res['Value']['Failed'] )
+    self.assertTrue( not res['Value']['Failed'] )
 
     # Test a write method that makes an error for master
     # We should get an error
     lfn = '/lhcb/c1/Error'
     res = fc.write1( lfn )
-    self.assert_( not res['OK'] )
+    self.assertTrue( not res['OK'] )
 
     # Test a write method that fails for master
     # The lfn should be in failed and only attempted for the master
     lfn = '/lhcb/c1/Failed'
     res = fc.write1( lfn )
-    self.assert_( res['OK'] )
-    self.assert_( not res['Value']['Successful'] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( not res['Value']['Successful'] )
     self.assertEqual( ['c1'], res['Value']['Failed'][lfn].keys() )
 
     # Test a write method that makes an error for non master
     # The lfn should be in failed for non master and successful for the master
     lfn = '/lhcb/c2/Error'
     res = fc.write1( lfn )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( ['c1'], res['Value']['Successful'][lfn].keys() )
     self.assertEqual( ['c2'], res['Value']['Failed'][lfn].keys() )
 
@@ -263,7 +263,7 @@ class TestWrite(unittest.TestCase):
     # The lfn should be in failed for non master and successful for the master
     lfn = '/lhcb/c2/Failed'
     res = fc.write1( lfn )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( ['c1'], res['Value']['Successful'][lfn].keys() )
     self.assertEqual( ['c2'], res['Value']['Failed'][lfn].keys() )
 
@@ -288,22 +288,22 @@ class TestWrite(unittest.TestCase):
     lfn2 = '/lhcb/c1_pass/c2_pass/lfn2'
     res = fc.write1( [lfn1, lfn2],
                      fcConditions = fcConditions )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( sorted( res['Value']['Successful'] ), sorted( [lfn1, lfn2] ) )
     self.assertEqual( sorted( res['Value']['Successful'][lfn1] ), sorted( ['c1', 'c2', 'c3'] ) )
     self.assertEqual( sorted( res['Value']['Successful'][lfn2] ), sorted( ['c1', 'c2', 'c3'] ) )
-    self.assert_( not res['Value']['Failed'] )
+    self.assertTrue( not res['Value']['Failed'] )
 
     # Everything pass for the master, only lfn2 for c2
     lfn1 = '/lhcb/c1_pass/lfn1'
     lfn2 = '/lhcb/c1_pass/c2_pass/lfn2'
     res = fc.write1( [lfn1, lfn2],
                      fcConditions = fcConditions )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( sorted( res['Value']['Successful'] ), sorted( [lfn1, lfn2] ) )
     self.assertEqual( sorted( res['Value']['Successful'][lfn1] ) , ['c1', 'c3'] )
     self.assertEqual( sorted( res['Value']['Successful'][lfn2] ), sorted( ['c1', 'c2','c3'] ) )
-    self.assert_( not res['Value']['Failed'] )
+    self.assertTrue( not res['Value']['Failed'] )
 
 
     # One is not valid for the master, so we do nothing
@@ -311,7 +311,7 @@ class TestWrite(unittest.TestCase):
     lfn2 = '/lhcb/c1_pass/c2_pass/lfn2'
     res = fc.write1( [lfn1, lfn2],
                      fcConditions = fcConditions )
-    self.assert_( not res['OK'] )
+    self.assertTrue( not res['OK'] )
 
 
   @mock.patch.object( DIRAC.Resources.Catalog.FileCatalog.FileCatalog, '_getSelectedCatalogs',
@@ -326,18 +326,18 @@ class TestWrite(unittest.TestCase):
 
     # all good
     res = fc.write2( "/lhcb/toto" )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'yeah' )
 
     # Fail in the master
     res = fc.write2( "/lhcb/c1" )
-    self.assert_( not res['OK'] )
-    self.assert_( not 'Value' in res )
+    self.assertTrue( not res['OK'] )
+    self.assertTrue( not 'Value' in res )
 
     # Fail in the non master
     res = fc.write2( "/lhcb/c2" )
-    self.assert_( res['OK'] )
-    self.assert_( 'Value' in res )
+    self.assertTrue(res['OK'])
+    self.assertTrue( 'Value' in res )
     self.assertEqual( res['Value'], 'yeah' )
 
 
@@ -364,39 +364,39 @@ class TestRead( unittest.TestCase ):
     # Test a write method which works for everybody
     lfn = '/lhcb/toto'
     res = fc.write1( lfn )
-    self.assert_( res['OK'] )
-    self.assert_( lfn in res['Value']['Successful'] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( lfn in res['Value']['Successful'] )
     self.assertEqual( sorted( ['c1', 'c2'] ), sorted( res['Value']['Successful'][lfn].keys() ) )
-    self.assert_( not res['Value']['Failed'] )
+    self.assertTrue( not res['Value']['Failed'] )
 
 
     # Test a write method that only the master has
     lfn = '/lhcb/toto'
     res = fc.write2( lfn )
-    self.assert_( res['OK'] )
-    self.assert_( lfn in res['Value']['Successful'] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( lfn in res['Value']['Successful'] )
     self.assertEqual( ['c1'], res['Value']['Successful'][lfn].keys() )
-    self.assert_( not res['Value']['Failed'] )
+    self.assertTrue( not res['Value']['Failed'] )
 
     # Test a write method that makes an error for master
     # We should get an error
     lfn = '/lhcb/c1/Error'
     res = fc.write1( lfn )
-    self.assert_( not res['OK'] )
+    self.assertTrue( not res['OK'] )
 
     # Test a write method that fails for master
     # The lfn should be in failed and only attempted for the master
     lfn = '/lhcb/c1/Failed'
     res = fc.write1( lfn )
-    self.assert_( res['OK'] )
-    self.assert_( not res['Value']['Successful'] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( not res['Value']['Successful'] )
     self.assertEqual( ['c1'], res['Value']['Failed'][lfn].keys() )
 
     # Test a write method that makes an error for non master
     # The lfn should be in failed for non master and successful for the master
     lfn = '/lhcb/c2/Error'
     res = fc.write1( lfn )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( ['c1'], res['Value']['Successful'][lfn].keys() )
     self.assertEqual( ['c2'], res['Value']['Failed'][lfn].keys() )
 
@@ -405,7 +405,7 @@ class TestRead( unittest.TestCase ):
     # The lfn should be in failed for non master and successful for the master
     lfn = '/lhcb/c2/Failed'
     res = fc.write1( lfn )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( ['c1'], res['Value']['Successful'][lfn].keys() )
     self.assertEqual( ['c2'], res['Value']['Failed'][lfn].keys() )
 

--- a/Resources/Storage/test/FIXME_Test_RFIOPlugIn.py
+++ b/Resources/Storage/test/FIXME_Test_RFIOPlugIn.py
@@ -37,7 +37,7 @@ def mock_StorageFactory_getCurrentURL( storageName, derivedStorageName ):
 #   def setUp( self ):
 #     factory = StorageFactory()
 #     res = factory.getStorages( 'CERN-RAW', ['RFIO'] )
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
 #     storageDetails = res['Value']
 
 class StoragePlugInTestCase( unittest.TestCase ):
@@ -70,9 +70,9 @@ class StoragePlugInTestCase( unittest.TestCase ):
     destDir = '/bla/'
     res = self.storage.createDirectory( destDir )
     print res
-    self.assert_( res['OK'] )
-    self.assert_( res['Value']['Successful'].has_key( destDir ) )
-    self.assert_( res['Value']['Successful'][destDir] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( res['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( res['Value']['Successful'][destDir] )
 
 class DirectoryTestCase( StoragePlugInTestCase ):
 
@@ -86,12 +86,12 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     nonExistantDirRes = self.storage.isDirectory( destDir )
 
     # Check the is directory operation
-    self.assert_( isDirRes['OK'] )
-    self.assert_( isDirRes['Value']['Successful'].has_key( destDir ) )
-    self.assert_( isDirRes['Value']['Successful'][destDir] )
+    self.assertTrue( isDirRes['OK'] )
+    self.assertTrue( isDirRes['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( isDirRes['Value']['Successful'][destDir] )
     # Check the non existant directory operation
-    self.assert_( nonExistantDirRes['OK'] )
-    self.assert_( nonExistantDirRes['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( nonExistantDirRes['OK'] )
+    self.assertTrue( nonExistantDirRes['Value']['Successful'].has_key( destDir ) )
     self.assertFalse( nonExistantDirRes['Value']['Successful'][destDir] )
 
   def test_putRemoveDirectory( self ):
@@ -125,14 +125,14 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     os.removedirs( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the remove dir operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -171,20 +171,20 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     os.removedirs( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the get metadata operation
-    self.assert_( getMetadataRes['OK'] )
-    self.assert_( getMetadataRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( getMetadataRes['OK'] )
+    self.assertTrue( getMetadataRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = getMetadataRes['Value']['Successful'][remoteDir]
-    self.assert_( resDict.has_key( 'Mode' ) )
+    self.assertTrue( resDict.has_key( 'Mode' ) )
     self.assertEqual( resDict['Mode'], 493 )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -223,20 +223,20 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     os.removedirs( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     #Now perform the checks for the get directory size operation
-    self.assert_( getDirSizeRes['OK'] )
-    self.assert_( getDirSizeRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( getDirSizeRes['OK'] )
+    self.assertTrue( getDirSizeRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = getDirSizeRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     self.assertEqual( resDict['Files'], numberOfFiles )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -275,21 +275,21 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     os.removedirs( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the list dir operation
-    self.assert_( listDirRes['OK'] )
-    self.assert_( listDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( listDirRes['OK'] )
+    self.assertTrue( listDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = listDirRes['Value']['Successful'][remoteDir]
-    self.assert_( resDict.has_key( 'SubDirs' ) )
-    self.assert_( resDict.has_key( 'Files' ) )
+    self.assertTrue( resDict.has_key( 'SubDirs' ) )
+    self.assertTrue( resDict.has_key( 'Files' ) )
     self.assertEqual( len( resDict['Files'].keys() ), numberOfFiles )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -335,20 +335,20 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     os.removedirs( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the get dir operation
-    self.assert_( getDirRes['OK'] )
-    self.assert_( getDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( getDirRes['OK'] )
+    self.assertTrue( getDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = getDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -372,16 +372,16 @@ class FileTestCase( StoragePlugInTestCase ):
     removeFileRes = self.storage.removeFile( destFile )
 
     # Check the failed put file operation
-    self.assert_( failedPutFileRes['OK'] )
-    self.assert_( failedPutFileRes['Value']['Failed'].has_key( destFile ) )
+    self.assertTrue( failedPutFileRes['OK'] )
+    self.assertTrue( failedPutFileRes['Value']['Failed'].has_key( destFile ) )
     expectedError = 'RFIOStorage.putFile: Source and destination file sizes do not match.'
     self.assertEqual( failedPutFileRes['Value']['Failed'][destFile], expectedError )
     # Check the successful put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
     # Check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
 
   """
   def test_putGetFile(self):
@@ -408,19 +408,19 @@ class FileTestCase( StoragePlugInTestCase ):
     os.remove(destLocalFile)
 
     # Check the put operation
-    self.assert_(putRes['OK'])
-    self.assert_(putRes['Value']['Successful'].has_key(destFile))
+    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['Value']['Successful'].has_key(destFile))
     # Check the failed get operation
-    self.assert_(failedGetRes['OK'])
-    self.assert_(failedGetRes['Value']['Failed'].has_key(destFile))
+    self.assertTrue(failedGetRes['OK'])
+    self.assertTrue(failedGetRes['Value']['Failed'].has_key(destFile))
     expectedError = 'RFIOStorage.getFile: Source and destination file sizes do not match.'
     self.assertEqual(failedGetRes['Value']['Failed'][destFile],expectedError)
     # Check the get operation
-    self.assert_(getFileRes['OK'])
-    self.assert_(getFileRes['Value']['Successful'].has_key(destFile))
+    self.assertTrue(getFileRes['OK'])
+    self.assertTrue(getFileRes['Value']['Successful'].has_key(destFile))
     # Check the remove operation
-    self.assert_(removeFileRes['OK'])
-    self.assert_(removeFileRes['Value']['Successful'].has_key(destFile))
+    self.assertTrue(removeFileRes['OK'])
+    self.assertTrue(removeFileRes['Value']['Successful'].has_key(destFile))
 
   """
   def test_putExistsFile( self ):
@@ -440,18 +440,18 @@ class FileTestCase( StoragePlugInTestCase ):
     failedExistRes = self.storage.exists( destFile )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
     # Check the exists operation
-    self.assert_( existsFileRes['OK'] )
-    self.assert_( existsFileRes['Value']['Successful'].has_key( destFile ) )
-    self.assert_( existsFileRes['Value']['Successful'][destFile] )
+    self.assertTrue( existsFileRes['OK'] )
+    self.assertTrue( existsFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( existsFileRes['Value']['Successful'][destFile] )
     # Check the removal operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
     # Check the failed exists operation
-    self.assert_( failedExistRes['OK'] )
-    self.assert_( failedExistRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( failedExistRes['OK'] )
+    self.assertTrue( failedExistRes['Value']['Successful'].has_key( destFile ) )
     self.assertFalse( failedExistRes['Value']['Successful'][destFile] )
 
   def test_putIsFile( self ):
@@ -472,18 +472,18 @@ class FileTestCase( StoragePlugInTestCase ):
     failedIsFileRes = self.storage.isFile( destDir )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
     # Check the is file operation
-    self.assert_( isFileRes['OK'] )
-    self.assert_( isFileRes['Value']['Successful'].has_key( destFile ) )
-    self.assert_( isFileRes['Value']['Successful'][destFile] )
+    self.assertTrue( isFileRes['OK'] )
+    self.assertTrue( isFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( isFileRes['Value']['Successful'][destFile] )
     # check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
     # Check that the directory is not a file
-    self.assert_( failedIsFileRes['OK'] )
-    self.assert_( failedIsFileRes['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( failedIsFileRes['OK'] )
+    self.assertTrue( failedIsFileRes['Value']['Successful'].has_key( destDir ) )
     self.assertFalse( failedIsFileRes['Value']['Successful'][destDir] )
 
   def test_putGetFileMetaData( self ):
@@ -506,26 +506,26 @@ class FileTestCase( StoragePlugInTestCase ):
     directoryMetadataRes = self.storage.getFileMetadata( destDir )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
     # Check the get metadata operation
-    self.assert_( getMetadataRes['OK'] )
-    self.assert_( getMetadataRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( getMetadataRes['OK'] )
+    self.assertTrue( getMetadataRes['Value']['Successful'].has_key( destFile ) )
     fileMetaData = getMetadataRes['Value']['Successful'][destFile]
-    #self.assert_(fileMetaData['Cached'])
+    #self.assertTrue(fileMetaData['Cached'])
     #self.assertFalse(fileMetaData['Migrated'])
     self.assertEqual( fileMetaData['Size'], fileSize )
     # check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
     # Check the get metadata for non existant file
-    self.assert_( failedMetadataRes['OK'] )
-    self.assert_( failedMetadataRes['Value']['Failed'].has_key( destFile ) )
+    self.assertTrue( failedMetadataRes['OK'] )
+    self.assertTrue( failedMetadataRes['Value']['Failed'].has_key( destFile ) )
     expectedError = "No such file or directory"
     self.assertEqual( failedMetadataRes['Value']['Failed'][destFile], expectedError )
     # Check that metadata operation with a directory
-    self.assert_( directoryMetadataRes['OK'] )
-    self.assert_( directoryMetadataRes['Value']['Failed'].has_key( destDir ) )
+    self.assertTrue( directoryMetadataRes['OK'] )
+    self.assertTrue( directoryMetadataRes['Value']['Failed'].has_key( destDir ) )
     expectedError = "RFIOStorage.getFileMetadata: Supplied path is not a file."
     self.assertEqual( directoryMetadataRes['Value']['Failed'][destDir], expectedError )
 
@@ -549,23 +549,23 @@ class FileTestCase( StoragePlugInTestCase ):
     directorySizeRes = self.storage.getFileSize( destDir )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
     # Check that we got the file size correctly
-    self.assert_( getSizeRes['OK'] )
-    self.assert_( getSizeRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( getSizeRes['OK'] )
+    self.assertTrue( getSizeRes['Value']['Successful'].has_key( destFile ) )
     self.assertEqual( getSizeRes['Value']['Successful'][destFile], fileSize )
     # check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
     # Check the get size with non existant file works properly
-    self.assert_( failedSizeRes['OK'] )
-    self.assert_( failedSizeRes['Value']['Failed'].has_key( destFile ) )
+    self.assertTrue( failedSizeRes['OK'] )
+    self.assertTrue( failedSizeRes['Value']['Failed'].has_key( destFile ) )
     expectedError = "No such file or directory"
     self.assertEqual( failedSizeRes['Value']['Failed'][destFile], expectedError )
     # Check that the passing a directory is handled correctly
-    self.assert_( directorySizeRes['OK'] )
-    self.assert_( directorySizeRes['Value']['Failed'].has_key( destDir ) )
+    self.assertTrue( directorySizeRes['OK'] )
+    self.assertTrue( directorySizeRes['Value']['Failed'].has_key( destDir ) )
     expectedError = "RFIOStorage.getFileSize: Supplied path is not a file."
     self.assertEqual( directorySizeRes['Value']['Failed'][destDir], expectedError )
 
@@ -585,27 +585,27 @@ class FileTestCase( StoragePlugInTestCase ):
     removeFileRes = self.storage.removeFile( destFile )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
     # Check the prestage file operation
-    self.assert_( prestageRes['OK'] )
-    self.assert_( prestageRes['Value']['Successful'].has_key( destFile ) )
-    self.assert_( prestageRes['Value']['Successful'][destFile] )
+    self.assertTrue( prestageRes['OK'] )
+    self.assertTrue( prestageRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( prestageRes['Value']['Successful'][destFile] )
     # Check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
 
     # These checks are currently disabled until a bug is fixed
     # Check what happens with deleted files
     #deletedPrestageRes = self.storage.prestageFile(destFile)
-    #self.assert_(deletedPrestageRes['OK'])
-    #self.assert_(deletedPrestageRes['Value']['Failed'].has_key(destFile))
+    #self.assertTrue(deletedPrestageRes['OK'])
+    #self.assertTrue(deletedPrestageRes['Value']['Failed'].has_key(destFile))
 
     # Check what happens with non-existant files #THIS IS A BUG, REPORT IR
     #testFile = "%s-THIS-IS-DEFINATELY-NOT-A-FILE" % destFile
     #nonExistantPrestageRes= self.storage.prestageFile(testFile)
-    #self.assert_(nonExistantPrestageRes['OK'])
-    #self.assert_(nonExistantPrestageRes['Value']['Failed'].has_key(destFile))
+    #self.assertTrue(nonExistantPrestageRes['OK'])
+    #self.assertTrue(nonExistantPrestageRes['Value']['Failed'].has_key(destFile))
 
   def test_putFilegetTransportURL( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet tURL test\n'
@@ -625,18 +625,18 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     print putFileRes
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
     # check the get turl operation
     print getTurlRes, destFile
-    self.assert_( getTurlRes['OK'] )
-    self.assert_( getTurlRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( getTurlRes['OK'] )
+    self.assertTrue( getTurlRes['Value']['Successful'].has_key( destFile ) )
     # check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
     #Check the get turl with non existant file operation
-    self.assert_( failedGetTurlRes['OK'] )
-    self.assert_( failedGetTurlRes['Value']['Failed'].has_key( destFile ) )
+    self.assertTrue( failedGetTurlRes['OK'] )
+    self.assertTrue( failedGetTurlRes['Value']['Failed'].has_key( destFile ) )
     expectedError = "RFIOStorage.getTransportURL: File does not exist."
     self.assertEqual( failedGetTurlRes['Value']['Failed'][destFile], expectedError )
 

--- a/Resources/Storage/test/FIXME_Test_StorageElement.py
+++ b/Resources/Storage/test/FIXME_Test_StorageElement.py
@@ -40,12 +40,12 @@ class StorageElementTestCase( unittest.TestCase ):
     # destinationDir = returnSingleResult( self.storageElement.getURL( self.destDirectory ) )['Value']
     destinationDir = self.destDirectory
     res = self.storageElement.createDirectory( destinationDir )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
   def tearDown( self ):
     # destinationDir = returnSingleResult( self.storageElement.getURL( self.destDirectory ) )['Value']
     res = self.storageElement.removeDirectory( self.destDirectory, recursive = True )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
 class GetInfoTestCase( StorageElementTestCase ):
 
@@ -56,42 +56,42 @@ class GetInfoTestCase( StorageElementTestCase ):
   def test_isValid( self ):
     print '\n\n#########################################################################\n\n\t\t\tIs valid test\n'
     res = self.storageElement.isValid()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
   def test_getRemotePlugins( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet remote protocols test\n'
     res = self.storageElement.getRemotePlugins()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( type( res['Value'] ), types.ListType )
 
   def test_getLocalPlugins( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet local protocols test\n'
     res = self.storageElement.getLocalPlugins()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( type( res['Value'] ), types.ListType )
 
   def test_getPlugins( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet protocols test\n'
     res = self.storageElement.getPlugins()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( type( res['Value'] ), types.ListType )
 
   #def test_isLocalSE( self ):
   #  print '\n\n#########################################################################\n\n\t\t\tIs local SE test\n'
   #  res = self.storageElement.isLocalSE()
-  #  self.assert_( res['OK'] )
+  #  self.assertTrue(res['OK'])
   #  self.assertFalse( res['Value'] )
 
   #def test_getStorageElementOption( self ):
   #  print '\n\n#########################################################################\n\n\t\t\tGet storage element option test\n'
   #  res = self.storageElement.getStorageElementOption( 'BackendType' )
-  #  self.assert_( res['OK'] )
+  #  self.assertTrue(res['OK'])
   #  self.assertEqual( res['Value'], 'DISET' )
 
   def test_getStorageParameters( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet storage parameters test\n'
     result = self.storageElement.getStorageParameters( 'DIP' )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     resDict = result['Value']
     self.assertEqual( resDict['Protocol'], 'dips' )
     #self.assertEqual( resDict['SpaceToken'], 'LHCb_RAW' )
@@ -121,21 +121,21 @@ class FileTestCases( StorageElementTestCase ):
     directoryExistsRes = returnSingleResult( self.storageElement.exists( destinationDir ) )
 
     # Check that the put was done correctly
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value'] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value'] )
     self.assertEqual( putFileRes['Value'], self.localFileSize )
     # Check that we checked the file correctly
-    self.assert_( existsRes['OK'] )
-    self.assert_( existsRes['Value'] )
+    self.assertTrue( existsRes['OK'] )
+    self.assertTrue( existsRes['Value'] )
     # Check that the removal was done correctly
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value'] )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value'] )
     # Check the exists for non existant file
-    self.assert_( missingExistsRes['OK'] )
+    self.assertTrue( missingExistsRes['OK'] )
     self.assertFalse( missingExistsRes['Value'] )
     # Check that directories exist
-    self.assert_( directoryExistsRes['OK'] )
-    self.assert_( directoryExistsRes['Value'] )
+    self.assertTrue( directoryExistsRes['OK'] )
+    self.assertTrue( directoryExistsRes['Value'] )
 
   def test_isFile( self ):
     print '\n\n#########################################################################\n\n\t\t\tIs file size test\n'
@@ -155,21 +155,21 @@ class FileTestCases( StorageElementTestCase ):
     directoryIsFileRes = returnSingleResult( self.storageElement.isFile( destinationDir ) )
 
     # Check that the put was done correctly
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value'] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value'] )
     self.assertEqual( putFileRes['Value'], self.localFileSize )
     # Check that we checked the file correctly
-    self.assert_( isFileRes['OK'] )
-    self.assert_( isFileRes['Value'] )
+    self.assertTrue( isFileRes['OK'] )
+    self.assertTrue( isFileRes['Value'] )
     # Check that the removal was done correctly
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value'] )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value'] )
     # Check the is file for non existant file
     self.assertFalse( missingIsFileRes['OK'] )
     expectedError = "File does not exist"
-    self.assert_( expectedError in missingIsFileRes['Message'] )
+    self.assertTrue( expectedError in missingIsFileRes['Message'] )
     # Check that is file operation with a directory
-    self.assert_( directoryIsFileRes['OK'] )
+    self.assertTrue( directoryIsFileRes['OK'] )
     self.assertFalse( directoryIsFileRes['Value'] )
 
   def test_putFile( self ):
@@ -183,12 +183,12 @@ class FileTestCases( StorageElementTestCase ):
     removeFileRes = returnSingleResult( self.storageElement.removeFile( destinationFilePath ) )
 
     # Check that the put was done correctly
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value'] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value'] )
     self.assertEqual( putFileRes['Value'], self.localFileSize )
     # Check that the removal was done correctly
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value'] )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value'] )
 
   def test_getFile( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet file test\n'
@@ -205,15 +205,15 @@ class FileTestCases( StorageElementTestCase ):
     os.remove( os.path.basename( destinationFilePath ) )
 
     # Check that the put was done correctly
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value'] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value'] )
     self.assertEqual( putFileRes['Value'], self.localFileSize )
     # Check that we got the file correctly
-    self.assert_( getFileRes['OK'] )
+    self.assertTrue( getFileRes['OK'] )
     self.assertEqual( getFileRes['Value'], self.localFileSize )
     # Check that the removal was done correctly
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value'] )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value'] )
 
   def test_getFileMetadata( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet file metadata test\n'
@@ -233,28 +233,28 @@ class FileTestCases( StorageElementTestCase ):
     directoryMetadataRes = returnSingleResult( self.storageElement.getFileMetadata( destinationDir ) )
 
     # Check that the put was done correctly
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value'] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value'] )
     self.assertEqual( putFileRes['Value'], self.localFileSize )
     # Check that the metadata was done correctly
-    self.assert_( getFileMetadataRes['OK'] )
+    self.assertTrue( getFileMetadataRes['OK'] )
     metadataDict = getFileMetadataRes['Value']
 
     # Works only for SRM2 plugin
-    # self.assert_( metadataDict['Cached'] )
+    # self.assertTrue( metadataDict['Cached'] )
     # self.assertFalse( metadataDict['Migrated'] )
     self.assertEqual( metadataDict['Size'], self.localFileSize )
     # Check that the removal was done correctly
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value'] )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value'] )
     # Check the get metadata for non existant file
     self.assertFalse( getMissingFileMetadataRes['OK'] )
     expectedError = "File does not exist"
-    self.assert_( expectedError in getMissingFileMetadataRes['Message'] )
+    self.assertTrue( expectedError in getMissingFileMetadataRes['Message'] )
     # Check that metadata operation with a directory
     self.assertFalse( directoryMetadataRes['OK'] )
     expectedError = "Supplied path is not a file"
-    self.assert_( expectedError in directoryMetadataRes['Message'] )
+    self.assertTrue( expectedError in directoryMetadataRes['Message'] )
 
   def test_getFileSize( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet file size test\n'
@@ -274,23 +274,23 @@ class FileTestCases( StorageElementTestCase ):
     directorySizeRes = returnSingleResult( self.storageElement.getFileSize( destinationDir ) )
 
     # Check that the put was done correctly
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value'] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value'] )
     self.assertEqual( putFileRes['Value'], self.localFileSize )
     # Check that the metadata was done correctly
-    self.assert_( getFileSizeRes['OK'] )
+    self.assertTrue( getFileSizeRes['OK'] )
     self.assertEqual( getFileSizeRes['Value'], self.localFileSize )
     # Check that the removal was done correctly
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value'] )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value'] )
     # Check the get metadata for non existant file
     self.assertFalse( getMissingFileSizeRes['OK'] )
     expectedError = "File does not exist"
-    self.assert_( expectedError in getMissingFileSizeRes['Message'] )
+    self.assertTrue( expectedError in getMissingFileSizeRes['Message'] )
     # Check that metadata operation with a directory
     self.assertFalse( directorySizeRes['OK'] )
     expectedError = "Supplied path is not a file"
-    self.assert_( expectedError in directorySizeRes['Message'] )
+    self.assertTrue( expectedError in directorySizeRes['Message'] )
 
 # Works only for SRM2 plugins
 #   def test_prestageFile( self ):
@@ -308,19 +308,19 @@ class FileTestCases( StorageElementTestCase ):
 #     missingPrestageFileRes = self.storageElement.prestageFile( destinationPfn, singleFile = True )
 #
 #     # Check that the put was done correctly
-#     self.assert_( putFileRes['OK'] )
-#     self.assert_( putFileRes['Value'] )
+#     self.assertTrue( putFileRes['OK'] )
+#     self.assertTrue( putFileRes['Value'] )
 #     self.assertEqual( putFileRes['Value'], self.localFileSize )
 #     # Check that the prestage was done correctly
-#     self.assert_( prestageFileRes['OK'] )
+#     self.assertTrue( prestageFileRes['OK'] )
 #     self.assertEqual( type( prestageFileRes['Value'] ), types.StringType )
 #     # Check that the removal was done correctly
-#     self.assert_( removeFileRes['OK'] )
-#     self.assert_( removeFileRes['Value'] )
+#     self.assertTrue( removeFileRes['OK'] )
+#     self.assertTrue( removeFileRes['Value'] )
 #     # Check the prestage for non existant file
 #     self.assertFalse( missingPrestageFileRes['OK'] )
 #     expectedError = "No such file or directory"
-#     self.assert_( expectedError in missingPrestageFileRes['Message'] )
+#     self.assertTrue( expectedError in missingPrestageFileRes['Message'] )
 
 # Works only for SRM2 plugins
 #   def test_prestageStatus( self ):
@@ -345,18 +345,18 @@ class FileTestCases( StorageElementTestCase ):
 #     removeFileRes = self.storageElement.removeFile( destinationPfn, singleFile = True )
 #
 #     # Check that the put was done correctly
-#     self.assert_( putFileRes['OK'] )
-#     self.assert_( putFileRes['Value'] )
+#     self.assertTrue( putFileRes['OK'] )
+#     self.assertTrue( putFileRes['Value'] )
 #     self.assertEqual( putFileRes['Value'], self.localFileSize )
 #     # Check that the prestage was done correctly
-#     self.assert_( prestageFileRes['OK'] )
+#     self.assertTrue( prestageFileRes['OK'] )
 #     self.assertEqual( type( prestageFileRes['Value'] ), types.StringType )
 #     # Check the file was found to be staged
-#     self.assert_( prestageStatusRes['OK'] )
-#     self.assert_( prestageStatusRes['Value'] )
+#     self.assertTrue( prestageStatusRes['OK'] )
+#     self.assertTrue( prestageStatusRes['Value'] )
 #     # Check that the removal was done correctly
-#     self.assert_( removeFileRes['OK'] )
-#     self.assert_( removeFileRes['Value'] )
+#     self.assertTrue( removeFileRes['OK'] )
+#     self.assertTrue( removeFileRes['Value'] )
 
 
 # Works only for SRM2 plugins
@@ -378,18 +378,18 @@ class FileTestCases( StorageElementTestCase ):
 #     removeFileRes = self.storageElement.removeFile( destinationPfn, singleFile = True )
 #
 #     # Check that the put was done correctly
-#     self.assert_( putFileRes['OK'] )
-#     self.assert_( putFileRes['Value'] )
+#     self.assertTrue( putFileRes['OK'] )
+#     self.assertTrue( putFileRes['Value'] )
 #     self.assertEqual( putFileRes['Value'], self.localFileSize )
 #     # Check that the file pin was done correctly
-#     self.assert_( pinFileRes['OK'] )
+#     self.assertTrue( pinFileRes['OK'] )
 #     self.assertEqual( type( pinFileRes['Value'] ), types.StringType )
 #     # Check the file was found to be staged
-#     self.assert_( releaseFileRes['OK'] )
-#     self.assert_( releaseFileRes['Value'] )
+#     self.assertTrue( releaseFileRes['OK'] )
+#     self.assertTrue( releaseFileRes['Value'] )
 #     # Check that the removal was done correctly
-#     self.assert_( removeFileRes['OK'] )
-#     self.assert_( removeFileRes['Value'] )
+#     self.assertTrue( removeFileRes['OK'] )
+#     self.assertTrue( removeFileRes['Value'] )
 
   def test_getURL( self ):
     print '\n\n#########################################################################\n\n\t\tGet access url test\n'
@@ -406,23 +406,23 @@ class FileTestCases( StorageElementTestCase ):
     getMissingTurlRes = self.storageElement.getURL( destinationFilePath, protocol = 'dips' )
 
     # Check that the put was done correctly
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value'] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value'] )
     self.assertEqual( putFileRes['Value'], self.localFileSize )
     # Check that we can get the tURL properly
-    self.assert_( getTurlRes['OK'] )
-    self.assert_( getTurlRes['Value'] )
-    self.assert_( type( getTurlRes['Value'] ) == types.DictType )
-    self.assert_( type( getTurlRes['Value']['Successful'][destinationFilePath] ) in types.StringTypes )
+    self.assertTrue( getTurlRes['OK'] )
+    self.assertTrue( getTurlRes['Value'] )
+    self.assertTrue( type( getTurlRes['Value'] ) == types.DictType )
+    self.assertTrue( type( getTurlRes['Value']['Successful'][destinationFilePath] ) in types.StringTypes )
     # Check that the removal was done correctly
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value'] )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value'] )
 
     # Works only for SRM2 plugins
     # # Check that non-existant files are handled correctly
     # self.assertFalse( getMissingTurlRes['OK'] )
     # expectedError = "File does not exist"
-    # self.assert_( expectedError in getMissingTurlRes['Message'] )
+    # self.assertTrue( expectedError in getMissingTurlRes['Message'] )
 
 class DirectoryTestCases( StorageElementTestCase ):
 
@@ -437,11 +437,11 @@ class DirectoryTestCases( StorageElementTestCase ):
     removeDirRes = self.storageElement.removeDirectory( directory, recursive = True )
 
     # Check that the creation was done correctly
-    self.assert_( createDirRes['OK'] )
-    self.assert_( createDirRes['Value'] )
+    self.assertTrue( createDirRes['OK'] )
+    self.assertTrue( createDirRes['Value'] )
     # Remove the directory
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value'] )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value'] )
 
   def test_isDirectory( self ):
     print '\n\n#########################################################################\n\n\t\t\tIs directory test\n'
@@ -453,10 +453,10 @@ class DirectoryTestCases( StorageElementTestCase ):
     nonExistantDirRes = self.storageElement.isDirectory( nonExistantDir )
 
     # Check that it works with the existing dir
-    self.assert_( isDirectoryRes['OK'] )
-    self.assert_( isDirectoryRes['Value'] )
+    self.assertTrue( isDirectoryRes['OK'] )
+    self.assertTrue( isDirectoryRes['Value'] )
     # Check that we handle non existant correctly
-    self.assert_( nonExistantDirRes['Value']['Failed'][nonExistantDir] in ['Path does not exist'] )
+    self.assertTrue( nonExistantDirRes['Value']['Failed'][nonExistantDir] in ['Path does not exist'] )
 
   def test_listDirectory( self ):
     print '\n\n#########################################################################\n\n\t\t\tList directory test\n'
@@ -484,27 +484,27 @@ class DirectoryTestCases( StorageElementTestCase ):
     shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value'] )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value'] )
     if putDirRes['Value']['Successful'][destDirectory]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][destDirectory]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][destDirectory]['Size'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( putDirRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
-    self.assert_( type( putDirRes['Value']['Successful'][destDirectory]['Size'] ) in  [types.IntType, types.LongType] )
+    self.assertTrue( type( putDirRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
+    self.assertTrue( type( putDirRes['Value']['Successful'][destDirectory]['Size'] ) in  [types.IntType, types.LongType] )
     # Perform the checks for the list dir operation
-    self.assert_( listDirRes['OK'] )
-    self.assert_( listDirRes['Value'] )
-    self.assert_( listDirRes['Value']['Successful'][destDirectory].has_key( 'SubDirs' ) )
-    self.assert_( listDirRes['Value']['Successful'][destDirectory].has_key( 'Files' ) )
+    self.assertTrue( listDirRes['OK'] )
+    self.assertTrue( listDirRes['Value'] )
+    self.assertTrue( listDirRes['Value']['Successful'][destDirectory].has_key( 'SubDirs' ) )
+    self.assertTrue( listDirRes['Value']['Successful'][destDirectory].has_key( 'Files' ) )
     self.assertEqual( len( listDirRes['Value']['Successful'][destDirectory]['Files'].keys() ), self.numberOfFiles )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value'] )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value'] )
     if removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
-    self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
 
   def test_getDirectoryMetadata( self ):
     print '\n\n#########################################################################\n\n\t\t\tDirectory metadata test\n'
@@ -530,31 +530,31 @@ class DirectoryTestCases( StorageElementTestCase ):
     shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value'] )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value'] )
     if putDirRes['Value']['Successful'][destDirectory]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][destDirectory]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][destDirectory]['Size'], self.numberOfFiles * sizeOfLocalFile )
-      self.assert_( type( putDirRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
-      self.assert_( type( putDirRes['Value']['Successful'][destDirectory]['Size'] ) in  [types.IntType, types.LongType] )
+      self.assertTrue( type( putDirRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( putDirRes['Value']['Successful'][destDirectory]['Size'] ) in  [types.IntType, types.LongType] )
     # Perform the checks for the list dir operation
-    self.assert_( metadataDirRes['OK'] )
-    self.assert_( metadataDirRes['Value'] )
+    self.assertTrue( metadataDirRes['OK'] )
+    self.assertTrue( metadataDirRes['Value'] )
 
     # Works only for the SRM2 plugin
-    # self.assert_( metadataDirRes['Value']['Mode'] )
-    # self.assert_( type( metadataDirRes['Value']['Mode'] ) == types.IntType )
+    # self.assertTrue( metadataDirRes['Value']['Mode'] )
+    # self.assertTrue( type( metadataDirRes['Value']['Mode'] ) == types.IntType )
 
-    self.assert_( metadataDirRes['Value']['Successful'][destDirectory]['Exists'] )
+    self.assertTrue( metadataDirRes['Value']['Successful'][destDirectory]['Exists'] )
     self.assertEqual( metadataDirRes['Value']['Successful'][destDirectory]['Type'], 'Directory' )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value'] )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value'] )
     if removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-      self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
-      self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
 
   def test_getDirectorySize( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet directory size test\n'
@@ -580,27 +580,27 @@ class DirectoryTestCases( StorageElementTestCase ):
     shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value'] )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value'] )
     if putDirRes['Value']['Successful'][destDirectory]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][destDirectory]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][destDirectory]['Size'], self.numberOfFiles * sizeOfLocalFile )
-      self.assert_( type( putDirRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
-      self.assert_( type( putDirRes['Value']['Successful'][destDirectory]['Size'] ) in  [types.IntType, types.LongType] )
+      self.assertTrue( type( putDirRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( putDirRes['Value']['Successful'][destDirectory]['Size'] ) in  [types.IntType, types.LongType] )
     # Perform the checks for the get dir size operation
-    self.assert_( getDirSizeRes['OK'] )
-    self.assert_( getDirSizeRes['Value'] )
+    self.assertTrue( getDirSizeRes['OK'] )
+    self.assertTrue( getDirSizeRes['Value'] )
     self.assertFalse( getDirSizeRes['Value']['Successful'][destDirectory]['SubDirs'] )
-    self.assert_( type( getDirSizeRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
-    self.assert_( type( getDirSizeRes['Value']['Successful'][destDirectory]['Size'] ) in [types.IntType, types.LongType] )
+    self.assertTrue( type( getDirSizeRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
+    self.assertTrue( type( getDirSizeRes['Value']['Successful'][destDirectory]['Size'] ) in [types.IntType, types.LongType] )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value'] )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value'] )
     if removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-      self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
-      self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
 
   def test_removeDirectory( self ):
     print '\n\n#########################################################################\n\n\t\t\tRemove directory test\n'
@@ -625,21 +625,21 @@ class DirectoryTestCases( StorageElementTestCase ):
     shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value'] )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value'] )
     if putDirRes['Value']['Successful'][destDirectory]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][destDirectory]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][destDirectory]['Size'], self.numberOfFiles * sizeOfLocalFile )
-      self.assert_( type( putDirRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
-      self.assert_( type( putDirRes['Value']['Successful'][destDirectory]['Size'] ) in  [types.IntType, types.LongType] )
+      self.assertTrue( type( putDirRes['Value']['Successful'][destDirectory]['Files'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( putDirRes['Value']['Successful'][destDirectory]['Size'] ) in  [types.IntType, types.LongType] )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value'] )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value'] )
     if removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-      self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
-      self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
 
   def test_getDirectory( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet directory test\n'
@@ -668,31 +668,31 @@ class DirectoryTestCases( StorageElementTestCase ):
       shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value'] )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value'] )
     for _dir in dirDict:
       if putDirRes['Value']['Successful'][_dir]['Files']:
         self.assertEqual( putDirRes['Value']['Successful'][_dir]['Files'], self.numberOfFiles )
         self.assertEqual( putDirRes['Value']['Successful'][_dir]['Size'], self.numberOfFiles * sizeOfLocalFile )
-        self.assert_( type( putDirRes['Value']['Successful'][_dir]['Files'] ) in [types.IntType, types.LongType] )
-        self.assert_( type( putDirRes['Value']['Successful'][_dir]['Size'] ) in  [types.IntType, types.LongType] )
+        self.assertTrue( type( putDirRes['Value']['Successful'][_dir]['Files'] ) in [types.IntType, types.LongType] )
+        self.assertTrue( type( putDirRes['Value']['Successful'][_dir]['Size'] ) in  [types.IntType, types.LongType] )
     # Perform the checks for the get directory operation
-    self.assert_( getDirRes['OK'] )
-    self.assert_( getDirRes['Value'] )
+    self.assertTrue( getDirRes['OK'] )
+    self.assertTrue( getDirRes['Value'] )
     for _dir in dirDict:
       if getDirRes['Value']['Successful'][_dir]['Files']:
         self.assertEqual( getDirRes['Value']['Successful'][_dir]['Files'], self.numberOfFiles )
         self.assertEqual( getDirRes['Value']['Successful'][_dir]['Size'], self.numberOfFiles * sizeOfLocalFile )
-        self.assert_( type( getDirRes['Value']['Successful'][_dir]['Files'] ) in [types.IntType, types.LongType] )
-        self.assert_( type( getDirRes['Value']['Successful'][_dir]['Size'] ) in [types.IntType, types.LongType] )
+        self.assertTrue( type( getDirRes['Value']['Successful'][_dir]['Files'] ) in [types.IntType, types.LongType] )
+        self.assertTrue( type( getDirRes['Value']['Successful'][_dir]['Size'] ) in [types.IntType, types.LongType] )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value'] )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value'] )
     if removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-      self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
-      self.assert_( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['FilesRemoved'] ) in [types.IntType, types.LongType] )
+      self.assertTrue( type( removeDirRes['Value']['Successful'][destDirectory]['SizeRemoved'] ) in [types.IntType, types.LongType] )
 
 
 if __name__ == '__main__':

--- a/Resources/Storage/test/FIXME_Test_StoragePlugIn.py
+++ b/Resources/Storage/test/FIXME_Test_StoragePlugIn.py
@@ -32,15 +32,15 @@ class StoragePlugInTestCase( unittest.TestCase ):
 
     factory = StorageFactory( 'lhcb' )
     res = factory.getStorages( storageElementToTest, [plugin] )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     storageDetails = res['Value']
     self.storage = storageDetails['StorageObjects'][0]
     self.storage.changeDirectory( 'lhcb/test/unit-test/TestStoragePlugIn' )
     destDir = self.storage.getCurrentURL( '' )['Value']
     res = self.storage.createDirectory( destDir )
-    self.assert_( res['OK'] )
-    self.assert_( res['Value']['Successful'].has_key( destDir ) )
-    self.assert_( res['Value']['Successful'][destDir] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( res['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( res['Value']['Successful'][destDir] )
     self.numberOfFiles = 1
 
   def tearDown( self ):
@@ -74,21 +74,21 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     # Perform the checks for the remove dir operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
 
   def test_isDirectory( self ):
     print '\n\n#########################################################################\n\n\t\t\tIs Directory test\n'
@@ -100,14 +100,14 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     nonExistantDirRes = self.storage.isDirectory( dummyDir )
 
     # Check the is directory operation
-    self.assert_( isDirRes['OK'] )
-    self.assert_( isDirRes['Value']['Successful'].has_key( destDir ) )
-    self.assert_( isDirRes['Value']['Successful'][destDir] )
+    self.assertTrue( isDirRes['OK'] )
+    self.assertTrue( isDirRes['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( isDirRes['Value']['Successful'][destDir] )
     # Check the non existant directory operation
-    self.assert_( nonExistantDirRes['OK'] )
-    self.assert_( nonExistantDirRes['Value']['Failed'].has_key( dummyDir ) )
+    self.assertTrue( nonExistantDirRes['OK'] )
+    self.assertTrue( nonExistantDirRes['Value']['Failed'].has_key( dummyDir ) )
     expectedError = 'Path does not exist'
-    self.assert_( expectedError in nonExistantDirRes['Value']['Failed'][dummyDir] )
+    self.assertTrue( expectedError in nonExistantDirRes['Value']['Failed'][dummyDir] )
 
   def test_putGetDirectoryMetadata( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet Directory Metadata test\n'
@@ -137,25 +137,25 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     # Perform the checks for the get metadata operation
-    self.assert_( getMetadataRes['OK'] )
-    self.assert_( getMetadataRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( getMetadataRes['OK'] )
+    self.assertTrue( getMetadataRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = getMetadataRes['Value']['Successful'][remoteDir]
-    self.assert_( resDict.has_key( 'Mode' ) )
-    self.assert_( type( resDict['Mode'] ) == IntType )
+    self.assertTrue( resDict.has_key( 'Mode' ) )
+    self.assertTrue( type( resDict['Mode'] ) == IntType )
     # Perform the checks for the remove directory operation
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
 
   def test_putGetDirectorySize( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet Directory Size test\n'
@@ -183,27 +183,27 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     #Now perform the checks for the get directory size operation
-    self.assert_( getDirSizeRes['OK'] )
-    self.assert_( getDirSizeRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( getDirSizeRes['OK'] )
+    self.assertTrue( getDirSizeRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = getDirSizeRes['Value']['Successful'][remoteDir]
-    self.assert_( type( resDict['Size'] ) in [LongType, IntType] )
-    self.assert_( type( resDict['Files'] ) == IntType )
+    self.assertTrue( type( resDict['Size'] ) in [LongType, IntType] )
+    self.assertTrue( type( resDict['Files'] ) == IntType )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
 
   def test_putListDirectory( self ):
     print '\n\n#########################################################################\n\n\t\t\tList Directory test\n'
@@ -231,28 +231,28 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     # Perform the checks for the list dir operation
-    self.assert_( listDirRes['OK'] )
-    self.assert_( listDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( listDirRes['OK'] )
+    self.assertTrue( listDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = listDirRes['Value']['Successful'][remoteDir]
-    self.assert_( resDict.has_key( 'SubDirs' ) )
-    self.assert_( resDict.has_key( 'Files' ) )
+    self.assertTrue( resDict.has_key( 'SubDirs' ) )
+    self.assertTrue( resDict.has_key( 'Files' ) )
     self.assertEqual( len( resDict['Files'].keys() ), self.numberOfFiles )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
 
   def test_putGetDirectory( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet Directory test\n'
@@ -282,30 +282,30 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     shutil.rmtree( localDir )
 
     # Perform the checks for the put dir operation
-    self.assert_( putDirRes['OK'] )
-    self.assert_( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( putDirRes['OK'] )
+    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
-    self.assert_( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Files'] ) == IntType )
+    self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     # Perform the checks for the get dir operation
-    self.assert_( getDirRes['OK'] )
-    self.assert_( getDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( getDirRes['OK'] )
+    self.assertTrue( getDirRes['Value']['Successful'].has_key( remoteDir ) )
     resDict = getDirRes['Value']['Successful'][remoteDir]
     if resDict['Files']:
       self.assertEqual( resDict['Files'], self.numberOfFiles )
       self.assertEqual( resDict['Size'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( resDict['Files'] ) == IntType )
-    self.assert_( type( resDict['Size'] ) in [LongType, IntType] )
+    self.assertTrue( type( resDict['Files'] ) == IntType )
+    self.assertTrue( type( resDict['Size'] ) in [LongType, IntType] )
     # Perform the checks for the remove directory operation
-    self.assert_( removeDirRes['OK'] )
-    self.assert_( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( removeDirRes['OK'] )
+    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
-    self.assert_( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'] ) == IntType )
+    self.assertTrue( type( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'] ) in [LongType, IntType] )
 
 class FileTestCase( StoragePlugInTestCase ):
 
@@ -323,13 +323,13 @@ class FileTestCase( StoragePlugInTestCase ):
     removeFileRes = self.storage.removeFile( destFile )
 
     # Check the successful put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
     self.assertEqual( putFileRes['Value']['Successful'][destFile], srcFileSize )
     # Check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( destFile ) )
-    self.assert_( removeFileRes['Value']['Successful'][destFile] )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( removeFileRes['Value']['Successful'][destFile] )
 
   def test_putGetFile( self ):
     print '\n\n#########################################################################\n\n\t\t\tPut and Get test\n'
@@ -350,17 +350,17 @@ class FileTestCase( StoragePlugInTestCase ):
     os.remove( testFileName )
 
     # Check the put operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the get operation
-    self.assert_( getFileRes['OK'] )
-    self.assert_( getFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( getFileRes['OK'] )
+    self.assertTrue( getFileRes['Value']['Successful'].has_key( remoteFile ) )
     self.assertEqual( getFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the remove operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( removeFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( removeFileRes['Value']['Successful'][remoteFile] )
 
   def test_putExistsFile( self ):
     print '\n\n#########################################################################\n\n\t\t\tExists test\n'
@@ -379,19 +379,19 @@ class FileTestCase( StoragePlugInTestCase ):
     failedExistRes = self.storage.exists( remoteFile )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the exists operation
-    self.assert_( existsFileRes['OK'] )
-    self.assert_( existsFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( existsFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( existsFileRes['OK'] )
+    self.assertTrue( existsFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( existsFileRes['Value']['Successful'][remoteFile] )
     # Check the removal operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
     # Check the failed exists operation
-    self.assert_( failedExistRes['OK'] )
-    self.assert_( failedExistRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( failedExistRes['OK'] )
+    self.assertTrue( failedExistRes['Value']['Successful'].has_key( remoteFile ) )
     self.assertFalse( failedExistRes['Value']['Successful'][remoteFile] )
 
   def test_putIsFile( self ):
@@ -412,20 +412,20 @@ class FileTestCase( StoragePlugInTestCase ):
     failedIsFileRes = self.storage.isFile( remoteDir )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( putFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the is file operation
-    self.assert_( isFileRes['OK'] )
-    self.assert_( isFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( isFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( isFileRes['OK'] )
+    self.assertTrue( isFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( isFileRes['Value']['Successful'][remoteFile] )
     # check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
     # Check that the directory is not a file
-    self.assert_( failedIsFileRes['OK'] )
-    self.assert_( failedIsFileRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( failedIsFileRes['OK'] )
+    self.assertTrue( failedIsFileRes['Value']['Successful'].has_key( remoteDir ) )
     self.assertFalse( failedIsFileRes['Value']['Successful'][remoteDir] )
 
   def test_putGetFileMetaData( self ):
@@ -448,30 +448,30 @@ class FileTestCase( StoragePlugInTestCase ):
     directoryMetadataRes = self.storage.getFileMetadata( remoteDir )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( putFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the get metadata operation
-    self.assert_( getMetadataRes['OK'] )
-    self.assert_( getMetadataRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( getMetadataRes['OK'] )
+    self.assertTrue( getMetadataRes['Value']['Successful'].has_key( remoteFile ) )
     fileMetaData = getMetadataRes['Value']['Successful'][remoteFile]
-    self.assert_( fileMetaData['Cached'] )
+    self.assertTrue( fileMetaData['Cached'] )
     self.assertFalse( fileMetaData['Migrated'] )
     self.assertEqual( fileMetaData['Size'], srcFileSize )
     # check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
     # Check the get metadata for non existant file
-    self.assert_( failedMetadataRes['OK'] )
-    self.assert_( failedMetadataRes['Value']['Failed'].has_key( remoteFile ) )
+    self.assertTrue( failedMetadataRes['OK'] )
+    self.assertTrue( failedMetadataRes['Value']['Failed'].has_key( remoteFile ) )
     expectedError = "File does not exist"
-    self.assert_( expectedError in failedMetadataRes['Value']['Failed'][remoteFile] )
+    self.assertTrue( expectedError in failedMetadataRes['Value']['Failed'][remoteFile] )
     # Check that metadata operation with a directory
-    self.assert_( directoryMetadataRes['OK'] )
-    self.assert_( directoryMetadataRes['Value']['Failed'].has_key( remoteDir ) )
+    self.assertTrue( directoryMetadataRes['OK'] )
+    self.assertTrue( directoryMetadataRes['Value']['Failed'].has_key( remoteDir ) )
     expectedError = "Supplied path is not a file"
-    self.assert_( expectedError in directoryMetadataRes['Value']['Failed'][remoteDir] )
+    self.assertTrue( expectedError in directoryMetadataRes['Value']['Failed'][remoteDir] )
 
   def test_putGetFileSize( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet file size test\n'
@@ -493,27 +493,27 @@ class FileTestCase( StoragePlugInTestCase ):
     directorySizeRes = self.storage.getFileSize( remoteDir )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( putFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check that we got the file size correctly
-    self.assert_( getSizeRes['OK'] )
-    self.assert_( getSizeRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( getSizeRes['OK'] )
+    self.assertTrue( getSizeRes['Value']['Successful'].has_key( remoteFile ) )
     self.assertEqual( getSizeRes['Value']['Successful'][remoteFile], srcFileSize )
     # check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
     # Check the get size with non existant file works properly
-    self.assert_( failedSizeRes['OK'] )
-    self.assert_( failedSizeRes['Value']['Failed'].has_key( remoteFile ) )
+    self.assertTrue( failedSizeRes['OK'] )
+    self.assertTrue( failedSizeRes['Value']['Failed'].has_key( remoteFile ) )
     expectedError = "File does not exist"
-    self.assert_( expectedError in failedSizeRes['Value']['Failed'][remoteFile] )
+    self.assertTrue( expectedError in failedSizeRes['Value']['Failed'][remoteFile] )
     # Check that the passing a directory is handled correctly
-    self.assert_( directorySizeRes['OK'] )
-    self.assert_( directorySizeRes['Value']['Failed'].has_key( remoteDir ) )
+    self.assertTrue( directorySizeRes['OK'] )
+    self.assertTrue( directorySizeRes['Value']['Failed'].has_key( remoteDir ) )
     expectedError = "Supplied path is not a file"
-    self.assert_( expectedError in directorySizeRes['Value']['Failed'][remoteDir] )
+    self.assertTrue( expectedError in directorySizeRes['Value']['Failed'][remoteDir] )
 
   def test_putPrestageFile( self ):
     print '\n\n#########################################################################\n\n\t\t\tFile prestage test\n'
@@ -532,22 +532,22 @@ class FileTestCase( StoragePlugInTestCase ):
     deletedPrestageRes = self.storage.prestageFile( remoteFile )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( putFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the prestage file operation
-    self.assert_( prestageRes['OK'] )
-    self.assert_( prestageRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( prestageRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( prestageRes['OK'] )
+    self.assertTrue( prestageRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( prestageRes['Value']['Successful'][remoteFile] )
     # Check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
     # Check that pre-staging non-existant file fails
-    self.assert_( deletedPrestageRes['OK'] )
-    self.assert_( deletedPrestageRes['Value']['Failed'].has_key( remoteFile ) )
+    self.assertTrue( deletedPrestageRes['OK'] )
+    self.assertTrue( deletedPrestageRes['Value']['Failed'].has_key( remoteFile ) )
     expectedError = "No such file or directory"
-    self.assert_( expectedError in deletedPrestageRes['Value']['Failed'][remoteFile] )
+    self.assertTrue( expectedError in deletedPrestageRes['Value']['Failed'][remoteFile] )
 
   def test_putFilegetTransportURL( self ):
     print '\n\n#########################################################################\n\n\t\t\tGet tURL test\n'
@@ -566,21 +566,21 @@ class FileTestCase( StoragePlugInTestCase ):
     failedGetTurlRes = self.storage.getTransportURL( remoteFile )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( putFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # check the get turl operation
-    self.assert_( getTurlRes['OK'] )
-    self.assert_( getTurlRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( getTurlRes['OK'] )
+    self.assertTrue( getTurlRes['Value']['Successful'].has_key( remoteFile ) )
     # check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
     #Check the get turl with non existant file operation
-    self.assert_( failedGetTurlRes['OK'] )
-    self.assert_( failedGetTurlRes['Value']['Failed'].has_key( remoteFile ) )
+    self.assertTrue( failedGetTurlRes['OK'] )
+    self.assertTrue( failedGetTurlRes['Value']['Failed'].has_key( remoteFile ) )
     expectedError = "File does not exist"
-    self.assert_( expectedError in failedGetTurlRes['Value']['Failed'][remoteFile] )
+    self.assertTrue( expectedError in failedGetTurlRes['Value']['Failed'][remoteFile] )
 
   def test_putPinRelease( self ):
     print '\n\n#########################################################################\n\n\t\t\tPin and Release test\n'
@@ -603,20 +603,20 @@ class FileTestCase( StoragePlugInTestCase ):
     removeFileRes = self.storage.removeFile( remoteFile )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( putFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the pin file operation
-    self.assert_( pinFileRes['OK'] )
-    self.assert_( pinFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( type( pinFileRes['Value']['Successful'][remoteFile] ) in StringTypes )
+    self.assertTrue( pinFileRes['OK'] )
+    self.assertTrue( pinFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( type( pinFileRes['Value']['Successful'][remoteFile] ) in StringTypes )
     # Check the release file operation
-    self.assert_( releaseFileRes['OK'] )
-    self.assert_( releaseFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( releaseFileRes['OK'] )
+    self.assertTrue( releaseFileRes['Value']['Successful'].has_key( remoteFile ) )
     # check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
 
   def test_putPrestageStatus( self ):
     print '\n\n#########################################################################\n\n\t\t\tPrestage status test\n'
@@ -643,22 +643,22 @@ class FileTestCase( StoragePlugInTestCase ):
     removeFileRes = self.storage.removeFile( remoteFile )
 
     # Check the put file operation
-    self.assert_( putFileRes['OK'] )
-    self.assert_( putFileRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( putFileRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( putFileRes['OK'] )
+    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the prestage file operation
-    self.assert_( prestageRes['OK'] )
-    self.assert_( prestageRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( prestageRes['Value']['Successful'][remoteFile] )
-    self.assert_( type( prestageRes['Value']['Successful'][remoteFile] ) in StringTypes )
+    self.assertTrue( prestageRes['OK'] )
+    self.assertTrue( prestageRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( prestageRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( type( prestageRes['Value']['Successful'][remoteFile] ) in StringTypes )
     # Check the prestage status operation
-    self.assert_( prestageStatusRes['OK'] )
-    self.assert_( prestageStatusRes['Value']['Successful'].has_key( remoteFile ) )
-    self.assert_( prestageStatusRes['Value']['Successful'][remoteFile] )
+    self.assertTrue( prestageStatusRes['OK'] )
+    self.assertTrue( prestageStatusRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( prestageStatusRes['Value']['Successful'][remoteFile] )
     # Check the remove file operation
-    self.assert_( removeFileRes['OK'] )
-    self.assert_( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( removeFileRes['OK'] )
+    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase( FileTestCase )

--- a/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
+++ b/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
@@ -51,18 +51,18 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
   def test__fillTheQueue( self ):
     operationsOnTransformationsDict = {1:{'Operations':['op1', 'op2'], 'Body':'veryBigBody'}}
     self.tmab._fillTheQueue( operationsOnTransformationsDict )
-    self.assert_( self.tmab.transInQueue == [1] )
-    self.assert_( self.tmab.transQueue.qsize() == 1 )
+    self.assertTrue( self.tmab.transInQueue == [1] )
+    self.assertTrue( self.tmab.transQueue.qsize() == 1 )
 
     operationsOnTransformationsDict = {2:{'Operations':['op3', 'op2'], 'Body':'veryveryBigBody'}}
     self.tmab._fillTheQueue( operationsOnTransformationsDict )
-    self.assert_( self.tmab.transInQueue == [1, 2] )
-    self.assert_( self.tmab.transQueue.qsize() == 2 )
+    self.assertTrue( self.tmab.transInQueue == [1, 2] )
+    self.assertTrue( self.tmab.transQueue.qsize() == 2 )
 
     operationsOnTransformationsDict = {2:{'Operations':['op3', 'op2'], 'Body':'veryveryBigBody'}}
     self.tmab._fillTheQueue( operationsOnTransformationsDict )
-    self.assert_( self.tmab.transInQueue == [1, 2] )
-    self.assert_( self.tmab.transQueue.qsize() == 2 )
+    self.assertTrue( self.tmab.transInQueue == [1, 2] )
+    self.assertTrue( self.tmab.transQueue.qsize() == 2 )
 
   def test_updateTaskStatusSuccess( self ):
     clients = {'TransformationClient':self.tc_mock, 'TaskManager':self.tm_mock}
@@ -77,7 +77,7 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
     # no tasks
     self.tc_mock.getTransformationTasks.return_value = {'OK': True, 'Value': []}
     res = self.tmab.updateTaskStatus( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # tasks, fail in update
     self.tc_mock.getTransformationTasks.return_value = {'OK': True,
@@ -123,7 +123,7 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
 
     self.tm_mock.getSubmittedTaskStatus.return_value = {'OK': True, 'Value': {}}
     res = self.tmab.updateTaskStatus( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # tasks, to update, no errors
     self.tc_mock.getTransformationTasks.return_value = {'OK': True,
@@ -146,7 +146,7 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
 
     self.tm_mock.getSubmittedTaskStatus.return_value = {'OK': True, 'Value': {'Running': [1, 2], 'Done': [3]}}
     res = self.tmab.updateTaskStatus( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
 
   def test_updateFileStatusSuccess( self ):
@@ -162,7 +162,7 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
     # no files
     self.tc_mock.getTransformationFiles.return_value = {'OK': True, 'Value': []}
     res = self.tmab.updateFileStatus( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # files, failing to update
     self.tc_mock.getTransformationFiles.return_value = {'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}
@@ -174,13 +174,13 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
     self.tc_mock.getTransformationFiles.return_value = {'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}
     self.tm_mock.getSubmittedFileStatus.return_value = {'OK': True, 'Value': []}
     res = self.tmab.updateFileStatus( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # files, something to update
     self.tc_mock.getTransformationFiles.return_value = {'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}
     self.tm_mock.getSubmittedFileStatus.return_value = {'OK': True, 'Value': {'file1': 'OK', 'file2': 'NOK'}}
     res = self.tmab.updateFileStatus( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
   def test_checkReservedTasks( self ):
     clients = {'TransformationClient':self.tc_mock, 'TaskManager':self.tm_mock}
@@ -195,7 +195,7 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
     # no tasks
     self.tc_mock.getTransformationTasks.return_value = {'OK': True, 'Value': []}
     res = self.tmab.checkReservedTasks( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # tasks, failing to update
     self.tc_mock.getTransformationTasks.return_value = {'OK': True,
@@ -231,7 +231,7 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
     self.tm_mock.updateTransformationReservedTasks.return_value = {'OK': True, 'Value': {'NoTasks': ['3_4', '5_6'],
                                                                                          'TaskNameIDs': {'1_1':123, '2_1':456}}}
     res = self.tmab.checkReservedTasks( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
 
 
@@ -248,7 +248,7 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
     # no tasks
     self.tc_mock.getTasksToSubmit.return_value = {'OK': True, 'Value': {'JobDictionary': {}}}
     res = self.tmab.submitTasks( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # tasks, errors
     self.tc_mock.getTasksToSubmit.return_value = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
@@ -277,7 +277,7 @@ class TaskManagerAgentBaseSuccess( AgentsTestCase ):
     self.tm_mock.submitTransformationTasks.return_value = {'OK': True, 'Value': [] }
     self.tm_mock.updateDBAfterTaskSubmission.return_value = {'OK': True, 'Value': [] }
     res = self.tmab.submitTasks( transIDOPBody, clients )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
 
 

--- a/TransformationSystem/Agent/test/Test_Plugins.py
+++ b/TransformationSystem/Agent/test/Test_Plugins.py
@@ -76,7 +76,7 @@ class PluginsBaseSuccess( PluginsTestCase ):
     pluginStandard = TransformationPlugin( 'Standard' )
     pluginStandard.setParameters( params )
     res = pluginStandard.run()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], [] )
 
   def test__Standard_Data_G10( self ):
@@ -87,7 +87,7 @@ class PluginsBaseSuccess( PluginsTestCase ):
     pluginStandard.setParameters( params )
     pluginStandard.setInputData( data )
     res = pluginStandard.run()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], [] )
 
   def test__Standard_Flush_G10( self ):
@@ -106,7 +106,7 @@ class PluginsBaseSuccess( PluginsTestCase ):
                     '/this/is/at.12']),
                   ('SE2', ['/this/is/als/at.2', '/this/is/at_23', '/this/is/at.2']),
                   ('SE4', ['/this/is/at_4'])]
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], sortedData )
 
   def test__Standard_G1( self ):
@@ -114,7 +114,7 @@ class PluginsBaseSuccess( PluginsTestCase ):
     pluginStandard = TransformationPlugin( 'Standard' )
     pluginStandard.setParameters( paramsBase )
     res = pluginStandard.run()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], [] )
 
   def test__Standard_Data_G1( self ):
@@ -123,7 +123,7 @@ class PluginsBaseSuccess( PluginsTestCase ):
     pluginStandard.setParameters( paramsBase )
     pluginStandard.setInputData( data )
     res = pluginStandard.run()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     sortedData = sorted([ (",".join(SEs), [lfn]) for lfn,SEs in data.iteritems() ])
     self.assertEqual( res['Value'], sortedData )
 
@@ -136,7 +136,7 @@ class PluginsBaseSuccess( PluginsTestCase ):
     pluginStandard.setInputData( data )
     res = pluginStandard.run()
     sortedData = sorted([ (",".join(SEs), [lfn]) for lfn,SEs in data.iteritems() ])
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], sortedData )
 
 #############################################################################

--- a/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -109,7 +109,7 @@ class PluginUtilitiesSuccess( ClientsTestCase ):
                                     '/this/is/at_23': ['SE2', 'SE3'],
                                     '/this/is/at_4': ['SE4']},
                                    'Flush' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], [( 'SE1', ['/this/is/at_123', '/this/is/at.12', '/this/is/at.1'] ),
                                      ( 'SE2', ['/this/is/at_23', '/this/is/at.2'] ),
                                      ( 'SE4', ['/this/is/at_4'] )] )
@@ -118,7 +118,7 @@ class PluginUtilitiesSuccess( ClientsTestCase ):
                                     '/this/is/at.12': ['SE1', 'SE2'],
                                     '/this/is/at.134': ['SE1', 'SE3', 'SE4']},
                                    'Flush' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     print res['Value']
     self.assertEqual( res['Value'], [( 'SE1', ['/this/is/at.123', '/this/is/at.134', '/this/is/at.12'] ) ] )
 
@@ -192,13 +192,13 @@ class RequestTasksSuccess( ClientsTestCase ):
     # No tasks in input
     taskDict = {}
     res = self.requestTasks.prepareTransformationTasks( '', taskDict, 'owner', 'ownerGroup', '/bih/boh/DN' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( len( taskDict ), 0 )
 
     # 3 tasks, 1 task not OK (in second transformation)
     taskDict = {123:{'TransformationID':2, 'TargetSE':'SE3', 'b3':'bb3', 'InputData':''}}
     res = self.requestTasks.prepareTransformationTasks( '', taskDict, 'owner', 'ownerGroup', '/bih/boh/DN' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     # We should "lose" one of the task in the preparation
     self.assertEqual( len( taskDict ), 0 )
 
@@ -208,11 +208,11 @@ class RequestTasksSuccess( ClientsTestCase ):
                 3:{'TransformationID':2, 'TargetSE':'SE3', 'b3':'bb3', 'InputData':''}}
 
     res = self.requestTasks.prepareTransformationTasks( '', taskDict, 'owner', 'ownerGroup', '/bih/boh/DN' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     # We should "lose" one of the task in the preparation
     self.assertEqual( len( taskDict ), 2 )
     for task in res['Value'].values():
-      self.assert_( isinstance( task['TaskObject'], Request ) )
+      self.assertTrue( isinstance( task['TaskObject'], Request ) )
       self.assertEqual( task['TaskObject'][0].Type, 'ReplicateAndRegister' )
       try:
         self.assertEqual( task['TaskObject'][0][0].LFN, '/this/is/a1.lfn' )
@@ -225,11 +225,11 @@ class RequestTasksSuccess( ClientsTestCase ):
 
     # # test another (single) OperationType
     res = self.requestTasks.prepareTransformationTasks( 'someType;LogUpload', taskDict, 'owner', 'ownerGroup', '/bih/boh/DN' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     # We should "lose" one of the task in the preparation
     self.assertEqual( len( taskDict ), 2 )
     for task in res['Value'].values():
-      self.assert_( isinstance( task['TaskObject'], Request ) )
+      self.assertTrue( isinstance( task['TaskObject'], Request ) )
       self.assertEqual( task['TaskObject'][0].Type, 'LogUpload' )
 
     # ## Multiple operations
@@ -244,11 +244,11 @@ class RequestTasksSuccess( ClientsTestCase ):
                 3:{'TransformationID':2, 'TargetSE':'SE3', 'b3':'bb3', 'InputData':''}}
 
     res = self.requestTasks.prepareTransformationTasks( jsonBody, taskDict, 'owner', 'ownerGroup', '/bih/boh/DN' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     # We should "lose" one of the task in the preparation
     self.assertEqual( len( taskDict ), 2 )
     for task in res['Value'].values():
-      self.assert_( isinstance( task['TaskObject'], Request ) )
+      self.assertTrue( isinstance( task['TaskObject'], Request ) )
       self.assertEqual( task['TaskObject'][0].Type, 'ReplicateAndRegister' )
       self.assertEqual( task['TaskObject'][1].Type, 'RemoveReplica' )
       try:
@@ -362,14 +362,14 @@ class TransformationSuccess( ClientsTestCase ):
   def test_setGet( self ):
 
     res = self.transformation.setTransformationName( 'TestTName' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     description = 'Test transformation description'
     res = self.transformation.setDescription( description )
     longDescription = 'Test transformation long description'
     res = self.transformation.setLongDescription( longDescription )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = self.transformation.setType( 'MCSimulation' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = self.transformation.setPlugin( 'aPlugin' )
     self.assertTrue( res['OK'] )
 
@@ -426,7 +426,7 @@ class TransformationSuccess( ClientsTestCase ):
     """
 
     res = self.transformation.getParameters()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     defaultParams = res['Value'].copy()
     for parameterName, defaultValue in res['Value'].items():
       if isinstance( defaultValue, basestring ):
@@ -436,24 +436,24 @@ class TransformationSuccess( ClientsTestCase ):
       # # set*
 
       setterName = 'set%s' % parameterName
-      self.assert_( hasattr( self.transformation, setterName ) )
+      self.assertTrue( hasattr( self.transformation, setterName ) )
       setter = getattr( self.transformation, setterName )
-      self.assert_( callable( setter ) )
+      self.assertTrue( callable( setter ) )
       res = setter( testValue )
-      self.assert_( res['OK'] )
+      self.assertTrue(res['OK'])
       # # get*
       getterName = "get%s" % parameterName
-      self.assert_( hasattr( self.transformation, getterName ) )
+      self.assertTrue( hasattr( self.transformation, getterName ) )
       getter = getattr( self.transformation, getterName )
-      self.assert_( callable( getter ) )
+      self.assertTrue( callable( getter ) )
       res = getter()
-      self.assert_( res['OK'] )
-      self.assert_( res['Value'], testValue )
+      self.assertTrue(res['OK'])
+      self.assertTrue( res['Value'], testValue )
 
     res = self.transformation.reset()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = self.transformation.getParameters()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     for parameterName, resetValue in res['Value'].items():
       self.assertEqual( resetValue, defaultParams[parameterName] )
     self.assertRaises( AttributeError, self.transformation.getTargetSE )

--- a/Workflow/Modules/test/Test_Modules.py
+++ b/Workflow/Modules/test/Test_Modules.py
@@ -476,7 +476,7 @@ class FailoverRequestSuccess( ModulesTestCase ):
         self.fr.workflow_commons = wf_commons
         self.fr.step_commons = step_commons
         res = self.fr.execute()
-        self.assert_( res['OK'] )
+        self.assertTrue(res['OK'])
 
 #############################################################################
 # Scripy.py

--- a/Workflow/Utilities/test/Test_Utilities.py
+++ b/Workflow/Utilities/test/Test_Utilities.py
@@ -47,7 +47,7 @@ from DIRAC.Workflow.Modules.<MODULE> import <MODULE>
 
     stepDef = getStepDefinition( 'App_Step', ['Script', 'FailoverRequest'] )
 
-    self.assert_( str( appDefn ) == str( stepDef ) )
+    self.assertTrue( str( appDefn ) == str( stepDef ) )
 
 
 
@@ -59,7 +59,7 @@ from DIRAC.Workflow.Modules.<MODULE> import <MODULE>
                                  parametersList = [[ 'name', 'type', 'value', 'desc' ],
                                                    [ 'name1', 'type1', 'value1', 'desc1' ]] )
 
-    self.assert_( str( appDefn ) == str( stepDef ) )
+    self.assertTrue( str( appDefn ) == str( stepDef ) )
 
   def test_getStepCPUTimes( self ):
     execT, cpuT = getStepCPUTimes( {} )

--- a/WorkloadManagementSystem/Client/test/Test_Client_WorkloadManagementSystem.py
+++ b/WorkloadManagementSystem/Client/test/Test_Client_WorkloadManagementSystem.py
@@ -74,7 +74,7 @@ class DownloadInputDataSuccess( ClientsTestCase ):
     open( '1.txt', 'w' ).close()
     res = self.dli._downloadFromSE( '/a/lfn/1.txt', 'mySE', {'mySE': []}, 'aGuid' )
     # file would be already local, so no real download
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     try:
       os.remove( '1.txt' )
     except OSError:
@@ -93,7 +93,7 @@ class DownloadInputDataSuccess( ClientsTestCase ):
     open( '1.txt', 'w' ).close()
     res = self.dli._downloadFromBestSE( '/a/lfn/1.txt', {'mySE': []}, 'aGuid' )
     # file would be already local, so no real download
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     try:
       os.remove( '1.txt' )
     except OSError:

--- a/WorkloadManagementSystem/Utilities/test/Test_ParametricJob.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_ParametricJob.py
@@ -63,7 +63,7 @@ class TestParametricUtilityCase( unittest.TestCase ):
     self.assertEqual( nParam, 3 )
 
     result = generateParametricJobs( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
     jobDescList = result['Value']
     self.assertEqual( nParam, len( jobDescList ) )
@@ -81,7 +81,7 @@ class TestParametricUtilityCase( unittest.TestCase ):
     self.assertEqual( nParam, 3 )
 
     result = generateParametricJobs( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
     jobDescList = result['Value']
     self.assertEqual( nParam, len( jobDescList ) )
@@ -99,7 +99,7 @@ class TestParametricUtilityCase( unittest.TestCase ):
     self.assertEqual( nParam, 3 )
 
     result = generateParametricJobs( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
     jobDescList = result['Value']
     self.assertEqual( nParam, len( jobDescList ) )
@@ -117,7 +117,7 @@ class TestParametricUtilityCase( unittest.TestCase ):
     self.assertEqual( nParam, 3 )
 
     result = generateParametricJobs( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
     jobDescList = result['Value']
     self.assertEqual( nParam, len( jobDescList ) )

--- a/docs/source/DeveloperGuide/AddingNewComponents/YourFirstDIRACCode/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/YourFirstDIRACCode/index.rst
@@ -60,7 +60,7 @@ We will put the unit test in DIRAC.Core.Utilities.test. The unit test has been f
      def test_success( self ):
        self.gConfigMock.getValue.return_value = 'attendedValue'
        res = checkCAOfUser( 'aUser', 'attendedValue' )
-       self.assert_( res['OK'] )
+       self.assertTrue(res['OK'])
 
      def test_failure( self ):
        self.gConfigMock.getValue.return_value = 'unAttendedValue'

--- a/tests/Integration/DataManagementSystem/FIXME_Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/FIXME_Test_DataManager.py
@@ -22,15 +22,15 @@ class ReplicaManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assert_(putRes['OK'])
-    self.assert_(putRes['Value'].has_key('Successful'))
-    self.assert_(putRes['Value']['Successful'].has_key(lfn))
-    self.assert_(putRes['Value']['Successful'][lfn])
+    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['Value'].has_key('Successful'))
+    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assert_(removeRes['OK'])
-    self.assert_(removeRes['Value'].has_key('Successful'))
-    self.assert_(removeRes['Value']['Successful'].has_key(lfn))
-    self.assert_(removeRes['Value']['Successful'][lfn])
+    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['Value'].has_key('Successful'))
+    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterReplicate(self):
     print '\n\n#########################################################################\n\n\t\t\tReplication test\n'
@@ -41,20 +41,20 @@ class ReplicaManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assert_(putRes['OK'])
-    self.assert_(putRes['Value'].has_key('Successful'))
-    self.assert_(putRes['Value']['Successful'].has_key(lfn))
-    self.assert_(putRes['Value']['Successful'][lfn])
+    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['Value'].has_key('Successful'))
+    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replicate was successful
-    self.assert_(replicateRes['OK'])
-    self.assert_(replicateRes['Value'].has_key('Successful'))
-    self.assert_(replicateRes['Value']['Successful'].has_key(lfn))
-    self.assert_(replicateRes['Value']['Successful'][lfn])
+    self.assertTrue(replicateRes['OK'])
+    self.assertTrue(replicateRes['Value'].has_key('Successful'))
+    self.assertTrue(replicateRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(replicateRes['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assert_(removeRes['OK'])
-    self.assert_(removeRes['Value'].has_key('Successful'))
-    self.assert_(removeRes['Value']['Successful'].has_key(lfn))
-    self.assert_(removeRes['Value']['Successful'][lfn])
+    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['Value'].has_key('Successful'))
+    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterGetReplicaMetadata(self):
     print '\n\n#########################################################################\n\n\t\t\tGet metadata test\n'
@@ -65,24 +65,24 @@ class ReplicaManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assert_(putRes['OK'])
-    self.assert_(putRes['Value'].has_key('Successful'))
-    self.assert_(putRes['Value']['Successful'].has_key(lfn))
-    self.assert_(putRes['Value']['Successful'][lfn])
+    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['Value'].has_key('Successful'))
+    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the metadata query was successful
-    self.assert_(metadataRes['OK'])
-    self.assert_(metadataRes['Value'].has_key('Successful'))
-    self.assert_(metadataRes['Value']['Successful'].has_key(lfn))
-    self.assert_(metadataRes['Value']['Successful'][lfn])
+    self.assertTrue(metadataRes['OK'])
+    self.assertTrue(metadataRes['Value'].has_key('Successful'))
+    self.assertTrue(metadataRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(metadataRes['Value']['Successful'][lfn])
     metadataDict = metadataRes['Value']['Successful'][lfn]
-    self.assert_(metadataDict.has_key('Cached'))
-    self.assert_(metadataDict.has_key('Migrated'))
-    self.assert_(metadataDict.has_key('Size'))
+    self.assertTrue(metadataDict.has_key('Cached'))
+    self.assertTrue(metadataDict.has_key('Migrated'))
+    self.assertTrue(metadataDict.has_key('Size'))
     # Check that the removal was successful
-    self.assert_(removeRes['OK'])
-    self.assert_(removeRes['Value'].has_key('Successful'))
-    self.assert_(removeRes['Value']['Successful'].has_key(lfn))
-    self.assert_(removeRes['Value']['Successful'][lfn])
+    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['Value'].has_key('Successful'))
+    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeRes['Value']['Successful'][lfn])
 
 
   def test_putAndRegsiterGetAccessUrl(self):
@@ -95,20 +95,20 @@ class ReplicaManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assert_(putRes['OK'])
-    self.assert_(putRes['Value'].has_key('Successful'))
-    self.assert_(putRes['Value']['Successful'].has_key(lfn))
-    self.assert_(putRes['Value']['Successful'][lfn])
+    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['Value'].has_key('Successful'))
+    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the access url was successful
-    self.assert_(getAccessUrlRes['OK'])
-    self.assert_(getAccessUrlRes['Value'].has_key('Successful'))
-    self.assert_(getAccessUrlRes['Value']['Successful'].has_key(lfn))
-    self.assert_(getAccessUrlRes['Value']['Successful'][lfn])
+    self.assertTrue(getAccessUrlRes['OK'])
+    self.assertTrue(getAccessUrlRes['Value'].has_key('Successful'))
+    self.assertTrue(getAccessUrlRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(getAccessUrlRes['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assert_(removeRes['OK'])
-    self.assert_(removeRes['Value'].has_key('Successful'))
-    self.assert_(removeRes['Value']['Successful'].has_key(lfn))
-    self.assert_(removeRes['Value']['Successful'][lfn])
+    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['Value'].has_key('Successful'))
+    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterRemoveReplica(self):
     print '\n\n#########################################################################\n\n\t\t\tRemove replica test\n'
@@ -119,20 +119,20 @@ class ReplicaManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assert_(putRes['OK'])
-    self.assert_(putRes['Value'].has_key('Successful'))
-    self.assert_(putRes['Value']['Successful'].has_key(lfn))
-    self.assert_(putRes['Value']['Successful'][lfn])
+    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['Value'].has_key('Successful'))
+    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
-    self.assert_(removeReplicaRes['OK'])
-    self.assert_(removeReplicaRes['Value'].has_key('Successful'))
-    self.assert_(removeReplicaRes['Value']['Successful'].has_key(lfn))
-    self.assert_(removeReplicaRes['Value']['Successful'][lfn])
+    self.assertTrue(removeReplicaRes['OK'])
+    self.assertTrue(removeReplicaRes['Value'].has_key('Successful'))
+    self.assertTrue(removeReplicaRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeReplicaRes['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assert_(removeRes['OK'])
-    self.assert_(removeRes['Value'].has_key('Successful'))
-    self.assert_(removeRes['Value']['Successful'].has_key(lfn))
-    self.assert_(removeRes['Value']['Successful'][lfn])
+    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['Value'].has_key('Successful'))
+    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_registerFile(self):
     lfn = '/lhcb/test/unit-test/ReplicaManager/registerFile/testFile.%s' % time.time()
@@ -146,20 +146,20 @@ class ReplicaManagerTestCase(unittest.TestCase):
     removeFileRes = self.dataManager.removeFile(lfn)
 
     # Check that the file registration was done correctly
-    self.assert_(registerRes['OK'])
-    self.assert_(registerRes['Value'].has_key('Successful'))
-    self.assert_(registerRes['Value']['Successful'].has_key(lfn))
-    self.assert_(registerRes['Value']['Successful'][lfn])
+    self.assertTrue(registerRes['OK'])
+    self.assertTrue(registerRes['Value'].has_key('Successful'))
+    self.assertTrue(registerRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(registerRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
-    # self.assert_(removeCatalogReplicaRes['OK'])
-    # self.assert_(removeCatalogReplicaRes['Value'].has_key('Successful'))
-    # self.assert_(removeCatalogReplicaRes['Value']['Successful'].has_key(lfn))
-    # self.assert_(removeCatalogReplicaRes['Value']['Successful'][lfn])
+    # self.assertTrue(removeCatalogReplicaRes['OK'])
+    # self.assertTrue(removeCatalogReplicaRes['Value'].has_key('Successful'))
+    # self.assertTrue(removeCatalogReplicaRes['Value']['Successful'].has_key(lfn))
+    # self.assertTrue(removeCatalogReplicaRes['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assert_(removeFileRes['OK'])
-    self.assert_(removeFileRes['Value'].has_key('Successful'))
-    self.assert_(removeFileRes['Value']['Successful'].has_key(lfn))
-    self.assert_(removeFileRes['Value']['Successful'][lfn])
+    self.assertTrue(removeFileRes['OK'])
+    self.assertTrue(removeFileRes['Value'].has_key('Successful'))
+    self.assertTrue(removeFileRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeFileRes['Value']['Successful'][lfn])
 
   def test_registerReplica(self):
     print '\n\n#########################################################################\n\n\t\t\tRegister replica test\n'
@@ -178,30 +178,30 @@ class ReplicaManagerTestCase(unittest.TestCase):
     removeFileRes = self.dataManager.removeFile(lfn)
 
     # Check that the file registration was done correctly
-    self.assert_(registerRes['OK'])
-    self.assert_(registerRes['Value'].has_key('Successful'))
-    self.assert_(registerRes['Value']['Successful'].has_key(lfn))
-    self.assert_(registerRes['Value']['Successful'][lfn])
+    self.assertTrue(registerRes['OK'])
+    self.assertTrue(registerRes['Value'].has_key('Successful'))
+    self.assertTrue(registerRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(registerRes['Value']['Successful'][lfn])
     # Check that the replica registration was successful
-    self.assert_(registerReplicaRes['OK'])
-    self.assert_(registerReplicaRes['Value'].has_key('Successful'))
-    self.assert_(registerReplicaRes['Value']['Successful'].has_key(lfn))
-    self.assert_(registerReplicaRes['Value']['Successful'][lfn])
+    self.assertTrue(registerReplicaRes['OK'])
+    self.assertTrue(registerReplicaRes['Value'].has_key('Successful'))
+    self.assertTrue(registerReplicaRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(registerReplicaRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
-    # self.assert_(removeCatalogReplicaRes1['OK'])
-    # self.assert_(removeCatalogReplicaRes1['Value'].has_key('Successful'))
-    # self.assert_(removeCatalogReplicaRes1['Value']['Successful'].has_key(lfn))
-    # self.assert_(removeCatalogReplicaRes1['Value']['Successful'][lfn])
+    # self.assertTrue(removeCatalogReplicaRes1['OK'])
+    # self.assertTrue(removeCatalogReplicaRes1['Value'].has_key('Successful'))
+    # self.assertTrue(removeCatalogReplicaRes1['Value']['Successful'].has_key(lfn))
+    # self.assertTrue(removeCatalogReplicaRes1['Value']['Successful'][lfn])
     # Check that the replica removal was successful
-    # self.assert_(removeCatalogReplicaRes2['OK'])
-    # self.assert_(removeCatalogReplicaRes2['Value'].has_key('Successful'))
-    # self.assert_(removeCatalogReplicaRes2['Value']['Successful'].has_key(lfn))
-    # self.assert_(removeCatalogReplicaRes2['Value']['Successful'][lfn])
+    # self.assertTrue(removeCatalogReplicaRes2['OK'])
+    # self.assertTrue(removeCatalogReplicaRes2['Value'].has_key('Successful'))
+    # self.assertTrue(removeCatalogReplicaRes2['Value']['Successful'].has_key(lfn))
+    # self.assertTrue(removeCatalogReplicaRes2['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assert_(removeFileRes['OK'])
-    self.assert_(removeFileRes['Value'].has_key('Successful'))
-    self.assert_(removeFileRes['Value']['Successful'].has_key(lfn))
-    self.assert_(removeFileRes['Value']['Successful'][lfn])
+    self.assertTrue(removeFileRes['OK'])
+    self.assertTrue(removeFileRes['Value'].has_key('Successful'))
+    self.assertTrue(removeFileRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeFileRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterGet(self):
     print '\n\n#########################################################################\n\n\t\t\tGet file test\n'
@@ -215,20 +215,20 @@ class ReplicaManagerTestCase(unittest.TestCase):
       os.remove(localFilePath)
 
     # Check that the put was successful
-    self.assert_(putRes['OK'])
-    self.assert_(putRes['Value'].has_key('Successful'))
-    self.assert_(putRes['Value']['Successful'].has_key(lfn))
-    self.assert_(putRes['Value']['Successful'][lfn])
+    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['Value'].has_key('Successful'))
+    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
-    self.assert_(getRes['OK'])
-    self.assert_(getRes['Value'].has_key('Successful'))
-    self.assert_(getRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(getRes['OK'])
+    self.assertTrue(getRes['Value'].has_key('Successful'))
+    self.assertTrue(getRes['Value']['Successful'].has_key(lfn))
     self.assertEqual(getRes['Value']['Successful'][lfn],localFilePath)
     # Check that the removal was successful
-    self.assert_(removeRes['OK'])
-    self.assert_(removeRes['Value'].has_key('Successful'))
-    self.assert_(removeRes['Value']['Successful'].has_key(lfn))
-    self.assert_(removeRes['Value']['Successful'][lfn])
+    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['Value'].has_key('Successful'))
+    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeRes['Value']['Successful'][lfn])
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase(ReplicaManagerTestCase)

--- a/tests/Integration/DataManagementSystem/Test_Client_DFC.py
+++ b/tests/Integration/DataManagementSystem/Test_Client_DFC.py
@@ -75,7 +75,7 @@ class UserGroupCase( DFCTestCase ):
 
     if isAdmin:
       # Check if our user is present
-      self.assert_( testUser in result['Value'], "getUsers failed: %s" % result )
+      self.assertTrue( testUser in result['Value'], "getUsers failed: %s" % result )
 
     # remove the user we created
     result = self.dfc.deleteUser( testUser )
@@ -108,7 +108,7 @@ class UserGroupCase( DFCTestCase ):
     self.assertEqual( result['OK'], expectedRes, "getGroups failed: %s" % result )
 
     if isAdmin:
-      self.assert_( testGroup in result['Value'] )
+      self.assertTrue( testGroup in result['Value'] )
 
     result = self.dfc.deleteGroup( testGroup )
     self.assertEqual( result['OK'], expectedRes, "deleteGroup failed: %s" % result )
@@ -135,33 +135,33 @@ class FileCase( DFCTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } } )
-    self.assert_( result['OK'], "addFile failed when adding new file %s" % result )
+    self.assertTrue( result['OK'], "addFile failed when adding new file %s" % result )
 
 
     result = self.dfc.exists( testFile )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
                        testFile, "exists( testFile) should be the same lfn %s" % result )
 
 
     result = self.dfc.exists( {testFile:'1000'} )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
                        testFile, "exists( testFile : 1000) should be the same lfn %s" % result )
 
     result = self.dfc.exists( {testFile:{'GUID' : '1000', 'PFN' : 'blabla'}} )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
                        testFile, "exists( testFile : 1000) should be the same lfn %s" % result )
 
     # In fact, we don't check if the GUID is correct...
     result = self.dfc.exists( {testFile:'1001'} )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
                        testFile, "exists( testFile : 1001) should be the same lfn %s" % result )
 
     result = self.dfc.exists( {testFile + '2' : '1000'} )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile + '2' ),
                        testFile, "exists( testFile2 : 1000) should return testFile %s" % result )
 
@@ -173,8 +173,8 @@ class FileCase( DFCTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } } )
-    self.assert_( result["OK"], "addFile failed when adding existing file %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "addFile failed: it should  be possible to add an existing lfn with the same attributes %s" % result )
+    self.assertTrue( result["OK"], "addFile failed when adding existing file %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "addFile failed: it should  be possible to add an existing lfn with the same attributes %s" % result )
 
   # Re-adding the same file
     result = self.dfc.addFile( { testFile: { 'PFN': 'testfilePFN',
@@ -182,8 +182,8 @@ class FileCase( DFCTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'1' } } )
-    self.assert_( result["OK"], "addFile failed when adding existing file %s" % result )
-    self.assert_( testFile in result["Value"]["Failed"], "addFile failed: it should not be possible to add an existing lfn with the different attributes %s" % result )
+    self.assertTrue( result["OK"], "addFile failed when adding existing file %s" % result )
+    self.assertTrue( testFile in result["Value"]["Failed"], "addFile failed: it should not be possible to add an existing lfn with the different attributes %s" % result )
 
 
     # Re-adding the different LFN but same GUID
@@ -192,83 +192,83 @@ class FileCase( DFCTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } } )
-    self.assert_( result["OK"], "addFile failed when adding non existing file with existing GUID %s" % result )
-    self.assert_( testFile + '2' in result["Value"]["Failed"], "addFile failed: it should not be possible to add an existing GUID %s" % result )
+    self.assertTrue( result["OK"], "addFile failed when adding non existing file with existing GUID %s" % result )
+    self.assertTrue( testFile + '2' in result["Value"]["Failed"], "addFile failed: it should not be possible to add an existing GUID %s" % result )
 
 
     ##################################################################################
     # Setting existing status of existing file
     result = self.dfc.setFileStatus( {testFile:"AprioriGood"} )
-    self.assert_( result["OK"], "setFileStatus failed when setting existing status of existing file %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "setFileStatus failed: %s should be in successful (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "setFileStatus failed when setting existing status of existing file %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "setFileStatus failed: %s should be in successful (%s)" % ( testFile, result ) )
 
     # Setting unexisting status of existing file
     result = self.dfc.setFileStatus( {testFile:"Happy"} )
-    self.assert_( result["OK"], "setFileStatus failed when setting un-existing status of existing file %s" % result )
-    self.assert_( testFile in result["Value"]["Failed"], "setFileStatus should have failed %s" % result )
+    self.assertTrue( result["OK"], "setFileStatus failed when setting un-existing status of existing file %s" % result )
+    self.assertTrue( testFile in result["Value"]["Failed"], "setFileStatus should have failed %s" % result )
 
     # Setting existing status of unexisting file
     result = self.dfc.setFileStatus( {nonExistingFile:"Trash"} )
-    self.assert_( result["OK"], "setFileStatus failed when setting existing status of non-existing file %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "setFileStatus failed: %s should be in failed (%s)" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "setFileStatus failed when setting existing status of non-existing file %s" % result )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "setFileStatus failed: %s should be in failed (%s)" % ( nonExistingFile, result ) )
 
     ##################################################################################
 
     result = self.dfc.isFile( [testFile, nonExistingFile] )
-    self.assert_( result["OK"], "isFile failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "isFile : %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( result["Value"]["Successful"][testFile], "isFile : %s should be seen as a file %s" % ( testFile, result ) )
-    self.assert_( nonExistingFile in result["Value"]["Successful"], "isFile : %s should be in Successful %s" % ( nonExistingFile, result ) )
-    self.assert_( result["Value"]["Successful"][nonExistingFile] == False, "isFile : %s should be seen as a file %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "isFile failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "isFile : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["Value"]["Successful"][testFile], "isFile : %s should be seen as a file %s" % ( testFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Successful"], "isFile : %s should be in Successful %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["Value"]["Successful"][nonExistingFile] == False, "isFile : %s should be seen as a file %s" % ( nonExistingFile, result ) )
 
     result = self.dfc.changePathOwner( {testFile :  "toto", nonExistingFile : "tata"} )
-    self.assert_( result["OK"], "changePathOwner failed: %s" % result )
+    self.assertTrue( result["OK"], "changePathOwner failed: %s" % result )
 
     # Only admin can change path owner
     if isAdmin:
-      self.assert_( testFile in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( testFile, result ) )
+      self.assertTrue( testFile in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( testFile, result ) )
     else:
-      self.assert_( testFile in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( testFile, result ) )
+      self.assertTrue( testFile in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( testFile, result ) )
       
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
     # Only admin can change path group
     result = self.dfc.changePathGroup( {testFile : "toto", nonExistingFile :"tata"} )
-    self.assert_( result["OK"], "changePathGroup failed: %s" % result )
+    self.assertTrue( result["OK"], "changePathGroup failed: %s" % result )
     if isAdmin:
-      self.assert_( testFile in result["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( testFile, result ) )
+      self.assertTrue( testFile in result["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( testFile, result ) )
     else:
-      self.assert_( testFile in result["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( testFile, result ) )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( nonExistingFile, result ) )
+      self.assertTrue( testFile in result["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( testFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
     result = self.dfc.changePathMode( {testFile : 044, nonExistingFile : 044} )
-    self.assert_( result["OK"], "changePathMode failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "changePathMode : %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "changePathMode : %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "changePathMode failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "changePathMode : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "changePathMode : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
     result = self.dfc.getFileSize( [testFile, nonExistingFile] )
-    self.assert_( result["OK"], "getFileSize failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getFileSize : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getFileSize failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getFileSize : %s should be in Successful %s" % ( testFile, result ) )
     self.assertEqual( result["Value"]["Successful"][testFile], 123, "getFileSize got incorrect file size %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "getFileSize : %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "getFileSize : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
     result = self.dfc.getFileMetadata( [testFile, nonExistingFile] )
-    self.assert_( result["OK"], "getFileMetadata failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getFileMetadata : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getFileMetadata failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getFileMetadata : %s should be in Successful %s" % ( testFile, result ) )
 
     # The owner changed only if we are admin
     if isAdmin:
       self.assertEqual( result["Value"]["Successful"][testFile]["Owner"], "toto", "getFileMetadata got incorrect Owner %s" % result )
 
     self.assertEqual( result["Value"]["Successful"][testFile]["Status"], "AprioriGood", "getFileMetadata got incorrect status %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "getFileMetadata : %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "getFileMetadata : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
 
     result = self.dfc.removeFile( [testFile, nonExistingFile] )
-    self.assert_( result["OK"], "removeFile failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "removeFile : %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( result["Value"]["Successful"][testFile], "removeFile : %s should be in True %s" % ( testFile, result ) )
-    self.assert_( result["Value"]["Successful"][nonExistingFile], "removeFile : %s should be in True %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "removeFile failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "removeFile : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["Value"]["Successful"][testFile], "removeFile : %s should be in True %s" % ( testFile, result ) )
+    self.assertTrue( result["Value"]["Successful"][nonExistingFile], "removeFile : %s should be in True %s" % ( nonExistingFile, result ) )
 
 
 
@@ -284,66 +284,66 @@ class ReplicaCase( DFCTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } } )
-    self.assert_( result['OK'], "addFile failed when adding new file %s" % result )
+    self.assertTrue( result['OK'], "addFile failed when adding new file %s" % result )
 
     # Adding new replica
     result = self.dfc.addReplica( {testFile : {"PFN" : "testFilePFN", "SE" : "otherSE"}} )
-    self.assert_( result['OK'], "addReplica failed when adding new Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "addReplica failed when adding new Replica %s" % result )
+    self.assertTrue( result['OK'], "addReplica failed when adding new Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "addReplica failed when adding new Replica %s" % result )
 
     # Adding the same replica
     result = self.dfc.addReplica( {testFile : {"PFN" : "testFilePFN", "SE" : "otherSE"}} )
-    self.assert_( result['OK'], "addReplica failed when adding new Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "addReplica failed when adding new Replica %s" % result )
+    self.assertTrue( result['OK'], "addReplica failed when adding new Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "addReplica failed when adding new Replica %s" % result )
 
     # Adding replica of a non existing file
     result = self.dfc.addReplica( {nonExistingFile : {"PFN" : "IdontexistPFN", "SE" : "otherSE"}} )
-    self.assert_( result['OK'], "addReplica failed when adding Replica to non existing Replica %s" % result )
-    self.assert_( nonExistingFile in result['Value']["Failed"], "addReplica for non existing file should go in Failed  %s" % result )
+    self.assertTrue( result['OK'], "addReplica failed when adding Replica to non existing Replica %s" % result )
+    self.assertTrue( nonExistingFile in result['Value']["Failed"], "addReplica for non existing file should go in Failed  %s" % result )
 
 
     # Setting existing status of existing Replica
     result = self.dfc.setReplicaStatus( {testFile: {"Status" : "Trash", "SE" : "otherSE"}} )
-    self.assert_( result["OK"], "setReplicaStatus failed when setting existing status of existing Replica %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "setReplicaStatus failed: %s should be in successful (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "setReplicaStatus failed when setting existing status of existing Replica %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "setReplicaStatus failed: %s should be in successful (%s)" % ( testFile, result ) )
 
     # Setting non existing status of existing Replica
     result = self.dfc.setReplicaStatus( {testFile: {"Status" : "randomStatus", "SE" : "otherSE"}} )
-    self.assert_( result["OK"], "setReplicaStatus failed when setting non-existing status of existing Replica %s" % result )
-    self.assert_( testFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "setReplicaStatus failed when setting non-existing status of existing Replica %s" % result )
+    self.assertTrue( testFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( testFile, result ) )
 
     # Setting existing status of non-existing Replica
     result = self.dfc.setReplicaStatus( {testFile: {"Status" : "Trash", "SE" : "nonExistingSe"}} )
-    self.assert_( result["OK"], "setReplicaStatus failed when setting existing status of non-existing Replica %s" % result )
-    self.assert_( testFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "setReplicaStatus failed when setting existing status of non-existing Replica %s" % result )
+    self.assertTrue( testFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( testFile, result ) )
 
     # Setting existing status of non-existing File
     result = self.dfc.setReplicaStatus( {nonExistingFile: {"Status" : "Trash", "SE" : "nonExistingSe"}} )
-    self.assert_( result["OK"], "setReplicaStatus failed when setting existing status of non-existing File %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "setReplicaStatus failed when setting existing status of non-existing File %s" % result )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( nonExistingFile, result ) )
 
 
     # Getting existing status of existing Replica but not visible
     result = self.dfc.getReplicaStatus( {testFile: "testSE"} )
-    self.assert_( result["OK"], "getReplicaStatus failed when getting existing status of existing Replica %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getReplicaStatus failed: %s should be in Successful (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getReplicaStatus failed when getting existing status of existing Replica %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getReplicaStatus failed: %s should be in Successful (%s)" % ( testFile, result ) )
 
     # Getting existing status of existing Replica but not visible
     result = self.dfc.getReplicaStatus( {testFile : "otherSE"} )
-    self.assert_( result["OK"], "getReplicaStatus failed when getting existing status of existing Replica but not visible %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getReplicaStatus failed: %s should be in Successful (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getReplicaStatus failed when getting existing status of existing Replica but not visible %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getReplicaStatus failed: %s should be in Successful (%s)" % ( testFile, result ) )
 
     # Getting status of non-existing File but not visible
     result = self.dfc.getReplicaStatus( {nonExistingFile: "testSE"} )
-    self.assert_( result["OK"], "getReplicaStatus failed when getting status of non existing File %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "getReplicaStatus failed: %s should be in failed (%s)" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "getReplicaStatus failed when getting status of non existing File %s" % result )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "getReplicaStatus failed: %s should be in failed (%s)" % ( nonExistingFile, result ) )
 
     # Getting replicas of existing File and non existing file, seeing all replicas
     result = self.dfc.getReplicas( [testFile, nonExistingFile], allStatus = True )
-    self.assert_( result["OK"], "getReplicas failed %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getReplicas failed, %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getReplicas failed %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getReplicas failed, %s should be in Successful %s" % ( testFile, result ) )
     self.assertEqual( result["Value"]["Successful"][testFile], {"otherSE" : testFile, "testSE" : testFile}, "getReplicas failed, %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "getReplicas failed, %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "getReplicas failed, %s should be in Failed %s" % ( nonExistingFile, result ) )
 
 
     expectedSize = {'PhysicalSize': {'TotalSize': 246,
@@ -353,41 +353,41 @@ class ReplicaCase( DFCTestCase ):
                                  'LogicalFiles': 1, 'LogicalDirectories': 0L, 'LogicalSize': 123}
 
     result = self.dfc.getDirectorySize( [testDir], True, False )
-    self.assert_( result["OK"], "getDirectorySize failed: %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "getDirectorySize : %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( result["OK"], "getDirectorySize failed: %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "getDirectorySize : %s should be in Successful %s" % ( testDir, result ) )
     self.assertEqual( result["Value"]["Successful"][testDir], expectedSize, "getDirectorySize got incorrect directory size %s" % result )
 
     result = self.dfc.getDirectorySize( [testDir], True, True )
 
-    self.assert_( result["OK"], "getDirectorySize (calc) failed: %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "getDirectorySize (calc): %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( result["OK"], "getDirectorySize (calc) failed: %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "getDirectorySize (calc): %s should be in Successful %s" % ( testDir, result ) )
     self.assertEqual( result["Value"]["Successful"][testDir], expectedSize, "getDirectorySize got incorrect directory size %s" % result )
 
 
 
     # removing master replica
     result = self.dfc.removeReplica( {testFile : { "SE" : "testSE"}} )
-    self.assert_( result['OK'], "removeReplica failed when removing master Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "removeReplica failed when removing master Replica %s" % result )
+    self.assertTrue( result['OK'], "removeReplica failed when removing master Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "removeReplica failed when removing master Replica %s" % result )
 
     # removing non existing replica of existing File
     result = self.dfc.removeReplica( {testFile : { "SE" : "nonExistingSe2"}} )
-    self.assert_( result['OK'], "removeReplica failed when removing non existing Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "removeReplica failed when removing new Replica %s" % result )
+    self.assertTrue( result['OK'], "removeReplica failed when removing non existing Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "removeReplica failed when removing new Replica %s" % result )
 
     # removing non existing replica of non existing file
     result = self.dfc.removeReplica( {nonExistingFile : { "SE" : "nonExistingSe3"}} )
-    self.assert_( result['OK'], "removeReplica failed when removing replica of non existing File %s" % result )
-    self.assert_( nonExistingFile in result['Value']["Successful"], "removeReplica of non existing file, %s should be in Successful %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result['OK'], "removeReplica failed when removing replica of non existing File %s" % result )
+    self.assertTrue( nonExistingFile in result['Value']["Successful"], "removeReplica of non existing file, %s should be in Successful %s" % ( nonExistingFile, result ) )
 
     # removing last replica
     result = self.dfc.removeReplica( {testFile : { "SE" : "otherSE"}} )
-    self.assert_( result['OK'], "removeReplica failed when removing last Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "removeReplica failed when removing last Replica %s" % result )
+    self.assertTrue( result['OK'], "removeReplica failed when removing last Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "removeReplica failed when removing last Replica %s" % result )
 
     # Cleaning after us
     result = self.dfc.removeFile( testFile )
-    self.assert_( result["OK"], "removeFile failed: %s" % result )
+    self.assertTrue( result["OK"], "removeFile failed: %s" % result )
 
 
 
@@ -400,54 +400,54 @@ class DirectoryCase( DFCTestCase ):
     """
     # Adding a new directory
     result = self.dfc.createDirectory( testDir )
-    self.assert_( result['OK'], "addDirectory failed when adding new directory %s" % result )
+    self.assertTrue( result['OK'], "addDirectory failed when adding new directory %s" % result )
 
     result = self.dfc.addFile( { testFile: { 'PFN': 'testfile',
                                          'SE': 'testSE' ,
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } } )
-    self.assert_( result['OK'], "addFile failed when adding new file %s" % result )
+    self.assertTrue( result['OK'], "addFile failed when adding new file %s" % result )
 
 
 
     # Re-adding the same directory (CAUTION, different from addFile)
     result = self.dfc.createDirectory( testDir )
-    self.assert_( result["OK"], "addDirectory failed when adding existing directory %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "addDirectory failed: it should be possible to add an existing lfn %s" % result )
+    self.assertTrue( result["OK"], "addDirectory failed when adding existing directory %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "addDirectory failed: it should be possible to add an existing lfn %s" % result )
 
 
     result = self.dfc.isDirectory( [testDir, nonExistingDir] )
-    self.assert_( result["OK"], "isDirectory failed: %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "isDirectory : %s should be in Successful %s" % ( testDir, result ) )
-    self.assert_( result["Value"]["Successful"][testDir], "isDirectory : %s should be seen as a directory %s" % ( testDir, result ) )
-    self.assert_( nonExistingDir in result["Value"]["Successful"], "isDirectory : %s should be in Successful %s" % ( nonExistingDir, result ) )
-    self.assert_( result["Value"]["Successful"][nonExistingDir] == False, "isDirectory : %s should be seen as a directory %s" % ( nonExistingDir, result ) )
+    self.assertTrue( result["OK"], "isDirectory failed: %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "isDirectory : %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( result["Value"]["Successful"][testDir], "isDirectory : %s should be seen as a directory %s" % ( testDir, result ) )
+    self.assertTrue( nonExistingDir in result["Value"]["Successful"], "isDirectory : %s should be in Successful %s" % ( nonExistingDir, result ) )
+    self.assertTrue( result["Value"]["Successful"][nonExistingDir] == False, "isDirectory : %s should be seen as a directory %s" % ( nonExistingDir, result ) )
 
     result = self.dfc.getDirectorySize( [testDir, nonExistingDir], False, False )
-    self.assert_( result["OK"], "getDirectorySize failed: %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "getDirectorySize : %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( result["OK"], "getDirectorySize failed: %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "getDirectorySize : %s should be in Successful %s" % ( testDir, result ) )
     self.assertEqual( result["Value"]["Successful"][testDir], {'LogicalFiles': 1, 'LogicalDirectories': 0, 'LogicalSize': 123}, "getDirectorySize got incorrect directory size %s" % result )
-    self.assert_( nonExistingDir in result["Value"]["Failed"], "getDirectorySize : %s should be in Failed %s" % ( nonExistingDir, result ) )
+    self.assertTrue( nonExistingDir in result["Value"]["Failed"], "getDirectorySize : %s should be in Failed %s" % ( nonExistingDir, result ) )
 
 
     result = self.dfc.getDirectorySize( [testDir, nonExistingDir], False, True )
-    self.assert_( result["OK"], "getDirectorySize (calc) failed: %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "getDirectorySize (calc): %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( result["OK"], "getDirectorySize (calc) failed: %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "getDirectorySize (calc): %s should be in Successful %s" % ( testDir, result ) )
     self.assertEqual( result["Value"]["Successful"][testDir], {'LogicalFiles': 1, 'LogicalDirectories': 0, 'LogicalSize': 123}, "getDirectorySize got incorrect directory size %s" % result )
-    self.assert_( nonExistingDir in result["Value"]["Failed"], "getDirectorySize (calc) : %s should be in Failed %s" % ( nonExistingDir, result ) )
+    self.assertTrue( nonExistingDir in result["Value"]["Failed"], "getDirectorySize (calc) : %s should be in Failed %s" % ( nonExistingDir, result ) )
 
 
 
     result = self.dfc.listDirectory( [parentDir, testDir, nonExistingDir] )
-    self.assert_( result["OK"], "listDirectory failed: %s" % result )
-    self.assert_( parentDir in result["Value"]["Successful"], "listDirectory : %s should be in Successful %s" % ( parentDir, result ) )
+    self.assertTrue( result["OK"], "listDirectory failed: %s" % result )
+    self.assertTrue( parentDir in result["Value"]["Successful"], "listDirectory : %s should be in Successful %s" % ( parentDir, result ) )
     self.assertEqual( result["Value"]["Successful"][parentDir]["SubDirs"].keys(), [testDir], \
                      "listDir : incorrect content for %s (%s)" % ( parentDir, result ) )
-    self.assert_( testDir in result["Value"]["Successful"], "listDirectory : %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( testDir in result["Value"]["Successful"], "listDirectory : %s should be in Successful %s" % ( testDir, result ) )
     self.assertEqual( result["Value"]["Successful"][testDir]["Files"].keys(), [testFile], \
                      "listDir : incorrect content for %s (%s)" % ( testDir, result ) )
-    self.assert_( nonExistingDir in result["Value"]["Failed"], "listDirectory : %s should be in Failed %s" % ( nonExistingDir, result ) )
+    self.assertTrue( nonExistingDir in result["Value"]["Failed"], "listDirectory : %s should be in Failed %s" % ( nonExistingDir, result ) )
 
 
 
@@ -465,36 +465,36 @@ class DirectoryCase( DFCTestCase ):
 
       result2 = self.dfc.getDirectoryMetadata( [parentDir, testDir] )
 
-      self.assert_( result["OK"], "changePathOwner failed: %s" % result )
-      self.assert_( resultG["OK"], "changePathOwner failed: %s" % result )
-      self.assert_( resultM["OK"], "changePathMode failed: %s" % result )
+      self.assertTrue( result["OK"], "changePathOwner failed: %s" % result )
+      self.assertTrue( resultG["OK"], "changePathOwner failed: %s" % result )
+      self.assertTrue( resultM["OK"], "changePathMode failed: %s" % result )
 
 
-      self.assert_( result2["OK"], "getDirectoryMetadata failed: %s" % result )
+      self.assertTrue( result2["OK"], "getDirectoryMetadata failed: %s" % result )
 
       # Since we were the owner we should have been able to do it in any case, admin or not
 
-      self.assert_( parentDir in resultM["Value"]["Successful"], "changePathMode : %s should be in Successful %s" % ( parentDir, resultM ) )
+      self.assertTrue( parentDir in resultM["Value"]["Successful"], "changePathMode : %s should be in Successful %s" % ( parentDir, resultM ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Mode' ), 0777, "parentDir should have mode  %s %s" % ( 0777, result2 ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Mode' ), 0775, "testDir should not have changed %s" % result2 )
 
 
       if isAdmin:
-        self.assert_( parentDir in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( parentDir, result ) )
+        self.assertTrue( parentDir in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( parentDir, result ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Owner' ), 'toto', "parentDir should belong to  %s %s" % ( proxyUser, result2 ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Owner' ), proxyUser, "testDir should not have changed %s" % result2 )
 
-        self.assert_( parentDir in resultG["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultG ) )
+        self.assertTrue( parentDir in resultG["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultG ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'OwnerGroup' ), 'toto', "parentDir should belong to  %s %s" % ( proxyUser, result2 ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'OwnerGroup' ), proxyGroup, "testDir should not have changed %s" % result2 )
 
 
       else:
-        self.assert_( parentDir in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( parentDir, result ) )
+        self.assertTrue( parentDir in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( parentDir, result ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Owner' ), proxyUser, "parentDir should not have changed %s" % result2 )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Owner' ), proxyUser, "testDir should not have changed %s" % result2 )
 
-        self.assert_( parentDir in resultG["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( parentDir, resultG ) )
+        self.assertTrue( parentDir in resultG["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( parentDir, resultG ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'OwnerGroup' ), proxyGroup, "parentDir should not have changed %s" % result2 )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'OwnerGroup' ), proxyGroup, "testDir should not have changed %s" % result2 )
 
@@ -510,38 +510,38 @@ class DirectoryCase( DFCTestCase ):
     result2 = self.dfc.getDirectoryMetadata( [parentDir, testDir] )
     result3 = self.dfc.getFileMetadata( testFile )
 
-    self.assert_( result["OK"], "changePathOwner failed: %s" % result )
-    self.assert_( resultG["OK"], "changePathOwner failed: %s" % result )
-    self.assert_( resultM["OK"], "changePathMode failed: %s" % result )
+    self.assertTrue( result["OK"], "changePathOwner failed: %s" % result )
+    self.assertTrue( resultG["OK"], "changePathOwner failed: %s" % result )
+    self.assertTrue( resultM["OK"], "changePathMode failed: %s" % result )
 
-    self.assert_( result2["OK"], "getDirectoryMetadata failed: %s" % result )
-    self.assert_( result3["OK"], "getFileMetadata failed: %s" % result )
+    self.assertTrue( result2["OK"], "getDirectoryMetadata failed: %s" % result )
+    self.assertTrue( result3["OK"], "getFileMetadata failed: %s" % result )
     
     # Since we were the owner we should have been able to do it in any case, admin or not
-    self.assert_( parentDir in resultM["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultM ) )
+    self.assertTrue( parentDir in resultM["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultM ) )
     self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Mode' ), 0777, "parentDir should have mode %s %s" % ( 0777, result2 ) )
     self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Mode' ), 0777, "testDir should have mode %s %s" % ( 0777, result2 ) )
     self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'Mode' ), 0777, "testFile should have mode %s %s" % ( 0777, result3 ) )
       
     if isAdmin:
-      self.assert_( parentDir in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( parentDir, result ) )
+      self.assertTrue( parentDir in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( parentDir, result ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Owner' ), 'toto', "parentDir should belong to %s %s" % ( proxyUser, result2 ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Owner' ), 'toto', "testDir should belong to %s %s" % ( proxyUser, result2 ) )
       self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'Owner' ), 'toto', "testFile should belong to %s %s" % ( proxyUser, result3 ) )
       
-      self.assert_( parentDir in resultG["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultG ) )
+      self.assertTrue( parentDir in resultG["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultG ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'OwnerGroup' ), 'toto', "parentDir should belong to %s %s" % ( proxyGroup, result2 ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'OwnerGroup' ), 'toto', "testDir should belong to %s %s" % ( proxyGroup, result2 ) )
       self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'OwnerGroup' ), 'toto', "testFile should belong to %s %s" % ( proxyGroup, result3 ) )
 
   
     else:
-      self.assert_( parentDir in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( parentDir, result ) )
+      self.assertTrue( parentDir in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( parentDir, result ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Owner' ), proxyUser, "parentDir should not have changed %s" % result2 )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Owner' ), proxyUser, "testDir should not have changed %s" % result2 )
       self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'Owner' ), proxyUser, "testFile should not have changed %s" % result3 )
       
-      self.assert_( parentDir in resultG["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( parentDir, resultG ) )
+      self.assertTrue( parentDir in resultG["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( parentDir, resultG ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'OwnerGroup' ), proxyGroup, "parentDir should not have changed %s" % result2 )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'OwnerGroup' ), proxyGroup, "testDir should not have changed %s" % result2 )
       self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'OwnerGroup' ), proxyGroup, "testFile should not have changed %s" % result3 )
@@ -550,14 +550,14 @@ class DirectoryCase( DFCTestCase ):
 
     # Cleaning after us
     result = self.dfc.removeFile( testFile )
-    self.assert_( result["OK"], "removeFile failed: %s" % result )
+    self.assertTrue( result["OK"], "removeFile failed: %s" % result )
 
     result = self.dfc.removeDirectory( [testDir, nonExistingDir] )
-    self.assert_( result["OK"], "removeDirectory failed: %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "removeDirectory : %s should be in Successful %s" % ( testDir, result ) )
-    self.assert_( result["Value"]["Successful"][testDir], "removeDirectory : %s should be in True %s" % ( testDir, result ) )
-    self.assert_( nonExistingDir in result["Value"]["Successful"], "removeDirectory : %s should be in Successful %s" % ( nonExistingDir, result ) )
-    self.assert_( result["Value"]["Successful"][nonExistingDir], "removeDirectory : %s should be in True %s" % ( nonExistingDir, result ) )
+    self.assertTrue( result["OK"], "removeDirectory failed: %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "removeDirectory : %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( result["Value"]["Successful"][testDir], "removeDirectory : %s should be in True %s" % ( testDir, result ) )
+    self.assertTrue( nonExistingDir in result["Value"]["Successful"], "removeDirectory : %s should be in Successful %s" % ( nonExistingDir, result ) )
+    self.assertTrue( result["Value"]["Successful"][nonExistingDir], "removeDirectory : %s should be in True %s" % ( nonExistingDir, result ) )
 
 
 

--- a/tests/Integration/DataManagementSystem/Test_Client_FTS.py
+++ b/tests/Integration/DataManagementSystem/Test_Client_FTS.py
@@ -169,7 +169,7 @@ class FTSClientChain( FTSDBTestCase ):
     print 'deleteFiles'
     for i in self.opIDs:
       res = self.ftsClient.deleteFTSFiles( i )
-      self.assert_( res['OK'] )
+      self.assertTrue(res['OK'])
 
 class FTSClientMix( FTSDBTestCase ):
 
@@ -183,7 +183,7 @@ class FTSClientMix( FTSDBTestCase ):
 #    ftsSchedule can't work since the FTSStrategy object is refreshed in the service so it can't be mocked
 #    for opID in self.opIDs:
 #      res = self.ftsClient.ftsSchedule( 12345, opID, opFileList )
-#      self.assert_( res['OK'] )
+#      self.assertTrue(res['OK'])
 
     print 'setFTSFilesWaiting'
     for operationID in self.opIDs:
@@ -194,7 +194,7 @@ class FTSClientMix( FTSDBTestCase ):
     print 'getFTSHistory'
     res = self.ftsClient.getFTSHistory()
     self.assertEqual( res['OK'], True )
-    self.assert_( type( res['Value'] ) == type( [] ) )
+    self.assertTrue( type( res['Value'] ) == type( [] ) )
 
     print 'getFTSJobsForRequest'
     res = self.ftsClient.getFTSJobsForRequest( 12345 )
@@ -217,7 +217,7 @@ class FTSClientMix( FTSDBTestCase ):
     print 'deleteFiles'
     for i in self.opIDs:
       res = self.ftsClient.deleteFTSFiles( i )
-      self.assert_( res['OK'] )
+      self.assertTrue(res['OK'])
 
 
 if __name__ == '__main__':

--- a/tests/Integration/DataManagementSystem/Test_Client_FTS3.py
+++ b/tests/Integration/DataManagementSystem/Test_Client_FTS3.py
@@ -59,43 +59,43 @@ class TestClientFTS3( unittest.TestCase ):
   def test_01_operation( self ):
 
     op = self.generateOperation( 'Transfer', 3, ['Target1', 'Target2' ], sources = ['Source1', 'Source2'] )
-    self.assert_( not op.isTotallyProcessed() )
+    self.assertTrue( not op.isTotallyProcessed() )
 
     res = self.client.persistOperation( op )
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     opID = res['Value']
 
     res = self.client.getOperation( opID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     op2 = res['Value']
 
 
 
-    self.assert_( isinstance( op2, FTS3TransferOperation ) )
-    self.assert_( not op2.isTotallyProcessed() )
+    self.assertTrue( isinstance( op2, FTS3TransferOperation ) )
+    self.assertTrue( not op2.isTotallyProcessed() )
 
     for attr in ['username', 'userGroup', 'sourceSEs' ]:
-      self.assert_( getattr( op, attr ) == getattr( op2, attr ) )
+      self.assertTrue( getattr( op, attr ) == getattr( op2, attr ) )
 
-    self.assert_( len( op.ftsFiles ) == len( op2.ftsFiles ) )
+    self.assertTrue( len( op.ftsFiles ) == len( op2.ftsFiles ) )
 
-    self.assert_( op2.status == FTS3Operation.INIT_STATE )
+    self.assertTrue( op2.status == FTS3Operation.INIT_STATE )
 
     fileIds = []
     for ftsFile in op2.ftsFiles:
       fileIds.append( ftsFile.fileID )
-      self.assert_( ftsFile.status == FTS3File.INIT_STATE )
+      self.assertTrue( ftsFile.status == FTS3File.INIT_STATE )
 
     # # Testing the limit feature
     # res = self.client.getOperationsWithFilesToSubmit( limit = 0 )
     #
-    # self.assert_( res['OK'], res )
-    # self.assert_( not res['Value'] )
+    # self.assertTrue( res['OK'], res )
+    # self.assertTrue( not res['Value'] )
     #
     # res = self.client.getOperationsWithFilesToSubmit()
-    # self.assert_( res['OK'] )
-    # self.assert_( len( res['Value'] ) == 1 )
+    # self.assertTrue(res['OK'])
+    # self.assertTrue( len( res['Value'] ) == 1 )
 
 
 
@@ -106,29 +106,29 @@ class TestClientFTS3( unittest.TestCase ):
                               'error': '' if fId % 2 else 'Tough luck'}
 
     res = self.client.updateFileStatus( fileStatusDict )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     res = self.client.getOperation( opID )
     op3 = res['Value']
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
-    self.assert_( op3.ftsFiles )
+    self.assertTrue( op3.ftsFiles )
     for ftsFile in op3.ftsFiles:
       if ftsFile.fileID % 2:
-        self.assert_( ftsFile.status == 'Finished' )
-        self.assert_( not ftsFile.error )
+        self.assertTrue( ftsFile.status == 'Finished' )
+        self.assertTrue( not ftsFile.error )
       else:
-        self.assert_( ftsFile.status == 'Failed' )
-        self.assert_( ftsFile.error == 'Tough luck' )
+        self.assertTrue( ftsFile.status == 'Failed' )
+        self.assertTrue( ftsFile.error == 'Tough luck' )
 
 
-    self.assert_( not op3.isTotallyProcessed() )
+    self.assertTrue( not op3.isTotallyProcessed() )
 
 
     # # The operation still should be considered as having files to submit
     # res = self.client.getOperationsWithFilesToSubmit()
-    # self.assert_( res['OK'] )
-    # self.assert_( len( res['Value'] ) == 1 )
+    # self.assertTrue(res['OK'])
+    # self.assertTrue( len( res['Value'] ) == 1 )
 
 
 
@@ -139,43 +139,43 @@ class TestClientFTS3( unittest.TestCase ):
       fileStatusDict[fId] = { 'status' : FTS3File.FINAL_STATES[fId % nbFinalStates]}
 
     res = self.client.updateFileStatus( fileStatusDict )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     res = self.client.getOperation( opID )
     op4 = res['Value']
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
-    self.assert_( op4.ftsFiles )
+    self.assertTrue( op4.ftsFiles )
     for ftsFile in op4.ftsFiles:
       if ftsFile.fileID % 2:
         # Files to finished cannot be changed
-        self.assert_( ftsFile.status == 'Finished' )
-        self.assert_( not ftsFile.error )
+        self.assertTrue( ftsFile.status == 'Finished' )
+        self.assertTrue( not ftsFile.error )
       else:
-        self.assert_( ftsFile.status == FTS3File.FINAL_STATES[ftsFile.fileID % nbFinalStates] )
-        self.assert_( ftsFile.error == 'Tough luck' )
+        self.assertTrue( ftsFile.status == FTS3File.FINAL_STATES[ftsFile.fileID % nbFinalStates] )
+        self.assertTrue( ftsFile.error == 'Tough luck' )
 
 
     # Now it should be considered as totally processed
-    self.assert_( op4.isTotallyProcessed() )
+    self.assertTrue( op4.isTotallyProcessed() )
     res = self.client.persistOperation( op4 )
 
 
     # # The operation still should not be considered anymore
     # res = self.client.getOperationsWithFilesToSubmit()
-    # self.assert_( res['OK'] )
-    # self.assert_( not res['Value'] )
+    # self.assertTrue(res['OK'])
+    # self.assertTrue( not res['Value'] )
 
 
     # # The operation should be in Processed state in the DB
     # # testing limit 0
     # res = self.client.getProcessedOperations( limit = 0 )
-    # self.assert_( res['OK'] )
-    # self.assert_( not res['Value'] )
+    # self.assertTrue(res['OK'])
+    # self.assertTrue( not res['Value'] )
     #
     # res = self.client.getProcessedOperations()
-    # self.assert_( res['OK'] )
-    # self.assert_( len( res['Value'] ) == 1 )
+    # self.assertTrue(res['OK'])
+    # self.assertTrue( len( res['Value'] ) == 1 )
 
 
 
@@ -197,19 +197,19 @@ class TestClientFTS3( unittest.TestCase ):
     op.ftsJobs.append( job1 )
 
     res = self.client.persistOperation( op )
-    self.assert_( res['OK'], res )
+    self.assertTrue( res['OK'], res )
     opID = res['Value']
 
     res = self.client.getOperation( opID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     op2 = res['Value']
-    self.assert_( len( op2.ftsJobs ) == 1 )
+    self.assertTrue( len( op2.ftsJobs ) == 1 )
     job2 = op2.ftsJobs[0]
-    self.assert_( job2.operationID == opID )
+    self.assertTrue( job2.operationID == opID )
 
     for attr in ['ftsGUID', 'ftsServer', 'username', 'userGroup' ]:
-      self.assert_( getattr( job1, attr ) == getattr( job2, attr ) )
+      self.assertTrue( getattr( job1, attr ) == getattr( job2, attr ) )
 
 
 
@@ -224,14 +224,14 @@ class TestClientFTS3( unittest.TestCase ):
     for i in xrange( 1000 ):
       op = self.generateOperation( 'Transfer', i % 20 + 1, ['Dest1'] )
       res = db.persistOperation( op )
-      self.assert_( res['OK'] )
+      self.assertTrue(res['OK'])
       listOfIds.append( res['Value'] )
 
     persistEnd = time.time()
 
     for opId in listOfIds:
       res = db.getOperation( opId )
-      self.assert_( res['OK'] )
+      self.assertTrue(res['OK'])
 
     getEnd = time.time()
 

--- a/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py
+++ b/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py
@@ -128,7 +128,7 @@ class SECase ( FileCatalogDBTestCase ):
     ret = self.db.addSE( seName, credDict )
     if isAdmin:
 
-      self.assert_( ret["OK"], "addSE failed when adding new SE: %s" % ret )
+      self.assertTrue( ret["OK"], "addSE failed when adding new SE: %s" % ret )
 
       seId = ret["Value"]
       # create it again
@@ -213,31 +213,31 @@ class FileCase( FileCatalogDBTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } }, credDict )
-    self.assert_( result['OK'], "addFile failed when adding new file %s" % result )
+    self.assertTrue( result['OK'], "addFile failed when adding new file %s" % result )
     result = self.db.exists( testFile , credDict )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
                        testFile, "exists( testFile) should be the same lfn %s" % result )
 
 
     result = self.db.exists( {testFile:'1000'} , credDict )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
                        testFile, "exists( testFile : 1000) should be the same lfn %s" % result )
 
     result = self.db.exists( {testFile:{'GUID' : '1000', 'PFN' : 'blabla'}} , credDict )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
                        testFile, "exists( testFile : 1000) should be the same lfn %s" % result )
 
     # In fact, we don't check if the GUID is correct...
     result = self.db.exists( {testFile:'1001'}, credDict )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile ),
                        testFile, "exists( testFile : 1001) should be the same lfn %s" % result )
 
     result = self.db.exists( {testFile + '2' : '1000'}, credDict )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].get( 'Successful', {} ).get( testFile + '2' ),
                        testFile, "exists( testFile2 : 1000) should return testFile %s" % result )
 
@@ -247,8 +247,8 @@ class FileCase( FileCatalogDBTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } }, credDict )
-    self.assert_( result["OK"], "addFile failed when adding existing file with same param %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "addFile failed: it should be possible to add an existing lfn with same param %s" % result )
+    self.assertTrue( result["OK"], "addFile failed when adding existing file with same param %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "addFile failed: it should be possible to add an existing lfn with same param %s" % result )
 
     # Adding same file with different param
     result = self.db.addFile( { testFile: { 'PFN': 'testfile',
@@ -256,8 +256,8 @@ class FileCase( FileCatalogDBTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'1' } }, credDict )
-    self.assert_( result["OK"], "addFile failed when adding existing file with different parem %s" % result )
-    self.assert_( testFile in result["Value"]["Failed"], "addFile failed: it should not be possible to add an existing lfn with different param %s" % result )
+    self.assertTrue( result["OK"], "addFile failed when adding existing file with different parem %s" % result )
+    self.assertTrue( testFile in result["Value"]["Failed"], "addFile failed: it should not be possible to add an existing lfn with different param %s" % result )
 
 
     result = self.db.addFile( { testFile + '2':  { 'PFN': 'testfile',
@@ -265,76 +265,76 @@ class FileCase( FileCatalogDBTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } }, credDict )
-    self.assert_( result["OK"], "addFile failed when adding existing file %s" % result )
-    self.assert_( testFile + '2' in result["Value"]["Failed"], "addFile failed: it should not be possible to add a new lfn with existing GUID %s" % result )
+    self.assertTrue( result["OK"], "addFile failed when adding existing file %s" % result )
+    self.assertTrue( testFile + '2' in result["Value"]["Failed"], "addFile failed: it should not be possible to add a new lfn with existing GUID %s" % result )
 
     ##################################################################################
     # Setting existing status of existing file
     result = self.db.setFileStatus( {testFile:"AprioriGood"}, credDict )
-    self.assert_( result["OK"], "setFileStatus failed when setting existing status of existing file %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "setFileStatus failed: %s should be in successful (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "setFileStatus failed when setting existing status of existing file %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "setFileStatus failed: %s should be in successful (%s)" % ( testFile, result ) )
 
     # Setting unexisting status of existing file
     result = self.db.setFileStatus( {testFile:"Happy"}, credDict )
-    self.assert_( result["OK"], "setFileStatus failed when setting un-existing status of existing file %s" % result )
-    self.assert_( testFile in result["Value"]["Failed"], "setFileStatus should have failed %s" % result )
+    self.assertTrue( result["OK"], "setFileStatus failed when setting un-existing status of existing file %s" % result )
+    self.assertTrue( testFile in result["Value"]["Failed"], "setFileStatus should have failed %s" % result )
 
     # Setting existing status of unexisting file
     result = self.db.setFileStatus( {nonExistingFile:"Trash"}, credDict )
-    self.assert_( result["OK"], "setFileStatus failed when setting existing status of non-existing file %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "setFileStatus failed: %s should be in failed (%s)" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "setFileStatus failed when setting existing status of non-existing file %s" % result )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "setFileStatus failed: %s should be in failed (%s)" % ( nonExistingFile, result ) )
 
     ##################################################################################
 
     result = self.db.isFile( [testFile, nonExistingFile], credDict )
-    self.assert_( result["OK"], "isFile failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "isFile : %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( result["Value"]["Successful"][testFile], "isFile : %s should be seen as a file %s" % ( testFile, result ) )
-    self.assert_( nonExistingFile in result["Value"]["Successful"], "isFile : %s should be in Successful %s" % ( nonExistingFile, result ) )
-    self.assert_( result["Value"]["Successful"][nonExistingFile] == False, "isFile : %s should be seen as a file %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "isFile failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "isFile : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["Value"]["Successful"][testFile], "isFile : %s should be seen as a file %s" % ( testFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Successful"], "isFile : %s should be in Successful %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["Value"]["Successful"][nonExistingFile] == False, "isFile : %s should be seen as a file %s" % ( nonExistingFile, result ) )
 
     result = self.db.changePathOwner( {testFile :  "toto", nonExistingFile : "tata"}, credDict )
-    self.assert_( result["OK"], "changePathOwner failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "changePathOwner failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
     result = self.db.changePathGroup( {testFile : "toto", nonExistingFile :"tata"}, credDict )
-    self.assert_( result["OK"], "changePathGroup failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "changePathGroup failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
     result = self.db.changePathMode( {testFile : 044, nonExistingFile : 044}, credDict )
-    self.assert_( result["OK"], "changePathMode failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "changePathMode : %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "changePathMode : %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "changePathMode failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "changePathMode : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "changePathMode : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
     result = self.db.getFileSize( [testFile, nonExistingFile], credDict )
-    self.assert_( result["OK"], "getFileSize failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getFileSize : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getFileSize failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getFileSize : %s should be in Successful %s" % ( testFile, result ) )
     self.assertEqual( result["Value"]["Successful"][testFile], 123, "getFileSize got incorrect file size %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "getFileSize : %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "getFileSize : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
     result = self.db.getFileMetadata( [testFile, nonExistingFile], credDict )
-    self.assert_( result["OK"], "getFileMetadata failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getFileMetadata : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getFileMetadata failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getFileMetadata : %s should be in Successful %s" % ( testFile, result ) )
     self.assertEqual( result["Value"]["Successful"][testFile]["Owner"], "toto", "getFileMetadata got incorrect Owner %s" % result )
     self.assertEqual( result["Value"]["Successful"][testFile]["Status"], "AprioriGood", "getFileMetadata got incorrect status %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "getFileMetadata : %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "getFileMetadata : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
 #      DOES NOT FOLLOW THE SUCCESSFUL/FAILED CONVENTION
 #     result = self.db.getFileDetails( [testFile, nonExistingFile], credDict )
-#     self.assert_( result["OK"], "getFileDetails failed: %s" % result )
-#     self.assert_( testFile in result["Value"]["Successful"], "getFileDetails : %s should be in Successful %s" % ( testFile, result ) )
+#     self.assertTrue( result["OK"], "getFileDetails failed: %s" % result )
+#     self.assertTrue( testFile in result["Value"]["Successful"], "getFileDetails : %s should be in Successful %s" % ( testFile, result ) )
 #     self.assertEqual( result["Value"]["Successful"][testFile]["Owner"], "toto", "getFileDetails got incorrect Owner %s" % result )
-#     self.assert_( nonExistingFile in result["Value"]["Failed"], "getFileDetails : %s should be in Failed %s" % ( nonExistingFile, result ) )
+#     self.assertTrue( nonExistingFile in result["Value"]["Failed"], "getFileDetails : %s should be in Failed %s" % ( nonExistingFile, result ) )
 
 #    ADD SOMETHING ABOUT FILE ANCESTORS AND DESCENDENTS
 
     result = self.db.removeFile( [testFile, nonExistingFile], credDict )
-    self.assert_( result["OK"], "removeFile failed: %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "removeFile : %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( result["Value"]["Successful"][testFile], "removeFile : %s should be in True %s" % ( testFile, result ) )
-    self.assert_( result["Value"]["Successful"][nonExistingFile], "removeFile : %s should be in True %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "removeFile failed: %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "removeFile : %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["Value"]["Successful"][testFile], "removeFile : %s should be in True %s" % ( testFile, result ) )
+    self.assertTrue( result["Value"]["Successful"][nonExistingFile], "removeFile : %s should be in True %s" % ( nonExistingFile, result ) )
 
 
 
@@ -350,90 +350,90 @@ class ReplicaCase( FileCatalogDBTestCase ):
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } }, credDict )
-    self.assert_( result['OK'], "addFile failed when adding new file %s" % result )
+    self.assertTrue( result['OK'], "addFile failed when adding new file %s" % result )
 
     # Adding new replica
     result = self.db.addReplica( {testFile : {"PFN" : "testFile", "SE" : "otherSE"}}, credDict )
-    self.assert_( result['OK'], "addReplica failed when adding new Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "addReplica failed when adding new Replica %s" % result )
+    self.assertTrue( result['OK'], "addReplica failed when adding new Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "addReplica failed when adding new Replica %s" % result )
 
     # Adding the same replica
     result = self.db.addReplica( {testFile : {"PFN" : "testFile", "SE" : "otherSE"}}, credDict )
-    self.assert_( result['OK'], "addReplica failed when adding new Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "addReplica failed when adding new Replica %s" % result )
+    self.assertTrue( result['OK'], "addReplica failed when adding new Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "addReplica failed when adding new Replica %s" % result )
 
     # Adding replica of a non existing file
     result = self.db.addReplica( {nonExistingFile : {"PFN" : "Idontexist", "SE" : "otherSE"}}, credDict )
-    self.assert_( result['OK'], "addReplica failed when adding Replica to non existing Replica %s" % result )
-    self.assert_( nonExistingFile in result['Value']["Failed"], "addReplica for non existing file should go in Failed  %s" % result )
+    self.assertTrue( result['OK'], "addReplica failed when adding Replica to non existing Replica %s" % result )
+    self.assertTrue( nonExistingFile in result['Value']["Failed"], "addReplica for non existing file should go in Failed  %s" % result )
 
 
     # Setting existing status of existing Replica
     result = self.db.setReplicaStatus( {testFile: {"Status" : "Trash", "SE" : "otherSE"}}, credDict )
-    self.assert_( result["OK"], "setReplicaStatus failed when setting existing status of existing Replica %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "setReplicaStatus failed: %s should be in successful (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "setReplicaStatus failed when setting existing status of existing Replica %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "setReplicaStatus failed: %s should be in successful (%s)" % ( testFile, result ) )
 
     # Setting non existing status of existing Replica
     result = self.db.setReplicaStatus( {testFile: {"Status" : "randomStatus", "SE" : "otherSE"}}, credDict )
-    self.assert_( result["OK"], "setReplicaStatus failed when setting non-existing status of existing Replica %s" % result )
-    self.assert_( testFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "setReplicaStatus failed when setting non-existing status of existing Replica %s" % result )
+    self.assertTrue( testFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( testFile, result ) )
 
     # Setting existing status of non-existing Replica
     result = self.db.setReplicaStatus( {testFile: {"Status" : "Trash", "SE" : "nonExistingSe"}}, credDict )
-    self.assert_( result["OK"], "setReplicaStatus failed when setting existing status of non-existing Replica %s" % result )
-    self.assert_( testFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "setReplicaStatus failed when setting existing status of non-existing Replica %s" % result )
+    self.assertTrue( testFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( testFile, result ) )
 
     # Setting existing status of non-existing File
     result = self.db.setReplicaStatus( {nonExistingFile: {"Status" : "Trash", "SE" : "nonExistingSe"}}, credDict )
-    self.assert_( result["OK"], "setReplicaStatus failed when setting existing status of non-existing File %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "setReplicaStatus failed when setting existing status of non-existing File %s" % result )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "setReplicaStatus failed: %s should be in Failed (%s)" % ( nonExistingFile, result ) )
 
 
     # Getting existing status of existing Replica but not visible
     result = self.db.getReplicaStatus( {testFile: "testSE"}, credDict )
-    self.assert_( result["OK"], "getReplicaStatus failed when getting existing status of existing Replica %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getReplicaStatus failed: %s should be in Successful (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getReplicaStatus failed when getting existing status of existing Replica %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getReplicaStatus failed: %s should be in Successful (%s)" % ( testFile, result ) )
 
     # Getting existing status of existing Replica but not visible
     result = self.db.getReplicaStatus( {testFile : "otherSE"}, credDict )
-    self.assert_( result["OK"], "getReplicaStatus failed when getting existing status of existing Replica but not visible %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getReplicaStatus failed: %s should be in Successful (%s)" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getReplicaStatus failed when getting existing status of existing Replica but not visible %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getReplicaStatus failed: %s should be in Successful (%s)" % ( testFile, result ) )
 
     # Getting status of non-existing File but not visible
     result = self.db.getReplicaStatus( {nonExistingFile: "testSE"}, credDict )
-    self.assert_( result["OK"], "getReplicaStatus failed when getting status of non existing File %s" % result )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "getReplicaStatus failed: %s should be in failed (%s)" % ( nonExistingFile, result ) )
+    self.assertTrue( result["OK"], "getReplicaStatus failed when getting status of non existing File %s" % result )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "getReplicaStatus failed: %s should be in failed (%s)" % ( nonExistingFile, result ) )
 
     # Getting replicas of existing File and non existing file, seeing all replicas
     result = self.db.getReplicas( [testFile, nonExistingFile], allStatus = True, credDict = credDict )
-    self.assert_( result["OK"], "getReplicas failed %s" % result )
-    self.assert_( testFile in result["Value"]["Successful"], "getReplicas failed, %s should be in Successful %s" % ( testFile, result ) )
+    self.assertTrue( result["OK"], "getReplicas failed %s" % result )
+    self.assertTrue( testFile in result["Value"]["Successful"], "getReplicas failed, %s should be in Successful %s" % ( testFile, result ) )
     self.assertEqual( result["Value"]["Successful"][testFile], {"otherSE" : "", "testSE" : ""}, "getReplicas failed, %s should be in Successful %s" % ( testFile, result ) )
-    self.assert_( nonExistingFile in result["Value"]["Failed"], "getReplicas failed, %s should be in Failed %s" % ( nonExistingFile, result ) )
+    self.assertTrue( nonExistingFile in result["Value"]["Failed"], "getReplicas failed, %s should be in Failed %s" % ( nonExistingFile, result ) )
 
     # removing master replica
     result = self.db.removeReplica( {testFile : { "SE" : "testSE"}}, credDict )
-    self.assert_( result['OK'], "removeReplica failed when removing master Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "removeReplica failed when removing master Replica %s" % result )
+    self.assertTrue( result['OK'], "removeReplica failed when removing master Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "removeReplica failed when removing master Replica %s" % result )
 
     # removing non existing replica of existing File
     result = self.db.removeReplica( {testFile : { "SE" : "nonExistingSe2"}}, credDict )
-    self.assert_( result['OK'], "removeReplica failed when removing non existing Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "removeReplica failed when removing new Replica %s" % result )
+    self.assertTrue( result['OK'], "removeReplica failed when removing non existing Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "removeReplica failed when removing new Replica %s" % result )
 
     # removing non existing replica of non existing file
     result = self.db.removeReplica( {nonExistingFile : { "SE" : "nonExistingSe3"}}, credDict )
-    self.assert_( result['OK'], "removeReplica failed when removing replica of non existing File %s" % result )
-    self.assert_( nonExistingFile in result['Value']["Successful"], "removeReplica of non existing file, %s should be in Successful %s" % ( nonExistingFile, result ) )
+    self.assertTrue( result['OK'], "removeReplica failed when removing replica of non existing File %s" % result )
+    self.assertTrue( nonExistingFile in result['Value']["Successful"], "removeReplica of non existing file, %s should be in Successful %s" % ( nonExistingFile, result ) )
 
     # removing last replica
     result = self.db.removeReplica( {testFile : { "SE" : "otherSE"}}, credDict )
-    self.assert_( result['OK'], "removeReplica failed when removing last Replica %s" % result )
-    self.assert_( testFile in result['Value']["Successful"], "removeReplica failed when removing last Replica %s" % result )
+    self.assertTrue( result['OK'], "removeReplica failed when removing last Replica %s" % result )
+    self.assertTrue( testFile in result['Value']["Successful"], "removeReplica failed when removing last Replica %s" % result )
 
     # Cleaning after us
     result = self.db.removeFile( testFile, credDict )
-    self.assert_( result["OK"], "removeFile failed: %s" % result )
+    self.assertTrue( result["OK"], "removeFile failed: %s" % result )
 
 
 
@@ -446,54 +446,54 @@ class DirectoryCase( FileCatalogDBTestCase ):
     """
     # Adding a new directory
     result = self.db.createDirectory( testDir, credDict )
-    self.assert_( result['OK'], "addDirectory failed when adding new directory %s" % result )
+    self.assertTrue( result['OK'], "addDirectory failed when adding new directory %s" % result )
 
     result = self.db.addFile( { testFile: { 'PFN': 'testfile',
                                          'SE': 'testSE' ,
                                          'Size':123,
                                          'GUID':'1000',
                                          'Checksum':'0' } }, credDict )
-    self.assert_( result['OK'], "addFile failed when adding new file %s" % result )
+    self.assertTrue( result['OK'], "addFile failed when adding new file %s" % result )
 
 
 
     # Re-adding the same directory (CAUTION, different from addFile)
     result = self.db.createDirectory( testDir, credDict )
-    self.assert_( result["OK"], "addDirectory failed when adding existing directory %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "addDirectory failed: it should be possible to add an existing lfn %s" % result )
+    self.assertTrue( result["OK"], "addDirectory failed when adding existing directory %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "addDirectory failed: it should be possible to add an existing lfn %s" % result )
 
 
     result = self.db.isDirectory( [testDir, nonExistingDir], credDict )
-    self.assert_( result["OK"], "isDirectory failed: %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "isDirectory : %s should be in Successful %s" % ( testDir, result ) )
-    self.assert_( result["Value"]["Successful"][testDir], "isDirectory : %s should be seen as a directory %s" % ( testDir, result ) )
-    self.assert_( nonExistingDir in result["Value"]["Successful"], "isDirectory : %s should be in Successful %s" % ( nonExistingDir, result ) )
-    self.assert_( result["Value"]["Successful"][nonExistingDir] == False, "isDirectory : %s should be seen as a directory %s" % ( nonExistingDir, result ) )
+    self.assertTrue( result["OK"], "isDirectory failed: %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "isDirectory : %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( result["Value"]["Successful"][testDir], "isDirectory : %s should be seen as a directory %s" % ( testDir, result ) )
+    self.assertTrue( nonExistingDir in result["Value"]["Successful"], "isDirectory : %s should be in Successful %s" % ( nonExistingDir, result ) )
+    self.assertTrue( result["Value"]["Successful"][nonExistingDir] == False, "isDirectory : %s should be seen as a directory %s" % ( nonExistingDir, result ) )
 
     result = self.db.getDirectorySize( [testDir, nonExistingDir], False, False, credDict )
-    self.assert_( result["OK"], "getDirectorySize failed: %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "getDirectorySize : %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( result["OK"], "getDirectorySize failed: %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "getDirectorySize : %s should be in Successful %s" % ( testDir, result ) )
     self.assertEqual( result["Value"]["Successful"][testDir], {'LogicalFiles': 1, 'LogicalDirectories': 0, 'LogicalSize': 123}, "getDirectorySize got incorrect directory size %s" % result )
-    self.assert_( nonExistingDir in result["Value"]["Failed"], "getDirectorySize : %s should be in Failed %s" % ( nonExistingDir, result ) )
+    self.assertTrue( nonExistingDir in result["Value"]["Failed"], "getDirectorySize : %s should be in Failed %s" % ( nonExistingDir, result ) )
 
 
     result = self.db.getDirectorySize( [testDir, nonExistingDir], False, True, credDict )
-    self.assert_( result["OK"], "getDirectorySize (calc) failed: %s" % result )
-    self.assert_( testDir in result["Value"]["Successful"], "getDirectorySize (calc): %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( result["OK"], "getDirectorySize (calc) failed: %s" % result )
+    self.assertTrue( testDir in result["Value"]["Successful"], "getDirectorySize (calc): %s should be in Successful %s" % ( testDir, result ) )
     self.assertEqual( result["Value"]["Successful"][testDir], {'LogicalFiles': 1, 'LogicalDirectories': 0, 'LogicalSize': 123}, "getDirectorySize got incorrect directory size %s" % result )
-    self.assert_( nonExistingDir in result["Value"]["Failed"], "getDirectorySize (calc) : %s should be in Failed %s" % ( nonExistingDir, result ) )
+    self.assertTrue( nonExistingDir in result["Value"]["Failed"], "getDirectorySize (calc) : %s should be in Failed %s" % ( nonExistingDir, result ) )
 
 
 
     result = self.db.listDirectory( [parentDir, testDir, nonExistingDir], credDict )
-    self.assert_( result["OK"], "listDirectory failed: %s" % result )
-    self.assert_( parentDir in result["Value"]["Successful"], "listDirectory : %s should be in Successful %s" % ( parentDir, result ) )
+    self.assertTrue( result["OK"], "listDirectory failed: %s" % result )
+    self.assertTrue( parentDir in result["Value"]["Successful"], "listDirectory : %s should be in Successful %s" % ( parentDir, result ) )
     self.assertEqual( result["Value"]["Successful"][parentDir]["SubDirs"].keys(), [testDir], \
                      "listDir : incorrect content for %s (%s)" % ( parentDir, result ) )
-    self.assert_( testDir in result["Value"]["Successful"], "listDirectory : %s should be in Successful %s" % ( testDir, result ) )
+    self.assertTrue( testDir in result["Value"]["Successful"], "listDirectory : %s should be in Successful %s" % ( testDir, result ) )
     self.assertEqual( result["Value"]["Successful"][testDir]["Files"].keys(), [testFile.split( "/" )[-1]], \
                      "listDir : incorrect content for %s (%s)" % ( testDir, result ) )
-    self.assert_( nonExistingDir in result["Value"]["Failed"], "listDirectory : %s should be in Failed %s" % ( nonExistingDir, result ) )
+    self.assertTrue( nonExistingDir in result["Value"]["Failed"], "listDirectory : %s should be in Failed %s" % ( nonExistingDir, result ) )
 
 
 
@@ -510,37 +510,37 @@ class DirectoryCase( FileCatalogDBTestCase ):
 
       result2 = self.db.getDirectoryMetadata( [parentDir, testDir], credDict )
 
-      self.assert_( result["OK"], "changePathOwner failed: %s" % result )
-      self.assert_( resultG["OK"], "changePathOwner failed: %s" % result )
-      self.assert_( resultM["OK"], "changePathMode failed: %s" % result )
+      self.assertTrue( result["OK"], "changePathOwner failed: %s" % result )
+      self.assertTrue( resultG["OK"], "changePathOwner failed: %s" % result )
+      self.assertTrue( resultM["OK"], "changePathMode failed: %s" % result )
 
 
-      self.assert_( result2["OK"], "getDirectoryMetadata failed: %s" % result )
+      self.assertTrue( result2["OK"], "getDirectoryMetadata failed: %s" % result )
 
       # Since we were the owner we should have been able to do it in any case, admin or not
 
-      self.assert_( parentDir in resultM["Value"]["Successful"], "changePathMode : %s should be in Successful %s" % ( parentDir, resultM ) )
+      self.assertTrue( parentDir in resultM["Value"]["Successful"], "changePathMode : %s should be in Successful %s" % ( parentDir, resultM ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Mode' ), 0777, "parentDir should have mode  %s %s" % ( 0777, result2 ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Mode' ), 0775, "testDir should not have changed %s" % result2 )
 
 
       if isAdmin:
-        self.assert_( parentDir in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( parentDir, result ) )
+        self.assertTrue( parentDir in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( parentDir, result ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Owner' ), 'toto', "parentDir should belong to  %s %s" % ( proxyUser, result2 ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Owner' ), proxyUser, "testDir should not have changed %s" % result2 )
 
-        self.assert_( parentDir in resultG["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultG ) )
+        self.assertTrue( parentDir in resultG["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultG ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'OwnerGroup' ), 'toto', "parentDir should belong to  %s %s" % ( proxyUser, result2 ) )
         self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'OwnerGroup' ), proxyGroup, "testDir should not have changed %s" % result2 )
 
 
       else:
         # depends on the policy manager so I comment
-  #       self.assert_( parentDir in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( parentDir, result ) )
+  #       self.assertTrue( parentDir in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( parentDir, result ) )
   #       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Owner' ), proxyUser, "parentDir should not have changed %s" % result2 )
   #       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Owner' ), proxyUser, "testDir should not have changed %s" % result2 )
 
-  #       self.assert_( parentDir in resultG["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( parentDir, resultG ) )
+  #       self.assertTrue( parentDir in resultG["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( parentDir, resultG ) )
   #       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'OwnerGroup' ), proxyGroup, "parentDir should not have changed %s" % result2 )
   #       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'OwnerGroup' ), proxyGroup, "testDir should not have changed %s" % result2 )
         pass
@@ -554,26 +554,26 @@ class DirectoryCase( FileCatalogDBTestCase ):
     result2 = self.db.getDirectoryMetadata( [parentDir, testDir], credDict )
     result3 = self.db.getFileMetadata( testFile, credDict )
 
-    self.assert_( result["OK"], "changePathOwner failed: %s" % result )
-    self.assert_( resultG["OK"], "changePathOwner failed: %s" % result )
-    self.assert_( resultM["OK"], "changePathMode failed: %s" % result )
+    self.assertTrue( result["OK"], "changePathOwner failed: %s" % result )
+    self.assertTrue( resultG["OK"], "changePathOwner failed: %s" % result )
+    self.assertTrue( resultM["OK"], "changePathMode failed: %s" % result )
 
-    self.assert_( result2["OK"], "getDirectoryMetadata failed: %s" % result )
-    self.assert_( result3["OK"], "getFileMetadata failed: %s" % result )
+    self.assertTrue( result2["OK"], "getDirectoryMetadata failed: %s" % result )
+    self.assertTrue( result3["OK"], "getFileMetadata failed: %s" % result )
 
     # Since we were the owner we should have been able to do it in any case, admin or not
-    self.assert_( parentDir in resultM["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultM ) )
+    self.assertTrue( parentDir in resultM["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultM ) )
     self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Mode' ), 0777, "parentDir should have mode %s %s" % ( 0777, result2 ) )
     self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Mode' ), 0777, "testDir should have mode %s %s" % ( 0777, result2 ) )
     self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'Mode' ), 0777, "testFile should have mode %s %s" % ( 0777, result3 ) )
 
     if isAdmin:
-      self.assert_( parentDir in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( parentDir, result ) )
+      self.assertTrue( parentDir in result["Value"]["Successful"], "changePathOwner : %s should be in Successful %s" % ( parentDir, result ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Owner' ), 'toto', "parentDir should belong to %s %s" % ( proxyUser, result2 ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Owner' ), 'toto', "testDir should belong to %s %s" % ( proxyUser, result2 ) )
       self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'Owner' ), 'toto', "testFile should belong to %s %s" % ( proxyUser, result3 ) )
 
-      self.assert_( parentDir in resultG["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultG ) )
+      self.assertTrue( parentDir in resultG["Value"]["Successful"], "changePathGroup : %s should be in Successful %s" % ( parentDir, resultG ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'OwnerGroup' ), 'toto', "parentDir should belong to %s %s" % ( proxyGroup, result2 ) )
       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'OwnerGroup' ), 'toto', "testDir should belong to %s %s" % ( proxyGroup, result2 ) )
       self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'OwnerGroup' ), 'toto', "testFile should belong to %s %s" % ( proxyGroup, result3 ) )
@@ -582,12 +582,12 @@ class DirectoryCase( FileCatalogDBTestCase ):
     else:
         # depends on the policy manager so I comment
 
-#       self.assert_( parentDir in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( parentDir, result ) )
+#       self.assertTrue( parentDir in result["Value"]["Failed"], "changePathOwner : %s should be in Failed %s" % ( parentDir, result ) )
 #       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'Owner' ), proxyUser, "parentDir should not have changed %s" % result2 )
 #       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'Owner' ), proxyUser, "testDir should not have changed %s" % result2 )
 #       self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'Owner' ), proxyUser, "testFile should not have changed %s" % result3 )
 #
-#       self.assert_( parentDir in resultG["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( parentDir, resultG ) )
+#       self.assertTrue( parentDir in resultG["Value"]["Failed"], "changePathGroup : %s should be in Failed %s" % ( parentDir, resultG ) )
 #       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( parentDir, {} ).get( 'OwnerGroup' ), proxyGroup, "parentDir should not have changed %s" % result2 )
 #       self.assertEqual( result2['Value'].get( 'Successful', {} ).get( testDir, {} ).get( 'OwnerGroup' ), proxyGroup, "testDir should not have changed %s" % result2 )
 #       self.assertEqual( result3['Value'].get( 'Successful', {} ).get( testFile, {} ).get( 'OwnerGroup' ), proxyGroup, "testFile should not have changed %s" % result3 )
@@ -598,7 +598,7 @@ class DirectoryCase( FileCatalogDBTestCase ):
 
     # Cleaning after us
     result = self.db.removeFile( testFile, credDict )
-    self.assert_( result["OK"], "removeFile failed: %s" % result )
+    self.assertTrue( result["OK"], "removeFile failed: %s" % result )
 
 
     pathParts = testDir.split( '/' )[1:]
@@ -612,16 +612,16 @@ class DirectoryCase( FileCatalogDBTestCase ):
 
     for toRemove in pathToRemove:
       result = self.db.removeDirectory( toRemove, credDict )
-      self.assert_( result["OK"], "removeDirectory failed: %s" % result )
+      self.assertTrue( result["OK"], "removeDirectory failed: %s" % result )
 
 
 #
 #     result = self.db.removeDirectory( [testDir, nonExistingDir], credDict )
-#     self.assert_( result["OK"], "removeDirectory failed: %s" % result )
-#     self.assert_( testDir in result["Value"]["Successful"], "removeDirectory : %s should be in Successful %s" % ( testDir, result ) )
-#     self.assert_( result["Value"]["Successful"][testDir], "removeDirectory : %s should be in True %s" % ( testDir, result ) )
-#     self.assert_( nonExistingDir in result["Value"]["Successful"], "removeDirectory : %s should be in Successful %s" % ( nonExistingDir, result ) )
-#     self.assert_( result["Value"]["Successful"][nonExistingDir], "removeDirectory : %s should be in True %s" % ( nonExistingDir, result ) )
+#     self.assertTrue( result["OK"], "removeDirectory failed: %s" % result )
+#     self.assertTrue( testDir in result["Value"]["Successful"], "removeDirectory : %s should be in Successful %s" % ( testDir, result ) )
+#     self.assertTrue( result["Value"]["Successful"][testDir], "removeDirectory : %s should be in True %s" % ( testDir, result ) )
+#     self.assertTrue( nonExistingDir in result["Value"]["Successful"], "removeDirectory : %s should be in Successful %s" % ( nonExistingDir, result ) )
+#     self.assertTrue( result["Value"]["Successful"][nonExistingDir], "removeDirectory : %s should be in True %s" % ( nonExistingDir, result ) )
 
 
 
@@ -661,8 +661,8 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
     retTable = self.db.getDirectorySize( dirList, True, False, credDict )
     retCalc = self.db.getDirectorySize( dirList, True, True, credDict )
 
-    self.assert_( retTable["OK"] )
-    self.assert_( retCalc["OK"] )
+    self.assertTrue( retTable["OK"] )
+    self.assertTrue( retCalc["OK"] )
 
 
     succTable = retTable['Value']['Successful']
@@ -671,7 +671,7 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
     # Since we have simple type, the == is recursive for dict :-)
     retEquals = ( succTable == succCalc )
 
-    self.assert_( retEquals, "Calc and table results different %s %s" % ( succTable, succCalc ) )
+    self.assertTrue( retEquals, "Calc and table results different %s %s" % ( succTable, succCalc ) )
 
     return retTable
 
@@ -704,11 +704,11 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
     for sen in ['se1', 'se2', 'se3']:
       ret = self.db.addSE( sen, credDict )
-      self.assert_( ret["OK"] )
+      self.assertTrue( ret["OK"] )
 
     for din in [d1, d2]:
       ret = self.db.createDirectory( din, credDict )
-      self.assert_( ret["OK"] )
+      self.assertTrue( ret["OK"] )
 
 
     ret = self.db.addFile( { f1: { 'PFN': 'f1se1',
@@ -724,11 +724,11 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
 
 
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
 
     ret = self.getAndCompareDirectorySize( [d1, d2] )
 
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
     d1s1 = self.getPhysicalSize( val, d1, 'se1' )
@@ -743,10 +743,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
                                f2 : {"PFN" : "f1se3", "SE" : "se3"}},
                               credDict )
 
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1, d2] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
     d1s1 = self.getPhysicalSize( val, d1, 'se1' )
@@ -761,10 +761,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
 
     ret = self.db.removeFile( [f1], credDict )
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1, d2] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
     # Here we should have the KeyError, since there are no files left on s1 in principle
@@ -783,10 +783,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
 
     ret = self.db.removeReplica( {f2 : { "SE" : "se2"}}, credDict )
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1, d2] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
     # Here we should have the KeyError, since there are no files left on s1 in principle
@@ -814,10 +814,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
                                          'Checksum':'3' } }, credDict )
 
 
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
 
     ret = self.getAndCompareDirectorySize( [d1, d2] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
     d1s1 = self.getPhysicalSize( val, d1, 'se1' )
@@ -834,10 +834,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
 
     ret = self.db.removeReplica( {f1 : { "SE" : "se1"}}, credDict )
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1, d2] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
 
@@ -860,10 +860,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
 
     ret = self.db.removeFile( [f1], credDict )
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1, d2] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
     try:
@@ -886,10 +886,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
     ret = self.db.removeReplica( {f2 : { "SE" : "se3"},
                                   f3 : { "SE" : "se3"}}, credDict )
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1, d2] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
 
@@ -919,10 +919,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
 
     ret = self.db.removeFile( [f2, f3], credDict )
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1, d2] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
 
@@ -968,10 +968,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
     ret = self.db.removeReplica( {f1 : { "SE" : "se1"},
                                   f2 : { "SE" : "se1"}}, credDict )
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
 
@@ -983,10 +983,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
 
     ret = self.db.removeFile( [f1, f2], credDict )
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
     d1l = self.getLogicalSize( val, d1 )
     self.assertEqual( d1l , ( 0, 0 ), "Unexpected size %s, expected %s" % ( d1l, ( 0, 0 ) ) )
@@ -1002,10 +1002,10 @@ class DirectoryUsageCase ( FileCatalogDBTestCase ):
 
     ret = self.db.removeReplica( {f1 : { "SE" : "se2"}}, credDict )
 
-    self.assert_( ret['OK'] )
+    self.assertTrue( ret['OK'] )
 
     ret = self.getAndCompareDirectorySize( [d1] )
-    self.assert_( ret["OK"] )
+    self.assertTrue( ret["OK"] )
     val = ret['Value']['Successful']
 
     try:

--- a/tests/Integration/Framework/Test_ComponentInstallUninstall.py
+++ b/tests/Integration/Framework/Test_ComponentInstallUninstall.py
@@ -83,9 +83,9 @@ class ComponentInstallationChain( TestComponentInstallation ):
 
     # Check installation in CS
     cfg = self.csClient.getCurrentCFG()[ 'Value' ]
-    self.assert_( cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification/' ) and cfg.isOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification' ) )
+    self.assertTrue( cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification/' ) and cfg.isOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification' ) )
 
-    self.assert_( cfg.getOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification' ) == 'dips://' + self.host + ':' + str( self.notificationPort ) + '/Framework/Notification' )
+    self.assertTrue( cfg.getOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification' ) == 'dips://' + self.host + ':' + str( self.notificationPort ) + '/Framework/Notification' )
 
     # Check installation in database
     if not service1Present:
@@ -98,7 +98,7 @@ class ComponentInstallationChain( TestComponentInstallation ):
                                                        { 'System': 'Framework', 'Type': 'service', 'Module': 'Notification' },
                                                        {}, False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) == 1 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) == 1 )
 
     # Check whether the second service is already present or not
     cfg = self.csClient.getCurrentCFG()[ 'Value' ]
@@ -112,7 +112,7 @@ class ComponentInstallationChain( TestComponentInstallation ):
     # Check installation in CS
     self.csClient.downloadCSData()
     cfg = self.csClient.getCurrentCFG()[ 'Value' ]
-    self.assert_( cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification2/' ) and cfg.isOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification2' ) )
+    self.assertTrue( cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification2/' ) and cfg.isOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification2' ) )
 
     if not service1Present:
       # Uninstall component
@@ -121,7 +121,7 @@ class ComponentInstallationChain( TestComponentInstallation ):
     # Check CS is intact ( there should still be at least one instance of Notification )
     self.csClient.downloadCSData()
     cfg = self.csClient.getCurrentCFG()[ 'Value' ]
-    self.assert_( cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification/' ) and cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification/' ) and cfg.isOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification' ) )
+    self.assertTrue( cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification/' ) and cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification/' ) and cfg.isOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification' ) )
 
     if not service2Present:
       # Uninstall second component
@@ -131,7 +131,7 @@ class ComponentInstallationChain( TestComponentInstallation ):
       # Check uninstallation in CS ( only if the services were not already present )
       self.csClient.downloadCSData()
       cfg = self.csClient.getCurrentCFG()[ 'Value' ]
-      self.assert_( not cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification/' ) and not cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification2/' ) and not cfg.isOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification' ) )
+      self.assertTrue( not cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification/' ) and not cfg.isSection( 'Systems/Framework/' + self.frameworkSetup + '/Services/Notification2/' ) and not cfg.isOption( 'Systems/Framework/' + self.frameworkSetup + '/URLs/Notification' ) )
 
   def testDatabase( self ):
 
@@ -143,13 +143,13 @@ class ComponentInstallationChain( TestComponentInstallation ):
     # Check installation in CS
     self.csClient.downloadCSData()
     cfg = self.csClient.getCurrentCFG()[ 'Value' ]
-    self.assert_( cfg.isSection( 'Systems/DataManagement/' + self.frameworkSetup + '/Databases/FTSDB/' ) )
+    self.assertTrue( cfg.isSection( 'Systems/DataManagement/' + self.frameworkSetup + '/Databases/FTSDB/' ) )
 
     # Check in database
     result = self.monitoringClient.getInstallations( { 'Instance': 'FTSDB', 'UnInstallationTime': None, 'InstalledBy': self.user },
                                                      { 'System': 'DataManagement', 'Type': 'DB', 'Module': 'FTSDB' },
                                                      {}, False )
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) == 1 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) == 1 )
 
     # Uninstall database
     self.client.do_uninstall( 'db FTSDB' )
@@ -157,7 +157,7 @@ class ComponentInstallationChain( TestComponentInstallation ):
     # Check uninstallation in CS
     self.csClient.downloadCSData()
     cfg = self.csClient.getCurrentCFG()[ 'Value' ]
-    self.assert_( not cfg.isSection( 'Systems/DataManagement/' + self.frameworkSetup + '/Databases/FTSDB/' ) )
+    self.assertTrue( not cfg.isSection( 'Systems/DataManagement/' + self.frameworkSetup + '/Databases/FTSDB/' ) )
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestComponentInstallation )

--- a/tests/Integration/Framework/Test_InstalledComponentsDB.py
+++ b/tests/Integration/Framework/Test_InstalledComponentsDB.py
@@ -44,7 +44,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                           'Module': 'TestModule',
                                           'Type': 'TestingFeature' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the component exists
     result = self.client.getComponents( { 'System': 'Test',
@@ -53,7 +53,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                           False,
                                           False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
 
     # Update the fields of the created component
     result = self.client.updateComponents( { 'System': 'Test',
@@ -61,7 +61,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                               'Type': 'TestingFeature' },
                                             { 'Module': 'NewTestModule' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the component with the modified fields exists
     result = self.client.getComponents( { 'System': 'Test',
@@ -70,14 +70,14 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                           False,
                                           False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
 
     # Remove the Component
     result = self.client.removeComponents( { 'System': 'Test',
                                               'Module': 'NewTestModule',
                                               'Type': 'TestingFeature' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the component was actually removed
     result = self.client.getComponents( { 'System': 'Test',
@@ -86,7 +86,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                           False,
                                           False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
 
     # Try to create an incomplete component
     result = self.client.addComponent( { 'System': 'Test' } )
@@ -113,20 +113,20 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                           False,
                                           False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) >= 1 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) >= 1 )
 
     result = self.client.getComponents( { 'System': 'Test',
                                           'Module': 'TestModule1' },
                                           False,
                                           False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
 
     self.client.removeComponents( { 'System': 'Test',
                                     'Module': 'TestModule2',
                                     'Type': 'TestingFeature1' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
   def testHosts( self ):
     """
@@ -136,7 +136,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
     # Create a sample host
     result = self.client.addHost( { 'HostName': 'TestHost', 'CPU': 'TestCPU' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the host exists
     result = self.client.getHosts( { 'HostName': 'TestHost',
@@ -144,14 +144,14 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                       False,
                                       False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
 
     # Update the fields of the created host
     result = self.client.updateHosts( { 'HostName': 'TestHost',
                                         'CPU': 'TestCPU' },
                                       { 'HostName': 'StillATestHost' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the host with the modified fields exists
     result = self.client.getHosts( { 'HostName': 'StillATestHost',
@@ -159,13 +159,13 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                       False,
                                       False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
 
     # Remove the Host
     result = self.client.removeHosts( { 'HostName': 'StillATestHost',
                                         'CPU': 'TestCPU' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the host was actually removed
     result = self.client.getHosts( { 'HostName': 'StillATestHost',
@@ -173,7 +173,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                       False,
                                       False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
 
     # Try to create an incomplete host
     result = self.client.addHost( { 'HostName': 'TestHost' } )
@@ -192,18 +192,18 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                       False,
                                       False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) >= 1 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) >= 1 )
 
     result = self.client.getHosts( { 'HostName': 'TestHost',
                                       'CPU': 'TestCPU1' },
                                       False,
                                       False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
 
     self.client.removeHosts( { 'HostName': 'TestHost', 'CPU': 'TestCPU2' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
   def testInstallations( self ):
     """
@@ -222,7 +222,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                     'CPU': 'TestCPU' },
                                   True )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the installation exists
     result = self.client.getInstallations( { 'Instance': 'TestInstallA111' },
@@ -233,7 +233,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                               'CPU': 'TestCPU' },
                                             False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
 
     # Update the fields of the created installation
     result = self.client.updateInstallations( { 'Instance': 'TestInstallA111' },
@@ -245,7 +245,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                               { 'Instance': 'TestInstallA222' }
                                             )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the installation with the modified fields exists
     result = self.client.getInstallations( { 'Instance': 'TestInstallA222' },
@@ -256,7 +256,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                               'CPU': 'TestCPU' },
                                             False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) > 0 )
 
     # Remove the Installation
     result = self.client.removeInstallations( { 'Instance': 'TestInstallA222' },
@@ -266,7 +266,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                               { 'HostName': 'fictional',
                                                 'CPU': 'TestCPU' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the installation was actually removed
     result = self.client.getInstallations( { 'Instance': 'TestInstallA222' },
@@ -277,7 +277,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                               'CPU': 'TestCPU' },
                                             False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
 
     # Create an installation associated with nonexistent Component
     result = self.client.addInstallation( 
@@ -332,7 +332,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                   {},
                   False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) == 2 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) == 2 )
 
     self.client.removeInstallations( {},
                                      { 'Module': 'UnexistentModule' },
@@ -342,20 +342,20 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
                                       { 'Module': 'UnexistentModule2' },
                     {}, False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) >= 1 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) >= 1 )
 
     result = self.client.getInstallations( {},
                                            { 'Module': 'UnexistentModule' },
                                            {},
                                            False )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) <= 0 )
 
     self.client.removeInstallations( {},
                                      { 'Module': 'UnexistentModule2' },
                                      {} )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Clean up what we created
     self.client.removeHosts( { 'HostName': 'fictional', 'CPU': 'TestCPU' } )
@@ -374,27 +374,27 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
     # Create a sample log
     result = self.client.updateLog( 'TestHost', { 'DIRACVersion': 'v6r15' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check that the log exists
     result = self.client.getLog( 'TestHost' )
 
-    self.assert_( result[ 'OK' ] and result[ 'Value' ][0][ 'DIRACVersion' ] == 'v6r15' )
+    self.assertTrue( result[ 'OK' ] and result[ 'Value' ][0][ 'DIRACVersion' ] == 'v6r15' )
 
     # Update the fields of the created log
     result = self.client.updateLog( 'TestHost' , { 'hostName': 'StillATestHost' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check if the log with the modified fields exists
     result = self.client.getLog( 'StillATestHost' )
 
-    self.assert_( result[ 'OK' ] and result[ 'Value' ][0][ 'DIRACVersion' ] == 'v6r15' )
+    self.assertTrue( result[ 'OK' ] and result[ 'Value' ][0][ 'DIRACVersion' ] == 'v6r15' )
 
     # Remove the log
     result = self.client.removeLogs( { 'hostName': 'StillATestHost' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
     # Check that the log was actually removed
     result = self.client.getLog( 'StillATestHost' )
@@ -410,7 +410,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
 
     result = self.client.getLog( 'TestHostC' )
 
-    self.assert_( result[ 'OK' ] and len( result[ 'Value' ] ) >= 1 )
+    self.assertTrue( result[ 'OK' ] and len( result[ 'Value' ] ) >= 1 )
 
     result = self.client.getLog( 'TestHostB' )
 
@@ -418,7 +418,7 @@ class ComponentMonitoringClientChain( TestClientComponentMonitoring ):
 
     result = self.client.removeLogs( { 'DIRACVersion': 'v7r1' } )
 
-    self.assert_( result[ 'OK' ] )
+    self.assertTrue( result[ 'OK' ] )
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase \

--- a/tests/Integration/Monitoring/Test_MonitoringReporter.py
+++ b/tests/Integration/Monitoring/Test_MonitoringReporter.py
@@ -118,14 +118,14 @@ class MonitoringReporterAdd( MonitoringTestCase ):
     for record in self.data:
       self.wmsMonitoringReporter.addRecord( record )
     result = self.wmsMonitoringReporter.commit()
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'], len( self.data ) )
   
   def test_addComponentRecords( self ):
     for record in self.data:
       self.componentMonitoringReporter.addRecord( record )
     result = self.componentMonitoringReporter.commit()
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'], len( self.data ) )
     
 
@@ -134,21 +134,21 @@ class MonitoringDeleteChain( MonitoringTestCase ):
 
   def test_deleteWMSIndex( self ):
     result = self.monitoringDB.getIndexName('WMSHistory')
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
     today = datetime.today().strftime( "%Y-%m-%d" )
     indexName = "%s-%s" % ( result['Value'], today )
     res = self.monitoringDB.deleteIndex( indexName )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
   
   def test_deleteComponentIndex( self ):
     result = self.monitoringDB.getIndexName('ComponentMonitoring')
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
     today = datetime.today().strftime( "%Y-%m" )
     indexName = "%s-%s" % ( result['Value'], today )
     res = self.monitoringDB.deleteIndex( indexName )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     
 
 if __name__ == '__main__':

--- a/tests/Integration/Monitoring/Test_MonitoringSystem.py
+++ b/tests/Integration/Monitoring/Test_MonitoringSystem.py
@@ -69,11 +69,11 @@ class MonitoringInsertData ( MonitoringTestCase ):
 
   def test_addMonitoringRecords( self ):
     result = self.client.addMonitoringRecords( 'moni', 'WMSHistory', self.data )
-    self.assert_( result['Message'] )
+    self.assertTrue( result['Message'] )
 
   def test_bulkinsert( self ):
     result = self.client.addRecords( "wmshistory_index", "WMSHistory", self.data )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'], len( self.data ) )
     time.sleep( 10 )
 
@@ -81,27 +81,27 @@ class MonitoringTestChain ( MonitoringTestCase ):
 
   def test_listReports( self ):
     result = self.client.listReports( 'WMSHistory' )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'], ['AverageNumberOfJobs', 'NumberOfJobs', 'NumberOfReschedules'] )
 
   def test_listUniqueKeyValues( self ):
     result = self.client.listUniqueKeyValues( 'WMSHistory' )
-    self.assert_( result['OK'] )
-    self.assert_( 'Status' in result['Value'] )
-    self.assert_( 'JobSplitType' in result['Value'] )
-    self.assert_( 'MinorStatus' in result['Value'] )
-    self.assert_( 'Site' in result['Value'] )
-    self.assert_( 'ApplicationStatus' in  result['Value'] )
-    self.assert_( 'User' in result['Value'] )
-    self.assert_( 'JobGroup' in result['Value'] )
-    self.assert_( 'UserGroup' in result['Value'] )
-    self.assert_( 'metric' in result['Value'] )
+    self.assertTrue(result['OK'])
+    self.assertTrue( 'Status' in result['Value'] )
+    self.assertTrue( 'JobSplitType' in result['Value'] )
+    self.assertTrue( 'MinorStatus' in result['Value'] )
+    self.assertTrue( 'Site' in result['Value'] )
+    self.assertTrue( 'ApplicationStatus' in  result['Value'] )
+    self.assertTrue( 'User' in result['Value'] )
+    self.assertTrue( 'JobGroup' in result['Value'] )
+    self.assertTrue( 'UserGroup' in result['Value'] )
+    self.assertTrue( 'metric' in result['Value'] )
     self.assertDictEqual( result['Value'], {u'Status': [u'running', u'waiting'], u'JobSplitType': [u'mcsimulation', u'mcreconstruction', u'user', u'mcstripping', u'datastripping'], u'MinorStatus': [u'unset'], u'Site': [u'lcg.cnaf.it', u'lcg.ral.uk', u'lcg.ihep.su', u'lcg.desyzn.de', u'lcg.bari.it', u'lcg.rrcki.ru', u'multiple', u'lcg.bristol.uk', u'lcg.nikhef.nl', u'group.ral.uk', u'lcg.bologna.it', u'lcg.cern.ch', u'lcg.gridka.de', u'lcg.pic.es'], u'ApplicationStatus': [u'unset'], u'User': [u'phicharp', u'olupton', u'clangenb', u'mamartin', u'mrwillia', u'mvesteri'], u'JobGroup': [u'lhcb', u'00050248', u'00050251', u'00049844', u'00049845', u'00049848', u'00050238', u'00050243', u'00050246', u'00049847', u'00050229', u'00050232', u'00050234', u'00050236', u'00050241', u'00050244', u'00050247', u'00050250', u'00050256', u'00050280', u'00050286', u'00050299', u'00050303'], u'UserGroup': [u'lhcb_mc', u'lhcb_user', u'lhcb_data'], u'metric': [u'wmshistory']} )
 
   def test_generatePlot( self ):
     params = ( 'WMSHistory', 'NumberOfJobs', datetime( 2016, 3, 16, 12, 30, 0, 0 ), datetime( 2016, 3, 17, 19, 29, 0, 0 ), {'grouping': ['Site']}, 'Site', {} )
     result = self.client.generateDelayedPlot( *params )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'], {'plot': 'Z:eNpljcEKwjAQRH8piWLbvQkeRLAeKnhOm7Us2CTsbsH69UYUFIQZZvawb4LUMKQYdjRoKH3kNGeK403W0JEiolSAMZxpwodXcsZukFZItipukFyxeSmiNIB3Zb_lUQL-wD4ssQYYc2Jt_VQuB-089cin6yH1Ur5FPev_UgnrSjXfpRp0yfjGGLgcuz2JJl7wCYg6Slo=', 'thumbnail': False} )
 
   def test_getPlot( self ):
@@ -109,33 +109,33 @@ class MonitoringTestChain ( MonitoringTestCase ):
     transferClient = TransferClient( 'Monitoring/Monitoring' )
     params = ( 'WMSHistory', 'NumberOfJobs', datetime( 2016, 3, 16, 12, 30, 0, 0 ), datetime( 2016, 3, 17, 19, 29, 0, 0 ), {'grouping': ['Site']}, 'Site', {} )
     result = self.client.generateDelayedPlot( *params )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     result = transferClient.receiveFile( tempFile, result['Value']['plot'] )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
   def test_getReport( self ):
     params = ( 'WMSHistory', 'NumberOfJobs', datetime( 2016, 3, 16, 12, 30, 0, 0 ), datetime( 2016, 3, 17, 19, 29, 0, 0 ), {'grouping': ['Site']}, 'Site', {} )
     result = self.client.getReport( *params )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertDictEqual( result['Value'], {'data': {u'multiple': {1458194400: 227.0}, u'lcg.ihep.su': {1458216000: 18.0}, u'lcg.cnaf.it': {1458151200: None, 1458172800: None, 1458162000: None, 1458194400: None, 1458216000: 22.0, 1458140400: 4.0, 1458183600: None, 1458205200: None}, u'lcg.nikhef.nl': {1458216000: 27.0}, u'lcg.bari.it': {1458216000: 34.0}, u'lcg.rrcki.ru': {1458226800: 3.0}, u'group.ral.uk': {1458140400: 34.0}, u'lcg.desyzn.de': {1458226800: 43.0}, u'lcg.ral.uk': {1458129600: 2.0, 1458172800: None, 1458162000: None, 1458194400: None, 1458216000: None, 1458140400: None, 1458183600: None, 1458205200: None, 1458226800: 5.0, 1458151200: None}, u'lcg.pic.es': {1458129600: 1.0}, u'lcg.gridka.de': {1458129600: 2.0}, u'lcg.bristol.uk': {1458216000: 9.0}, u'lcg.cern.ch': {1458140400: 120.0}, u'lcg.bologna.it': {1458216000: 1.0}}, 'granularity': 10800} )
 
   def test_getLastDayData( self ):
     params = {'Status':'Running', 'Site':'LCG.NIKHEF.nl'}
     result = self.client.getLastDayData( 'WMSHistory', params )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( len( result['Value'] ), 2 )
 
 class MonitoringDeleteChain( MonitoringTestCase ):
 
   def test_deleteNonExistingIndex( self ):
     res = self.client.deleteIndex( "alllaaaaa" )
-    self.assert_( res['Message'] )
+    self.assertTrue( res['Message'] )
 
   def test_deleteIndex( self ):
     today = datetime.today().strftime( "%Y-%m-%d" )
     result = "%s-%s" % ( 'wmshistory_index', today )
     res = self.client.deleteIndex( result )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'test_wmshistory_index-%s' % today )
 
 

--- a/tests/Integration/RequestManagementSystem/Test_Client_Req.py
+++ b/tests/Integration/RequestManagementSystem/Test_Client_Req.py
@@ -85,7 +85,7 @@ class ReqClientMix( ReqClientTestCase ):
 
   def test01fullChain( self ):
     put = self.requestClient.putRequest( self.request )
-    self.assert_( put['OK'] )
+    self.assertTrue( put['OK'] )
 
     self.assertEqual( type( put['Value'] ), long )
     reqID = put['Value']
@@ -99,7 +99,7 @@ class ReqClientMix( ReqClientTestCase ):
                                    'File': { 'Waiting': 2L} } } )
 
     get = self.requestClient.getRequest( reqID )
-    self.assert_( get['OK'] )
+    self.assertTrue( get['OK'] )
     self.assertEqual( isinstance( get['Value'], Request ), True )
     # # summary - the request became "Assigned"
     res = RequestDB().getDBSummary()
@@ -124,7 +124,7 @@ class ReqClientMix( ReqClientTestCase ):
 
     res = self.requestClient.readRequestsForJobs( [123] )
     self.assertEqual( res['OK'], True, res['Message'] if 'Message' in res else 'OK' )
-    self.assert_( isinstance( res['Value']['Successful'][123], Request ) )
+    self.assertTrue( isinstance( res['Value']['Successful'][123], Request ) )
 
     # Adding new request
     request2 = Request()

--- a/tests/Integration/ResourceStatusSystem/Test_FullChain.py
+++ b/tests/Integration/ResourceStatusSystem/Test_FullChain.py
@@ -85,7 +85,7 @@ class PDPDecision_Success( PDPTestCase ):
     # empty
     pdp.setup( None )
     res = pdp.takeDecision()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # site
     decisionParams = {'element'     : 'Site',
@@ -97,7 +97,7 @@ class PDPDecision_Success( PDPTestCase ):
                       'tokenOwner'  : None}
     pdp.setup( decisionParams )
     res = pdp.takeDecision()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['policyCombinedResult']['Status'], 'Banned' )
 
     # site2
@@ -111,7 +111,7 @@ class PDPDecision_Success( PDPTestCase ):
                       'tokenOwner'  : None}
     pdp.setup( decisionParams )
     res = pdp.takeDecision()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['policyCombinedResult']['Status'], 'Banned' )
 
     # mySE
@@ -124,7 +124,7 @@ class PDPDecision_Success( PDPTestCase ):
                       'tokenOwner'  : None}
     pdp.setup( decisionParams )
     res = pdp.takeDecision()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['policyCombinedResult']['Status'], 'Active' )
 
     # SE1
@@ -137,7 +137,7 @@ class PDPDecision_Success( PDPTestCase ):
                       'tokenOwner'  : None}
     pdp.setup( decisionParams )
     res = pdp.takeDecision()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['policyCombinedResult']['Status'], 'Banned' )
 
 ################################################################################

--- a/tests/Integration/Resources/Catalog/FIXME_Test_CatalogPlugin.py
+++ b/tests/Integration/Resources/Catalog/FIXME_Test_CatalogPlugin.py
@@ -27,7 +27,7 @@ class CatalogPlugInTestCase(unittest.TestCase):
 
     self.catalog = FileCatalog(catalogs=[catalogClientToTest])
     valid = self.catalog.isOK()
-    self.assert_(valid)
+    self.assertTrue(valid)
     self.destDir = '/lhcb/test/unit-test/TestCatalogPlugin'
     self.link = "%s/link" % self.destDir
 
@@ -42,7 +42,7 @@ class CatalogPlugInTestCase(unittest.TestCase):
     for i in xrange(self.numberOfFiles):
       lfn = "%s/testFile_%d" % (self.destDir,i)
       res = self.registerFile(lfn)
-      self.assert_(res)
+      self.assertTrue(res)
       self.files.append(lfn)
 
   def registerFile(self,lfn):
@@ -57,17 +57,17 @@ class CatalogPlugInTestCase(unittest.TestCase):
     return self.parseResult(res,lfn)
 
   def parseResult(self,res,path):
-    self.assert_(res['OK'])
-    self.assert_(res['Value'])
-    self.assert_(res['Value']['Successful'])
-    self.assert_(res['Value']['Successful'].has_key(path))
+    self.assertTrue(res['OK'])
+    self.assertTrue(res['Value'])
+    self.assertTrue(res['Value']['Successful'])
+    self.assertTrue(res['Value']['Successful'].has_key(path))
     return res['Value']['Successful'][path]
 
   def parseError(self,res,path):
-    self.assert_(res['OK'])
-    self.assert_(res['Value'])
-    self.assert_(res['Value']['Failed'])
-    self.assert_(res['Value']['Failed'].has_key(path))
+    self.assertTrue(res['OK'])
+    self.assertTrue(res['Value'])
+    self.assertTrue(res['Value']['Failed'])
+    self.assertTrue(res['Value']['Failed'].has_key(path))
     return res['Value']['Failed'][path]
 
   def cleanDirectory(self):
@@ -82,7 +82,7 @@ class CatalogPlugInTestCase(unittest.TestCase):
       self.purgeFiles(toRemove)
     res = self.catalog.removeDirectory(self.destDir)
     returnValue = self.parseResult(res,self.destDir)
-    self.assert_(returnValue)
+    self.assertTrue(returnValue)
 
   def purgeFiles(self,lfns):
     for lfn in lfns:
@@ -105,7 +105,7 @@ class FileTestCase(CatalogPlugInTestCase):
     # Test isFile with a file
     res = self.catalog.isFile(self.files[0])
     returnValue = self.parseResult(res,self.files[0])
-    self.assert_(returnValue)
+    self.assertTrue(returnValue)
     # Test isFile for missing path
     res = self.catalog.isFile(self.files[0][:-1])
     error = self.parseError(res,self.files[0][:-1])
@@ -123,7 +123,7 @@ class FileTestCase(CatalogPlugInTestCase):
     self.assertEqual(returnValue['Size'],10000000)
     self.metadata = ['Status', 'ChecksumType', 'NumberOfLinks', 'CreationDate', 'Checksum', 'ModificationDate', 'Mode', 'GUID', 'Size']
     for key in self.metadata:
-      self.assert_(returnValue.has_key(key))
+      self.assertTrue(returnValue.has_key(key))
     # Test getFileMetadata for missing path
     res = self.catalog.getFileMetadata(self.files[0][:-1])
     error = self.parseError(res,self.files[0][:-1])
@@ -135,7 +135,7 @@ class FileTestCase(CatalogPlugInTestCase):
     self.assertEqual(returnValue['Size'],0)
     self.metadata = ['Status', 'ChecksumType', 'NumberOfLinks', 'CreationDate', 'Checksum', 'ModificationDate', 'Mode', 'GUID', 'Size']
     for key in self.metadata:
-      self.assert_(returnValue.has_key(key))
+      self.assertTrue(returnValue.has_key(key))
 
   def test_getFileSize(self):
     # Test getFileSize with a file
@@ -194,7 +194,7 @@ class FileTestCase(CatalogPlugInTestCase):
     # Test exists with a file
     res = self.catalog.exists(self.files[0])
     returnValue = self.parseResult(res,self.files[0])
-    self.assert_(returnValue)
+    self.assertTrue(returnValue)
     # Test exists for missing path
     res = self.catalog.exists(self.files[0][:-1])
     returnValue = self.parseResult(res,self.files[0][:-1])
@@ -202,7 +202,7 @@ class FileTestCase(CatalogPlugInTestCase):
     # Test exists with a directory
     res = self.catalog.exists(self.destDir)
     returnValue = self.parseResult(res,self.destDir)
-    self.assert_(returnValue)
+    self.assertTrue(returnValue)
 
   def test_addReplica(self):
     # Test getReplicas with a file
@@ -215,7 +215,7 @@ class FileTestCase(CatalogPlugInTestCase):
     registrationDict[self.files[0]] = {'SE':'DIRAC-storage2','PFN':'protocol2://host:port/storage/path%s' % self.files[0]}
     res = self.catalog.addReplica(registrationDict)
     returnValue = self.parseResult(res,self.files[0])
-    self.assert_(returnValue)
+    self.assertTrue(returnValue)
     # Check the addReplica worked correctly
     res = self.catalog.getReplicas(self.files[0])
     returnValue = self.parseResult(res,self.files[0])
@@ -235,7 +235,7 @@ class FileTestCase(CatalogPlugInTestCase):
     lfnDict[self.files[0]] = {'PFN': 'protocol://host:port/storage/path%s' % self.files[0],'SE':'DIRAC-storage' ,'Status':'P'}
     res = self.catalog.setReplicaStatus(lfnDict)
     returnValue = self.parseResult(res,self.files[0])
-    self.assert_(returnValue)
+    self.assertTrue(returnValue)
     # Check the setReplicaStatus worked correctly
     res = self.catalog.getReplicas(self.files[0])
     returnValue = self.parseResult(res,self.files[0])
@@ -246,7 +246,7 @@ class FileTestCase(CatalogPlugInTestCase):
     lfnDict[self.files[0]] = {'PFN': 'protocol://host:port/storage/path%s' % self.files[0],'SE':'DIRAC-storage' ,'Status':'U'}
     res = self.catalog.setReplicaStatus(lfnDict)
     returnValue = self.parseResult(res,self.files[0])
-    self.assert_(returnValue)
+    self.assertTrue(returnValue)
     # Check the setReplicaStatus worked correctly
     res = self.catalog.getReplicas(self.files[0])
     returnValue = self.parseResult(res,self.files[0])
@@ -266,7 +266,7 @@ class FileTestCase(CatalogPlugInTestCase):
     lfnDict[self.files[0]] = {'PFN': 'protocol://host:port/storage/path%s' % self.files[0],'SE':'DIRAC-storage' ,'NewSE':'DIRAC-storage2'}
     res = self.catalog.setReplicaHost(lfnDict)
     returnValue = self.parseResult(res,self.files[0])
-    self.assert_(returnValue)
+    self.assertTrue(returnValue)
     # Check the setReplicaHost worked correctly
     res = self.catalog.getReplicas(self.files[0])
     returnValue = self.parseResult(res,self.files[0])
@@ -286,7 +286,7 @@ class DirectoryTestCase(CatalogPlugInTestCase):
     # Test isDirectory with a directory
     res = self.catalog.isDirectory(self.destDir)
     returnValue = self.parseResult(res,self.destDir)
-    self.assert_(returnValue)
+    self.assertTrue(returnValue)
     # Test isDirectory with a file
     res = self.catalog.isDirectory(self.files[0])
     returnValue = self.parseResult(res,self.files[0])
@@ -304,14 +304,14 @@ class DirectoryTestCase(CatalogPlugInTestCase):
     self.assertEqual(returnValue['Size'],0)
     self.assertEqual(returnValue['NumberOfSubPaths'],self.numberOfFiles)
     for key in self.dirMetadata:
-      self.assert_(returnValue.has_key(key))
+      self.assertTrue(returnValue.has_key(key))
     # Test getDirectoryMetadata with a file
     res = self.catalog.getDirectoryMetadata(self.files[0])
     returnValue = self.parseResult(res,self.files[0])
     self.assertEqual(returnValue['Status'],'-')
     self.assertEqual(returnValue['Size'],10000000)
     for key in self.dirMetadata:
-      self.assert_(returnValue.has_key(key))
+      self.assertTrue(returnValue.has_key(key))
     # Test getDirectoryMetadata for missing path
     res = self.catalog.getDirectoryMetadata(self.files[0][:-1])
     error = self.parseError(res,self.files[0][:-1])
@@ -327,11 +327,11 @@ class DirectoryTestCase(CatalogPlugInTestCase):
     self.assertEqual(sorted(returnValue['Files'].keys()),sorted(self.files))
     directoryFiles = returnValue['Files']
     for lfn,fileDict in directoryFiles.items():
-      self.assert_(fileDict.has_key('Replicas'))
+      self.assertTrue(fileDict.has_key('Replicas'))
       self.assertEqual(len(fileDict['Replicas']),1)
-      self.assert_(fileDict.has_key('MetaData'))
+      self.assertTrue(fileDict.has_key('MetaData'))
       for key in self.fileMetadata:
-        self.assert_(fileDict['MetaData'].has_key(key))
+        self.assertTrue(fileDict['MetaData'].has_key(key))
     # Test listDirectory for a file
     res = self.catalog.listDirectory(self.files[0],True)
     error = self.parseError(res,self.files[0])
@@ -345,7 +345,7 @@ class DirectoryTestCase(CatalogPlugInTestCase):
     # Test getDirectoryReplicas for directory
     res = self.catalog.getDirectoryReplicas(self.destDir,True)
     returnValue = self.parseResult(res,self.destDir)
-    self.assert_(returnValue.has_key(self.files[0]))
+    self.assertTrue(returnValue.has_key(self.files[0]))
     fileReplicas = returnValue[self.files[0]]
     self.assertEqual(fileReplicas.keys(),['DIRAC-storage'])
     self.assertEqual(fileReplicas.values(),['protocol://host:port/storage/path%s' % self.files[0]])
@@ -363,7 +363,7 @@ class DirectoryTestCase(CatalogPlugInTestCase):
     res = self.catalog.getDirectorySize(self.destDir)
     returnValue = self.parseResult(res,self.destDir)
     for key in ['Files','TotalSize','SubDirs','ClosedDirs','SiteUsage']:
-      self.assert_(returnValue.has_key(key))
+      self.assertTrue(returnValue.has_key(key))
     self.assertEqual(returnValue['Files'],self.numberOfFiles)
     self.assertEqual(returnValue['TotalSize'],(self.numberOfFiles*10000000))
     #TODO create a sub dir, check, close it, check

--- a/tests/Integration/Test_ElasticsearchDB.py
+++ b/tests/Integration/Test_ElasticsearchDB.py
@@ -41,7 +41,7 @@ class ElasticBulkCreateChain( ElasticTestCase ):
 
   def test_bulkindex( self ):
     result = self.el.bulk_index( 'integrationtest', 'test', self.data )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'], 10 )
     time.sleep( 10 )
   
@@ -51,7 +51,7 @@ class ElasticBulkCreateChain( ElasticTestCase ):
                                  doc_type = 'test',
                                  data = self.data,
                                  period = 'month' )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'], 10 )
     time.sleep( 10 )
 
@@ -63,23 +63,23 @@ class ElasticCreateChain( ElasticTestCase ):
 
   def test_wrongdataindex( self ):
     result = self.el.createIndex( 'dsh63tsdgad', {} )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     index_name = result['Value']
     result = self.el.index( index_name, 'test', {"Color": "red", "quantity": 1, "Product": "a", "timestamp": 1458226213})
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     result = self.el.index( index_name, 'test', {"Color": "red", "quantity": 1, "Product": "a", "timestamp": "2015-02-09T16:15:00Z"})
-    self.assert_( result['Message'] )
+    self.assertTrue( result['Message'] )
     result = self.el.deleteIndex( index_name )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
 
   def test_index( self ):
     result = self.el.createIndex( 'integrationtest', {} )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.index_name = result['Value']
     for i in self.data:
       result = self.el.index( self.index_name, 'test', i )
-      self.assert_( result['OK'] )
+      self.assertTrue(result['OK'])
 
 
 
@@ -87,18 +87,18 @@ class ElasticDeleteChain( ElasticTestCase ):
 
   def test_deleteNonExistingIndex(self):
     result = self.el.deleteIndex( 'dsdssuu' )
-    self.assert_( result['Message'] )
+    self.assertTrue( result['Message'] )
 
   def test_deleteIndex( self ):
     result = generateFullIndexName( 'integrationtest' )
     res = self.el.deleteIndex( result )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], result )
 
   def test_deleteMonthlyIndex( self ):
     result = generateFullIndexName( 'integrationtestmontly', 'month' )
     res = self.el.deleteIndex( result )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], result )
 
 class ElasticTestChain( ElasticTestCase ):
@@ -108,22 +108,22 @@ class ElasticTestChain( ElasticTestCase ):
                                port = elPort, 
                                useSSL = False )
     result = generateFullIndexName( 'integrationtest' )
-    self.assert_( len( result ) > len( 'integrationtest' ) )
+    self.assertTrue( len( result ) > len( 'integrationtest' ) )
     self.index_name = result
 
   def test_getIndexes( self ):
     result = self.el.getIndexes()
-    self.assert_( len( result ) > 0 )
+    self.assertTrue( len( result ) > 0 )
 
 
   def test_getDocTypes( self ):
     result = self.el.getDocTypes( self.index_name )
-    self.assert_( result )
+    self.assertTrue( result )
     self.assertDictEqual( result['Value'], {u'test': {u'properties': {u'Color': {u'type': u'string'}, u'timestamp': {u'type': u'long'}, u'Product': {u'type': u'string'}, u'quantity': {u'type': u'long'}}}} )
 
   def test_exists( self ):
     result = self.el.exists( self.index_name )
-    self.assert_( result )
+    self.assertTrue( result )
 
   def test_generateFullIndexName( self ):
     indexName = 'test'
@@ -141,13 +141,13 @@ class ElasticTestChain( ElasticTestCase ):
   
   def test_getUniqueValue( self ):
     result = self.el.getUniqueValue( self.index_name, 'Color', )
-    self.assert_( result )
+    self.assertTrue( result )
     self.assertEqual( result['Value'], [] )
     result = self.el.getUniqueValue( self.index_name, 'Product' )
-    self.assert_( result )
+    self.assertTrue( result )
     self.assertEqual( result['Value'], [] )
     result = self.el.getUniqueValue( self.index_name, 'quantity' )
-    self.assert_( result )
+    self.assertTrue( result )
     self.assertEqual( result['Value'], [] )
 
   def test_query( self ):

--- a/tests/Integration/TransformationSystem/Test_TS_DFC_Catalog.py
+++ b/tests/Integration/TransformationSystem/Test_TS_DFC_Catalog.py
@@ -62,17 +62,17 @@ class TransformationClientChainID( TestTSDFCCatalogTestCase ):
     for MDField in MDFieldDict.keys():
       MDFieldType = MDFieldDict[MDField]
       res = self.fc.addMetadataField( MDField, MDFieldType )
-      self.assert_( res['OK'] )
+      self.assertTrue(res['OK'])
 
     ### Create a directory in the DFC and set the directory metadata
     dirpath1 = '/dir1'
     res = self.fc.createDirectory( dirpath1 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Successful'][dirpath1][self.metaCatalog], True )
 
     MDdict1 = {'particle':'gamma_diffuse', 'zenith':20}
     res = self.fc.setMetadata( dirpath1 , MDdict1 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     #### Add a first file to all catalog plugins and check that it's not added to the TS Catalog
     filename = 'file1'
@@ -80,7 +80,7 @@ class TransformationClientChainID( TestTSDFCCatalogTestCase ):
     fileTuple = ( lfn1, 'destUrl', 0, 'ALPHA-Disk', 'D41D8CD9-8F00-B204-E980-0998ECF8427E', '001' )
 
     res = self.dm.registerFile( fileTuple )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Successful'][lfn1][self.metaCatalog], True )
     self.assertEqual( res['Value']['Successful'][lfn1]['TSCatalog'], False )
 
@@ -88,12 +88,12 @@ class TransformationClientChainID( TestTSDFCCatalogTestCase ):
     MDdict1b = {'particle':'gamma_diffuse', 'zenith':{"<=": 20}}
     mqJson1b = json.dumps( MDdict1b )
     res = self.transClient.addTransformation( 'transformationName', 'description', 'longDescription', 'MCSimulation', 'Standard', 'Manual', mqJson1b )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     transID = res['Value']
 
     ### Verify that the created file is added to the transformation
     res = self.transClient.getTransformationFiles( {'TransformationID':transID} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'][0]['LFN'], lfn1 )
 
     ### Add a second file having the same metadata and check that it's added also to the TS Catalog
@@ -101,49 +101,49 @@ class TransformationClientChainID( TestTSDFCCatalogTestCase ):
     lfn2 = os.path.join( dirpath1, filename )
     fileTuple = ( lfn2, 'destUrl', 0, 'ALPHA-Disk', 'D41D8CD9-8F00-B204-E980-0998ECF8427E', '001' )
     res = self.dm.registerFile( fileTuple )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Successful'][lfn2][self.metaCatalog], True )
     self.assertEqual( res['Value']['Successful'][lfn2]['TSCatalog'], True )
 
     ### Verify that the second file has been automatically added to the transformation
     res = self.transClient.getTransformationFiles( {'TransformationID': transID} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'][1]['LFN'], lfn2 )
 
     #### Add a third file having different metadata not matching the transformation query
     # and check that it's not added to the TS Catalog
     dirpath2 = '/dir2'
     res = self.fc.createDirectory( dirpath2 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Successful'][dirpath2][self.metaCatalog], True )
 
     MDdict2 = {'particle':'gamma_diffuse', 'zenith':40}
     res = self.fc.setMetadata( dirpath2 , MDdict2 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     fileName = 'file3'
     lfn3 = os.path.join( dirpath2, fileName )
     fileTuple = ( lfn3, 'destUrl', 0, 'ALPHA-Disk', 'D41D8CD9-8F00-B204-E980-0998ECF8427E', '001' )
     res = self.dm.registerFile( fileTuple )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Successful'][lfn3][self.metaCatalog], True )
     self.assertEqual( res['Value']['Successful'][lfn3]['TSCatalog'], False )
 
     ### Verify that the third file has not been added to the the transformation
     res = self.transClient.getTransformationFiles( {'TransformationID':transID} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     for ires in res['Value']:
       self.assertNotEqual( ires['LFN'], lfn3 )
 
     ### Delete the transformation
     re = self.transClient.deleteTransformation( transID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     ### Create another transformation having a query not matching none of the files added to the DFC
     MDdict3 = {'particle':'gamma', 'zenith':60}
     mqJson3 = json.dumps( MDdict3 )
     res = self.transClient.addTransformation( 'transformationName', 'description', 'longDescription', 'MCSimulation', 'Standard', 'Manual', mqJson3 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     transID = res['Value']
 
     ### Verify that no files have been added to the transformation
@@ -152,11 +152,11 @@ class TransformationClientChainID( TestTSDFCCatalogTestCase ):
 
     ### Delete the transformation
     res = self.transClient.deleteTransformation( transID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     ### Create another transformation having an empty query
     res = self.transClient.addTransformation( 'transformationName', 'description', 'longDescription', 'MCSimulation', 'Standard', 'Manual', '' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     transID = res['Value']
 
     ### Verify that no files have been added to the transformation
@@ -165,31 +165,31 @@ class TransformationClientChainID( TestTSDFCCatalogTestCase ):
 
     ### Delete the transformation
     res = self.transClient.deleteTransformation( transID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     ### Remove files from DFC and TSCatalog
     res = self.fc.removeFile( lfn1 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Successful'][lfn1][self.metaCatalog], True )
     self.assertEqual( res['Value']['Successful'][lfn1]['TSCatalog'], True )
     res = self.fc.removeFile( lfn2 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Successful'][lfn2][self.metaCatalog], True )
     self.assertEqual( res['Value']['Successful'][lfn2]['TSCatalog'], True )
     res = self.fc.removeFile( lfn3 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Successful'][lfn3][self.metaCatalog], True )
     self.assertEqual( res['Value']['Successful'][lfn3]['TSCatalog'], 'File does not exist' )
 
     ### Remove directories from DFC
     dirlist = [dirpath1, dirpath2]
     res = self.fc.removeDirectory( dirlist )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     ### Remove metadata fields from DFC
     for MDField in MDFieldDict.keys():
       res = self.fc.deleteMetadataField( MDField )
-      self.assert_( res['OK'] )
+      self.assertTrue(res['OK'])
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestTSDFCCatalogTestCase )

--- a/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
@@ -77,7 +77,7 @@ class TestWMSTestCase( unittest.TestCase ):
     jca.initialize()
     res = jca.removeJobsByStatus( { 'Status' : ['Killed', 'Deleted'] } )
     print res
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
 class WMSChain( TestWMSTestCase ):
 
@@ -99,7 +99,7 @@ class WMSChain( TestWMSTestCase ):
 
     # submit the job
     res = wmsClient.submitJob( job._toJDL( xmlFile = jobDescription ) )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
   # self.assertEqual( type( res['Value'] ), int )
   # self.assertEqual( res['Value'], res['JobID'] )
   # jobID = res['JobID']
@@ -110,13 +110,13 @@ class WMSChain( TestWMSTestCase ):
 
     # reset the job
     res = wmsClient.resetJob( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # reschedule the job
     res = wmsClient.rescheduleJob( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobStatus( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'Received' )
 
     # updating the status again
@@ -124,9 +124,9 @@ class WMSChain( TestWMSTestCase ):
 
     # kill the job
     res = wmsClient.killJob( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobStatus( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'Killed' )
 
     # updating the status aaaagain
@@ -134,16 +134,16 @@ class WMSChain( TestWMSTestCase ):
 
     # kill the job
     res = wmsClient.killJob( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobStatus( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'Done' )  # this time it won't kill... it's done!
 
     # delete the job - this will just set its status to "deleted"
     res = wmsClient.deleteJob( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobStatus( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'Deleted' )
 
 
@@ -162,75 +162,75 @@ class JobMonitoring( TestWMSTestCase ):
 
     # submitting the job. Checking few stuff
     res = wmsClient.submitJob( job._toJDL( xmlFile = jobDescription ) )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     jobID = int ( res['Value'] )
     # jobID = res['JobID']
     res = jobMonitor.getJobJDL( jobID, True )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobJDL( jobID, False )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobsParameters( [jobID], [] )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], {} )
     res = jobMonitor.getJobsParameters( [jobID], ['Owner'] )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # Adding stuff
     res = jobStateUpdate.setJobStatus( jobID, 'Matched', 'matching', 'source' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobStateUpdate.setJobParameters( jobID, [( 'par1', 'par1Value' ), ( 'par2', 'par2Value' )] )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobStateUpdate.setJobApplicationStatus( jobID, 'app status', 'source' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 #     res = jobStateUpdate.setJobFlag()
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
 #     res = jobStateUpdate.unsetJobFlag()
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
     res = jobStateUpdate.setJobSite( jobID, 'Site' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 #     res = jobMonitor.traceJobParameter( 'Site', 1, 'Status' )
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
 
     # now checking few things
     res = jobMonitor.getJobStatus( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'Running' )
     res = jobMonitor.getJobParameter( jobID, 'par1' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], {'par1': 'par1Value'} )
     res = jobMonitor.getJobParameters( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], {'par1': 'par1Value', 'par2': 'par2Value'} )
     res = jobMonitor.getJobAttribute( jobID, 'Site' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'Site' )
     res = jobMonitor.getJobAttributes( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['ApplicationStatus'], 'app status' )
     self.assertEqual( res['Value']['JobName'], 'helloWorld' )
     res = jobMonitor.getJobSummary( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['ApplicationStatus'], 'app status' )
     self.assertEqual( res['Value']['Status'], 'Running' )
     res = jobMonitor.getJobHeartBeatData( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], [] )
     res = jobMonitor.getInputData( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], [] )
     res = jobMonitor.getJobPrimarySummary( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getAtticJobParameters( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobStateUpdate.setJobsStatus( [jobID], 'Done', 'MinorStatus', 'Unknown' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobSummary( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Status'], 'Done' )
     self.assertEqual( res['Value']['MinorStatus'], 'MinorStatus' )
     self.assertEqual( res['Value']['ApplicationStatus'], 'app status' )
     res = jobStateUpdate.sendHeartBeat( jobID, {'bih':'bih'}, {'boh':'boh'} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
 
     # delete the job - this will just set its status to "deleted"
@@ -249,7 +249,7 @@ class JobMonitoring( TestWMSTestCase ):
 #     job.setBannedSites( ['LCG.CERN.ch', 'LCG.CNAF.it', 'LCG.GRIDKA.de', 'LCG.IN2P3.fr',
 #                          'LCG.NIKHEF.nl', 'LCG.PIC.es', 'LCG.RAL.uk', 'LCG.SARA.nl'] )
 #     res = WMSClient().submitJob( job._toJDL( xmlFile = jobDescription ) )
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
 #     self.assertEqual( type( res['Value'] ), int )
 
 
@@ -275,59 +275,59 @@ class JobMonitoringMore( TestWMSTestCase ):
           job.setType( jobType )
           jobDescription = createFile( job )
           res = wmsClient.submitJob( job._toJDL( xmlFile = jobDescription ) )
-          self.assert_( res['OK'] )
+          self.assertTrue(res['OK'])
           jobID = res['Value']
           jobIDs.append( jobID )
 
     res = jobMonitor.getSites()
-    self.assert_( res['OK'] )
-    self.assert_( set( res['Value'] ) <= set( dests + ['ANY', 'DIRAC.Jenkins.ch'] ) )
+    self.assertTrue(res['OK'])
+    self.assertTrue( set( res['Value'] ) <= set( dests + ['ANY', 'DIRAC.Jenkins.ch'] ) )
     res = jobMonitor.getJobTypes()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( sorted( res['Value'] ), sorted( types ) )
     res = jobMonitor.getApplicationStates()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( sorted( res['Value'] ), sorted( ['Unknown'] ) )
 
     res = jobMonitor.getOwners()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getOwnerGroup()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getProductionIds()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobGroups()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getStates()
-    self.assert_( res['OK'] )
-    self.assert_( sorted( res['Value'] ) in [['Received'], sorted( ['Received', 'Waiting'] )] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( sorted( res['Value'] ) in [['Received'], sorted( ['Received', 'Waiting'] )] )
     res = jobMonitor.getMinorStates()
-    self.assert_( res['OK'] )
-    self.assert_( sorted( res['Value'] ) in [['Job accepted'], sorted( ['Job accepted', 'matching'] ) ] )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( sorted( res['Value'] ) in [['Job accepted'], sorted( ['Job accepted', 'matching'] ) ] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobs()
-    self.assert_( res['OK'] )
-    self.assert_( set( [str( x ) for x in jobIDs] ) <= set( res['Value'] ) )
+    self.assertTrue(res['OK'])
+    self.assertTrue( set( [str( x ) for x in jobIDs] ) <= set( res['Value'] ) )
 #     res = jobMonitor.getCounters(attrList)
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
     res = jobMonitor.getCurrentJobCounters()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     try:
-      self.assert_( res['Value'].get( 'Received' ) + res['Value'].get( 'Waiting' ) >= long( len( dests ) * len( lfnss ) * len( types ) ) )
+      self.assertTrue( res['Value'].get( 'Received' ) + res['Value'].get( 'Waiting' ) >= long( len( dests ) * len( lfnss ) * len( types ) ) )
     except TypeError:
       pass
     res = jobMonitor.getJobsSummary( jobIDs )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobMonitor.getJobPageSummaryWeb( {}, [], 0, 100 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     res = jobStateUpdate.setJobStatusBulk( jobID,
                                            {str( datetime.datetime.utcnow() ):{'Status': 'Running',
                                                                                'MinorStatus': 'MinorStatus',
                                                                                'ApplicationStatus': 'ApplicationStatus',
                                                                                'Source': 'Unknown'}} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = jobStateUpdate.setJobsParameter( {jobID:['Status', 'Running']} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     # delete the jobs - this will just set its status to "deleted"
     wmsClient.deleteJob( jobIDs )
@@ -341,7 +341,7 @@ class JobMonitoringMore( TestWMSTestCase ):
 #     jobDescription = createFile( job )
 #
 #     res = WMSClient().submitJob( job._toJDL( xmlFile = jobDescription ) )
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
 #
 #     WMSClient().deleteJob( res['Value'] )
 
@@ -356,38 +356,38 @@ class WMSAdministrator( TestWMSTestCase ):
 
     sitesList = ['My.Site.org', 'Your.Site.org']
     res = wmsAdministrator.setSiteMask( sitesList )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.getSiteMask()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( sorted( res['Value'] ), sorted( sitesList ) )
     res = wmsAdministrator.banSite( 'My.Site.org', 'This is a comment' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.getSiteMask()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( sorted( res['Value'] ), ['Your.Site.org'] )
     res = wmsAdministrator.allowSite( 'My.Site.org', 'This is a comment' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.getSiteMask()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( sorted( res['Value'] ), sorted( sitesList ) )
 
     res = wmsAdministrator.getSiteMaskLogging( sitesList )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['My.Site.org'][0][3], 'No comment' )
     res = wmsAdministrator.getSiteMaskSummary()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['My.Site.org'], 'Active' )
 
     res = wmsAdministrator.getSiteSummaryWeb( {}, [], 0, 100 )
-    self.assert_( res['OK'] )
-    self.assert_( res['Value']['TotalRecords'] in [0, 1, 2, 34] )
+    self.assertTrue(res['OK'])
+    self.assertTrue( res['Value']['TotalRecords'] in [0, 1, 2, 34] )
     res = wmsAdministrator.getSiteSummarySelectors()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     res = wmsAdministrator.clearMask()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.getSiteMask()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], [] )
 
 class WMSAdministratorPilots( TestWMSTestCase ):
@@ -401,22 +401,22 @@ class WMSAdministratorPilots( TestWMSTestCase ):
 
 
     res = wmsAdministrator.addPilotTQReference( ['aPilot'], 1, '/a/ownerDN', 'a/owner/Group' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.getCurrentPilotCounters( {} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], {'Submitted': 1L} )
     res = pilotAgentDB.deletePilot( 'aPilot' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.getCurrentPilotCounters( {} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], {} )
 
     res = wmsAdministrator.addPilotTQReference( ['anotherPilot'], 1, '/a/ownerDN', 'a/owner/Group' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.storePilotOutput( 'anotherPilot', 'This is an output', 'this is an error' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.getPilotOutput( 'anotherPilot' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], {'OwnerDN': '/a/ownerDN',
                                      'OwnerGroup': 'a/owner/Group',
                                      'StdErr': 'this is an error',
@@ -426,24 +426,24 @@ class WMSAdministratorPilots( TestWMSTestCase ):
 #     res = wmsAdministrator.getJobPilotOutput( 1 )
 #     self.assertEqual( res['Value'], {'OwnerDN': '/a/ownerDN', 'OwnerGroup': 'a/owner/Group',
 #                                      'StdErr': 'this is an error', 'FileList': [], 'StdOut': 'This is an output'} )
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
     res = wmsAdministrator.getPilotInfo( 'anotherPilot' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['anotherPilot']['AccountingSent'], 'False' )
     self.assertEqual( res['Value']['anotherPilot']['PilotJobReference'], 'anotherPilot' )
 
     res = wmsAdministrator.selectPilots( {} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 #     res = wmsAdministrator.getPilotLoggingInfo( 'anotherPilot' )
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
     res = wmsAdministrator.getPilotSummary( '', '' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['Total']['Submitted'], 1 )
     res = wmsAdministrator.getPilotMonitorWeb( {}, [], 0, 100 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['TotalRecords'], 1 )
     res = wmsAdministrator.getPilotMonitorSelectors()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], {'GridType': ['DIRAC'],
                                      'OwnerGroup': ['a/owner/Group'],
                                      'DestinationSite': ['NotAssigned'],
@@ -452,31 +452,31 @@ class WMSAdministratorPilots( TestWMSTestCase ):
                                      'GridSite': ['Unknown'],
                                      'Owner': []} )
     res = wmsAdministrator.getPilotSummaryWeb( {}, [], 0, 100 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['TotalRecords'], 1 )
 
     res = wmsAdministrator.setAccountingFlag( 'anotherPilot', 'True' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.setPilotStatus( 'anotherPilot', 'Running' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.getPilotInfo( 'anotherPilot' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value']['anotherPilot']['AccountingSent'], 'True' )
     self.assertEqual( res['Value']['anotherPilot']['Status'], 'Running' )
 
     res = wmsAdministrator.setJobForPilot( 123, 'anotherPilot' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.setPilotBenchmark( 'anotherPilot', 12.3 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.countPilots( {} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 #     res = wmsAdministrator.getCounters()
 #     # getPilotStatistics
 
     res = pilotAgentDB.deletePilot( 'anotherPilot' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     res = wmsAdministrator.getCurrentPilotCounters( {} )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], {} )
 
 
@@ -499,23 +499,23 @@ class Matcher ( TestWMSTestCase ):
     job.setType( 'User' )
     jobDescription = createFile( job )
     res = wmsClient.submitJob( job._toJDL( xmlFile = jobDescription ) )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     jobID = res['Value']
 
     res = JobStateUpdate.setJobStatus( jobID, 'Waiting', 'matching', 'source' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
 
     tqDB = TaskQueueDB()
     tqDefDict = {'OwnerDN': '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch',
                  'OwnerGroup':'prod', 'Setup':'dirac-JenkinsSetup', 'CPUTime':86400}
     res = tqDB.insertJob( jobID, tqDefDict, 10 )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 
     res = matcher.requestJob( resourceDescription )
     print res
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     wmsClient.deleteJob( jobID )
 
 

--- a/tests/Integration/WorkloadManagementSystem/Test_JobDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_JobDB.py
@@ -49,11 +49,11 @@ class JobDBTestCase( unittest.TestCase ):
 
   def tearDown( self ):
     result = self.jobDB.selectJobs( {} )
-    self.assert_( result['OK'], 'Status after selectJobs' )
+    self.assertTrue( result['OK'], 'Status after selectJobs' )
     jobs = result['Value']
     for job in jobs:
       result = self.jobDB.removeJobFromDB( job )
-      self.assert_( result['OK'] )
+      self.assertTrue(result['OK'])
 
 
 class JobSubmissionCase( JobDBTestCase ):
@@ -63,16 +63,16 @@ class JobSubmissionCase( JobDBTestCase ):
   def test_insertAndRemoveJobIntoDB( self ):
 
     res = self.jobDB.insertNewJobIntoDB( jdl, 'owner', '/DN/OF/owner', 'ownerGroup', 'someSetup' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     jobID = res['JobID']
     res = self.jobDB.getJobAttribute( jobID, 'Status' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'Received' )
     res = self.jobDB.getJobAttribute( jobID, 'MinorStatus' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'Job accepted' )
     res = self.jobDB.getJobOptParameters( jobID )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], {} )
     
 class JobRescheduleCase(JobDBTestCase):  
@@ -80,17 +80,17 @@ class JobRescheduleCase(JobDBTestCase):
   def test_rescheduleJob(self):
     
     res = self.jobDB.insertNewJobIntoDB( jdl, 'owner', '/DN/OF/owner', 'ownerGroup', 'someSetup' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     jobID = res['JobID']
 
     result = self.jobDB.rescheduleJob(jobID)
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     
     res = self.jobDB.getJobAttribute( jobID, 'Status' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
     self.assertEqual( res['Value'], 'Received' )
     result = self.jobDB.getJobAttribute( jobID, 'MinorStatus' )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'], 'Job Rescheduled' )
 
 
@@ -99,7 +99,7 @@ class CountJobsCase(JobDBTestCase):
   def test_getCounters(self):
   
     result = self.jobDB.getCounters( 'Jobs', ['Status', 'MinorStatus'], {}, '2007-04-22 00:00:00' )
-    self.assert_( result['OK'],'Status after getCounters') 
+    self.assertTrue( result['OK'],'Status after getCounters') 
        
       
 if __name__ == '__main__':

--- a/tests/Integration/WorkloadManagementSystem/Test_JobLoggingDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_JobLoggingDB.py
@@ -28,26 +28,26 @@ class JobLoggingCase( JobLoggingDBTestCase ):
                                            minor = 'date=datetime.datetime.utcnow()',
                                            date = datetime.datetime.utcnow(),
                                            source = 'Unittest' )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     date = '2006-04-25 14:20:17'
     result = self.jlogDB.addLoggingRecord( 1, status = "testing",
                                            minor = '2006-04-25 14:20:17',
                                            date = date,
                                            source = 'Unittest' )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     result = self.jlogDB.addLoggingRecord( 1, status = "testing",
                                            minor = 'No date 1',
                                            source = 'Unittest' )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     result = self.jlogDB.addLoggingRecord( 1, status = "testing",
                                            minor = 'No date 2',
                                            source = 'Unittest' )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     result = self.jlogDB.getJobLoggingInfo( 1 )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
     result = self.jlogDB.getWMSTimeStamps( 1 )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
     self.jlogDB.deleteJob( 1 )
 

--- a/tests/Integration/WorkloadManagementSystem/Test_SandboxStoreClient.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_SandboxStoreClient.py
@@ -62,22 +62,22 @@ class SSC( TestSSCTestCase ):
     exeScriptLocation = find_all( 'exe-script.py', '..', '/DIRAC/tests/Integration' )[0]
     fileList = [exeScriptLocation]
     res = ssc.uploadFilesAsSandbox( fileList )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 #     SEPFN = res['Value'].split( '|' )[1]
     res = ssc.uploadFilesAsSandboxForJob( fileList, 1, 'Input' )
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 #     res = ssc.downloadSandboxForJob( 1, 'Input' ) #to run this would need the RSS on
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
 
     # only ones needing the DB
     res = smDB.getUnusedSandboxes()
-    self.assert_( res['OK'] )
+    self.assertTrue(res['OK'])
 #     print res
 #     ssc.get
 #     smDB.getSandboxId( SEName, SEPFN, requesterName, requesterGroup )
     # cleaning
 #     res = smDB.deleteSandboxes( SBIdList )
-#     self.assert_( res['OK'] )
+#     self.assertTrue(res['OK'])
 
 
 

--- a/tests/Integration/WorkloadManagementSystem/Test_TaskQueueDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_TaskQueueDB.py
@@ -29,15 +29,15 @@ class TQChain( TQDBTestCase ):
     """
     tqDefDict = {'OwnerDN': '/my/DN', 'OwnerGroup':'myGroup', 'Setup':'aSetup', 'CPUTime':50000}
     result = self.tqDB.insertJob( 123, tqDefDict, 10 )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     result = self.tqDB.getTaskQueueForJobs( [123] )
-    self.assert_( result['OK'] )
-    self.assert_( 123 in result['Value'].keys() )
+    self.assertTrue(result['OK'])
+    self.assertTrue( 123 in result['Value'].keys() )
     tq = result['Value'][123]
     result = self.tqDB.deleteJob( 123 )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     result = self.tqDB.deleteTaskQueue( tq )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
 class TQTests( TQDBTestCase ):
   """
@@ -50,27 +50,27 @@ class TQTests( TQDBTestCase ):
     self.tqDB.insertJob( 123, tqDefDict, 10 )
 
     result = self.tqDB.getNumTaskQueues()
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'], 1 )
     result = self.tqDB.retrieveTaskQueues()
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     self.assertEqual( result['Value'].values()[0],
                       {'OwnerDN': '/my/DN', 'Jobs': 1L, 'OwnerGroup': 'myGroup',
                        'Setup': 'aSetup', 'CPUTime': 86400L, 'Priority': 1.0} )
     result = self.tqDB.findOrphanJobs()
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
     result = self.tqDB.recalculateTQSharesForAll()
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
     # this will also remove the job
     result = self.tqDB.matchAndGetJob( {'Setup': 'aSetup', 'CPUTime': 300000} )
-    self.assert_( result['OK'] )
-    self.assert_( result['Value']['matchFound'] )
+    self.assertTrue(result['OK'])
+    self.assertTrue( result['Value']['matchFound'] )
     self.assertEqual( result['Value']['jobId'], 123L )
     tq = result['Value']['taskQueueId']
 
     result = self.tqDB.deleteTaskQueue( tq )
-    self.assert_( result['OK'] )
+    self.assertTrue(result['OK'])
 
 
 

--- a/tests/System/unitTestUserJobs.py
+++ b/tests/System/unitTestUserJobs.py
@@ -53,12 +53,12 @@ class submitSuccess( GridSubmissionTestCase ):
 #     counter = 0
 #     while counter < 36:
 #       jobStatus = self.dirac.status( jobsSubmittedList )
-#       self.assert_( jobStatus['OK'] )
+#       self.assertTrue( jobStatus['OK'] )
 #       for jobID in jobsSubmittedList:
 #         status = jobStatus['Value'][jobID]['Status']
 #         minorStatus = jobStatus['Value'][jobID]['MinorStatus']
 #         if status == 'Done':
-#           self.assert_( minorStatus in ['Execution Complete', 'Requests Done'] )
+#           self.assertTrue( minorStatus in ['Execution Complete', 'Requests Done'] )
 #           jobsSubmittedList.remove( jobID )
 #           res = self.dirac.getJobOutputLFNs( jobID )
 #           if res['OK']:


### PR DESCRIPTION
Just replacing unittest deprecated aliases as per https://docs.python.org/2/library/unittest.html#deprecated-aliases
