### PR TITLE
[v6r20] Minor fixes for TransformationSystem

### DIFF
--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -8,6 +8,8 @@
     initialize method and on the _getClients method.
 """
 
+__RCSID__ = "$Id$"
+
 import time
 import datetime
 from Queue import Queue
@@ -26,8 +28,6 @@ from DIRAC.TransformationSystem.Client.TaskManager import WorkflowTasks
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 from DIRAC.TransformationSystem.Agent.TransformationAgentsUtilities import TransformationAgentsUtilities
 from DIRAC.Core.Utilities.List import breakListIntoChunks
-
-__RCSID__ = "$Id$"
 
 AGENT_NAME = 'Transformation/TaskManagerAgentBase'
 
@@ -48,6 +48,11 @@ class TaskManagerAgentBase(AgentModule, TransformationAgentsUtilities):
     self.transType = []
 
     self.tasksPerLoop = 50
+
+    # credentials
+    self.shifterProxy = None
+    self.credentials = None
+    self.credTuple = (None, None, None)
 
     self.pluginLocation = ''
     self.bulkSubmissionFlag = False
@@ -77,12 +82,11 @@ class TaskManagerAgentBase(AgentModule, TransformationAgentsUtilities):
     self.transClient = TransformationClient()
 
     # Bulk submission flag
-    self.bulkSubmissionFlag = self.am_getOption('BulkSubmission', False)
+    self.bulkSubmissionFlag = self.am_getOption('BulkSubmission', self.bulkSubmissionFlag)
 
     # Shifter credentials to use, could replace the use of shifterProxy eventually
-    self.shifterProxy = self.am_getOption('shifterProxy', None)
-    self.credentials = self.am_getOption('ShifterCredentials', None)
-    self.credTuple = (None, None, None)
+    self.shifterProxy = self.am_getOption('shifterProxy', self.shifterProxy)
+    self.credentials = self.am_getOption('ShifterCredentials', self.credentials)
     resCred = self.__getCredentials()
     if not resCred['OK']:
       return resCred
@@ -580,8 +584,7 @@ class TaskManagerAgentBase(AgentModule, TransformationAgentsUtilities):
     transformationIDsAndBodies = [(transformation['TransformationID'],
                                    transformation['Body'],
                                    transformation['AuthorDN'],
-                                   transformation['AuthorGroup'],
-                                   ) for transformation in transformations['Value']]
+                                   transformation['AuthorGroup']) for transformation in transformations['Value']]
     for transID, body, t_ownerDN, t_ownerGroup in transformationIDsAndBodies:
       if transID in operationsOnTransformationDict:
         operationsOnTransformationDict[transID]['Operations'].append(operation)
@@ -589,8 +592,7 @@ class TaskManagerAgentBase(AgentModule, TransformationAgentsUtilities):
         operationsOnTransformationDict[transID] = {'Body': body, 'Operations': [operation],
                                                    'Owner': owner if owner else getUsernameForDN(t_ownerDN)['Value'],
                                                    'OwnerGroup': ownerGroup if owner else t_ownerGroup,
-                                                   'OwnerDN': ownerDN if owner else t_ownerDN
-                                                   }
+                                                   'OwnerDN': ownerDN if owner else t_ownerDN}
 
   def __getCredentials(self):
     """Get the credentials to use if ShifterCredentials are set, otherwise do nothing.

--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -195,8 +195,6 @@ class TaskManagerAgentBase(AgentModule, TransformationAgentsUtilities):
         self._addOperationForTransformations(operationsOnTransformationDict, 'submitTasks', transformations,
                                              owner=owner, ownerGroup=ownerGroup, ownerDN=ownerDN)
 
-
-
     self._fillTheQueue(operationsOnTransformationDict)
 
     return S_OK()

--- a/TransformationSystem/Agent/WorkflowTaskAgent.py
+++ b/TransformationSystem/Agent/WorkflowTaskAgent.py
@@ -48,6 +48,9 @@ The following options can be set for the WorkflowTaskAgent.
     # Status of transformations for which to check reserved tasks
     CheckReservedStatus = Active,Completing,Stopped
 
+    # Fill in this option if you want to activate bulk submission (for speed up)
+    BulkSubmission = yes
+
   }
 
 * The options *SubmitTasks*, *MonitorTasks*, *MonitorFiles*, and *CheckReserved*
