### PR TITLE
[v6r20]  Allow to define the message queue name

### DIFF
--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -67,10 +67,12 @@ class SystemAdministratorHandler(RequestHandler):
 
     # Check the flag for dynamic monitoring
     dynamicMonitoring = cls.srv_getCSOption('DynamicMonitoring', False)
+    messagequeue = cls.srv_getCSOption('MessageQueue', 'dirac.componentmonitoring')
 
     if dynamicMonitoring:
       global gMonitoringReporter
-      gMonitoringReporter = MonitoringReporter(monitoringType="ComponentMonitoring")
+      gMonitoringReporter = MonitoringReporter(
+          monitoringType="ComponentMonitoring", failoverQueueName=messagequeue)
       gThreadScheduler.addPeriodicTask(120, cls.__storeProfiling)
 
     keepSoftwareVersions = cls.srv_getCSOption('KeepSoftwareVersions', 0)

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -67,12 +67,12 @@ class SystemAdministratorHandler(RequestHandler):
 
     # Check the flag for dynamic monitoring
     dynamicMonitoring = cls.srv_getCSOption('DynamicMonitoring', False)
-    messagequeue = cls.srv_getCSOption('MessageQueue', 'dirac.componentmonitoring')
+    messageQueue = cls.srv_getCSOption('MessageQueue', 'dirac.componentmonitoring')
 
     if dynamicMonitoring:
       global gMonitoringReporter
       gMonitoringReporter = MonitoringReporter(
-          monitoringType="ComponentMonitoring", failoverQueueName=messagequeue)
+          monitoringType="ComponentMonitoring", failoverQueueName=messageQueue)
       gThreadScheduler.addPeriodicTask(120, cls.__storeProfiling)
 
     keepSoftwareVersions = cls.srv_getCSOption('KeepSoftwareVersions', 0)

--- a/MonitoringSystem/Client/MonitoringReporter.py
+++ b/MonitoringSystem/Client/MonitoringReporter.py
@@ -35,16 +35,16 @@ class MonitoringReporter(object):
   :param __documents: contains the recods which will be inserted to the db\
   :type __documents: python:list
   :param str __monitoringType: type of the records which will be inserted to the db. For example: WMSHistory.
+  :param str __failoverQueueName: the name of the messaging queue. For example: /queue/dirac.certification
   """
 
-  def __init__(self, monitoringType=''):
+  def __init__(self, monitoringType='', failoverQueueName='dirac.monitoring'):
 
     self.__maxRecordsInABundle = 5000
     self.__documentLock = threading.RLock()
     self.__documents = []
-    self.__monitoringType = None
-
     self.__monitoringType = monitoringType
+    self.__failoverQueueName = failoverQueueName
 
   def processRecords(self):
     """
@@ -58,7 +58,7 @@ class MonitoringReporter(object):
     else:
       return retVal
 
-    result = createConsumer("Monitoring::Queue::%s" % self.__monitoringType)
+    result = createConsumer("Monitoring::Queue::%s" % self.__failoverQueueName)
     if not result['OK']:
       gLogger.error("Fail to create Consumer: %s" % result['Message'])
       return S_ERROR("Fail to create Consumer: %s" % result['Message'])
@@ -157,7 +157,7 @@ class MonitoringReporter(object):
     This method is used to create a producer
     """
     mqProducer = None
-    result = createProducer("Monitoring::Queue::%s" % self.__monitoringType)
+    result = createProducer("Monitoring::Queue::%s" % self.__failoverQueueName)
     if not result['OK']:
       gLogger.warn("Fail to create Producer:", result['Message'])
     else:

--- a/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
+++ b/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
@@ -55,7 +55,7 @@ class StatesMonitoringAgent(AgentModule):
     self.am_setOption("PollingTime", self.reportPeriod)
     self.messagequeue = self.am_getOption('MessageQueue', 'dirac.wmshistory')
 
-    self.monitoringReporter = MonitoringReporter(monitoringType="WMSHistory", self.messagequeue)
+    self.monitoringReporter = MonitoringReporter(monitoringType="WMSHistory", failoverQueueName="self.messagequeue")
 
     for field in self.__summaryKeyFieldsMapping:
       if field == 'User':

--- a/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
+++ b/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
@@ -45,7 +45,6 @@ class StatesMonitoringAgent(AgentModule):
 
   jobDB = None
   monitoringReporter = None
-  reportPeriod = None
 
   def initialize(self):
     """ Standard constructor
