### PR TITLE
[v6r20] Emacs file pattern in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ pip-log.txt
 *.un~
 Session.vim
 
+# Emacs 
+*~
+
 # Intellij
 .idea/
 DIRAC.iml


### PR DESCRIPTION
Emacs specific file pattern is not in .gitignore, while Vim has a section...
I don't know if this needs the following lines for release notes... I don't think it would go into the releases... anyway, I just respect the template.

BEGINRELEASENOTES

Please follow the template:
*Git
CHANGE: emacs backup file pattern added to .gitignore

ENDRELEASENOTES
