### PR TITLE
[v6r19] Minor fixes for maxNumberOfProcessors flag

### DIFF
--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -502,7 +502,7 @@ class CheckWNCapabilities( CommandBase ):
       self.log.warn("Could not retrieve number of processors, assuming 1")
       numberOfProcessors = 1
     self.cfg.append(
-        '-o "/Resources/Computing/CEDefaults/NumberOfProcessors=%d"' % numberOfProcessors)
+        '-o "/Resources/Computing/CEDefaults/NumberOfProcessors=%d"' % int(numberOfProcessors))
 
     maxRAM = self.pp.queueParameters.get('MaxRAM', maxRAM)
     if maxRAM:

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -409,7 +409,7 @@ class PilotParams( object ):
                      ( 'k', 'keepPP', 'Do not clear PYTHONPATH on start' ),
                      ( 'l:', 'project=', 'Project to install' ),
                      ( 'p:', 'platform=', 'Use <platform> instead of local one' ),
-                     ('P:', 'maxNumberOfProcessors=',
+                     ( 'm:', 'maxNumberOfProcessors=',
                       'specify a max number of processors to use'),
                      ( 'u:', 'url=', 'Use <url> to download tarballs' ),
                      ( 'r:', 'release=', 'DIRAC release to install' ),
@@ -480,7 +480,7 @@ class PilotParams( object ):
         self.installation = v
       elif o == '-p' or o == '--platform':
         self.platform = v
-      elif o == '-P' or o == '--maxNumberOfProcessors':
+      elif o == '-m' or o == '--maxNumberOfProcessors':
         self.maxNumberOfProcessors = v
       elif o == '-D' or o == '--disk':
         try:


### PR DESCRIPTION
Hi,

We found a couple of minor bugs while testing the new maxNumberOfProcessors flag... It has to be cast to an int at one place to avoid an exception. It also seems that the -P option is passed through to dirac-install (due to code at https://github.com/DIRACGrid/DIRAC/blob/rel-v6r19/WorkloadManagementSystem/PilotAgent/pilotCommands.py#L184 ), I wasn't sure if this was actually used anywhere, so I didn't want to change it. Instead I've simply changed the short code for maxProcs to be -m instead.

Other than this, the maxNumberOfProcs code all seems to work perfectly.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: Cast maxNumOfProcs to an int.
CHANGE: Change maxNumOfProcs short option from -P to -m.
ENDRELEASENOTES