### PR TITLE
[v6r19] DFC: compatibility with MySQL 5.7

### DIFF
--- a/DataManagementSystem/DB/FileCatalogWithFkAndPsDB.sql
+++ b/DataManagementSystem/DB/FileCatalogWithFkAndPsDB.sql
@@ -1595,7 +1595,7 @@ BEGIN
   WHERE c.ParentID = dir_id
   AND SEName != 'FakeSE'
   AND (SESize != 0 OR SEFiles != 0)
-  GROUP BY u.SEID
+  GROUP BY se.SEName
   ORDER BY NULL;
 
 
@@ -1623,7 +1623,7 @@ BEGIN
   JOIN FC_StorageElements se ON se.SEID = r.SEID
   JOIN FC_DirectoryClosure dc ON dc.ChildID = f.DirID
   WHERE dc.ParentID = dir_id
-  GROUP BY se.SEID
+  GROUP BY se.SEName
   ORDER BY NULL;
 
 END //


### PR DESCRIPTION
In prod for LHCb

BEGINRELEASENOTES
*DMS
FIX: Fixes for the DFC to be compatible with strict group by mode (https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by)

ENDRELEASENOTES
