### PR TITLE
[v6r20] Deploying environment variables through SiteDirector

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1,9 +1,9 @@
 ########################################################################
 # File :    SiteDirector.py
-# Author :  A.T.
+# Author :  A.T., F.S.
 ########################################################################
 
-"""  The Site Director is an agent performing pilot job submission to particular sites.
+"""  The Site Director is an agent performing pilot job submission to particular sites/Computing Elements.
 """
 
 __RCSID__ = "$Id$"

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1089,7 +1089,7 @@ class SiteDirector(AgentModule):
   def _writePilotScript(self, workingDirectory, pilotOptions,
                         proxy=None,
                         pilotExecDir='',
-                        envVariables = None):
+                        envVariables=None):
     """ Bundle together and write out the pilot executable script, admix the proxy if given
 
      :param workingDirectory: pilot wrapper working directory
@@ -1111,10 +1111,10 @@ class SiteDirector(AgentModule):
     except BaseException as be:
       self.log.exception("Exception during pilot modules files compression", lException=be)
 
-    localPilot = pilotWrapperScript(pilotFilesCompressedEncodedDict = pilotFilesCompressedEncodedDict,
-                                    pilotOptions = pilotOptions,
-                                    pilotExecDir = pilotExecDir,
-                                    envVariables = envVariables)
+    localPilot = pilotWrapperScript(pilotFilesCompressedEncodedDict=pilotFilesCompressedEncodedDict,
+                                    pilotOptions=pilotOptions,
+                                    pilotExecDir=pilotExecDir,
+                                    envVariables=envVariables)
 
     return _writePilotWrapperFile(workingDirectory=workingDirectory, localPilot=localPilot)
 

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -965,8 +965,11 @@ class SiteDirector(AgentModule):
       pilotsSubmitted = pilotsToSubmit
     pilotOptions = ' '.join(pilotOptions)
     self.log.verbose('pilotOptions: %s' % pilotOptions)
-    executable = self._writePilotScript(self.workingDirectory, pilotOptions,
-                                        proxy, jobExecDir, envVariables)
+    executable = self._writePilotScript(workingDirectory=self.workingDirectory,
+                                        pilotOptions=pilotOptions,
+                                        proxy=proxy,
+                                        pilotExecDir=jobExecDir,
+                                        envVariables=envVariables)
     return executable, pilotsSubmitted
 
 #####################################################################################

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -770,10 +770,12 @@ class SiteDirector(AgentModule):
 
     bundleProxy = self.queueDict[queue].get('BundleProxy', False)
     jobExecDir = self.queueDict[queue]['ParametersDict'].get('JobExecDir', '')
+    envVariables = self.queueDict[queue]['ParametersDict'].get('EnvironmentVariables', None)
 
     executable, pilotSubmissionChunk = self.getExecutable(queue, pilotsToSubmit,
                                                           bundleProxy=bundleProxy,
-                                                          jobExecDir=jobExecDir)
+                                                          jobExecDir=jobExecDir,
+                                                          envVariables=envVariables)
 
     submitResult = ce.submitJob(executable, '', pilotSubmissionChunk)
     # FIXME: The condor thing only transfers the file with some
@@ -934,7 +936,8 @@ class SiteDirector(AgentModule):
     return totalSlots
 
 #####################################################################################
