### PR TITLE
[v6r20] GLUE2: add 2500 for SI00 benchmark

### DIFF
--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -133,6 +133,7 @@ def __getGlue2ShareInfo(host, shareEndpoints, shareInfoDict, cesDict):
                 'GlueHostOperatingSystemName': '',
                 'GlueHostOperatingSystemRelease': '',
                 'GlueHostArchitecturePlatformType': 'x86_64',
+                'GlueHostBenchmarkSI00': '2500',  # needed for the queue to be used by the sitedirector
                 'MANAGER': '',
                 }]
   try:
@@ -218,6 +219,7 @@ def __getGlue2ExecutionEnvironmentInfo(host, executionEnvironment):
               'GlueHostOperatingSystemName': osFamily,
               'GlueHostOperatingSystemRelease': osVersion,
               'GlueHostArchitecturePlatformType': architecture,
+              'GlueHostBenchmarkSI00': '2500',  # needed for the queue to be used by the sitedirector
               'MANAGER': manager,  # to create the ARC QueueName mostly
              }
 


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: Glue2 will return a constant 2500 for the SI00 queue parameter, any value is needed so that the SiteDirector does not ignore the queue, fixes #3790 

ENDRELEASENOTES
