### PR TITLE
[v6r20] add dirac-admin-check-config-options script

### DIFF
--- a/ConfigurationSystem/scripts/dirac-admin-check-config-options.py
+++ b/ConfigurationSystem/scripts/dirac-admin-check-config-options.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python
+"""Check configuration options against the defaults in the ConfigTemplate.cfg files.
+
+This script can help to discover discrepancies in the configuration:
+
+  - Typos in option names
+  - Removed options
+  - Missing authorization settings
+
+This script should be run by dirac administrators after major updates.
+
+"""
+
+__RCSID__ = "$Id$"
+
+import os
+from pprint import pformat
+
+from DIRAC import gLogger, S_ERROR, S_OK, gConfig
+from DIRAC.Core.Base import Script
+from DIRAC.Core.Utilities.CFG import CFG
+from DIRAC.Core.Utilities.List import fromChar
+
+LOG = gLogger
+
+
+class CheckConfig(object):
+  """Compare the ConfigTemplate with current configuration."""
+
+  def __init__(self):
+    self.systems = None
+    self.showModified = False
+    self.showAdded = False
+    self.showMissingSections = False
+    self.showMissingOptions = False
+
+  def _setSystems(self, val):
+    self.systems = fromChar(val)
+    return S_OK()
+
+  def _setShowModified(self, _):
+    self.showModified = True
+    return S_OK()
+
+  def _setShowAdded(self, _):
+    self.showAdded = True
+    return S_OK()
+
+  def _setShowMissingSections(self, _):
+    self.showMissingSections = True
+    return S_OK()
+
+  def _setShowMissingOptions(self, _):
+    self.showMissingOptions = True
+    return S_OK()
+
+  def _setSwitches(self):
+    Script.registerSwitch("S:", "system=", "Systems to check, by default all of them are checked", self._setSystems)
+    Script.registerSwitch("M", "modified", "Show entries which differ from the default", self._setShowModified)
+    Script.registerSwitch("A", "added", "Show entries which do not exist in ConfigTemplate", self._setShowAdded)
+    Script.registerSwitch("U", "missingSection", "Show sections which do not exist in the current configuration",
+                          self._setShowMissingSections)
+    Script.registerSwitch("O", "missingOption", "Show options which do not exist in the current configuration",
+                          self._setShowMissingOptions)
+
+    Script.setUsageMessage('\n'.join([self.__doc__,
+                                      'Usage:',
+                                      '  %s [option|cfgfile] -[MAUO] [-S <system]' % Script.scriptName]))
+    Script.parseCommandLine(ignoreErrors=True)
+    if not any([self.showModified, self.showAdded, self.showMissingSections, self.showMissingOptions]):
+      LOG.error("\nERROR: Set at least one of the flags M A U O")
+      Script.showHelp()
+
+  def _check(self):
+    """Obtain default configuration and current configuration and print the diff."""
+    cfg = CFG()
+    templateLocations = self._findConfigTemplates()
+    for templatePath in templateLocations:
+      cfgRes = self._parseConfigTemplate(templatePath, cfg)
+      if cfgRes['OK']:
+        cfg = cfgRes['Value']
+
+    currentCfg = self._getCurrentConfig()
+    if not currentCfg['OK']:
+      return
+    currentCfg = currentCfg['Value']
+    diff = currentCfg.getModifications(cfg, ignoreOrder=True, ignoreComments=True)
+
+    LOG.debug("*" * 80)
+    LOG.debug("Default Configuration: %s" % str(cfg))
+    LOG.debug("*" * 80)
+    LOG.debug("Current Configuration: %s " % str(currentCfg))
+    for entry in diff:
+      self._printDiff(entry)
+
+  def _parseConfigTemplate(self, templatePath, cfg=None):
+    """Parse the ConfigTemplate.cfg files.
+
+    :param str templatePath: path to the folder containing a ConfigTemplate.cfg file
+    :param CFG cfg: cfg to merge with the systems config
+    :returns: CFG object
+    """
+    cfg = CFG() if cfg is None else cfg
+
+    system = os.path.split(templatePath.rstrip("/"))[1]
+    if system.lower().endswith('system'):
+      system = system[:-len('System')]
+
+    if self.systems and system not in self.systems:
+      return S_OK(cfg)
+
+    templatePath = os.path.join(templatePath, 'ConfigTemplate.cfg')
+    if not os.path.exists(templatePath):
+      return S_ERROR("File not found: %s" % templatePath)
+
+    loadCfg = CFG()
+    loadCfg.loadFromFile(templatePath)
+
+    newCfg = CFG()
+    newCfg.createNewSection("/%s" % system, contents=loadCfg)
+
+    cfg = cfg.mergeWith(newCfg)
+
+    return S_OK(cfg)
+
+  @staticmethod
+  def _findConfigTemplates():
+    """Traverse folders in DIRAC and find ConfigTemplate.cfg files."""
+    configTemplates = set()
+    diracPath = os.environ.get("DIRAC")
+    for baseDirectory, _subdirectories, files in os.walk(diracPath):
+      if 'ConfigTemplate.cfg' in files:
+        configTemplates.add(baseDirectory)
+    return configTemplates
+
+  def _getCurrentConfig(self):
+    """Return the current system configuration."""
+    from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
+    gConfig.forceRefresh()
+
+    fullCfg = CFG()
+    setup = gConfig.getValue('/DIRAC/Setup', '')
+    setupList = gConfig.getSections('/DIRAC/Setups', [])
+    if not setupList['OK']:
+      return S_ERROR('Could not get /DIRAC/Setups sections')
+    setupList = setupList['Value']
+    if setup not in setupList:
+      return S_ERROR('Setup %s is not in allowed list: %s' % (setup, ', '.join(setupList)))
+    serviceSetups = gConfig.getOptionsDict('/DIRAC/Setups/%s' % setup)
+    if not serviceSetups['OK']:
+      return S_ERROR('Could not get /DIRAC/Setups/%s options' % setup)
+    serviceSetups = serviceSetups['Value']  # dict
+    for system, setup in serviceSetups.items():
+      if self.systems and system not in self.systems:
+        continue
+      systemCfg = gConfigurationData.remoteCFG.getAsCFG("/Systems/%s/%s" % (system, setup))
+      for section in systemCfg.listSections():
+        if section not in ('Agents', 'Services', 'Executors'):
+          systemCfg.deleteKey(section)
+
+      fullCfg.createNewSection("/%s" % system, contents=systemCfg)
+
+    return S_OK(fullCfg)
+
+  def _printDiff(self, entry, level=''):
+    """Format the changes."""
+    if len(entry) == 5:
+      diffType, entryName, _value, changes, _comment = entry
+    elif len(entry) == 4:
+      diffType, entryName, _value, changes = entry
+
+    fullPath = os.path.join(level, entryName)
+
+    if diffType == 'modSec':
+      for change in changes:
+        self._printDiff(change, fullPath)
+    elif diffType == 'modOpt':
+      if self.showModified:
+        LOG.notice("Changed option %r from %r" % (fullPath, changes))
+    elif diffType == 'delOpt':
+      if self.showAdded:
+        LOG.notice("Option %r does not exist in template" % fullPath)
+    elif diffType == 'delSec':
+      if self.showAdded:
+        LOG.notice("Section %r does not exist in template" % fullPath)
+    elif diffType == 'addSec':
+      if self.showMissingSections:
+        LOG.notice("Section %r not found in current configuration: %s" % (fullPath, pformat(changes)))
+    elif diffType == 'addOpt':
+      if self.showMissingOptions:
+        LOG.notice("Option %r not found in current configuration. Default value is %r" % (fullPath, changes))
+    else:
+      LOG.error("Unknown DiffType", "%s, %s, %s" % (diffType, fullPath, changes))
+
+  def run(self):
+    """Run configuration comparison."""
+    self._setSwitches()
+    self._check()
+    return S_OK()
+
+
+if __name__ == "__main__":
+  CheckConfig().run()

