### PR TITLE
Fix zero value of CPU usage in monitoring

### DIFF
--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -31,6 +31,8 @@ from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
 
 gMonitoringReporter = None
 
+gProfilers = {}
+
 # pylint: disable=no-self-use
 
 
@@ -756,7 +758,9 @@ class SystemAdministratorHandler(RequestHandler):
             gLogger.error("Wrongly configured component: %s" % instance)
             continue
           pid = startupComps[instance]['PID']
-          profiler = Profiler.Profiler(pid)
+          if pid not in gProfilers:
+            gProfilers[pid] = Profiler.Profiler(pid)
+          profiler = gProfilers[pid]
           result = profiler.getAllProcessData()
           if result['OK']:
             log = result['Value']['stats']

--- a/MonitoringSystem/private/Plotters/ComponentMonitoringPlotter.py
+++ b/MonitoringSystem/private/Plotters/ComponentMonitoringPlotter.py
@@ -90,7 +90,7 @@ class ComponentMonitoringPlotter( BasePlotter ):
     :param dict reportRequest contains attributes used to create the plot.
     :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
-    return self.__reportAllResources( reportRequest, "cpuUsage", "time" )
+    return self.__reportAllResources( reportRequest, "cpuUsage", "percentage" )
 
   def _plotCpuUsage( self, reportRequest, plotInfo, filename ):
     """

--- a/MonitoringSystem/private/Plotters/ComponentMonitoringPlotter.py
+++ b/MonitoringSystem/private/Plotters/ComponentMonitoringPlotter.py
@@ -9,7 +9,8 @@ from DIRAC.MonitoringSystem.private.Plotters.BasePlotter import BasePlotter
 
 __RCSID__ = "$Id$"
 
-class ComponentMonitoringPlotter( BasePlotter ):
+
+class ComponentMonitoringPlotter(BasePlotter):
 
   """
   .. class:: ComponentMonitoringPlotter
@@ -23,57 +24,56 @@ class ComponentMonitoringPlotter( BasePlotter ):
   _typeName = "ComponentMonitoring"
   _typeKeyFields = ComponentMonitoring().keyFields
 
-
-  def __reportAllResources( self, reportRequest, metric, unit ):
+  def __reportAllResources(self, reportRequest, metric, unit):
 
     selectFields = [metric]
-    retVal = self._getTimedData( startTime = reportRequest[ 'startTime' ],
-                                 endTime = reportRequest[ 'endTime' ],
-                                 selectFields = selectFields,
-                                 preCondDict = reportRequest[ 'condDict' ],
-                                 metadataDict = {'DynamicBucketing': False,
-                                                 "metric": "avg"} )
-    if not retVal[ 'OK' ]:
+    retVal = self._getTimedData(startTime=reportRequest['startTime'],
+                                endTime=reportRequest['endTime'],
+                                selectFields=selectFields,
+                                preCondDict=reportRequest['condDict'],
+                                metadataDict={'DynamicBucketing': False,
+                                              "metric": "avg"})
+    if not retVal['OK']:
       return retVal
 
-    dataDict, granularity = retVal[ 'Value' ]
+    dataDict, granularity = retVal['Value']
     try:
-      _, _, _, unitName = self._findSuitableUnit( dataDict, self._getAccumulationMaxValue( dataDict ), unit )
+      _, _, _, unitName = self._findSuitableUnit(dataDict, self._getAccumulationMaxValue(dataDict), unit)
     except AttributeError as e:
-      gLogger.warn( e )
+      gLogger.warn(e)
       unitName = unit
 
-    return S_OK( { 'data' : dataDict, 'granularity' : granularity, 'unit': unitName} )
+    return S_OK({'data': dataDict, 'granularity': granularity, 'unit': unitName})
 
-  def __plotAllResources( self, reportRequest, plotInfo, filename, title ):
+  def __plotAllResources(self, reportRequest, plotInfo, filename, title):
 
-    metadata = {'title' : '%s by %s' % ( title, reportRequest[ 'grouping' ] ),
-                'starttime' : reportRequest[ 'startTime' ],
-                'endtime' : reportRequest[ 'endTime' ],
-                'span' : plotInfo[ 'granularity' ],
-                'skipEdgeColor' : True,
-                'ylabel' : plotInfo[ 'unit' ]}
+    metadata = {'title': '%s by %s' % (title, reportRequest['grouping']),
+                'starttime': reportRequest['startTime'],
+                'endtime': reportRequest['endTime'],
+                'span': plotInfo['granularity'],
+                'skipEdgeColor': True,
+                'ylabel': plotInfo['unit']}
 
-    plotInfo[ 'data' ] = self._fillWithZero( granularity = plotInfo[ 'granularity' ],
-                                             startEpoch = reportRequest[ 'startTime' ],
-                                             endEpoch = reportRequest[ 'endTime' ],
-                                             dataDict = plotInfo[ 'data' ] )
+    plotInfo['data'] = self._fillWithZero(granularity=plotInfo['granularity'],
+                                          startEpoch=reportRequest['startTime'],
+                                          endEpoch=reportRequest['endTime'],
+                                          dataDict=plotInfo['data'])
 
