### PR TITLE
[v6r19] CS option for extra JDL parameters for a CREAM CE

### DIFF
--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
@@ -80,3 +80,16 @@ Options for the HTCondorCEs
 | DaysToKeepLogFiles  | How many days pilot log files are kept on the disk  | 15                                                        |
 |                     | before they are removed                             |                                                           |
 +---------------------+-----------------------------------------------------+-----------------------------------------------------------+
+
+
+.. _res-comp-cream:
+
+CREAM CE Parameters
+-------------------
+
++---------------------+-----------------------------------------------------+-----------------------------------------------------------+
+| **Name**            | **Description**                                     | **Example**                                               |
++---------------------+-----------------------------------------------------+-----------------------------------------------------------+
+| ExtraJDLParameters  | Additional JDL parameters to submit pilot jobs      | ExtraJDLParameters = GPUNumber=1; OneMore="value"         |
+|                     | to CREAm CE. Separate entries with ";".             |                                                           |
++---------------------+-----------------------------------------------------+-----------------------------------------------------------+


### PR DESCRIPTION
  This PR ads a possibility to define extra CREAM job JDL parameters for a given queue of a CREAM CE. The option can contain several JDL parameters separated by ; . For example:

   Resources
   {
      ...
     Queues
     {
        pbs-cream-gpu
        {
           ExtraJDLParameters = GPUProcessors=1; YetAnotherParameter="value"
        }
      }
      ...
  }

BEGINRELEASENOTES

*Resources
FIX: CREAMComputingElement - added CS option for extra JDL parameters 

ENDRELEASENOTES
