### PR TITLE
[v6r20] Adjust voms-proxy-init command timeouts

### DIFF
--- a/Core/Security/VOMS.py
+++ b/Core/Security/VOMS.py
@@ -19,6 +19,13 @@ from DIRAC.Core.Utilities import List, Time, Os
 
 class VOMS(BaseSecurity):
 
+  def __init__(self, timeout=40, *args, **kwargs):
+    """ Create VOMS class, setting specific timeout for VOMS shell commands. """
+    # Per-server timeout for voms-proxy-init, should be at maximum timeout/n
+    # where n as the number of voms servers to try.
+    self._servTimeout = 12
+    super(VOMS, self).__init__(timeout, *args, **kwargs)
+
   def getVOMSAttributes(self, proxy, switch="all"):
     """
     Return VOMS proxy attributes as list elements if switch="all" (default) OR
@@ -268,6 +275,7 @@ class VOMS(BaseSecurity):
       cmdArgs.append('-vomses "%s"' % vomsesPath)
     if chain.isRFC().get('Value'):
       cmdArgs.append("-r")
+    cmdArgs.append('-timeout %u' % self._servTimeout)
 
     vpInitCmd = ''
     for vpInit in ('voms-proxy-init', 'voms-proxy-init2'):


### PR DESCRIPTION
Hi,

We found that when one VOMS server is down, the failover within voms-proxy-init doesn't work. It seems to generally have a timeout for a single server which is longer than the 30 second timeout which DIRAC set s on the whole command (so it doesn't try the second server).  (In most cases, DIRAC will run the command again a few minutes later and due to the random server selection in voms, it generally will eventually get a proxy, it's just not very efficient).

This patch increases the timeout for the voms-proxy-init command in DIRAC to 40 seconds and sets the individual timeout for each server in voms-proxy-init to 12 seconds, so it can try at least three servers before the hard limit is reached.

Regards,
Simon

BEGINRELEASENOTES
*Core
FIX: Adjust voms-proxy-init timeouts
ENDRELEASENOTES
