### PR TITLE
[v6r20] remove obsolete command in user message

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-put-and-register-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-put-and-register-request.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     DIRAC.exit( -1 )
 
   gLogger.always( "Request '%s' has been put to ReqDB for execution." % requestName )
-  gLogger.always( "You can monitor its status using command: 'dirac-rms-show-request %s'" % requestName )
+  gLogger.always( "You can monitor its status using command: 'dirac-rms-request %s'" % requestName )
   DIRAC.exit( 0 )
 
 

--- a/DataManagementSystem/scripts/dirac-dms-put-and-register-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-put-and-register-request.py
@@ -86,8 +86,8 @@ if __name__ == "__main__":
     gLogger.error( "unable to put request '%s': %s" % ( requestName, putRequest["Message"] ) )
     DIRAC.exit( -1 )
 
-  gLogger.always( "Request '%s' has been put to ReqDB for execution." % requestName )
-  gLogger.always( "You can monitor its status using command: 'dirac-rms-request %s'" % requestName )
+  gLogger.always("Request '%s' has been put to ReqDB for execution." % requestName)
+  gLogger.always("You can monitor its status using command: 'dirac-rms-request %s'" % requestName)
   DIRAC.exit( 0 )
 
 

--- a/DataManagementSystem/scripts/dirac-dms-replicate-and-register-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-replicate-and-register-request.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
     gLogger.always( "%d requests have been put to ReqDB for execution, with name %s_<num>" % ( count, requestName ) )
   if requestIDs:
     gLogger.always( "RequestID(s): %s" % " ".join( requestIDs ) )
-  gLogger.always( "You can monitor requests' status using command: 'dirac-rms-show-request <requestName/ID>'" )
+  gLogger.always( "You can monitor requests' status using command: 'dirac-rms-request <requestName/ID>'" )
   DIRAC.exit( error )
 
 

--- a/DataManagementSystem/scripts/dirac-dms-replicate-and-register-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-replicate-and-register-request.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
     gLogger.always( "%d requests have been put to ReqDB for execution, with name %s_<num>" % ( count, requestName ) )
   if requestIDs:
     gLogger.always( "RequestID(s): %s" % " ".join( requestIDs ) )
-  gLogger.always( "You can monitor requests' status using command: 'dirac-rms-request <requestName/ID>'" )
+  gLogger.always("You can monitor requests' status using command: 'dirac-rms-request <requestName/ID>'")
   DIRAC.exit( error )
 
 


### PR DESCRIPTION

BEGINRELEASENOTES

*DataManagementSystem
FIX: Update obsolete dirac-rms-show-request command in user message displayed when running dirac-dms-replicate-and-register-request

ENDRELEASENOTES
