### PR TITLE
[v6r20] DIRAC StorageElement report for free and total disk space

### DIFF
--- a/DataManagementSystem/Service/StorageElementHandler.py
+++ b/DataManagementSystem/Service/StorageElementHandler.py
@@ -25,7 +25,7 @@ The class can be used as the basis for more advanced StorageElement implementati
 
 """
 
-## imports
+# imports
 import os
 import shutil
 import stat
@@ -33,7 +33,7 @@ import re
 import errno
 import shlex
 
-## from DIRAC
+# from DIRAC
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
@@ -50,9 +50,10 @@ BASE_PATH = ""
 MAX_STORAGE_SIZE = 0
 USE_TOKENS = False
 
-UNIT_CONVERSION = { "KB": 1024, "MB": 1024 * 1024, "GB": 1024 * 1024 * 1024, "TB": 1024 * 1024 * 1024 * 1024 }
+UNIT_CONVERSION = {"KB": 1024, "MB": 1024 * 1024, "GB": 1024 * 1024 * 1024, "TB": 1024 * 1024 * 1024 * 1024}
 
-def getDiskSpace(path, size = 'TB', total = False):
+
+def getDiskSpace(path, size='TB', total=False):
   """
     Returns disk usage of the given path.
     If no size is specified, terabytes will be used by default.
@@ -61,7 +62,7 @@ def getDiskSpace(path, size = 'TB', total = False):
 
   size_to_convert = size.upper()
   if size_to_convert not in UNIT_CONVERSION:
-    return S_ERROR( "No valid size specified" )
+    return S_ERROR("No valid size specified")
   convert = UNIT_CONVERSION[size_to_convert]
 
   try:
@@ -74,12 +75,13 @@ def getDiskSpace(path, size = 'TB', total = False):
       # return free space
       queried_size = st.f_bavail
 
-    result = float( queried_size * st.f_frsize ) / float(convert)
+    result = float(queried_size * st.f_frsize) / float(convert)
 
   except OSError as e:
-    return S_ERROR( errno.EIO, "Error while getting the available disk space: %s" % repr(e) )
+    return S_ERROR(errno.EIO, "Error while getting the available disk space: %s" % repr(e))
 
-  return S_OK( round(result, 4) )
+  return S_OK(round(result, 4))
+
 
 def getTotalDiskSpace():
   """  Returns the total maximum volume of the SE storage in MB. The total volume
@@ -92,14 +94,15 @@ def getTotalDiskSpace():
   global BASE_PATH
   global MAX_STORAGE_SIZE
 
-  result = getDiskSpace(BASE_PATH, size = 'MB', total = True)
+  result = getDiskSpace(BASE_PATH, size='MB', total=True)
   if not result['OK']:
     return result
   totalSpace = result['Value']
   maxTotalSpace = min(totalSpace, MAX_STORAGE_SIZE) if MAX_STORAGE_SIZE else totalSpace
   return S_OK(maxTotalSpace)
 
-def getFreeDiskSpace( ignoreMaxStorageSize = True ):
+
+def getFreeDiskSpace(ignoreMaxStorageSize=True):
   """ Returns the free disk space still available for writing taking into account
       the total available disk space and the MAX_STORAGE_SIZE limitation
 
@@ -125,7 +128,8 @@ def getFreeDiskSpace( ignoreMaxStorageSize = True ):
   freeSpace = maxTotalSpace - occupiedSpace
   return S_OK(freeSpace)
 
-def initializeStorageElementHandler( serviceInfo ):
+
+def initializeStorageElementHandler(serviceInfo):
   """  Initialize Storage Element global settings
   """
 
@@ -133,28 +137,29 @@ def initializeStorageElementHandler( serviceInfo ):
   global USE_TOKENS
   global MAX_STORAGE_SIZE
 
-  BASE_PATH = getServiceOption( serviceInfo, "BasePath", BASE_PATH )
+  BASE_PATH = getServiceOption(serviceInfo, "BasePath", BASE_PATH)
   if not BASE_PATH:
