### PR TITLE
[v6r20] VOMS2CS: fix voChanged flag, bring back notification emails

### DIFF
--- a/ConfigurationSystem/Agent/VOMS2CSAgent.py
+++ b/ConfigurationSystem/Agent/VOMS2CSAgent.py
@@ -25,7 +25,6 @@ class VOMS2CSAgent(AgentModule):
     super(VOMS2CSAgent, self).__init__(*args, **kwargs)
 
     self.voList = []
-    self.voChanged = False
     self.dryRun = False
 
     self.autoAddUsers = False
@@ -63,7 +62,6 @@ class VOMS2CSAgent(AgentModule):
   def execute(self):
 
     for vo in self.voList:
-      self.voChanged = False
       voAdminUser = getVOOption(vo, "VOAdmin")
       voAdminMail = None
       if voAdminUser:
@@ -94,6 +92,7 @@ class VOMS2CSAgent(AgentModule):
       susUsers = resultDict.get("SuspendedUsers", [])
       csapi = resultDict.get("CSAPI")
       adminMessages = resultDict.get("AdminMessages", {'Errors': [], 'Info': []})
+      voChanged = resultDict.get("VOChanged", False)
       self.log.info("Run user results: new %d, modified %d, deleted %d, new/suspended %d" %
                     (len(newUsers), len(modUsers), len(delUsers), len(susUsers)))
 
@@ -129,7 +128,7 @@ class VOMS2CSAgent(AgentModule):
           for user in result['Value']['Successful']:
             adminMessages['Info'].append("Created home directory for user %s" % user)
 
-      if self.voChanged or self.detailedReport:
+      if voChanged or self.detailedReport:
         mailMsg = ""
         if adminMessages['Errors']:
           mailMsg += "\nErrors list:\n  %s" % "\n  ".join(adminMessages['Errors'])

--- a/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -127,6 +127,7 @@ class VOMS2CSSynchronizer(object):
     self.autoModifyUsers = autoModifyUsers
     self.autoAddUsers = autoAddUsers
     self.autoDeleteUsers = autoDeleteUsers
+    self.voChanged = False
 
   def syncCSWithVOMS(self):
     """ Performs the synchronization of the DIRAC registry with the VOMS data. The resulting
@@ -379,6 +380,7 @@ class VOMS2CSSynchronizer(object):
 
     resultDict['CSAPI'] = self.csapi
     resultDict['AdminMessages'] = self.adminMsgs
+    resultDict['VOChanged'] = self.voChanged
     return S_OK(resultDict)
 
   def getVOUserData(self, refreshFlag=False):

--- a/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -375,7 +375,8 @@ class VOMS2CSSynchronizer(object):
           self.adminMsgs['Errors'].append('Error in deleting users from CS:\n  %s' % str(oldUsers))
           self.log.error('Error while user deletion from CS', result)
       else:
-        self.adminMsgs['Info'].append('The following users to be checked for deletion:\n  %s' % str(oldUsers))
+        self.adminMsgs['Info'].append('The following users to be checked for deletion:\n\t%s' %
+                                      "\n\t".join(sorted(oldUsers)))
         self.log.info('The following users to be checked for deletion: %s' % str(oldUsers))
 
     resultDict['CSAPI'] = self.csapi


### PR DESCRIPTION

BEGINRELEASENOTES

*CS
FIX: The VOMS2CSAgent was not sending notification emails when the DetailedReport option was set to False, it will now send emails again when things change for a VO.
CHANGE: VOMS2CSAgent: Users to be checked for deletion are now printed sorted and line by line

ENDRELEASENOTES
