### PR TITLE
add setting of X509_USER_PROXY in pilot wrapper script

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -122,6 +122,9 @@ logger.info("Launching dirac-pilot script from %%s" %%os.getcwd())
 logger.info("But first unpacking pilot files")
 %(mString)s
 
+# add X509_USER_PROXY to etablish pilot env in Cluster WNs 
+os.environ["X509_USER_PROXY"] = os.path.join(pilotWorkingDirectory, 'proxy')
+
 # now finally launching the pilot script (which should be called dirac-pilot.py)
 cmd = "python dirac-pilot.py %(pilotOptions)s"
 logger.info('Executing: %%s' %% cmd)

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -122,7 +122,7 @@ logger.info("Launching dirac-pilot script from %%s" %%os.getcwd())
 logger.info("But first unpacking pilot files")
 %(mString)s
 
-# add X509_USER_PROXY to etablish pilot env in Cluster WNs 
+# add X509_USER_PROXY to etablish pilot env in Cluster WNs
 os.environ["X509_USER_PROXY"] = os.path.join(pilotWorkingDirectory, 'proxy')
 
 # now finally launching the pilot script (which should be called dirac-pilot.py)


### PR DESCRIPTION
BEGINRELEASENOTES

*WorkloadManagement system
FIX: Add setting of X509_USER_PROXY in pilot wrapper script, which is needed to establish pilot env in work nodes of Cluster sites.

ENDRELEASENOTES
