### PR TITLE
[v6r20] dirac-external-requirements restored

### DIFF
--- a/Core/scripts/dirac-externals-requirements.py
+++ b/Core/scripts/dirac-externals-requirements.py
@@ -25,13 +25,16 @@ __RCSID__ = "$Id$"
 # Default installation type
 instType = "server"
 
+
 def setInstallType(val):
   global instType
   instType = val
   return S_OK()
 
+
 Script.registerSwitch("t:", "type=", "Installation type. 'server' by default.", setInstallType)
 Script.parseCommandLine(ignoreErrors=True)
+
 
 def pipInstall(package, switches=""):
   # The right pip should be in the PATH, which is the case after sourcing the DIRAC bashrc

--- a/Core/scripts/dirac-externals-requirements.py
+++ b/Core/scripts/dirac-externals-requirements.py
@@ -43,10 +43,6 @@ def pipInstall(package, switches=""):
 # Collect all the requested python modules to install
 reqDict = {}
 
-if instType.find("client") == 0:
-  gLogger.error("Client installations do not support externals requirements")
-  sys.exit(0)
-
 for entry in os.listdir(rootPath):
   if len(entry) < 5 or entry.find("DIRAC") != len(entry) - 5:
     continue

--- a/Core/scripts/dirac-externals-requirements.py
+++ b/Core/scripts/dirac-externals-requirements.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 ########################################################################
 # File :   dirac-externals-requirements
-# Author : Adri/Federico
+# Author : Adri/Federico/Andrei
 ########################################################################
