### PR TITLE
[v6r20] Add JEncode for json serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ pytests.xml
 nosetests.xml
 coverage.xml
 Local_*
+.hypothesis

--- a/Core/Utilities/JEncode.py
+++ b/Core/Utilities/JEncode.py
@@ -1,0 +1,186 @@
+""" DIRAC Encoding utilities based on json
+"""
+
+import datetime
+import json
+
+
+# Describes the way date time will be transmetted
+# We do not keep miliseconds
+DATETIME_DEFAULT_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+
+class JSerializable(object):
+  """
+      Base class to define a serializable object by DIRAC.
+
+      An object that ought to be serialized throught DISET shoud:
+        * inherit from this class
+        * define the _attrToSerialize list as class member. It is a list of
+          strings containing the name of the attributes that should be serialized
+        * have a constructor that takes no arguments, or only keywords arguments
+
+      Exemple:
+
+        class Serializable(JSerializable):
+
+          _attrToSerialize = ['myAttr']
+
+          def __init__(self, myAttr = None):
+            self.myAttr = myAttr
+
+      Limitations:
+        * This will not work for classes defined inside classes. The class definition shoud be
+          visible from the global scope
+        * Class attributes cannot be serialized as such. They are converted to instance attributes.
+
+
+  """
+
+  def _toJSON(self):
+    """ Translates the objct into a dictionary.
+        It is meant to be called by JSONDecoder only.
+
+        It relies on the attribute _attrToSerialize to know which attributes to
+        serialize.
+
+        The returned dictionary contains the attributes serialized as well as
+        hints for reconstructing the object upon receive.
+
+        :raises TypeError: If the object is not serializable (no _attrToSerialize defined)
+
+        :returns: a dictionary representing the object
+
+
+    """
+
+    # If the object does not have _attrToSerialize defined
+    # Raise TypeError
+    if not hasattr(self, '_attrToSerialize'):
+      raise TypeError("Object not serializable. _attrToSerialize not defined")
+
+    jsonData = {}
+
+    # Store the class name and the module name
+    jsonData['__dCls'] = self.__class__.__name__
+    jsonData['__dMod'] = self.__module__
+
+    # self._attrToSerialize will be defined by the child class
+    for attr in self._attrToSerialize:  # pylint: disable=no-member
+      # If an argument to serialize is not defined,
+      # we continue. This is handy for arguments that
+      # are defined dynamicaly ,like SQLAlchemy does.
+      if not hasattr(self, attr):
+        continue
+      attrValue = getattr(self, attr)
+      if attrValue is not None:
+        jsonData[attr] = attrValue
+
+    return jsonData
+
+
+class DJSONEncoder(json.JSONEncoder):
+  """ This custom encoder is to add support to json for
+      tuple, datetime, and any object inheriting from JSerializable
+  """
+
+  def default(self, obj):  # pylint: disable=method-hidden
+    """ Add supports for datetime and JSerializable class to default json
+
+        :param obj: object to serialize
+
+        :return: json string of the serialized objects
+
+    """
+
+    # If we have a datetime object, dumps its string representation
+    if isinstance(obj, datetime.datetime):
+      return {'__dCls': 'dt', 'obj': obj.strftime(DATETIME_DEFAULT_FORMAT)}
+    # if the object inherits from JSJerializable, try to serialize it
+    elif isinstance(obj, JSerializable):
+      return obj._toJSON()  # pylint: disable=protected-access
+
+    # otherwise, let the parent do
+    return super(DJSONEncoder, self).default(obj)
+
+
+class DJSONDecoder(json.JSONDecoder):
+  """ This custom decoder is to add support to json for
+      tuple, datetime, and any object inheriting from JSerializable
+  """
+
+  def __init__(self, *args, **kargs):
+    """
+        Init method needed in order to give the object_hook to have special
+        deserialization method.
+
+    """
+    super(DJSONDecoder, self).__init__(object_hook=self.dict_to_object,
+                                       *args, **kargs)
+
+  @staticmethod
+  def dict_to_object(dataDict):
+    """ Convert the dictionary into an object.
+        Adds deserialization support for datetype and JSerializable
+
+        :param dataDict: json dictionary representing the data
+
+        :returns: deserialized object
+    """
+
+    className = dataDict.pop('__dCls', None)
+
+    # If the class is of type dt (datetime)
+    if className == 'dt':
+      return datetime.datetime.strptime(dataDict['obj'], DATETIME_DEFAULT_FORMAT)
+    elif className:
+      import importlib
+
+      # Get the module
+      modName = dataDict.pop('__dMod')
+
+      # Load the module
+      mod = importlib.import_module(modName)
+      # import the class
+      cl = getattr(mod, className)
+      # Instantiate the object
+      obj = cl()
+
+      # Set each attribute
+      for attrName, attrValue in dataDict.iteritems():
+        # If the value is None, do not set it
+        # This is needed to play along well with SQLalchemy
+        if attrValue is None:
+          continue
+
+        setattr(obj, attrName, attrValue)
+
+      return obj
+
+    # If we do not know how to serialize, just return the dictionary
+    return dataDict
+
+
+def encode(inData):
+  """ Encode the input data into a JSON string
+
+      :param inData: anything that can be serialized.
+                     Namely, anything that can be serialized by standard json package,
+                     datetime object, tuples,  and any class that inherits from JSerializable
+
+      :return: a json string
+  """
+  return json.dumps(inData, cls=DJSONEncoder)
+
+
+def decode(encodedData):
+  """ Decode the json encoded string
+
+      :param encodedData: json encoded string
+
+      :return: the decoded objects, encoded object length
+
+      Arguably, the length of the encodedData is useless,
+      but it is for compatibility
+  """
+  return json.loads(encodedData, cls=DJSONDecoder), len(encodedData)

