### PR TITLE
[v6r20] Get back discoverInterfaces function

### DIFF
--- a/Core/Utilities/Network.py
+++ b/Core/Utilities/Network.py
@@ -7,7 +7,42 @@ __RCSID__ = "$Id$"
 import socket
 import urlparse
 import os
+import struct
+import array
+import fcntl
+import platform
+
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
+
+
+def discoverInterfaces():
+  max_possible = 128
+  maxBytes = max_possible * 32
+  mySocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+  names = array.array('B', '\0' * maxBytes)
+  # 0x8912 SICGIFCONF
+  fcntlOut = fcntl.ioctl(mySocket.fileno(), 0x8912, struct.pack('iL', maxBytes, names.buffer_info()[0]))
+  outbytes = struct.unpack('iL', fcntlOut)[0]
+  namestr = names.tostring()
+  ifaces = {}
+  arch = platform.architecture()[0]
+  if arch.find('32') == 0:
+    for i in range(0, outbytes, 32):
+      name = namestr[i:i + 32].split('\0', 1)[0]
+      ip = namestr[i + 20:i + 24]
+      ifaces[name] = {'ip': socket.inet_ntoa(ip), 'mac': getMACFromInterface(name)}
+  else:
+    for i in range(0, outbytes, 40):
+      name = namestr[i:i + 16].split('\0', 1)[0]
+      ip = namestr[i + 20:i + 24]
+      ifaces[name] = {'ip': socket.inet_ntoa(ip), 'mac': getMACFromInterface(name)}
+  return ifaces
+
+
+def getMACFromInterface(ifname):
+  mySocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+  info = fcntl.ioctl(mySocket.fileno(), 0x8927, struct.pack('256s', ifname[:15]))
+  return ''.join(['%02x:' % ord(char) for char in info[18:24]])[:-1]
 
 
 def getFQDN():


### PR DESCRIPTION
The function "discoverInterfaces" is removed in early v6r20 version. But VMDIRAC still need it in Agent/VirtualMachineMonitorAgent.py
So here it is added again, together with function "getMACFromInterface" which is called by it.

BEGINRELEASENOTES

*Core
FIX: Add function "discoverInterfaces" again which is still needed for VMDIRAC

ENDRELEASENOTES
