### PR TITLE
[v6r19] Logging: add space after message only if varmessage is not empty

### DIFF
--- a/FrameworkSystem/private/standardLogging/Logging.py
+++ b/FrameworkSystem/private/standardLogging/Logging.py
@@ -412,6 +412,7 @@ class Logging(object):
       # not either.
       extra = {'componentname': self._componentName,
                'varmessage': sVarMsg,
+               'spacer': '' if not sVarMsg else ' ',
                'customname': self._customName}
       self._logger.log(level, "%s", sMsg, exc_info=exc_info, extra=extra)
       # test to know if the message is displayed or not

--- a/FrameworkSystem/test/testLogging/Test_DisplayOptions.py
+++ b/FrameworkSystem/test/testLogging/Test_DisplayOptions.py
@@ -27,13 +27,13 @@ class Test_DisplayOptions(Test_Logging):
     Set the headers
     """
     gLogger.showHeaders(False)
-    gLogger.notice('message')
+    gLogger.notice('message', 'varmessage')
 
     oldgLogger.showHeaders(False)
-    oldgLogger.notice('message')
+    oldgLogger.notice('message', 'varmessage')
 
-    self.assertEqual("message \n", self.buffer.getvalue())
-    self.assertEqual(self.buffer.getvalue().replace(" ", ""), self.oldbuffer.getvalue().replace(" ", ""))
+    self.assertEqual("message varmessage\n", self.buffer.getvalue())
+    self.assertEqual(self.buffer.getvalue(), self.oldbuffer.getvalue())
     self.buffer.truncate(0)
     self.oldbuffer.truncate(0)
 
@@ -98,8 +98,8 @@ class Test_DisplayOptions(Test_Logging):
     oldgLogger.showThreadIDs(False)
     oldgLogger.notice('message')
 
-    self.assertEqual("message \n", self.buffer.getvalue())
-    self.assertEqual(self.buffer.getvalue().replace(" ", ""), self.oldbuffer.getvalue().replace(" ", ""))
+    self.assertEqual("message\n", self.buffer.getvalue())
+    self.assertEqual(self.buffer.getvalue(), self.oldbuffer.getvalue())
     self.buffer.truncate(0)
     self.oldbuffer.truncate(0)
 
@@ -111,8 +111,8 @@ class Test_DisplayOptions(Test_Logging):
     oldgLogger.showThreadIDs(True)
     oldgLogger.notice('message')
 
-    self.assertEqual("message \n", self.buffer.getvalue())
-    self.assertEqual(self.buffer.getvalue().replace(" ", ""), self.oldbuffer.getvalue().replace(" ", ""))
+    self.assertEqual("message\n", self.buffer.getvalue())
+    self.assertEqual(self.buffer.getvalue(), self.oldbuffer.getvalue())
     self.buffer.truncate(0)
     self.oldbuffer.truncate(0)
 
@@ -163,7 +163,7 @@ class Test_DisplayOptions(Test_Logging):
     with open(self.filename) as file:
       message = file.read()
 
-    self.assertEqual(message, "message \n")
+    self.assertEqual(message, "message\n")
     logstring1 = cleaningLog(self.buffer.getvalue())
     self.assertEqual(logstring1, "UTCFramework/sublogNOTICE:message\n")
 
@@ -182,8 +182,8 @@ class Test_DisplayOptions(Test_Logging):
     with open(self.filename) as file:
       message = file.read()
 
-    self.assertEqual(message, "message \n")
-    self.assertEqual(self.buffer.getvalue(), "message \n")
+    self.assertEqual(message, "message\n")
+    self.assertEqual(self.buffer.getvalue(), "message\n")
 
   def test_05setSubLoggLoggerShowHeaders(self):
     """
@@ -202,7 +202,7 @@ class Test_DisplayOptions(Test_Logging):
     with open(self.filename) as file:
       message = file.read()
 
-    self.assertEqual(message, "message \n")
+    self.assertEqual(message, "message\n")
     logstring1 = cleaningLog(self.buffer.getvalue())
     self.assertEqual(logstring1, "UTCFramework/sublog3NOTICE:message\n")
 
@@ -223,7 +223,7 @@ class Test_DisplayOptions(Test_Logging):
     with open(self.filename) as file:
       message = file.read()
 
-    self.assertEqual(message, "message \n")
+    self.assertEqual(message, "message\n")
     logstring1 = cleaningLog(self.buffer.getvalue())
     self.assertEqual(logstring1, "UTCFramework/sublog4NOTICE:message\n")
 
@@ -246,8 +246,8 @@ class Test_DisplayOptions(Test_Logging):
     with open(self.filename) as file:
       message = file.read()
 
-    self.assertEqual(message, "message \nmessage \n")
-    self.assertEqual(self.buffer.getvalue(), "message \n")
+    self.assertEqual(message, "message\nmessage\n")
+    self.assertEqual(self.buffer.getvalue(), "message\n")
 
   def test_07subLogShowHeadersChangeSetSubLogger(self):
     """
@@ -268,7 +268,7 @@ class Test_DisplayOptions(Test_Logging):
     with open(self.filename) as file:
       message = file.read()
 
-    self.assertEqual(message, "message \nmessage \n")
+    self.assertEqual(message, "message\nmessage\n")
     logstring1 = cleaningLog(self.buffer.getvalue())
     self.assertEqual(logstring1, "UTCFramework/sublog6/subsublogNOTICE:message\n")
 
@@ -293,7 +293,7 @@ class Test_DisplayOptions(Test_Logging):
     with open(self.filename) as file:
       message = file.read()
 
-    self.assertIn("UTC Framework/sublog7/subsublog NOTICE: message \nmessage \n", message)
+    self.assertIn("UTC Framework/sublog7/subsublog NOTICE: message\nmessage\n", message)
     logstring1 = cleaningLog(self.buffer.getvalue())
     self.assertEqual(logstring1, "UTCFramework/sublog7/subsublogNOTICE:message\n")
 
@@ -312,14 +312,14 @@ class Test_DisplayOptions(Test_Logging):
     with open(self.filename) as file:
       message = file.read()
 
-    self.assertEqual("message \n", message)
+    self.assertEqual("message\n", message)
 
     gLogger.showHeaders(True)
     sublog.notice("message")
     
     with open(self.filename) as file:
       message = file.read()
-    self.assertIn("UTC Framework/sublog8 NOTICE: message \n", message)
+    self.assertIn("UTC Framework/sublog8 NOTICE: message\n", message)
 
 
 if __name__ == '__main__':

--- a/Resources/LogBackends/AbstractBackend.py
+++ b/Resources/LogBackends/AbstractBackend.py
@@ -88,5 +88,5 @@ class AbstractBackend(object):
       if options['threadIDIsShown']:
         fmt += ' [%(thread)d]'
       fmt += ' %(levelname)s: '
-    fmt += '%(message)s %(varmessage)s'
+    fmt += '%(message)s%(spacer)s%(varmessage)s'
     return (datefmt, fmt)


### PR DESCRIPTION
BEGINRELEASENOTES

*Framework
FIX: Remove the space after log messages if no variable message is printed, fixes #3587 

ENDRELEASENOTES

- [x] Need to fix the tests that expect additional space
