### PR TITLE
[v6r20] Accounting: for users always select only this user

### DIFF
--- a/AccountingSystem/private/Policies/JobPolicy.py
+++ b/AccountingSystem/private/Policies/JobPolicy.py
@@ -56,6 +56,8 @@ class JobPolicy( object ):
       if 'UserGroup' == groupingField:
         condDict[ 'User' ] = credDict[ 'username' ]
         condDict[ 'UserGroup' ] = credDict[ 'group' ]
+      else:
+        condDict['User'] = credDict['username']
     else:
       if 'User' in condDict:
         del( condDict[ 'User' ] )


### PR DESCRIPTION

BEGINRELEASENOTES

*Accounting
CHANGE: ReportGenerator: Authenticated users without JOB_SHARING will now only get plots showing their own jobs, solves #3776 

ENDRELEASENOTES
