### PR TITLE
[V6r20] Fixes for Glue2 at CERN and some other inconsistencies

### DIFF
--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -190,8 +190,14 @@ def __getGlue2ExecutionEnvironmentInfo(host, executionEnvironment):
   response = __ldapsearchBDII(filt=filt, attr=None, host=host, base="o=glue", selectionString="GLUE2")
   if not response['OK']:
     return response
-  if len(response['Value']) != 1:
-    return S_ERROR("Unexpected response for ExecutionEnvironment: %s" % response['Value'])
+  if not response['Value']:
+    return S_ERROR("No information found for %s" % executionEnvironment)
+  if len(response['Value']) > 1:
+    gLogger.info('SCHEMA ERROR: Multiple execution environments with the same ID: %s' % executionEnvironment)
+    gLogger.debug('Multiple results:\n %s' % pformat(response['Value']))
+    # only take the first one
+    response['Value'] = response['Value'][:1]
+
   gLogger.debug("Found ExecutionEnvironment %s:\n%s" % (executionEnvironment, pformat(response)))
   exeInfo = response['Value'][0]['attr']  # pylint: disable=unsubscriptable-object
   maxRam = exeInfo.get('GLUE2ExecutionEnvironmentMainMemorySize', '')

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -116,7 +116,14 @@ def __getGlue2ShareInfo(host, shareEndpoints, shareInfoDict, cesDict):
       continue
     exeInfo.append(resExeInfo['Value'])
   if not exeInfo:
-    return S_ERROR("Cannot get execution environment information")
+    gLogger.warn('Did not find information for execution environment %s, using dummy values' % executionEnvironments)
+    exeInfo = [{'GlueHostMainMemoryRAMSize': '1999',  # intentionally identifiably dummy value
+                'GlueHostOperatingSystemVersion': '',
+                'GlueHostOperatingSystemName': '',
+                'GlueHostOperatingSystemRelease': '',
+                'GlueHostArchitecturePlatformType': 'x86_64',
+                'MANAGER': '',
+                }]
   try:
     # take the CE with the lowest MainMemory
     exeInfo = sorted(exeInfo, key=lambda k: int(k['GlueHostMainMemoryRAMSize']))

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -1,6 +1,13 @@
-""" Module collecting functions dealing with the GLUE2 information schema
+"""Module collecting functions dealing with the GLUE2 information schema
 
 :author: A.Sailer
+
+Known problems:
+
+ * ARC CEs do not seem to publish wall or CPU time per queue anywhere
+ * There is no consistency between which memory information is provided where,
+   execution environment vs. information for a share
+ * Some execution environment IDs are used more than once
 
 """
 

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -9,6 +9,9 @@ Known problems:
    execution environment vs. information for a share
  * Some execution environment IDs are used more than once
 
+Print outs with "SCHEMA PROBLEM" point -- in my opinion -- to errors in the
+published information, like a foreign key pointing to non-existant entry.
+
 """
 
 from pprint import pformat
@@ -66,7 +69,7 @@ def getGlue2CEInfo(vo, host):
       gLogger.error("Could not get share information for %s: %s" % (shareID, shareRes['Message']))
       continue
     if not shareRes['Value']:
-      gLogger.warn("Did not not find any share information for %s" % (shareID, ))
+      gLogger.info("SCHEMA PROBLEM: Did not not find any share information for %s" % (shareID, ))
       continue
     siteDict.setdefault(siteName, {'CEs': {}})
     for shareInfo in shareRes['Value']:
@@ -119,7 +122,8 @@ def __getGlue2ShareInfo(host, shareEndpoints, shareInfoDict, cesDict):
   for executionEnvironment in executionEnvironments:
     resExeInfo = __getGlue2ExecutionEnvironmentInfo(host, executionEnvironment)
     if not resExeInfo['OK']:
-      gLogger.warn("Cannot get execution environment info for %r" % executionEnvironment, resExeInfo['Message'])
+      gLogger.info("SCHEMA PROBLEM: Cannot get execution environment info for %r" % executionEnvironment,
+                   resExeInfo['Message'])
       continue
     exeInfo.append(resExeInfo['Value'])
   if not exeInfo:
@@ -193,7 +197,7 @@ def __getGlue2ExecutionEnvironmentInfo(host, executionEnvironment):
   if not response['Value']:
     return S_ERROR("No information found for %s" % executionEnvironment)
   if len(response['Value']) > 1:
-    gLogger.info('SCHEMA ERROR: Multiple execution environments with the same ID: %s' % executionEnvironment)
+    gLogger.info('SCHEMA PROBLEM: Multiple execution environments with the same ID: %s' % executionEnvironment)
     gLogger.debug('Multiple results:\n %s' % pformat(response['Value']))
     # only take the first one
     response['Value'] = response['Value'][:1]


### PR DESCRIPTION

BEGINRELEASENOTES
*Core
FIX: The Glue2 parsing handles some common issues more gracefully
   * handle multiple execution environments at a single computing share (i.e., CERN)
   * handle multiple execution environments with the same ID (e.g., SARA)
   * handle cases where the execution environment just does not exist, use sensible dummy values in this case (many sites)

CHANGE: some print outs are prefixed with "SCHEMA PROBLEM", which seem to point to problems in the published information, i.e. keys pointing to non-existent entries, or non-unique IDs

ENDRELEASENOTES
