### PR TITLE
[v6r20] Fix job parameters for bulk submission

### DIFF
--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -1033,7 +1033,7 @@ class Job(API):
               paramsDict[pName]['value'] += ';%%(%s)s' % pName
             else:
               paramsDict[pName]['value'] = '%%(%s)s' % pName
-        else:
+        elif "jdl" in paramsDict[pName]['type'].lower():
           if isinstance(paramsDict[pName]['value'], list):
             currentParams = paramsDict[pName]['value']
           elif isinstance(paramsDict[pName]['value'], basestring):

--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -1034,22 +1034,20 @@ class Job(API):
             else:
               paramsDict[pName]['value'] = '%%(%s)s' % pName
         elif "jdl" in paramsDict[pName]['type'].lower():
+          # If a parameter with the same name as the sequence name already exists
+          # and is a list, then extend it by the sequence value. If it is not a
+          # list, then replace it by the sequence value
           if isinstance(paramsDict[pName]['value'], list):
             currentParams = paramsDict[pName]['value']
-          elif isinstance(paramsDict[pName]['value'], basestring):
-            if paramsDict[pName]['value']:
-              currentParams = paramsDict[pName]['value'].split(';')
+            tmpList = []
+            pData = self.parameterSeqs[pName]
+            if isinstance(pData[0], list):
+              for pElement in pData:
+                tmpList.append(currentParams + pElement)
             else:
-              currentParams = []
-          tmpList = []
-          pData = self.parameterSeqs[pName]
-          if isinstance(pData[0], list):
-            for pElement in pData:
-              tmpList.append(currentParams + pElement)
-          else:
-            for pElement in pData:
-              tmpList.append(currentParams + [pElement])
-          self.parameterSeqs[pName] = tmpList
+              for pElement in pData:
+                tmpList.append(currentParams + [pElement])
+            self.parameterSeqs[pName] = tmpList
           paramsDict[pName]['value'] = '%%(%s)s' % pName
       else:
         paramsDict[pName] = {}

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -514,7 +514,14 @@ class WorkflowTasks(TaskBase):
     jobType = oJob.workflow.findParameter('JobType').getValue()
     transGroup = str(transID).zfill(8)
 
-    oJob._setParamValue('PRODUCTION_ID', str(transID).zfill(8))  # pylint: disable=protected-access
+    # Verify that the JOB_ID parameter is added to the workflow
+    if not oJob.workflow.findParameter('JOB_ID'):
+      oJob._addParameter(oJob.workflow, 'JOB_ID', 'string', '00000000', "Initial JOB_ID")
+
+    if oJob.workflow.findParameter('PRODUCTION_ID'):
+      oJob._setParamValue('PRODUCTION_ID', str(transID).zfill(8))  # pylint: disable=protected-access
+    else:
+      oJob._addParameter(oJob.workflow, 'PRODUCTION_ID', 'string', str(transID).zfill(8), "Production ID")  # pylint: disable=protected-access
     oJob.setType(jobType)
     self._logVerbose('Adding default transformation group of %s' % (transGroup),
                      transID=transID, method=method)
@@ -608,7 +615,21 @@ class WorkflowTasks(TaskBase):
         self._logVerbose('Adding default transformation group of %s' % (transGroup),
                          transID=transID, method=method)
         oJobTemplate.setJobGroup(transGroup)
-        oJobTemplate._setParamValue('PRODUCTION_ID', str(transID).zfill(8))
+        if oJobTemplate.workflow.findParameter('PRODUCTION_ID'):
+          oJobTemplate._setParamValue('PRODUCTION_ID', str(transID).zfill(8))
+        else:
+          oJobTemplate._addParameter(oJobTemplate.workflow,
+                                     'PRODUCTION_ID',
+                                     'string',
+                                     str(transID).zfill(8),
+                                     "Production ID")
+        if not oJobTemplate.workflow.findParameter('JOB_ID'):
+          oJobTemplate._addParameter(oJobTemplate.workflow,
+                                     'JOB_ID',
+                                     'string',
+                                     '00000000',
+                                     "Initial JOB_ID")
+
 
       paramsDict['Site'] = site
       paramsDict['JobType'] = jobType

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -521,7 +521,11 @@ class WorkflowTasks(TaskBase):
     if oJob.workflow.findParameter('PRODUCTION_ID'):
       oJob._setParamValue('PRODUCTION_ID', str(transID).zfill(8))  # pylint: disable=protected-access
     else:
