### PR TITLE
[v6r19] Ensure section exists before trying to get it in JobManifest

### DIFF
--- a/WorkloadManagementSystem/Client/JobState/JobManifest.py
+++ b/WorkloadManagementSystem/Client/JobState/JobManifest.py
@@ -199,9 +199,11 @@ class JobManifest( object ):
 
   def getSection( self, secName ):
     self.__dirty = True
+    if secName not in self.__manifest:
+      return S_ERROR( "%s does not exist" % secName )
     sec = self.__manifest[ secName ]
     if not sec:
-      return S_ERROR( "%s does not exist" )
+      return S_ERROR( "%s section empty" % secName )
     return S_OK( sec )
 
 


### PR DESCRIPTION
Hi,

We were seeing crashes from a malformed JDL due to a missing check in JobManifest getSection, this minor patch prevents the crash (so the optimisers keep running...).

Regards,
Simon


BEGINRELEASENOTES
*WorkloadManagementSystem FIX: Catch missing section in JobManifest getSection
ENDRELEASENOTES