### PR TITLE
[v6r20] Print DEncode traceback information

### DIFF
--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -23,10 +23,9 @@ import traceback
 from pprint import pprint
 
 
-
 # Setting this environment variable will enable the dump of the debugging
 # call stack
-DIRAC_DEBUG_DENCODE_CALLSTACK=bool(os.environ.get('DIRAC_DEBUG_DENCODE_CALLSTACK', False))
+DIRAC_DEBUG_DENCODE_CALLSTACK = bool(os.environ.get('DIRAC_DEBUG_DENCODE_CALLSTACK', False))
 
 
 def printDebugCallstack():
@@ -47,18 +46,15 @@ def printDebugCallstack():
     # Get all the arguments of the call
     allArgs = inspect.getargvalues(frame)
     # Keep only the arguments that are parameters of the call, as well as their value
-    return dict([(argName, allArgs.locals[argName]) for argName in allArgs.args ])
-
+    return dict([(argName, allArgs.locals[argName]) for argName in allArgs.args])
 
   tb = traceback.format_stack()
   frames = inspect.stack(context=100)
-
 
   # print the traceback that leads us here
   # remove the last element which is the traceback module call
   for line in tb[:-1]:
     print line
-
 
   # Now we try to navigate up to the caller of dEncode.
   # For this, we find the frame in which we enter dEncode.
@@ -69,277 +65,320 @@ def printDebugCallstack():
     framesIter = iter(frames)
     for frame in framesIter:
       # First check that we are using either 'encode' or 'decode' function
-      if frame[3] in ('encode','decode'):
+      if frame[3] in ('encode', 'decode'):
         # Then check it is the good file
         if frame[1].endswith('DIRAC/Core/Utilities/DEncode.py'):
           # Keep the arguments of the DEncode call
           dencArgs = stripArgs(frame[0])
           # Take the calling frame
           frame = next(framesIter)
-          print "Calling frame: %s"%(frame[1:3],)
+          print "Calling frame: %s" % (frame[1:3],)
           print "With arguments ",
           pprint(dencArgs)
           break
 
-
-  except:
+  except BaseException:
     pass
-  print "="*100
+  print "=" * 100
   print
   print
 
 
 _dateTimeObject = datetime.datetime.utcnow()
-_dateTimeType = type( _dateTimeObject )
-_dateType = type( _dateTimeObject.date() )
-_timeType = type( _dateTimeObject.time() )
+_dateTimeType = type(_dateTimeObject)
+_dateType = type(_dateTimeObject.date())
+_timeType = type(_dateTimeObject.time())
 
 g_dEncodeFunctions = {}
 g_dDecodeFunctions = {}
 
-#Encoding and decoding ints
-def encodeInt( iValue, eList ):
-  eList.extend( ( "i", str( iValue ), "e" ) )
+# Encoding and decoding ints
 
-def decodeInt( data, i ):
+
+def encodeInt(iValue, eList):
+  eList.extend(("i", str(iValue), "e"))
+
+
+def decodeInt(data, i):
   i += 1
-  end = data.index( 'e', i )
-  value = int( data[i:end] )
-  return ( value, end + 1 )
+  end = data.index('e', i)
+  value = int(data[i:end])
+  return (value, end + 1)
 
-g_dEncodeFunctions[ types.IntType ] = encodeInt
-g_dDecodeFunctions[ "i" ] = decodeInt
 
-#Encoding and decoding longs
-def encodeLong( iValue, eList ):
+g_dEncodeFunctions[types.IntType] = encodeInt
+g_dDecodeFunctions["i"] = decodeInt
+
+# Encoding and decoding longs
+
+
+def encodeLong(iValue, eList):
   # corrected by KGG   eList.extend( ( "l", str( iValue ), "e" ) )
-  eList.extend( ( "I", str( iValue ), "e" ) )
+  eList.extend(("I", str(iValue), "e"))
 
-def decodeLong( data, i ):
+
+def decodeLong(data, i):
   i += 1
-  end = data.index( 'e', i )
-  value = long( data[i:end] )
-  return ( value, end + 1 )
+  end = data.index('e', i)
+  value = long(data[i:end])
+  return (value, end + 1)
 
-g_dEncodeFunctions[ types.LongType ] = encodeLong
-g_dDecodeFunctions[ "I" ] = decodeLong
 
-#Encoding and decoding floats
-def encodeFloat( iValue, eList ):
-  eList.extend( ( "f", str( iValue ), "e" ) )
+g_dEncodeFunctions[types.LongType] = encodeLong
+g_dDecodeFunctions["I"] = decodeLong
 
