### PR TITLE
[v6r19] Fixes for multi-core support

### DIFF
--- a/Resources/Computing/CREAMComputingElement.py
+++ b/Resources/Computing/CREAMComputingElement.py
@@ -95,7 +95,7 @@ class CREAMComputingElement( ComputingElement ):
     return name, diracStamp
 
   def _reset( self ):
-    self.queue = self.ceParameters['Queue']
+    self.queue = self.ceParameters.get("CEQueueName", self.ceParameters['Queue'])
     self.outputURL = self.ceParameters.get( 'OutputURL', 'gsiftp://localhost' )
     if 'GridEnv' in self.ceParameters:
       self.gridEnv = self.ceParameters['GridEnv']

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -286,16 +286,23 @@ class ReplaceDIRACCode( CommandBase ):
     from urllib2 import urlopen
     from zipfile import ZipFile
 
-    zipresp = urlopen(self.pp.genericOption)
-    zfile = ZipFile(BytesIO(zipresp.read()))
-    os.mkdir(os.getcwd() + os.path.sep + 'AlternativeCode')
-    zfile.extractall(os.getcwd() + os.path.sep + 'AlternativeCode')
-    zfile.close()
-    zipresp.close()
-    os.rename(os.getcwd() + os.path.sep + 'AlternativeCode' + os.path.sep + os.listdir('./AlternativeCode')[0],
-              os.getcwd() + os.path.sep + 'AlternativeCode' + os.path.sep + 'DIRAC')
-    self.pp.installEnv['PYTHONPATH'] = os.getcwd() + os.path.sep + 'AlternativeCode' + os.path.sep + 'DIRAC' ':' \
-                                       + self.pp.installEnv['PYTHONPATH']
+    genericOptionDict = {}
+    for opt in self.pp.genericOptions:
+      key,value = opt.split('=')
+      genericOptionDict[key] = value
+
+    if "AlternativeCodeArchive" in genericOptionDict:
+      zipUrl = genericOptionDict['AlternativeCodeArchive']
+      zipresp = urlopen(zipUrl)
+      zfile = ZipFile(BytesIO(zipresp.read()))
+      os.mkdir(os.getcwd() + os.path.sep + 'AlternativeCode')
+      zfile.extractall(os.getcwd() + os.path.sep + 'AlternativeCode')
+      zfile.close()
+      zipresp.close()
+      os.rename(os.getcwd() + os.path.sep + 'AlternativeCode' + os.path.sep + os.listdir('./AlternativeCode')[0],
+                os.getcwd() + os.path.sep + 'AlternativeCode' + os.path.sep + 'DIRAC')
+      self.pp.installEnv['PYTHONPATH'] = os.getcwd() + os.path.sep + 'AlternativeCode' + os.path.sep + 'DIRAC' ':' \
+                                         + self.pp.installEnv['PYTHONPATH']
 
 class ConfigureBasics( CommandBase ):
   """ This command completes DIRAC installation, e.g. calls dirac-configure to:
@@ -342,6 +349,7 @@ class ConfigureBasics( CommandBase ):
 
     self._getBasicsCFG()
     self._getSecurityCFG()
+    self._genericOptionsCFG()
 
     if self.pp.debugFlag:
       self.cfg.append( '-ddd' )
@@ -355,6 +363,22 @@ class ConfigureBasics( CommandBase ):
     if retCode:
       self.log.error( "Could not configure DIRAC basics [ERROR %d]" % retCode )
       self.exitWithError( retCode )
+
+  def _genericOptionsCFG(self):
+    """ Append pilot generic options
+    """
+    modList = []
+    for opt in self.pp.genericOptions:
+      key,value = opt.split('=')
+      if key.endswith('/Tag'):
+        self.pp.tags += value.split(',')
+      elif key.endswith('/RequiredTag'):
+        self.pp.reqtags += value.split(',')
+      else:
+        modList.append(opt)
+
+    # Do not continue "Tag" options
+    self.pp.genericOptions = modList
 
   def _getBasicsCFG( self ):
     """  basics (needed!)

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -422,6 +422,10 @@ class CheckCECapabilities( CommandBase ):
       if ceParam in resourceDict:
         self.cfg.append( '-o  /Resources/Computing/CEDefaults/%s=%s' % ( ceParam, resourceDict[ ceParam ] ) )
 
+    # If MaxNumberOfProcessors not defined check for NumberOfProcessors and make it 1 by default
+    if self.pp.maxNumberOfProcessors == 0:
+      self.pp.maxNumberOfProcessors = int(resourceDict.get("MaxNumberOfProcessors", resourceDict.get("NumberOfProcessors", 1)))
+
     # Tags must be added to already defined tags if any
     if resourceDict.get( 'Tag' ):
       self.pp.tags += resourceDict['Tag']

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -377,7 +377,7 @@ class PilotParams( object ):
     self.gateway = ""
     self.useServerCertificate = False
     self.pilotScriptName = ''
-    self.genericOption = []
+    self.genericOptions = []
     # DIRAC client installation environment
     self.diracInstalled = False
     self.diracExtensions = []
@@ -507,4 +507,4 @@ class PilotParams( object ):
         except ValueError:
           pass
       elif o in ( '-o', '--option' ):
-        self.genericOption.append(v)
+        self.genericOptions.append(v)

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -377,7 +377,7 @@ class PilotParams( object ):
     self.gateway = ""
     self.useServerCertificate = False
     self.pilotScriptName = ''
-    self.genericOption = ''
+    self.genericOption = []
     # DIRAC client installation environment
     self.diracInstalled = False
     self.diracExtensions = []
@@ -507,4 +507,4 @@ class PilotParams( object ):
         except ValueError:
           pass
       elif o in ( '-o', '--option' ):
-        self.genericOption = v
+        self.genericOption.append(v)


### PR DESCRIPTION
  Several fixes for supporting multi-core jobs. Addresses the same issue as #3730. 

  The PR restores the possibility to pass generic options ('-o') to the dirac-pilot executable that will
be passed to the pilot local configuration. In particular, the MPSiteDirector can define extra RequiredTag=XProcessors as a generic option for the exact number of processors for this pilot. This tag will be mixed together with other possible tags in the CE global configuration. 

  Also restored the NumberOfProcessors evaluation to 1 if the corresponding Queue does not defined
MaxNumberOfProcessors. This avoids pilot to send NumberOfProcessors more than 1 for single-core slots.   

  Added possibility to define CEQueueName parameter for CREAMComputingElement queues. This is needed if one wants to define a different logical queue with different parameters for the same CE queue. The queue name defaults to the queue section name if not overridden by CEQueueName

BEGINRELEASENOTES

*WMS
FIX: pilotTools - change genericOption parameter to genericOptions to hold a list of options
FIX: pilotCommands - add genericOptions to the local pilot configuration
FIX: pilotCommands - make NumberOfProcessors = 1 if nowhere defined (default)

*Resources
FIX: CREAMComputingElement - possibility to defined CEQueueName to be used in the pilot submission command

ENDRELEASENOTES
