### PR TITLE
a bug in multi-vo mode when counting totalslots

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -925,7 +925,7 @@ class SiteDirector(AgentModule):
               self.log.info("PilotAgentsDB report(%s_%s): Wait=%d, Run=%d, Max=%d" %
                             (ceName, queueName, waitingJobs, runningJobs, maxTotalJobs))
           totalSlots = min((maxTotalJobs - totalJobs), (maxWaitingJobs - waitingJobs))
-          self.queueSlots[queue]['AvailableSlots'] = totalSlots
+          self.queueSlots[queue]['AvailableSlots'] = max(totalSlots, 0)
 
     self.queueSlots[queue]['AvailableSlotsCount'] += 1
 


### PR DESCRIPTION
When a site is running with multi-vo mode, the value of totalSlots is possible to get minus. When getting minus, the site will never get chances to submit pilots again because no case there to deal with minus. The possible reason about this situation is when two instances of SiteDirector are checking and submiting pilots for a nearly full queue, one could possily get a value of totalJobs more than real value.
totalSlots = min( (maxTotalJobs - totalJobs), (maxWaitingJobs - waitingJobs) )
This situation can be solved when returning totalSlots to zero 

BEGINRELEASENOTES
Thank you for writing the text to appear in the release notes. It will show up
exactly as it appears between the two bold lines

Please follow the template:
*Subsystem
NEW/CHANGE/FIX: explanation

For examples look into release.notes

ENDRELEASENOTES