-    gLogger.error( 'Failed to get the base path' )
-    return S_ERROR( 'Failed to get the base path' )
+    gLogger.error('Failed to get the base path')
+    return S_ERROR('Failed to get the base path')
   mkDir(BASE_PATH)
 
-  USE_TOKENS = getServiceOption( serviceInfo, "%UseTokens", USE_TOKENS )
-  MAX_STORAGE_SIZE = getServiceOption( serviceInfo, "MaxStorageSize", MAX_STORAGE_SIZE )
+  USE_TOKENS = getServiceOption(serviceInfo, "%UseTokens", USE_TOKENS)
+  MAX_STORAGE_SIZE = getServiceOption(serviceInfo, "MaxStorageSize", MAX_STORAGE_SIZE)
 
-  gLogger.info( 'Starting DIRAC Storage Element' )
-  gLogger.info( 'Base Path: %s' % BASE_PATH )
-  gLogger.info( 'Max size: %d MB' % MAX_STORAGE_SIZE )
-  gLogger.info( 'Use access control tokens: ' + str( USE_TOKENS ) )
+  gLogger.info('Starting DIRAC Storage Element')
+  gLogger.info('Base Path: %s' % BASE_PATH)
+  gLogger.info('Max size: %d MB' % MAX_STORAGE_SIZE)
+  gLogger.info('Use access control tokens: ' + str(USE_TOKENS))
   return S_OK()
 
-class StorageElementHandler( RequestHandler ):
+
+class StorageElementHandler(RequestHandler):
   """
   .. class:: StorageElementHandler
 
   """
 
-  def __confirmToken( self, token, path, mode ):
+  def __confirmToken(self, token, path, mode):
     """ Confirm the access rights for the path in a given mode
     """
     # Not yet implemented
