### PR TITLE
[v6r20] UserProxy contextManager, StorageManager, JobScheduling fix

### DIFF
--- a/Core/Utilities/Proxy.py
+++ b/Core/Utilities/Proxy.py
@@ -1,14 +1,14 @@
 """
-Utilities to execute a function with a given proxy.
+Utilities to execute one or more functions with a given proxy.
 
-executeWithUserProxy decorator example usage::
+:func:`executeWithUserProxy` decorator example usage::
 
   @executeWithUserProxy
-  def testFcn( x, i, kw = 'qwerty' ):
+  def testFcn(x, i, kw='qwerty'):
 
     print "args", x, i
     print "kwargs", kw
-    print os.environ.get( 'X509_USER_PROXY' )
+    print os.environ.get('X509_USER_PROXY')
     return S_OK()
 
   ...
@@ -16,7 +16,16 @@ executeWithUserProxy decorator example usage::
   result = testFcn( 1.0, 1, kw = 'asdfghj', proxyUserName = 'atsareg', proxyUserGroup = 'biomed_user' )
 
 
-UserProxy context manager example::
+:func:`executeWithUserProxy` function wrapper example::
+
+  def undecoratedFunction(foo='bar'):
+     print foo, os.environ.get('X509_USER_PROXY')
+     return S_OK()
+
+  executeWithUserProxy(testFcn)(foo='baz', proxyUserName='atsareg', proxyUserGroup='biomed_user')
+
+
+:class:`UserProxy` context manager example::
 
   with userProxy(proxyUserName='user', proxyUserGroup='group') as proxyResult:
     if proxyResult['OK']:
@@ -166,15 +175,7 @@ def executeWithoutServerCertificate( fcn ):
 
 
 class UserProxy(object):
-  """Implement a Context Manager to execute functions with a user proxy.
-
-  Example:
-
-    with UserProxy(proxyUserName='user', proxyUserGroup='group') as proxyResult:
-      if proxyResult['OK']:
-        functionThatNeedsAProxy()
-        anotherFunction()
-  """
+  """Implement a context manager to execute functions with a user proxy."""
 
   def __init__(self,
                proxyUserName=None,

--- a/Core/Utilities/Proxy.py
+++ b/Core/Utilities/Proxy.py
@@ -18,8 +18,9 @@ executeWithUserProxy decorator example usage::
 """
 
 import os
+from contextlib import contextmanager
 
-from DIRAC                                               import gConfig, gLogger, S_ERROR
+from DIRAC import gConfig, gLogger, S_ERROR, S_OK
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient     import gProxyManager
 from DIRAC.ConfigurationSystem.Client.ConfigurationData  import gConfigurationData
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry   import getVOMSAttributeForGroup, getDNForUsername
@@ -53,39 +54,19 @@ def executeWithUserProxy( fcn ):
     vomsFlag = kwargs.pop( 'proxyWithVOMS', True )
     proxyFilePath = kwargs.pop( 'proxyFilePath', False )
     executionLockFlag = kwargs.pop( 'executionLock', False )
-    if executionLockFlag:
-      executionLock = LockRing().getLock( '_UseUserProxy_', recursive = True )
 
     if ( userName or userDN ) and userGroup:
 
-      # Setup user proxy
-      originalUserProxy = os.environ.get( 'X509_USER_PROXY' )
-      if userDN:
-        userDNs = [userDN]
-      else:
-        result = getDNForUsername( userName )
-        if not result[ 'OK' ]:
-          return result
-        userDNs = result['Value']  # a same user may have more than one DN
-      vomsAttr = ''
-      if vomsFlag:
-        vomsAttr = getVOMSAttributeForGroup( userGroup )
-
-      result = getProxy( userDNs, userGroup, vomsAttr, proxyFilePath )
-
-      if not result['OK']:
-        return result
-
-      if executionLockFlag:
-        executionLock.acquire()
-
-      proxyFile = result['Value']
-      os.environ['X509_USER_PROXY'] = proxyFile
-
-      # Check if the caller is executing with the host certificate
-      useServerCertificate = gConfig.useServerCertificate()
-      if useServerCertificate:
-        gConfigurationData.setOptionInCFG( '/DIRAC/Security/UseServerCertificate', 'false' )
+      proxyResults = _putProxy(userName=userName,
+                               userDN=userDN,
+                               userGroup=userGroup,
+                               vomsFlag=vomsFlag,
+                               proxyFilePath=proxyFilePath,
+                               executionLockFlag=executionLockFlag,
+                               )
+      if not proxyResults['OK']:
+        return proxyResults
+      originalUserProxy, useServerCertificate, executionLock = proxyResults['Value']
 
       try:
         return fcn( *args, **kwargs )
@@ -94,16 +75,7 @@ def executeWithUserProxy( fcn ):
         exceptType = lException.__class__.__name__
         return S_ERROR( "Exception - %s: %s" % ( exceptType, value ) )
       finally:
