### PR TITLE
[v6r19] Fixes for multi-core support

### DIFF
--- a/Resources/Computing/CREAMComputingElement.py
+++ b/Resources/Computing/CREAMComputingElement.py
@@ -95,7 +95,7 @@ class CREAMComputingElement( ComputingElement ):
     return name, diracStamp
 
   def _reset( self ):
-    self.queue = self.ceParameters['Queue']
+    self.queue = self.ceParameters.get("CEQueueName", self.ceParameters['Queue'])
     self.outputURL = self.ceParameters.get( 'OutputURL', 'gsiftp://localhost' )
     if 'GridEnv' in self.ceParameters:
       self.gridEnv = self.ceParameters['GridEnv']

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -422,6 +422,10 @@ class CheckCECapabilities( CommandBase ):
       if ceParam in resourceDict:
         self.cfg.append( '-o  /Resources/Computing/CEDefaults/%s=%s' % ( ceParam, resourceDict[ ceParam ] ) )
 
+    # If MaxNumberOfProcessors not defined check for NumberOfProcessors and make it 1 by default
+    if self.pp.maxNumberOfProcessors == 0:
+      self.pp.maxNumberOfProcessors = int(resourceDict.get("MaxNumberOfProcessors", resourceDict.get("NumberOfProcessors", 1)))
+
     # Tags must be added to already defined tags if any
     if resourceDict.get( 'Tag' ):
       self.pp.tags += resourceDict['Tag']

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -418,23 +418,26 @@ class CheckCECapabilities( CommandBase ):
 
     self.cfg = []
     # Pick up all the relevant resource parameters that will be used in the job matching
-    for ceParam in [ "WholeNode", "NumberOfProcessors" ]:
-      if ceParam in resourceDict:
-        self.cfg.append( '-o  /Resources/Computing/CEDefaults/%s=%s' % ( ceParam, resourceDict[ ceParam ] ) )
+    if "WholeNode" in resourceDict:
+      self.pp.tags.append('WholeNode')
 
-    # If MaxNumberOfProcessors not defined check for NumberOfProcessors and make it 1 by default
+    # If MaxNumberOfProcessors not defined check for NumberOfProcessors
     if self.pp.maxNumberOfProcessors == 0:
-      self.pp.maxNumberOfProcessors = int(resourceDict.get("MaxNumberOfProcessors", resourceDict.get("NumberOfProcessors", 1)))
+      self.pp.maxNumberOfProcessors = int(resourceDict.get("MaxNumberOfProcessors", resourceDict.get("NumberOfProcessors", 0)))
 
     # Tags must be added to already defined tags if any
     if resourceDict.get( 'Tag' ):
       self.pp.tags += resourceDict['Tag']
+
+    self.pp.tags = list(set(self.pp.tags))
     if self.pp.tags:
       self.cfg.append( '-o "/Resources/Computing/CEDefaults/Tag=%s"' % ','.join( ( str( x ) for x in self.pp.tags ) ) )
 
     # RequiredTags are similar to tags.
     if resourceDict.get( 'RequiredTag' ):
       self.pp.reqtags += resourceDict['RequiredTag']
+
+    self.pp.reqtags = list(set(self.pp.reqtags))
     if self.pp.reqtags:
       self.cfg.append( '-o "/Resources/Computing/CEDefaults/RequiredTag=%s"' % ','.join( ( str( x ) for x in self.pp.reqtags ) ) )
 
@@ -483,10 +486,10 @@ class CheckWNCapabilities( CommandBase ):
     if retCode:
       self.log.error( "Could not get resource parameters [ERROR %d]" % retCode )
       self.exitWithError( retCode )
-    numberOfProcessors = 0
+    numberOfProcessors = 1
     try:
       result = result.split( ' ' )
-      numberOfProcessors = int( result[0] )
+      numberOfProcessorsOnWN = int( result[0] )
       maxRAM = int( result[1] )
     except ValueError:
       self.log.error( "Wrong Command output %s" % result )
@@ -495,12 +498,10 @@ class CheckWNCapabilities( CommandBase ):
     self.cfg = []
     # If NumberOfProcessors or MaxRAM are defined in the resource configuration, these
     # values are preferred
-    numberOfProcessors = self.pp.queueParameters.get(
-        'NumberOfProcessors', numberOfProcessors)
-    # if maxNumberOfProcessors is asked in pilotWrapper
-    if self.pp.maxNumberOfProcessors:
-      self.log.debug("Overriding with a requested number of processors")
-      numberOfProcessors = self.pp.maxNumberOfProcessors
+    if "WholeNode" in self.pp.tags:
+      numberOfProcessors = numberOfProcessorsOnWN
+    if self.pp.maxNumberOfProcessors > 0:
+      numberOfProcessors = min(numberOfProcessorsOnWN, self.pp.maxNumberOfProcessors)
 
     if not numberOfProcessors:
       self.log.warn("Could not retrieve number of processors, assuming 1")
@@ -572,9 +573,6 @@ class ConfigureSite( CommandBase ):
     for o, v in self.pp.optList:
       if o == '-o' or o == '--option':
         self.cfg.append( '-o "%s"' % v )
-      elif o == '-s' or o == '--section':
-        self.cfg.append( '-s "%s"' % v )
-
 
     if self.pp.pilotReference != 'Unknown':
       self.cfg.append( '-o /LocalSite/PilotReference=%s' % self.pp.pilotReference )