@@ -167,7 +172,7 @@ class StorageElementHandler( RequestHandler ):
         :param int size: size of a new file to store in the StorageElement
         :return: S_OK/S_ERROR, Value is boolean flag True if enough space is available
     """
-    result = getFreeDiskSpace(ignoreMaxStorageSize = False)
+    result = getFreeDiskSpace(ignoreMaxStorageSize=False)
     if not result['OK']:
       return result
     freeSpace = result['Value']
@@ -177,7 +182,7 @@ class StorageElementHandler( RequestHandler ):
 
     # We do not have enough space taking into account MAX_STORAGE_SIZE limit
     # check if the total disk space is enough however
-    result = getFreeDiskSpace(ignoreMaxStorageSize = True)
+    result = getFreeDiskSpace(ignoreMaxStorageSize=True)
     if not result['OK']:
       return result
     freeSpace = result['Value']
@@ -186,89 +191,89 @@ class StorageElementHandler( RequestHandler ):
       gLogger.warn('Space limited by MAX_STORAGE_SIZE is not enough to store file')
     return S_OK(spaceFlag)
 
-  def __resolveFileID( self, fileID ):
+  def __resolveFileID(self, fileID):
     """ get path to file for a given :fileID: """
 
-    port = self.getCSOption( 'Port', '' )
+    port = self.getCSOption('Port', '')
     if not port:
       return ''
 
     if ":%s" % port in fileID:
-      loc = fileID.find( ":%s" % port )
+      loc = fileID.find(":%s" % port)
       if loc >= 0:
-        fileID = fileID[loc + len( ":%s" % port ):]
+        fileID = fileID[loc + len(":%s" % port):]
 
     serviceName = self.serviceInfoDict['serviceName']
-    loc = fileID.find( serviceName )
+    loc = fileID.find(serviceName)
     if loc >= 0:
-      fileID = fileID[loc + len( serviceName ):]
+      fileID = fileID[loc + len(serviceName):]
 
-    loc = fileID.find( '?=' )
+    loc = fileID.find('?=')
     if loc >= 0:
       fileID = fileID[loc + 2:]
 
-    if fileID.find( BASE_PATH ) == 0:
+    if fileID.find(BASE_PATH) == 0:
       return fileID
     while fileID and fileID[0] == '/':
       fileID = fileID[1:]
-    return os.path.join( BASE_PATH, fileID )
+    return os.path.join(BASE_PATH, fileID)
 
   @staticmethod
-  def __getFileStat( path ):
+  def __getFileStat(path):
     """ Get the file stat information
     """
     resultDict = {}
     try:
-      statTuple = os.stat( path )
-    except OSError, x:
-      if str( x ).find( 'No such file' ) >= 0:
+      statTuple = os.stat(path)
+    except OSError as x:
+      if str(x).find('No such file') >= 0:
         resultDict['Exists'] = False
-        return S_OK( resultDict )
+        return S_OK(resultDict)
       else:
-        return S_ERROR( 'Failed to get metadata for %s' % path )
+        return S_ERROR('Failed to get metadata for %s' % path)
 
     resultDict['Exists'] = True
     mode = statTuple[stat.ST_MODE]
     resultDict['Type'] = "File"
     resultDict['File'] = True
     resultDict['Directory'] = False
-    if stat.S_ISDIR( mode ):
+    if stat.S_ISDIR(mode):
       resultDict['Type'] = "Directory"
       resultDict['File'] = False
     resultDict['Directory'] = True
     resultDict['Size'] = statTuple[stat.ST_SIZE]
-    resultDict['TimeStamps'] = ( statTuple[stat.ST_ATIME], statTuple[stat.ST_MTIME], statTuple[stat.ST_CTIME] )
+    resultDict['TimeStamps'] = (statTuple[stat.ST_ATIME], statTuple[stat.ST_MTIME], statTuple[stat.ST_CTIME])
     resultDict['Cached'] = 1
     resultDict['Migrated'] = 0
     resultDict['Lost'] = 0
     resultDict['Unavailable'] = 0
-    resultDict['Mode'] = stat.S_IMODE( mode )
-
+    resultDict['Mode'] = stat.S_IMODE(mode)
 
     if resultDict['File']:
-      cks = fileAdler( path )
+      cks = fileAdler(path)
       resultDict['Checksum'] = cks
 
+    resultDict = StorageBase._addCommonMetadata(resultDict)
 
-    resultDict = StorageBase._addCommonMetadata( resultDict )
-
-
-    return S_OK( resultDict )
+    return S_OK(resultDict)
 
   types_exists = [basestring]
-  def export_exists( self, fileID ):
+
+  def export_exists(self, fileID):
     """ Check existence of the fileID """
-    if os.path.exists( self.__resolveFileID( fileID ) ):
-      return S_OK( True )
-    return S_OK( False )
+    if os.path.exists(self.__resolveFileID(fileID)):
+      return S_OK(True)
+    return S_OK(False)
 
   types_getMetadata = [basestring]
-  def export_getMetadata( self, fileID ):
+
+  def export_getMetadata(self, fileID):
     """ Get metadata for the file or directory specified by fileID
     """
-    return self.__getFileStat( self.__resolveFileID( fileID ) )
+    return self.__getFileStat(self.__resolveFileID(fileID))
 
   types_getFreeDiskSpace = []
+
   @staticmethod
   def export_getFreeDiskSpace():
     """ Get the free disk space of the storage element
@@ -278,6 +283,7 @@ class StorageElementHandler( RequestHandler ):
     return getFreeDiskSpace()
 
   types_getTotalDiskSpace = []
