### PR TITLE
[v6r20] Fix the sandbox download in API

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1674,7 +1674,7 @@ class Dirac(API):
 
     # New download
     result = SandboxStoreClient(useCertificates=self.useCertificates).downloadSandboxForJob(jobID, 'Output', dirPath,
-                                                                                            unpack)
+                                                                                            False, unpack)
     if result['OK']:
       self.log.info('Files retrieved and extracted in %s' % (dirPath))
       if self.jobRepo:

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1674,7 +1674,7 @@ class Dirac(API):
 
     # New download
     result = SandboxStoreClient(useCertificates=self.useCertificates).downloadSandboxForJob(jobID, 'Output', dirPath,
-                                                                                            False, unpack)
+                                                                                            inMemory=False, unpack=unpack)
     if result['OK']:
       self.log.info('Files retrieved and extracted in %s' % (dirPath))
       if self.jobRepo:


### PR DESCRIPTION

BEGINRELEASENOTES

*Interface
FIX: Fix the sandbox download, returning the inMemory default.

ENDRELEASENOTES
