### PR TITLE
[v6r20] FTS3: resubmit files in status Canceled on the FTS server

### DIFF
--- a/DataManagementSystem/Client/FTS3Operation.py
+++ b/DataManagementSystem/Client/FTS3Operation.py
@@ -165,7 +165,7 @@ class FTS3Operation(FTS3Serializable):
       # The file was never submitted or
       # The file failed from the point of view of FTS
       # but no more than the maxAttemptsPerFile
-      elif ftsFile.status in ('New', 'Failed'):
+      elif ftsFile.status in [FTS3File.INIT_STATE] + FTS3File.FTS_FAILED_STATES:
         toSubmit.append(ftsFile)
 
     return toSubmit


### PR DESCRIPTION
This fixes a bug that had as consequence of not resubmitting files that are marked as Canceled by the FTS3 server, while they should (errors like timeout put the file in Canceled and not Failed for FTS...)

BEGINRELEASENOTES

*DMS
FIX: FTS3: resubmit files in status Canceled on the FTS server

ENDRELEASENOTES