@@ -594,7 +592,7 @@ class ConfigureSite( CommandBase ):
       self.cfg.append( "-o /DIRAC/Security/CertFile=%s/hostcert.pem" % self.pp.certsLocation )
       self.cfg.append( "-o /DIRAC/Security/KeyFile=%s/hostkey.pem" % self.pp.certsLocation )
 
-    # these are needed as this is not the fist time we call dirac-configure
+    # these are needed as this is not the first time we call dirac-configure
     self.cfg.append( '-FDMH' )
     if self.pp.localConfigFile:
       self.cfg.append( '-O %s' % self.pp.localConfigFile )

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -434,8 +434,8 @@ class PilotParams( object ):
                      ( 'F:', 'pilotCFGFile=', 'Specify pilot CFG file' ),
                      ( 'R:', 'reference=', 'Use this pilot reference' ),
                      ( 'x:', 'execute=', 'Execute instead of JobAgent' ),
-                     ( 't:', 'tag=', 'extra tags for resource description',
-                     ( '', 'requiredTag=', 'extra required tags for resource description')  )
+                     ( 't:', 'tag=', 'extra tags for resource description' ),
+                     ( '', 'requiredTag=', 'extra required tags for resource description')
                    )
 
     self.__initOptions()

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -434,6 +434,8 @@ class PilotParams( object ):
                      ( 'F:', 'pilotCFGFile=', 'Specify pilot CFG file' ),
                      ( 'R:', 'reference=', 'Use this pilot reference' ),
                      ( 'x:', 'execute=', 'Execute instead of JobAgent' ),
+                     ( 't:', 'tag=', 'extra tags for resource description',
+                     ( '', 'requiredTag=', 'extra required tags for resource description')  )
                    )
 
     self.__initOptions()
@@ -508,3 +510,7 @@ class PilotParams( object ):
           pass
       elif o in ( '-o', '--option' ):
         self.genericOption = v
+      elif o in ( '-t', '--tag' ):
+        self.tags.append(v)
+      elif o == '--requiredTag':
+        self.reqtags.append(v)

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
@@ -58,6 +58,9 @@ This sub-subsection specify the attributes of each particular CE of the site. Mu
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/Queues/<QUEUE_NAME>*                | Name of the queue exactly how is published                  | jobmanager-pbs-formation       |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/CEQueueName*    | Name of the queue in the corresponding CE if not the same   |                                |
+|                                                | as the name of the queue section                            | CEQueueName = pbs-grid         |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/Queues/<QUEUE_NAME>/maxCPUTime*     | Maximum time allowed to jobs to run in the queue            | maxCPUTime = 1440              |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/Queues/<QUEUE_NAME>/MaxTotalJobs*   | If the CE is a CREAM CE the maximum number of jobs in all   | MaxTotalJobs =200              |

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
@@ -54,6 +54,10 @@ This sub-subsection specify the attributes of each particular CE of the site. Mu
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/WholeNode*                          | CE allows *whole node* jobs                                 | WholeNode = True               |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Tag*                                | List of tags specific for the CE                            | Tag = GPU,96RAM                |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/RequiredTag*                        | List of required tags that a job to be eligible must have   | RequiredTag = GPU,96RAM        |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/Queues*                             | Subsection. Queues available for this VO in the CE          | Queues                         |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/Queues/<QUEUE_NAME>*                | Name of the queue exactly how is published                  | jobmanager-pbs-formation       |
@@ -76,4 +80,8 @@ This sub-subsection specify the attributes of each particular CE of the site. Mu
 | *<CE_NAME>/Queues/<QUEUE_NAME>/MaxProcessors*  | overrides *<CE_NAME>/MaxProcessors* at queue level          | MaxProcessors = 12             |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/Queues/<QUEUE_NAME>/WholeNode*      | overrides *<CE_NAME>/WholeNode* at queue level              | WholeNode = True               |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/Tag*            | List of tags specific for the Queue                         | Tag = GPU,96RAM                |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/RequiredTag*    | List of required tags that a job to be eligible must have   | RequiredTag = GPU,96RAM        |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+


### PR DESCRIPTION
Several fixes for supporting multi-core jobs. Addresses the same issue as #3730 and replaces it.

Added two options to the dirac-pilot script (--tag and --requiredTag) to pass tags and required tags directly to the pilots. This can be used to pass dynamically created tags in addition to tags statically
defined in the CE/Queue configuration. All the tags are aggregated before passing to the matcher. 

The PR restores the NumberOfProcessors evaluation to 1 if the corresponding Queue does not define
MaxNumberOfProcessors or a WholeNode tag is not defined for the pilot. This avoids pilot to send NumberOfProcessors more than 1 for single-core slots. This assumes that in cloud or BOINC environments, the pilots are supposed to defined WholeNode tag as it should be.

Added possibility to define CEQueueName parameter for CREAMComputingElement queues. This is needed if one wants to define a different logical queue with different parameters for the same CE queue. The queue name defaults to the queue section name if not overridden by CEQueueName

BEGINRELEASENOTES

*WMS
FIX: pilotTools - added --tag and --requiredTag options
FIX: pilotCommands - make NumberOfProcessors = 1 if nowhere defined (default)

*Resources
FIX: CREAMComputingElement - possibility to defined CEQueueName to be used in the pilot submission command

ENDRELEASENOTES