+
   @staticmethod
   def export_getTotalDiskSpace():
     """ Get the total disk space of the storage element
@@ -287,18 +293,19 @@ class StorageElementHandler( RequestHandler ):
     return getTotalDiskSpace()
 
   types_createDirectory = [basestring]
-  def export_createDirectory( self, dir_path ):
+
+  def export_createDirectory(self, dir_path):
     """ Creates the directory on the storage
     """
-    path = self.__resolveFileID( dir_path )
-    gLogger.info( "StorageElementHandler.createDirectory: Attempting to create %s." % path )
-    if os.path.exists( path ):
-      if os.path.isfile( path ):
+    path = self.__resolveFileID(dir_path)
+    gLogger.info("StorageElementHandler.createDirectory: Attempting to create %s." % path)
+    if os.path.exists(path):
+      if os.path.isfile(path):
         errStr = "Supplied path exists and is a file"
-        gLogger.error( "StorageElementHandler.createDirectory: %s." % errStr, path )
-        return S_ERROR( errStr )
+        gLogger.error("StorageElementHandler.createDirectory: %s." % errStr, path)
+        return S_ERROR(errStr)
       else:
-        gLogger.info( "StorageElementHandler.createDirectory: %s already exists." % path )
+        gLogger.info("StorageElementHandler.createDirectory: %s already exists." % path)
         return S_OK()
     # Need to think about permissions.
     try:
@@ -306,57 +313,58 @@ class StorageElementHandler( RequestHandler ):
       return S_OK()
     except Exception as x:
       errStr = "Exception creating directory."
-      gLogger.error( "StorageElementHandler.createDirectory: %s" % errStr, str( x ) )
-      return S_ERROR( errStr )
+      gLogger.error("StorageElementHandler.createDirectory: %s" % errStr, str(x))
+      return S_ERROR(errStr)
 
   types_listDirectory = [basestring, basestring]
-  def export_listDirectory( self, dir_path, mode ):
+
+  def export_listDirectory(self, dir_path, mode):
     """ Return the dir_path directory listing
     """
     is_file = False
-    path = self.__resolveFileID( dir_path )
-    if not os.path.exists( path ):
-      return S_ERROR( 'Directory %s does not exist' % dir_path )
-    elif os.path.isfile( path ):
-      fname = os.path.basename( path )
+    path = self.__resolveFileID(dir_path)
+    if not os.path.exists(path):
+      return S_ERROR('Directory %s does not exist' % dir_path)
+    elif os.path.isfile(path):
+      fname = os.path.basename(path)
       is_file = True
     else:
-      dirList = os.listdir( path )
+      dirList = os.listdir(path)
 
     resultDict = {}
     if mode == 'l':
       if is_file:
-        result = self.__getFileStat( fname )
+        result = self.__getFileStat(fname)
         if result['OK']:
           resultDict[fname] = result['Value']
-          return S_OK( resultDict )
+          return S_OK(resultDict)
         else:
-          return S_ERROR( 'Failed to get the file stat info' )
+          return S_ERROR('Failed to get the file stat info')
       else:
         failed_list = []
         one_OK = False
         for fname in dirList:
-          result = self.__getFileStat( path + '/' + fname )
+          result = self.__getFileStat(path + '/' + fname)
           if result['OK']:
             resultDict[fname] = result['Value']
             one_OK = True
           else:
-            failed_list.append( fname )
+            failed_list.append(fname)
         if failed_list:
           if one_OK:
-            result = S_ERROR( 'Failed partially to get the file stat info' )
+            result = S_ERROR('Failed partially to get the file stat info')
           else:
-            result = S_ERROR( 'Failed to get the file stat info' )
+            result = S_ERROR('Failed to get the file stat info')
           result['FailedList'] = failed_list
           result['Value'] = resultDict
         else:
-          result = S_OK( resultDict )
+          result = S_OK(resultDict)
 
         return result
     else:
-      return S_OK( dirList )
+      return S_OK(dirList)
 
-  def transfer_fromClient( self, fileID, token, fileSize, fileHelper ):
+  def transfer_fromClient(self, fileID, token, fileSize, fileHelper):
     """ Method to receive file from clients.
         fileID is the local file name in the SE.
         fileSize can be Xbytes or -1 if unknown.
@@ -367,46 +375,46 @@ class StorageElementHandler( RequestHandler ):
       return S_ERROR('Failed to get available free space')
     elif not result['Value']:
       return S_ERROR('Not enough disk space')
-    file_path = self.__resolveFileID( fileID )
+    file_path = self.__resolveFileID(fileID)
     try:
-      mkDir(os.path.dirname( file_path ))
-      fd = open( file_path, "wb" )
-    except Exception, error:
-      return S_ERROR( "Cannot open to write destination file %s: %s" % ( file_path, str( error ) ) )
+      mkDir(os.path.dirname(file_path))
+      fd = open(file_path, "wb")
+    except Exception as error:
+      return S_ERROR("Cannot open to write destination file %s: %s" % (file_path, str(error)))
     if "NoCheckSum" in token:
       fileHelper.disableCheckSum()
