### PR TITLE
[v6r19] Fix escaping in sitedirector pilot template

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -959,7 +959,7 @@ import bz2
 import logging
 import time
 
-formatter = logging.Formatter(fmt='%(asctime)s UTC %(levelname)-8s %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+formatter = logging.Formatter(fmt='%%(asctime)s UTC %%(levelname)-8s %%(message)s', datefmt='%%Y-%%m-%%d %%H:%%M:%%S')
 logging.Formatter.converter = time.gmtime
 try:
   screen_handler = logging.StreamHandler(stream=sys.stdout)
@@ -1002,7 +1002,7 @@ except Exception as x:
   shutil.rmtree( pilotWorkingDirectory )
   sys.exit(-1)
 cmd = "python %(pilotScript)s %(pilotOptions)s"
-logger.info('Executing: %s' % cmd)
+logger.info('Executing: %%s' %% cmd)
 sys.stdout.flush()
 os.system( cmd )
 

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -993,10 +993,10 @@ try:
   os.environ["X509_CERT_DIR"]=os.path.join(pilotWorkingDirectory, 'etc/grid-security/certificates')
   # TODO: structure the output
   print '==========================================================='
-  logger.debug('Environment of execution host\n')
+  logger.debug('Environment of execution host\\n')
   for key, val in os.environ.iteritems():
     logger.debug( key + '=' + val )
-  print '===========================================================\n'
+  print '===========================================================\\n'
 except Exception as x:
   print >> sys.stderr, x
   shutil.rmtree( pilotWorkingDirectory )


### PR DESCRIPTION
Hi,

We've found that the SiteDirectors crash in v6r19p6 when they try to submit pilots due to a problem with string substitutions in the pilot template; this patch fixes the problem.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Correct escaping in SiteDirector pilot template
ENDRELEASENOTES
