### PR TITLE
[v6r20] Fix in the replica report

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/SEManager.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SEManager.py
@@ -177,7 +177,11 @@ class SEManagerDB( SEManagerBase ):
       self.db.seDefinitions[seID]['LastUpdate'] = 0.
 
     # We have to refresh the SE definition from the CS
-    result = gConfig.getOptionsDict( '/Resources/StorageElements/%s/AccessProtocol.1' % se )
+    result = gConfig.getSections('/Resources/StorageElements/%s' % se)
+    if not result['OK']:
+      return result
+    pluginSection = result['Value'][0]
+    result = gConfig.getOptionsDict('/Resources/StorageElements/%s/%s' % (se, pluginSection))
     if not result['OK']:
       return result
     seDict = result['Value']

--- a/Resources/Catalog/FileCatalogClient.py
+++ b/Resources/Catalog/FileCatalogClient.py
@@ -111,7 +111,7 @@ class FileCatalogClient(FileCatalogClientBase):
     result = rpcClient.getReplicas(lfns, allStatus)
     if not result['OK']:
       return result
-    vo = getVOfromProxyGroup().get( 'Value', None )
+    vo = getVOfromProxyGroup().get('Value', None)
 
     lfnDict = result['Value']
     seDict = result['Value'].get('SEPrefixes', {})

--- a/Resources/Catalog/FileCatalogClient.py
+++ b/Resources/Catalog/FileCatalogClient.py
@@ -118,11 +118,13 @@ class FileCatalogClient(FileCatalogClientBase):
     for lfn in lfnDict['Successful']:
       for se in lfnDict['Successful'][lfn]:
         if not lfnDict['Successful'][lfn][se]:
+          # The PFN was not returned, construct it on the fly
           # For some VO's the prefix can be non-standard
-          if "VOPrefix" in seDict and se in seDict['VOPrefix'] and vo in seDict['VOPrefix'][se]:
-            lfnDict['Successful'][lfn][se] = seDict['VOPrefix'][se][vo] + lfn
-          elif se in seDict:
-            lfnDict['Successful'][lfn][se] = seDict[se] + lfn
+          voPrefix = seDict.get("VOPrefix", {}).get(se, {}).get(vo)
+          sePrefix = seDict.get(se)
+          prefix = voPrefix if voPrefix else sePrefix
+          if prefix:
+            lfnDict['Successful'][lfn][se] = prefix + lfn
 
     return S_OK(lfnDict)
 

--- a/docs/source/AdministratorGuide/Resources/Storage/index.rst
+++ b/docs/source/AdministratorGuide/Resources/Storage/index.rst
@@ -14,14 +14,27 @@ DIRAC provides an abstraction of a SE interface that allows to access different 
       WriteAccess = Active
       AccessProtocol.1
       {
+        # The name of the DIRAC Plugin module to be used for implementation
+        # of the access protocol
         PluginName = SRM2
+        # Flag specifying the access type (local/remote)
         Access = remote
+        # Protocol name
         Protocol = srm
+        # Host endpoint
         Host = srm-lhcb.cern.ch
         Port = 8443
+        # WSUrl part of the SRM-type PFNs
         WSUrl = /srm/managerv2?SFN=
+        # Path to navigate to the VO namespace on the storage
         Path = /castor/cern.ch/grid
+        # SRM space token
         SpaceToken = LHCb_USER
+        # VO specific path definitions
+        VOPath
+        {
+          biomed = /castor/cern.ch/biomed/grid
+        }
       }
     }
 
@@ -39,6 +52,14 @@ Configuration options are:
 * `CheckAccess`: default `True`. Allowed for Check if no RSS enabled
 * `RemoveAccess`: default `True`. Allowed for Remove if no RSS enabled
 
+VO specific paths
+^^^^^^^^^^^^^^^^^
+
+Storage Elements supporting multiple VO's can have definitions slightly differing with respect
+to the `Path` used to navigate to the VO specific namespace in the physical storage. If a generic
+`Path` can not be suitable for all the allowed VO's a `VOPath` section can be added to the Plugin
+definition section as shown in the example above. In this section a specific `Path` can be defined for
+each VO which needs it.
 
 
 -------------------


### PR DESCRIPTION
After changing the meaning of the plugin section name, the SE information was not properly
evaluated by the SEManager of the File Catalog. This PR fixes it. It also takes properly into account the possible definitions of VO specific paths when constructing PFNs on the fly in the getReplicas() client method, this fixes the PFNs reported by dls -L or similar commands.

BEGINRELEASENOTES

*DMS
FIX: SEManager - adapt to the new meaning of the SE plugin section name
FIX: SEManager - return also VO specific prefixes for the getReplicas() and similar calls
FIX: FileCatalogClient - take into account VO specific prefixes when constructing PFNs on the fly

ENDRELEASENOTES
