### PR TITLE
[v6r20] add replication transformation groupname

### DIFF
--- a/TransformationSystem/Utilities/ReplicationCLIParameters.py
+++ b/TransformationSystem/Utilities/ReplicationCLIParameters.py
@@ -14,6 +14,7 @@ class Params(object):
     self.targetSE = []
     self.sourceSE = ''
     self.groupSize = 1
+    self.groupName = None
     self.extraname = ''
     self.flavour = 'Replication'
     self.plugin = 'Broadcast'
@@ -64,6 +65,10 @@ class Params(object):
       return S_ERROR("Expected integer for groupsize")
     return S_OK()
 
+  def setGroupName(self, name):
+    self.groupName = name
+    return S_OK()
+
   def setPlugin(self, plugin):
     self.plugin = plugin
     return S_OK()
@@ -80,6 +85,7 @@ class Params(object):
     """
 
     script.registerSwitch("G:", "GroupSize=", "Number of Files per transformation task", self.setGroupSize)
+    script.registerSwitch("R:", "GroupName=", "TransformationGroup Name", self.setGroupName)
     script.registerSwitch("S:", "SourceSEs=", "SourceSE(s) to use, comma separated list", self.setSourceSE)
     script.registerSwitch("N:", "Extraname=", "String to append to transformation name", self.setExtraname)
     script.registerSwitch("P:", "Plugin=", "Plugin to use for transformation", self.setPlugin)

--- a/TransformationSystem/Utilities/ReplicationTransformation.py
+++ b/TransformationSystem/Utilities/ReplicationTransformation.py
@@ -58,7 +58,7 @@ def createDataTransformation(flavour, targetSE, sourceSE,
   trans.setDescription(description)
   trans.setLongDescription(description)
   trans.setType('Replication')
-  trans.setGroup(transGroup)
+  trans.setTransformationGroup(transGroup)
   trans.setGroupSize(groupSize)
   trans.setPlugin(plugin)
 

--- a/TransformationSystem/scripts/dirac-transformation-replication.py
+++ b/TransformationSystem/scripts/dirac-transformation-replication.py
@@ -30,6 +30,7 @@ def _createTrafo():
                                          extraData=clip.extraData,
                                          extraname=clip.extraname,
                                          groupSize=clip.groupSize,
+                                         tGroup=clip.groupName,
                                          plugin=clip.plugin,
                                          enable=clip.enable,
                                          )


### PR DESCRIPTION

BEGINRELEASENOTES

*TS
NEW: new option for dirac-transformation-replication scrip `--GroupName/-R`
FIX: The TransformationGroup is now properly set for transformation created with dirac-transformation-replication, previously a transformation parameter Group was created instead.


ENDRELEASENOTES
