### PR TITLE
getLocalSitesForSE not to crash with a stray SE

### DIFF
--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -309,6 +309,8 @@ class DMSHelpers(object):
     sites = [site for site in mapping if se in mapping[site]]
     if len(sites) > 1 and self.__opsHelper.getValue('DataManagement/ForceSingleSitePerSE', True):
       return S_ERROR('SE is at more than one site')
+    if len(sites) == 0:
+      return S_ERROR('SE does not belong to any site')
     return S_OK(sites)
 
   def getProtocolSitesForSE(self, se):


### PR DESCRIPTION
Just to avoid to have getLocalSitesForSE crashing when the specified SE does not belong to a site.
Don't ask why we have such a SE...

BEGINRELEASENOTES

*DataManagementSystem
FIX: getLocalSitesForSE not to crash when the specified SE does not belong to a site 

ENDRELEASENOTES
