### PR TITLE
[v6r19] Log proper message on cadir initalisation failure

### DIFF
--- a/Core/DISET/private/Transports/SSL/SocketInfo.py
+++ b/Core/DISET/private/Transports/SSL/SocketInfo.py
@@ -184,7 +184,7 @@ class SocketInfo:
                                        [ crlsDict[k] for k in crlsDict ] )
         SocketInfo.__cachedCAsCRLsLastLoaded = time.time()
     except:
-      gLogger.exception( "ASD" )
+      gLogger.exception( "Failed to init CA store" )
     finally:
       SocketInfo.__cachedCAsCRLsLoadLock.release()
     #Generate CA Store


### PR DESCRIPTION
Hi,

A very quick fix for a log message... I was debugging something for one of my users and found the DIRAC tools printing "ASD" to my console :-)

Regards,
Simon


BEGINRELEASENOTES
*Core
FIX: Log proper message on cadir init failure.
ENDRELEASENOTES
