### PR TITLE
[v6r20] Fix FTS3 multi-VO support

### DIFF
--- a/DataManagementSystem/Client/FTS3Operation.py
+++ b/DataManagementSystem/Client/FTS3Operation.py
@@ -171,7 +171,7 @@ class FTS3Operation(FTS3Serializable):
     return toSubmit
 
   @staticmethod
-  def _checkSEAccess(seName, accessType):
+  def _checkSEAccess(seName, accessType, vo=None):
     """Check the Status of a storage element
         :param seName: name of the StorageElement
         :param accessType ReadAccess, WriteAccess,CheckAccess,RemoveAccess
@@ -185,7 +185,7 @@ class FTS3Operation(FTS3Serializable):
     # if access["Value"][seName][accessType] not in ( "Active", "Degraded" ):
     #   return S_ERROR( "%s does not have %s in Active or Degraded" % ( seName, accessType ) )
 
-    status = StorageElement(seName).getStatus()
+    status = StorageElement(seName, vo=vo).getStatus()
     if not status['OK']:
       return status
 
@@ -381,7 +381,7 @@ class FTS3TransferOperation(FTS3Operation):
 
     for targetSE, ftsFiles in filesGroupedByTarget.iteritems():
 
-      res = self._checkSEAccess(targetSE, 'WriteAccess')
+      res = self._checkSEAccess(targetSE, 'WriteAccess', vo=self.vo)
 
       if not res['OK']:
         log.error(res)
@@ -511,7 +511,7 @@ class FTS3StagingOperation(FTS3Operation):
 
     for targetSE, ftsFiles in filesGroupedByTarget.iteritems():
 
-      res = self._checkSEAccess(targetSE, 'ReadAccess')
+      res = self._checkSEAccess(targetSE, 'ReadAccess', vo=self.vo)
       if not res['OK']:
         log.error(res)
         continue


### PR DESCRIPTION
Hi,

While testing the FTS3 stuff, we kept getting the error:
```
2018-08-01 13:05:15 UTC DataManagement/FTS3Agent WARN: No VO information available
2018-08-01 13:05:15 UTC DataManagement/FTS3Agent/1/req_4/op_4/_prepareNewJobs ERROR: {'Errno': 13, 'Message': 'Permission denied ( 13 : StorageElement.isValid: StorageElement is not allowed for VO)', 'OK': False, 'CallStack': ['  File "/opt/dirac/Linux_x86_64_glibc-2.12/lib/python2.7/threading.py", line 774, in __bootstrap\n    self.__bootstrap_inner()\n', '  File "/opt/dirac/Linux_x86_64_glibc-2.12/lib/python2.7/threading.py", line 801, in __bootstrap_inner\n    self.run()\n', '  File "/opt/dirac/Linux_x86_64_glibc-2.12/lib/python2.7/threading.py", line 754, in run\n    self.__target(*self.__args, **self.__kwargs)\n', '  File "/opt/dirac/Linux_x86_64_glibc-2.12/lib/python2.7/multiprocessing/pool.py", line 113, in worker\n    result = (True, func(*args, **kwds))\n', '  File "/opt/dirac/DIRAC/DataManagementSystem/Agent/FTS3Agent.py", line 296, in _treatOperation\n    maxFilesPerJob=self.maxFilesPerJob, maxAttemptsPerFile=self.maxAttemptsPerFile)\n', '  File "/opt/dirac/DIRAC/DataManagementSystem/Client/FTS3Operation.py", line 383, in prepareNewJobs\n    res = self._checkSEAccess(targetSE, \'WriteAccess\')\n', '  File "/opt/dirac/DIRAC/DataManagementSystem/Client/FTS3Operation.py", line 187, in _checkSEAccess\n    status = StorageElement(seName).getStatus()\n', '  File "/opt/dirac/DIRAC/Resources/Storage/StorageElement.py", line 326, in getStatus\n    valid = self.isValid()\n', '  File "/opt/dirac/DIRAC/Resources/Storage/StorageElement.py", line 449, in isValid\n    return S_ERROR(errno.EACCES, "StorageElement.isValid: StorageElement is not allowed for VO")\n']}
```

This patch sets the VO name, which seems to fix the problem.

Regards,
Simon

BEGINRELEASENOTES
*DataManagementSystem
FIX: Fix FTS3 multi-VO support by setting VO name in SE constructor.
ENDRELEASENOTES
