### PR TITLE
[v6r19] Core: remove hard check of GSI version at run time

### DIFF
--- a/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfoFactory.py
@@ -16,9 +16,6 @@ from DIRAC.Core.DISET.private.Transports.SSL.SocketInfo import SocketInfo
 from DIRAC.Core.DISET.private.Transports.SSL.SessionManager import gSessionManager
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
-if GSI.__version__ < "0.6.5":
-  raise Exception( "Required GSI version >= 0.6.5" )
-
 class SocketInfoFactory(object):
 
   def __init__(self):


### PR DESCRIPTION
This check is meaningless at this stage. And, TBH, LHCb currently struggles in having GSI 0.6.5 :-) 


BEGINRELEASENOTES
*Core
CHANGE: version check of GSI at run time is removed
ENDRELEASENOTES
