### PR TITLE
[v6r19] simple fix for RSS script: expiration time is a date

### DIFF
--- a/ResourceStatusSystem/scripts/dirac-rss-query-db.py
+++ b/ResourceStatusSystem/scripts/dirac-rss-query-db.py
@@ -159,8 +159,6 @@ def getToken( key ):
     now = Time.dateTime()
     #datetime.datetime.utcnow()
     expirationDate = now + datetime.timedelta( seconds=tokenExpiration['Value'] )
-    expirationDate = Time.toString( expirationDate )
-    expirationDate = expirationDate.split('.')[0]
     return expirationDate
 
 


### PR DESCRIPTION

BEGINRELEASENOTES

*RSS
FIX: expiration time is a date (dirac-rss-query0db)

ENDRELEASENOTES
