### PR TITLE
[v6r19] Fix web summary exception when site only has single dot

### DIFF
--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1824,7 +1824,7 @@ class JobDB( DB ):
     countryCounts = {}
     for siteFullName in resultDict:
       siteDict = resultDict[siteFullName]
-      if siteFullName.find( '.' ) != -1:
+      if siteFullName.count( '.' ) == 2:
         grid, site, country = siteFullName.split( '.' )
       else:
         grid, site, country = 'Unknown', 'Unknown', 'Unknown'


### PR DESCRIPTION
Hi,

We've found the getSiteSummaryWeb function throws an exception if someone has submitted a job with only one '.' character in the name, this patch fixes the problem.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: Don't trigger exception in webSummary if a site with a single dot is in the system.
ENDRELEASENOTES
