### PR TITLE
[v6r20] Bdii2CSAgent: add SelectedSites option, only update information for SelectedSites

### DIFF
--- a/ConfigurationSystem/ConfigTemplate.cfg
+++ b/ConfigurationSystem/ConfigTemplate.cfg
@@ -21,6 +21,7 @@ Agents
   {
     BannedCEs =
     BannedSEs =
+    SelectedSites =
     ProcessCEs = yes
     ProcessSEs = no
     MailTo =


### PR DESCRIPTION

BEGINRELEASENOTES
*Configuration
NEW: Bdii2CSAgent: New option **SelectedSites**, if any sites are set, only those will be updated

ENDRELEASENOTES

(I have some CEs that belong to different "sites" in the BDII, but the same DiracSite so I cannot use getDIRACSiteName from the GOCDB sitemapping)

Todo:
- [ ] Agent option documentation, literalinclude or not literalinclude...