### PR TITLE
[v6r20] RSS: try/except for OperationalError for sqlite

### DIFF
--- a/ResourceStatusSystem/PolicySystem/Actions/EmailAction.py
+++ b/ResourceStatusSystem/PolicySystem/Actions/EmailAction.py
@@ -5,14 +5,14 @@
 
 '''
 
+__RCSID__ = '$Id$'
+
 import os
 import sqlite3
 from DIRAC import S_ERROR, S_OK
 from DIRAC.ResourceStatusSystem.PolicySystem.Actions.BaseAction import BaseAction
 from DIRAC.Core.Utilities.SiteSEMapping import getSitesForSE
 from DIRAC.Core.Utilities.SiteCEMapping import getSiteForCE
-
-__RCSID__ = '$Id:  $'
 
 
 class EmailAction(BaseAction):
@@ -29,7 +29,7 @@ class EmailAction(BaseAction):
     else:
       self.cacheFile = os.path.realpath('cache.db')
 
-  def run( self ):
+  def run(self):
     ''' Checks it has the parameters it needs and writes the date to a cache file.
     '''
     # Minor security checks
@@ -90,15 +90,14 @@ class EmailAction(BaseAction):
                       Time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                      );''')
 
+        conn.execute("INSERT INTO ResourceStatusCache (SiteName, ResourceName, Status, PreviousStatus, StatusType)"
+                     " VALUES ('" + siteName + "', '" + name + "', '" + status +
+                     "', '" + previousStatus + "', '" + statusType + "' ); ")
+
+        conn.commit()
+
       except sqlite3.OperationalError:
         self.log.error('Email cache database is locked')
-
-      conn.execute("INSERT INTO ResourceStatusCache (SiteName, ResourceName, Status, PreviousStatus, StatusType)"
-                   " VALUES ('" + siteName + "', '" + name + "', '" + status +
-                   "', '" + previousStatus + "', '" + statusType + "' ); "
-                  )
-
-      conn.commit()
 
     return S_OK()
 


### PR DESCRIPTION
I will remove these sqlite DBs in favor of simply using MySQL: https://github.com/DIRACGrid/DIRAC/issues/3781


BEGINRELEASENOTES

*RSS
FIX: try/except for OperationalError for sqlite (EmailAction)

ENDRELEASENOTES
