### PR TITLE
[v6r20] Environment variable for stomp logging

### DIFF
--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -3,61 +3,62 @@ Class for management of Stomp MQ connections, e.g. RabbitMQ
 """
 
 import json
+import os
 import socket
 import stomp
 import ssl
 import time
 
-from DIRAC.Resources.MessageQueue.MQConnector  import MQConnector
+from DIRAC.Resources.MessageQueue.MQConnector import MQConnector
 from DIRAC.Core.Security import Locations
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities.DErrno import EMQUKN, EMQCONN
 
 
-class StompMQConnector( MQConnector ):
+class StompMQConnector(MQConnector):
   """
   Class for management of message queue connections
   Allows to both send and receive messages from a queue
   """
 
-  def __init__( self, parameters = {} ):
+  def __init__(self, parameters={}):
     """ Standard constructor
     """
-    super( StompMQConnector, self ).__init__()
-    self.log = gLogger.getSubLogger( self.__class__.__name__ )
+    super(StompMQConnector, self).__init__()
+    self.log = gLogger.getSubLogger(self.__class__.__name__)
     self.parameters = parameters.copy()
     self.connections = {}
 
-    if self.log.getLevel() == 'DEBUG':
+    if 'DIRAC_DEBUG_STOMP' in os.environ:
       gLogger.enableLogsFromExternalLibs()
 
-  def setupConnection( self, parameters = None ):
+  def setupConnection(self, parameters=None):
     #"""
-    #Establishes a new connection to a Stomp server, e.g. RabbitMQ
+    # Establishes a new connection to a Stomp server, e.g. RabbitMQ
     #:param dict parameters: dictionary with additional MQ parameters if any
     #:return: S_OK/S_ERROR
     #"""
 
     if parameters is not None:
-      self.parameters.update( parameters )
+      self.parameters.update(parameters)
 
-    #Check that the minimum set of parameters is present
-    if not all( p in parameters for p in ( 'Host', 'VHost' )):
-      return S_ERROR( 'Input parameters are missing!' )
+    # Check that the minimum set of parameters is present
+    if not all(p in parameters for p in ('Host', 'VHost')):
+      return S_ERROR('Input parameters are missing!')
 
     # Make the actual connection
-    host = self.parameters.get( 'Host' )
-    port = self.parameters.get( 'Port', 61613 )
-    vhost = self.parameters.get( 'VHost' )
+    host = self.parameters.get('Host')
+    port = self.parameters.get('Port', 61613)
+    vhost = self.parameters.get('VHost')
 
-    sslVersion = self.parameters.get( 'SSLVersion' )
-    hostcert = self.parameters.get( 'HostCertificate' )
-    hostkey = self.parameters.get( 'HostKey' )
+    sslVersion = self.parameters.get('SSLVersion')
+    hostcert = self.parameters.get('HostCertificate')
+    hostkey = self.parameters.get('HostKey')
     # get local key and certificate if not available via configuration
-    if sslVersion and not ( hostcert or hostkey ):
+    if sslVersion and not (hostcert or hostkey):
       paths = Locations.getHostCertificateAndKeyLocation()
       if not paths:
-        return S_ERROR( 'Could not find a certificate!' )
+        return S_ERROR('Could not find a certificate!')
       else:
         hostcert = paths[0]
         hostkey = paths[1]
@@ -65,91 +66,90 @@ class StompMQConnector( MQConnector ):
     try:
 
       # get IP addresses of brokers
-      brokers = socket.gethostbyname_ex( host )
-      self.log.info( 'Broker name resolves to %s IP(s)' % len( brokers[2] ) )
+      brokers = socket.gethostbyname_ex(host)
+      self.log.info('Broker name resolves to %s IP(s)' % len(brokers[2]))
 
       if sslVersion is None:
         pass
       elif sslVersion == 'TLSv1':
         sslVersion = ssl.PROTOCOL_TLSv1
       else:
-        return S_ERROR( EMQCONN, 'Invalid SSL version provided: %s' % sslVersion )
+        return S_ERROR(EMQCONN, 'Invalid SSL version provided: %s' % sslVersion)
 
       for ip in brokers[2]:
         if sslVersion:
-          self.connections[ip] = stomp.Connection( 
-                                                  [ ( ip, int( port ) ) ],
-                                                  use_ssl = True,
-                                                  ssl_version = sslVersion,
-                                                  ssl_key_file = hostkey,
-                                                  ssl_cert_file = hostcert,
-                                                  vhost = vhost,
-                                                  keepalive = True
-                                                )
+          self.connections[ip] = stomp.Connection(
+              [(ip, int(port))],
+              use_ssl=True,
+              ssl_version=sslVersion,
+              ssl_key_file=hostkey,
+              ssl_cert_file=hostcert,
+              vhost=vhost,
+              keepalive=True
+          )
         else:
