### PR TITLE
[v6r20] IntalledComponentDB: fix filterfields with unicode string

### DIFF
--- a/FrameworkSystem/DB/InstalledComponentsDB.py
+++ b/FrameworkSystem/DB/InstalledComponentsDB.py
@@ -437,7 +437,7 @@ class InstalledComponentsDB(object):
             toAppend = element
             if isinstance(toAppend, datetime.datetime):
               toAppend = toAppend.strftime("%Y-%m-%d %H:%M:%S")
-            if isinstance(toAppend, (datetime.datetime, str)):
+            if isinstance(toAppend, basestring):
               toAppend = '\'%s\'' % (toAppend)
             if i == 0:
               sql = '%s%s' % (sql, toAppend)


### PR DESCRIPTION
I got this error when trying the component history web app
```
2018-09-13 12:46:02 UTC Framework/ComponentMonitoring NOTICE: 
         Returning response ([::ffff:128.142.163.77]:49660)[diracAdmin:sailer] (0.01 secs) 
         ERROR: Could not filter the fields: (_mysql_exceptions.OperationalError) 
         (1054, "Unknown column 'voilcdirac012.cern.ch' in 'where clause'") 
         [SQL: u'SELECT `Hosts`.`HostID` AS `Hosts_HostID`, `Hosts`.`HostName` AS 
         `Hosts_HostName`, `Hosts`.`CPU` AS `Hosts_CPU` \n
          FROM `Hosts` \nWHERE HostName IN ( voilcdirac012.cern.ch, voilcdirac02.cern.ch )'] 
          (Background on this error at: http://sqlalche.me/e/e3q8)
```
This comes from the fact that the host strings are unicode strings (because of the browser?),
 so we have to check for `basestring` instance.
Also the datetime type cannot happen in this line as its replaced in the previous statement.
BEGINRELEASENOTES

*Framework
FIX: InstalledComponentDB.__filterFields: fix error in "Component History Web App" when filter values are unicode
ENDRELEASENOTES
