### PR TITLE
[v6r19] Pass optional extra flags to getExecutable function in SiteDirector

### DIFF
--- a/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
+++ b/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
@@ -326,7 +326,8 @@ class MultiProcessorSiteDirector( SiteDirector ):
           jobExecDir = self.queueDict[queue]['ParametersDict'].get( 'JobExecDir', jobExecDir )
           httpProxy = self.queueDict[queue]['ParametersDict'].get( 'HttpProxy', '' )
 
-          result = self.getExecutable( queue, pilotsToSubmit, bundleProxy, httpProxy, jobExecDir )
+          result = self.getExecutable( queue, pilotsToSubmit, bundleProxy, httpProxy, jobExecDir,
+                                       processors=processors )
           if not result['OK']:
             return result
 

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -774,14 +774,15 @@ class SiteDirector( AgentModule ):
     return totalSlots
 
 #####################################################################################
-  def getExecutable( self, queue, pilotsToSubmit, bundleProxy = True, httpProxy = '', jobExecDir = '' ):
+  def getExecutable( self, queue, pilotsToSubmit, bundleProxy = True, httpProxy = '', jobExecDir = '',
+                     **kwargs ):
     """ Prepare the full executable for queue
     """
 
     proxy = None
     if bundleProxy:
       proxy = self.proxy
-    pilotOptions, pilotsToSubmit = self._getPilotOptions( queue, pilotsToSubmit )
+    pilotOptions, pilotsToSubmit = self._getPilotOptions( queue, pilotsToSubmit, **kwargs )
     if pilotOptions is None:
       self.log.error( "Pilot options empty, error in compilation" )
       return S_ERROR( "Errors in compiling pilot options" )
@@ -790,7 +791,7 @@ class SiteDirector( AgentModule ):
     return S_OK( [ executable, pilotsToSubmit ] )
 
 #####################################################################################
-  def _getPilotOptions( self, queue, pilotsToSubmit ):
+  def _getPilotOptions( self, queue, pilotsToSubmit, **kwargs ):
     """ Prepare pilot options
     """
     queueDict = self.queueDict[queue]['ParametersDict']


### PR DESCRIPTION
Hi,

This adds a kwargs parameter to getExecutable and _getPilotOptions in the SiteDirector, which contains job processor count in the MultiProcessorSiteDirector.

This will allow us to pass through to the new maxNumberOfProcessors pilot option in the GridPPDIRAC module without having to override the whole of the submitJobs function (without this we would be unable to get the number of processors in our overridden getPilotOptions function).

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagementSystem
CHANGE: Allow kwargs to SiteDirector getExecutable & _getPilotOptions functions.
ENDRELEASENOTES