-          self.connections[ip] = stomp.Connection( 
-                                                  [ ( ip, int( port ) ) ],
-                                                  vhost = vhost,
-                                                  keepalive = True
-                                                )
+          self.connections[ip] = stomp.Connection(
+              [(ip, int(port))],
+              vhost=vhost,
+              keepalive=True
+          )
 
     except Exception as e:
-      return S_ERROR( EMQCONN, 'Failed to setup connection: %s' % e )
-    return S_OK( 'Setup successful' )
+      return S_ERROR(EMQCONN, 'Failed to setup connection: %s' % e)
+    return S_OK('Setup successful')
 
-  def put( self, message, parameters = None ):
+  def put(self, message, parameters=None):
     """
     Sends a message to the queue
     message contains the body of the message
 
     :param str message: string or any json encodable structure
     """
-    destination = parameters.get( 'destination', '' )
+    destination = parameters.get('destination', '')
     error = False
     for connection in self.connections.itervalues():
       try:
-        if isinstance( message, ( list, set, tuple ) ):
+        if isinstance(message, (list, set, tuple)):
           for msg in message:
-            connection.send( body = json.dumps( msg ), destination = destination )
+            connection.send(body=json.dumps(msg), destination=destination)
             error = False
             break
         else:
-          connection.send( body = json.dumps( message ), destination = destination )
+          connection.send(body=json.dumps(message), destination=destination)
           error = False
           break
       except Exception as e:
         error = e
 
     if error is not False:
-      return S_ERROR( EMQUKN, 'Failed to send message: %s' % error )
+      return S_ERROR(EMQUKN, 'Failed to send message: %s' % error)
 
-    return S_OK( 'Message sent successfully' )
+    return S_OK('Message sent successfully')
 
-  def connect( self, parameters = None ):
-    host = self.parameters.get( 'Host' )
-    port = self.parameters.get( 'Port' )
-    user = self.parameters.get( 'User' )
-    password = self.parameters.get( 'Password' )
-    
+  def connect(self, parameters=None):
+    host = self.parameters.get('Host')
+    port = self.parameters.get('Port')
+    user = self.parameters.get('User')
+    password = self.parameters.get('Password')
+
     connected = False
     for ip, connection in self.connections.iteritems():
       try:
         connection.start()
-        connection.connect( username = user, passcode = password )
-        time.sleep( 1 )
+        connection.connect(username=user, passcode=password)
+        time.sleep(1)
         if connection.is_connected():
-          self.log.info( "Connected to %s:%s" % ( ip, port ) )
+          self.log.info("Connected to %s:%s" % (ip, port))
           connected = True
       except Exception as e:
-        self.log.error( 'Failed to connect: %s' % e )
+        self.log.error('Failed to connect: %s' % e)
 
     if connected:
-      return S_OK( "Connected to %s" % host )
+      return S_OK("Connected to %s" % host)
     else:
-      return S_ERROR( EMQCONN, "Failed to connect to  %s" % host )
+      return S_ERROR(EMQCONN, "Failed to connect to  %s" % host)
 
-
-  def disconnect( self, parameters = None ):
+  def disconnect(self, parameters=None):
     """
     Disconnects from the message queue server
     """
@@ -158,60 +158,61 @@ class StompMQConnector( MQConnector ):
       try:
         connection.disconnect()
       except Exception as e:
-        self.log.error( 'Failed to disconnect: %s' % e )
+        self.log.error('Failed to disconnect: %s' % e)
         fail = True
 
     if fail:
-      return S_ERROR( EMQUKN, 'Failed to disconnect from at least one broker' )
+      return S_ERROR(EMQUKN, 'Failed to disconnect from at least one broker')
     else:
-      return S_OK( 'Successfully disconnected from all brokers' )
+      return S_OK('Successfully disconnected from all brokers')
 
-  def subscribe( self, parameters = None ):
-    mId = parameters.get( 'messengerId', '' )
-    callback = parameters.get( 'callback', None )
-    dest = parameters.get( 'destination', '' )
+  def subscribe(self, parameters=None):
+    mId = parameters.get('messengerId', '')
+    callback = parameters.get('callback', None)
+    dest = parameters.get('destination', '')
     headers = {}
-    if self.parameters.get( 'Persistent', '' ).lower() in ['true', 'yes', '1']:
-      headers = { 'persistent': 'true' }
+    if self.parameters.get('Persistent', '').lower() in ['true', 'yes', '1']:
+      headers = {'persistent': 'true'}
     ack = 'auto'
     acknowledgement = False
