### PR TITLE
[v6r19] Bug fix, deprecating 2 methods in Job.py

### DIFF
--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -28,21 +28,22 @@ import urllib
 import shlex
 import StringIO
 
-from DIRAC                                                    import S_OK, S_ERROR, gLogger
-from DIRAC.Core.Workflow.Parameter                            import Parameter
-from DIRAC.Core.Workflow.Workflow                             import Workflow
-from DIRAC.Core.Base.API                                      import API
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight                import ClassAd
-from DIRAC.Core.Security.ProxyInfo                            import getProxyInfo
-from DIRAC.ConfigurationSystem.Client.Helpers.Registry        import getVOForGroup
-from DIRAC.Core.Utilities.Subprocess                          import systemCall
-from DIRAC.Core.Utilities.List                                import uniqueElements
-from DIRAC.Core.Utilities.SiteCEMapping                       import getSiteForCE, getSites
-from DIRAC.ConfigurationSystem.Client.Helpers.Operations      import Operations
-from DIRAC.ConfigurationSystem.Client.Helpers                 import Resources
-from DIRAC.Interfaces.API.Dirac                               import Dirac
-from DIRAC.Workflow.Utilities.Utils                           import getStepDefinition, addStepToWorkflow
-from DIRAC.Core.Utilities.DErrno                              import EWMSJDL
+from DIRAC import S_OK, S_ERROR, gLogger
+from DIRAC.Core.Base.API import API
+from DIRAC.Core.Security.ProxyInfo import getProxyInfo
+from DIRAC.Core.Workflow.Parameter import Parameter
+from DIRAC.Core.Workflow.Workflow import Workflow
+from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.Decorators import deprecated
+from DIRAC.Core.Utilities.Subprocess import systemCall
+from DIRAC.Core.Utilities.List import uniqueElements
+from DIRAC.Core.Utilities.SiteCEMapping import getSiteForCE, getSites
+from DIRAC.Core.Utilities.DErrno import EWMSJDL
+from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC.ConfigurationSystem.Client.Helpers import Resources
+from DIRAC.Interfaces.API.Dirac import Dirac
+from DIRAC.Workflow.Utilities.Utils import getStepDefinition, addStepToWorkflow
 
 __RCSID__ = "$Id$"
 
@@ -244,6 +245,8 @@ class Job( API ):
     return S_OK()
 
   #############################################################################
+
+  @deprecated("Use function setParameterSequence")
   def setParametricInputSandbox( self, files ):
     """Helper function.
 
@@ -334,6 +337,8 @@ class Job( API ):
     return S_OK()
 
   #############################################################################
+
+  @deprecated("Use function setParameterSequence")
   def setParametricInputData( self, lfns ):
     """Helper function.
 

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -282,7 +282,8 @@ class JobDB( DB ):
         if not ret['OK']:
           return ret
         paramNameList.append( ret['Value'] )
-      cmd = "SELECT Name, Value from JobParameters WHERE JobID=%s and Name in (%s)" % ( e_jobID, ','.join( paramNameList ) )
+      cmd = "SELECT Name, Value from JobParameters WHERE JobID=%s and Name in (%s)" % (e_jobID,
+                                                                                       ','.join(paramNameList))
       result = self._query( cmd )
       if result['OK']:
         if result['Value']:
@@ -1519,8 +1520,8 @@ class JobDB( DB ):
       safeSites = []
       for site in sites:
         res = self._escapeString( site )
-        if not ret['OK']:
-          return ret
+        if not res['OK']:
+          return res
         safeSites.append( res['Value'] )
       sitesString = ",".join( safeSites )
       cmd = "SELECT Site, Status FROM SiteMask WHERE Site in (%s)" % sitesString


### PR DESCRIPTION

BEGINRELEASENOTES

*Interfaces
CHANGE: using the deprecated decorator for 2 deprecated methods

*WMS
FIX: fixed typo in JobDB().getSiteMaskStatus() method

ENDRELEASENOTES
