### PR TITLE
[v6r20] Fix matcher/taskqueue in no-matches found case

### DIFF
--- a/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -987,7 +987,7 @@ WHERE j.JobId = %s AND t.TQId = j.TQId" %
       return result
     return self.retrieveTaskQueues([tqTuple[0] for tqTuple in result['Value']])
 
-  def retrieveTaskQueues(self, tqIdList=False):
+  def retrieveTaskQueues(self, tqIdList=None):
     """
     Get all the task queues
     """
@@ -998,8 +998,9 @@ WHERE j.JobId = %s AND t.TQId = j.TQId" %
       sqlGroupEntries.append("`tq_TaskQueues`.%s" % field)
     sqlCmd = "SELECT %s FROM `tq_TaskQueues`, `tq_Jobs`" % ", ".join(sqlSelectEntries)
     sqlTQCond = ""
-    if tqIdList:
+    if tqIdList is not None:
       if not tqIdList:
+        # Empty list => Fast-track no matches
         return S_OK({})
       else:
         sqlTQCond += " AND `tq_TaskQueues`.TQId in ( %s )" % ", ".join([str(id_) for id_ in tqIdList])


### PR DESCRIPTION
Hi,

While testing v6r20 we found that the site directors were submitting pilots for jobs they shouldn't, even for jobs owned by other VOs (the pilots themselves never actually pick up the jobs). This causes jobs to take a very long time to run as pilots are submitted randomly until a combination that happens to match a job runs.

We've tracked this down to a change in behaviour of the retrieveTaskQueues when given an empty list of tq IDs... In the old version it would (correctly) return no matches, in the new version it returns _all_ task queues. This patch restores the old behaviour, which seems to fix the problem.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: Ensure retrieveTaskQueues doesn't return anything when given an empty list of TQ IDs.
ENDRELEASENOTES