-def decodeFloat( data, i ):
+# Encoding and decoding floats
+
+
+def encodeFloat(iValue, eList):
+  eList.extend(("f", str(iValue), "e"))
+
+
+def decodeFloat(data, i):
   i += 1
-  end = data.index( 'e', i )
-  if end + 1 < len( data ) and data[end + 1] in ( '+', '-' ):
+  end = data.index('e', i)
+  if end + 1 < len(data) and data[end + 1] in ('+', '-'):
     eI = end
-    end = data.index( 'e', end + 1 )
-    value = float( data[i:eI] ) * 10 ** int( data[eI + 1:end] )
+    end = data.index('e', end + 1)
+    value = float(data[i:eI]) * 10 ** int(data[eI + 1:end])
   else:
-    value = float( data[i:end] )
-  return ( value, end + 1 )
+    value = float(data[i:end])
+  return (value, end + 1)
 
-g_dEncodeFunctions[ types.FloatType ] = encodeFloat
-g_dDecodeFunctions[ "f" ] = decodeFloat
 
-#Encoding and decoding booleand
-def encodeBool( bValue, eList ):
+g_dEncodeFunctions[types.FloatType] = encodeFloat
+g_dDecodeFunctions["f"] = decodeFloat
+
+# Encoding and decoding booleand
+
+
+def encodeBool(bValue, eList):
   if bValue:
-    eList.append( "b1" )
+    eList.append("b1")
   else:
-    eList.append( "b0" )
+    eList.append("b0")
 
-def decodeBool( data, i ):
-  if data[ i + 1 ] == "0":
-    return ( False, i + 2 )
+
+def decodeBool(data, i):
+  if data[i + 1] == "0":
+    return (False, i + 2)
   else:
-    return ( True, i + 2 )
+    return (True, i + 2)
 
-g_dEncodeFunctions[ types.BooleanType ] = encodeBool
-g_dDecodeFunctions[ "b" ] = decodeBool
 
-#Encoding and decoding strings
-def encodeString( sValue, eList ):
-  eList.extend( ( 's', str( len( sValue ) ), ':', sValue ) )
+g_dEncodeFunctions[types.BooleanType] = encodeBool
+g_dDecodeFunctions["b"] = decodeBool
 
-def decodeString( data, i ):
+# Encoding and decoding strings
+
+
+def encodeString(sValue, eList):
+  eList.extend(('s', str(len(sValue)), ':', sValue))
+
+
+def decodeString(data, i):
   i += 1
-  colon = data.index( ":", i )
-  value = int( data[ i : colon ] )
+  colon = data.index(":", i)
+  value = int(data[i: colon])
   colon += 1
   end = colon + value
-  return ( data[ colon : end] , end )
+  return (data[colon: end], end)
 
-g_dEncodeFunctions[ types.StringType ] = encodeString
-g_dDecodeFunctions[ "s" ] = decodeString
 
-#Encoding and decoding unicode strings
-def encodeUnicode( sValue, eList ):
-  valueStr = sValue.encode( 'utf-8' )
-  eList.extend( ( 'u', str( len( valueStr ) ), ':', valueStr ) )
+g_dEncodeFunctions[types.StringType] = encodeString
+g_dDecodeFunctions["s"] = decodeString
 
-def decodeUnicode( data, i ):
+# Encoding and decoding unicode strings
+
+
+def encodeUnicode(sValue, eList):
+  valueStr = sValue.encode('utf-8')
+  eList.extend(('u', str(len(valueStr)), ':', valueStr))
+
+
+def decodeUnicode(data, i):
   i += 1
-  colon = data.index( ":", i )
-  value = int( data[ i : colon ] )
+  colon = data.index(":", i)
+  value = int(data[i: colon])
   colon += 1
   end = colon + value
-  return ( unicode( data[ colon : end], 'utf-8' ) , end )
+  return (unicode(data[colon: end], 'utf-8'), end)
 
-g_dEncodeFunctions[ types.UnicodeType ] = encodeUnicode
-g_dDecodeFunctions[ "u" ] = decodeUnicode
 
-#Encoding and decoding datetime
-def encodeDateTime( oValue, eList ):
-  if type( oValue ) == _dateTimeType:
-    tDateTime = ( oValue.year, oValue.month, oValue.day, \
-                      oValue.hour, oValue.minute, oValue.second, \
-                      oValue.microsecond, oValue.tzinfo )
-    eList.append( "za" )
+g_dEncodeFunctions[types.UnicodeType] = encodeUnicode
+g_dDecodeFunctions["u"] = decodeUnicode
+
+# Encoding and decoding datetime
+
+
+def encodeDateTime(oValue, eList):
+  if isinstance(oValue, _dateTimeType):
+    tDateTime = (oValue.year, oValue.month, oValue.day,
+                 oValue.hour, oValue.minute, oValue.second,
+                 oValue.microsecond, oValue.tzinfo)
+    eList.append("za")
     # corrected by KGG encode( tDateTime, eList )
