### PR TITLE
[v6r19] Fix inheritance of SRM2 protocols List

### DIFF
--- a/Resources/Storage/SRM2Storage.py
+++ b/Resources/Storage/SRM2Storage.py
@@ -23,10 +23,12 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
 from DIRAC.Core.Utilities.Subprocess import pythonCall
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Utilities.File import getSize
+from DIRAC.Core.Utilities.Decorators import deprecated
 
 # # RCSID
 __RCSID__ = "$Id$"
 
+@deprecated('Replaced by gfal2 based plugins', onlyOnce = True)
 class SRM2Storage( StorageBase ):
   """ .. class:: SRM2Storage
 

--- a/Resources/Storage/StorageBase.py
+++ b/Resources/Storage/StorageBase.py
@@ -57,6 +57,14 @@ class StorageBase( object ):
 
     self.__updateParameters( parameterDict )
 
+    # Keep the list of all parameters passed for constructions
+    # Taken from the CS
+    # In a further major release, this could be nerged together
+    # with protocolParameters. There is no reason for it to
+    # be so strict about the possible content.  
+    self._allProtocolParameters = parameterDict
+
+
 
     if hasattr( self, '_INPUT_PROTOCOLS' ):
       self.protocolParameters['InputProtocols'] = getattr( self, '_INPUT_PROTOCOLS' )

--- a/StorageManagementSystem/Agent/StageRequestAgent.py
+++ b/StorageManagementSystem/Agent/StageRequestAgent.py
@@ -224,8 +224,8 @@ class StageRequestAgent( AgentModule ):
     """ Retrieve cache size for SE
     """
     if storageElement not in self.storageElementCache:
-      self.storageElementCache[storageElement] = gConfig.getValue( "/Resources/StorageElements/%s/DiskCacheTB" % storageElement,
-                                                                   1. ) * 1000. / THROTTLING_STEPS
+      diskCacheTB = float(StorageElement(storageElement).options.get('DiskCacheTB', 1.0))
+      self.storageElementCache[storageElement] = diskCacheTB * 1000. / THROTTLING_STEPS
     return self.storageElementCache[storageElement]
 
   def __add( self, storageElement, size ):


### PR DESCRIPTION
Because of some hardcoded path, the protocols list for SRM2 was not correctly inherited.
This PR fixes this issue.

It also makes the Stager survive inheritance
I tested the SRM change with our integration tests

BEGINRELEASENOTES

*Resources
FIX: Use parameters given at construction for SRM2 protocols List

*StorageManagement
FIX: use StorageElement object to get disk cache size

ENDRELEASENOTES