--- a/Core/Utilities/CFG.py
+++ b/Core/Utilities/CFG.py
@@ -739,14 +739,17 @@ class CFG( object ):
                                     cfgToMergeWith[ section ] )
     return mergedCFG
 
-  def getModifications( self, newerCfg, ignoreMask = None, parentPath = "" ):
+  def getModifications(self, newerCfg, ignoreMask=None, parentPath="",
+                       ignoreOrder=False, ignoreComments=False):
     """
     Compare two cfgs
 
     :type newerCfg: ~DIRAC.Core.Utilities.CFG.CFG
     :param newerCfg: Cfg to compare with
-    :type prefix: string
-    :param prefix: Internal use only
+    :param list ignoreMask: List of paths to ignore
+    :param str parentPath: Start from this path
+    :param ignoreOrder: Do not return changes only in ordering
+    :param ignoreComments: Do not return changes for changed commens
     :return: A list of modifications
     """
     modList = []
@@ -764,11 +767,11 @@ class CFG( object ):
                           newerCfg.getComment( newOption ) ) )
       else:
         modified = False
-        if iPos != self.__orderedList.index( newOption ):
+        if iPos != self.__orderedList.index(newOption) and not ignoreOrder:
           modified = True
         elif newerCfg[ newOption ] != self[ newOption ]:
           modified = True
-        elif newerCfg.getComment( newOption ) != self.getComment( newOption ):
+        elif newerCfg.getComment(newOption) != self.getComment(newOption) and not ignoreComments:
           modified = True
         if modified:
           modList.append( ( 'modOpt', newOption, iPos,
@@ -798,8 +801,9 @@ class CFG( object ):
           modified = True
         elif newerCfg.getComment( newSection ) != self.getComment( newSection ):
           modified = True
-        subMod = self[ newSection ].getModifications( newerCfg[ newSection ],
-                                                      ignoreMask, newSecPath )
+        subMod = self[newSection].getModifications(newerCfg[newSection],
+                                                   ignoreMask, newSecPath,
+                                                   ignoreOrder, ignoreComments)
         if subMod:
           modified = True
         if modified:

--- a/Core/Utilities/CFG.py
+++ b/Core/Utilities/CFG.py
@@ -439,6 +439,21 @@ class CFG( object ):
       except Exception:
         return defaultValue
 
+  def getAsCFG(self, path=""):
+    """Return subsection as CFG object.
+
+    :param str path: Path to the section
+    :return: CFG object, of path is not found the CFG is empty
+    """
+    if not path:
+      return self.clone()
+    splitPath = path.lstrip('/').split('/')
+    basePath = splitPath[0]
+    remainingPath = splitPath[1:]
+    if basePath not in self.__dataDict:
+      return CFG()
+    return self.__dataDict[basePath].getAsCFG("/".join(remainingPath))
+
   def getAsDict( self, path = "" ):
     """
     Get the contents below a given path as a dict


### PR DESCRIPTION

BEGINRELEASENOTES

*CS
NEW: dirac-admin-check-config-options script to compare options and values between the current Configuration and the ConfigTemplates. Allows one to find wrong or missing option names or just see the difference between the current settings and the default values.

ENDRELEASENOTES

This script will become even more useful, when all the options are in the ConfigTemplates.