--- a/docs/README
+++ b/docs/README
@@ -4,8 +4,9 @@ How to build DIRAC documentation
 1. Create DIRAC client environment by an appropriate
    source bashrc
 
-2. Go to the Tools directory of the DIRAC source code repository
-   cd DIRAC/docs/Tools
+2. Go to the Documentation directory of the DIRAC source code repository
+   cd DIRAC/docs/
 
 3. Run the documentation building script
-   ./makeDocs.sh
+   READTHEDOCS=True make html
+

--- a/docs/source/DeveloperGuide/Internals/Core/ClientServer.rst
+++ b/docs/source/DeveloperGuide/Internals/Core/ClientServer.rst
@@ -1,0 +1,134 @@
+===========================
+Client Service Interactions
+===========================
+
+*******
+Clients
+*******
+
+The client can interact with services using RPC calls. DIRAC provides an abstraction which allows to easily add new clients.
+
+
+.. graphviz::
+
+   digraph {
+   YourClient -> Client [label=inherit];
+   Client -> RPCClient [label=use];
+   RPCClient -> InnerRPCClient [label=use];
+   TransferClient -> BaseClient [label=inherit];
+   InnerRPCClient -> BaseClient [label=inherit];
+   BaseClient -> Transports [label=use];
+
+   YourClient  [shape=polygon,sides=4];
+   Client  [shape=polygon,sides=4, label = "DIRAC.Core.Base.Client"];
+   RPCClient  [shape=polygon,sides=4, label = "DIRAC.Core.DISET.RPCClient"];
+   InnerRPCClient  [shape=polygon,sides=4, label = "DIRAC.Core.DISET.private.InnerRPCClient"];
+   TransferClient  [shape=polygon,sides=4, label = "DIRAC.Core.DISET.private.TransferClient"];
+   BaseClient [shape=polygon,sides=4, label = "DIRAC.Core.DISET.private.BaseClient"] ;
+   Transports [shape=polygon,sides=4];
+   }
+
+
+
+
+The BaseClient class contains the low level logic to discover the URLs from System/Component, the connection retry and failover mechanism, the discovery of the credentials to use, and the mechanism to initialize actions with the server. It relies on a Transport class to actually perform the communication.
+
+InnerRPCClient inherits from BaseClient, and just contain the logic to perform an RPC call: it proposes to the server an RPC action. TransferClient implements the FileTransfer logic.
+
+RPCClient translates non existing methods into RPC calls. It does this by using an InnerRPCClient.
+
+the Client class contains a similar logic to emulate methods, but parses specific arguments at each call (url, rpc and timeout) to instantiate an RPCClient. All parameters given to it at initialization will be passed to RPCClient, and propagated down to BaseClient.
+
+Refer to the code documentation of each class for more details. It is good to know however that many connection details can be specified at the creation of the client, and are not necessarily taken from the environment, like the proxy to use.
+
+Here is a rough overview of what is happening when you are calling a method from a client.
+
+.. code-block:: python
+
+   from DIRAC.Core.Base.Cliet import Client
+
+   c = Client()
+   c.serverURL('DataManagement/FileCatalog') # The subclient would have to define it themselves as well
+
+   # This returns a function pointing to Client.executeRPC
+   pingMethod = c.ping
+   # Calling <class 'DIRAC.Core.Base.Client.Client'>.__getattr__(('ping',))
+
+   # When performing the executiong, the whole chain happens
+   pingMethod()
+
+
+   # Calling <class 'DIRAC.Core.Base.Client.Client'>.executeRPC(): this parses the specific arguments URL and  timeout
+   #   if given in the call parameters
+   # Calling <class 'DIRAC.Core.Base.Client.Client'>._getRPC(False, '', 120): we generate an RPCClient
+   # Calling <class 'DIRAC.Core.DISET.RPCClient.RPCClient'>.__getattr__('ping'): we forward the call to the RPCClient
+   # Calling <class 'DIRAC.Core.DISET.RPCClient.RPCClient'>.__doRPC('ping',()): the RPCClient emulates the existance of the
+   #   function and forwards it to the InnerRPCClient
+   # Calling <class 'DIRAC.Core.DISET.private.InnerRPCClient.InnerRPCClient'>.executeRPC('ping', ()): the RPC call is finally
+   #   executed
+
+ThreadConfig
+============
+
+This special class is to be used in case you want to execute an operation on behalf of somebody else. Typically the WebApp uses it. This object is a singleton, but all its attributes are thread local. The host/identity wanting to use that requires the TrustedHost property.
+
+Let's take an example
+
+.. code-block:: python
+
+      from DIRAC.Core.DISET.RPCClient import RPCClient
+      rpc = RPCClient('System/Component')
+
+      rpc.ping()
+
+In the previous code, the code will be executed as whatever is set in the environment: host certificate or proxy.
+
+.. code-block:: python
+
+      from DIRAC.Core.DISET.RPCClient import RPCClient
+      from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
+
+      thConfig = ThreadConfig()
+      thConfig.setDN('/Whatever/User')
+
+      rpc = RPCClient('System/Component')
+      rpc.ping()
+
+In that case, the call will still be performed using whatever is set in the environment, however the remote service will act as if the request was done by ``/Whatever/user`` (providing that the TrustedHost property is granted).
+And because of the ``threading.local`` inheritance, we can have separate users actions like bellow.
+
+.. code-block:: python
+
+     import threading
+     from DIRAC.Core.DISET.RPCClient import RPCClient
+     from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
+
+     thConfig = ThreadConfig()
+
+     class myThread (threading.Thread):
+
+       def __init__(self, name):
+          super(myThread, self).__init__()
+          self.name = name
+
+       def run(self):
+          thConfig.setDN(self.name)
+          rpc = RPCClient('DataManagement/FileCatalog')
+          rpc.ping()
+
+
+     threads = []
+
+     thread1 = myThread("/Whatever/user1")
+     thread2 = myThread("/Whatever/user2")
+
+     thread1.start()
+     thread2.start()
+
+     # Add threads to thread list
+     threads.append(thread1)
+     threads.append(thread2)
+
+     # Wait for all threads to complete
+     for t in threads:
+        t.join()

