### PR TITLE
[v6r19] API.Dirac.__getJDLParameters: fix isinstance check for class

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -2600,7 +2600,9 @@ class Dirac( API ):
     :param jdl: a JDL
     :type jdl: ~DIRAC.Interfaces.API.Job.Job or str or file
     """
-    if isinstance(jdl, DIRAC.Interfaces.API.Job.Job):
+    # import here, becase Job module imports this module
+    from DIRAC.Interfaces.API.Job import Job
+    if isinstance(jdl, Job):
       jdl = jdl._toJDL()
     elif os.path.exists( jdl ):
       with open( jdl, 'r' ) as jdlFile:

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -2600,9 +2600,7 @@ class Dirac( API ):
     :param jdl: a JDL
     :type jdl: ~DIRAC.Interfaces.API.Job.Job or str or file
     """
-    # import here, becase Job module imports this module
-    from DIRAC.Interfaces.API.Job import Job
-    if isinstance(jdl, Job):
+    if hasattr(jdl, '_toJDL'):
       jdl = jdl._toJDL()
     elif os.path.exists( jdl ):
       with open( jdl, 'r' ) as jdlFile:

--- a/Interfaces/API/test/Test_DIRAC.py
+++ b/Interfaces/API/test/Test_DIRAC.py
@@ -24,3 +24,11 @@ class DiracTestCases(unittest.TestCase):
     self.assertEqual('Value', ret['Value']['Parameter'])
     self.assertIn('Parameter2', ret['Value'])
     self.assertEqual('Value2', ret['Value']['Parameter2'])
+
+  def test_JobJob(self):
+    from DIRAC.Interfaces.API.Job import Job
+    job = Job(stdout='printer', stderr='/dev/null')
+    ret = self.dirac._Dirac__getJDLParameters(job)
+    self.assertTrue(ret['OK'])
+    self.assertEqual('printer', ret['Value']['StdOutput'])
+    self.assertEqual('/dev/null', ret['Value']['StdError'])

--- a/Interfaces/API/test/Test_DIRAC.py
+++ b/Interfaces/API/test/Test_DIRAC.py
@@ -1,0 +1,26 @@
+""" Unit tests for the Dirac interface module
+"""
+# pylint: disable=no-member, protected-access
+
+import unittest
+
+from DIRAC.Interfaces.API.Dirac import Dirac
+
+
+class DiracTestCases(unittest.TestCase):
+  """ Dirac API test cases
+  """
+  def setUp(self):
+    self.dirac = Dirac()
+
+  def tearDown(self):
+    pass
+
+  def test_basicJob(self):
+    jdl = "Parameter=Value;Parameter2=Value2"
+    ret = self.dirac._Dirac__getJDLParameters(jdl)
+    self.assertTrue(ret['OK'])
+    self.assertIn('Parameter', ret['Value'])
+    self.assertEqual('Value', ret['Value']['Parameter'])
+    self.assertIn('Parameter2', ret['Value'])
+    self.assertEqual('Value2', ret['Value']['Parameter2'])


### PR DESCRIPTION
I get an exception in my agent when trying to get the jobJDL(see below)
I guess in other places this works if DIRAC.Interfaces.API.Job.Job is imported from the calling module.

BEGINRELEASENOTES
*API
FIX: fix exception when using Dirac.Job.getJobJDL
ENDRELEASENOTES

```
2017-11-03 15:30:16 UTC ILCTransformation/DataRecoveryAgent ERROR: Agent exception while calling method <bound method DataRecoveryAgent.execute of <DataRecoveryAgent.DataRecoveryAgent object at 0x7ff603de8950>>
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/Base/AgentModule.py", line 320, in am_secureCall
    result = functor( *args )
  File "/opt/dirac/pro/ILCDIRAC/ILCTransformationSystem/Agent/DataRecoveryAgent.py", line 283, in execute
    self.treatProduction( int(prodID), transName, transType )
  File "/opt/dirac/pro/ILCDIRAC/ILCTransformationSystem/Agent/DataRecoveryAgent.py", line 331, in treatProduction
    self.checkAllJobs( jobs, tInfo, tasksDict, lfnTaskDict )
  File "/opt/dirac/pro/ILCDIRAC/ILCTransformationSystem/Agent/DataRecoveryAgent.py", line 365, in checkAllJobs
    job.getJobInformation( self.diracILC )
  File "/opt/dirac/pro/ILCDIRAC/ILCTransformationSystem/Utilities/JobInfo.py", line 69, in getJobInformation
    jdlParameters = self.__getJDL( dILC )
  File "/opt/dirac/pro/ILCDIRAC/ILCTransformationSystem/Utilities/JobInfo.py", line 133, in __getJDL
    res = dILC.getJobJDL( int(self.jobID) )
  File "/opt/dirac/pro/DIRAC/Interfaces/API/Dirac.py", line 2590, in getJobJDL
    result = self.__getJDLParameters( result['Value'] )
  File "/opt/dirac/pro/DIRAC/Interfaces/API/Dirac.py", line 2603, in __getJDLParameters
    if isinstance(jdl, DIRAC.Interfaces.API.Job.Job):
AttributeError: 'module' object has no attribute 'Job'
```

