### PR TITLE
[v6r20] fix fts3 deadlock

### DIFF
--- a/DataManagementSystem/Agent/FTS3Agent.py
+++ b/DataManagementSystem/Agent/FTS3Agent.py
@@ -400,6 +400,20 @@ class FTS3Agent(AgentModule):
 
     return S_OK()
 
+  def kickJobs(self):
+    """ kick stuck jobs """
+
+    log = gLogger.getSubLogger("kickJobs", child=True)
+
+    res = self.fts3db.kickStuckJobs(limit=self.maxKick, kickDelay=self.kickDelay)
+    if not res['OK']:
+      return res
+
+    kickedJobs = res['Value']
+    log.info("Kicked %s stuck jobs" % kickedJobs)
+
+    return S_OK()
+
   def deleteOperations(self):
     """ delete final operations """
 
@@ -435,6 +449,13 @@ class FTS3Agent(AgentModule):
 
     if not res['OK']:
       log.error("Error treating operations", res)
+      return res
+
+    log.info("Kicking stuck jobs")
+    res = self.kickJobs()
+
+    if not res['OK']:
+      log.error("Error kicking jobs", res)
       return res
 
     log.info("Kicking stuck operations")

--- a/DataManagementSystem/Agent/FTS3Agent.py
+++ b/DataManagementSystem/Agent/FTS3Agent.py
@@ -1,5 +1,34 @@
 """
-  FTS3Agent implementation
+ .. versionadded:: v6r20
+
+  FTS3Agent implementation.
+  It is in charge of submitting and monitoring all the transfers. It can be duplicated.
+
+
+::
+
+  FTS3Agent
+  {
+    PollingTime = 120
+    MaxThreads = 10
+    # How many Operation we will treat in one loop
+    OperationBulkSize = 20
+    # How many Job we will monitor in one loop
+    JobBulkSize = 20
+    # Max number of files to go in a single job
+    MaxFilesPerJob = 100
+    # Max number of attempt per file
+    MaxAttemptsPerFile = 256
+    # days before removing jobs
+    DeleteGraceDays = 180
+    # Max number of deletes per cycle
+    DeleteLimitPerCycle = 100
+    # hours before kicking jobs with old assignment tag
+    KickAssignedHours  = 1
+    # Max number of kicks per cycle
+    KickLimitPerCycle = 100
+  }
+
 """
 
 __RCSID__ = "$Id$"
@@ -64,7 +93,7 @@ class FTS3Agent(AgentModule):
     # Number of Jobs we treat in one loop
     self.jobBulkSize = self.am_getOption("JobBulkSize", 20)
     self.maxFilesPerJob = self.am_getOption("MaxFilesPerJob", 100)
-    self.maxAttemptsPerFile = self.am_getOption("maxAttemptsPerFile", 256)
+    self.maxAttemptsPerFile = self.am_getOption("MaxAttemptsPerFile", 256)
     self.kickDelay = self.am_getOption("KickAssignedHours", 1)
     self.maxKick = self.am_getOption("KickLimitPerCycle", 100)
     self.deleteDelay = self.am_getOption("DeleteGraceDays", 180)

--- a/DataManagementSystem/Client/FTS3File.py
+++ b/DataManagementSystem/Client/FTS3File.py
@@ -22,7 +22,10 @@ class FTS3File(FTS3Serializable):
   # These are the states that we consider final.
   # No new attempts will be done on our side for
   # FTS3Files reaching one of these
-  FINAL_STATES = ['Canceled', 'Finished', 'Defunct']
+  # Note that Canceled is not final state, because
+  # FTS fails some transfers as "Canceled" (gsiftp timeout)
+
+  FINAL_STATES = ['Finished', 'Defunct']
 
   FTS_SUCCESS_STATES = ['Finished']
   FTS_FAILED_STATES = ['Canceled', 'Failed']

--- a/DataManagementSystem/ConfigTemplate.cfg
+++ b/DataManagementSystem/ConfigTemplate.cfg
@@ -118,7 +118,7 @@ Agents
     # Max number of files to go in a single job
     MaxFilesPerJob = 100
     # Max number of attempt per file
-    maxAttemptsPerFile = 256
+    MaxAttemptsPerFile = 256
     # days before removing jobs
     DeleteGraceDays = 180
     # Max number of deletes per cycle

--- a/DataManagementSystem/DB/FTS3DB.py
+++ b/DataManagementSystem/DB/FTS3DB.py
@@ -47,7 +47,7 @@ fts3FileTable = Table('Files', metadata,
                              server_default=FTS3File.INIT_STATE,
                              index=True),
                       mysql_engine='InnoDB',
-                     )
+                      )
 
 mapper(FTS3File, fts3FileTable)
 
