### PR TITLE
[v6r20] RMS: exit the REA when the result queue is buggy

### DIFF
--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -25,6 +25,7 @@ __RCSID__ = '$Id$'
 # @date 2013/03/12 15:36:56
 # @brief Definition of RequestExecutingAgent class.
 # # imports
+import sys
 import time
 # # from DIRAC
 from DIRAC import S_OK, S_ERROR, gConfig
@@ -343,8 +344,13 @@ class RequestExecutingAgent( AgentModule ):
 
     self.log.info( 'Flushing callbacks (%d requests still in cache)' % len( self.__requestCache ) )
     processed = self.processPool().processResults()
+    # This happens when the result queue is screwed up.
+    # Returning S_ERROR proved not to be sufficient,
+    # and when in this situation, there is nothing we can do.
+    # So we just exit. runit will restart from scratch.
     if processed < 0:
-      return S_ERROR( "Results queue is screwed up" )
+      self.log.fatal("Results queue is screwed up")
+      sys.exit(1)
     # # clean return
     return S_OK()
 


### PR DESCRIPTION
There is still this crazy bug in the processPool that the result queue can return True when calling `empty`, and have a non zero size when asking for `size`. 
This shows as such in the logs
```
2018-01-14 13:01:14 UTC RequestManagement/RequestExecutingAgent/ProcessPool WARN: Results queue is empty but
has non zero size: 8 
```

When this happens, there is absolutely nothing that can be done to unlock the situation, and the agent should just exit. Up to now, we were returning S_ERROR, hopping that starting a new loop would help, but it does not.
So now we just exit all together, and wait for runit to restart.

BEGINRELEASENOTES
*RMS
FIX: Really exit the RequestExecutingAgent when the result queue is buggy
ENDRELEASENOTES
