### PR TITLE
[v6r19] Reinitialize ObjectLoader and Logging after the CS is fully loaded

### DIFF
--- a/ConfigurationSystem/Client/LocalConfiguration.py
+++ b/ConfigurationSystem/Client/LocalConfiguration.py
@@ -184,8 +184,8 @@ class LocalConfiguration( object ):
       return S_ERROR( str( e ) )
     return S_OK()
 
-  def __initLogger( self, componentName, logSection ):
-    gLogger.initialize( componentName, logSection )
+  def __initLogger( self, componentName, logSection, forceInit = False ):
+    gLogger.initialize( componentName, logSection, forceInit = forceInit )
 
     if self.__debugMode == 1:
       gLogger.setLevel( "VERBOSE" )
@@ -349,8 +349,22 @@ class LocalConfiguration( object ):
   def enableCS( self ):
     """
     Force the connection the Configuration Server
+
+    (And incidentaly reinitialize the ObjectLoader and logger)
     """
-    return gRefresher.enable()
+    res =  gRefresher.enable()
+
+    # This is quite ugly but necessary for the logging
+    # We force the reinitialization of the ObjectLoader
+    # so that it also takes into account the extensions
+    # (since the first time it is loaded by the logger BEFORE the full CS init)
+    # And then we regenerate all the backend
+    if res['OK']:
+      from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
+      objLoader = ObjectLoader()
+      objLoader.reloadRootModules()
+      self.__initLogger( self.componentName, self.loggingSection, forceInit = True )
+    return res
 
   def isCSEnabled( self ):
     """

--- a/Core/Utilities/ObjectLoader.py
+++ b/Core/Utilities/ObjectLoader.py
@@ -24,11 +24,38 @@ class ObjectLoader( object ):
   def __init__( self, baseModules = False ):
     """ init
     """
+    # We save the original arguments in case
+    # we need to reinitialize the rootModules
+    # CAUTION: we cant do it after doing
+    # baseModules = ['DIRAC']
+    # because then baseModules, self.baseModules, and __rootModules
+    # are the same and edited in place by __generateRootModules !!
+    # (Think of it, it's a binding to a list)
+    self.originalBaseModules = baseModules
+    self._init(baseModules)
+
+  def _init(self, baseModules):
+    """ Actually performs the initialization """
+
     if not baseModules:
       baseModules = [ 'DIRAC' ]
     self.__rootModules = baseModules
     self.__objs = {}
     self.__generateRootModules( baseModules )
+
+  def reloadRootModules(self):
+    """ Retrigger the initialization of the rootModules.
+
+        This should be used with care.
+        Currently, its only use is (and should stay) to retrigger
+        the initialization after the CS has been fully initialized in
+        LocalConfiguration.enableCS
+    """
+    # Load the original baseModule argument that was given
+    # to the constructor
+    baseModules = self.originalBaseModules
+    # and replay the init sequence
+    self._init(baseModules)
 
   def __rootImport( self, modName, hideExceptions = False ):
     """ Auto search which root module has to be used

--- a/FrameworkSystem/private/standardLogging/Logging.py
+++ b/FrameworkSystem/private/standardLogging/Logging.py
@@ -17,15 +17,15 @@ class Logging(object):
   Logging is a wrapper of the logger object from the standard "logging" library which integrate
   some DIRAC concepts. It is the equivalent to the old gLogger object.
 
-  It is used like an interface to use the logger object of the "logging" library. 
-  Its purpose is to replace transparently the old gLogger object in the existing code in order to 
-  minimize the changes. 
+  It is used like an interface to use the logger object of the "logging" library.
+  Its purpose is to replace transparently the old gLogger object in the existing code in order to
+  minimize the changes.
 
   In this way, each Logging embed a logger of "logging". It is possible to create sublogger,
   set and get the level of the embedded logger and create log messages with it.
 
   Logging could delegate the initialization and the configuration to a factory of the root logger be it can not
-  because it has to wrap the old gLogger.  
+  because it has to wrap the old gLogger.
 
   Logging should not be instancied directly. It is LoggingRoot which is instancied and which instantiates Logging
   objects.
@@ -44,8 +44,8 @@ class Logging(object):
     """
     Initialization of the Logging object.
     By default, 'fatherName' and 'name' are empty, because getChild accepts only string and the first empty
-    string corresponds to the root logger. 
-    Example: 
+    string corresponds to the root logger.
+    Example:
     logging.getLogger('') == logging.getLogger('root') == root logger
     logging.getLogger('root').getChild('log') == root.log == log child of root
 
@@ -120,7 +120,7 @@ class Logging(object):
     The options of the children will be updated if they were not modified before by a developer.
 
     :params optionName: string representing the name of the option to modify
-    :params value: boolean to give to the option  
+    :params value: boolean to give to the option
     :params directCall: boolean indicating if it is a call by the user or not
     """
     # lock to prevent that two threads change the options at the same time
@@ -178,7 +178,7 @@ class Logging(object):
     self._lockObjectLoader.acquire()
     try:
       # load the Backend class
-      _class = objLoader.loadObject('DIRAC.Resources.LogBackends.%sBackend' % desiredBackend)
+      _class = objLoader.loadObject('Resources.LogBackends.%sBackend' % desiredBackend)
     finally:
       self._lockObjectLoader.release()
 
