### PR TITLE
[v6r19] RMS: fix a bug in the ReplicateAndRegister 

### DIFF
--- a/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
+++ b/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
@@ -420,17 +420,12 @@ class ReplicateAndRegister(DMSRequestOperationsBase):
     errors = defaultdict(int)
     delayExecution = 0
     for opFile in waitingFiles:
-      if opFile.Status == 'Failed':
-        err = "File already Failed"
-        errors[err] += 1
-        continue
       if opFile.Error in ("Couldn't get metadata",
                           "File doesn't exist",
                           'No active replica found',
                           "All replicas have a bad checksum",):
         err = "File already in error status"
         errors[err] += 1
-        continue
 
       gMonitor.addMark("ReplicateAndRegisterAtt", 1)
       opFile.Error = ''


### PR DESCRIPTION
fix a bug in the ReplicateAndRegister  preventing requests to be retried
Files failing once would never be attempted anymore



BEGINRELEASENOTES
* RMS
FIX: Fix a bug in ReplicateAndRegister Operation preventing files having failed once to be retried

ENDRELEASENOTES
