### PR TITLE
[v6r20] FileManager._getRepIDsForReplica: faster query

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager.py
@@ -496,9 +496,12 @@ class FileManager( FileManagerBase ):
   def _getRepIDsForReplica(self,replicaTuples,connection=False):
     connection = self._getConnection(connection)
     queryTuples = []
+    fileIDs = []
     for fileID,seID in replicaTuples:
       queryTuples.append("(%d,%d)" % (fileID,seID))
-    req = "SELECT RepID,FileID,SEID FROM FC_Replicas WHERE (FileID,SEID) IN (%s)" % intListToString(queryTuples)
+      fileIDs.append(fileID)
+    req = "SELECT RepID,FileID,SEID FROM FC_Replicas WHERE (FileID,SEID) IN (%s) AND FileID in (%s)" % \
+          (intListToString(queryTuples), intListToString(fileIDs))
     res = self.db._query(req,connection)
     if not res['OK']:
       return res


### PR DESCRIPTION
add the list of fileIDs to the query to allow mySQL to use the index (might depend on mysql version)
The index fo the tuple is not used according to EXPLAIN SELECT...

Without the list of FileIDs the query needs to check all rows (11 million in this case)
```
mysql> EXPLAIN SELECT RepID,FileID,SEID FROM FC_Replicas WHERE (FileID,SEID) IN ((38555741,6),(38555931,6),(38555834,6),(38555833,6),(38555777,6),(38555745,6),(38555775,6),(38555643,6),(38555916,6),(38555637,6));
+----+-------------+-------------+-------+---------------+----------+---------+------+----------+--------------------------+
| id | select_type | table       | type  | possible_keys | key      | key_len | ref  | rows     | Extra                    |
+----+-------------+-------------+-------+---------------+----------+---------+------+----------+--------------------------+
|  1 | SIMPLE      | FC_Replicas | index | NULL          | FileID_2 | 8       | NULL | 11646283 | Using where; Using index |
+----+-------------+-------------+-------+---------------+----------+---------+------+----------+--------------------------+
1 row in set (0.00 sec)
```

With the list of FileIDs it can directly find the rows.
```
mysql> EXPLAIN SELECT RepID,FileID,SEID FROM FC_Replicas WHERE (FileID,SEID) IN ((38555741,6),(38555931,6),(38555834,6),(38555833,6),(38555777,6),(38555745,6),(38555775,6),(38555643,6),(38555916,6),(38555637,6)) AND FileID in (38555741,38555931,38555834,38555833,38555777,38555745,38555775,38555643,38555916,38555637);+----+-------------+-------------+-------+-----------------+----------+---------+------+------+--------------------------+
| id | select_type | table       | type  | possible_keys   | key      | key_len | ref  | rows | Extra                    |
+----+-------------+-------------+-------+-----------------+----------+---------+------+------+--------------------------+
|  1 | SIMPLE      | FC_Replicas | range | FileID,FileID_2 | FileID_2 | 4       | NULL |   10 | Using where; Using index |
+----+-------------+-------------+-------+-----------------+----------+---------+------+------+--------------------------+
1 row in set (0.01 sec)
```

This problem only exists when more than 1 replica is being selected, but if there is more than 1 the query takes *forever* 
```
mysql> SELECT RepID,FileID,SEID FROM FC_Replicas WHERE (FileID,SEID) IN ((38555741,6),(38555931,6),(38555834,6),(38555833,6),(38555777,6),(38555745,6),(38555775,6),(38555643,6),(38555916,6),(38555637,6));
Empty set (9 min 0.44 sec)
```
instead of no time.
```
mysql> SELECT RepID,FileID,SEID FROM FC_Replicas WHERE (FileID,SEID) IN ((38555741,6),(38555931,6),(38555834,6),(38555833,6),(38555777,6),(38555745,6),(38555775,6),(38555643,6),(38555916,6),(38555637,6)) AND FileID in (38555741,38555931,38555834,38555833,38555777,38555745,38555775,38555643,38555916,38555637);
Empty set (0.00 sec)
```




BEGINRELEASENOTES

*DMS
FIX: Faster query for _getRepIDsForReplica in the `FileManager` when looking up more than one replica

ENDRELEASENOTES
