### PR TITLE
[v6r19] Restored parametric jobs limit

### DIFF
--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -250,7 +250,7 @@ dStrError = {
               EENOPID: "No PID of process",
               # WMS/Workflow
               EWMSUKN : "Unknown WMS error",
-              EWMSJDL : "Invalid JDL",
+              EWMSJDL : "Invalid job description",
               EWMSRESC : "Job to Reschedule",
               # DMS/StorageManagement
               EFILESIZE : "Bad file size",

--- a/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -18,7 +18,7 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 from DIRAC.WorkloadManagementSystem.DB.JobLoggingDB import JobLoggingDB
 from DIRAC.WorkloadManagementSystem.DB.TaskQueueDB     import TaskQueueDB
-from DIRAC.WorkloadManagementSystem.Utilities.ParametricJob import generateParametricJobs, getNumberOfParameters
+from DIRAC.WorkloadManagementSystem.Utilities.ParametricJob import generateParametricJobs, getParameterVectorLength
 from DIRAC.Core.DISET.MessageClient import MessageClient
 from DIRAC.WorkloadManagementSystem.Service.JobPolicy import JobPolicy, \
                                                              RIGHT_SUBMIT, RIGHT_RESCHEDULE, \
@@ -115,7 +115,10 @@ class JobManagerHandler( RequestHandler ):
 
     # Check if the job is a parametric one
     jobClassAd = ClassAd( jobDesc )
-    nParameters = getNumberOfParameters( jobClassAd )
+    result = getParameterVectorLength( jobClassAd )
+    if not result['OK']:
+      return result
+    nParameters = result['Value']
     parametricJob = False
     if nParameters > 0:
       parametricJob = True

--- a/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -118,11 +118,11 @@ class JobManagerHandler( RequestHandler ):
     result = getParameterVectorLength( jobClassAd )
     if not result['OK']:
       return result
-    nParameters = result['Value']
+    nJobs = result['Value']
     parametricJob = False
-    if nParameters > 0:
+    if nJobs > 0:
       parametricJob = True
-      if nParameters > self.maxParametricJobs:
+      if nJobs > self.maxParametricJobs:
         return S_ERROR( EWMSJDL, "Number of parametric jobs exceeds the limit of %d" % self.maxParametricJobs )
       result = generateParametricJobs( jobClassAd )
       if not result['OK']:

--- a/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -27,6 +27,7 @@ from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.StorageManagementSystem.Client.StorageManagerClient import StorageManagerClient
+from DIRAC.Core.Utilities.DErrno import EWMSJDL
 
 # This is a global instance of the JobDB class
 gJobDB = False
@@ -118,6 +119,8 @@ class JobManagerHandler( RequestHandler ):
     parametricJob = False
     if nParameters > 0:
       parametricJob = True
+      if nParameters > self.maxParametricJobs:
+        return S_ERROR( EWMSJDL, "Number of parametric jobs exceeds the limit of %d" % self.maxParametricJobs )
       result = generateParametricJobs( jobClassAd )
       if not result['OK']:
         return result

--- a/WorkloadManagementSystem/Utilities/ParametricJob.py
+++ b/WorkloadManagementSystem/Utilities/ParametricJob.py
@@ -1,7 +1,7 @@
 """ Utilities to process parametric job definitions and generate
     bunches of parametric jobs. It exposes the following functions:
 
-    getNumberOfParameters() - to get the total size of the bunch of parametric jobs
+    getParameterVectorLength() - to get the total size of the bunch of parametric jobs
     generateParametricJobs() - to get a list of expanded descriptions of all the jobs
 """
 
@@ -28,20 +28,26 @@ def __getParameterSequence( nPar, parList = [], parStart = 1, parStep = 0, parFa
 
   return parameterList
 
-def getNumberOfParameters( jobClassAd ):
-  """ Get the number of parameters in the parametric job description
+def getParameterVectorLength( jobClassAd ):
+  """ Get the length of parameter vector in the parametric job description
 
   :param jobClassAd: ClassAd job description object
-  :return: int number of parameters, 0 if not a parametric job
+  :return: result structure with the Value: int number of parameters, None if not a parametric job
   """
-  if jobClassAd.lookupAttribute( 'Parameters' ):
-    if jobClassAd.isAttributeList( 'Parameters' ):
-      parameterList = jobClassAd.getListFromExpression( 'Parameters' )
-      return len( parameterList )
-    else:
-      return jobClassAd.getAttributeInt( 'Parameters' )
-  else:
-    return None
+
+  nParameters = None
+  attributes = jobClassAd.getAttributes()
+  for attribute in attributes:
+    if attribute.startswith( "Parameters" ):
+      if jobClassAd.isAttributeList( attribute ):
+        parameterList = jobClassAd.getListFromExpression( attribute )
+        nPar = len( parameterList )
+      else:
+        nPar = jobClassAd.getAttributeInt( attribute )
+      if nParameters is not None and nPar != nParameters:
+        return S_ERROR( EWMSJDL, "Different length of parameter vectors" )
+      nParameters = nPar
+  return S_OK( nParameters )
 
 def __updateAttribute( classAd, attribute, parName, parValue ):
 
@@ -78,9 +84,12 @@ def generateParametricJobs( jobClassAd ):
   if not jobClassAd.lookupAttribute( 'Parameters' ):
     return S_OK( [ jobClassAd.asJDL() ] )
 
-  nParameters = getNumberOfParameters( jobClassAd )
+  result = getParameterVectorLength( jobClassAd )
+  if not result['OK']:
+    return result
+  nParameters = result['Value']
   if nParameters is None:
-    return S_ERROR( EWMSJDL, 'Can not determine number of job parameters' )
+    return S_ERROR( EWMSJDL, 'Can not determine the number of job parameters' )
   if nParameters <= 0:
     return S_ERROR( EWMSJDL, 'Illegal number of job parameters %d' % ( nParameters ) )
 

--- a/WorkloadManagementSystem/Utilities/test/Test_ParametricJob.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_ParametricJob.py
@@ -6,8 +6,16 @@
 import unittest
 
 from DIRAC.WorkloadManagementSystem.Utilities.ParametricJob import generateParametricJobs, \
-                                                                   getNumberOfParameters
+                                                                   getParameterVectorLength
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+
+TEST_JDL_NO_PARAMETERS = """
+[
+  Executable = "my_executable";
+  Arguments = "%s";
+  JobName = "Test_%n";
+]
+"""
 
 TEST_JDL_SIMPLE = """
 [
@@ -53,12 +61,27 @@ TEST_JDL_MULTI = """
 ]
 """
 
+TEST_JDL_MULTI_BAD = """
+[
+  Executable = "my_executable";
+  Arguments = "%(A)s %(B)s";
+  JobName = "Test_%n";
+  Parameters = 3;
+  ParameterStart.A = 1;
+  ParameterStep.A = 1;
+  ParameterFactor.A = 2;
+  Parameters.B = { "a","b","c","d" };
+]
+"""
+
 class TestParametricUtilityCase( unittest.TestCase ):
 
   def test_Simple(self):
 
     clad = ClassAd( TEST_JDL_SIMPLE )
-    nParam = getNumberOfParameters( clad )
+    result = getParameterVectorLength( clad )
+    self.assert_( result['OK'] )
+    nParam = result['Value']
 
     self.assertEqual( nParam, 3 )
 
@@ -76,7 +99,9 @@ class TestParametricUtilityCase( unittest.TestCase ):
   def test_SimpleBunch(self):
 
     clad = ClassAd( TEST_JDL_SIMPLE_BUNCH )
-    nParam = getNumberOfParameters( clad )
+    result = getParameterVectorLength( clad )
+    self.assert_( result['OK'] )
+    nParam = result['Value']
 
     self.assertEqual( nParam, 3 )
 
@@ -94,7 +119,9 @@ class TestParametricUtilityCase( unittest.TestCase ):
   def test_SimpleProgression(self):
 
     clad = ClassAd( TEST_JDL_SIMPLE_PROGRESSION )
-    nParam = getNumberOfParameters( clad )
+    result = getParameterVectorLength( clad )
+    self.assert_( result['OK'] )
+    nParam = result['Value']
 
     self.assertEqual( nParam, 3 )
 
@@ -112,7 +139,9 @@ class TestParametricUtilityCase( unittest.TestCase ):
   def test_Multi(self):
 
     clad = ClassAd( TEST_JDL_MULTI )
-    nParam = getNumberOfParameters( clad )
+    result = getParameterVectorLength( clad )
+    self.assert_( result['OK'] )
+    nParam = result['Value']
 
     self.assertEqual( nParam, 3 )
 
@@ -126,6 +155,20 @@ class TestParametricUtilityCase( unittest.TestCase ):
     jobClassAd = ClassAd( jobDescList[1] )
     self.assertEqual( jobClassAd.getAttributeString( 'Arguments' ), '3 b' )
     self.assertEqual( jobClassAd.getAttributeString( 'JobName' ), 'Test_1' )
+
+  def test_MultiBad(self):
+
+    clad = ClassAd( TEST_JDL_MULTI_BAD )
+    result = getParameterVectorLength( clad )
+    self.assert_( not result['OK'] )
+
+  def test_NoParameters(self):
+
+    clad = ClassAd( TEST_JDL_NO_PARAMETERS )
+    result = getParameterVectorLength( clad )
+    self.assert_( result['OK'] )
+    nParam = result['Value']
+    self.assert_( nParam is None )
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestParametricUtilityCase )

--- a/WorkloadManagementSystem/Utilities/test/Test_ParametricJob.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_ParametricJob.py
@@ -80,13 +80,13 @@ class TestParametricUtilityCase( unittest.TestCase ):
 
     clad = ClassAd( TEST_JDL_SIMPLE )
     result = getParameterVectorLength( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue( result['OK'] )
     nParam = result['Value']
 
     self.assertEqual( nParam, 3 )
 
     result = generateParametricJobs( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue( result['OK'] )
 
     jobDescList = result['Value']
     self.assertEqual( nParam, len( jobDescList ) )
@@ -100,13 +100,13 @@ class TestParametricUtilityCase( unittest.TestCase ):
 
     clad = ClassAd( TEST_JDL_SIMPLE_BUNCH )
     result = getParameterVectorLength( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue( result['OK'] )
     nParam = result['Value']
 
     self.assertEqual( nParam, 3 )
 
     result = generateParametricJobs( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue( result['OK'] )
 
     jobDescList = result['Value']
     self.assertEqual( nParam, len( jobDescList ) )
@@ -120,13 +120,13 @@ class TestParametricUtilityCase( unittest.TestCase ):
 
     clad = ClassAd( TEST_JDL_SIMPLE_PROGRESSION )
     result = getParameterVectorLength( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue( result['OK'] )
     nParam = result['Value']
 
     self.assertEqual( nParam, 3 )
 
     result = generateParametricJobs( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue( result['OK'] )
 
     jobDescList = result['Value']
     self.assertEqual( nParam, len( jobDescList ) )
@@ -140,13 +140,13 @@ class TestParametricUtilityCase( unittest.TestCase ):
 
     clad = ClassAd( TEST_JDL_MULTI )
     result = getParameterVectorLength( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue( result['OK'] )
     nParam = result['Value']
 
     self.assertEqual( nParam, 3 )
 
     result = generateParametricJobs( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue( result['OK'] )
 
     jobDescList = result['Value']
     self.assertEqual( nParam, len( jobDescList ) )
@@ -160,15 +160,15 @@ class TestParametricUtilityCase( unittest.TestCase ):
 
     clad = ClassAd( TEST_JDL_MULTI_BAD )
     result = getParameterVectorLength( clad )
-    self.assert_( not result['OK'] )
+    self.assertTrue( not result['OK'] )
 
   def test_NoParameters(self):
 
     clad = ClassAd( TEST_JDL_NO_PARAMETERS )
     result = getParameterVectorLength( clad )
-    self.assert_( result['OK'] )
+    self.assertTrue( result['OK'] )
     nParam = result['Value']
-    self.assert_( nParam is None )
+    self.assertTrue( nParam is None )
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestParametricUtilityCase )

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Services/JobManager/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Services/JobManager/index.rst
@@ -3,4 +3,12 @@ Systems / WorkloadManagement / <INSTANCE> / Service / JobManager - Sub-subsectio
 
 JobManagerHandler is the implementation of the JobManager service in the DISET framework
 
-No special options required to configure this service.
+Some extra options are required to configure this service:
+
++---------------------------+----------------------------------------------+-----------------------------------------+
+| **Name**                  | **Description**                              | **Example**                             |
++---------------------------+----------------------------------------------+-----------------------------------------+
+| *MaxParametricJobs*       | Max number of jobs that can be submitted at  |                                         |
+|                           | once using parametric jobs mechanism,        | MaxParametricJobs = 100                 |
+|                           | default = 20                                 |                                         |
++---------------------------+----------------------------------------------+-----------------------------------------+


### PR DESCRIPTION
  The MaxParametericJobs configuration option defines the limit for the number of jobs that can be submitted in one go.

BEGINRELEASENOTES
*WMS
FIX: JobManagerHandler - restored the use of MaxParametricJobs configuration option
CHANGE: ParametricJob - added getParameterVectorLength() to replace getNumberOfParameters with a more detailed check of the job JDL validity
ENDRELEASENOTES