-  def getExecutable(self, queue, pilotsToSubmit, bundleProxy=True, jobExecDir='',
+  def getExecutable(self, queue, pilotsToSubmit,
+                    bundleProxy=True, jobExecDir='', envVariables=None,
                     **kwargs):
     """ Prepare the full executable for queue
 
@@ -962,7 +965,8 @@ class SiteDirector(AgentModule):
       pilotsSubmitted = pilotsToSubmit
     pilotOptions = ' '.join(pilotOptions)
     self.log.verbose('pilotOptions: %s' % pilotOptions)
-    executable = self._writePilotScript(self.workingDirectory, pilotOptions, proxy, jobExecDir)
+    executable = self._writePilotScript(self.workingDirectory, pilotOptions,
+                                        proxy, jobExecDir, envVariables)
     return executable, pilotsSubmitted
 
 #####################################################################################
@@ -1084,7 +1088,8 @@ class SiteDirector(AgentModule):
 
   def _writePilotScript(self, workingDirectory, pilotOptions,
                         proxy=None,
-                        pilotExecDir=''):
+                        pilotExecDir='',
+                        envVariables = None):
     """ Bundle together and write out the pilot executable script, admix the proxy if given
 
      :param workingDirectory: pilot wrapper working directory
@@ -1106,9 +1111,10 @@ class SiteDirector(AgentModule):
     except BaseException as be:
       self.log.exception("Exception during pilot modules files compression", lException=be)
 
-    localPilot = pilotWrapperScript(pilotFilesCompressedEncodedDict,
-                                    pilotOptions,
-                                    pilotExecDir)
+    localPilot = pilotWrapperScript(pilotFilesCompressedEncodedDict = pilotFilesCompressedEncodedDict,
+                                    pilotOptions = pilotOptions,
+                                    pilotExecDir = pilotExecDir,
+                                    envVariables = envVariables)
 
     return _writePilotWrapperFile(workingDirectory=workingDirectory, localPilot=localPilot)
 

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -46,15 +46,18 @@ def pilotWrapperScript(pilotFilesCompressedEncodedDict=None,
      :rtype: basestring
   """
 
+  if pilotFilesCompressedEncodedDict is None:
+    pilotFilesCompressedEncodedDict = {}
+
   if envVariables is None:
     envVariables = {}
 
   mString = ""
-  if pilotFilesCompressedEncodedDict:  # are there some pilot files to unpack? then we create the unpacking string
-    for pfName, encodedPf in pilotFilesCompressedEncodedDict.iteritems():
-      mString += """
+  for pfName, encodedPf in pilotFilesCompressedEncodedDict.iteritems():  # are there some pilot files to unpack?
+                                                                         # then we create the unpacking string
+    mString += """
 try:
-  with open('%(pfName)s', "w") as fd:
+  with open('%(pfName)s', 'w') as fd:
     fd.write(bz2.decompress(base64.b64decode(\"\"\"%(encodedPf)s\"\"\")))
   os.chmod('%(pfName)s', stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 except BaseException as x:
@@ -65,9 +68,8 @@ except BaseException as x:
        'pfName': pfName}
 
   envVariablesString = ""
-  if envVariables:  # are there some environment variables to add?
-    for name, value in envVariables.iteritems():
-      envVariablesString += """
+  for name, value in envVariables.iteritems():  # are there some environment variables to add?
+    envVariablesString += """
 os.environ[\"%(name)s\"]=\"%(value)s\"
 """ % {'name': name,
        'value': value}

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -28,7 +28,8 @@ import requests
 
 def pilotWrapperScript(pilotFilesCompressedEncodedDict=None,
                        pilotOptions='',
-                       pilotExecDir=''):
+                       pilotExecDir='',
+                       envVariables=None):
   """ Returns the content of the pilot wrapper script.
 
       The pilot wrapper script is a bash script that invokes the system python. Linux only.
@@ -45,6 +46,9 @@ def pilotWrapperScript(pilotFilesCompressedEncodedDict=None,
      :rtype: basestring
   """
 
+  if envVariables is None:
+    envVariables = {}
+
   mString = ""
   if pilotFilesCompressedEncodedDict:  # are there some pilot files to unpack? then we create the unpacking string
     for pfName, encodedPf in pilotFilesCompressedEncodedDict.iteritems():
@@ -59,6 +63,16 @@ except BaseException as x:
   sys.exit(-1)
 """ % {'encodedPf': encodedPf,
        'pfName': pfName}
+
+  envVariablesString = ""
+  if envVariables:  # are there some environment variables to add?
+    for name, value in envVariables.iteritems():
+      envVariablesString += """
+os.environ[\"%(name)s\"]=\"%(value)s\"
+""" % {'name': name,
+       'value': value}
+
+  mString = mString + envVariablesString
 
   localPilot = """#!/bin/bash
 /usr/bin/env python << EOF

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
@@ -30,8 +30,8 @@ class PilotWrapperTestCaseCreation(PilotWrapperTestCase):
     """
     res = pilotWrapperScript()
 
-    print res
-    # no assert as it makes little sense
+    self.assertTrue('cmd = "python dirac-pilot.py "' in res)
+    self.assertTrue('os.environ["someName"]="someValue"' not in res)
 
   def test_scriptoptions(self):
     """ test script creation
@@ -42,8 +42,8 @@ class PilotWrapperTestCaseCreation(PilotWrapperTestCase):
                                          'someOther.py': 'someOtherContent'},
         pilotOptions="-c 123 --foo bar")
 
-    print res
-    # no assert as it makes little sense
+    self.assertTrue("with open('dirac-install.py', 'w') as fd:" in res)
+    self.assertTrue('os.environ["someName"]="someValue"' not in res)
 
   def test_scriptReal(self):
     """ test script creation
@@ -75,8 +75,9 @@ class PilotWrapperTestCaseCreation(PilotWrapperTestCase):
                                          'pilotCommands.py': diracPilotCommandsEncoded},
         pilotOptions="-c 123 --foo bar")
 
-    print res
-    # no assert as it makes little sense
+    self.assertTrue("with open('dirac-pilot.py', 'w') as fd:" in res)
+    self.assertTrue("with open('dirac-install.py', 'w') as fd:" in res)
+    self.assertTrue('os.environ["someName"]="someValue"' not in res)
 
   def test_scriptWithEnvVars(self):
     """ test script creation