-    g_dEncodeFunctions[ type( tDateTime ) ]( tDateTime, eList )
-  elif type( oValue ) == _dateType:
-    tData = ( oValue.year, oValue.month, oValue. day )
-    eList.append( "zd" )
+    g_dEncodeFunctions[type(tDateTime)](tDateTime, eList)
+  elif isinstance(oValue, _dateType):
+    tData = (oValue.year, oValue.month, oValue. day)
+    eList.append("zd")
     # corrected by KGG encode( tData, eList )
-    g_dEncodeFunctions[ type( tData ) ]( tData, eList )
-  elif type( oValue ) == _timeType:
-    tTime = ( oValue.hour, oValue.minute, oValue.second, oValue.microsecond, oValue.tzinfo )
-    eList.append( "zt" )
+    g_dEncodeFunctions[type(tData)](tData, eList)
+  elif isinstance(oValue, _timeType):
+    tTime = (oValue.hour, oValue.minute, oValue.second, oValue.microsecond, oValue.tzinfo)
+    eList.append("zt")
     # corrected by KGG encode( tTime, eList )
-    g_dEncodeFunctions[ type( tTime ) ]( tTime, eList )
+    g_dEncodeFunctions[type(tTime)](tTime, eList)
   else:
-    raise Exception( "Unexpected type %s while encoding a datetime object" % str( type( oValue ) ) )
+    raise Exception("Unexpected type %s while encoding a datetime object" % str(type(oValue)))
 
-def decodeDateTime( data, i ):
+
+def decodeDateTime(data, i):
   i += 1
   dataType = data[i]
   # corrected by KGG tupleObject, i = decode( data, i + 1 )
-  tupleObject, i = g_dDecodeFunctions[ data[ i + 1 ] ]( data, i + 1 )
+  tupleObject, i = g_dDecodeFunctions[data[i + 1]](data, i + 1)
   if dataType == 'a':
-    dtObject = datetime.datetime( *tupleObject )
+    dtObject = datetime.datetime(*tupleObject)
   elif dataType == 'd':
-    dtObject = datetime.date( *tupleObject )
+    dtObject = datetime.date(*tupleObject)
   elif dataType == 't':
-    dtObject = datetime.time( *tupleObject )
+    dtObject = datetime.time(*tupleObject)
   else:
-    raise Exception( "Unexpected type %s while decoding a datetime object" % dataType )
-  return ( dtObject, i )
+    raise Exception("Unexpected type %s while decoding a datetime object" % dataType)
+  return (dtObject, i)
 
-g_dEncodeFunctions[ _dateTimeType ] = encodeDateTime
-g_dEncodeFunctions[ _dateType ] = encodeDateTime
-g_dEncodeFunctions[ _timeType ] = encodeDateTime
-g_dDecodeFunctions[ 'z' ] = decodeDateTime
 
-#Encoding and decoding None
-def encodeNone( oValue, eList ):
-  eList.append( "n" )
+g_dEncodeFunctions[_dateTimeType] = encodeDateTime
+g_dEncodeFunctions[_dateType] = encodeDateTime
+g_dEncodeFunctions[_timeType] = encodeDateTime
+g_dDecodeFunctions['z'] = decodeDateTime
 
-def decodeNone( data, i ):
-  return ( None, i + 1 )
+# Encoding and decoding None
 
-g_dEncodeFunctions[ types.NoneType ] = encodeNone
-g_dDecodeFunctions[ 'n' ] = decodeNone
 
-#Encode and decode a list
-def encodeList( lValue, eList ):
-  eList.append( "l" )
+def encodeNone(oValue, eList):
+  eList.append("n")
+
+
+def decodeNone(data, i):
+  return (None, i + 1)
+
+
+g_dEncodeFunctions[types.NoneType] = encodeNone
+g_dDecodeFunctions['n'] = decodeNone
+
+# Encode and decode a list
+
+
+def encodeList(lValue, eList):
+  eList.append("l")
   for uObject in lValue:
-    g_dEncodeFunctions[ type( uObject ) ]( uObject, eList )
-  eList.append( "e" )
+    g_dEncodeFunctions[type(uObject)](uObject, eList)
+  eList.append("e")
 
