### PR TITLE
[v6r19] Fix recursive resolution of SEGroup

### DIFF
--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -50,6 +50,7 @@ def resolveSEGroup(seGroupList, allSEs=None):
         recursive = resolveSEGroup(se1, allSEs=allSEs)
         if not recursive:
           return []
+        newSEs.remove(se1)
         newSEs += recursive
     seList += newSEs
 


### PR DESCRIPTION
BEGINRELEASENOTES
* DataManagementSystem
FIX: recursive resolution of SEGroup was keeping the SEGroup in the list

ENDRELEASENOTES
