### PR TITLE
[v6r20] TaskQueueDB: fix exception in getActiveTaskQueues

### DIFF
--- a/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -1029,7 +1029,7 @@ WHERE j.JobId = %s AND t.TQId = j.TQId" %
         tqId = record[0]
         value = record[1]
         if tqId not in tqData:
-          if tqIdList is False or tqId in tqIdList:
+          if tqIdList is None or tqId in tqIdList:
             self.log.warn(
                 "Task Queue %s is defined in field %s but does not exist, triggering a cleaning" %
                 (tqId, field))


### PR DESCRIPTION
tpIdList's default value is now `None`
```
Exception:
Traceback (most recent call last):
  File /opt/dirac/pro/DIRAC/Core/DISET/RequestHandler.py, line 270, in __RPCCallFunction
    uReturnValue = oMethod(*args)
  File /opt/dirac/pro/DIRAC/WorkloadManagementSystem/Service/MatcherHandler.py, line 112, in export_getActiveTaskQueues
    return gTaskQueueDB.retrieveTaskQueues()
  File /opt/dirac/pro/DIRAC/WorkloadManagementSystem/DB/TaskQueueDB.py, line 1032, in retrieveTaskQueues
    if tqIdList is False or tqId in tqIdList:
TypeError: argument of type 'NoneType' is not iterable
```

BEGINRELEASENOTES

*WMS
FIX: Fix exception in TaskQueueDB.getActiveTaskQueues, triggered by dirac-admin-show-task-queues

ENDRELEASENOTES
