### PR TITLE
[v6r20] ReplicateAndRegister: do not set status to done if any targetSE is done

### DIFF
--- a/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
+++ b/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
@@ -691,7 +691,6 @@ class ReplicateAndRegister(DMSRequestOperationsBase):
         # # call DataManager
         if targetSE in validReplicas:
           self.log.warn("Request to replicate %s to an existing location: %s" % (lfn, targetSE))
-          opFile.Status = 'Done'
           continue
         res = self.dm.replicateAndRegister(lfn, targetSE, sourceSE=sourceSE, catalog=catalogs)
         if res["OK"]:


### PR DESCRIPTION
if transfer should go to multiple target SEs and one needs more than
one attempt, the file was set to done and therefore the transfer was never
done to the other SEs

If the file is already at all targetSE this will set the file to done:

https://github.com/DIRACGrid/DIRAC/blob/5a63100abe5b155ae07a7137fdcc88c4cc966d85/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py#L495-L500


BEGINRELEASENOTES

*DMS
FIX: ReplicateAndRegister: fix a problem when transferring files to multiple storage elements, if more than one attempt was needed the transfer to all SEs was not always happening.

ENDRELEASENOTES