@@ -63,12 +66,12 @@ The following options can be set for the WorkflowTaskAgent.
 
 """
 
+__RCSID__ = "$Id$"
+
 from DIRAC import S_OK
 
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations    import Operations
 from DIRAC.TransformationSystem.Agent.TaskManagerAgentBase  import TaskManagerAgentBase
-
-__RCSID__ = "$Id$"
 
 AGENT_NAME = 'Transformation/WorkflowTaskAgent'
 

--- a/TransformationSystem/Agent/WorkflowTaskAgent.py
+++ b/TransformationSystem/Agent/WorkflowTaskAgent.py
@@ -70,32 +70,34 @@ __RCSID__ = "$Id$"
 
 from DIRAC import S_OK
 
-from DIRAC.ConfigurationSystem.Client.Helpers.Operations    import Operations
-from DIRAC.TransformationSystem.Agent.TaskManagerAgentBase  import TaskManagerAgentBase
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC.TransformationSystem.Agent.TaskManagerAgentBase import TaskManagerAgentBase
 
 AGENT_NAME = 'Transformation/WorkflowTaskAgent'
 
-class WorkflowTaskAgent( TaskManagerAgentBase ):
+
+class WorkflowTaskAgent(TaskManagerAgentBase):
   """ An AgentModule class to submit workflow tasks
   """
-  def __init__( self, *args, **kwargs ):
+
+  def __init__(self, *args, **kwargs):
     """ c'tor
     """
-    TaskManagerAgentBase.__init__( self, *args, **kwargs )
+    TaskManagerAgentBase.__init__(self, *args, **kwargs)
 
     self.transType = []
 
-  def initialize( self ):
+  def initialize(self):
     """ Standard initialize method
     """
-    res = TaskManagerAgentBase.initialize( self )
+    res = TaskManagerAgentBase.initialize(self)
     if not res['OK']:
       return res
 
-    agentTSTypes = self.am_getOption( 'TransType', [] )
+    agentTSTypes = self.am_getOption('TransType', [])
     if agentTSTypes:
       self.transType = agentTSTypes
     else:
-      self.transType = Operations().getValue( 'Transformations/DataProcessing', ['MCSimulation', 'Merge'] )
+      self.transType = Operations().getValue('Transformations/DataProcessing', ['MCSimulation', 'Merge'])
 
     return S_OK()

--- a/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
+++ b/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
@@ -15,11 +15,11 @@ from DIRAC import gLogger
 from DIRAC.TransformationSystem.Agent.TaskManagerAgentBase import TaskManagerAgentBase
 from DIRAC.TransformationSystem.Agent.TransformationAgent import TransformationAgent
 
-gLogger.setLevel( 'DEBUG' )
+gLogger.setLevel('DEBUG')
 
 
 mockAM = MagicMock()
-tmab_m = importlib.import_module( 'DIRAC.TransformationSystem.Agent.TaskManagerAgentBase' )
+tmab_m = importlib.import_module('DIRAC.TransformationSystem.Agent.TaskManagerAgentBase')
 tmab_m.AgentModule = mockAM
 tmab_m.FileReport = MagicMock()
 tmab = TaskManagerAgentBase()
@@ -27,11 +27,12 @@ tmab.log = gLogger
 tmab.am_getOption = mockAM
 tmab.log.setLevel('DEBUG')
 
+
 @pytest.mark.parametrize("operationsOnTransformationsDict, expected", [
-    ({1:{'Operations':['op1', 'op2'], 'Body':'veryBigBody'}}, ([1], 1)),
-    ({2:{'Operations':['op3', 'op2'], 'Body':'veryveryBigBody'}}, ([1, 2], 2)),
-    ({2:{'Operations':['op3', 'op2'], 'Body':'veryveryBigBody'}}, ([1, 2], 2))
-    ])
+    ({1: {'Operations': ['op1', 'op2'], 'Body':'veryBigBody'}}, ([1], 1)),
+    ({2: {'Operations': ['op3', 'op2'], 'Body':'veryveryBigBody'}}, ([1, 2], 2)),
+    ({2: {'Operations': ['op3', 'op2'], 'Body':'veryveryBigBody'}}, ([1, 2], 2))
+])
 def test__fillTheQueue(operationsOnTransformationsDict, expected):
   tmab._fillTheQueue(operationsOnTransformationsDict)
   assert tmab.transInQueue == expected[0]
@@ -42,29 +43,27 @@ def test__fillTheQueue(operationsOnTransformationsDict, expected):
 
 tc_mock = MagicMock()
 tm_mock = MagicMock()
-clients = {'TransformationClient':tc_mock, 'TaskManager':tm_mock}
+clients = {'TransformationClient': tc_mock, 'TaskManager': tm_mock}
 
-transIDOPBody = {1:{'Operations':['op1', 'op2'], 'Body':'veryBigBody'}}
+transIDOPBody = {1: {'Operations': ['op1', 'op2'], 'Body': 'veryBigBody'}}
 tasks = {'OK': True, 'Value': [{'CreationTime': None,
                                 'ExternalID': '1',
                                 'ExternalStatus': 'Reserved',
                                 'LastUpdateTime': None,
-                                'RunNumber': 0L,
+                                'RunNumber': 0,
                                 'TargetSE': 'Unknown',
-                                'TaskID': 1L,
-                                'TransformationID': 101L},
-                               {'CreationTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
+                                'TaskID': 1,
+                                'TransformationID': 101},
+                               {'CreationTime': datetime.datetime(2014, 7, 21, 14, 19, 3),
                                 'ExternalID': '0',
                                 'ExternalStatus': 'Reserved',
-                                'LastUpdateTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
-                                'RunNumber': 0L,
+                                'LastUpdateTime': datetime.datetime(2014, 7, 21, 14, 19, 3),
+                                'RunNumber': 0,
                                 'TargetSE': 'Unknown',
-                                'TaskID': 2L,
-                                'TransformationID': 101L}]}
+                                'TaskID': 2,
+                                'TransformationID': 101}]}
 sOk = {'OK': True, 'Value': []}
 sError = {'OK': False, 'Message': 'a mess'}
-
-
 
 
 @pytest.mark.parametrize("tcMockReturnValue, tmMockGetSubmittedTaskStatusReturnvalue, expected", [
@@ -73,23 +72,22 @@ sError = {'OK': False, 'Message': 'a mess'}
     (tasks, sError, False),  # tasks, fail in update
     (tasks, {'OK': True, 'Value': {}}, True),  # tasks, nothing to update
     (tasks, {'OK': True, 'Value': {'Running': [1, 2], 'Done': [3]}}, True)  # tasks, to update, no errors
-    ])
+])
 def test_updateTaskStatusSuccess(tcMockReturnValue, tmMockGetSubmittedTaskStatusReturnvalue, expected):
   tc_mock.getTransformationTasks.return_value = tcMockReturnValue
   tm_mock.getSubmittedTaskStatus.return_value = tmMockGetSubmittedTaskStatusReturnvalue
-  res = tmab.updateTaskStatus( transIDOPBody, clients )
+  res = tmab.updateTaskStatus(transIDOPBody, clients)
   assert res['OK'] == expected
-
 
 
 @pytest.mark.parametrize("tcMockGetTransformationFilesReturnValue, tmMockGetSubmittedFileStatusReturnValue, expected", [
     (sError, None, False),  # errors
     (sOk, None, True),  # no files
-    ({'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}, sError, False),  # files, failing to update
-    ({'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}, sOk, True),  # files, nothing to update
-    ({'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]},
-     {'OK': True, 'Value': {'file1': 'OK', 'file2': 'NOK'}}, True ),  # files, something to update
-    ])
+    ({'OK': True, 'Value': [{'file1': 'boh', 'TaskID': 1}]}, sError, False),  # files, failing to update
+    ({'OK': True, 'Value': [{'file1': 'boh', 'TaskID': 1}]}, sOk, True),  # files, nothing to update
+    ({'OK': True, 'Value': [{'file1': 'boh', 'TaskID': 1}]},
+     {'OK': True, 'Value': {'file1': 'OK', 'file2': 'NOK'}}, True),  # files, something to update
+])
 def test_updateFileStatusSuccess(tcMockGetTransformationFilesReturnValue,
                                  tmMockGetSubmittedFileStatusReturnValue,
                                  expected):
@@ -99,17 +97,15 @@ def test_updateFileStatusSuccess(tcMockGetTransformationFilesReturnValue,
   assert res['OK'] == expected
 
 
-
-
 @pytest.mark.parametrize("tcMockGetTransformationTasksReturnValue, tmMockUpdateTransformationReservedTasksReturnValue, tcMockSetTaskStatusAndWmsIDReturnValue, expected", [
     (sError, None, None, False),  # errors getting
     (sOk, None, None, True),  # no tasks
     (tasks, sError, None, False),  # tasks, failing to update
-    (tasks, {'OK': True, 'Value': {'NoTasks': [], 'TaskNameIDs': {'1_1':123, '2_1':456}}},
+    (tasks, {'OK': True, 'Value': {'NoTasks': [], 'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
      sError, False),  # tasks, something to update, fail
-    (tasks, {'OK': True, 'Value': {'NoTasks': ['3_4', '5_6'], 'TaskNameIDs': {'1_1':123, '2_1':456}}},
+    (tasks, {'OK': True, 'Value': {'NoTasks': ['3_4', '5_6'], 'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
      {'OK': True}, True),  # tasks, something to update, no fail
-    ])
+])
 def test_checkReservedTasks(tcMockGetTransformationTasksReturnValue,
                             tmMockUpdateTransformationReservedTasksReturnValue,
                             tcMockSetTaskStatusAndWmsIDReturnValue,
@@ -121,12 +117,11 @@ def test_checkReservedTasks(tcMockGetTransformationTasksReturnValue,
   assert res['OK'] == expected
 
 
-
-
 transIDOPBody = {1: {'Operations': ['op1', 'op2'], 'Body': 'veryBigBody',
                      'Owner': 'prodMan', 'OwnerDN': '/ca=man/user=prodMan', 'OwnerGroup': 'prodMans'}}
 sOkJobDict = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
 sOkJobs = {'OK': True, 'Value': {123: 'foo', 456: 'bar'}}
+
 
 @pytest.mark.parametrize("tcMockGetTasksToSubmitReturnValue, tmMockPrepareTransformationTasksReturnValue, tmMockSubmitTransformationTasksReturnValue, tmMockUpdateDBAfterTaskSubmissionReturnValue, expected", [
     (sError, None, None, None, False),  # errors getting
@@ -135,7 +130,7 @@ sOkJobs = {'OK': True, 'Value': {123: 'foo', 456: 'bar'}}
     (sOkJobDict, sOkJobs, sError, None, False),  # tasks, still errors
     (sOkJobDict, sOkJobs, sOk, sError, False),  # tasks, still errors
     (sOkJobDict, sOkJobs, sOk, sOk, True),  # tasks, no errors
-    ])
+])
 def test_submitTasks(tcMockGetTasksToSubmitReturnValue,
                      tmMockPrepareTransformationTasksReturnValue,
                      tmMockSubmitTransformationTasksReturnValue,
@@ -145,52 +140,51 @@ def test_submitTasks(tcMockGetTasksToSubmitReturnValue,
   tm_mock.prepareTransformationTasks.return_value = tmMockPrepareTransformationTasksReturnValue
   tm_mock.submitTransformationTasks.return_value = tmMockSubmitTransformationTasksReturnValue
   tm_mock.updateDBAfterTaskSubmission.return_value = tmMockUpdateDBAfterTaskSubmissionReturnValue
-  res = tmab.submitTasks( transIDOPBody, clients )
+  res = tmab.submitTasks(transIDOPBody, clients)
   assert res['OK'] == expected
 
 
+# TransformationAgent
 
 
-### TransformationAgent
-
-
-ta_m = importlib.import_module( 'DIRAC.TransformationSystem.Agent.TransformationAgent' )
+ta_m = importlib.import_module('DIRAC.TransformationSystem.Agent.TransformationAgent')
 ta_m.AgentModule = mockAM
 ta = TransformationAgent()
 ta.log = gLogger
 ta.am_getOption = mockAM
 
-goodFiles = {'OK':True,
-             'Value':[{'ErrorCount': 1L,
-                       'FileID': 17990660L,
-                       'InsertedTime': datetime.datetime( 2012, 3, 15, 17, 5, 50 ),
-                       'LFN': '/00012574_00000239_1.charmcompleteevent.dst',
-                       'LastUpdate': datetime.datetime( 2012, 3, 16, 23, 43, 26 ),
-                       'RunNumber': 90269L,
-                       'Status': 'Unused',
-                       'TargetSE': 'Unknown',
-                       'TaskID': '222',
-                       'TransformationID': 17042L,
-                       'UsedSE': 'CERN-DST,IN2P3-DST,PIC-DST,RAL-DST'},
-                      {'ErrorCount': 1L,
-                       'FileID': 17022945L,
-                       'InsertedTime': datetime.datetime( 2012, 3, 15, 17, 5, 50 ),
-                       'LFN': '/00012574_00000119_1.charmcompleteevent.dst',
-                       'LastUpdate': datetime.datetime( 2012, 3, 16, 23, 54, 59 ),
-                       'RunNumber': 90322L,
-                       'Status': 'Unused',
-                       'TargetSE': 'Unknown',
-                       'TaskID': '82',
-                       'TransformationID': 17042L,
-                       'UsedSE': 'CERN-DST,CNAF-DST,RAL-DST,SARA-DST'}]
-            }
-noFiles = {'OK':True, 'Value':[]}
+goodFiles = {'OK': True,
+             'Value': [{'ErrorCount': 1,
+                        'FileID': 17990660,
+                        'InsertedTime': datetime.datetime(2012, 3, 15, 17, 5, 50),
+                        'LFN': '/00012574_00000239_1.charmcompleteevent.dst',
+                        'LastUpdate': datetime.datetime(2012, 3, 16, 23, 43, 26),
+                        'RunNumber': 90269,
+                        'Status': 'Unused',
+                        'TargetSE': 'Unknown',
+                        'TaskID': '222',
+                        'TransformationID': 17042,
+                        'UsedSE': 'CERN-DST,IN2P3-DST,PIC-DST,RAL-DST'},
+                       {'ErrorCount': 1,
+                        'FileID': 17022945,
+                        'InsertedTime': datetime.datetime(2012, 3, 15, 17, 5, 50),
+                        'LFN': '/00012574_00000119_1.charmcompleteevent.dst',
+                        'LastUpdate': datetime.datetime(2012, 3, 16, 23, 54, 59),
+                        'RunNumber': 90322,
+                        'Status': 'Unused',
+                        'TargetSE': 'Unknown',
+                        'TaskID': '82',
+                        'TransformationID': 17042,
+                        'UsedSE': 'CERN-DST,CNAF-DST,RAL-DST,SARA-DST'}]
+             }
+noFiles = {'OK': True, 'Value': []}
 
-@pytest.mark.parametrize("transDict, getTFiles, expected",[
-    ({'TransformationID': 123, 'Status': 'Stopped', 'Type': 'Replication' }, goodFiles, True),
-    ({'TransformationID': 123, 'Status': 'Stopped', 'Type': 'Removal' }, noFiles, True)
-    ])
+
+@pytest.mark.parametrize("transDict, getTFiles, expected", [
+    ({'TransformationID': 123, 'Status': 'Stopped', 'Type': 'Replication'}, goodFiles, True),
+    ({'TransformationID': 123, 'Status': 'Stopped', 'Type': 'Removal'}, noFiles, True)
+])
 def test__getTransformationFiles(transDict, getTFiles, expected):
   tc_mock.getTransformationFiles.return_value = getTFiles
-  res = ta._getTransformationFiles( transDict, {'TransformationClient': tc_mock} )
+  res = ta._getTransformationFiles(transDict, {'TransformationClient': tc_mock})
   assert res['OK'] == expected

--- a/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
+++ b/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
@@ -97,15 +97,19 @@ def test_updateFileStatusSuccess(tcMockGetTransformationFilesReturnValue,
   assert res['OK'] == expected
 
 
-@pytest.mark.parametrize("tcMockGetTransformationTasksReturnValue, tmMockUpdateTransformationReservedTasksReturnValue, tcMockSetTaskStatusAndWmsIDReturnValue, expected", [
-    (sError, None, None, False),  # errors getting
-    (sOk, None, None, True),  # no tasks
-    (tasks, sError, None, False),  # tasks, failing to update
-    (tasks, {'OK': True, 'Value': {'NoTasks': [], 'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
-     sError, False),  # tasks, something to update, fail
-    (tasks, {'OK': True, 'Value': {'NoTasks': ['3_4', '5_6'], 'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
-     {'OK': True}, True),  # tasks, something to update, no fail
-])
+@pytest.mark.parametrize("tcMockGetTransformationTasksReturnValue," +
+                         "tmMockUpdateTransformationReservedTasksReturnValue, " +
+                         "tcMockSetTaskStatusAndWmsIDReturnValue, " +
+                         "expected", [(sError, None, None, False),  # errors getting
+                                      (sOk, None, None, True),  # no tasks
+                                      (tasks, sError, None, False),  # tasks, failing to update
+                                      (tasks, {'OK': True,
+                                               'Value': {'NoTasks': [], 'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
+                                       sError, False),  # tasks, something to update, fail
+                                      (tasks, {'OK': True,
+                                               'Value': {'NoTasks': ['3_4', '5_6'],
+                                                         'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
+                                       {'OK': True}, True)])  # tasks, something to update, no fail
 def test_checkReservedTasks(tcMockGetTransformationTasksReturnValue,
                             tmMockUpdateTransformationReservedTasksReturnValue,
                             tcMockSetTaskStatusAndWmsIDReturnValue,
@@ -123,14 +127,17 @@ sOkJobDict = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
 sOkJobs = {'OK': True, 'Value': {123: 'foo', 456: 'bar'}}
 
 
-@pytest.mark.parametrize("tcMockGetTasksToSubmitReturnValue, tmMockPrepareTransformationTasksReturnValue, tmMockSubmitTransformationTasksReturnValue, tmMockUpdateDBAfterTaskSubmissionReturnValue, expected", [
-    (sError, None, None, None, False),  # errors getting
-    ({'OK': True, 'Value': {'JobDictionary': {}}}, None, None, None, True),  # no tasks
-    (sOkJobDict, sError, None, None, False),  # tasks, errors
-    (sOkJobDict, sOkJobs, sError, None, False),  # tasks, still errors
-    (sOkJobDict, sOkJobs, sOk, sError, False),  # tasks, still errors
-    (sOkJobDict, sOkJobs, sOk, sOk, True),  # tasks, no errors
-])
+@pytest.mark.parametrize("tcMockGetTasksToSubmitReturnValue, " +
+                         "tmMockPrepareTransformationTasksReturnValue, " +
+                         "tmMockSubmitTransformationTasksReturnValue, " +
+                         "tmMockUpdateDBAfterTaskSubmissionReturnValue, " +
+                         "expected", [(sError, None, None, None, False),  # errors getting
+                                      ({'OK': True, 'Value': {'JobDictionary': {}}},
+                                       None, None, None, True),  # no tasks
+                                      (sOkJobDict, sError, None, None, False),  # tasks, errors
+                                      (sOkJobDict, sOkJobs, sError, None, False),  # tasks, still errors
+                                      (sOkJobDict, sOkJobs, sOk, sError, False),  # tasks, still errors
+                                      (sOkJobDict, sOkJobs, sOk, sOk, True)])  # tasks, no errors
 def test_submitTasks(tcMockGetTasksToSubmitReturnValue,
                      tmMockPrepareTransformationTasksReturnValue,
                      tmMockSubmitTransformationTasksReturnValue,

--- a/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
+++ b/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
@@ -97,19 +97,20 @@ def test_updateFileStatusSuccess(tcMockGetTransformationFilesReturnValue,
   assert res['OK'] == expected
 
 
-@pytest.mark.parametrize("tcMockGetTransformationTasksReturnValue,"
-                         + "tmMockUpdateTransformationReservedTasksReturnValue, "
-                         + "tcMockSetTaskStatusAndWmsIDReturnValue, "
-                         + "expected", [(sError, None, None, False),  # errors getting
-                                        (sOk, None, None, True),  # no tasks
-                                        (tasks, sError, None, False),  # tasks, failing to update
-                                        (tasks, {'OK': True,
-                                                 'Value': {'NoTasks': [], 'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
-                                         sError, False),  # tasks, something to update, fail
-                                        (tasks, {'OK': True,
-                                                 'Value': {'NoTasks': ['3_4', '5_6'],
-                                                           'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
-                                         {'OK': True}, True)])  # tasks, something to update, no fail
+@pytest.mark.parametrize(', '.join(["tcMockGetTransformationTasksReturnValue",
+                                    "tmMockUpdateTransformationReservedTasksReturnValue",
+                                    "tcMockSetTaskStatusAndWmsIDReturnValue",
+                                    "expected"]),
+                         [(sError, None, None, False),  # errors getting
+                          (sOk, None, None, True),  # no tasks
+                          (tasks, sError, None, False),  # tasks, failing to update
+                          (tasks, {'OK': True,
+                                   'Value': {'NoTasks': [], 'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
+                           sError, False),  # tasks, something to update, fail
+                          (tasks, {'OK': True,
+                                   'Value': {'NoTasks': ['3_4', '5_6'],
+                                             'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
+                           {'OK': True}, True)])  # tasks, something to update, no fail
 def test_checkReservedTasks(tcMockGetTransformationTasksReturnValue,
                             tmMockUpdateTransformationReservedTasksReturnValue,
                             tcMockSetTaskStatusAndWmsIDReturnValue,
@@ -127,17 +128,18 @@ sOkJobDict = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
 sOkJobs = {'OK': True, 'Value': {123: 'foo', 456: 'bar'}}
 
 
-@pytest.mark.parametrize("tcMockGetTasksToSubmitReturnValue, "
-                         + "tmMockPrepareTransformationTasksReturnValue, "
-                         + "tmMockSubmitTransformationTasksReturnValue, "
-                         + "tmMockUpdateDBAfterTaskSubmissionReturnValue, "
-                         + "expected", [(sError, None, None, None, False),  # errors getting
-                                        ({'OK': True, 'Value': {'JobDictionary': {}}},
-                                         None, None, None, True),  # no tasks
-                                        (sOkJobDict, sError, None, None, False),  # tasks, errors
-                                        (sOkJobDict, sOkJobs, sError, None, False),  # tasks, still errors
-                                        (sOkJobDict, sOkJobs, sOk, sError, False),  # tasks, still errors
-                                        (sOkJobDict, sOkJobs, sOk, sOk, True)])  # tasks, no errors
+@pytest.mark.parametrize(', '.join(["tcMockGetTasksToSubmitReturnValue",
+                                    "tmMockPrepareTransformationTasksReturnValue",
+                                    "tmMockSubmitTransformationTasksReturnValue",
+                                    "tmMockUpdateDBAfterTaskSubmissionReturnValue",
+                                    "expected"]),
+                         [(sError, None, None, None, False),  # errors getting
+                          ({'OK': True, 'Value': {'JobDictionary': {}}},
+                           None, None, None, True),  # no tasks
+                          (sOkJobDict, sError, None, None, False),  # tasks, errors
+                          (sOkJobDict, sOkJobs, sError, None, False),  # tasks, still errors
+                          (sOkJobDict, sOkJobs, sOk, sError, False),  # tasks, still errors
+                          (sOkJobDict, sOkJobs, sOk, sOk, True)])  # tasks, no errors
 def test_submitTasks(tcMockGetTasksToSubmitReturnValue,
                      tmMockPrepareTransformationTasksReturnValue,
                      tmMockSubmitTransformationTasksReturnValue,

--- a/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
+++ b/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
@@ -97,19 +97,19 @@ def test_updateFileStatusSuccess(tcMockGetTransformationFilesReturnValue,
   assert res['OK'] == expected
 
 
-@pytest.mark.parametrize("tcMockGetTransformationTasksReturnValue," +
-                         "tmMockUpdateTransformationReservedTasksReturnValue, " +
-                         "tcMockSetTaskStatusAndWmsIDReturnValue, " +
-                         "expected", [(sError, None, None, False),  # errors getting
-                                      (sOk, None, None, True),  # no tasks
-                                      (tasks, sError, None, False),  # tasks, failing to update
-                                      (tasks, {'OK': True,
-                                               'Value': {'NoTasks': [], 'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
-                                       sError, False),  # tasks, something to update, fail
-                                      (tasks, {'OK': True,
-                                               'Value': {'NoTasks': ['3_4', '5_6'],
-                                                         'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
-                                       {'OK': True}, True)])  # tasks, something to update, no fail
+@pytest.mark.parametrize("tcMockGetTransformationTasksReturnValue,"
+                         + "tmMockUpdateTransformationReservedTasksReturnValue, "
+                         + "tcMockSetTaskStatusAndWmsIDReturnValue, "
+                         + "expected", [(sError, None, None, False),  # errors getting
+                                        (sOk, None, None, True),  # no tasks
+                                        (tasks, sError, None, False),  # tasks, failing to update
+                                        (tasks, {'OK': True,
+                                                 'Value': {'NoTasks': [], 'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
+                                         sError, False),  # tasks, something to update, fail
+                                        (tasks, {'OK': True,
+                                                 'Value': {'NoTasks': ['3_4', '5_6'],
+                                                           'TaskNameIDs': {'1_1': 123, '2_1': 456}}},
+                                         {'OK': True}, True)])  # tasks, something to update, no fail
 def test_checkReservedTasks(tcMockGetTransformationTasksReturnValue,
                             tmMockUpdateTransformationReservedTasksReturnValue,
                             tcMockSetTaskStatusAndWmsIDReturnValue,
@@ -127,17 +127,17 @@ sOkJobDict = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
 sOkJobs = {'OK': True, 'Value': {123: 'foo', 456: 'bar'}}
 
 
-@pytest.mark.parametrize("tcMockGetTasksToSubmitReturnValue, " +
-                         "tmMockPrepareTransformationTasksReturnValue, " +
-                         "tmMockSubmitTransformationTasksReturnValue, " +
-                         "tmMockUpdateDBAfterTaskSubmissionReturnValue, " +
-                         "expected", [(sError, None, None, None, False),  # errors getting
-                                      ({'OK': True, 'Value': {'JobDictionary': {}}},
-                                       None, None, None, True),  # no tasks
-                                      (sOkJobDict, sError, None, None, False),  # tasks, errors
-                                      (sOkJobDict, sOkJobs, sError, None, False),  # tasks, still errors
-                                      (sOkJobDict, sOkJobs, sOk, sError, False),  # tasks, still errors
-                                      (sOkJobDict, sOkJobs, sOk, sOk, True)])  # tasks, no errors
+@pytest.mark.parametrize("tcMockGetTasksToSubmitReturnValue, "
+                         + "tmMockPrepareTransformationTasksReturnValue, "
+                         + "tmMockSubmitTransformationTasksReturnValue, "
+                         + "tmMockUpdateDBAfterTaskSubmissionReturnValue, "
+                         + "expected", [(sError, None, None, None, False),  # errors getting
+                                        ({'OK': True, 'Value': {'JobDictionary': {}}},
+                                         None, None, None, True),  # no tasks
+                                        (sOkJobDict, sError, None, None, False),  # tasks, errors
+                                        (sOkJobDict, sOkJobs, sError, None, False),  # tasks, still errors
+                                        (sOkJobDict, sOkJobs, sOk, sError, False),  # tasks, still errors
+                                        (sOkJobDict, sOkJobs, sOk, sOk, True)])  # tasks, no errors
 def test_submitTasks(tcMockGetTasksToSubmitReturnValue,
                      tmMockPrepareTransformationTasksReturnValue,
                      tmMockSubmitTransformationTasksReturnValue,

--- a/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
+++ b/TransformationSystem/Agent/test/Test_Agent_TransformationSystem.py
@@ -4,9 +4,10 @@
 # pylint: disable=protected-access, missing-docstring, invalid-name, line-too-long
 
 # imports
-import unittest
 import importlib
 import datetime
+
+import pytest
 from mock import MagicMock
 
 from DIRAC import gLogger
@@ -17,321 +18,179 @@ from DIRAC.TransformationSystem.Agent.TransformationAgent import TransformationA
 gLogger.setLevel( 'DEBUG' )
 
 
+mockAM = MagicMock()
+tmab_m = importlib.import_module( 'DIRAC.TransformationSystem.Agent.TaskManagerAgentBase' )
+tmab_m.AgentModule = mockAM
+tmab_m.FileReport = MagicMock()
+tmab = TaskManagerAgentBase()
+tmab.log = gLogger
+tmab.am_getOption = mockAM
+tmab.log.setLevel('DEBUG')
 
-class AgentsTestCase( unittest.TestCase ):
-  """ Base class for the Agents test cases
-  """
-  def setUp( self ):
-    self.mockAM = MagicMock()
-    self.tmab_m = importlib.import_module( 'DIRAC.TransformationSystem.Agent.TaskManagerAgentBase' )
-    self.tmab_m.AgentModule = self.mockAM
-    self.tmab_m.FileReport = MagicMock()
-    self.tmab = TaskManagerAgentBase()
-    self.tmab.log = gLogger
-    self.tmab.am_getOption = self.mockAM
-    self.tmab.log.setLevel( 'DEBUG' )
-
-    self.ta_m = importlib.import_module( 'DIRAC.TransformationSystem.Agent.TransformationAgent' )
-    self.ta_m.AgentModule = self.mockAM
-    self.ta = TransformationAgent()
-    self.ta.log = gLogger
-    self.ta.am_getOption = self.mockAM
-    self.tmab.log.setLevel( 'DEBUG' )
-
-    self.tc_mock = MagicMock()
-    self.tm_mock = MagicMock()
-
-  def tearDown( self ):
-#     sys.modules.pop( 'DIRAC.Core.Base.AgentModule' )
-#     sys.modules.pop( 'DIRAC.TransformationSystem.Agent.TransformationAgent' )
-    pass
-
-class TaskManagerAgentBaseSuccess( AgentsTestCase ):
-
-  def test__fillTheQueue( self ):
-    operationsOnTransformationsDict = {1:{'Operations':['op1', 'op2'], 'Body':'veryBigBody'}}
-    self.tmab._fillTheQueue( operationsOnTransformationsDict )
-    self.assertTrue( self.tmab.transInQueue == [1] )
-    self.assertTrue( self.tmab.transQueue.qsize() == 1 )
-
-    operationsOnTransformationsDict = {2:{'Operations':['op3', 'op2'], 'Body':'veryveryBigBody'}}
-    self.tmab._fillTheQueue( operationsOnTransformationsDict )
-    self.assertTrue( self.tmab.transInQueue == [1, 2] )
-    self.assertTrue( self.tmab.transQueue.qsize() == 2 )
-
-    operationsOnTransformationsDict = {2:{'Operations':['op3', 'op2'], 'Body':'veryveryBigBody'}}
-    self.tmab._fillTheQueue( operationsOnTransformationsDict )
-    self.assertTrue( self.tmab.transInQueue == [1, 2] )
-    self.assertTrue( self.tmab.transQueue.qsize() == 2 )
-
-  def test_updateTaskStatusSuccess( self ):
-    clients = {'TransformationClient':self.tc_mock, 'TaskManager':self.tm_mock}
-
-    transIDOPBody = {1:{'Operations':['op1', 'op2'], 'Body':'veryBigBody'}}
-
-    # errors getting
-    self.tc_mock.getTransformationTasks.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.updateTaskStatus( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # no tasks
-    self.tc_mock.getTransformationTasks.return_value = {'OK': True, 'Value': []}
-    res = self.tmab.updateTaskStatus( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
-
-    # tasks, fail in update
-    self.tc_mock.getTransformationTasks.return_value = {'OK': True,
-                                                        'Value': [{'CreationTime': None,
-                                                                   'ExternalID': '1',
-                                                                   'ExternalStatus': 'Reserved',
-                                                                   'LastUpdateTime': None,
-                                                                   'RunNumber': 0L,
-                                                                   'TargetSE': 'Unknown',
-                                                                   'TaskID': 1L,
-                                                                   'TransformationID': 101L},
-                                                                  {'CreationTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
-                                                                   'ExternalID': '0',
-                                                                   'ExternalStatus': 'Reserved',
-                                                                   'LastUpdateTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
-                                                                   'RunNumber': 0L,
-                                                                   'TargetSE': 'Unknown',
-                                                                   'TaskID': 2L,
-                                                                   'TransformationID': 101L}]}
-
-    self.tm_mock.getSubmittedTaskStatus.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.updateTaskStatus( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # tasks, nothing to update
-    self.tc_mock.getTransformationTasks.return_value = {'OK': True,
-                                                        'Value': [{'CreationTime': None,
-                                                                   'ExternalID': '1',
-                                                                   'ExternalStatus': 'Reserved',
-                                                                   'LastUpdateTime': None,
-                                                                   'RunNumber': 0L,
-                                                                   'TargetSE': 'Unknown',
-                                                                   'TaskID': 1L,
-                                                                   'TransformationID': 101L},
-                                                                  {'CreationTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
-                                                                   'ExternalID': '0',
-                                                                   'ExternalStatus': 'Reserved',
-                                                                   'LastUpdateTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
-                                                                   'RunNumber': 0L,
-                                                                   'TargetSE': 'Unknown',
-                                                                   'TaskID': 2L,
-                                                                   'TransformationID': 101L}]}
-
-    self.tm_mock.getSubmittedTaskStatus.return_value = {'OK': True, 'Value': {}}
-    res = self.tmab.updateTaskStatus( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
-
-    # tasks, to update, no errors
-    self.tc_mock.getTransformationTasks.return_value = {'OK': True,
-                                                        'Value': [{'CreationTime': None,
-                                                                   'ExternalID': '1',
-                                                                   'ExternalStatus': 'Reserved',
-                                                                   'LastUpdateTime': None,
-                                                                   'RunNumber': 0L,
-                                                                   'TargetSE': 'Unknown',
-                                                                   'TaskID': 1L,
-                                                                   'TransformationID': 101L},
-                                                                  {'CreationTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
-                                                                   'ExternalID': '0',
-                                                                   'ExternalStatus': 'Reserved',
-                                                                   'LastUpdateTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
-                                                                   'RunNumber': 0L,
-                                                                   'TargetSE': 'Unknown',
-                                                                   'TaskID': 2L,
-                                                                   'TransformationID': 101L}]}
-
-    self.tm_mock.getSubmittedTaskStatus.return_value = {'OK': True, 'Value': {'Running': [1, 2], 'Done': [3]}}
-    res = self.tmab.updateTaskStatus( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
+@pytest.mark.parametrize("operationsOnTransformationsDict, expected", [
+    ({1:{'Operations':['op1', 'op2'], 'Body':'veryBigBody'}}, ([1], 1)),
+    ({2:{'Operations':['op3', 'op2'], 'Body':'veryveryBigBody'}}, ([1, 2], 2)),
+    ({2:{'Operations':['op3', 'op2'], 'Body':'veryveryBigBody'}}, ([1, 2], 2))
+    ])
+def test__fillTheQueue(operationsOnTransformationsDict, expected):
+  tmab._fillTheQueue(operationsOnTransformationsDict)
+  assert tmab.transInQueue == expected[0]
+  assert tmab.transQueue.qsize() == expected[1]
 
 
-  def test_updateFileStatusSuccess( self ):
-    clients = {'TransformationClient':self.tc_mock, 'TaskManager':self.tm_mock}
+# useful stuff
 
-    transIDOPBody = {1:{'Operations':['op1', 'op2'], 'Body':'veryBigBody'}}
+tc_mock = MagicMock()
+tm_mock = MagicMock()
+clients = {'TransformationClient':tc_mock, 'TaskManager':tm_mock}
 
-    # errors getting
-    self.tc_mock.getTransformationFiles.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.updateFileStatus( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # no files
-    self.tc_mock.getTransformationFiles.return_value = {'OK': True, 'Value': []}
-    res = self.tmab.updateFileStatus( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
-
-    # files, failing to update
-    self.tc_mock.getTransformationFiles.return_value = {'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}
-    self.tm_mock.getSubmittedFileStatus.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.updateFileStatus( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # files, nothing to update
-    self.tc_mock.getTransformationFiles.return_value = {'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}
-    self.tm_mock.getSubmittedFileStatus.return_value = {'OK': True, 'Value': []}
-    res = self.tmab.updateFileStatus( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
-
-    # files, something to update
-    self.tc_mock.getTransformationFiles.return_value = {'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}
-    self.tm_mock.getSubmittedFileStatus.return_value = {'OK': True, 'Value': {'file1': 'OK', 'file2': 'NOK'}}
-    res = self.tmab.updateFileStatus( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
-
-  def test_checkReservedTasks( self ):
-    clients = {'TransformationClient':self.tc_mock, 'TaskManager':self.tm_mock}
-
-    transIDOPBody = {1:{'Operations':['op1', 'op2'], 'Body':'veryBigBody'}}
-
-    # errors getting
-    self.tc_mock.getTransformationTasks.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.checkReservedTasks( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # no tasks
-    self.tc_mock.getTransformationTasks.return_value = {'OK': True, 'Value': []}
-    res = self.tmab.checkReservedTasks( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
-
-    # tasks, failing to update
-    self.tc_mock.getTransformationTasks.return_value = {'OK': True,
-                                                        'Value': [{'CreationTime': None,
-                                                                   'ExternalID': '1',
-                                                                   'ExternalStatus': 'Reserved',
-                                                                   'LastUpdateTime': None,
-                                                                   'RunNumber': 0L,
-                                                                   'TargetSE': 'Unknown',
-                                                                   'TaskID': 1L,
-                                                                   'TransformationID': 101L},
-                                                                  {'CreationTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
-                                                                   'ExternalID': '0',
-                                                                   'ExternalStatus': 'Reserved',
-                                                                   'LastUpdateTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
-                                                                   'RunNumber': 0L,
-                                                                   'TargetSE': 'Unknown',
-                                                                   'TaskID': 2L,
-                                                                   'TransformationID': 101L}]}
-    self.tm_mock.updateTransformationReservedTasks.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.checkReservedTasks( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # tasks, something to update, fail
-    self.tc_mock.setTaskStatusAndWmsID.return_value = {'OK': False, 'Message': 'a mess'}
-    self.tm_mock.updateTransformationReservedTasks.return_value = {'OK': True, 'Value': {'NoTasks': [],
-                                                                                         'TaskNameIDs': {'1_1':123, '2_1':456}}}
-    res = self.tmab.checkReservedTasks( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # tasks, something to update, no fail
-    self.tc_mock.setTaskStatusAndWmsID.return_value = {'OK': True}
-    self.tm_mock.updateTransformationReservedTasks.return_value = {'OK': True, 'Value': {'NoTasks': ['3_4', '5_6'],
-                                                                                         'TaskNameIDs': {'1_1':123, '2_1':456}}}
-    res = self.tmab.checkReservedTasks( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
+transIDOPBody = {1:{'Operations':['op1', 'op2'], 'Body':'veryBigBody'}}
+tasks = {'OK': True, 'Value': [{'CreationTime': None,
+                                'ExternalID': '1',
+                                'ExternalStatus': 'Reserved',
+                                'LastUpdateTime': None,
+                                'RunNumber': 0L,
+                                'TargetSE': 'Unknown',
+                                'TaskID': 1L,
+                                'TransformationID': 101L},
+                               {'CreationTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
+                                'ExternalID': '0',
+                                'ExternalStatus': 'Reserved',
+                                'LastUpdateTime': datetime.datetime( 2014, 7, 21, 14, 19, 3 ),
+                                'RunNumber': 0L,
+                                'TargetSE': 'Unknown',
+                                'TaskID': 2L,
+                                'TransformationID': 101L}]}
+sOk = {'OK': True, 'Value': []}
+sError = {'OK': False, 'Message': 'a mess'}
 
 
 
-  def test_submitTasks( self ):
-    clients = {'TransformationClient':self.tc_mock, 'TaskManager':self.tm_mock}
 
-    transIDOPBody = {1: {'Operations': ['op1', 'op2'], 'Body': 'veryBigBody',
-                         'Owner': 'prodMan', 'OwnerDN': '/ca=man/user=prodMan', 'OwnerGroup': 'prodMans'}}
-
-    # errors getting
-    self.tc_mock.getTasksToSubmit.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.submitTasks( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # no tasks
-    self.tc_mock.getTasksToSubmit.return_value = {'OK': True, 'Value': {'JobDictionary': {}}}
-    res = self.tmab.submitTasks( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
-
-    # tasks, errors
-    self.tc_mock.getTasksToSubmit.return_value = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
-    self.tm_mock.prepareTransformationTasks.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.submitTasks( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # tasks, still errors
-    self.tc_mock.getTasksToSubmit.return_value = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
-    self.tm_mock.prepareTransformationTasks.return_value = {'OK': True, 'Value': {123: 'foo', 456: 'bar'}}
-    self.tm_mock.submitTransformationTasks.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.submitTasks( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # tasks, still errors
-    self.tc_mock.getTasksToSubmit.return_value = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
-    self.tm_mock.prepareTransformationTasks.return_value = {'OK': True, 'Value': {123: 'foo', 456: 'bar'}}
-    self.tm_mock.submitTransformationTasks.return_value = {'OK': True, 'Value': [] }
-    self.tm_mock.updateDBAfterTaskSubmission.return_value = {'OK': False, 'Message': 'a mess'}
-    res = self.tmab.submitTasks( transIDOPBody, clients )
-    self.assertFalse( res['OK'] )
-
-    # tasks, no errors
-    self.tc_mock.getTasksToSubmit.return_value = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
-    self.tm_mock.prepareTransformationTasks.return_value = {'OK': True, 'Value': {123: 'foo', 456: 'bar'}}
-    self.tm_mock.submitTransformationTasks.return_value = {'OK': True, 'Value': [] }
-    self.tm_mock.updateDBAfterTaskSubmission.return_value = {'OK': True, 'Value': [] }
-    res = self.tmab.submitTasks( transIDOPBody, clients )
-    self.assertTrue(res['OK'])
+@pytest.mark.parametrize("tcMockReturnValue, tmMockGetSubmittedTaskStatusReturnvalue, expected", [
+    (sError, {'OK': True}, False),  # errors
+    (sOk, {'OK': True}, True),  # no tasks
+    (tasks, sError, False),  # tasks, fail in update
+    (tasks, {'OK': True, 'Value': {}}, True),  # tasks, nothing to update
+    (tasks, {'OK': True, 'Value': {'Running': [1, 2], 'Done': [3]}}, True)  # tasks, to update, no errors
+    ])
+def test_updateTaskStatusSuccess(tcMockReturnValue, tmMockGetSubmittedTaskStatusReturnvalue, expected):
+  tc_mock.getTransformationTasks.return_value = tcMockReturnValue
+  tm_mock.getSubmittedTaskStatus.return_value = tmMockGetSubmittedTaskStatusReturnvalue
+  res = tmab.updateTaskStatus( transIDOPBody, clients )
+  assert res['OK'] == expected
 
 
 
-class TransformationAgentSuccess( AgentsTestCase ):
-
-  def test__getTransformationFiles( self ):
-    goodFiles = {'OK':True,
-                 'Value':[{'ErrorCount': 1L,
-                           'FileID': 17990660L,
-                           'InsertedTime': datetime.datetime( 2012, 3, 15, 17, 5, 50 ),
-                           'LFN': '/00012574_00000239_1.charmcompleteevent.dst',
-                           'LastUpdate': datetime.datetime( 2012, 3, 16, 23, 43, 26 ),
-                           'RunNumber': 90269L,
-                           'Status': 'Unused',
-                           'TargetSE': 'Unknown',
-                           'TaskID': '222',
-                           'TransformationID': 17042L,
-                           'UsedSE': 'CERN-DST,IN2P3-DST,PIC-DST,RAL-DST'},
-                          {'ErrorCount': 1L,
-                           'FileID': 17022945L,
-                           'InsertedTime': datetime.datetime( 2012, 3, 15, 17, 5, 50 ),
-                           'LFN': '/00012574_00000119_1.charmcompleteevent.dst',
-                           'LastUpdate': datetime.datetime( 2012, 3, 16, 23, 54, 59 ),
-                           'RunNumber': 90322L,
-                           'Status': 'Unused',
-                           'TargetSE': 'Unknown',
-                           'TaskID': '82',
-                           'TransformationID': 17042L,
-                           'UsedSE': 'CERN-DST,CNAF-DST,RAL-DST,SARA-DST'}]
-                }
-    noFiles = {'OK':True, 'Value':[]}
-
-    for getTFiles in [goodFiles, noFiles]:
-      self.tc_mock.getTransformationFiles.return_value = getTFiles
-
-      transDict = {'TransformationID': 123, 'Status': 'Stopped', 'Type': 'Replication' }
-      res = self.ta._getTransformationFiles( transDict, {'TransformationClient': self.tc_mock} )
-      self.assertTrue( res['OK'] )
-
-      transDict = {'TransformationID': 123, 'Status': 'Stopped', 'Type': 'Removal' }
-      res = self.ta._getTransformationFiles( transDict, {'TransformationClient': self.tc_mock} )
-      self.assertTrue( res['OK'] )
+@pytest.mark.parametrize("tcMockGetTransformationFilesReturnValue, tmMockGetSubmittedFileStatusReturnValue, expected", [
+    (sError, None, False),  # errors
+    (sOk, None, True),  # no files
+    ({'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}, sError, False),  # files, failing to update
+    ({'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]}, sOk, True),  # files, nothing to update
+    ({'OK': True, 'Value': [{'file1': 'boh', 'TaskID':1}]},
+     {'OK': True, 'Value': {'file1': 'OK', 'file2': 'NOK'}}, True ),  # files, something to update
+    ])
+def test_updateFileStatusSuccess(tcMockGetTransformationFilesReturnValue,
+                                 tmMockGetSubmittedFileStatusReturnValue,
+                                 expected):
+  tc_mock.getTransformationFiles.return_value = tcMockGetTransformationFilesReturnValue
+  tm_mock.getSubmittedFileStatus.return_value = tmMockGetSubmittedFileStatusReturnValue
+  res = tmab.updateFileStatus(transIDOPBody, clients)
+  assert res['OK'] == expected
 
 
 
-#############################################################################
-# Test Suite run
-#############################################################################
 
-if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( AgentsTestCase )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TaskManagerAgentBaseSuccess ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TransformationAgentSuccess ) )
-  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
+@pytest.mark.parametrize("tcMockGetTransformationTasksReturnValue, tmMockUpdateTransformationReservedTasksReturnValue, tcMockSetTaskStatusAndWmsIDReturnValue, expected", [
+    (sError, None, None, False),  # errors getting
+    (sOk, None, None, True),  # no tasks
+    (tasks, sError, None, False),  # tasks, failing to update
+    (tasks, {'OK': True, 'Value': {'NoTasks': [], 'TaskNameIDs': {'1_1':123, '2_1':456}}},
+     sError, False),  # tasks, something to update, fail
+    (tasks, {'OK': True, 'Value': {'NoTasks': ['3_4', '5_6'], 'TaskNameIDs': {'1_1':123, '2_1':456}}},
+     {'OK': True}, True),  # tasks, something to update, no fail
+    ])
+def test_checkReservedTasks(tcMockGetTransformationTasksReturnValue,
+                            tmMockUpdateTransformationReservedTasksReturnValue,
+                            tcMockSetTaskStatusAndWmsIDReturnValue,
+                            expected):
+  tc_mock.getTransformationTasks.return_value = tcMockGetTransformationTasksReturnValue
+  tm_mock.updateTransformationReservedTasks.return_value = tmMockUpdateTransformationReservedTasksReturnValue
+  tc_mock.setTaskStatusAndWmsID.return_value = tcMockSetTaskStatusAndWmsIDReturnValue
+  res = tmab.checkReservedTasks(transIDOPBody, clients)
+  assert res['OK'] == expected
 
-# EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#
+
+
+
+transIDOPBody = {1: {'Operations': ['op1', 'op2'], 'Body': 'veryBigBody',
+                     'Owner': 'prodMan', 'OwnerDN': '/ca=man/user=prodMan', 'OwnerGroup': 'prodMans'}}
+sOkJobDict = {'OK': True, 'Value': {'JobDictionary': {123: 'foo', 456: 'bar'}}}
+sOkJobs = {'OK': True, 'Value': {123: 'foo', 456: 'bar'}}
+
+@pytest.mark.parametrize("tcMockGetTasksToSubmitReturnValue, tmMockPrepareTransformationTasksReturnValue, tmMockSubmitTransformationTasksReturnValue, tmMockUpdateDBAfterTaskSubmissionReturnValue, expected", [
+    (sError, None, None, None, False),  # errors getting
+    ({'OK': True, 'Value': {'JobDictionary': {}}}, None, None, None, True),  # no tasks
+    (sOkJobDict, sError, None, None, False),  # tasks, errors
+    (sOkJobDict, sOkJobs, sError, None, False),  # tasks, still errors
+    (sOkJobDict, sOkJobs, sOk, sError, False),  # tasks, still errors
+    (sOkJobDict, sOkJobs, sOk, sOk, True),  # tasks, no errors
+    ])
+def test_submitTasks(tcMockGetTasksToSubmitReturnValue,
+                     tmMockPrepareTransformationTasksReturnValue,
+                     tmMockSubmitTransformationTasksReturnValue,
+                     tmMockUpdateDBAfterTaskSubmissionReturnValue,
+                     expected):
+  tc_mock.getTasksToSubmit.return_value = tcMockGetTasksToSubmitReturnValue
+  tm_mock.prepareTransformationTasks.return_value = tmMockPrepareTransformationTasksReturnValue
+  tm_mock.submitTransformationTasks.return_value = tmMockSubmitTransformationTasksReturnValue
+  tm_mock.updateDBAfterTaskSubmission.return_value = tmMockUpdateDBAfterTaskSubmissionReturnValue
+  res = tmab.submitTasks( transIDOPBody, clients )
+  assert res['OK'] == expected
+
+
+
+
+### TransformationAgent
+
+
+ta_m = importlib.import_module( 'DIRAC.TransformationSystem.Agent.TransformationAgent' )
+ta_m.AgentModule = mockAM
+ta = TransformationAgent()
+ta.log = gLogger
+ta.am_getOption = mockAM
+
+goodFiles = {'OK':True,
+             'Value':[{'ErrorCount': 1L,
+                       'FileID': 17990660L,
+                       'InsertedTime': datetime.datetime( 2012, 3, 15, 17, 5, 50 ),
+                       'LFN': '/00012574_00000239_1.charmcompleteevent.dst',
+                       'LastUpdate': datetime.datetime( 2012, 3, 16, 23, 43, 26 ),
+                       'RunNumber': 90269L,
+                       'Status': 'Unused',
+                       'TargetSE': 'Unknown',
+                       'TaskID': '222',
+                       'TransformationID': 17042L,
+                       'UsedSE': 'CERN-DST,IN2P3-DST,PIC-DST,RAL-DST'},
+                      {'ErrorCount': 1L,
+                       'FileID': 17022945L,
+                       'InsertedTime': datetime.datetime( 2012, 3, 15, 17, 5, 50 ),
+                       'LFN': '/00012574_00000119_1.charmcompleteevent.dst',
+                       'LastUpdate': datetime.datetime( 2012, 3, 16, 23, 54, 59 ),
+                       'RunNumber': 90322L,
+                       'Status': 'Unused',
+                       'TargetSE': 'Unknown',
+                       'TaskID': '82',
+                       'TransformationID': 17042L,
+                       'UsedSE': 'CERN-DST,CNAF-DST,RAL-DST,SARA-DST'}]
+            }
+noFiles = {'OK':True, 'Value':[]}
+
+@pytest.mark.parametrize("transDict, getTFiles, expected",[
+    ({'TransformationID': 123, 'Status': 'Stopped', 'Type': 'Replication' }, goodFiles, True),
+    ({'TransformationID': 123, 'Status': 'Stopped', 'Type': 'Removal' }, noFiles, True)
+    ])
+def test__getTransformationFiles(transDict, getTFiles, expected):
+  tc_mock.getTransformationFiles.return_value = getTFiles
+  res = ta._getTransformationFiles( transDict, {'TransformationClient': tc_mock} )
+  assert res['OK'] == expected

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -599,7 +599,6 @@ class WorkflowTasks(TaskBase):
                                "%%(%s)s" % name,
                                name)
 
-
       for pName, seq in seqDict.iteritems():
         paramSeqDict.setdefault(pName, []).append(seq)
 
@@ -651,7 +650,6 @@ class WorkflowTasks(TaskBase):
                                      'string',
                                      '00000000',
                                      "Initial JOB_ID")
-
 
       paramsDict['Site'] = site
       paramsDict['JobType'] = jobType

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -109,8 +109,7 @@ class RequestTasks(TaskBase):
 
   def __init__(self, transClient=None, logger=None, requestClient=None,
                requestClass=None, requestValidator=None,
-               ownerDN=None, ownerGroup=None,
-               ):
+               ownerDN=None, ownerGroup=None):
     """ c'tor
 
         the requestClass is by default Request.
