### PR TITLE
[v6r20] Make unpacking downloaded sandboxes optional

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1635,7 +1635,7 @@ class Dirac(API):
     return result
 
   #############################################################################
-  def getOutputSandbox(self, jobID, outputDir=None, oversized=True, noJobDir=False):
+  def getOutputSandbox(self, jobID, outputDir=None, oversized=True, noJobDir=False, unpack=True):
     """Retrieve output sandbox for existing JobID.
 
        This method allows the retrieval of an existing job output sandbox.
@@ -1673,7 +1673,8 @@ class Dirac(API):
     mkDir(dirPath)
 
     # New download
-    result = SandboxStoreClient(useCertificates=self.useCertificates).downloadSandboxForJob(jobID, 'Output', dirPath)
+    result = SandboxStoreClient(useCertificates=self.useCertificates).downloadSandboxForJob(jobID, 'Output', dirPath,
+                                                                                            unpack)
     if result['OK']:
       self.log.info('Files retrieved and extracted in %s' % (dirPath))
       if self.jobRepo:

--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -254,7 +254,7 @@ class SandboxStoreClient(object):
       entitiesList.append("Job:%s" % jobId)
     return self.__unassignEntities(entitiesList)
 
-  def downloadSandboxForJob(self, jobId, sbType, destinationPath="", inMemory=False):
+  def downloadSandboxForJob(self, jobId, sbType, destinationPath="", inMemory=False, unpack=True):
     """ Download SB for a job """
     result = self.__getSandboxesForEntity("Job:%s" % jobId)
     if not result['OK']:
@@ -266,11 +266,11 @@ class SandboxStoreClient(object):
     # If inMemory, ensure we return the newest sandbox only
     if inMemory:
       sbLocation = sbDict[sbType][-1]
-      result = self.downloadSandbox(sbLocation, destinationPath, inMemory)
+      result = self.downloadSandbox(sbLocation, destinationPath, inMemory, unpack)
       return result
 
     for sbLocation in sbDict[sbType]:
-      result = self.downloadSandbox(sbLocation, destinationPath, inMemory)
+      result = self.downloadSandbox(sbLocation, destinationPath, inMemory, unpack)
       if not result['OK']:
         return result
     return S_OK()


### PR DESCRIPTION
BEGINRELEASENOTES

*Interface
CHANGE: Make the unpacking of downloaded sandboxes optional in the API

ENDRELEASENOTES