### PR TITLE
[v6r20] VOMSService: use utility to get user proxy 

### DIFF
--- a/Core/Security/VOMSService.py
+++ b/Core/Security/VOMSService.py
@@ -8,6 +8,7 @@ import os
 
 from DIRAC import gConfig, S_OK, S_ERROR
 from DIRAC.Core.Utilities import DErrno
+from DIRAC.Core.Security.Locations import getProxyLocation
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOOption
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import getVO
 
@@ -68,7 +69,7 @@ class VOMSService(object):
     :return: user dictionary keyed by the user DN
     """
 
-    userProxy = os.environ['X509_USER_PROXY']
+    userProxy = getProxyLocation()
     caPath = os.environ['X509_CERT_DIR']
     rawUserList = []
     result = None


### PR DESCRIPTION
using `getProxyLocation` allows one to directly call `VOMSService.getUsers` without wrapping things with `executeWithUserProxy`. This change is otherwise fully compatible, because the first thing `getProxyLocation`  does is looking at X509_USER_PROXY, but it will also find the proxy in the default location.

BEGINRELEASENOTES

*CORE
FIX:  VOMSService.getUsers: fix exception for missing environment variable X509_USER_PROXY when directly calling the function 

ENDRELEASENOTES