-    return self._generateStackedLinePlot( filename = filename,
-                                          dataDict = plotInfo[ 'data' ],
-                                          metadata = metadata )
-
+    return self._generateStackedLinePlot(filename=filename,
+                                         dataDict=plotInfo['data'],
+                                         metadata=metadata)
 
   _reportRunningThreadsName = "Number of running threads"
-  def _reportRunningThreads( self, reportRequest ):
+
+  def _reportRunningThreads(self, reportRequest):
     """
     It is used to retrieve the data from the database.
     :param dict reportRequest contains attributes used to create the plot.
     :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
-    return self.__reportAllResources( reportRequest, "threads", "threads" )
+    return self.__reportAllResources(reportRequest, "threads", "threads")
 
-  def _plotRunningThreads( self, reportRequest, plotInfo, filename ):
+  def _plotRunningThreads(self, reportRequest, plotInfo, filename):
     """
     It creates the plot.
     :param dict reportRequest plot attributes
@@ -81,18 +81,19 @@ class ComponentMonitoringPlotter( BasePlotter ):
     :param str filename
     :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
-    return self.__plotAllResources( reportRequest, plotInfo, filename, 'Number of running threads' )
+    return self.__plotAllResources(reportRequest, plotInfo, filename, 'Number of running threads')
 
   _reportCpuUsageName = "CPU usage"
-  def _reportCpuUsage( self, reportRequest ):
+
+  def _reportCpuUsage(self, reportRequest):
     """
     It is used to retrieve the data from the database.
     :param dict reportRequest contains attributes used to create the plot.
     :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
-    return self.__reportAllResources( reportRequest, "cpuUsage", "percentage" )
+    return self.__reportAllResources(reportRequest, "cpuUsage", "percentage")
 
-  def _plotCpuUsage( self, reportRequest, plotInfo, filename ):
+  def _plotCpuUsage(self, reportRequest, plotInfo, filename):
     """
     It creates the plot.
     :param dict reportRequest plot attributes
@@ -100,18 +101,19 @@ class ComponentMonitoringPlotter( BasePlotter ):
     :param str filename
     :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
-    return self.__plotAllResources( reportRequest, plotInfo, filename, 'CPU usage' )
+    return self.__plotAllResources(reportRequest, plotInfo, filename, 'CPU usage')
 
   _reportMemoryUsageName = "Memory usage"
-  def _reportMemoryUsage( self, reportRequest ):
+
+  def _reportMemoryUsage(self, reportRequest):
     """
     It is used to retrieve the data from the database.
     :param dict reportRequest contains attributes used to create the plot.
     :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
-    return self.__reportAllResources( reportRequest, "memoryUsage", "bytes" )
+    return self.__reportAllResources(reportRequest, "memoryUsage", "bytes")
 
-  def _plotMemoryUsage( self, reportRequest, plotInfo, filename ):
+  def _plotMemoryUsage(self, reportRequest, plotInfo, filename):
     """
     It creates the plot.
     :param dict reportRequest plot attributes
@@ -119,18 +121,19 @@ class ComponentMonitoringPlotter( BasePlotter ):
     :param str filename
     :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
-    return self.__plotAllResources( reportRequest, plotInfo, filename, 'Memory usage' )
+    return self.__plotAllResources(reportRequest, plotInfo, filename, 'Memory usage')
 
   _reportRunningTimeName = "Running time"
-  def _reportRunningTime( self, reportRequest ):
+
+  def _reportRunningTime(self, reportRequest):
     """
     It is used to retrieve the data from the database.
     :param dict reportRequest contains attributes used to create the plot.
     :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
-    return self.__reportAllResources( reportRequest, "runningTime", "time" )
+    return self.__reportAllResources(reportRequest, "runningTime", "time")
 
-  def _plotRunningTime( self, reportRequest, plotInfo, filename ):
+  def _plotRunningTime(self, reportRequest, plotInfo, filename):
     """
     It creates the plot.
     :param dict reportRequest plot attributes
@@ -138,4 +141,4 @@ class ComponentMonitoringPlotter( BasePlotter ):
     :param str filename
     :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
-    return self.__plotAllResources( reportRequest, plotInfo, filename, 'Running time' )
+    return self.__plotAllResources(reportRequest, plotInfo, filename, 'Running time')


### PR DESCRIPTION
The cpu usage plot in Component Monitoring always show zero value. This is because the Profiler instance is created and deleted in a single loop, and cpu usage could not be calculated unless it is called twice or more. Here I created a global dict to hold all Profiler instance persistently.

Although this works fine, I am still not certain that it is the correct way to use global variable in a service handler.

BEGINRELEASENOTES

*Framework
FIX: SystemAdministrator - Get the correct cpu usage data for each component

ENDRELEASENOTES
