### PR TITLE
[v6r20] Saving output of jobs run with 'runLocal' when they fail (for DEBUG purposes)

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -932,7 +932,7 @@ class Dirac(API):
     os.chdir(curDir)
 
     if status:  # if it fails, copy content of execution dir in current directory
-      shutil.copytree(tmpdir, os.path.join(curDir, os.path.basename(tmpdir)))
+      shutil.copytree(tmpdir, os.path.join(curDir, os.path.basename(os.path.dirname(tmpdir))))
 
     self.log.verbose('Cleaning up %s...' % tmpdir)
     self.__cleanTmp(tmpdir)

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -929,12 +929,17 @@ class Dirac(API):
           else:
             return S_ERROR('Can not copy OutputSandbox file %s' % osFile)
 
+    os.chdir(curDir)
+
+    if status:  # if it fails, copy content of execution dir in current directory
+      shutil.copytree(tmpdir, os.path.join(curDir, os.path.basename(tmpdir)))
+
     self.log.verbose('Cleaning up %s...' % tmpdir)
     self.__cleanTmp(tmpdir)
-    os.chdir(curDir)
 
     if status:
       return S_ERROR('Execution completed with non-zero status %s' % (status))
+
     return S_OK('Execution completed successfully')
 
   def _getLocalInputData(self, parameters):


### PR DESCRIPTION

BEGINRELEASENOTES

*Interfaces
CHANGE: Saving output of jobs run with 'runLocal' when they fail (for DEBUG purposes)

ENDRELEASENOTES