-def decodeList( data, i ):
+
+def decodeList(data, i):
   oL = []
   i += 1
-  while data[ i ] != "e":
-    ob, i = g_dDecodeFunctions[ data[ i ] ]( data, i )
-    oL.append( ob )
-  return( oL, i + 1 )
+  while data[i] != "e":
+    ob, i = g_dDecodeFunctions[data[i]](data, i)
+    oL.append(ob)
+  return(oL, i + 1)
 
-g_dEncodeFunctions[ types.ListType ] = encodeList
-g_dDecodeFunctions[ "l" ] = decodeList
 
-#Encode and decode a tuple
-def encodeTuple( lValue, eList ):
+g_dEncodeFunctions[types.ListType] = encodeList
+g_dDecodeFunctions["l"] = decodeList
+
+# Encode and decode a tuple
+
+
+def encodeTuple(lValue, eList):
 
   if DIRAC_DEBUG_DENCODE_CALLSTACK:
-    print '='*45, "Encoding tuples", '='*45
+    print '=' * 45, "Encoding tuples", '=' * 45
     printDebugCallstack()
 
-  eList.append( "t" )
+  eList.append("t")
   for uObject in lValue:
-    g_dEncodeFunctions[ type( uObject ) ]( uObject, eList )
-  eList.append( "e" )
+    g_dEncodeFunctions[type(uObject)](uObject, eList)
+  eList.append("e")
 
-def decodeTuple( data, i ):
+
+def decodeTuple(data, i):
   if DIRAC_DEBUG_DENCODE_CALLSTACK:
-    print '='*45, "Decoding tuples", '='*45
+    print '=' * 45, "Decoding tuples", '=' * 45
     printDebugCallstack()
 
-  oL, i = decodeList( data, i )
-  return ( tuple( oL ), i )
+  oL, i = decodeList(data, i)
+  return (tuple(oL), i)
 
-g_dEncodeFunctions[ types.TupleType ] = encodeTuple
-g_dDecodeFunctions[ "t" ] = decodeTuple
 
-#Encode and decode a dictionary
-def encodeDict( dValue, eList ):
+g_dEncodeFunctions[types.TupleType] = encodeTuple
+g_dDecodeFunctions["t"] = decodeTuple
+
+# Encode and decode a dictionary
+
+
+def encodeDict(dValue, eList):
 
   if DIRAC_DEBUG_DENCODE_CALLSTACK:
     # If we have numbers as keys
-    if any([isinstance(x,(int,float, long)) for x in dValue]):
-      print '='*40, "Encoding dict with numeric keys", '='*40
+    if any([isinstance(x, (int, float, long)) for x in dValue]):
+      print '=' * 40, "Encoding dict with numeric keys", '=' * 40
       printDebugCallstack()
 
-  eList.append( "d" )
-  for key in sorted( dValue ):
-    g_dEncodeFunctions[ type( key ) ]( key, eList )
-    g_dEncodeFunctions[ type( dValue[key] ) ]( dValue[key], eList )
-  eList.append( "e" )
+  eList.append("d")
+  for key in sorted(dValue):
+    g_dEncodeFunctions[type(key)](key, eList)
+    g_dEncodeFunctions[type(dValue[key])](dValue[key], eList)
+  eList.append("e")
 
-def decodeDict( data, i ):
+
+def decodeDict(data, i):
   oD = {}
   i += 1
-  while data[ i ] != "e":
+  while data[i] != "e":
 
     if DIRAC_DEBUG_DENCODE_CALLSTACK:
       # If we have numbers as keys
       if data[i] in ('i', 'I', 'f'):
-        print '='*40, "Decoding dict with numeric keys", '='*40
+        print '=' * 40, "Decoding dict with numeric keys", '=' * 40
         printDebugCallstack()
 
-    k, i = g_dDecodeFunctions[ data[ i ] ]( data, i )
-    oD[ k ], i = g_dDecodeFunctions[ data[ i ] ]( data, i )
-  return ( oD, i + 1 )
-
-g_dEncodeFunctions[ types.DictType ] = encodeDict
-g_dDecodeFunctions[ "d" ] = decodeDict
+    k, i = g_dDecodeFunctions[data[i]](data, i)
+    oD[k], i = g_dDecodeFunctions[data[i]](data, i)
+  return (oD, i + 1)
 
 
+g_dEncodeFunctions[types.DictType] = encodeDict
+g_dDecodeFunctions["d"] = decodeDict
 