@@ -61,8 +61,10 @@ fts3JobTable = Table('Jobs', metadata,
                      Column('lastUpdate', DateTime, onupdate=func.utc_timestamp()),
                      Column('lastMonitor', DateTime),
                      Column('completeness', Float),
-                     Column('username', String(255)),  # Could be fetched from Operation, but bad for perf
-                     Column('userGroup', String(255)),  # Could be fetched from Operation, but bad for perf
+                     # Could be fetched from Operation, but bad for perf
+                     Column('username', String(255)),
+                     # Could be fetched from Operation, but bad for perf
+                     Column('userGroup', String(255)),
                      Column('ftsGUID', String(255)),
                      Column('ftsServer', String(255)),
                      Column('error', String(2048)),
@@ -80,7 +82,8 @@ fts3OperationTable = Table('Operations', metadata,
                            Column('operationID', Integer, primary_key=True),
                            Column('username', String(255)),
                            Column('userGroup', String(255)),
-                           Column('rmsReqID', Integer, server_default='-1'),  # -1 because with 0 we get any request
+                           # -1 because with 0 we get any request
+                           Column('rmsReqID', Integer, server_default='-1'),
                            Column('rmsOpID', Integer, server_default='0'),
                            Column('sourceSEs', String(255)),
                            Column('activity', String(255)),
@@ -94,7 +97,7 @@ fts3OperationTable = Table('Operations', metadata,
                            Column('type', String(255)),
                            Column('assignment', String(255), server_default=None),
                            mysql_engine='InnoDB',
-                          )
+                           )
 
 
 fts3Operation_mapper = mapper(FTS3Operation, fts3OperationTable,
@@ -225,7 +228,8 @@ class FTS3DB(object):
 
     """
 
-    # expire_on_commit is set to False so that we can still use the object after we close the session
+    # expire_on_commit is set to False so that we can still use the object
+    # after we close the session
     session = self.dbSession(expire_on_commit=False)
 
     try:
@@ -322,33 +326,33 @@ class FTS3DB(object):
 
     # This here is inneficient as we update every files, even if it did not change, and we commit every time.
     # It would probably be best to update only the files that changed.
-    # However, commiting every time is the recommendation of MySQL (https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks-handling.html)
+    # However, commiting every time is the recommendation of MySQL
+    # (https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks-handling.html)
 
     for fileID, valueDict in fileStatusDict.iteritems():
 
       session = self.dbSession()
       try:
 
-          updateDict = {FTS3File.status: valueDict['status']}
+        updateDict = {FTS3File.status: valueDict['status']}
 
-          # We only update error if it is specified
-          if 'error' in valueDict:
-            newError = valueDict['error']
-            # Replace empty string with None
-            if not newError:
-              newError = None
-            updateDict[FTS3File.error] = newError
+        # We only update error if it is specified
+        if 'error' in valueDict:
+          newError = valueDict['error']
+          # Replace empty string with None
+          if not newError:
+            newError = None
+          updateDict[FTS3File.error] = newError
 
-          session.execute(update(FTS3File)
-                          .where(and_(FTS3File.fileID == fileID,
-                                      ~ FTS3File.status.in_(FTS3File.FINAL_STATES)
-                                      )
-                                 )
-                          .values(updateDict)
-                          )
+        session.execute(update(FTS3File)
+                        .where(and_(FTS3File.fileID == fileID,
+                                    ~ FTS3File.status.in_(FTS3File.FINAL_STATES)
+                                    )
+                               )
+                        .values(updateDict)
+                        )
 
-          session.commit()
-
+        session.commit()
 
       except SQLAlchemyError as e:
         session.rollback()
@@ -491,13 +495,16 @@ class FTS3DB(object):
       rowCount = 0
 
       if opIDs:
-        result = session.execute(update(FTS3Operation)
-                                 .where(FTS3Operation.operationID.in_(opIDs))
-                                 .where(FTS3Operation.lastUpdate < (func.date_sub(func.utc_timestamp(),
-                                                                                  text('INTERVAL %d HOUR' % kickDelay
-                                                                                       ))))
-                                 .values({'assignment': None})
-                                 )
+        result = session.execute(
+            update(FTS3Operation) .where(
+                FTS3Operation.operationID.in_(opIDs)) .where(
+                FTS3Operation.lastUpdate < (
+                    func.date_sub(
+                        func.utc_timestamp(), text(
+                            'INTERVAL %d HOUR' %
+                            kickDelay)))) .values(
+                {
+                    'assignment': None}))
         rowCount = result.rowcount
 
       session.commit()
@@ -508,6 +515,54 @@ class FTS3DB(object):
     except SQLAlchemyError as e:
       session.rollback()
       return S_ERROR("kickStuckOperations: unexpected exception : %s" % e)
+    finally:
+      session.close()
+
+  def kickStuckJobs(self, limit=20, kickDelay=2):
+    """finds jobs that have not been updated for more than a given
+      time but are still assigned and resets the assignment
+
+    :param int limit: number of jobs to treat
+    :param int kickDelay: age of the lastUpdate in hours
+    :returns: S_OK/S_ERROR with number of kicked jobs
+
+    """
+
+    session = self.dbSession(expire_on_commit=False)
+
+    try:
+
+      ftsJobs = session.query(FTS3Job.jobID)\
+          .filter(FTS3Job.lastUpdate < (func.date_sub(func.utc_timestamp(),
+                                                      text('INTERVAL %d HOUR' % kickDelay
+                                                           ))))\
+          .filter(~FTS3Job.assignment.is_(None))\
+          .limit(limit)
+
+      jobIDs = [jobTuple[0] for jobTuple in ftsJobs]
+      rowCount = 0
+
+      if jobIDs:
+        result = session.execute(
+            update(FTS3Job) .where(
+                FTS3Job.jobID.in_(jobIDs)) .where(
+                FTS3Job.lastUpdate < (
+                    func.date_sub(
+                        func.utc_timestamp(), text(
+                            'INTERVAL %d HOUR' %
+                            kickDelay)))) .values(
+                {
+                    'assignment': None}))
+        rowCount = result.rowcount
+
+      session.commit()
+      session.expunge_all()
+
+      return S_OK(rowCount)
+
+    except SQLAlchemyError as e:
+      session.rollback()
+      return S_ERROR("kickStuckJobs: unexpected exception : %s" % e)
     finally:
       session.close()
 
@@ -523,11 +578,16 @@ class FTS3DB(object):
 
     try:
 
-      ftsOps = session.query(FTS3Operation.operationID)\
-          .filter(FTS3Operation.lastUpdate < (func.date_sub(func.utc_timestamp(),
-                                                            text('INTERVAL %d DAY' % deleteDelay))))\
-          .filter(FTS3Operation.status.in_(FTS3Operation.FINAL_STATES))\
-          .limit(limit)
+      ftsOps = session.query(
+          FTS3Operation.operationID) .filter(
+          FTS3Operation.lastUpdate < (
+              func.date_sub(
+                  func.utc_timestamp(),
+                  text(
+                      'INTERVAL %d DAY' %
+                      deleteDelay)))) .filter(
+          FTS3Operation.status.in_(
+              FTS3Operation.FINAL_STATES)) .limit(limit)
 
       opIDs = [opTuple[0] for opTuple in ftsOps]
       rowCount = 0

--- a/DataManagementSystem/DB/FTS3DB.py
+++ b/DataManagementSystem/DB/FTS3DB.py
@@ -318,7 +318,7 @@ class FTS3DB(object):
     """Update the file ftsStatus and error
         The update is only done if the file is not in a final state
 
-        TODO: maybe in should query first the status and filter the rows I want to update !
+        TODO: maybe it should query first the status and filter the rows I want to update !
 
        :param fileStatusDict : { fileID : { status , error } }
 

--- a/dirac.cfg
+++ b/dirac.cfg
@@ -31,7 +31,7 @@ Systems
            OperationBulkSize = 20 # How many Operation we will treat in one loop
            JobBulkSize = 20 # How many Job we will monitor in one loop
            MaxFilesPerJob = 100 # Max number of files to go in a single job
-           maxAttemptsPerFile = 256 # Max number of attempt per file
+           MaxAttemptsPerFile = 256 # Max number of attempt per file
            DeleteGraceDays = 180 # days before removing jobs
            DeleteLimitPerCycle = 100 # Max number of deletes per cycle
            KickAssignedHours  = 1 # hours before kicking jobs with old assignment tag

--- a/docs/source/AdministratorGuide/Systems/DataManagement/fts3.rst
+++ b/docs/source/AdministratorGuide/Systems/DataManagement/fts3.rst
@@ -75,16 +75,7 @@ FTS3Agent
 
 This agent is in charge of performing and monitoring all the transfers. Note that this agent can be duplicated as many time as you wish.
 
-There are various configuration options for this system:
-
-* `OperationBulkSize` (default 20): How many Operation we will treat in one loop
-* `JobBulkSize` (default 20): How many Job we will monitor in one loop
-* `MaxFilesPerJob` (default 100): Max number of files to go in a single job
-* `maxAttemptsPerFile` (default 256): Max number of attempt per file
-* `DeleteGraceDays` (default 180): days before removing jobs
-* `DeleteLimitPerCycle` (default 100): Max number of deletes per cycle
-* `KickAssignedHours` (default 1): hours before kicking jobs with old assignment tag
-* `KickLimitPerCycle` (default 100):  Max number of kicks per cycle
+See :py:mod:`~DIRAC.DataManagementSystem.Agent.FTS3Agent` for configuration details.
 
 FTS3 system overview
 --------------------


### PR DESCRIPTION
BEGINRELEASENOTES

*DMS

NEW:  FTS3 add kicking of stuck jobs
FIX: FTS3 update files in sequence to avoid mysql deadlock
CHANGE: Canceled is not a final state for FTS3 Files
CHANGE: FTS3Operations are finalized if the Request is in a final state (instead of Scheduled)

ENDRELEASENOTES
