### PR TITLE
[v6r20] Call optimizer for non-bulk jobs

### DIFF
--- a/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -196,6 +196,9 @@ class JobManagerHandler(RequestHandler):
 
     result['JobID'] = result['Value']
     result['requireProxyUpload'] = self.__checkIfProxyUploadIsRequired()
+    # Ensure non-parametric jobs (i.e. non-bulk) get sent to optimizer immediately
+    if not parametricJob:
+      self.__sendJobsToOptimizationMind(jobIDList)
     return result
 
 ###########################################################################


### PR DESCRIPTION
Hi,

We found that in v6r20 jobs would sit in the received state for up to 5 minutes, whereas in earlier versions processing was almost instantaneous. It looks like nothing calls the Optimizer for normal non-bulk jobs in v6r20, so this patch just adds back that statement...

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: Call optimizer fast-path for non-bulk jobs
ENDRELEASENOTES