-    result = fileHelper.networkToDataSink( fd, maxFileSize = ( MAX_STORAGE_SIZE * 1024 * 1024 ) )
-    if not result[ 'OK' ]:
+    result = fileHelper.networkToDataSink(fd, maxFileSize=(MAX_STORAGE_SIZE * 1024 * 1024))
+    if not result['OK']:
       return result
     fd.close()
     return result
 
-  def transfer_toClient( self, fileID, token, fileHelper ):
+  def transfer_toClient(self, fileID, token, fileHelper):
     """ Method to send files to clients.
         fileID is the local file name in the SE.
         token is used for access rights confirmation.
     """
-    file_path = self.__resolveFileID( fileID )
+    file_path = self.__resolveFileID(fileID)
     if "NoCheckSum" in token:
       fileHelper.disableCheckSum()
-    result = fileHelper.getFileDescriptor( file_path, 'r' )
+    result = fileHelper.getFileDescriptor(file_path, 'r')
     if not result['OK']:
       result = fileHelper.sendEOF()
       # check if the file does not really exist
-      if not os.path.exists( file_path ):
-        return S_ERROR( 'File %s does not exist' % os.path.basename( file_path ) )
+      if not os.path.exists(file_path):
+        return S_ERROR('File %s does not exist' % os.path.basename(file_path))
       else:
-        return S_ERROR( 'Failed to get file descriptor' )
+        return S_ERROR('Failed to get file descriptor')
 
     fileDescriptor = result['Value']
-    result = fileHelper.FDToNetwork( fileDescriptor )
+    result = fileHelper.FDToNetwork(fileDescriptor)
     fileHelper.oFile.close()
     if not result['OK']:
-      return S_ERROR( 'Failed to get file ' + fileID )
+      return S_ERROR('Failed to get file ' + fileID)
     else:
       return result
 
-  def transfer_bulkFromClient( self, fileID, token, ignoredSize, fileHelper ):
+  def transfer_bulkFromClient(self, fileID, token, ignoredSize, fileHelper):
     """ Receive files packed into a tar archive by the fileHelper logic.
         token is used for access rights confirmation.
     """
@@ -415,109 +423,113 @@ class StorageElementHandler( RequestHandler ):
       return S_ERROR('Failed to get available free space')
     elif not result['Value']:
       return S_ERROR('Not enough disk space')
-    dirName = fileID.replace( '.bz2', '' ).replace( '.tar', '' )
-    dir_path = self.__resolveFileID( dirName )
-    res = fileHelper.networkToBulk( dir_path )
+    dirName = fileID.replace('.bz2', '').replace('.tar', '')
+    dir_path = self.__resolveFileID(dirName)
+    res = fileHelper.networkToBulk(dir_path)
     if not res['OK']:
-      gLogger.error( 'Failed to receive network to bulk.', res['Message'] )
+      gLogger.error('Failed to receive network to bulk.', res['Message'])
       return res
-    if not os.path.exists( dir_path ):
-      return S_ERROR( 'Failed to receive data' )
+    if not os.path.exists(dir_path):
+      return S_ERROR('Failed to receive data')
     try:
