### PR TITLE
[v6r20]  catch mroe exception in the ReqClient for displaying FTS Jobs

### DIFF
--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -496,7 +496,11 @@ def printFTSJobs(request):
           gLogger.always('         FTS jobs associated: %s' % ','.join('%s (%s)' % (job.FTSGUID, job.Status)
                                                                        for job in ftsJobs))
 
-  except ImportError as err:
+  # ImportError can be thrown for the old client
+  # AttributeError can be thrown because the deserialization will not have
+  # happened correctly on the new fts3 (CC7 typically), and the error is not
+  # properly propagated
+  except (ImportError, AttributeError) as err:
     gLogger.debug("Could not instantiate FtsClient because of Exception", repr(err))
 
 


### PR DESCRIPTION
Replaces https://github.com/DIRACGrid/DIRAC/pull/3802
@marianne013 can you please test this hack we talked about ? It will just avoid your script to crash, but it won't display the requests. Sorry I did not try it. 



BEGINRELEASENOTES

*RMS
FIX:  catch more exception in the ReqClient when trying to display the associated FTS jobs


ENDRELEASENOTES
