### PR TITLE
change DB condition to count all waiting pilot jobs

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -499,7 +499,7 @@ class SiteDirector(AgentModule):
         tqIDList = additionalInfo.keys()
         result = pilotAgentsDB.countPilots({'TaskQueueID': tqIDList,
                                             'Status': WAITING_PILOT_STATUS},
-                                           None, lastUpdateTime)
+                                           None)
         if not result['OK']:
           self.log.error('Failed to get Number of Waiting pilots', result['Message'])
           totalWaitingPilots = 0


### PR DESCRIPTION
This should solve the issue that by default additional pilots are submitting every hour because SiteDirector agent doesn't count older pilots which are in Waiting state more than hour.