### PR TITLE
[v6r20] Doc: add a documented dirac.cfg

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -1,0 +1,234 @@
+Systems
+{
+   DataManagementSystem
+   {
+      Agents
+      {
+         #http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html#cleanftsdbagent
+         # Used to clean the database
+         CleanFTSDBAgent
+         {
+            DeleteGraceDays = 21 # time after which deleting a job in a final status
+            DeleteLimitPerCycle = 100 # max number of jobs to delete per agent cycle
+         }
+         # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html#ftsagent
+         # Agent to perform the fts transfers
+         FTSAgent
+         {
+
+            MaxFilesPerJob = 10 # maximum number of files in a single fts job
+            MaxRequests = 1000 # maximum number of requests to look at per agent's cycle
+            MaxThreads = 60 # maximum number of threads
+            MaxTransferAttempts = 256 # maximum number of time we attempt to transfer a file
+            MinThreads = 10 # minimum number of threads
+            MonitoringInterval = 1800 # interval between two monitoring of an FTSJob in second
+            PinTime = 18000 # when staging, pin time requested in the FTS job in second
+            ProcessJobRequests = True # if this agent is meant to process job only transfers (see `http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html#multiple-ftsagents)
+         }
+      }
+      Services
+      {
+         # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/dfc.html#filecataloghandler
+         FileCatalogHandler
+         {
+            DatasetManager = DatasetManager
+            DefaultUmask = 0775
+            DirectoryManager = DirectoryLevelTree
+            DirectoryMetadata = DirectoryMetadata
+            FileManager = FileManager
+            FileMetadata = FileMetadata
+            GlobalReadAccess = True
+            LFNPFNConvention = Strong
+            ResolvePFN = True
+            SecurityManager = NoSecurityManager
+            SEManager = SEManagerDB
+            UniqueGUID = False
+            UserGroupManager = UserAndGroupManagerDB
+            ValidFileStatus = [AprioriGoodTrashRemovingProbing]
+            ValidReplicaStatus = [AprioriGoodTrashRemovingProbing]
+            VisibleFileStatus = [AprioriGood]
+            VisibleReplicaStatus = [AprioriGood]
+
+         }
+         # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html#ftsmanager
+         FTSManagerHandler
+         {
+            # No specific configuration
+         }
+      }
+      Databases
+      {
+         # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/dfc.html#filecatalogdb
+         FileCatalogDB
+         {
+            # No specific configuration
+         }
+         # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html#ftsdb
+         FTSDB
+         {
+            # No specific configuration
+         }
+      }
+   }
+   RequestManagementSystem
+   {
+      Agents
+      {
+         RequestExecutingAgent
+         {
+            OperationHandlers
+            {
+               ReplicateAndRegister
+               {
+                  FTSMode = True # If True, will use FTS to transfer files
+                  FTSBannedGroups = lhcb_user # list of groups for which not to use FTS
+               }
+            }
+         }
+      }
+   }
+}
+Resources
+{
+   # Where all your Catalogs are defined
+   FileCatalogs
+   {
+      # There is one section per catalog
+      # See http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Catalogs/index.html
+      <MyCatalog>
+      {
+         CatalogType = <myCatalogType> # used for plugin selection
+         CatalogURL = <myCatalogURL> # used for DISET URL
+         <anyOptions> # Passed to the constructor of the plugin
+      }
+   }
+   # FTS endpoint definition http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html#fts-servers-definition
+   FTSEndpoints
+   {
+      FTS3
+      {
+         CERN-FTS3 = https://fts3.cern.ch:8446
+      }
+   }
+   # Abstract definition of storage elements, used to be inherited.
+   # see http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Storages/index.html#storageelementbases
+   StorageElementBases
+   {
+     # The base SE definition can contain all the options of a normal SE
+     # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Storages/index.html#storageelements
+     CERN-EOS
+     {
+       BackendType = eos # backend type of storage element
+       SEType = T0D1 # Tape or Disk SE
+       UseCatalogURL = True # used the stored url or generate it (default False)
+       ReadAccess = True # Allowed for Read if no RSS enabled
+       WriteAccess = True # Allowed for Write if no RSS enabled
+       CheckAccess = True # Allowed for Check if no RSS enabled
+       RemoveAccess = True # Allowed for Remove if no RSS enabled
+       GFAL2_SRM2 # Protocol section, see  # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Storages/index.html#available-protocol-plugins
+       {
+         Host = srm-eoslhcb.cern.ch
+         Port = 8443
+         PluginName = GFAL2_SRM2 # If different from the section name
+         Protocol = srm # primary protocol
+         Path = /eos/lhcb/grid/prod # base path
+         Access = remote
+         SpaceToken = LHCb-EOS
+         WSUrl = /srm/v2/server?SFN=
+       }
+     }
+   }
+   # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Storages/index.html#storageelements
+   StorageElements
+   {
+     CERN-DST-EOS # Just inherit everything from CERN-EOS, without change
+     {
+       BaseSE = CERN-EOS
+     }
+     CERN-USER # inherit from CERN-EOS
+     {
+       BaseSE = CERN-EOS
+       GFAL2_SRM2 # Modify the options for Gfal2
+       {
+         Path = /eos/lhcb/grid/user
+         SpaceToken = LHCb_USER
+       }
+       GFAL2_XROOT # Add an extra protocol
+       {
+         Host = eoslhcb.cern.ch
+         Port = 8443
+         Protocol = root
+         Path = /eos/lhcb/grid/user
+         Access = remote
+         SpaceToken = LHCb-EOS
+         WSUrl = /srm/v2/server?SFN=
+       }
+     }
+     CERN-ALIAS
+     {
+        Alias = CERN-USER # Use CERN-USER when instanciating CERN-ALIAS
+     }
+   }
+   # See http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Storages/index.html#storageelementgroups
+   StorageElementGroups
+   {
+      CERN-Storages = CERN-DST-EOS, CERN-USER
+   }
+
+}
+Operations
+{
+   # This is the default section of operations.
+   # Any value here can be overwriten in the setup specific section
+   Defaults
+   {
+      DataManagement
+      {
+         # see http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Catalogs/index.html#multi-protocol
+         # for the next 4 options
+         AccessProtocols = srm,dips
+         RegistrationProtocols = srm,dips
+         ThirdPartyProtocols = srm
+         WriteProtocols = srm,dips
+
+         # FTS related options. See http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html
+         FTSVersion = FTS3 # should only be that...
+         FTSPlacement
+         {
+            FTS3
+            {
+               ServerPolicy = Random # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html#ftsserver-policy
+            }
+         }
+
+      }
+      Services
+      {
+         Catalogs # See http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Catalogs/index.html
+         {
+            CatalogList = Catalog1, Catalog2, etc # List of catalogs defined in Resources to use
+            # Each catalog defined in Resources should also contain some runtime options here
+            <MyCatalog>
+            {
+               Status = Active # enable the catalog or not (default Active)
+               AccessType = Read-Write # No default, must be set
+               Master = True # See http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Catalogs/index.html#master-catalog
+               # Dynamic conditions to enable or not the catalog
+               Conditions  # See http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Catalogs/index.html#conditional-filecatalogs
+               {
+                  WRITE = <myWriteCondition>
+                  READ = <myReadCondition>
+                  ALL = <valid for all conditions>
+                  <myMethod> = <myCondition valid only for myMethod>
+               }
+            }
+         }
+      }
+   }
+   # Options in this section will only be used when running with the
+   # <MySetup> setup
+   <MySetup>
+   {
+
+   }
+}


### PR DESCRIPTION
When looking at big projects outside, you can see a full configuration files, with all the options documented. I think it is a very nice way of doing. 
Since I am exploring the code to write doc for the DUW, I took the opportunity to start such a file. 
I know, it's work to keep it up to date. But I think it is totally worth it. 
What do you think ? 

BEGINRELEASENOTES

*Docs
NEW: add a documented dirac.cfg 

ENDRELEASENOTES