-""" If /RequiredExternals/ is found in releases.cfg, then some packages to install with pip may be found. This will do it.
+""" If RequiredExternals section is found in releases.cfg of any extension,
+    then some python packages to install with pip may be found. This script
+    will install the requested modules.
+
+    The command is called from the dirac-install general installation command.
 """
 
 import os
 import sys
-from pip.index import PackageFinder
-from pip.req import InstallRequirement, RequirementSet
-from pip.locations import user_dir, src_prefix
-from pip.download import PipSession
+import commands
 
 from DIRAC.Core.Base import Script
 Script.disableCS()
@@ -21,74 +22,70 @@ from DIRAC.Core.Utilities.CFG import CFG
 
 __RCSID__ = "$Id$"
 
+# Default installation type
 instType = "server"
 
-def setInstallType( val ):
+def setInstallType(val):
   global instType
   instType = val
   return S_OK()
 
-Script.registerSwitch( "t:", "type=", "Installation type. 'server' by default.", setInstallType )
-Script.parseCommandLine( ignoreErrors = True )
+Script.registerSwitch("t:", "type=", "Installation type. 'server' by default.", setInstallType)
+Script.parseCommandLine(ignoreErrors=True)
 
+def pipInstall(package, switches=""):
+  # The right pip should be in the PATH, which is the case after sourcing the DIRAC bashrc
+  cmd = "pip install --trusted-host pypi.python.org %s %s" % (switches, package)
+  gLogger.notice("Executing %s" % cmd)
+  return commands.getstatusoutput(cmd)
+
+
+# Collect all the requested python modules to install
 reqDict = {}
 
-if instType.find( "client" ) == 0:
-  gLogger.error( "Client installations do not support externals requirements" )
-  sys.exit( 0 )
+if instType.find("client") == 0:
+  gLogger.error("Client installations do not support externals requirements")
+  sys.exit(0)
 
-for entry in os.listdir( rootPath ):
-  if len( entry ) < 5 or entry.find( "DIRAC" ) != len( entry ) - 5 :
+for entry in os.listdir(rootPath):
+  if len(entry) < 5 or entry.find("DIRAC") != len(entry) - 5:
     continue
-  reqFile = os.path.join( rootPath, entry, "releases.cfg" )
+  reqFile = os.path.join(rootPath, entry, "releases.cfg")
   try:
-    with open( reqFile, "r" ) as extfd:
-      reqCFG = CFG().loadFromBuffer( extfd.read() )
-  except:
-    gLogger.warn( "%s not found" % reqFile )
+    with open(reqFile, "r") as extfd:
+      reqCFG = CFG().loadFromBuffer(extfd.read())
+  except BaseException:
+    gLogger.verbose("%s not found" % reqFile)
     continue
-  reqs = reqCFG.getOption( "/RequiredExternals/%s" % instType.capitalize(), [] )
-  if not reqs:
-    gLogger.warn( "%s does not have requirements for %s installation" % ( entry, instType ) )
+  reqList = reqCFG.getOption("/RequiredExternals/%s" % instType.capitalize(), [])
+  if not reqList:
+    gLogger.verbose("%s does not have requirements for %s installation" % (entry, instType))
     continue
-  for req in reqs:
+  for req in reqList:
     reqName = False
     reqCond = ""
-    for cond in ( "==", ">=" ):
-      iP = cond.find( req )
+    for cond in ("==", ">="):
+      iP = cond.find(req)
       if iP > 0:
-        reqName = req[ :iP ]
-        reqCond = req[ iP: ]
+        reqName = req[:iP]
+        reqCond = req[iP:]
         break
     if not reqName:
       reqName = req
     if reqName not in reqDict:
-      reqDict[ reqName ] = ( reqCond, entry )
+      reqDict[reqName] = (reqCond, entry)
     else:
-      gLogger.notice( "Skipping %s, it's already requested by %s" % ( reqName, reqDict[ reqName ][1] ) )
+      gLogger.notice("Skipping %s, it's already requested by %s" % (reqName, reqDict[reqName][1]))
 
 if not reqDict:
-  gLogger.notice( "Nothing to be installed" )
-  sys.exit( 0 )
-
-gLogger.notice( "Requesting installation of %s" % ", ".join( [ "%s%s" % ( reqName, reqDict[ reqName ][0] ) for reqName in reqDict ] ) )
-
-requirement_set = RequirementSet(
-    build_dir = user_dir,
-    src_dir = src_prefix,
-    download_dir = None,
-    session = PipSession()
-    )
+  gLogger.notice("No extra python module requested to be installed")
+  sys.exit(0)
 
 for reqName in reqDict:
-  requirement_set.add_requirement( InstallRequirement.from_line( "%s%s" % ( reqName, reqDict[ reqName ][0] ), None ) )
-
-install_options = []
-global_options = []
-finder = PackageFinder( find_links = [], index_urls = ["http://pypi.python.org/simple/"] )
-
-requirement_set.prepare_files( finder )
-requirement_set.install( install_options, global_options )
-
-
-gLogger.notice( "Installed %s" % "".join( [ str( package.name ) for package in requirement_set.successfully_installed ] ) )
+  package = "%s%s" % (reqName, reqDict[reqName][0])
+  gLogger.notice("Requesting installation of %s" % package)
+  status, output = pipInstall(package)
+  if status != 0:
+    gLogger.error(output)
+  else:
+    gLogger.notice("Successfully installed %s" % package)

--- a/docs/source/DeveloperGuide/DevelopmentModel/DIRACProjects/index.rst
+++ b/docs/source/DeveloperGuide/DevelopmentModel/DIRACProjects/index.rst
@@ -43,11 +43,20 @@ shown below::
        depends = DIRAC:v5r12p1
      }
    }
+   RequiredExternals
+   {
+     Server = tornado>=4.4.2, apache-libcloud==2.2.1
+     Client = apache-libcloud==2.2.1
+   }
 
 The *DefaultModules* option (outside any section) defines what modules will be installed by default 
 if there's nothing explicitly specified at installation time. Because there is only one module defined 
 in *DefaultModules* each release will try to install the *MyExt* module with the same version as the 
-release name. Each release can require a certain version of any other project (DIRAC is also an project). 
+release name. Each release can require a certain version of any other project (DIRAC is also an project).
+
+The *RequiredExternals* section contains lists of extra python modules that can be installed with
+a *pip* installer for different installation types. Each module in the lists is specified in a format
+suitable to pass to the *pip* command.
 
 An example with more than one module follows::
 

--- a/releases.cfg
+++ b/releases.cfg
@@ -26,7 +26,7 @@ Releases
   v6r20-pre16
   {
     Modules = DIRAC, VMDIRAC:v2r2, RESTDIRAC:v0r5, COMDIRAC:v0r17, WebAppDIRAC:v3r1p4
-    Externals = v6r6p6
+    Externals = v6r6p7
   }
   v6r19p17
   {

--- a/releases.cfg
+++ b/releases.cfg
@@ -25,7 +25,7 @@ Releases
   }
   v6r20-pre16
   {
-    Modules = DIRAC, VMDIRAC:v2r2, RESTDIRAC:v0r5, COMDIRAC:v0r17, WebAppDIRAC:v3r1p4, MPIDIRAC:v0r1, FSDIRAC:v0r3, BoincDIRAC:v0r1
+    Modules = DIRAC, VMDIRAC:v2r2, RESTDIRAC:v0r5, COMDIRAC:v0r17, WebAppDIRAC:v3r1p4
     Externals = v6r6p6
   }
   v6r19p17


### PR DESCRIPTION
  The dirac-external-requirements command is restored. It is called in the end of the dirac-install process to collect all the extra python modules requested in the DIRAC package and in the extension packages. It allows to define extra python module dependencies in the releases.cfg of each package
and not put it into the Externals. 

BEGINRELEASENOTES
*Core
CHANGE: dirac-external-requirements - reimplemented to use preinstalled pip command rather than 
                 the pip python API 
ENDRELEASENOTES
