### PR TITLE
[v6r20] using python modules in WatchdogLinux

### DIFF
--- a/WorkloadManagementSystem/JobWrapper/WatchdogLinux.py
+++ b/WorkloadManagementSystem/JobWrapper/WatchdogLinux.py
@@ -12,31 +12,34 @@
 
 __RCSID__ = "$Id$"
 
+import os
 import socket
+import resource
+import getpass
 
-from DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog  import Watchdog
-from DIRAC.Core.Utilities.Subprocess                     import shellCall
-from DIRAC                                               import S_OK, S_ERROR
+from DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog import Watchdog
+from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Os import getDiskSpace
 
 
-class WatchdogLinux( Watchdog ):
+class WatchdogLinux(Watchdog):
 
-  def __init__( self, pid, exeThread, spObject, jobCPUTime, memoryLimit = 0, processors = 1, systemFlag = 'linux', jobArgs = {} ):
+  def __init__(self, pid, exeThread, spObject, jobCPUTime,
+               memoryLimit=0, processors=1, systemFlag='linux', jobArgs={}):
     """ Constructor, takes system flag as argument.
     """
-    Watchdog.__init__( self, 
-                       pid = pid, 
-                       exeThread = exeThread, 
-                       spObject = spObject, 
-                       jobCPUTime = jobCPUTime, 
-                       memoryLimit = memoryLimit, 
-                       processors = processors, 
-                       systemFlag = systemFlag, 
-                       jobArgs = jobArgs )
+    Watchdog.__init__(self,
+                      pid=pid,
+                      exeThread=exeThread,
+                      spObject=spObject,
+                      jobCPUTime=jobCPUTime,
+                      memoryLimit=memoryLimit,
+                      processors=processors,
+                      systemFlag=systemFlag,
+                      jobArgs=jobArgs)
 
   ############################################################################
-  def getNodeInformation( self ):
+  def getNodeInformation(self):
     """Try to obtain system HostName, CPU, Model, cache and memory.  This information
        is not essential to the running of the jobs but will be reported if
        available.
@@ -44,24 +47,20 @@ class WatchdogLinux( Watchdog ):
     result = S_OK()
     try:
       result["HostName"] = socket.gethostname()
-      with open( "/proc/cpuinfo", "r" ) as cpuInfo:
+      with open("/proc/cpuinfo", "r") as cpuInfo:
         info = cpuInfo.readlines()
         result["CPU(MHz)"] = info[7].split(':')[1].replace(' ', '').replace('\n', '')
         result["ModelName"] = info[4].split(':')[1].replace(' ', '').replace('\n', '')
         result["CacheSize(kB)"] = info[8].split(':')[1].replace(' ', '').replace('\n', '')
-      with open( "/proc/meminfo", "r" ) as memInfo:
+      with open("/proc/meminfo", "r") as memInfo:
         info = memInfo.readlines()
         result["Memory(kB)"] = info[3].split(':')[1].replace(' ', '').replace('\n', '')
-      account = 'Unknown'
-      localID = shellCall(10,'whoami')
-      if localID['OK']:
-        account = localID['Value'][1].strip()
-      result["LocalAccount"] = account
+      result["LocalAccount"] = getpass.getuser()
     except Exception as x:
       self.log.fatal('Watchdog failed to obtain node information with Exception:')
       self.log.fatal(str(x))
       result = S_ERROR()
-      result['Message']='Failed to obtain system information for '+self.systemFlag
+      result['Message'] = 'Failed to obtain system information for ' + self.systemFlag
       return result
 
     return result
@@ -70,26 +69,15 @@ class WatchdogLinux( Watchdog ):
   def getLoadAverage(self):
     """Obtains the load average.
     """
-    comm = '/bin/cat /proc/loadavg'
-    loadAvgDict = shellCall( 5, comm )
-    if loadAvgDict['OK']:
-      return S_OK( float( loadAvgDict['Value'][1].split( )[0] ) )
-    else:
-      self.log.warn( 'Could not obtain load average' )
-      return S_ERROR( 'Could not obtain load average' )
+    return S_OK(float(os.getloadavg()[0]))
 
   #############################################################################
   def getMemoryUsed(self):
     """Obtains the memory used.
     """
-    comm = '/usr/bin/free'
-    memDict = shellCall( 5, comm )
-    if memDict['OK']:
-      mem = memDict['Value'][1].split()[8]
-      return S_OK( float( mem ) )
-    else:
-      self.log.warn( 'Could not obtain memory used' )
-      return S_ERROR( 'Could not obtain memory used' )
+    mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss + \
+        resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    return S_OK(float(mem))
 
   #############################################################################
   def getDiskSpace(self):
@@ -99,11 +87,11 @@ class WatchdogLinux( Watchdog ):
     diskSpace = getDiskSpace()
 
     if diskSpace == -1:
-      result = S_ERROR( 'Could not obtain disk usage' )
-      self.log.warn( ' Could not obtain disk usage' )
+      result = S_ERROR('Could not obtain disk usage')
+      self.log.warn(' Could not obtain disk usage')
       result['Value'] = -1
 
-    result['Value'] = float( diskSpace )
+    result['Value'] = float(diskSpace)
     return result
 
 #EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#


### PR DESCRIPTION
Calls to /usr/bin/free happened to fail under unknown circumstances, generating exceptions that were setting the job as "Failed", while the same job happily completed later.

BEGINRELEASENOTES

*Subsystem
CHANGE: using python modules in WatchdogLinux instead of shell calls

ENDRELEASENOTES
