### PR TITLE
[v6r20] Add protocol option to dirac-dms-lfn-accessURL

### DIFF
--- a/Interfaces/scripts/dirac-dms-lfn-accessURL.py
+++ b/Interfaces/scripts/dirac-dms-lfn-accessURL.py
@@ -11,22 +11,24 @@ __RCSID__ = "$Id$"
 import DIRAC
 from DIRAC.Core.Base import Script
 
-Script.setUsageMessage( '\n'.join( [ __doc__.split( '\n' )[1],
-                                     'Usage:',
-                                     '  %s [option|cfgfile] ... LFN SE' % Script.scriptName,
-                                     'Arguments:',
-                                     '  LFN:      Logical File Name or file containing LFNs',
-                                     '  SE:       Valid DIRAC SE' ] ) )
-Script.parseCommandLine( ignoreErrors = True )
+Script.setUsageMessage('\n'.join([ __doc__.split('\n')[1],
+                                   'Usage:',
+                                   '  %s [option|cfgfile] ... LFN SE' % Script.scriptName,
+                                   'Arguments:',
+                                   '  LFN:      Logical File Name or file containing LFNs',
+                                   '  SE:       Valid DIRAC SE' ]))
+Script.parseCommandLine(ignoreErrors = True)
 args = Script.getPositionalArgs()
 
-if len( args ) < 2:
+# pylint: disable=wrong-import-position
+from DIRAC.Interfaces.API.Dirac import Dirac
+
+if len(args) < 2:
   Script.showHelp()
 
-if len( args ) > 2:
+if len(args) > 2:
   print 'Only one LFN SE pair will be considered'
 
-from DIRAC.Interfaces.API.Dirac                         import Dirac
 dirac = Dirac()
 exitCode = 0
 
@@ -34,16 +36,16 @@ lfn = args[0]
 seName = args[1]
 
 try:
-  f = open( lfn, 'r' )
+  f = open(lfn, 'r')
   lfns = f.read().splitlines()
   f.close()
-except:
+except IOError:
   lfns = [lfn]
 
 for lfn in lfns:
-  result = dirac.getAccessURL( lfn, seName, printOutput = True )
+  result = dirac.getAccessURL(lfn, seName, printOutput=True)
   if not result['OK']:
     print 'ERROR: ', result['Message']
     exitCode = 2
 
-DIRAC.exit( exitCode )
+DIRAC.exit(exitCode)

--- a/Interfaces/scripts/dirac-dms-lfn-accessURL.py
+++ b/Interfaces/scripts/dirac-dms-lfn-accessURL.py
@@ -13,10 +13,11 @@ from DIRAC.Core.Base import Script
 
 Script.setUsageMessage('\n'.join([ __doc__.split('\n')[1],
                                    'Usage:',
-                                   '  %s [option|cfgfile] ... LFN SE' % Script.scriptName,
+                                   '  %s [option|cfgfile] ... LFN SE [PROTO]' % Script.scriptName,
                                    'Arguments:',
                                    '  LFN:      Logical File Name or file containing LFNs',
-                                   '  SE:       Valid DIRAC SE' ]))
+                                   '  SE:       Valid DIRAC SE',
+                                   '  PROTO:    Optional protocol for accessURL']))
 Script.parseCommandLine(ignoreErrors = True)
 args = Script.getPositionalArgs()
 
@@ -26,7 +27,7 @@ from DIRAC.Interfaces.API.Dirac import Dirac
 if len(args) < 2:
   Script.showHelp()
 
-if len(args) > 2:
+if len(args) > 3:
   print 'Only one LFN SE pair will be considered'
 
 dirac = Dirac()
@@ -34,6 +35,9 @@ exitCode = 0
 
 lfn = args[0]
 seName = args[1]
+proto = False
+if len(args) > 2:
+  proto = args[2]
 
 try:
   f = open(lfn, 'r')
@@ -43,7 +47,7 @@ except IOError:
   lfns = [lfn]
 
 for lfn in lfns:
-  result = dirac.getAccessURL(lfn, seName, printOutput=True)
+  result = dirac.getAccessURL(lfn, seName, protocol=proto, printOutput=True)
   if not result['OK']:
     print 'ERROR: ', result['Message']
     exitCode = 2

--- a/Interfaces/scripts/dirac-dms-lfn-accessURL.py
+++ b/Interfaces/scripts/dirac-dms-lfn-accessURL.py
@@ -11,14 +11,14 @@ __RCSID__ = "$Id$"
 import DIRAC
 from DIRAC.Core.Base import Script
 
-Script.setUsageMessage('\n'.join([ __doc__.split('\n')[1],
-                                   'Usage:',
-                                   '  %s [option|cfgfile] ... LFN SE [PROTO]' % Script.scriptName,
-                                   'Arguments:',
-                                   '  LFN:      Logical File Name or file containing LFNs',
-                                   '  SE:       Valid DIRAC SE',
-                                   '  PROTO:    Optional protocol for accessURL']))
-Script.parseCommandLine(ignoreErrors = True)
+Script.setUsageMessage('\n'.join([__doc__.split('\n')[1],
+                                  'Usage:',
+                                  '  %s [option|cfgfile] ... LFN SE [PROTO]' % Script.scriptName,
+                                  'Arguments:',
+                                  '  LFN:      Logical File Name or file containing LFNs',
+                                  '  SE:       Valid DIRAC SE',
+                                  '  PROTO:    Optional protocol for accessURL']))
+Script.parseCommandLine(ignoreErrors=True)
 args = Script.getPositionalArgs()
 
 # pylint: disable=wrong-import-position


### PR DESCRIPTION
Hi,

We find it useful to be able to get a specific protocol from dirac-dms-lfn-accessURL, for example if you want to use it with ROOT directly (i..e need a root:// URL rather than srm://) when an SE supports more than one AccessProtocol. This patch just maps this functionality (which is already in the API) through to the command line.

Regards,
Simon

BEGINRELEASENOTES
*Interfaces
NEW: Add protocol option to dirac-dms-lfn-accessURL
ENDRELEASENOTES