### PR TITLE
[v6r19] Fix getSiteMaskStatus call in SiteDirector

### DIFF
--- a/ResourceStatusSystem/Client/SiteStatus.py
+++ b/ResourceStatusSystem/Client/SiteStatus.py
@@ -74,9 +74,10 @@ class SiteStatus( object ):
     return S_OK(getCacheDictFromRawData(rawCache['Value']))
 
 
-  def getSiteStatuses( self, siteNamesList = None ):
+  def getSiteStatuses( self, siteNames = None ):
     """
     Method that queries the database for status of the sites in a given list.
+    A single string site name may also be provides as "siteNames"
     If the input is None, it is interpreted as * ( all ).
 
     If match is positive, the output looks like:
@@ -98,18 +99,20 @@ class SiteStatus( object ):
               )
 
     :Parameters:
-      **siteNamesList** - `list`
+      **siteNames** - `list` or `str`
         name(s) of the sites to be matched
 
     :return: S_OK() || S_ERROR()
     """
 
     if self.rssFlag:
-      return self.__getRSSSiteStatus(siteNamesList)
+      return self.__getRSSSiteStatus(siteNames)
     else:
       siteStatusDict = {}
-      if siteNamesList:
-        for siteName in siteNamesList:
+      if siteNames:
+        if isinstance(siteNames, basestring):
+          siteNames = [siteNames]
+        for siteName in siteNames:
           result = RPCClient('WorkloadManagement/WMSAdministrator').getSiteMaskStatus(siteName)
           if not result['OK']:
             return result
@@ -148,7 +151,7 @@ class SiteStatus( object ):
     return cacheMatch
 
 
-  def getUsableSites( self, siteNamesList = None ):
+  def getUsableSites( self, siteNames = None ):
     """
     Returns all sites that are usable if their
     statusType is either Active or Degraded; in a list.
@@ -162,13 +165,13 @@ class SiteStatus( object ):
           S_ERROR( ... )
 
     :Parameters:
-      **siteNamesList** - `List`
+      **siteNames** - `List` or `str`
         name(s) of the sites to be matched
 
     :return: S_OK() || S_ERROR()
     """
 
-    siteStatusDictRes = self.getSiteStatuses(siteNamesList)
+    siteStatusDictRes = self.getSiteStatuses(siteNames)
     if not siteStatusDictRes['OK']:
       return siteStatusDictRes
     siteStatusList = [x[0] for x in siteStatusDictRes['Value'].iteritems() if x[1] in ['Active', 'Degraded']]

--- a/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
+++ b/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
@@ -157,7 +157,7 @@ class MultiProcessorSiteDirector( SiteDirector ):
       processorTags = []
 
       # Check the status of the Site
-      result = self.siteClient.getUsableSites(siteName)
+      result = self.siteClient.getUsableSites( [ siteName ] )
       if not result['OK']:
         self.log.error("Can not get the status of site %s: %s" %
                        (siteName, result['Message']))

--- a/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
+++ b/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
@@ -157,7 +157,7 @@ class MultiProcessorSiteDirector( SiteDirector ):
       processorTags = []
 
       # Check the status of the Site
-      result = self.siteClient.getUsableSites( [ siteName ] )
+      result = self.siteClient.getUsableSites( siteName )
       if not result['OK']:
         self.log.error("Can not get the status of site %s: %s" %
                        (siteName, result['Message']))

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -487,7 +487,7 @@ class SiteDirector( AgentModule ):
       siteMask = siteName in siteMaskList
 
       # Check the status of the Site
-      result = self.siteClient.getUsableSites( [ siteName ] )
+      result = self.siteClient.getUsableSites( siteName )
       if not result['OK']:
         self.log.error("Can not get the status of site",
                        " %s: %s" % (siteName, result['Message']))

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -487,7 +487,7 @@ class SiteDirector( AgentModule ):
       siteMask = siteName in siteMaskList
 
       # Check the status of the Site
-      result = self.siteClient.getUsableSites(siteName)
+      result = self.siteClient.getUsableSites( [ siteName ] )
       if not result['OK']:
         self.log.error("Can not get the status of site",
                        " %s: %s" % (siteName, result['Message']))

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1513,7 +1513,14 @@ class JobDB( DB ):
 
 #############################################################################
   def getSiteMaskStatus( self, sites = None ):
-    """ Get the currently site mask status
+    """ Get the current site mask status
+        :param:sites - A string for a single site to check, or a list
+                       to check multiple sites.
+        :returns:If input was a list, a dictionary of sites, keys are site
+                 names and values are the site statuses. Unknown sites are
+                 not included in the output dictionary.
+                 If input was a string, then a single value with that site's
+                 status, or S_ERROR if the site does not exist in the DB.
     """
     if isinstance(sites, list):
       safeSites = []
@@ -1535,7 +1542,10 @@ class JobDB( DB ):
         return ret
       cmd = "SELECT Status FROM SiteMask WHERE Site=%s" % ret['Value']
       result = self._query( cmd )
-      return S_OK( result['Value'][0][0] )
+      if result['Value']:
+        return S_OK( result['Value'][0][0] )
+      else:
+        return S_ERROR( "Unknown site %s" % sites )
 
     else:
       cmd = "SELECT Site,Status FROM SiteMask"


### PR DESCRIPTION
Hi,

I finally finished tracking this down, it turns out there were two bugs, one triggered by the other (if the RSS is inactive):
 * SiteStatus.getSiteStatuses expects a list (if it's given a string, it loops over each character).
 * getSiteMaskStatus would crash if the given string was for a site which didn't exist (if it's given a single character as a site name, for example).

This patch fixes the above two issues.

Regards,
Simon


BEGINRELEASENOTES
*WorkloadManagement
FIX: Fix getSiteMaskStatus in SiteDirector and MultiProcessSD
ENDRELEASENOTES
