### PR TITLE
[v6r19] dirac-dms-user-lfn: always prepend '*' for wildcard

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-user-lfns.py
+++ b/DataManagementSystem/scripts/dirac-dms-user-lfns.py
@@ -35,7 +35,7 @@ for switch in Script.getUnprocessedSwitches():
   if switch[0] == "Y" or switch[0].lower() == "years":
     years = int( switch[1] )
   if switch[0].lower() == "w" or switch[0].lower() == "wildcard":
-    wildcard = switch[1]
+    wildcard = '*'+switch[1]
   if switch[0].lower() == "b" or switch[0].lower() == "basedir":
     baseDir = switch[1]
   if switch[0].lower() == "e" or switch[0].lower() == "emptydirs":


### PR DESCRIPTION
without a leading \* for the wildcard no matches were ever found unless the full path is specified or '\*' is prepended in the wildcard expression. This makes the wildcard more intuitive to use, will not affect anybody negatively. Full path will still match even with leading '\*'

BEGINRELEASENOTES

*DMS

CHANGE: dirac-dms-user-lfns: the wildcard flag will always assume leading "\*" to match files, unless the full path was specified in the wildcard no files were previously matched

ENDRELEASENOTES
