### PR TITLE
[v6r20] Fix in the pilot wrapper generation

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -128,6 +128,10 @@ logger.info("Launching dirac-pilot script from %%s" %%os.getcwd())
 logger.info("But first unpacking pilot files")
 %(mString)s
 
+# Checking that the proxy is in the pilot bundle
+if os.path.isfile('proxy'):
+  os.environ["X509_USER_PROXY"] = os.path.join(pilotWorkingDirectory, 'proxy')
+
 # now finally launching the pilot script (which should be called dirac-pilot.py)
 cmd = "python dirac-pilot.py %(pilotOptions)s"
 logger.info('Executing: %%s' %% cmd)


### PR DESCRIPTION
After the rearrangement of the pilot wrapper generation code the case when the pilot proxy is bundled together with the pilot wrapper was not treated. This PR restores it.

BEGINRELEASENOTES

*WMS
FIX: PilotWrapper - restored setting X509_USER_PROXY in case of adding the pilot proxy into the bundle

ENDRELEASENOTES