@@ -88,7 +89,7 @@ class PilotWrapperTestCaseCreation(PilotWrapperTestCase):
         envVariables={'someName': 'someValue',
                       'someMore': 'oneMore'})
 
-    print res
+    self.assertTrue('os.environ["someName"]="someValue"' in res)
 
 
 #############################################################################

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
@@ -78,6 +78,18 @@ class PilotWrapperTestCaseCreation(PilotWrapperTestCase):
     print res
     # no assert as it makes little sense
 
+  def test_scriptWithEnvVars(self):
+    """ test script creation
+    """
+    res = pilotWrapperScript(
+        pilotFilesCompressedEncodedDict={'dirac-install.py': 'someContentOfDiracInstall',
+                                         'someOther.py': 'someOtherContent'},
+        pilotOptions="-c 123 --foo bar",
+        envVariables={'someName': 'someValue',
+                      'someMore': 'oneMore'})
+
+    print res
+
 
 #############################################################################
 # Test Suite run

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Agents/SiteDirector/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/WorkloadManagement/Agents/SiteDirector/index.rst
@@ -3,40 +3,47 @@ Systems / WorkloadManagement / <INSTANCE> / Agents / SiteDirector - Sub-subsecti
 
 Site director is in charge of submit pilot jobs to special Computing Elements.
  
-Special attributes for this agent are (updated for v6r15):
+Special attributes for this agent are (updated for v6r20):
  
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | **Name**                        | **Description**                        | **Example**                                                       |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *CETypes*                       | List of CEs types allowed to submit    | CETypes = CREAM                                                   |
-|                                 | pilot jobs                             |                                                                   |
+|                                 | pilot jobs (default: 'any')            |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
-| *CEs*                           | List of CEs to submit pilot jobs       | CEs = ce01.in2p3.fr                                               |
+| *CEs*                           | List of CEs where to submit            | CEs = ce01.in2p3.fr                                               |
+|                                 | pilot jobs (default: 'any')            |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *Site*                          | Sites name list where the pilots will  | Site =                                                            |
 |                                 | be submitted                           |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *PilotDN*                       | Pilot DN used to submit the            | PilotDN =  /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Vanessa Hamar        |
-|                                 | pilot jobs                             |                                                                   |
+|                                 | pilot jobs (default: 'any')            |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *PilotGroup*                    | DIRAC group used to submit the pilot   | PilotGroup = dirac_pilot                                          |
-|                                 | jobs                                   |                                                                   |
+|                                 | jobs.                                  |                                                                   |
+|                                 | If not found here, what is in          |                                                                   |
+|                                 | Operations/Pilot section of the CS     |                                                                   |
+|                                 | will be used                           |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *GetPilotOutput*                | Boolean value used to indicate the     | GetPilotOutput = True                                             |
 |                                 | pilot output will be or not retrieved  |                                                                   |
+|                                 | (default: False)                       |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *GridEnv*                       | Path where is located the file to      | GridEnv = /usr/profile.d/grid-env                                 |
 |                                 | load Grid Environment Variables        |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
-| *MaxQueueLength*                | Maximum cputime used for a queue, will | MaxQueueLength = 86400*3                                          |
+| *MaxQueueLength*                | Maximum cputime used for a queue, will | MaxQueueLength = 3x86400                                          |
 |                                 | set maxCPU time to this value          |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *SendPilotAccounting*           | Boolean value than indicates if the    | SendPilotAccounting = yes                                         |
 |                                 | pilot job will send information for    |                                                                   |
 |                                 | accounting                             |                                                                   |
+|                                 | (default: True)                        |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *UpdatePilotStatus*             | Attribute used to define if the status | UpdatePilotStatus = True                                          |
 |                                 | of the pilot will be updated           |                                                                   |
+|                                 | (default: True)                        |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *WorkDirectory*                 | Working Directory in the CE            | WorkDirectory = /tmp                                              |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
@@ -64,7 +71,7 @@ Special attributes for this agent are (updated for v6r15):
 | *AddPilotsToEmptySites*         | To submit pilots to empty sites        | AddPilotsToEmptySites = True                                      |
 |                                 | in any case (False by default)         |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
-| *PilotStatusUpdateCycleFactor*  |                                        |                                                                   |
+| *PilotStatusUpdateCycleFactor*  | Deafult: 10                            |                                                                   |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+
 | *Pilot3*                        | To submit pilot 3 or not               | Pilot3 = True                                                     |
 +---------------------------------+----------------------------------------+-------------------------------------------------------------------+


### PR DESCRIPTION
Originally (in v6r19) there was the possibility to deploy "HTTP_PROXY" environment variables. This is a more generic way.

BEGINRELEASENOTES

*WMS
NEW: Added possibility for deploying environment variables in the pilot wrapper through SiteDirector

ENDRELEASENOTES
