### PR TITLE
Fix broken Dockerfile

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -22,7 +22,9 @@ RUN mkdir -p /opt/dirac/DIRAC && \
     cd /opt/dirac
 
 # Installing DIRAC in /opt/dirac
-RUN curl -L -o dirac-install https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py && \
+RUN \
+    cd /opt/dirac && \
+    curl -L -o dirac-install https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py && \
     chmod +x dirac-install && \
     ./dirac-install -r v6r17 -t server -i 27 -g 2017-01-27 && \
     rm -rf /opt/dirac/.installCache && \


### PR DESCRIPTION
cd commands don't cross RUN commands.

BEGINRELEASENOTES
FIX: Dockerfile
ENDRELEASENOTES