-      oJob._addParameter(oJob.workflow, 'PRODUCTION_ID', 'string', str(transID).zfill(8), "Production ID")  # pylint: disable=protected-access
+      oJob._addParameter(oJob.workflow,  # pylint: disable=protected-access
+                         'PRODUCTION_ID',
+                         'string',
+                         str(transID).zfill(8),
+                         "Production ID")
     oJob.setType(jobType)
     self._logVerbose('Adding default transformation group of %s' % (transGroup),
                      transID=transID, method=method)

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -539,7 +539,7 @@ class WorkflowTasks(TaskBase):
         self._logVerbose('Setting Site: ', str(sites), transID=transID)
         seqDict['Site'] = sites
 
-      seqDict['JobName'] = transGroup
+      seqDict['JobName'] = self._transTaskName(transID, taskID)
       seqDict['JOB_ID'] = str(taskID).zfill(8)
 
       self._logDebug('TransID: %s, TaskID: %s, paramsDict: %s' % (transID, taskID, str(paramsDict)),

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -583,6 +583,15 @@ class WorkflowTasks(TaskBase):
         for name, output in res['Value'].iteritems():
           seqDict[name] = ';'.join(output)
           outputParameterList.append(name)
+          if oJob.workflow.findParameter(name):
+            oJob._setParamValue(name, "%%(%s)s" % name)  # pylint: disable=protected-access
+          else:
+            oJob._addParameter(oJob.workflow,  # pylint: disable=protected-access
+                               name,
+                               'JDL',
+                               "%%(%s)s" % name,
+                               name)
+
 
       for pName, seq in seqDict.iteritems():
         paramSeqDict.setdefault(pName, []).append(seq)

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -568,6 +568,7 @@ class WorkflowTasks(TaskBase):
                              transID=transID, method=method)
             seqDict[paramName] = paramValue
 
+      outputParameterList = []
       if self.outputDataModule:
         res = self.getOutputData({'Job': oJob._toXML(), 'TransformationID': transID,  # pylint: disable=protected-access
                                   'TaskID': taskID, 'InputData': inputData})
@@ -577,12 +578,13 @@ class WorkflowTasks(TaskBase):
           continue
         for name, output in res['Value'].iteritems():
           seqDict[name] = ';'.join(output)
+          outputParameterList.append(name)
 
       for pName, seq in seqDict.iteritems():
         paramSeqDict.setdefault(pName, []).append(seq)
 
     for paramName, paramSeq in paramSeqDict.iteritems():
-      if paramName in ('JOB_ID', 'PRODUCTION_ID', 'InputData'):
+      if paramName in ['JOB_ID', 'PRODUCTION_ID', 'InputData'] + outputParameterList:
         oJob.setParameterSequence(paramName, paramSeq, addToWorkflow=paramName)
       else:
         oJob.setParameterSequence(paramName, paramSeq)


### PR DESCRIPTION
This PR addresses the problem reported in the issue #3707 and discussed there. There is also a 
check that JOB_ID and PRODUCTION_ID workflow parameter placeholders are defined. This avoids
the necessity to define then explicitly while creation of a transformation. 

BEGINRELEASENOTES
*Transformation
FIX: TaskManager - fix the generated JobName to be of the form ProdID_TaskID
FIX: TaskManager - check the JOB_ID and PRODUCTION_ID parameters are defined in the workflow
*Interfaces
FIX: Job API - do not merge workflow non-JDL parameters with the sequence parameters of the same name
ENDRELEASENOTES
