### PR TITLE
[v6r20] Obsolete parameter maxQueueSize removed

### DIFF
--- a/FrameworkSystem/DB/UserProfileDB.py
+++ b/FrameworkSystem/DB/UserProfileDB.py
@@ -75,7 +75,7 @@ class UserProfileDB( DB ):
     """
     self.__permValues = [ 'USER', 'GROUP', 'VO', 'ALL' ]
     self.__permAttrs = [ 'ReadAccess', 'PublishAccess' ]
-    DB.__init__( self, 'UserProfileDB', 'Framework/UserProfileDB', 10 )
+    DB.__init__( self, 'UserProfileDB', 'Framework/UserProfileDB' )
     retVal = self.__initializeDB()
     if not retVal[ 'OK' ]:
       raise Exception( "Can't create tables: %s" % retVal[ 'Message' ] )

--- a/FrameworkSystem/DB/UserProfileDB.py
+++ b/FrameworkSystem/DB/UserProfileDB.py
@@ -75,7 +75,7 @@ class UserProfileDB( DB ):
     """
     self.__permValues = [ 'USER', 'GROUP', 'VO', 'ALL' ]
     self.__permAttrs = [ 'ReadAccess', 'PublishAccess' ]
-    DB.__init__( self, 'UserProfileDB', 'Framework/UserProfileDB' )
+    DB.__init__(self, 'UserProfileDB', 'Framework/UserProfileDB')
     retVal = self.__initializeDB()
     if not retVal[ 'OK' ]:
       raise Exception( "Can't create tables: %s" % retVal[ 'Message' ] )


### PR DESCRIPTION
Following this change https://github.com/DIRACGrid/DIRAC/commit/a4c32b552f307f0acc1383ac640dae4e84b9f11f
DB.\_\_init\_\_ should not be called with maxQueueSize, which would be interpreted as the debug flag, and create *DB.debug.log

BEGINRELEASENOTES

*FrameworkSystem
FIX: obsolete parameter maxQueueSize in UserProfileDB initialization removed, not to make UserProfileDB.debug.log

ENDRELEASENOTES
