### PR TITLE
[v6r19] Fix exception in SiteDirector for updatePilotStatus

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -205,10 +205,10 @@ class ARCComputingElement( ComputingElement ):
     # And none of our supported batch systems have a "-" in their name
     self.arcQueue = self.queue.split("-",2)[2]
     result = self._prepareProxy()
-    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
     if not result['OK']:
       gLogger.error( 'ARCComputingElement: failed to set up proxy', result['Message'] )
       return result
+    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
 
     gLogger.verbose( "Executable file path: %s" % executableFile )
     if not os.access( executableFile, 5 ):
@@ -276,10 +276,10 @@ class ARCComputingElement( ComputingElement ):
     """
 
     result = self._prepareProxy()
-    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
     if not result['OK']:
       gLogger.error( 'ARCComputingElement: failed to set up proxy', result['Message'] )
       return result
+    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
 
     jobList = list( jobIDList )
     if isinstance( jobIDList, basestring ):
@@ -300,10 +300,10 @@ class ARCComputingElement( ComputingElement ):
     """
 
     result = self._prepareProxy()
-    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
     if not result['OK']:
       gLogger.error( 'ARCComputingElement: failed to set up proxy', result['Message'] )
       return result
+    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
 
     # Try to find out which VO we are running for.
     vo = ''
@@ -352,10 +352,10 @@ class ARCComputingElement( ComputingElement ):
     """
 
     result = self._prepareProxy()
-    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
     if not result['OK']:
       gLogger.error( 'ARCComputingElement: failed to set up proxy', result['Message'] )
       return result
+    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
 
     jobTmpList = list( jobIDList )
     if isinstance( jobIDList, basestring ):
@@ -410,10 +410,10 @@ class ARCComputingElement( ComputingElement ):
         as strings.
     """
     result = self._prepareProxy()
-    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
     if not result['OK']:
       gLogger.error( 'ARCComputingElement: failed to set up proxy', result['Message'] )
       return result
+    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
 
     if jobID.find( ':::' ) != -1:
       pilotRef, stamp = jobID.split( ':::' )

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1121,7 +1121,7 @@ EOF
     for queue in self.queueDict:
       ce = self.queueDict[queue]['CE']
 
-      if not ce.isProxyValid( 120 ):
+      if not ce.isProxyValid(120)['OK']:
         result = gProxyManager.getPilotProxyFromDIRACGroup( self.pilotDN, self.pilotGroup, 1000 )
         if not result['OK']:
           return result

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1125,6 +1125,7 @@ EOF
         result = gProxyManager.getPilotProxyFromDIRACGroup( self.pilotDN, self.pilotGroup, 1000 )
         if not result['OK']:
           return result
+        self.proxy = result['Value']
         ce.setProxy( self.proxy, 940 )
 
       ceName = self.queueDict[queue]['CEName']


### PR DESCRIPTION
```
2017-11-05 22:48:26 UTC WorkloadManagement/SiteDirectorArc ERROR: Agent exception while calling method <bound method SiteDirector.execute of <SiteDirector.SiteDirector object at 0x7fd0db4a7910>>
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/Base/AgentModule.py", line 320, in am_secureCall
    result = functor( *args )
  File "/opt/dirac/pro/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 386, in execute
    result = self.updatePilotStatus()
  File "/opt/dirac/pro/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 1159, in updatePilotStatus
    result = ce.getJobOutput( pRefStamp )
  File "/opt/dirac/pro/DIRAC/Resources/Computing/ARCComputingElement.py", line 413, in getJobOutput
    self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
  File "/opt/dirac/pro/Linux_x86_64_glibc-2.12/lib/python2.7/UserDict.py", line 40, in __getitem__
    raise KeyError(key)
KeyError: 'X509_USER_PROXY'
```
BEGINRELEASENOTES
*WMS
FIX: SiteDirector: fix proxy validity check in updatePilotStatus, a new proxy was never created because `isProxyValid` returns non-empty dictionary
*Resources
FIX: ARCComputingElement: the proxy environment variable was assumed before the return value of the prepareProxy function was checked, which could lead to exceptions

ENDRELEASENOTES
