### PR TITLE
[v6r20] GFAL2_SRM2Storage: only set spacetoken if not an empty string, fixes stager problem

### DIFF
--- a/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/Resources/Storage/GFAL2_SRM2Storage.py
@@ -64,7 +64,8 @@ class GFAL2_SRM2Storage(GFAL2_StorageBase):
 
     '''
     self.ctx.set_opt_integer("SRM PLUGIN", "OPERATION_TIMEOUT", self.gfal2Timeout)
-    self.ctx.set_opt_string("SRM PLUGIN", "SPACETOKENDESC", self.spaceToken)
+    if self.spaceToken:
+      self.ctx.set_opt_string("SRM PLUGIN", "SPACETOKENDESC", self.spaceToken)
     self.ctx.set_opt_integer("SRM PLUGIN", "REQUEST_LIFETIME", self.gfal2requestLifetime)
     # Setting the TURL protocol to gsiftp because with other protocols we have authorisation problems
 #    self.ctx.set_opt_string_list( "SRM PLUGIN", "TURL_PROTOCOLS", self.defaultLocalProtocols )


### PR DESCRIPTION
This PR fixes a problem when trying to stage at StorageElements that do not have a spaceToken
Error messages like:
```
"Invalid request descriptor ( 53 : Error occured while prestaging file GError('[gfal2_bring_online][gfal_plugin_bring_onlineG][gfal_srmv2_bring_onlineG][gfal_srm_report_error] srm-ifce err: Invalid request descriptor, err: [SE][GetSpaceTokens][SRM_INVALID_REQUEST] httpg://dcache-se-desy.desy.de:8443/srm/managerv2: No such space tokens\\n', 53))
```
The SE does not have a spaceToken. When I apply my patch everything is working nicely, or at least without error messages

Also tested with
```python
import os, gfal2, logging
logger = logging.getLogger('')
logging.basicConfig()
logger.setLevel(logging.DEBUG)
gfal2.set_verbose(gfal2.verbose_level.trace)
logger.info("\n\n\n\nSTART!")
def do():
  path = 'srm://dcache-se-desy.desy.de:8443/srm/managerv2?SFN=/pnfs/desy.de/ilc/prod/ilc/mc-opt-3/ild/sim/500-TDR_ws/aa_lowpt_WW/ILD_s5_v02/v02-00-01/00010238/002/sv02-00-01.mILD_s5_v02.E500-TDR_ws.I39212.Paaddhad.eW.pW.n002_347.d_sim_00010238_2090.slcio'
  lifetime = 36000
  stageTimeout= 12 * 60 * 60
  ctx = gfal2.creat_context()
  # uncomment to break
  # ctx.set_opt_string("SRM PLUGIN", "SPACETOKENDESC", '')
  status, token = ctx.bring_online(path, lifetime, stageTimeout, True)
do()
```

BEGINRELEASENOTES

*SMS
FIX: Fix StageRequestAgent failures for SEs without a SpaceToken

*Resources:
FIX: GFAL2_SRM2Storage: only set SPACETOKENDESC when SpaceToken is not an empty string

ENDRELEASENOTES
