### PR TITLE
[v7] Dirac.runLocal: have to define DIRACROOT before expandvars is called

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -858,12 +858,6 @@ class Dirac(API):
 
     self.log.info('Attempting to submit job to local site: %s' % DIRAC.siteName())
 
-    if 'Executable' in parameters:
-      executable = os.path.expandvars(parameters['Executable'])
-    else:
-      return self._errorReport('Missing job "Executable"')
-
-    command = '%s %s' % (executable, arguments)
     # If not set differently in the CS use the root from the current DIRAC installation
     siteRoot = gConfig.getValue('/LocalSite/Root', DIRAC.rootPath)
 
@@ -871,6 +865,13 @@ class Dirac(API):
     self.log.verbose('DIRACROOT = %s' % (siteRoot))
     os.environ['DIRACPYTHON'] = sys.executable
     self.log.verbose('DIRACPYTHON = %s' % (sys.executable))
+
+    if 'Executable' in parameters:
+      executable = os.path.expandvars(parameters['Executable'])
+    else:
+      return self._errorReport('Missing job "Executable"')
+
+    command = '%s %s' % (executable, arguments)
 
     self.log.info('Executing: %s' % command)
     executionEnv = dict(os.environ)

--- a/Interfaces/API/test/Test_DIRAC.py
+++ b/Interfaces/API/test/Test_DIRAC.py
@@ -32,13 +32,16 @@ def dirac():
 def job():
   from DIRAC.Interfaces.API.Job import Job
   job = Job(stdout='printer', stderr='/dev/null')
+  job.setInputSandbox(['LFN:/vo/user/i/initial/important.tar.gz',
+                       '/abspath/absfile.xml',
+                       'file_in_pwd.xml',
+                       ])
   return job
 
 
 @pytest.fixture
 def osmock():
   os = MagicMock(return_value=False, name="OS")
-  os.getcwd.return_value = '/root'
   os.environ = dict()
 
   def expandMock(*args, **kwargs):
@@ -46,7 +49,29 @@ def osmock():
        'DIRACROOT' in args[0]:
       return args[0].replace('$DIRACROOT', os.environ['DIRACROOT'])
     return args[0]
+
+  def existsMock(*args, **kwargs):
+    print "exists", args
+    if any(f in args[0] for f in ('jobDescription', '/pwd/file_in_pwd.xml')):
+      return True
+    if 'absfile' in args[0] and args[0].startswith('/abspath'):
+      return True
+    return False
+
+  def joinMock(*args):
+    path = '/'
+    for l in args:
+      path += l.strip('/') + '/'
+    return path.rstrip('/')
+
+  os.getcwd.side_effect = ['/pwd/'] + ['/pwd/tempFolder/'] * 100
+
   os.path.expandvars.side_effect = expandMock
+  os.path.exists.side_effect = existsMock
+  os.path.isabs.side_effect = lambda x: x.startswith('/')
+  os.path.isdir.return_value = False
+  os.path.join.side_effect = joinMock
+  os.path.basename.side_effect = lambda x: x.rsplit('/', 1)[-1]
   return os
 
 
@@ -83,13 +108,15 @@ def test_JobJob(dirac, job):
 
 def test_runLocal(dirac, job, mocker, osmock, confMock):
   mocker.patch('DIRAC.Interfaces.API.Dirac.os', new=osmock)
-  mocker.patch('DIRAC.Interfaces.API.Dirac.tempfile')
-  mocker.patch('DIRAC.Interfaces.API.Dirac.shutil')
-  mocker.patch('DIRAC.Interfaces.API.Dirac.gConfig', new=confMock)
-  sysMock = mocker.patch('DIRAC.Interfaces.API.Dirac.systemCall')
-  sysMock.return_value = S_OK([0, 'No output', 'No errors'])
   mocker.patch('DIRAC.Interfaces.API.Dirac.tarfile', new=MagicMock(return_value=False))
   mocker.patch('__builtin__.open')
+  mocker.patch('DIRAC.Interfaces.API.Dirac.gConfig', new=confMock)
+  tempMock = mocker.patch('DIRAC.Interfaces.API.Dirac.tempfile')
+  tempMock.mkdtemp.return_value = 'tempFolder'
+  shMock = mocker.patch('DIRAC.Interfaces.API.Dirac.shutil', new=MagicMock(name="Shutil"))
+  sysMock = mocker.patch('DIRAC.Interfaces.API.Dirac.systemCall')
+  sysMock.return_value = S_OK([0, 'No output', 'No errors'])
+  dirac.getFile = MagicMock(return_value=S_OK())
   ret = dirac.runLocal(job)
   LOG.info("dirac log calls: %s", dirac.log.call_args_list)
   LOG.info("CallStack: %s", pformat(ret.get('CallStack', {})))
@@ -97,3 +124,6 @@ def test_runLocal(dirac, job, mocker, osmock, confMock):
                                                     'jobDescription.xml', '-o', 'LogLevel=info']
   assert ret.get('Message', None) is None
   assert ret['OK']
+  assert call('/abspath/absfile.xml', '/pwd/tempFolder/') in shMock.copy.call_args_list
+  assert call('/pwd/file_in_pwd.xml', '/pwd/tempFolder/') in shMock.copy.call_args_list
+  assert call('/vo/user/i/initial/important.tar.gz') in dirac.getFile.call_args_list