-        # Restore the default host certificate usage if necessary
-        if useServerCertificate:
-          gConfigurationData.setOptionInCFG( '/DIRAC/Security/UseServerCertificate', 'true' )
-        if originalUserProxy:
-          os.environ['X509_USER_PROXY'] = originalUserProxy
-        else:
-          os.environ.pop( 'X509_USER_PROXY' )
-        if executionLockFlag:
-          executionLock.release()
-
+        _restoreProxyState(originalUserProxy, useServerCertificate, executionLock)
     else:
       # No proxy substitution requested
       return fcn( *args, **kwargs )
@@ -183,3 +155,102 @@ def executeWithoutServerCertificate( fcn ):
       executionLock.release()
 
   return wrapped_fcn
+
+
+@contextmanager
+def userProxy(proxyUserName=None,
+              proxyUserGroup=None,
+              proxyUserDN=None,
+              proxyWithVOMS=True,
+              proxyFilePath=None,
+              executionLock=False,
+              ):
+  """Execute a block with a user proxy.
+
+  Example:
+
+    with userProxy(proxyUserName='user', proxyUserGroup='group') as proxyResult:
+      if proxyResult['OK']:
+        functionThatNeedsAProxy()
+
+  :param str proxyUserName: the user name of the proxy to be used
+  :param str proxyUserGroup: the user group of the proxy to be used
+  :param str proxyUserDN: the user DN of the proxy to be used
+  :param bool proxyWithVOMS: optional flag to dress or not the user proxy with VOMS extension ( default True )
+  :param str proxyFilePath: optional file location for the temporary proxy
+  :param bool executionLock: flag to execute with a lock for the time of user proxy application ( default False )
+  """
+  if not ((proxyUserName or proxyUserDN) and proxyUserGroup):
+    yield S_OK()
+  else:  # Setup user proxy
+    proxyResults = _putProxy(userDN=proxyUserDN,
+                             userName=proxyUserName,
+                             userGroup=proxyUserGroup,
+                             vomsFlag=proxyWithVOMS,
+                             executionLockFlag=executionLock,
+                             proxyFilePath=proxyFilePath,
+                             )
+    if not proxyResults['OK']:
+      returnValue = proxyResults
+      originalUserProxy, useServerCertificate, executionLock = None, None, None
+    else:
+      returnValue = S_OK()
+      originalUserProxy, useServerCertificate, executionLock = proxyResults['Value']
+
+    try:
+      yield returnValue
+    finally:
+      if returnValue['OK']:
+        _restoreProxyState(originalUserProxy, useServerCertificate, executionLock)
+
+
+def _putProxy(userDN=None, userName=None, userGroup=None, vomsFlag=None, proxyFilePath=None, executionLockFlag=False):
+  """Download proxy, place in a file and populate X509_USER_PROXY environment variable.
+
+  Parameters like `userProxy` or `executeWithUserProxy`.
+  :returns: Tuple of originalUserProxy, useServerCertificate, executionLock
+  """
+  # Setup user proxy
+  if userDN:
+    userDNs = [userDN]
+  else:
+    result = getDNForUsername(userName)
+    if not result['OK']:
+      return result
+    userDNs = result['Value']  # a same user may have more than one DN
+    vomsAttr = ''
+    if vomsFlag:
+      vomsAttr = getVOMSAttributeForGroup(userGroup)
+
+    result = getProxy(userDNs, userGroup, vomsAttr, proxyFilePath)
+
+    if not result['OK']:
+      return result
+
+    executionLock = LockRing().getLock('_UseUserProxy_', recursive=True) if executionLockFlag else None
+    if executionLockFlag:
+      executionLock.acquire()
+
+    os.environ['X509_USER_PROXY'], originalUserProxy = result['Value'], os.environ.get('X509_USER_PROXY')
+
+    # Check if the caller is executing with the host certificate
+    useServerCertificate = gConfig.useServerCertificate()
+    if useServerCertificate:
+      gConfigurationData.setOptionInCFG('/DIRAC/Security/UseServerCertificate', 'false')
+
+  return S_OK((originalUserProxy, useServerCertificate, executionLock))
+
+
+def _restoreProxyState(originalUserProxy=None, useServerCertificate=None, executionLock=None):
+  """Restore the default host certificate and proxy state if necessary.
+
+  Parameters like the output from `_putProxy`.
+  """
+  if useServerCertificate:
+    gConfigurationData.setOptionInCFG('/DIRAC/Security/UseServerCertificate', 'true')
+  if originalUserProxy:
+    os.environ['X509_USER_PROXY'] = originalUserProxy
+  else:
+    os.environ.pop('X509_USER_PROXY', None)
+  if executionLock:
+    executionLock.release()


### PR DESCRIPTION

I realise this is a lot of refactoring changes for a patch, and I want to test this more thoroughly, but I put it here now for discussion.

BEGINRELEASENOTES

*CORE
NEW: New Core.Utilities.Proxy.UserProxy class to be used as a contextManager
FIX: Fix race condition in Core.Utilities.Proxy.executeWithUserProxy, the $X509_USER_PROXY environment variable from one thread could leak to another, fixes #3764

*SMS:
FIX: Fix setting of the user proxy for StorageElement.getFileMetadata calls, fixes #3764

*WMS
FIX: The solution for bug #3764 fixes a problem with the JobScheduling executor, where files could end up in the checking state with the error "Couldn't get storage metadata of some files"

ENDRELEASENOTES
