### PR TITLE
[v6r20] dirac-rms-request: fix check for FTSClient, silence error

### DIFF
--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -456,8 +456,12 @@ def printRequest(request, status=None, full=False, verbose=True, terse=False):
     if request.RequestID:
       from DIRAC.DataManagementSystem.Client.FTSClient import FTSClient
       ftsClient = FTSClient()
-  except Exception as e:
-    gLogger.debug("Could not instantiate FtsClient", repr(e))
+      res = ftsClient.ping()
+      if not res['OK']:
+        gLogger.debug("Could not instantiate FtsClient", res)
+        ftsClient = None
+  except ImportError as err:
+    gLogger.debug("Could not instantiate FtsClient because of Exception", repr(err))
 
   if full:
     output = ''


### PR DESCRIPTION
In the past the FTSClient instantiation would throw an exception, this is no longer the case, so we ping the service, which fails if it doesn't exist.

Otherwise we always get this error message:
> Failed getFTSJobsForRequest URL for service DataManagement/FTSManager not found

Note that the FTS3Client does not have the equivalent functionality as far as I could see

BEGINRELEASENOTES
*RMS
FIX: dirac-rms-request: silence a warning, when not using the old FTS Services

ENDRELEASENOTES