@@ -379,9 +379,9 @@ class Logging(object):
   def _createLogRecord(self, level, sMsg, sVarMsg, exc_info=False):
     """
     Create a log record according to the level of the message. The log record is always sent to the different backends
-    Backends have their own levels and can manage the display of the message or not according to the level. 
-    Nevertheless, backends and the logger have the same level value, 
-    so we can test if the message will be displayed or not. 
+    Backends have their own levels and can manage the display of the message or not according to the level.
+    Nevertheless, backends and the logger have the same level value,
+    so we can test if the message will be displayed or not.
 
     :params level: positive integer representing the level of the log record
     :params sMsg: string representing the message

--- a/FrameworkSystem/private/standardLogging/LoggingRoot.py
+++ b/FrameworkSystem/private/standardLogging/LoggingRoot.py
@@ -17,14 +17,14 @@ from DIRAC.Core.Utilities import DIRACSingleton
 class LoggingRoot(Logging):
   """
   LoggingRoot is a Logging object and it is particular because it is the first parent of the chain.
-  In this context, it has more possibilities because it is the one that initializes the logger of the 
+  In this context, it has more possibilities because it is the one that initializes the logger of the
   standard logging library and it configures it with the configuration.
 
   There is a difference between the parent Logging and the other because the parent defines the behaviour
-  of all the Logging objects, so it needs a specific class.  
+  of all the Logging objects, so it needs a specific class.
 
-  LoggingRoot has to be unique, because we want one and only one parent on the top of the chain: that is why 
-  we created a singleton to keep it unique. 
+  LoggingRoot has to be unique, because we want one and only one parent on the top of the chain: that is why
+  we created a singleton to keep it unique.
   """
   __metaclass__ = DIRACSingleton.DIRACSingleton
 
@@ -39,7 +39,7 @@ class LoggingRoot(Logging):
     - set the correct level defines by the user, or the default
     - add the custom level to logging: verbose, notice, always
     - register a default backend: stdout : all messages will be displayed here
-    - update the format according to the command line argument 
+    - update the format according to the command line argument
     """
     super(LoggingRoot, self).__init__()
 
@@ -81,24 +81,27 @@ class LoggingRoot(Logging):
     self.__configureLevel()
     self._generateBackendFormat()
 
-  def initialize(self, systemName, cfgPath):
+  def initialize(self, systemName, cfgPath, forceInit= False):
     """
     Configure the root Logging.
     It can be possible to :
-    - attach it some backends : LogBackends = stdout,stderr,file,server 
+    - attach it some backends : LogBackends = stdout,stderr,file,server
     - attach backend options : BackendOptions { FileName = /tmp/file.log }
     - add colors and the path of the call : LogColor = True, LogShowLine = True
     - precise a level : LogLevel = DEBUG
 
     :params systemName: string represented as "system name/component name"
     :params cfgPath: string of the configuration path
+    :params forceInit: Force the initialization even if it had already happened.
+                       This should not be used !! The only case is LocalConfiguration.enableCS
+                       In order to take into account extensions' backends
     """
     # we have to put the import line here to avoid a dependancy loop
     from DIRAC import gConfig
 
     self._lockConfig.acquire()
     try:
-      if not LoggingRoot.__configuredLogging:
+      if not LoggingRoot.__configuredLogging or forceInit:
         Logging._componentName = systemName
 
         # Prepare to remove all the backends from the root Logging as in the old gLogger.
@@ -133,8 +136,8 @@ class LoggingRoot(Logging):
 
   def __getBackendsFromCFG(self, cfgPath):
     """
-    Get backends from the configuration and register them in LoggingRoot. 
-    This is the new way to get the backends providing a general configuration. 
+    Get backends from the configuration and register them in LoggingRoot.
+    This is the new way to get the backends providing a general configuration.
 
     :params cfgPath: string of the configuration path
     """
@@ -163,10 +166,10 @@ class LoggingRoot(Logging):
 
   def __getBackendOptionsFromCFG(self, cfgPath, backend):
     """
-    Get backend options from the configuration. 
+    Get backend options from the configuration.
 
     :params cfgPath: string of the configuration path
-    :params backend: string representing a backend identifier: stdout, file, f04 
+    :params backend: string representing a backend identifier: stdout, file, f04
     """
     # We have to put the import lines here to avoid a dependancy loop
     from DIRAC import gConfig
@@ -229,11 +232,11 @@ class LoggingRoot(Logging):
   @staticmethod
   def __enableLogsFromExternalLibs(isEnabled=True):
     """
-    Configure the root logger from 'logging' for an external library use. 
+    Configure the root logger from 'logging' for an external library use.
     By default the root logger is configured with:
     - debug level,
     - stderr output
-    - custom format close to the DIRAC format 
+    - custom format close to the DIRAC format
 
     :params isEnabled: boolean value. True allows the logs in the external lib,
                        False do not.
@@ -244,5 +247,5 @@ class LoggingRoot(Logging):
       logging.basicConfig(level=logging.DEBUG,
                           format='%(asctime)s UTC ExternalLibrary/%(name)s %(levelname)s: %(message)s',
                           datefmt='%Y-%m-%d %H:%M:%S')
-    else: 
+    else:
       rootLogger.addHandler(logging.NullHandler())


### PR DESCRIPTION
There is a bootstrap issue with the new logging system. The global sequence of initialization goes as follow:

* load local dirac.cfg
* instantiate gLogger and hence ObjectLoader singleton
* load global CS

Now, if there are extensions, they are most of the time declared in the central CS, which is loaded after the ObjectLoader is used for the first time. And since it is a singleton, it will not "refresh" them.
This PR is to fix this issue. After loading the central CS, we retrigger the initialization of the gLogger, and force the ObjectLoader to reconsider the extensions

PS: sorry for all the white space mess, the original author did not have correct settings


BEGINRELEASENOTES

* Configuration
FIX: retrigger the initialization of the logger and the ObjectLoader after all the CS has been loaded

ENDRELEASENOTES
