### PR TITLE
[v6r19] Ensure getUsableSites receives a list

### DIFF
--- a/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
+++ b/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
@@ -157,7 +157,7 @@ class MultiProcessorSiteDirector( SiteDirector ):
       processorTags = []
 
       # Check the status of the Site
-      result = self.siteClient.getUsableSites(siteName)
+      result = self.siteClient.getUsableSites( [ siteName ] )
       if not result['OK']:
         self.log.error("Can not get the status of site %s: %s" %
                        (siteName, result['Message']))

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -487,7 +487,7 @@ class SiteDirector( AgentModule ):
       siteMask = siteName in siteMaskList
 
       # Check the status of the Site
-      result = self.siteClient.getUsableSites(siteName)
+      result = self.siteClient.getUsableSites( [ siteName ] )
       if not result['OK']:
         self.log.error("Can not get the status of site",
                        " %s: %s" % (siteName, result['Message']))


### PR DESCRIPTION
Hi,

The site director now calls getUsableSites, however it calls it with a string, but the function expects a list. This triggers an exception: ```Server error while serving getSiteMaskStatus: tuple index out of range``` (preventing any pilot jobs from being submitted). This patch converts it to a list to avoid the problem.

Regards,
Simon


BEGINRELEASENOTES
*WorkloadManagement
FIX: Ensure getUsableSites receives a list from SD
ENDRELEASENOTES