--- a/docs/source/DeveloperGuide/Internals/Core/Serialization.rst
+++ b/docs/source/DeveloperGuide/Internals/Core/Serialization.rst
@@ -1,0 +1,92 @@
+=============
+Serialization
+=============
+
+The serialization mechanism currently used in DIRAC is called DEncode. It is a custom serialization mechanism.
+
+The aim in the medium term is to replace it with standard JSON serialization.
+
+We will describe here these two.
+
+*******
+DEncode
+*******
+
+DEncode (:py:mod:`~DIRAC.Core.Utilities.DEncode`) contains two functions:
+
+  * encode: returns the string representation of the input.
+  * decode: returns the decoded information from the string input, as well as the length of the information decoded.
+
+
+.. code-block:: python
+
+  from DIRAC.Core.Utilities.DEncode import encode, decode
+
+  myData = {'a' : [1,2,3], 2 : 'toto' }
+
+  # Encode the structure
+  myEncodedData = encode(myData)
+
+  # myEncodedData is the string 'di2es4:totos1:ali1ei2ei3eee'
+
+  # Decode the data back
+  decode(myEncodedData)
+
+  # returns a tuple containing the decoded data
+  # and the length decoded
+  # ({2: 'toto', 'a': [1, 2, 3]}, 27)
+
+DEncode supports the following type:
+
+  * boolean
+  * datetime
+  * dict
+  * int
+  * float (CAUTION, see bellow)
+  * list
+  * long
+  * none
+  * string
+  * tuple
+  * unicode
+
+It is a know fact that DEncode is not stable for floats:
+
+.. code-block:: python
+
+  from DIRAC.Core.Utilities.DEncode import encode, decode
+
+  d = 133143986190.0
+
+  import sys
+
+  sys.maxint > d
+  # True
+
+  encode(d)
+  # 'f1.3314398619e+11e'
+
+  decode(encode(d))
+  # (133143986190.00002, 18)
+
+Notice that 133143986190.0 != 133143986190.00002
+
+
+*******
+JEncode
+*******
+
+.. warning:: This serialization is not in use yet
+
+JEncode (:py:mod:`~DIRAC.Core.Utilities.JEncode`) is based on JSON, but exposes the same interface as DEncode, that is an `encode` and a `decode` functions.
+
+However, because of the nature of JSON (https://tools.ietf.org/html/rfc7159), there are some limitations and changes with respect to DEncode:
+
+  * all UTF-8 by default. Non default would be other UTF encoding
+  * Tuples are converted to arrays
+  * the keys of dictionaries are always strings. This means that any other type of key will be cast to a string (including numbers !). As a consequence, it is up to the sender/receiver to cast that in whatever type is desired.
+
+JEncode contains a special serializer and deserializer which enhance the default one with:
+
+  * Support for datetime: the serialization format is hardcoded and corresponds to `%Y-%m-%d %H:%M:%S` (see https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior). This means that milliseconds are not kept. Note as well that only dates starting after 01-01-1900 are serializable.
+  * Support for custom object serialization inheriting from `JSerializable` (:py:class:`~DIRAC.Core.Utilities.JEncode.JSerializable`). See the Code documentation for more details on the restrinctions and how to use it.

--- a/docs/source/DeveloperGuide/Internals/Core/index.rst
+++ b/docs/source/DeveloperGuide/Internals/Core/index.rst
@@ -1,134 +1,14 @@
-===========================
-Client Service Interactions
-===========================
+.. _developpers_internals_core:
 
-*******
-Clients
-*******
-
-The client can interact with services using RPC calls. DIRAC provides an abstraction which allows to easily add new clients.
+==================================
+DIRAC Internals Core documentation
+==================================
 
 
-.. graphviz::
+Documentation aboout the low level behavior of DIRAC
 
-   digraph {
-   YourClient -> Client [label=inherit];
-   Client -> RPCClient [label=use];
-   RPCClient -> InnerRPCClient [label=use];
-   TransferClient -> BaseClient [label=inherit];
-   InnerRPCClient -> BaseClient [label=inherit];
-   BaseClient -> Transports [label=use];
+.. toctree::
+   :maxdepth: 1
 
-   YourClient  [shape=polygon,sides=4];
-   Client  [shape=polygon,sides=4, label = "DIRAC.Core.Base.Client"];
-   RPCClient  [shape=polygon,sides=4, label = "DIRAC.Core.DISET.RPCClient"];
-   InnerRPCClient  [shape=polygon,sides=4, label = "DIRAC.Core.DISET.private.InnerRPCClient"];
-   TransferClient  [shape=polygon,sides=4, label = "DIRAC.Core.DISET.private.TransferClient"];
-   BaseClient [shape=polygon,sides=4, label = "DIRAC.Core.DISET.private.BaseClient"] ;
-   Transports [shape=polygon,sides=4];
-   }
-
-
-
-
-The BaseClient class contains the low level logic to discover the URLs from System/Component, the connection retry and failover mechanism, the discovery of the credentials to use, and the mechanism to initialize actions with the server. It relies on a Transport class to actually perform the communication.
-
-InnerRPCClient inherits from BaseClient, and just contain the logic to perform an RPC call: it proposes to the server an RPC action. TransferClient implements the FileTransfer logic.
-
-RPCClient translates non existing methods into RPC calls. It does this by using an InnerRPCClient.
-
-the Client class contains a similar logic to emulate methods, but parses specific arguments at each call (url, rpc and timeout) to instantiate an RPCClient. All parameters given to it at initialization will be passed to RPCClient, and propagated down to BaseClient.
-
-Refer to the code documentation of each class for more details. It is good to know however that many connection details can be specified at the creation of the client, and are not necessarily taken from the environment, like the proxy to use.
-
-Here is a rough overview of what is happening when you are calling a method from a client.
-
-.. code-block:: python
-
-   from DIRAC.Core.Base.Cliet import Client
-
-   c = Client()
-   c.serverURL('DataManagement/FileCatalog') # The subclient would have to define it themselves as well
-
-   # This returns a function pointing to Client.executeRPC
-   pingMethod = c.ping
-   # Calling <class 'DIRAC.Core.Base.Client.Client'>.__getattr__(('ping',))
-
-   # When performing the executiong, the whole chain happens
-   pingMethod()
-
-
-   # Calling <class 'DIRAC.Core.Base.Client.Client'>.executeRPC(): this parses the specific arguments URL and  timeout
-   #   if given in the call parameters
-   # Calling <class 'DIRAC.Core.Base.Client.Client'>._getRPC(False, '', 120): we generate an RPCClient
-   # Calling <class 'DIRAC.Core.DISET.RPCClient.RPCClient'>.__getattr__('ping'): we forward the call to the RPCClient
-   # Calling <class 'DIRAC.Core.DISET.RPCClient.RPCClient'>.__doRPC('ping',()): the RPCClient emulates the existance of the
-   #   function and forwards it to the InnerRPCClient
-   # Calling <class 'DIRAC.Core.DISET.private.InnerRPCClient.InnerRPCClient'>.executeRPC('ping', ()): the RPC call is finally
-   #   executed
-
-   ThreadConfig
-   ============
-
-   This special class is to be used in case you want to execute an operation on behalf of somebody else. Typically the WebApp uses it. This object is a singleton, but all its attributes are thread local. The host/identity wanting to use that requires the TrustedHost property.
-
-   Let's take an example
-
-   .. code-block:: python
-
-      from DIRAC.Core.DISET.RPCClient import RPCClient
-      rpc = RPCClient('System/Component')
-
-      rpc.ping()
-
-   In the previous code, the code will be executed as whatever is set in the environment: host certificate or proxy.
-
-   .. code-block:: python
-
-      from DIRAC.Core.DISET.RPCClient import RPCClient
-      from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
-
-      thConfig = ThreadConfig()
-      thConfig.setDN('/Whatever/User')
-
-      rpc = RPCClient('System/Component')
-      rpc.ping()
-
-   In that case, the call will still be performed using whatever is set in the environment, however the remote service will act as if the request was done by ``/Whatever/user`` (providing that the TrustedHost property is granted).
-   And because of the ``threading.local`` inheritance, we can have separate users actions like bellow.
-
-   .. code-block:: python
-
-     import threading
-     from DIRAC.Core.DISET.RPCClient import RPCClient
-     from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
-
-     thConfig = ThreadConfig()
-
-     class myThread (threading.Thread):
-
-       def __init__(self, name):
-          super(myThread, self).__init__()
-          self.name = name
-
-       def run(self):
-          thConfig.setDN(self.name)
-          rpc = RPCClient('DataManagement/FileCatalog')
-          rpc.ping()
-
-
-     threads = []
-
-     thread1 = myThread("/Whatever/user1")
-     thread2 = myThread("/Whatever/user2")
-
-     thread1.start()
-     thread2.start()
-
-     # Add threads to thread list
-     threads.append(thread1)
-     threads.append(thread2)
-
-     # Wait for all threads to complete
-     for t in threads:
-        t.join()
+   ClientServer.rst
+   Serialization.rst

--- a/docs/source/DeveloperGuide/Internals/index.rst
+++ b/docs/source/DeveloperGuide/Internals/index.rst
@@ -3,7 +3,7 @@ How DIRAC works underneath
 ==================================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    ../../AdministratorGuide/Systems/WorkloadManagement/JobPriorities/index
    Core/index


### PR DESCRIPTION
This PR contains all the code necessary to perform JSON serialization enhanced with datetime and custom types.
I added a doc about the serialization in general.
Tests are updated as well.

This code is still not used anywhere. It will be enabled progressively. 
Future PRs to come.

@andresailer @petricm : you guys are the doc experts. I desperately tried to add a link to the code documentation (using `:py:mod`) but miserably failed. Any hint ? Thanks

BEGINRELEASENOTES
*Core
NEW: JEncode for json based serialization
ENDRELEASENOTES
