### PR TITLE
 [v6r20] TaskManager fix for multiple output data files case

### DIFF
--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -581,7 +581,7 @@ class WorkflowTasks(TaskBase):
                          transID=transID, method=method)
           continue
         for name, output in res['Value'].iteritems():
-          seqDict[name] = ';'.join(output)
+          seqDict[name] = output
           outputParameterList.append(name)
           if oJob.workflow.findParameter(name):
             oJob._setParamValue(name, "%%(%s)s" % name)  # pylint: disable=protected-access


### PR DESCRIPTION
This PR addresses #3720

BEGINRELEASENOTES

*TS
FIX: TaskManager - pass output data arguments as lists rather than strings to the parametric job description

ENDRELEASENOTES