### PR TITLE
[v6r19] MySQL - catch exception when closing closed connection

### DIFF
--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -324,9 +324,11 @@ class MySQL( object ):
         else:
           try:
             data[0].close()
-          except MySQLdb.ProgrammingError:
+          except MySQLdb.ProgrammingError as exc:
+            gLogger.warn("ProgrammingError exception while closing MySQL connection: %s" % exc)
             pass
-          except Exception:
+          except Exception as exc:
+            gLogger.warn("Exception while closing MySQL connection: %s" % exc)
             pass
       except KeyError:
         pass

--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -322,7 +322,12 @@ class MySQL( object ):
         if len( self.__spares ) < self.__maxSpares:
           self.__spares.append( ( data[0], data[1] ) )
         else:
-          data[ 0 ].close()
+          try:
+            data[0].close()
+          except MySQLdb.ProgrammingError:
+            pass
+          except Exception:
+            pass
       except KeyError:
         pass
 


### PR DESCRIPTION
  This exception is presumably provoking freezing the FileCatalog service because of an unreleased lock. 

BEGINRELEASENOTES

*Core
FIX: MySQL - catch exception when closing closed connection

ENDRELEASENOTES
