### PR TITLE
[v6r19] Allow user access to getSiteMaskStatus

### DIFF
--- a/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -55,6 +55,7 @@ Services
       setPilotBenchmark = authenticated
       setPilotStatus = authenticated
       getSiteMask = authenticated
+      getSiteMaskStatus = authenticated
       ping = authenticated
       getPilots = authenticated
       allowSite = SiteManager

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1516,7 +1516,13 @@ class JobDB( DB ):
     """ Get the currently site mask status
     """
     if isinstance(sites, list):
-      sitesString = ",".join( "'%s'" % site for site in sites)
+      safe_sites = []
+      for site in sites:
+        res = self._escapeString( site )
+        if not ret['OK']:
+          return ret
+        safe_sites.append( res['Value'] )
+      sitesString = ",".join( safe_sites )
       cmd = "SELECT Site, Status FROM SiteMask WHERE Site in (%s)" % sitesString
 
       result = self._query( cmd )
@@ -1524,7 +1530,11 @@ class JobDB( DB ):
 
     elif isinstance(sites, str):
 
-      cmd = "SELECT Status FROM SiteMask WHERE Site='%s'" % sites
+      ret = self._escapeString( sites )
+      if not ret['OK']:
+        return ret
+      sites = ret['Value']
+      cmd = "SELECT Status FROM SiteMask WHERE Site=%s" % sites
       result = self._query( cmd )
       return S_OK( result['Value'][0][0] )
 

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1516,13 +1516,13 @@ class JobDB( DB ):
     """ Get the currently site mask status
     """
     if isinstance(sites, list):
-      safe_sites = []
+      safeSites = []
       for site in sites:
         res = self._escapeString( site )
         if not ret['OK']:
           return ret
-        safe_sites.append( res['Value'] )
-      sitesString = ",".join( safe_sites )
+        safeSites.append( res['Value'] )
+      sitesString = ",".join( safeSites )
       cmd = "SELECT Site, Status FROM SiteMask WHERE Site in (%s)" % sitesString
 
       result = self._query( cmd )
@@ -1533,8 +1533,7 @@ class JobDB( DB ):
       ret = self._escapeString( sites )
       if not ret['OK']:
         return ret
-      sites = ret['Value']
-      cmd = "SELECT Status FROM SiteMask WHERE Site=%s" % sites
+      cmd = "SELECT Status FROM SiteMask WHERE Site=%s" % ret['Value']
       result = self._query( cmd )
       return S_OK( result['Value'][0][0] )
 


### PR DESCRIPTION
Hi,

Following the release of v6r19p7 we noticed that the dirac-admin-get-site-mask command started returning permission denied for normal users. We traced this to a change in the function used (getSiteMask -> getSiteMaskStatus). I can't see any problems with allowing authenticated users access to the getSiteMaskStatus function by default (it gives basically the same information as getSiteMask), although I did notice it has some SQL escaping issues, which this patch also fixes.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Allow user access to getSiteMaskStatus
ENDRELEASENOTES
