### PR TITLE
[v6r19] Add strict multiprocessor mode

### DIFF
--- a/WorkloadManagementSystem/Client/Matcher.py
+++ b/WorkloadManagementSystem/Client/Matcher.py
@@ -208,6 +208,12 @@ class Matcher( object ):
         paramTags = [ '%d%s' % ( par, key ) for par in paramList ]
         if paramTags:
           resourceDict.setdefault( "Tag", [] ).extend( paramTags )
+    # If strict MP mode is requested, match jobs which only have
+    # _exactly_ same number of cores required as are avaialble.
+    if "StrictMP" in resourceDescription and nProcessors:
+      if resourceDescription["StrictMP"].lower() == 'true':
+        reqTag = [ "%uProcessors" % nProcessors ]
+        resourceDict.setdefault( "RequiredTag", [] ).extend( reqTag )
 
     if "WholeNode" in resourceDescription:
       resourceDict.setdefault( "Tag", [] ).append( "WholeNode" )

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -515,6 +515,9 @@ class CheckWNCapabilities( CommandBase ):
       self.log.warn(
           "Could not retrieve MaxRAM, this parameter won't be filled")
 
+    if self.pp.strictMP:
+      self.cfg.append('-o "/Resources/Computing/CEDefaults/StrictMP=True"')
+
     if self.cfg:
       self.cfg.append( '-FDMH' )
 

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -364,6 +364,9 @@ class PilotParams( object ):
     self.platform = ""
     # in case users want to specify the max number of processors requested, per pilot
     self.maxNumberOfProcessors = 0
+    # Enable strict multi-processing mode: Only match jobs which have exactly the
+    # same number of cores as the node.
+    self.strictMP = False
     self.minDiskSpace = 2560 #MB
     self.pythonVersion = '27'
     self.userGroup = ""
@@ -411,6 +414,7 @@ class PilotParams( object ):
                      ( 'p:', 'platform=', 'Use <platform> instead of local one' ),
                      ( 'm:', 'maxNumberOfProcessors=',
                       'specify a max number of processors to use'),
+                     ( 'T', 'strictMP', 'Enable strict-multiprocessing mode' ),
                      ( 'u:', 'url=', 'Use <url> to download tarballs' ),
                      ( 'r:', 'release=', 'DIRAC release to install' ),
                      ( 'n:', 'name=', 'Set <Site> as Site Name' ),
@@ -482,6 +486,8 @@ class PilotParams( object ):
         self.platform = v
       elif o == '-m' or o == '--maxNumberOfProcessors':
         self.maxNumberOfProcessors = v
+      elif o in ( '-T', '--strictMP' ):
+        self.strictMP = True
       elif o == '-D' or o == '--disk':
         try:
           self.minDiskSpace = int( v )


### PR DESCRIPTION
Hi,

We've found that with multiprocessor pilots on our grid nodes can match any smaller job, which isn't the behaviour we want, i.e.:
 - A user submits an 8 core job.
 - The (GridPP modified) MPSiteDirector sees the job in the queue and submits a pilot including the maxNumberOfProcessors option set to 8.
 - The 8 core pilot queues and eventually runs.
 - The pilot matches any job in queue that it can run, say a single core job from another user, the remaining 7 cores are left idle by the batch system.

This patch adds a "StrictMultiprocessor/StrictMP" mode to the pilot, which makes it so that it can only match jobs which have the exactly the same size (by adding a RequiredTag for the maximum number of processors available). This solves our problem as then an 8-core pilot will only ever match an 8-core payload, so no resources are wasted (and is off by default, so doesn't change the default behaviour for everyone else).

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagementSystem
NEW: Add strict multi-processor matching option
ENDRELEASENOTES