@@ -127,8 +126,7 @@ class RequestTasks(TaskBase):
     if not requestClient:
       self.requestClient = ReqClient(useCertificates=useCertificates,
                                      delegatedDN=ownerDN,
-                                     delegatedGroup=ownerGroup,
-                                     )
+                                     delegatedGroup=ownerGroup)
     else:
       self.requestClient = requestClient
 
@@ -332,8 +330,7 @@ class RequestTasks(TaskBase):
     """
     if isinstance(oRequest, self.requestClass):
       return self.requestClient.putRequest(oRequest, useFailoverProxy=False, retryMainService=2)
-    else:
-      return S_ERROR("Request should be a Request object")
+    return S_ERROR("Request should be a Request object")
 
   def updateTransformationReservedTasks(self, taskDicts):
     requestNameIDs = {}
@@ -424,8 +421,7 @@ class WorkflowTasks(TaskBase):
 
   def __init__(self, transClient=None, logger=None, submissionClient=None, jobMonitoringClient=None,
                outputDataModule=None, jobClass=None, opsH=None, destinationPlugin=None,
-               ownerDN=None, ownerGroup=None,
-               ):
+               ownerDN=None, ownerGroup=None):
     """ Generates some default objects.
         jobClass is by default "DIRAC.Interfaces.API.Job.Job". An extension of it also works:
         VOs can pass in their job class extension, if present
@@ -440,8 +436,7 @@ class WorkflowTasks(TaskBase):
     if not submissionClient:
       self.submissionClient = WMSClient(useCertificates=useCertificates,
                                         delegatedDN=ownerDN,
-                                        delegatedGroup=ownerGroup,
-                                        )
+                                        delegatedGroup=ownerGroup)
     else:
       self.submissionClient = submissionClient
 


### PR DESCRIPTION

BEGINRELEASENOTES

*TransformationSystem
CHANGE: re-written a large test as pytest (much less verbosity, plan to extend it)
FIX: added BulkSubmission option in documentation for WorkflowTaskAgent

ENDRELEASENOTES
