### PR TITLE
[v6r20] Add missing RegisterReplica Operation for RMS

### DIFF
--- a/RequestManagementSystem/ConfigTemplate.cfg
+++ b/RequestManagementSystem/ConfigTemplate.cfg
@@ -60,6 +60,13 @@ Agents
         MaxAttempts = 256
         TimeOutPerFile = 600
       }
+      RegisterReplica
+      {
+        Location = DIRAC/DataManagementSystem/Agent/RequestOperations/RegisterReplica
+        LogLevel = INFO
+        MaxAttempts = 256
+        TimeOutPerFile = 120
+      }
       RemoveReplica
       {
         Location = DIRAC/DataManagementSystem/Agent/RequestOperations/RemoveReplica


### PR DESCRIPTION
I just copied the default setting from RemoveReplica, so that might not be correct, it does work though.
BEGINRELEASENOTES
*DMS
FIX: Added template for RegisterReplica
ENDRELEASENOTES