-      os.chmod( dir_path, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH )
-    except Exception, error:
-      gLogger.exception( 'Could not set permissions of destination directory.', dir_path, error )
+      os.chmod(dir_path, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+    except Exception as error:
+      gLogger.exception('Could not set permissions of destination directory.', dir_path, error)
     return S_OK()
 
-  def transfer_bulkToClient( self, fileId, token, fileHelper ):
+  def transfer_bulkToClient(self, fileId, token, fileHelper):
     """ Send directories and files specified in the fileID.
         The fileID string can be a single directory name or a list of
         colon (:) separated file/directory names.
         token is used for access rights confirmation.
     """
-    fileInput = self.__resolveFileID( fileId )
-    tmpList = fileInput.split( ':' )
-    tmpList = [ os.path.join( BASE_PATH, x ) for x in tmpList ]
+    fileInput = self.__resolveFileID(fileId)
+    tmpList = fileInput.split(':')
+    tmpList = [os.path.join(BASE_PATH, x) for x in tmpList]
     strippedFiles = []
     compress = False
     for fileID in tmpList:
-      if re.search( '.bz2', fileID ):
-        fileID = fileID.replace( '.bz2', '' )
+      if re.search('.bz2', fileID):
+        fileID = fileID.replace('.bz2', '')
         compress = True
-      fileID = fileID.replace( '.tar', '' )
-      strippedFiles.append( self.__resolveFileID( fileID ) )
-    res = fileHelper.bulkToNetwork( strippedFiles, compress = compress )
+      fileID = fileID.replace('.tar', '')
+      strippedFiles.append(self.__resolveFileID(fileID))
+    res = fileHelper.bulkToNetwork(strippedFiles, compress=compress)
     if not res['OK']:
-      gLogger.error( 'Failed to send bulk to network', res['Message'] )
+      gLogger.error('Failed to send bulk to network', res['Message'])
     return res
 
   types_remove = [basestring, basestring]
-  def export_remove( self, fileID, token ):
-    """ Remove fileID from the storage. token is used for access rights confirmation. """
-    return self.__removeFile( self.__resolveFileID( fileID ), token )
 
-  def __removeFile( self, fileID, token ):
+  def export_remove(self, fileID, token):
+    """ Remove fileID from the storage. token is used for access rights confirmation. """
+    return self.__removeFile(self.__resolveFileID(fileID), token)
+
+  def __removeFile(self, fileID, token):
     """ Remove one file with fileID name from the storage
     """
-    filename = self.__resolveFileID( fileID )
-    if self.__confirmToken( token, fileID, 'x' ):
+    filename = self.__resolveFileID(fileID)
+    if self.__confirmToken(token, fileID, 'x'):
       try:
-        os.remove( filename )
+        os.remove(filename)
         return S_OK()
-      except OSError, error:
-        if str( error ).find( 'No such file' ) >= 0:
+      except OSError as error:
+        if str(error).find('No such file') >= 0:
           # File does not exist anyway
           return S_OK()
         else:
-          return S_ERROR( 'Failed to remove file %s' % fileID )
+          return S_ERROR('Failed to remove file %s' % fileID)
     else:
-      return S_ERROR( 'File removal %s not authorized' % fileID )
+      return S_ERROR('File removal %s not authorized' % fileID)
 
   types_getDirectorySize = [basestring]
-  def export_getDirectorySize( self, fileID ):
+
+  def export_getDirectorySize(self, fileID):
     """ Get the size occupied by the given directory
     """
-    dir_path = self.__resolveFileID( fileID )
-    if os.path.exists( dir_path ):
+    dir_path = self.__resolveFileID(fileID)
+    if os.path.exists(dir_path):
       try:
-        space = self.__getDirectorySize( dir_path )
-        return S_OK( space )
-      except Exception, error:
-        gLogger.exception( "Exception while getting size of directory", dir_path, error )
-        return S_ERROR( "Exception while getting size of directory" )
+        space = self.__getDirectorySize(dir_path)
+        return S_OK(space)
+      except Exception as error:
+        gLogger.exception("Exception while getting size of directory", dir_path, error)
+        return S_ERROR("Exception while getting size of directory")
     else:
-      return S_ERROR( "Directory does not exists" )
+      return S_ERROR("Directory does not exists")
 
   types_removeDirectory = [basestring, basestring]
-  def export_removeDirectory( self, fileID, token ):
+
+  def export_removeDirectory(self, fileID, token):
     """ Remove the given directory from the storage
     """
 
-    dir_path = self.__resolveFileID( fileID )
-    if not self.__confirmToken( token, fileID, 'x' ):
-      return S_ERROR( 'Directory removal %s not authorized' % fileID )
+    dir_path = self.__resolveFileID(fileID)
+    if not self.__confirmToken(token, fileID, 'x'):
+      return S_ERROR('Directory removal %s not authorized' % fileID)
     else:
-      if not os.path.exists( dir_path ):
+      if not os.path.exists(dir_path):
         return S_OK()
       else:
         try:
-          shutil.rmtree( dir_path )
+          shutil.rmtree(dir_path)
           return S_OK()
-        except Exception, error:
-          gLogger.error( "Failed to remove directory", dir_path )
-          gLogger.error( str( error ) )
-          return S_ERROR( "Failed to remove directory %s" % dir_path )
+        except Exception as error:
+          gLogger.error("Failed to remove directory", dir_path)
+          gLogger.error(str(error))
+          return S_ERROR("Failed to remove directory %s" % dir_path)
 
-  types_removeFileList = [ list, basestring ]
-  def export_removeFileList( self, fileList, token ):
+  types_removeFileList = [list, basestring]
+
+  def export_removeFileList(self, fileList, token):
     """ Remove files in the given list
     """
     failed_list = []
     partial_success = False
     for fileItem in fileList:
-      result = self.__removeFile( fileItem, token )
+      result = self.__removeFile(fileItem, token)
       if not result['OK']:
-        failed_list.append( fileItem )
+        failed_list.append(fileItem)
       else:
         partial_success = True
 
@@ -525,15 +537,16 @@ class StorageElementHandler( RequestHandler ):
       return S_OK()
     else:
       if partial_success:
-        result = S_ERROR( 'Bulk file removal partially failed' )
+        result = S_ERROR('Bulk file removal partially failed')
         result['FailedList'] = failed_list
       else:
-        result = S_ERROR( 'Bulk file removal failed' )
+        result = S_ERROR('Bulk file removal failed')
       return result
 
 ###################################################################
 
   types_getAdminInfo = []
+
   @staticmethod
   def export_getAdminInfo():
     """ Send the storage element administration information
@@ -541,24 +554,24 @@ class StorageElementHandler( RequestHandler ):
     storageDict = {}
     storageDict['BasePath'] = BASE_PATH
     storageDict['MaxCapacity'] = MAX_STORAGE_SIZE
-    used_space = getDirectorySize( BASE_PATH )
-    stats = os.statvfs( BASE_PATH )
-    available_space = ( stats.f_bsize * stats.f_bavail ) / 1024 / 1024
+    used_space = getDirectorySize(BASE_PATH)
+    stats = os.statvfs(BASE_PATH)
+    available_space = (stats.f_bsize * stats.f_bavail) / 1024 / 1024
     allowed_space = MAX_STORAGE_SIZE - used_space
-    actual_space = min( available_space, allowed_space )
+    actual_space = min(available_space, allowed_space)
     storageDict['AvailableSpace'] = actual_space
     storageDict['UsedSpace'] = used_space
-    return S_OK( storageDict )
+    return S_OK(storageDict)
 
   @staticmethod
-  def __getDirectorySize( path ):
+  def __getDirectorySize(path):
     """ Get the total size of the given directory in bytes
     """
     comm = "du -sb %s" % path
-    result = systemCall( 10, shlex.split( comm ) )
+    result = systemCall(10, shlex.split(comm))
     if not result['OK'] or result['Value'][0]:
       return 0
     else:
       output = result['Value'][1]
-      size = int( output.split()[0] )
+      size = int(output.split()[0])
       return size

--- a/DataManagementSystem/Service/StorageElementHandler.py
+++ b/DataManagementSystem/Service/StorageElementHandler.py
@@ -105,6 +105,10 @@ def getFreeDiskSpace( ignoreMaxStorageSize = True ):
 
       :return: S_OK/S_ERROR, Value is the free space of the SE storage in MB
   """
+
+  global MAX_STORAGE_SIZE
+  global BASE_PATH
+
   result = getDiskSpace(BASE_PATH, 'MB')
   if not result['OK']:
     return result


### PR DESCRIPTION
Methods of the DIRAC StorageElement service getFreeDiskSpace() and getTotalDiskSpace() are reimplemented without input arguments. The return values are always in MB. 

The MaxStorageSize CS option is now taken into account when reporting free and total space. The check of available disk space when adding new files is also taking into account the MaxStorageSize, however to avoid massive failures after the update only warning is printed if MaxStorageSize is exceeded while there is still enough available disk space. In the next releases this will become an error 

BEGINRELEASENOTES

*DMS
NEW: StorageElement service - getFreeDiskSpace() and getTotalDiskSpace() take into account MAX_STORAGE_SIZE parameter value

ENDRELEASENOTES