-    if self.parameters.get( 'Acknowledgement', '' ).lower() in ['true', 'yes', '1']:
+    if self.parameters.get('Acknowledgement', '').lower() in ['true', 'yes', '1']:
       acknowledgement = True
       ack = 'client-individual'
     if not callback:
-      self.log.error( "No callback specified!" )
+      self.log.error("No callback specified!")
 
     for connection in self.connections.itervalues():
-      listener = StompListener( callback, acknowledgement, connection, mId )
-      connection.set_listener( '', listener )
-      connection.subscribe( destination = dest,
-                            id = mId,
-                            ack = ack,
-                            headers = headers )
-    return S_OK( 'Subscription successful' )
+      listener = StompListener(callback, acknowledgement, connection, mId)
+      connection.set_listener('', listener)
+      connection.subscribe(destination=dest,
+                           id=mId,
+                           ack=ack,
+                           headers=headers)
+    return S_OK('Subscription successful')
 
-  def unsubscribe( self, parameters ):
-    dest = parameters.get( 'destination', '' )
-    mId = parameters.get( 'messengerId', '' )
+  def unsubscribe(self, parameters):
+    dest = parameters.get('destination', '')
+    mId = parameters.get('messengerId', '')
     fail = False
     for connection in self.connections.itervalues():
       try:
-        connection.unsubscribe( destination = dest, id = mId )
+        connection.unsubscribe(destination=dest, id=mId)
       except Exception as e:
-        self.log.error( 'Failed to unsubscribe: %s' % e )
+        self.log.error('Failed to unsubscribe: %s' % e)
         fail = True
 
     if fail:
-      return S_ERROR( EMQUKN, 'Failed to unsubscribe from at least one destination' )
+      return S_ERROR(EMQUKN, 'Failed to unsubscribe from at least one destination')
     else:
-      return S_OK( 'Successfully unsubscribed from all destinations' )
+      return S_OK('Successfully unsubscribed from all destinations')
 
-class StompListener ( stomp.ConnectionListener ):
+
+class StompListener (stomp.ConnectionListener):
   """
   Internal listener class responsible for handling new messages and errors.
   """
 
-  def __init__( self, callback, ack, connection, messengerId ):
+  def __init__(self, callback, ack, connection, messengerId):
     """
     Initializes the internal listener object
 
@@ -220,34 +221,33 @@ class StompListener ( stomp.ConnectionListener ):
     :param connection: a stomp.Connection object used to send the acknowledgement
     """
 
-    self.log = gLogger.getSubLogger( 'StompListener' )
+    self.log = gLogger.getSubLogger('StompListener')
     if not callback:
-      self.log.error( 'Error initializing StompMQConnector!callback is None' )
+      self.log.error('Error initializing StompMQConnector!callback is None')
     self.callback = callback
     self.ack = ack
     self.mId = messengerId
     self.connection = connection
 
-
-  def on_message( self, headers, body ):
+  def on_message(self, headers, body):
     """
     Function called upon receiving a message
     :param dict headers: message headers
     :param json body: message body
     """
-    result = self.callback( headers, json.loads( body ) )
+    result = self.callback(headers, json.loads(body))
     if self.ack:
       if result['OK']:
-        self.connection.ack( headers['message-id'], self.mId )
+        self.connection.ack(headers['message-id'], self.mId)
       else:
-        self.connection.nack( headers['message-id'], self.mId )
+        self.connection.nack(headers['message-id'], self.mId)
 
-  def on_error( self, headers, message ):
+  def on_error(self, headers, message):
     """ Function called when an error happens
     """
-    self.log.error( message )
+    self.log.error(message)
 
-  def on_disconnected( self ):
+  def on_disconnected(self):
     """ Callback function called after disconnecting from broker.
     """
-    self.log.warn( 'Disconnected from broker' )
+    self.log.warn('Disconnected from broker')

--- a/docs/source/AdministratorGuide/DIRACSites/MessageQueues/index.rst
+++ b/docs/source/AdministratorGuide/DIRACSites/MessageQueues/index.rst
@@ -78,3 +78,6 @@ like described in :ref:`development_use_mq`, for example::
    result = consumer.get( message )
    if result['OK']:
      message = result['Value']
+
+
+In order not to spam the logs, the log output of Stomp is always silence, unless the environment variable `DIRAC_DEBUG_STOMP` is set to any value


### PR DESCRIPTION
DIRAC logs were unreadable with the stomp logging, so I conditioned them to an environment variable.
Most of the changes are autopep8. I modified the doc accordingly


BEGINRELEASENOTES

*Resources
CHANGE: enable Stomp logging only if DIRAC_DEBUG_STOMP environment variable is set to any value
ENDRELEASENOTES
