### PR TITLE
[v6r19] Configuration: log the exception when not able to write the cfg file

### DIFF
--- a/ConfigurationSystem/private/ConfigurationData.py
+++ b/ConfigurationSystem/private/ConfigurationData.py
@@ -346,8 +346,8 @@ class ConfigurationData( object ):
       with open( configurationFile, "w" ) as fd:
         fd.write( str( self.remoteCFG ) )
     except Exception as e:
-      gLogger.fatal( "Cannot write new configuration to disk!",
-                     "file %s" % configurationFile )
+      gLogger.fatal("Cannot write new configuration to disk!",
+                    "file %s exception %s" % (configurationFile, repr(e)))
       return S_ERROR( "Can't write cs file %s!: %s" % ( configurationFile, repr( e ).replace( ',)', ')' ) ) )
     if backupName:
       self.__backupCurrentConfiguration( backupName )


### PR DESCRIPTION
Our master CS regularely gets stuck with two error messages:
```
FATAL: Cannot write new configuration to disk! file XYX
ERROR: Can't verify proxy or certificate file XYZ:No certificate loaded ( 1105 : )
```

Not terribly useful. Since the first error can only happen at one place, I log a bit more info. it is running as hotfix in LHCb

BEGINRELEASENOTES
*ConfigurationSystem
CHANGE: Better logging of the Configuration file write exception
ENDRELEASENOTES
