### PR TITLE
[v6r20] TaskManager: bulksubmission: fix occasional exception

### DIFF
--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -780,8 +780,10 @@ class WorkflowTasks(TaskBase):
     if not taskDict:
       return S_OK(taskDict)
     startTime = time.time()
-    transID = taskDict.values()[0]['TransformationID']
+
     oJob = taskDict.pop('BulkJobObject')
+    # we can only do this, once the job has been popped, or we _might_ crash
+    transID = taskDict.values()[0]['TransformationID']
     if oJob is None:
       self._logError('no bulk Job object found', transID=transID, method='submitTransformationTasksBulk')
       return S_ERROR(ETSUKN, 'No bulk job object provided for submission')


### PR DESCRIPTION

Sometimes the order is like:
```
[<DIRAC.Interfaces.API.Job.Job object at 0x7fe0c40aff50>,
 {'InputData': '',
  'Status': 'Created',
  'TargetSE': 'Unknown',
  'TaskID': 38L,
  'TransformationID': 401094L},
 {'InputData': '',
  'Status': 'Created',
  'TargetSE': 'Unknown',
  'TaskID': 39L,
  'TransformationID': 401094L}]
```
Sometimes the Job comes later, if the job is the first entry, there will be an exception:
```
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/TransformationSystem/Agent/TaskManagerAgentBase.py", line 306, in _execute
    res = getattr(self, operation)(transIDOPBody, clients)
  File "/opt/dirac/pro/DIRAC/TransformationSystem/Agent/TaskManagerAgentBase.py", line 573, in submitTasks
    res = clients['TaskManager'].submitTransformationTasks(preparedTransformationTasks['Value'])
  File "/opt/dirac/pro/DIRAC/TransformationSystem/Client/TaskManager.py", line 800, in submitTransformationTasks
    return self.__submitTransformationTasksBulk(taskDict)
  File "/opt/dirac/pro/DIRAC/TransformationSystem/Client/TaskManager.py", line 810, in __submitTransformationTasksBulk
    transID = taskDict.values()[0]['TransformationID']
TypeError: 'Job' object has no attribute '__getitem__'
```
(Note line numbers vary because of local developments)

BEGINRELEASENOTES

*TS
FIX: TaskManger with bulksubmission might have occasional exception, depending on order of entries in a dictionary

ENDRELEASENOTES