--- a/Interfaces/API/test/Test_DIRAC.py
+++ b/Interfaces/API/test/Test_DIRAC.py
@@ -1,34 +1,99 @@
 """ Unit tests for the Dirac interface module
 """
-# pylint: disable=no-member, protected-access
+# pylint: disable=no-member, protected-access, missing-docstring
+import logging
 
-import unittest
+from pprint import pformat
+import pytest
+from mock import MagicMock, call
 
 from DIRAC.Interfaces.API.Dirac import Dirac
+from DIRAC import S_OK
+
+logging.basicConfig()
+LOG = logging.getLogger('TestDirac')
+LOG.setLevel(logging.ERROR)
 
 
-class DiracTestCases(unittest.TestCase):
-  """ Dirac API test cases
-  """
-  def setUp(self):
-    self.dirac = Dirac()
+@pytest.fixture
+def dirac():
+  d = Dirac()
+  d.log = MagicMock(name="Log")
+  d.log.debug = d.log
+  d.log.info = d.log
+  d.log.notice = d.log
+  d.log.verbose = d.log
+  d.log.error = d.log
+  d.log.warn = d.log
+  return d
 
-  def tearDown(self):
-    pass
 
-  def test_basicJob(self):
-    jdl = "Parameter=Value;Parameter2=Value2"
-    ret = self.dirac._Dirac__getJDLParameters(jdl)
-    self.assertTrue(ret['OK'])
-    self.assertIn('Parameter', ret['Value'])
-    self.assertEqual('Value', ret['Value']['Parameter'])
-    self.assertIn('Parameter2', ret['Value'])
-    self.assertEqual('Value2', ret['Value']['Parameter2'])
+@pytest.fixture
+def job():
+  from DIRAC.Interfaces.API.Job import Job
+  job = Job(stdout='printer', stderr='/dev/null')
+  return job
 
-  def test_JobJob(self):
-    from DIRAC.Interfaces.API.Job import Job
-    job = Job(stdout='printer', stderr='/dev/null')
-    ret = self.dirac._Dirac__getJDLParameters(job)
-    self.assertTrue(ret['OK'])
-    self.assertEqual('printer', ret['Value']['StdOutput'])
-    self.assertEqual('/dev/null', ret['Value']['StdError'])
+
+@pytest.fixture
+def osmock():
+  os = MagicMock(return_value=False, name="OS")
+  os.getcwd.return_value = '/root'
+  os.environ = dict()
+
+  def expandMock(*args, **kwargs):
+    if 'DIRACROOT' in os.environ and \
+       'DIRACROOT' in args[0]:
+      return args[0].replace('$DIRACROOT', os.environ['DIRACROOT'])
+    return args[0]
+  os.path.expandvars.side_effect = expandMock
+  return os
+
+
+@pytest.fixture
+def confMock():
+  gConf = MagicMock(name="gConfig")
+
+  def getVal(*args, **kwargs):
+    if '/LocalSite/Root' in args[0]:
+      return '/root/dirac'
+    if len(args) == 2:
+      return args[1]
+    return 'defaultValue'
+  gConf.getValue.side_effect = getVal
+  return gConf
+
+
+def test_basicJob(dirac):
+  jdl = "Parameter=Value;Parameter2=Value2"
+  ret = dirac._Dirac__getJDLParameters(jdl)
+  assert ret['OK']
+  assert 'Parameter' in ret['Value']
+  assert ret['Value']['Parameter'] == 'Value'
+  assert 'Parameter2' in ret['Value']
+  assert ret['Value']['Parameter2'] == 'Value2'
+
+
+def test_JobJob(dirac, job):
+  ret = dirac._Dirac__getJDLParameters(job)
+  assert ret['OK']
+  assert ret['Value']['StdOutput'] == 'printer'
+  assert ret['Value']['StdError'] == '/dev/null'
+
+
+def test_runLocal(dirac, job, mocker, osmock, confMock):
+  mocker.patch('DIRAC.Interfaces.API.Dirac.os', new=osmock)
+  mocker.patch('DIRAC.Interfaces.API.Dirac.tempfile')
+  mocker.patch('DIRAC.Interfaces.API.Dirac.shutil')
+  mocker.patch('DIRAC.Interfaces.API.Dirac.gConfig', new=confMock)
+  sysMock = mocker.patch('DIRAC.Interfaces.API.Dirac.systemCall')
+  sysMock.return_value = S_OK([0, 'No output', 'No errors'])
+  mocker.patch('DIRAC.Interfaces.API.Dirac.tarfile', new=MagicMock(return_value=False))
+  mocker.patch('__builtin__.open')
+  ret = dirac.runLocal(job)
+  LOG.info("dirac log calls: %s", dirac.log.call_args_list)
+  LOG.info("CallStack: %s", pformat(ret.get('CallStack', {})))
+  assert sysMock.call_args_list[0][1]['cmdSeq'] == ['/root/dirac/scripts/dirac-jobexec',
+                                                    'jobDescription.xml', '-o', 'LogLevel=info']
+  assert ret.get('Message', None) is None
+  assert ret['OK']


### PR DESCRIPTION

`systemCall` does not expand shell variables ($DIRACROOT), which was only defined after the call to `os.path.expandvars`. In the past `shellCall` was called with `$DIRACROOT/scripts/dirac-jobexec`, which worked because `shellCall` expands the variables.

* No release notes, because this is a fix to PR #3808 in the same release
* This currently breaks our nightly `integration` job tests, so a fast merge would be appreciated. 