@@ -53,8 +52,7 @@ class StatesMonitoringAgent(AgentModule):
 
     self.jobDB = JobDB()
 
-    self.reportPeriod = 120
-    self.am_setOption("PollingTime", self.reportPeriod)
+    self.am_setOption("PollingTime", 900)
     self.messageQueue = self.am_getOption('MessageQueue', 'dirac.wmshistory')
 
     self.monitoringReporter = MonitoringReporter(monitoringType="WMSHistory", failoverQueueName=self.messageQueue)

--- a/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
+++ b/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
@@ -53,8 +53,9 @@ class StatesMonitoringAgent(AgentModule):
 
     self.reportPeriod = 120
     self.am_setOption("PollingTime", self.reportPeriod)
+    self.messagequeue = self.am_getOption('MessageQueue', 'dirac.wmshistory')
 
-    self.monitoringReporter = MonitoringReporter(monitoringType="WMSHistory")
+    self.monitoringReporter = MonitoringReporter(monitoringType="WMSHistory", self.messagequeue)
 
     for field in self.__summaryKeyFieldsMapping:
       if field == 'User':

--- a/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
+++ b/WorkloadManagementSystem/Agent/StatesMonitoringAgent.py
@@ -1,10 +1,12 @@
-########################################################################
-# File :    StatesMonitoringAgent.py
-# Author :  Zoltan Mathe
-########################################################################
-"""  StatesMonitoringAgent sends periodically numbers of jobs in various states for various
+''' StatesMonitoringAgent
+  sends periodically numbers of jobs in various states for various
      sites to the Monitoring system to create historical plots.
-"""
+.. literalinclude:: ../ConfigTemplate.cfg
+  :start-after: ##BEGIN StatesMonitoringAgent
+  :end-before: ##END
+  :dedent: 2
+  :caption: StatesMonitoringAgent options
+'''
 
 __RCSID__ = "$Id$"
 
@@ -53,9 +55,9 @@ class StatesMonitoringAgent(AgentModule):
 
     self.reportPeriod = 120
     self.am_setOption("PollingTime", self.reportPeriod)
-    self.messagequeue = self.am_getOption('MessageQueue', 'dirac.wmshistory')
+    self.messageQueue = self.am_getOption('MessageQueue', 'dirac.wmshistory')
 
-    self.monitoringReporter = MonitoringReporter(monitoringType="WMSHistory", failoverQueueName="self.messagequeue")
+    self.monitoringReporter = MonitoringReporter(monitoringType="WMSHistory", failoverQueueName=self.messageQueue)
 
     for field in self.__summaryKeyFieldsMapping:
       if field == 'User':

--- a/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -202,10 +202,14 @@ Agents
   {
     PollingTime = 120
   }
+  ##BEGIN StatesMonitoringAgent
   StatesMonitoringAgent
   {
     PollingTime = 120
+    # the name of the message queue used for the failover
+    MessageQueue = dirac.wmshistory
   }
+  ##END
 }
 Executors
 {

--- a/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -205,7 +205,7 @@ Agents
   ##BEGIN StatesMonitoringAgent
   StatesMonitoringAgent
   {
-    PollingTime = 120
+    PollingTime = 900
     # the name of the message queue used for the failover
     MessageQueue = dirac.wmshistory
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ sphinx
 hypothesis
 python-json-logger>=0.1.8
 multi-mechanize>=1.2.0
+tornado>=5.0.0


### PR DESCRIPTION

BEGINRELEASENOTES

*MonitoringSystem
CHANGE: The default name of the Message Queue can be changed

ENDRELEASENOTES
