### PR TITLE
[v6r19] Increase dirac-proxy-init CRL update frequency

### DIFF
--- a/FrameworkSystem/scripts/dirac-proxy-init.py
+++ b/FrameworkSystem/scripts/dirac-proxy-init.py
@@ -209,8 +209,8 @@ class ProxyInit( object ):
       return
     newestFPath = max( crlList, key=os.path.getmtime )
     newestFTime = os.path.getmtime( newestFPath )
-    if newestFTime > ( time.time() - ( 28 * 24 * 3600 ) ):
-      # At least one of the files has been updated in the last 28 days
+    if newestFTime > ( time.time() - ( 2 * 24 * 3600 ) ):
+      # At least one of the files has been updated in the last 2 days
       return S_OK()
     if not os.access(caDir, os.W_OK):
       gLogger.error("Your CRLs appear to be outdated, but you have no access to update them.")


### PR DESCRIPTION
Hi,

I would like to suggest increasing the CRL update frequency in dirac-proxy-init... We've found that CERN updates their CRLs every 3.5 days, so the in-built 28 day limit is not much help there. I thought about ways that the algorithm could be improved, but I couldn't think of any improvements beyond just decreasing the time (ideally it would just always pull individual CRLs that are nearing the expiry time, but that would require a lot of changes to bundle delivery (to allow pulling single files)) .

Regards,
Simon

BEGINRELEASENOTES
*Framework
CHANGE: Increase dirac-proxy-init CRL update frequency
ENDRELEASENOTES
