### PR TITLE
[v6r20] Logging: add JSON log formatter for the MQ Handler

### DIFF
--- a/FrameworkSystem/private/standardLogging/Formatter/JsonFormatter.py
+++ b/FrameworkSystem/private/standardLogging/Formatter/JsonFormatter.py
@@ -1,0 +1,24 @@
+"""
+Formatter as JSON structure
+"""
+
+from pythonjsonlogger.jsonlogger import JsonFormatter as libJsonFormatter
+
+from DIRAC.FrameworkSystem.private.standardLogging.Formatter.BaseFormatter import BaseFormatter
+
+__RCSID__ = "$Id$"
+
+
+class JsonFormatter(libJsonFormatter, BaseFormatter):
+  """ This class will format the log messages as a JSON structure.
+      It is just a wrapper around jsonlogger, however we need it because
+      the constructor of BaseFormatter takes different arguments
+  """
+
+  def __init__(self, fmt, datefmt, options):
+    """
+        Constructor that just fowards the arguments to the two parents classes
+    """
+
+    libJsonFormatter.__init__(self, fmt, datefmt)
+    BaseFormatter.__init__(self, fmt, datefmt, options)

--- a/FrameworkSystem/private/standardLogging/Handler/MessageQueueHandler.py
+++ b/FrameworkSystem/private/standardLogging/Handler/MessageQueueHandler.py
@@ -4,7 +4,9 @@ Message Queue Handler
 
 __RCSID__ = "$Id$"
 
+import json
 import logging
+import socket
 
 from DIRAC.Resources.MessageQueue.MQCommunication import createProducer
 
@@ -16,6 +18,8 @@ class MessageQueueHandler(logging.Handler):
 
   It is useful to send log messages to a destination, like the StreamHandler to a stream, the FileHandler to a file.
   Here, this handler send log messages to a message queue server.
+
+  There is an assumption made that the formatter used is JsonFormatter
   """
 
   def __init__(self, queue):
@@ -30,6 +34,7 @@ class MessageQueueHandler(logging.Handler):
     result = createProducer(queue)
     if result['OK']:
       self.producer = result['Value']
+    self.hostname = socket.gethostname()
 
   def emit(self, record):
     """
@@ -37,6 +42,8 @@ class MessageQueueHandler(logging.Handler):
 
     :params record: log record object
     """
+    # add the hostname to the record
+    record.hostname = self.hostname
     strRecord = self.format(record)
     if self.producer is not None:
-      self.producer.put(strRecord)
+      self.producer.put(json.loads(strRecord))

--- a/Resources/LogBackends/MessageQueueBackend.py
+++ b/Resources/LogBackends/MessageQueueBackend.py
@@ -1,44 +1,44 @@
-""" 
-Message Queue wrapper 
+"""
+Message Queue wrapper
 """
 
 __RCSID__ = "$Id$"
 
 from DIRAC.FrameworkSystem.private.standardLogging.Handler.MessageQueueHandler import MessageQueueHandler
 from DIRAC.Resources.LogBackends.AbstractBackend import AbstractBackend
-from DIRAC.FrameworkSystem.private.standardLogging.Formatter.BaseFormatter import BaseFormatter
+from DIRAC.FrameworkSystem.private.standardLogging.Formatter.JsonFormatter import JsonFormatter
 
 
 class MessageQueueBackend(AbstractBackend):
-  """  
-  MessageQueueBackend is used to create an abstraction of the handler and the formatter concepts from logging.  
+  """
+  MessageQueueBackend is used to create an abstraction of the handler and the formatter concepts from logging.
   Here, we have:
-    - MessageQueueHandler: which is a custom handler created in DIRAC to send 
-      log records to a Message Queue server. You can find it in: FrameworkSys./private/standardlogging/Handler  
+    - MessageQueueHandler: which is a custom handler created in DIRAC to send
+      log records to a Message Queue server. You can find it in: FrameworkSys./private/standardlogging/Handler
     - BaseFormatter: is a custom Formatter object, created for DIRAC in order to get the appropriate display.
     You can find it in FrameworkSystem/private/standardLogging/Formatter
   """
 
   def __init__(self):
-    """ 
+    """
     Initialization of the MessageQueueBackend
     """
-    super(MessageQueueBackend, self).__init__(None, BaseFormatter)
+    super(MessageQueueBackend, self).__init__(None, JsonFormatter)
     self.__queue = ''
 
   def createHandler(self, parameters=None):
-    """ 
-    Each backend can initialize its attributes and create its handler with them. 
+    """
+    Each backend can initialize its attributes and create its handler with them.
 
-    :params parameters: dictionary of parameters. ex: {'FileName': file.log} 
+    :params parameters: dictionary of parameters. ex: {'FileName': file.log}
     """
     if parameters is not None:
       self.__queue = parameters.get("MsgQueue", self.__queue)
     self._handler = MessageQueueHandler(self.__queue)
 
   def setLevel(self, level):
-    """ 
+    """
     No possibility to set the level of the MessageQueue handler.
-    It is not set by default so it can send all Log Records of all levels to the MessageQueue. 
+    It is not set by default so it can send all Log Records of all levels to the MessageQueue.
     """
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ stomp.py>=3.1.5
 suds-jurko>=0.6
 sphinx
 hypothesis
+python-json-logger>=0.1.8


### PR DESCRIPTION
This PR just adds functionality. It allows to send JSON formatted logs to Message queues. Tested in LHCb certification setup.
Requires https://github.com/DIRACGrid/Externals/pull/33

BEGINRELEASENOTES
*Framework
NEW: add JsonFormatter for logs
CHANGE: MessageQueue log handler uses JsonFormatter
ENDRELEASENOTES