-#Encode function
-def encode( uObject ):
+
+# Encode function
+def encode(uObject):
   try:
     eList = []
-    #print "ENCODE FUNCTION : %s" % g_dEncodeFunctions[ type( uObject ) ]
-    g_dEncodeFunctions[ type( uObject ) ]( uObject, eList )
-    return "".join( eList )
+    # print "ENCODE FUNCTION : %s" % g_dEncodeFunctions[ type( uObject ) ]
+    g_dEncodeFunctions[type(uObject)](uObject, eList)
+    return "".join(eList)
   except Exception:
     raise
 
-def decode( data ):
+
+def decode(data):
   if not data:
     return data
   try:
-    #print "DECODE FUNCTION : %s" % g_dDecodeFunctions[ sStream [ iIndex ] ]
-    return g_dDecodeFunctions[ data[ 0 ] ]( data, 0 )
+    # print "DECODE FUNCTION : %s" % g_dDecodeFunctions[ sStream [ iIndex ] ]
+    return g_dDecodeFunctions[data[0]](data, 0)
   except Exception:
     raise
 
 
 if __name__ == "__main__":
-  gObject = {2:"3", True : ( 3, None ), 2.0 * 10 ** 20 : 2.0 * 10 ** -10 }
+  gObject = {2: "3", True: (3, None), 2.0 * 10 ** 20: 2.0 * 10 ** -10}
   print "Initial: %s" % gObject
-  gData = encode( gObject )
+  gData = encode(gObject)
   print "Encoded: %s" % gData
-  print "Decoded: %s, [%s]" % decode( gData )
+  print "Decoded: %s, [%s]" % decode(gData)


### PR DESCRIPTION
BILD SPOILER ALERT:
we want to be able to spot where a serialization that would fail or be incorrect in json happens in DISET.
There are currently 2 known cases: tuples, dictionaries whose keys are numbers.
This PR adds a function that will print the callstack as well as the arguments of the call when such cases are met. The output looks something like that:
```
============================================= Encoding tuples =============================================
  File "/tmp/ping.py", line 2, in <module>
    print RPCClient('dips://lbtestvobox.cern.ch:9197/DataManagement/FileCatalog').ping()

  File "/home/chaen/dirac/DIRAC/Core/DISET/RPCClient.py", line 43, in __call__
    return self.__doRPCFunc( self.__remoteFuncName, args )

  File "/home/chaen/dirac/DIRAC/Core/DISET/RPCClient.py", line 88, in __doRPC
    return self.__innerRPCClient.executeRPC( sFunctionName, args )

  File "/home/chaen/dirac/DIRAC/Core/DISET/private/InnerRPCClient.py", line 46, in executeRPC
    retVal = self._proposeAction( transport, ( "RPC", functionName ) )

  File "/home/chaen/dirac/DIRAC/Core/DISET/private/BaseClient.py", line 527, in _proposeAction
    retVal = transport.sendData( S_OK( stConnectionInfo ) )

  File "/home/chaen/dirac/DIRAC/Core/DISET/private/Transports/BaseTransport.py", line 120, in sendData
    sCodedData = DEncode.encode( uData )

  File "/home/chaen/dirac/DIRAC/Core/Utilities/DEncode.py", line 313, in encode
    g_dEncodeFunctions[ type( uObject ) ]( uObject, eList )

  File "/home/chaen/dirac/DIRAC/Core/Utilities/DEncode.py", line 290, in encodeDict
    g_dEncodeFunctions[ type( dValue[key] ) ]( dValue[key], eList )

  File "/home/chaen/dirac/DIRAC/Core/Utilities/DEncode.py", line 275, in encodeTuple
    g_dEncodeFunctions[ type( uObject ) ]( uObject, eList )

  File "/home/chaen/dirac/DIRAC/Core/Utilities/DEncode.py", line 268, in encodeTuple
    printDebugCallstack()

Calling frame: ('/home/chaen/dirac/DIRAC/Core/DISET/private/Transports/BaseTransport.py', 120)
With arguments {'uObject': {'OK': True,
             'Value': (('DataManagement/FileCatalog',
                        'LHCb-Certification',
                        'lhcb'),
                       ('RPC', 'ping'),
                       '')}}
====================================================================================================
```


It is disabled by default and only active when the environment variable  `DIRAC_DEBUG_DENCODE_CALLSTACK` is set to `True`

BEGINRELEASENOTES

*Core
NEW: Add conditional printout of the traceback when serializing/deserializing non json compatible object in DEncode (enabled with DIRAC_DEBUG_DENCODE_CALLSTACK environment variable)

ENDRELEASENOTES
