### PR TITLE
[v6r19] Don't overwrite tags if requiredtags are set.

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -153,15 +153,18 @@ def getQueue( site, ce, queue ):
     return result
   resultDict = result['Value']
 
+  # Get queue defaults
+  result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/CEs/%s/Queues/%s' % ( grid, site, ce, queue ) )
+  if not result['OK']:
+    return result
+  resultDict.update( result['Value'] )
+
+  # Handle tag lists for the queue
   for tagFieldName in ( 'Tag', 'RequiredTag' ): 
     Tags = []
     ceTags = resultDict.get( tagFieldName )
     if ceTags:
       Tags = fromChar( ceTags )
-    result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/CEs/%s/Queues/%s' % ( grid, site, ce, queue ) )
-    if not result['OK']:
-      return result
-    resultDict.update( result['Value'] )
     queueTags = resultDict.get( tagFieldName )
     if queueTags:
       queueTags = fromChar( queueTags )


### PR DESCRIPTION
Hi,

Yet another RequiredTags fix unfortunately... There was an edge case that if the tags were set on the queue (rather than the CE), the required tags would cause the tags list to be overwritten with the original string. There was a bit of logic that should have been outside of the loop (so it doesn't overwrite the updates on the second go around).

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Don't overwrite queue tags if requiredtags are set.
ENDRELEASENOTES
