### PR TITLE
[v7] docstrings: fix :param and :return[s] syntax

### DIFF
--- a/.travis.d/checkDocs.sh
+++ b/.travis.d/checkDocs.sh
@@ -1,0 +1,16 @@
+sudo apt-get install graphviz;
+cd docs;
+SPHINXOPTS=-wsphinxWarnings READTHEDOCS=True make html
+
+# check for :param / :return in html, points to faulty syntax, missing empty lines, etc.
+grep --color -nH -e :param -e :return -r build/html/CodeDocumentation/ > sphinxWarnings
+
+# Check that sphinxWarnings is not empty
+if [ -s sphinxWarnings ]; then
+    echo "********************************************************************************"
+    echo "Warnings When Creating Doc:"
+    echo "********************************************************************************"
+    cat sphinxWarnings
+    echo "********************************************************************************"
+    exit 1
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ script:
   - if [[ "${CHECK}" == "py.test"  ]];
     then py.test;
     elif [[ "${CHECK}" == "docs"  ]];
-    then sudo apt-get install graphviz; cd docs; SPHINXOPTS=-wsphinxWarnings READTHEDOCS=True make html;
-    if [ -s sphinxWarnings ]; then cat sphinxWarnings; echo "Warnings When Creating Doc"; exit 1; fi
+    then .travis.d/checkDocs.sh;
     elif [[ "${CHECK}" == "pylint"  ]];
     then travis_wait 30 .travis.d/runPylint.sh;
     elif [[ "${CHECK}" == "format" ]] && [[ "${TRAVIS_PULL_REQUEST}" != "false" ]];

--- a/AccountingSystem/Service/ReportGeneratorHandler.py
+++ b/AccountingSystem/Service/ReportGeneratorHandler.py
@@ -103,6 +103,7 @@ class ReportGeneratorHandler( RequestHandler ):
   def export_generatePlot( self, reportRequest ):
     """
     Plot a accounting
+
     Arguments:
       - viewName : Name of view (easy!)
       - startTime
@@ -123,6 +124,7 @@ class ReportGeneratorHandler( RequestHandler ):
   def export_getReport( self, reportRequest ):
     """
     Plot a accounting
+
     Arguments:
       - viewName : Name of view (easy!)
       - startTime
@@ -143,6 +145,7 @@ class ReportGeneratorHandler( RequestHandler ):
   def export_listReports( self, typeName ):
     """
     List all available plots
+
     Arguments:
       - none
     """
@@ -153,6 +156,7 @@ class ReportGeneratorHandler( RequestHandler ):
   def export_listUniqueKeyValues( self, typeName ):
     """
     List all values for all keys in a type
+
     Arguments:
       - none
     """

--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -302,7 +302,7 @@ def getDIRACPlatform(OSList):
       In practice the "highest" version (which should be the most "desirable" one is returned first)
 
       :param list OSList: list of platforms defined by resource providers
-      :return : a list of DIRAC platforms that can be specified in job descriptions
+      :return: a list of DIRAC platforms that can be specified in job descriptions
   """
 
   # For backward compatibility allow a single string argument

--- a/Core/DISET/AuthManager.py
+++ b/Core/DISET/AuthManager.py
@@ -259,6 +259,7 @@ class AuthManager(object):
   def matchProperties(self, credDict, validProps, caseSensitive=False):
     """
     Return True if one or more properties are in the valid list of properties
+
     :type  props: list
     :param props: List of properties to match
     :type  validProps: list

--- a/Core/DISET/TransferClient.py
+++ b/Core/DISET/TransferClient.py
@@ -46,13 +46,13 @@ class TransferClient( BaseClient ):
     """
     Send a file to server
 
-    :type filename : string / file descriptor / file object
-    :param filename : File to send to server
-    :type fileId : any
-    :param fileId : Identification of the file being sent
-    :type token : string
-    :param token : Optional token for the file
-    :return : S_OK/S_ERROR
+    :type filename: string / file descriptor / file object
+    :param filename: File to send to server
+    :type fileId: any
+    :param fileId: Identification of the file being sent
+    :type token: string
+    :param token: Optional token for the file
+    :return: S_OK/S_ERROR
     """
     fileHelper = FileHelper()
     if "NoCheckSum" in token:
@@ -79,13 +79,13 @@ class TransferClient( BaseClient ):
     """
     Receive a file from the server
 
-    :type filename : string / file descriptor / file object
-    :param filename : File to receive from server
-    :type fileId : any
-    :param fileId : Identification of the file being received
-    :type token : string
-    :param token : Optional token for the file
-    :return : S_OK/S_ERROR
+    :type filename: string / file descriptor / file object
+    :param filename: File to receive from server
+    :type fileId: any
+    :param fileId: Identification of the file being received
+    :type token: string
+    :param token: Optional token for the file
+    :return: S_OK/S_ERROR
     """
     fileHelper = FileHelper()
     if "NoCheckSum" in token:
@@ -122,17 +122,17 @@ class TransferClient( BaseClient ):
     """
     Send a bulk of files to server
 
-    :type fileList : list of ( string / file descriptor / file object )
-    :param fileList : Files to send to server
-    :type bulkId : any
-    :param bulkId : Identification of the files being sent
-    :type token : string
-    :param token : Token for the bulk
-    :type compress : boolean
-    :param compress : Enable compression for the bulk. By default its True
-    :type bulkSize : integer
-    :param bulkSize : Optional size of the bulk
-    :return : S_OK/S_ERROR
+    :type fileList: list of ( string / file descriptor / file object )
+    :param fileList: Files to send to server
+    :type bulkId: any
+    :param bulkId: Identification of the files being sent
+    :type token: string
+    :param token: Token for the bulk
+    :type compress: boolean
+    :param compress: Enable compression for the bulk. By default its True
+    :type bulkSize: integer
+    :param bulkSize: Optional size of the bulk
+    :return: S_OK/S_ERROR
     """
     bogusEntries = self.__checkFileList( fileList )
     if bogusEntries:
@@ -159,15 +159,15 @@ class TransferClient( BaseClient ):
     """
     Receive a bulk of files from server
 
-    :type destDir : list of ( string / file descriptor / file object )
-    :param destDir : Files to receive from server
-    :type bulkId : any
-    :param bulkId : Identification of the files being received
-    :type token : string
-    :param token : Token for the bulk
-    :type compress : boolean
-    :param compress : Enable compression for the bulk. By default its True
-    :return : S_OK/S_ERROR
+    :type destDir: list of ( string / file descriptor / file object )
+    :param destDir: Files to receive from server
+    :type bulkId: any
+    :param bulkId: Identification of the files being received
+    :type token: string
+    :param token: Token for the bulk
+    :type compress: boolean
+    :param compress: Enable compression for the bulk. By default its True
+    :return: S_OK/S_ERROR
     """
     if not os.path.isdir( destDir ):
       return S_ERROR( "%s is not a directory for bulk receival" % destDir )
@@ -193,13 +193,13 @@ class TransferClient( BaseClient ):
     """
     List the contents of a bulk
 
-    :type bulkId : any
-    :param bulkId : Identification of the bulk to list
-    :type token : string
-    :param token : Token for the bulk
-    :type compress : boolean
-    :param compress : Enable compression for the bulk. By default its True
-    :return : S_OK/S_ERROR
+    :type bulkId: any
+    :param bulkId: Identification of the bulk to list
+    :type token: string
+    :param token: Token for the bulk
+    :type compress: boolean
+    :param compress: Enable compression for the bulk. By default its True
+    :return: S_OK/S_ERROR
     """
     if compress:
       bulkId = "%s.tar.bz2" % bulkId

--- a/Core/LCG/GGUSTicketsClient.py
+++ b/Core/LCG/GGUSTicketsClient.py
@@ -37,6 +37,7 @@ class GGUSTicketsClient:
 
   def getTicketsList( self, siteName = None, startDate = None, endDate = None ):
     """ Return tickets of entity in name
+
        :param name: should be the name of the site
        :param startDate: starting date (optional)
        :param endDate: end date (optional)

--- a/Core/Security/ProxyFile.py
+++ b/Core/Security/ProxyFile.py
@@ -14,6 +14,7 @@ from DIRAC.Core.Security.Locations import getProxyLocation
 
 def writeToProxyFile( proxyContents, fileName = False ):
   """ Write a proxy string to file
+
       arguments:
         - proxyContents : string object to dump to file
         - fileName : filename to dump to
@@ -39,6 +40,7 @@ def writeToProxyFile( proxyContents, fileName = False ):
 def writeChainToProxyFile( proxyChain, fileName ):
   """
   Write an X509Chain to file
+
   arguments:
     - proxyChain : X509Chain object to dump to file
     - fileName : filename to dump to

--- a/Core/Security/VOMSService.py
+++ b/Core/Security/VOMSService.py
@@ -53,6 +53,7 @@ class VOMSService(object):
 
   def attGetUserNickname(self, dn, _ca=None):
     """ Get user nickname for a given DN if any
+
     :param str dn: user DN
     :param str _ca: CA, kept for backward compatibility
     :return:  S_OK with Value: nickname

--- a/Core/Utilities/ClassAd/ClassAdLight.py
+++ b/Core/Utilities/ClassAd/ClassAdLight.py
@@ -309,6 +309,7 @@ class ClassAd:
 
   def getAttributes( self ):
     """ Get the list of all the attribute names
+
     :return: list of names as strings
     """
     return self.contents.keys()

--- a/Core/Utilities/DictCache.py
+++ b/Core/Utilities/DictCache.py
@@ -34,7 +34,7 @@ class DictCache( object ):
   def exists( self, cKey, validSeconds = 0 ):
     """
       Returns True/False if the key exists for the given number of seconds
-      Arguments:
+
       :param cKey: identification key of the record
       :param validSeconds: The amount of seconds the key has to be valid for
     """

--- a/Core/Utilities/ElasticSearchDB.py
+++ b/Core/Utilities/ElasticSearchDB.py
@@ -42,6 +42,7 @@ class ElasticSearchDB(object):
   ########################################################################
   def __init__(self, host, port, user=None, password=None, indexPrefix='', useSSL=True):
     """ c'tor
+
     :param self: self reference
     :param str host: name of the database for example: MonitoringDB
     :param str port: The full name of the database for example: 'Monitoring/MonitoringDB'
@@ -179,8 +180,8 @@ class ElasticSearchDB(object):
   ########################################################################
   def getDocTypes(self, indexName):
     """
-    :param str indexName is the name of the index...
-    :return S_OK or S_ERROR
+    :param str indexName: is the name of the index...
+    :return: S_OK or S_ERROR
     """
     result = []
     try:
@@ -208,6 +209,7 @@ class ElasticSearchDB(object):
   def exists(self, indexName):
     """
     it checks the existance of an index
+
     :param str indexName: the name of the index
     """
     return self.__client.indices.exists(indexName)
@@ -236,7 +238,7 @@ class ElasticSearchDB(object):
 
   def deleteIndex(self, indexName):
     """
-    :param str indexName the name of the index to be deleted...
+    :param str indexName: the name of the index to be deleted...
     """
     try:
       retVal = self.__client.indices.delete(indexName)
@@ -331,9 +333,9 @@ class ElasticSearchDB(object):
 
   def getUniqueValue(self, indexName, key, orderBy=False):
     """
-    :param str indexName the name of the index which will be used for the query
-    :param dict orderBy it is a dictionary in case we want to order the result {key:'desc'} or {key:'asc'}
-    It returns a list of unique value for a certain key from the dictionary.
+    :param str indexName: the name of the index which will be used for the query
+    :param dict orderBy: it is a dictionary in case we want to order the result {key:'desc'} or {key:'asc'}
+    :returns: a list of unique value for a certain key from the dictionary.
     """
 
     query = self._Search(indexName)
@@ -379,6 +381,7 @@ class ElasticSearchDB(object):
   def pingDB(self):
     """
     Try to connect to the database
+
     :return: S_OK(TRUE/FALSE)
     """
     connected = False

--- a/Core/Utilities/Plotting/Plots.py
+++ b/Core/Utilities/Plotting/Plots.py
@@ -9,7 +9,7 @@ from DIRAC import S_OK, S_ERROR
 
 def checkMetadata( metadata ):
   """ 
-  :param dict metadata it contains information which will used in the plot creation.
+  :param dict metadata: it contains information which will used in the plot creation.
   """
   if 'span' in metadata:
     granularity = metadata[ 'span' ]
@@ -23,9 +23,10 @@ def checkMetadata( metadata ):
 def generateNoDataPlot( fileName, data, metadata ):
   """
   Tis generate an image with a specific error message.
-  :param str fileName name of the file
-  :param list data data
-  :param dict metadata metadata information
+
+  :param str fileName: name of the file
+  :param list data: data
+  :param dict metadata: metadata information
   """
   try:
     with open( fileName, "wb" ) as fn:
@@ -38,8 +39,9 @@ def generateNoDataPlot( fileName, data, metadata ):
 def generateErrorMessagePlot( msgText ):
   """
   It creates a plot whith a specific error message
-  :param str msgText the text which will appear on the plot.
-  :return the plot.
+
+  :param str msgText: the text which will appear on the plot.
+  :return: the plot.
   """
   fn = cStringIO.StringIO()
   textGraph( msgText, fn, {} )
@@ -51,9 +53,10 @@ def generateErrorMessagePlot( msgText ):
 def generateTimedStackedBarPlot( fileName, data, metadata ):
   """
   It is used to create a time based line plot.
-  :param str fileName the name of the file
-  :param list data the data which is used to create the plot
-  :param dict metadata extra information used to create the plot.
+
+  :param str fileName: the name of the file
+  :param list data: the data which is used to create the plot
+  :param dict metadata: extra information used to create the plot.
   """
   try:
     with open( fileName, "wb" ) as fn:
@@ -70,9 +73,9 @@ def generateQualityPlot( fileName, data, metadata ):
   """
   It is used to create 2D plots.
   
-  :param str fileName the name of the file
-  :param list data the data which is used to create the plot
-  :param dict metadata extra information used to create the plot.
+  :param str fileName: the name of the file
+  :param list data: the data which is used to create the plot
+  :param dict metadata: extra information used to create the plot.
   """
   try:
     with open( fileName, "wb" ) as fn:
@@ -90,9 +93,10 @@ def generateQualityPlot( fileName, data, metadata ):
 def generateCumulativePlot( fileName, data, metadata ):
   """
   It is used to create cumulativ plots.
-  :param str fileName the name of the file
-  :param list data the data which is used to create the plot
-  :param dict metadata extra information used to create the plot.
+
+  :param str fileName: the name of the file
+  :param list data: the data which is used to create the plot
+  :param dict metadata: extra information used to create the plot.
   """
   try:
     with open( fileName, "wb" ) as fn:
@@ -107,9 +111,10 @@ def generateCumulativePlot( fileName, data, metadata ):
 def generateStackedLinePlot( fileName, data, metadata ):
   """
   It is used to create stacked line plot.
-  :param str fileName the name of the file
-  :param list data the data which is used to create the plot
-  :param dict metadata extra information used to create the plot.
+
+  :param str fileName: the name of the file
+  :param list data: the data which is used to create the plot
+  :param dict metadata: extra information used to create the plot.
   """
   try:
     with open( fileName, "wb" ) as fn:
@@ -125,9 +130,10 @@ def generateStackedLinePlot( fileName, data, metadata ):
 def generatePiePlot( fileName, data, metadata ):
   """
   It is used to create pie charts.
-  :param str fileName the nanme of the file
-  :param list data the data which is used to create the plot
-  :param dict metadata extra information used to create the plot.
+
+  :param str fileName: the nanme of the file
+  :param list data: the data which is used to create the plot
+  :param dict metadata: extra information used to create the plot.
   """
   try:
     with open( fileName, "wb" ) as fn:

--- a/Core/scripts/dirac-create-distribution-tarball.py
+++ b/Core/scripts/dirac-create-distribution-tarball.py
@@ -455,19 +455,11 @@ class TarModuleCreator(object):
           rstData.append("")
     # Write releasenotes.rst
     try:
-<<<<<<< HEAD
-      rstFilePath = os.path.join( self.params.destination, self.params.name, rstFileName )
-      with open( rstFilePath, "w" ) as fd:
-        fd.write( "\n".join( rstData ) )
-    except Exception as excp:
-      return S_ERROR( "Could not write %s: %s" % ( rstFileName, excp ) )
-=======
       rstFilePath = os.path.join(self.params.destination, self.params.name, rstFileName)
       with open(rstFilePath, "w") as fd:
         fd.write("\n".join(rstData))
-    except Exception, excp:
+    except Exception as excp:
       return S_ERROR("Could not write %s: %s" % (rstFileName, excp))
->>>>>>> rel-v6r20
     return S_OK()
 
   def __generateReleaseNotes(self):
@@ -521,23 +513,13 @@ class TarModuleCreator(object):
     try:
       with open(relNotesRST) as fd:
         rstData = fd.read()
-<<<<<<< HEAD
     except Exception as excp:
-      return S_ERROR( "Could not read %s: %s" % ( relNotesRST, excp ) )
-    try:
-      parts = docutils.core.publish_parts( rstData, writer_name = 'html' )
-    except Exception as excp:
-      return S_ERROR( "Cannot generate the html %s: %s" % ( baseNotesPath, str( excp ) ) )
-    baseList = [ baseNotesPath ]
-=======
-    except Exception, excp:
       return S_ERROR("Could not read %s: %s" % (relNotesRST, excp))
     try:
       parts = docutils.core.publish_parts(rstData, writer_name='html')
-    except Exception, excp:
+    except Exception as excp:
       return S_ERROR("Cannot generate the html %s: %s" % (baseNotesPath, str(excp)))
     baseList = [baseNotesPath]
->>>>>>> rel-v6r20
     if self.params.outRelNotes:
       gLogger.notice("Leaving a copy of the release notes outside the tarballs")
       baseList.append("%s/%s.%s.%s" % (self.params.destination, baseRSTFile, self.params.name, self.params.version))

--- a/Core/scripts/dirac-create-distribution-tarball.py
+++ b/Core/scripts/dirac-create-distribution-tarball.py
@@ -370,7 +370,7 @@ class TarModuleCreator(object):
       return S_OK("")
     try:
       with open(relNotes, "r") as fd:
-        relaseContents = fd.readlines()
+        releaseContents = fd.readlines()
     except Exception as excp:
       return S_ERROR("Could not open %s: %s" % (relNotes, excp))
     gLogger.info("Loaded %s" % relNotes)

--- a/DataManagementSystem/Client/FTS3Client.py
+++ b/DataManagementSystem/Client/FTS3Client.py
@@ -31,6 +31,7 @@ class FTS3Client(Client):
 
   def getOperation(self, operationID, **kwargs):
     """ Get the FTS3Operation from the database
+
         :param operationID: id of the operation
         :return: FTS3Operation object
     """
@@ -48,6 +49,7 @@ class FTS3Client(Client):
 
   def getActiveJobs(self, limit=20, lastMonitor=None, jobAssignmentTag='Assigned', ** kwargs):
     """ Get all the FTSJobs that are not in a final state
+
         :param limit: max number of jobs to retrieve
         :return: list of FTS3Jobs
     """
@@ -65,14 +67,16 @@ class FTS3Client(Client):
 
   def updateFileStatus(self, fileStatusDict, **kwargs):
     """ Update the file ftsStatus and error
-       :param fileStatusDict : { fileID : { status , error } }
+
+       :param fileStatusDict: { fileID : { status , error } }
     """
 
     return self._getRPC(**kwargs).updateFileStatus(fileStatusDict)
 
   def updateJobStatus(self, jobStatusDict, **kwargs):
     """ Update the job Status and error
-       :param jobStatusDict : { jobID : { status , error } }
+
+       :param jobStatusDict: { jobID : { status , error } }
     """
 
     return self._getRPC(**kwargs).updateJobStatus(jobStatusDict)

--- a/DataManagementSystem/Client/FTS3Job.py
+++ b/DataManagementSystem/Client/FTS3Job.py
@@ -441,7 +441,7 @@ class FTS3Job(FTS3Serializable):
         :param ucert: path to the user certificate/proxy. Might be inferred by the fts cli (see its doc)
         :param protocols: list of protocols from which we should choose the protocol to use
 
-        :returns S_OK([FTSFiles ids of files submitted])
+        :returns: S_OK([FTSFiles ids of files submitted])
     """
 
     log = gLogger.getSubLogger("submit/%s/%s_%s" %

--- a/DataManagementSystem/Client/FTS3Operation.py
+++ b/DataManagementSystem/Client/FTS3Operation.py
@@ -154,7 +154,7 @@ class FTS3Operation(FTS3Serializable):
 
         :param maxAttemptsPerFile: the maximum number of attempts to be tried for a file
 
-        :return List of FTS3File to submit
+        :return: List of FTS3File to submit
     """
 
     toSubmit = []
@@ -173,10 +173,11 @@ class FTS3Operation(FTS3Serializable):
   @staticmethod
   def _checkSEAccess(seName, accessType, vo=None):
     """Check the Status of a storage element
+
         :param seName: name of the StorageElement
         :param accessType ReadAccess, WriteAccess,CheckAccess,RemoveAccess
 
-        :return S_ERROR if not allowed or error, S_OK() otherwise
+        :return: S_ERROR if not allowed or error, S_OK() otherwise
     """
     # Check that the target is writable
     # access = self.rssClient.getStorageElementStatus( seName, accessType )
@@ -199,12 +200,13 @@ class FTS3Operation(FTS3Serializable):
 
   def _createNewJob(self, jobType, ftsFiles, targetSE, sourceSE=None):
     """ Create a new FTS3Job object
+
         :param jobType: type of job to create (Transfer, Staging, Removal)
         :param ftsFiles: list of FTS3File objects the job has to work on
         :param targetSE: SE on which to operate
         :param sourceSE: source SE, only useful for Transfer jobs
 
-        :return FTS3Job object
+        :return: FTS3Job object
      """
 
     newJob = FTS3Job()
@@ -245,7 +247,7 @@ class FTS3Operation(FTS3Serializable):
         :param maxFilesPerJob: maximum number of files assigned to a job
         :param maxAttemptsPerFile: maximum number of retry after an fts failure
 
-        :return list of jobs
+        :return: list of jobs
     """
     raise NotImplementedError("You should not be using the base class")
 
@@ -333,6 +335,7 @@ class FTS3Operation(FTS3Serializable):
     """ Construct an FTS3Operation object from the RMS Request and Operation corresponding.
         The attributes taken are the OwnerGroup, Request and Operation IDS, sourceSE,
         and activity and priority if they are defined in the Argument field of the operation
+
         :param rmsReq: RMS Request object
         :param rmsOp: RMS Operation object
         :param username: username to which associate the FTS3Operation (normally comes from the Req OwnerDN)

--- a/DataManagementSystem/DB/FTS3DB.py
+++ b/DataManagementSystem/DB/FTS3DB.py
@@ -323,7 +323,7 @@ class FTS3DB(object):
 
         TODO: maybe it should query first the status and filter the rows I want to update !
 
-       :param fileStatusDict : { fileID : { status , error } }
+       :param fileStatusDict: { fileID : { status , error } }
 
     """
 
@@ -371,7 +371,7 @@ class FTS3DB(object):
         The update is only done if the job is not in a final state
         The assignment flag is released
 
-       :param jobStatusDict : { jobID : { status , error, completeness } }
+       :param jobStatusDict: { jobID : { status , error, completeness } }
     """
     session = self.dbSession()
     try:

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
@@ -396,7 +396,7 @@ class DirectoryTreeBase:
   def changeDirectoryOwner( self, paths, recursive = False ):
     """ Bulk setting of the directory owner
 
-        :param dictionary paths : dictionary < lfn : owner >
+        :param dictionary paths: dictionary < lfn : owner >
     """
     return self._changeDirectoryParameter( paths,
                                            self._setDirectoryOwner,
@@ -407,7 +407,7 @@ class DirectoryTreeBase:
   def changeDirectoryGroup( self, paths, recursive = False ):
     """ Bulk setting of the directory group
 
-        :param dictionary paths : dictionary < lfn : group >
+        :param dictionary paths: dictionary < lfn : group >
     """
     return self._changeDirectoryParameter( paths,
                                            self._setDirectoryGroup,
@@ -427,7 +427,7 @@ class DirectoryTreeBase:
   def changeDirectoryMode( self, paths, recursive = False ):
     """ Bulk setting of the directory mode
 
-        :param dictionary paths : dictionary < lfn : mode >
+        :param dictionary paths: dictionary < lfn : mode >
     """
     return self._changeDirectoryParameter( paths,
                                            self._setDirectoryMode,
@@ -441,7 +441,7 @@ class DirectoryTreeBase:
                                  recursive = False ):
     """ Bulk setting of the directory parameter with recursion for all the subdirectories and files
 
-        :param dictionary paths : dictionary < lfn : value >, where value is the value of parameter to be set
+        :param dictionary paths: dictionary < lfn : value >, where value is the value of parameter to be set
         :param function directoryFunction: function to change directory(ies) parameter
         :param function fileFunction: function to change file(s) parameter
         :param bool recursive: flag to apply the operation recursively

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManagerBase.py
@@ -1219,7 +1219,8 @@ class FileManagerBase(object):
 
   def changeFileGroup(self, lfns):
     """ Get set the group for the supplied files
-        :param lfns : dictionary < lfn : group >
+
+        :param lfns: dictionary < lfn : group >
         :param int/str newGroup: optional new group/groupID the same for all the supplied lfns
      """
     res = self._findFiles(lfns, ['FileID', 'GID'])
@@ -1248,7 +1249,8 @@ class FileManagerBase(object):
 
   def changeFileOwner(self, lfns):
     """ Set the owner for the supplied files
-        :param lfns : dictionary < lfn : owner >
+
+        :param lfns: dictionary < lfn : owner >
         :param int/str newOwner: optional new user/userID the same for all the supplied lfns
     """
     res = self._findFiles(lfns, ['FileID', 'UID'])
@@ -1277,7 +1279,8 @@ class FileManagerBase(object):
 
   def changeFileMode(self, lfns):
     """" Set the mode for the supplied files
-        :param lfns : dictionary < lfn : mode >
+
+        :param lfns: dictionary < lfn : mode >
         :param int newMode: optional new mode the same for all the supplied lfns
     """
     res = self._findFiles(lfns, ['FileID', 'Mode'])

--- a/DataManagementSystem/DB/FileCatalogComponents/SecurityPolicies/VOMSPolicy.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SecurityPolicies/VOMSPolicy.py
@@ -374,8 +374,8 @@ class VOMSPolicy( SecurityManagerBase ):
         For existing directories, we must have the write permission
         on the parent
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
 
@@ -410,8 +410,8 @@ class VOMSPolicy( SecurityManagerBase ):
         For existing files, we must have the write permission
         on the parent
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
 
@@ -444,8 +444,8 @@ class VOMSPolicy( SecurityManagerBase ):
     """ Test Read permission on the directory.
         If the directory does not exist, we do not allow.
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
 
@@ -459,8 +459,8 @@ class VOMSPolicy( SecurityManagerBase ):
         be it a file or a directory.
         So it reads permissions from a directory
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
 
@@ -472,8 +472,8 @@ class VOMSPolicy( SecurityManagerBase ):
         be it a file or a directory.
         So it reads permissions from a directory
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
 
@@ -485,8 +485,8 @@ class VOMSPolicy( SecurityManagerBase ):
     """ Test Read permission on the file associated to the replica.
         If the file does not exist, we allow.
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
     return self.__testPermissionOnFile( paths, 'Read', credDict,
@@ -496,8 +496,8 @@ class VOMSPolicy( SecurityManagerBase ):
     """ Test Write permission on the file associated to the replica.
         If the file does not exist, we allow.
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
     return self.__testPermissionOnFile( paths, 'Write', credDict,
@@ -507,8 +507,8 @@ class VOMSPolicy( SecurityManagerBase ):
     """ Test Write permission on the file.
         If the file does not exist, we allow.
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
     return self.__testPermissionOnFile( paths, 'Write', credDict,
@@ -520,8 +520,8 @@ class VOMSPolicy( SecurityManagerBase ):
     """ Test Write permission on the directory/file.
         If the directory/file does not exist, we allow.
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
 
@@ -532,8 +532,8 @@ class VOMSPolicy( SecurityManagerBase ):
   def __policyDeny( self, paths, credDict ):
     """ Denies the access to all the paths given
 
-        :param paths : list/dict of path
-        :param credDict : credential of the user
+        :param paths: list/dict of path
+        :param credDict: credential of the user
         :returns: Successful with True of False, and Failed.
     """
 
@@ -547,9 +547,9 @@ class VOMSPolicy( SecurityManagerBase ):
   def hasAccess( self, opType, paths, credDict ):
     """ Checks whether a given operation on given paths is permitted
 
-        :param opType : name of the operation (the FileCatalog methods in fact...)
+        :param opType: name of the operation (the FileCatalog methods in fact...)
         :param paths: list/dictionary of path on which we want to apply the operation
-        :param credDict : credential of the users (with at least username, group and properties)
+        :param credDict: credential of the users (with at least username, group and properties)
 
         :returns: Successful dict with True or False, and Failed dict. In fact, it is not neccesarily
                 a boolean, rather an int (binary operation results)

--- a/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/DirectoryClosure.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/DirectoryClosure.py
@@ -34,7 +34,7 @@ class DirectoryClosure( DirectoryTreeBase ):
   def findDir( self, path, connection = False ):
     """  Find directory ID for the given path
 
-      :param path : path of the directory
+      :param path: path of the directory
 
       :returns: S_OK(id) and res['Level'] as the depth
     """
@@ -77,7 +77,7 @@ class DirectoryClosure( DirectoryTreeBase ):
 
         Removing a non existing directory is successful. In that case, DirID is 0
 
-        :param path : path of the dir
+        :param path: path of the dir
 
         :returns: S_OK() and res['DirID'] the id of the directory removed
     """
@@ -106,9 +106,9 @@ class DirectoryClosure( DirectoryTreeBase ):
   def existsDir( self, path ):
     """ Check the existence of a directory at the specified path
 
-      :param path : directory path
+      :param path: directory path
 
-      :returns  S_OK( { 'Exists' : False } ) if the directory does not exist
+      :returns: S_OK( { 'Exists' : False } ) if the directory does not exist
                 S_OK( { 'Exists' : True, 'DirID' : directory id  } ) if the directory exists
     """
 
@@ -124,7 +124,7 @@ class DirectoryClosure( DirectoryTreeBase ):
   def getDirectoryPath( self, dirID ):
     """ Get directory name by directory ID
 
-        :param dirID : directory ID
+        :param dirID: directory ID
 
         :returns: S_OK(dir name), or S_ERROR if it does not exist
 
@@ -143,8 +143,9 @@ class DirectoryClosure( DirectoryTreeBase ):
 
   def getDirectoryPaths( self, dirIDList ):
     """ Get directory names by directory ID list
-        :param dirIDList : list of dirIds
-        :returns S_OK( { dirID : dirName} )
+
+        :param dirIDList: list of dirIds
+        :returns: S_OK( { dirID : dirName} )
     """
 
     dirs = dirIDList
@@ -171,7 +172,7 @@ class DirectoryClosure( DirectoryTreeBase ):
     """ Get IDs of all the directories in the parent hierarchy for a directory
         specified by its path, including itself
 
-        :param path : path of the directory
+        :param path: path of the directory
 
         :returns: S_OK( list of ids ), S_ERROR if not found
     """
@@ -192,7 +193,7 @@ class DirectoryClosure( DirectoryTreeBase ):
     """ Get IDs of all the directories in the parent hierarchy for a directory
         specified by its ID, including itself
 
-        :param dirID : id of the dictionary
+        :param dirID: id of the dictionary
 
         :returns: S_OK( list of ids )
 
@@ -231,9 +232,9 @@ class DirectoryClosure( DirectoryTreeBase ):
   def getSubdirectoriesByID( self, dirID, requestString = False, includeParent = False ):
     """ Get all the subdirectories of the given directory at a given level
 
-        :param dirID : id of the directory
-        :param requestString : if true, returns an sql query to get the information
-        :param includeParent : if true, the parent (dirID) will be included
+        :param dirID: id of the directory
+        :param requestString: if true, returns an sql query to get the information
+        :param includeParent: if true, the parent (dirID) will be included
 
         :returns: S_OK ( { dirID, depth } ) if requestString is False
                  S_OK(request) if requestString is True
@@ -258,7 +259,7 @@ class DirectoryClosure( DirectoryTreeBase ):
   def getAllSubdirectoriesByID( self, dirIdList ):
     """ Get IDs of all the subdirectories of directories in a given list
 
-        :param dirList : list of dir Ids
+        :param dirList: list of dir Ids
         :returns: S_OK([ unordered dir ids ])
     """
 
@@ -280,7 +281,7 @@ class DirectoryClosure( DirectoryTreeBase ):
   def getSubdirectories( self, path ):
     """ Get subdirectories of the given directory
 
-        :param path : path of the directory
+        :param path: path of the directory
 
         :returns: S_OK ( { dirID, depth } )
     """
@@ -299,8 +300,8 @@ class DirectoryClosure( DirectoryTreeBase ):
   def countSubdirectories(self, dirId, includeParent = True):
     """ Count the number of subdirectories
 
-        :param dirID : id of the directory
-        :param includeParent : count itself
+        :param dirID: id of the directory
+        :param includeParent: count itself
 
         :returns: S_OK(value)
     """
@@ -336,8 +337,8 @@ class DirectoryClosure( DirectoryTreeBase ):
   def makeDirectory( self, path, credDict, status = 1 ):
     """ Create a directory
 
-        :param path : has to be an absolute path. The parent dir has to exist
-        :param credDict : credential dict of the owner of the directory
+        :param path: has to be an absolute path. The parent dir has to exist
+        :param credDict: credential dict of the owner of the directory
         :param: status ????
 
         :returns: S_OK (dirID) with a flag res['NewDirectory'] to True or False
@@ -406,7 +407,7 @@ class DirectoryClosure( DirectoryTreeBase ):
       Rem: the speed could be enhanced if we were joining the FC_Files and FC_Directory* in the query.
           For the time being, it can stay like this
 
-      :param path : path of the directory
+      :param path: path of the directory
 
       :returns: S_OK(true) if there are no file nor directorie, S_OK(False) otherwise
     """
@@ -445,9 +446,9 @@ class DirectoryClosure( DirectoryTreeBase ):
   def getDirectoryParameters( self, pathOrDirId ):
     """ Get parameters of the given directory
 
-      :param pathOrDirID : the path or the id of the directory
+      :param pathOrDirID: the path or the id of the directory
 
-      :returns S_OK(dict), where dict has the following keys:
+      :returns: S_OK(dict), where dict has the following keys:
                       "DirID", "UID", "Owner", "GID", "OwnerGroup", "Status", "Mode", "CreationDate", "ModificationDate"
     """
     # Which procedure to use
@@ -487,9 +488,9 @@ class DirectoryClosure( DirectoryTreeBase ):
       Rem: the parent class has a more generic method, which is called
            in case we are given an unknown parameter
 
-      :param path : path of the directory
-      :param pname : name of the parameter to set
-      :param pvalue : value of the parameter (an id or a value)
+      :param path: path of the directory
+      :param pname: name of the parameter to set
+      :param pvalue: value of the parameter (an id or a value)
 
       :returns: S_OK(nb of row changed). It should always be 1 !
               S_ERROR if the directory does not exist
@@ -673,7 +674,7 @@ class DirectoryClosure( DirectoryTreeBase ):
                                  recursive = False ):
     """ Bulk setting of the directory parameter with recursion for all the subdirectories and files
 
-        :param dictionary paths : dictionary < lfn : value >, where value is the value of parameter to be set
+        :param dict paths: dictionary < lfn : value >, where value is the value of parameter to be set
         :param function directoryFunction: function to change directory(ies) parameter
         :param function fileFunction: function to change file(s) parameter
         :param bool recursive: flag to apply the operation recursively

--- a/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/FileManagerPs.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/WithFkAndPs/FileManagerPs.py
@@ -825,7 +825,7 @@ class FileManagerPs(FileManagerBase):
   def countFilesInDir(self, dirId):
     """ Count how many files there is in a given Directory
 
-        :param dirID : directory id
+        :param dirID: directory id
 
         :returns: S_OK(value) or S_ERROR
     """

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -50,6 +50,7 @@ class FTS3ManagerHandler(RequestHandler):
   @classmethod
   def export_persistOperation(cls, opJSON):
     """ update or insert request into db
+
         :param opJSON: json string representing the operation
 
         :return: OperationID
@@ -82,6 +83,7 @@ class FTS3ManagerHandler(RequestHandler):
   @classmethod
   def export_getActiveJobs(cls, limit, lastMonitor, jobAssignmentTag):
     """ Get all the FTSJobs that are not in a final state
+
         :param limit: max number of jobs to retrieve
         :param jobAssignmentTag: tag to put in the DB
         :param lastMonitor: jobs monitored earlier than the given date
@@ -105,7 +107,8 @@ class FTS3ManagerHandler(RequestHandler):
   @classmethod
   def export_updateFileStatus(cls, fileStatusDict):
     """ Update the file ftsStatus and error
-       :param fileStatusDict : { fileID : { status , error } }
+
+       :param fileStatusDict: { fileID : { status , error } }
     """
 
     return cls.fts3db.updateFileStatus(fileStatusDict)
@@ -115,7 +118,8 @@ class FTS3ManagerHandler(RequestHandler):
   @classmethod
   def export_updateJobStatus(cls, jobStatusDict):
     """ Update the job Status and error
-       :param jobStatusDict : { jobID : { status , error } }
+
+       :param jobStatusDict: { jobID : { status , error } }
     """
 
     return cls.fts3db.updateJobStatus(jobStatusDict)
@@ -126,6 +130,7 @@ class FTS3ManagerHandler(RequestHandler):
   def export_getNonFinishedOperations(cls, limit, operationAssignmentTag):
     """ Get all the FTS3Operations that are missing a callback, i.e.
         in 'Processed' state
+
         :param limit: max number of operations to retrieve
         :return: json list of FTS3Operation
     """

--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -22,7 +22,7 @@ def resolveSEGroup(seGroupList, allSEs=None):
   :param allSEs: if provided, list of all known SEs
   :type allSEs: list
 
-  :return : list of resolved SEs or [] if error
+  :return: list of resolved SEs or [] if error
   """
   if allSEs is None:
     res = gConfig.getSections('/Resources/StorageElements')

--- a/DataManagementSystem/private/FTS2/FTS2Placement.py
+++ b/DataManagementSystem/private/FTS2/FTS2Placement.py
@@ -20,12 +20,12 @@ class FTS2Placement(FTSAbstractPlacement):
     """ For multiple source to multiple destination, find the optimal replication
         strategy.
 
-       :param sourceSEs : list of source SE
-       :param targetSEs : list of destination SE
-       :param size : size of the File
-       :param strategy : which strategy to use
+       :param sourceSEs: list of source SE
+       :param targetSEs: list of destination SE
+       :param size: size of the File
+       :param strategy: which strategy to use
 
-       :returns S_OK(dict) < route name :  { dict with key Ancestor, SourceSE, TargetSEtargetSE, Strategy } >
+       :returns: S_OK(dict) < route name :  { dict with key Ancestor, SourceSE, TargetSEtargetSE, Strategy } >
     """
 
     return self.fts2Strategy.replicationTree( sourceSEs = sourceSEs,
@@ -47,8 +47,8 @@ class FTS2Placement(FTSAbstractPlacement):
   def findRoute( self, sourceSE, targetSE ):
     """ Find the appropriate route from point A to B
 
-      :param sourceSE : source SE
-      :param targetSE : destination SE
+      :param sourceSE: source SE
+      :param targetSE: destination SE
 
       :returns: S_OK(FTSRoute)
 
@@ -71,7 +71,7 @@ class FTS2Placement(FTSAbstractPlacement):
        Check if the source is readable, the target writable,
        and we don't have to many active jobs on that route
 
-       :param route : FTSRoute
+       :param route: FTSRoute
 
        :returns: S_OK or S_ERROR(reason)
     """
@@ -100,7 +100,7 @@ class FTS2Placement(FTSAbstractPlacement):
     """Declare that one starts a transfer on a given route.
        Accounting purpose only
 
-       :param route : FTSRoute that is used
+       :param route: FTSRoute that is used
 
     """
     edge = self.fts2Strategy.ftsGraph.findRoute( route.sourceSE, route.targetSE )
@@ -114,7 +114,7 @@ class FTS2Placement(FTSAbstractPlacement):
     """Declare that one finishes a transfer on a given route.
        Accounting purpose only
 
-       :param route : FTSRoute that is used
+       :param route: FTSRoute that is used
 
     """
     edge = self.fts2Strategy.ftsGraph.findRoute( route.sourceSE, route.targetSE )

--- a/DataManagementSystem/private/FTS3/FTS3Placement.py
+++ b/DataManagementSystem/private/FTS3/FTS3Placement.py
@@ -41,12 +41,12 @@ class FTS3Placement( FTSAbstractPlacement ):
     """ For multiple source to multiple destination, find the optimal replication
         strategy.
 
-       :param sourceSEs : list of source SE
-       :param targetSEs : list of destination SE
-       :param size : size of the File
-       :param strategy : which strategy to use
+       :param sourceSEs: list of source SE
+       :param targetSEs: list of destination SE
+       :param size: size of the File
+       :param strategy: which strategy to use
 
-       :returns S_OK(dict) < route name :  { dict with key Ancestor, SourceSE, TargetSEtargetSE, Strategy } >
+       :returns: S_OK(dict) < route name :  { dict with key Ancestor, SourceSE, TargetSEtargetSE, Strategy } >
 
        For the time being, we are waiting for FTS3 to provide advisory mechanisms. So we just use
        simple techniques
@@ -137,8 +137,8 @@ class FTS3Placement( FTSAbstractPlacement ):
   def findRoute( self, sourceSE, targetSE ):
     """ Find the appropriate route from point A to B
 
-      :param sourceSE : source SE
-      :param targetSE : destination SE
+      :param sourceSE: source SE
+      :param targetSE: destination SE
 
       :returns: S_OK(FTSRoute)
 
@@ -162,7 +162,7 @@ class FTS3Placement( FTSAbstractPlacement ):
         If a route was not valid for some reason, then FTS would know it
         thanks to the blacklist sent by RSS, and would deal with it itself.
 
-       :param route : FTSRoute
+       :param route: FTSRoute
 
        :returns: S_OK or S_ERROR(reason)
     """

--- a/DataManagementSystem/private/FTS3Utilities.py
+++ b/DataManagementSystem/private/FTS3Utilities.py
@@ -15,6 +15,7 @@ from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
 
 def _checkSourceReplicas(ftsFiles):
   """ Check the active replicas
+
       :params ftsFiles: list of FT3Files
 
       :returns: Successful/Failed {lfn : { SE1 : PFN1, SE2 : PFN2 } , ... }
@@ -33,10 +34,10 @@ def selectUniqueSourceforTransfers(multipleSourceTransfers):
       In this particular case, we always choose the one that has the biggest
       amount of replicas,
 
-      :param multipleSourceTransfers : { sourceSE : [FTSFiles] }
+      :param multipleSourceTransfers: { sourceSE : [FTSFiles] }
 
 
-      :return { source SE : [ FTSFiles] } where each LFN appears only once
+      :return: { source SE : [ FTSFiles] } where each LFN appears only once
   """
   # the more an SE has files, the more likely it is that it is a big good old T1 site.
   # So we start packing with these SEs
@@ -67,8 +68,8 @@ def generatePossibleTransfersBySources(ftsFiles, allowedSources=None):
       CAUTION ! a given LFN can be in multiple source
       You still have to choose your source !
 
-      :param allowedSources : list of allowed sources
-      :param ftsFiles : list of FTS3File object
+      :param allowedSources: list of allowed sources
+      :param ftsFiles: list of FTS3File object
       :return:  S_OK({ sourceSE: [ FTS3Files] })
 
   """
@@ -108,8 +109,8 @@ def selectUniqueRandomSource(ftsFiles, allowedSources=None):
   """
       For a list of FTS3files object, select a random source, and group the files by source.
 
-      :param allowedSources : list of allowed sources
-      :param ftsFiles : list of FTS3File object
+      :param allowedSources: list of allowed sources
+      :param ftsFiles: list of FTS3File object
 
       :return:  S_OK({ sourceSE: [ FTS3Files] })
 
@@ -149,7 +150,7 @@ def groupFilesByTarget(ftsFiles):
   """
         For a list of FTS3files object, group the Files by target
 
-        :param ftsFiles : list of FTS3File object
+        :param ftsFiles: list of FTS3File object
         :return: {targetSE : [ ftsFiles] } }
 
     """
@@ -201,7 +202,7 @@ class FTS3Serializable(object):
                the 'magic' arguments used for rebuilding the
                object
 
-        :return dictionary to be transformed into json
+        :return: dictionary to be transformed into json
     """
     jsonData = {}
     datetimeAttributes = []

--- a/DataManagementSystem/private/FTSAbstractPlacement.py
+++ b/DataManagementSystem/private/FTSAbstractPlacement.py
@@ -9,9 +9,9 @@ class FTSRoute(object):
   
   def __init__( self, sourceSE, targetSE, ftsServer ):
     """
-      :param sourceSE : source se
-      :param targetSE : destination SE
-      :param ftsServer : fts server to use
+      :param sourceSE: source se
+      :param targetSE: destination SE
+      :param ftsServer: fts server to use
     """
 
     self.sourceSE = sourceSE
@@ -28,8 +28,9 @@ class FTSAbstractPlacement( object ):
   def __init__( self, csPath = None, ftsHistoryViews = None ):
     """
        Nothing special done here
-       :param csPath : path of the CS
-       :param ftsHistoryViews : history view of the db (useful for FTS2)
+
+       :param csPath: path of the CS
+       :param ftsHistoryViews: history view of the db (useful for FTS2)
     """
     self.csPath = csPath
     self.ftsHistoryViews = ftsHistoryViews
@@ -43,12 +44,12 @@ class FTSAbstractPlacement( object ):
     """ For multiple source to multiple destination, find the optimal replication
         strategy.
 
-       :param sourceSEs : list of source SE
-       :param targetSEs : list of destination SE
-       :param size : size of the File
-       :param strategy : which strategy to use
+       :param sourceSEs: list of source SE
+       :param targetSEs: list of destination SE
+       :param size: size of the File
+       :param strategy: which strategy to use
 
-       :returns S_OK(dict) < route name :  { dict with key Ancestor, SourceSE, TargetSEtargetSE, Strategy } >
+       :returns: S_OK(dict) < route name :  { dict with key Ancestor, SourceSE, TargetSEtargetSE, Strategy } >
     """
 
     return S_ERROR( 'IMPLEMENT ME' )
@@ -63,8 +64,9 @@ class FTSAbstractPlacement( object ):
   
   def findRoute( self, sourceSE, targetSE ):
     """ Find the appropriate route from point A to B
-      :param sourceSE : source SE
-      :param targetSE : destination SE
+
+      :param sourceSE: source SE
+      :param targetSE: destination SE
 
       :returns: S_OK(FTSRoute)
 
@@ -75,7 +77,7 @@ class FTSAbstractPlacement( object ):
     """ Check whether a given route is valid
        (whatever that means here)
 
-       :param route : FTSRoute
+       :param route: FTSRoute
 
        :returns: S_OK or S_ERROR(reason)
     """
@@ -86,7 +88,7 @@ class FTSAbstractPlacement( object ):
     """Declare that one starts a transfer on a given route.
        Accounting purpose only
 
-       :param route : FTSRoute that is used
+       :param route: FTSRoute that is used
 
     """
     return S_OK()
@@ -95,7 +97,7 @@ class FTSAbstractPlacement( object ):
     """Declare that one finishes a transfer on a given route.
        Accounting purpose only
 
-       :param route : FTSRoute that is used
+       :param route: FTSRoute that is used
 
     """
     return S_OK()

--- a/FrameworkSystem/Client/ProxyManagerClient.py
+++ b/FrameworkSystem/Client/ProxyManagerClient.py
@@ -381,11 +381,12 @@ class ProxyManagerClient( object ):
   def renewProxy( self, proxyToBeRenewed = False, minLifeTime = 3600, newProxyLifeTime = 43200, proxyToConnect = False ):
     """
     Renew a proxy using the ProxyManager
+
     Arguments:
-      proxyToBeRenewed : proxy to renew
-      minLifeTime : if proxy life time is less than this, renew. Skip otherwise
-      newProxyLifeTime : life time of new proxy
-      proxyToConnect : proxy to use for connecting to the service
+      proxyToBeRenewed: proxy to renew
+      minLifeTime: if proxy life time is less than this, renew. Skip otherwise
+      newProxyLifeTime: life time of new proxy
+      proxyToConnect: proxy to use for connecting to the service
     """
     retVal = multiProxyArgument( proxyToBeRenewed )
     if not retVal[ 'Value' ]:

--- a/FrameworkSystem/Client/SystemAdministratorIntegrator.py
+++ b/FrameworkSystem/Client/SystemAdministratorIntegrator.py
@@ -57,12 +57,14 @@ class SystemAdministratorIntegrator( object ):
 
   def getSilentHosts( self ):
     """ Get a list of non-responding hosts
+
     :return: list of hosts
     """
     return self.silentHosts
 
   def getRespondingHosts( self ):
     """ Get a list of responding hosts
+
     :return: list of hosts
     """
     return self.__hosts

--- a/FrameworkSystem/Client/WebAppCompiler.py
+++ b/FrameworkSystem/Client/WebAppCompiler.py
@@ -90,9 +90,10 @@ class WebAppCompiler(object):
     """
     It creates a temporary file using different templates. For example: /tmp/zmathe/tmp4sibR5.compilejs.app.tpl
     This is required to compile the web framework.
+
     :params str tplName: it is the name of the template
     :params dict extra: it contains the application location, which will be added to the temporary file
-    :return the location of the file
+    :return: the location of the file
     """
     inTpl = os.path.join(self.__compileTemplate, tplName)
     try:
@@ -309,6 +310,7 @@ class WebAppCompiler(object):
   def getAppDependencies(self):
     """
     Generate the dependency dictionary
+
     :return: Dict
     """
     if self.__params.name != 'WebAppDIRAC':

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -664,6 +664,7 @@ class SystemAdministratorHandler(RequestHandler):
   def export_getUsedPorts(self):
     """
     Retrieve the ports in use by services on this host
+
     :return: Returns a dictionary containing, for each system, which port is being used by which service
     """
     result = gComponentInstaller.getSetupComponents()

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1158,11 +1158,12 @@ class Dirac(API):
 
   def checkSEAccess(self, se, access='Write'):
     """ returns the value of a certain SE status flag (access or other)
+
       :param se: Storage Element name
       :type se: string
       :param access: type of access
       :type access: string in ('Read', 'Write', 'Remove', 'Check')
-      : returns: True or False
+      :returns: True or False
     """
     return StorageElement(se, vo=self.vo).status().get(access, False)
 

--- a/MonitoringSystem/Client/MonitoringClient.py
+++ b/MonitoringSystem/Client/MonitoringClient.py
@@ -84,14 +84,15 @@ class MonitoringClient(object):
   def getReport(self, typeName, reportName, startTime, endTime, condDict, grouping, extraArgs=None):
     """
     It is used to get the raw data used to create a plot.
-    :param str typeName the type of the monitoring
-    :param str reportName the name of the plotter used to create the plot for example:  NumberOfJobs
-    :param int startTime epoch time, start time of the plot
-    :param int endTime epoch time, end time of the plot
-    :param dict condDict is the conditions used to gnerate the plot: {'Status':['Running'],'grouping': ['Site'] }
-    :param str grouping is the grouping of the data for example: 'Site'
-    :paran dict extraArgs epoch time which can be last day, last week, last month
-    :rerturn S_OK or S_ERROR
+
+    :param str typeName: the type of the monitoring
+    :param str reportName: the name of the plotter used to create the plot for example:  NumberOfJobs
+    :param int startTime: epoch time, start time of the plot
+    :param int endTime: epoch time, end time of the plot
+    :param dict condDict: is the conditions used to gnerate the plot: {'Status':['Running'],'grouping': ['Site'] }
+    :param str grouping: is the grouping of the data for example: 'Site'
+    :param dict extraArgs: epoch time which can be last day, last week, last month
+    :rerturn: S_OK or S_ERROR
     """
     rpcClient = self.__getServer()
     if not isinstance(extraArgs, dict):

--- a/MonitoringSystem/Client/MonitoringReporter.py
+++ b/MonitoringSystem/Client/MonitoringReporter.py
@@ -87,6 +87,7 @@ class MonitoringReporter(object):
   def addRecord(self, rec):
     """
     It inserts the record to the list
+
     :param dict rec: it kontains a key/value pair.
     """
     self.__documents.append(rec)
@@ -94,6 +95,7 @@ class MonitoringReporter(object):
   def publishRecords(self, records, mqProducer=None):
     """
     send data to the MQ. If the mqProducer instance is provided, it will be used for publishing the data to MQ.
+
     :param list records: contains a list of key/value pairs (dictionaries)
     :param object mqProducer: We can provide the instance of a producer, which will be used to publish the data
     """

--- a/MonitoringSystem/Client/Types/BaseType.py
+++ b/MonitoringSystem/Client/Types/BaseType.py
@@ -29,6 +29,7 @@ class BaseType( object ):
   ########################################################################
   def __init__( self ):
     """ c'tor
+
     :param self: self reference
     """
     self.doc_type = None

--- a/MonitoringSystem/Client/Types/ComponentMonitoring.py
+++ b/MonitoringSystem/Client/Types/ComponentMonitoring.py
@@ -18,6 +18,7 @@ class ComponentMonitoring( BaseType ):
     super( ComponentMonitoring, self ).__init__()
 
     """ c'tor
+
     :param self: self reference
     """
 

--- a/MonitoringSystem/Client/Types/WMSHistory.py
+++ b/MonitoringSystem/Client/Types/WMSHistory.py
@@ -18,6 +18,7 @@ class WMSHistory( BaseType ):
     super( WMSHistory, self ).__init__()
 
     """ c'tor
+
     :param self: self reference
     """
 

--- a/MonitoringSystem/private/DBUtils.py
+++ b/MonitoringSystem/private/DBUtils.py
@@ -56,9 +56,10 @@ class DBUtils ( object ):
 
   def __init__( self, db, setup ):
     """ c'tor
+
     :param self: self reference
-    :param object the database module
-    :param str setup DIRAC setup
+    :param db: the database module
+    :param str setup: DIRAC setup
     """
     self.__db = db
     self.__setup = setup

--- a/MonitoringSystem/private/MainReporter.py
+++ b/MonitoringSystem/private/MainReporter.py
@@ -15,15 +15,14 @@ __RCSID__ = "$Id$"
 class PlottersList( object ):
 
   """
-  .. class:: PlottersList
-
   Used to determine all available plotters used to create the plots
 
-  :param dict __plotters stores the available plotters
+  :param dict __plotters: stores the available plotters
   """
   def __init__( self ):
 
     """ c'tor
+
     :param self: self reference
     """
 
@@ -45,20 +44,18 @@ class PlottersList( object ):
 
 
 class MainReporter( object ):
-
   """
-  .. class:: MainReporter
-
-  :param object __db database object
-  :param str __setup DIRAC setup
-  :param str __csSection CS section used to configure some parameters.
-  :param list __plotterList available plotters
+  :param object __db: database object
+  :param str __setup: DIRAC setup
+  :param str __csSection: CS section used to configure some parameters.
+  :param list __plotterList: available plotters
   """
   def __init__( self, db, setup ):
     """ c'tor
+
     :param self: self reference
-    :param object the database module
-    :param str setup DIRAC setup
+    :param object: the database module
+    :param str setup: DIRAC setup
     """
     self.__db = db
     self.__setup = setup
@@ -68,8 +65,10 @@ class MainReporter( object ):
   def __calculateReportHash( self, reportRequest ):
     """
     It creates an unique identifier
-    :param dict reportRequest plot attributes used to create the plot
-    :return str it return an unique value
+
+    :param dict reportRequest: plot attributes used to create the plot
+    :return: an unique value
+    :rtype: str
     """
     requestToHash = dict( reportRequest )
     granularity = gConfig.getValue( "%s/CacheTimeGranularity" % self.__csSection, 300 )
@@ -84,10 +83,12 @@ class MainReporter( object ):
   def generate( self, reportRequest, credDict ):
     """
     It is used to create a plot.
-    :param dict reportRequest plot attributes used to create the plot
 
-    Note: I know credDict is not used, but if we plan to add some policy, we need to use it!
-    :return dict S_OK/S_ERROR the values used to create the plot
+    :param dict reportRequest: plot attributes used to create the plot
+
+    .. note:: I know credDict is not used, but if we plan to add some policy, we need to use it!
+
+    :return: dict S_OK/S_ERROR the values used to create the plot
     """
     typeName = reportRequest[ 'typeName' ]
     plotterClass = self.__plotterList.getPlotterClass( typeName )
@@ -101,8 +102,9 @@ class MainReporter( object ):
   def list( self, typeName ):
     """
     It returns the available plots
-    :param str typeName monitoring type
-    :return dict S_OK/S_ERROR list of available reports (plots)
+
+    :param str typeName: monitoring type
+    :return: dict S_OK/S_ERROR list of available reports (plots)
     """
     plotterClass = self.__plotterList.getPlotterClass( typeName )
     if not plotterClass['OK']:

--- a/MonitoringSystem/private/Plotters/BasePlotter.py
+++ b/MonitoringSystem/private/Plotters/BasePlotter.py
@@ -44,6 +44,7 @@ class BasePlotter( DBUtils ):
   def __init__( self, db, setup, extraArgs = None ):
     super( BasePlotter, self ).__init__( db, setup )
     """ c'tor
+
     :param self: self reference
     """
 
@@ -69,7 +70,8 @@ class BasePlotter( DBUtils ):
   def generate( self, reportRequest ):
     """
     It retrives the data from the database and create the plot
-    :param dict reportRequest contains the plot attributes
+
+    :param dict reportRequest: contains the plot attributes
     """
     reportHash = reportRequest[ 'hash' ]
     reportName = reportRequest[ 'reportName' ]
@@ -110,11 +112,10 @@ class BasePlotter( DBUtils ):
   def __retrieveReportData( self, reportRequest, reportHash ):
     """
     It uses the appropriate Plotter to retrieve the data from the database.
-    :param dict reportRequest the dictionary which contains the conditions used to create
-    the plot
-    :param str reportHash it is the unique identifier used to cache a plot
-    :return dict S_OK/S_ERROR if the data found in the cache it returns from it
-    otherwise it uses the cache.
+
+    :param dict reportRequest: the dictionary which contains the conditions used to create the plot
+    :param str reportHash: it is the unique identifier used to cache a plot
+    :return: dict S_OK/S_ERROR if the data found in the cache it returns from it otherwise it uses the cache.
     """
     funcName = "_report%s" % reportRequest[ 'reportName' ]
     if not hasattr( self, funcName ):
@@ -127,11 +128,11 @@ class BasePlotter( DBUtils ):
                                      dataFunc = funcObj )
 
   def __generatePlotForReport( self, reportRequest, reportHash, reportData ):
-    """
-    It creates the plot
-    :param dict reportRequest contains the plot attributes
-    :param str reportHash unique string which identify the plot
-    :param dict repotData contains the data used to generate the plot.
+    """It creates the plot
+
+    :param dict reportRequest: contains the plot attributes
+    :param str reportHash: unique string which identify the plot
+    :param dict repotData: contains the data used to generate the plot.
     """
 
     funcName = "_plot%s" % reportRequest[ 'reportName' ]
@@ -148,11 +149,12 @@ class BasePlotter( DBUtils ):
   def _getTimedData( self, startTime, endTime, selectFields, preCondDict, metadataDict = None ):
     """
     It retrieves the time series data from the database.
-    :param int startTime epoch time
-    :param int endTime epoch time
-    :param list selectFields the value what we want to plot
-    :param dict preCondDict plot attributes
-    :param dict metadataDict extra arguments used to create the plot.
+
+    :param int startTime: epoch time
+    :param int endTime: epoch time
+    :param list selectFields: the value what we want to plot
+    :param dict preCondDict: plot attributes
+    :param dict metadataDict: extra arguments used to create the plot.
 
     """
 
@@ -202,11 +204,12 @@ class BasePlotter( DBUtils ):
   def _getSummaryData( self, startTime, endTime, selectFields, preCondDict, metadataDict = None ):
     """
     It returns the adat used to create the pie chart plot.
-    :param int startTime epoch time
-    :param int endTime epoch time
-    :param list selectFields the value what we want to plot
-    :param dict preCondDict plot attributes
-    :param dict metadataDict extra arguments used to create the plot.
+
+    :param int startTime: epoch time
+    :param int endTime: epoch time
+    :param list selectFields: the value what we want to plot
+    :param dict preCondDict: plot attributes
+    :param dict metadataDict: extra arguments used to create the plot.
     """
     grouping = preCondDict['grouping'][0]
     condDict = {}
@@ -271,9 +274,9 @@ class BasePlotter( DBUtils ):
     return reportDataDict, graphDataDict, maxValue, unitData[0]
 
   def __checkPlotMetadata( self, metadata ):
-    """
-    It check the plot metadata arguments
-    :param dict metadata contains the plot metadata
+    """It check the plot metadata arguments
+
+    :param dict metadata: contains the plot metadata
     """
     if self._extraArgs.get( self._EA_WIDTH ):
       try:
@@ -289,9 +292,9 @@ class BasePlotter( DBUtils ):
       metadata[ 'title' ] = self._extraArgs[ self._EA_TITLE ]
 
   def __checkThumbnailMetadata( self, metadata ):
-    """
-     checks the plot thumbnail data
-     :param dict metadata contains the thumbnail data
+    """checks the plot thumbnail data
+
+     :param dict metadata: contains the thumbnail data
      """
     if self._EA_THUMBNAIL in self._extraArgs and self._extraArgs[ self._EA_THUMBNAIL ]:
       thbMD = dict( metadata )
@@ -312,12 +315,12 @@ class BasePlotter( DBUtils ):
     return False
 
   def __plotData( self, filename, dataDict, metadata, funcToPlot ):
-    """
-    It create the plot.
-    :param str filename the name of the file which contains the plot
-    :param dict dataDict data used to crate the plot
-    :param dict metadata plot metadata
-    :param object funcToPlot the method which create the plot using the appropriate method.
+    """It create the plot.
+
+    :param str filename: the name of the file which contains the plot
+    :param dict dataDict: data used to crate the plot
+    :param dict metadata: plot metadata
+    :param object funcToPlot: the method which create the plot using the appropriate method.
     """
     self.__checkPlotMetadata( metadata )
     if not dataDict:

--- a/MonitoringSystem/private/Plotters/ComponentMonitoringPlotter.py
+++ b/MonitoringSystem/private/Plotters/ComponentMonitoringPlotter.py
@@ -66,79 +66,79 @@ class ComponentMonitoringPlotter(BasePlotter):
   _reportRunningThreadsName = "Number of running threads"
 
   def _reportRunningThreads(self, reportRequest):
-    """
-    It is used to retrieve the data from the database.
-    :param dict reportRequest contains attributes used to create the plot.
+    """It is used to retrieve the data from the database.
+
+    :param dict reportRequest: contains attributes used to create the plot.
     :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
     return self.__reportAllResources(reportRequest, "threads", "threads")
 
   def _plotRunningThreads(self, reportRequest, plotInfo, filename):
-    """
-    It creates the plot.
-    :param dict reportRequest plot attributes
-    :param dict plotInfo contains all the data which are used to create the plot
-    :param str filename
-    :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
+    """It creates the plot.
+
+    :param dict reportRequest: plot attributes
+    :param dict plotInfo: contains all the data which are used to create the plot
+    :param str filename:
+    :return: S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
     return self.__plotAllResources(reportRequest, plotInfo, filename, 'Number of running threads')
 
   _reportCpuUsageName = "CPU usage"
 
   def _reportCpuUsage(self, reportRequest):
-    """
-    It is used to retrieve the data from the database.
-    :param dict reportRequest contains attributes used to create the plot.
-    :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
+    """It is used to retrieve the data from the database.
+
+    :param dict reportRequest: contains attributes used to create the plot.
+    :return: S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
     return self.__reportAllResources(reportRequest, "cpuUsage", "percentage")
 
   def _plotCpuUsage(self, reportRequest, plotInfo, filename):
-    """
-    It creates the plot.
-    :param dict reportRequest plot attributes
-    :param dict plotInfo contains all the data which are used to create the plot
-    :param str filename
-    :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
+    """It creates the plot.
+
+    :param dict reportRequest: plot attributes
+    :param dict plotInfo: contains all the data which are used to create the plot
+    :param str filename:
+    :return: S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
     return self.__plotAllResources(reportRequest, plotInfo, filename, 'CPU usage')
 
   _reportMemoryUsageName = "Memory usage"
 
   def _reportMemoryUsage(self, reportRequest):
-    """
-    It is used to retrieve the data from the database.
-    :param dict reportRequest contains attributes used to create the plot.
-    :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
+    """It is used to retrieve the data from the database.
+
+    :param dict reportRequest: contains attributes used to create the plot.
+    :return: S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
     return self.__reportAllResources(reportRequest, "memoryUsage", "bytes")
 
   def _plotMemoryUsage(self, reportRequest, plotInfo, filename):
-    """
-    It creates the plot.
-    :param dict reportRequest plot attributes
-    :param dict plotInfo contains all the data which are used to create the plot
-    :param str filename
-    :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
+    """It creates the plot.
+
+    :param dict reportRequest: plot attributes
+    :param dict plotInfo: contains all the data which are used to create the plot
+    :param str filename:
+    :return: S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
     return self.__plotAllResources(reportRequest, plotInfo, filename, 'Memory usage')
 
   _reportRunningTimeName = "Running time"
 
   def _reportRunningTime(self, reportRequest):
-    """
-    It is used to retrieve the data from the database.
-    :param dict reportRequest contains attributes used to create the plot.
-    :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
+    """It is used to retrieve the data from the database.
+
+    :param dict reportRequest: contains attributes used to create the plot.
+    :return: S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
     return self.__reportAllResources(reportRequest, "runningTime", "time")
 
   def _plotRunningTime(self, reportRequest, plotInfo, filename):
-    """
-    It creates the plot.
-    :param dict reportRequest plot attributes
-    :param dict plotInfo contains all the data which are used to create the plot
-    :param str filename
-    :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
+    """It creates the plot.
+
+    :param dict reportRequest: plot attributes
+    :param dict plotInfo: contains all the data which are used to create the plot
+    :param str filename:
+    :return: S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
     return self.__plotAllResources(reportRequest, plotInfo, filename, 'Running time')

--- a/MonitoringSystem/private/Plotters/WMSHistoryPlotter.py
+++ b/MonitoringSystem/private/Plotters/WMSHistoryPlotter.py
@@ -24,10 +24,10 @@ class WMSHistoryPlotter( BasePlotter ):
   _typeKeyFields =  WMSHistory().keyFields 
 
   def _reportNumberOfJobs( self, reportRequest ):
-    """
-    It is used to retrieve the data from the database.
-    :param dict reportRequest contains attributes used to create the plot.
-    :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length 
+    """It is used to retrieve the data from the database.
+
+    :param dict reportRequest: contains attributes used to create the plot.
+    :return: S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
     selectFields = ['Jobs']
     retVal = self._getTimedData( startTime = reportRequest[ 'startTime' ],
@@ -41,12 +41,12 @@ class WMSHistoryPlotter( BasePlotter ):
     return S_OK( { 'data' : dataDict, 'granularity' : granularity } )
 
   def _plotNumberOfJobs( self, reportRequest, plotInfo, filename ):
-    """
-    It creates the plot.
-    :param dict reportRequest plot attributes
-    :param dict plotInfo contains all the data which are used to create the plot
-    :param str filename
-    :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
+    """It creates the plot.
+
+    :param dict reportRequest: plot attributes
+    :param dict plotInfo: contains all the data which are used to create the plot
+    :param str filename:
+    :return: S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
     metadata = {'title' : 'Jobs by %s' % reportRequest[ 'grouping' ],
                 'starttime' : reportRequest[ 'startTime' ],
@@ -66,10 +66,10 @@ class WMSHistoryPlotter( BasePlotter ):
 
 
   def _reportNumberOfReschedules( self, reportRequest ):
-    """
-    It is used to retrieve the data from the database.
-    :param dict reportRequest contains attributes used to create the plot.
-    :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length 
+    """It is used to retrieve the data from the database.
+
+    :param dict reportRequest: contains attributes used to create the plot.
+    :return: S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
     selectFields = ['Reschedules']
     retVal = self._getTimedData( startTime = reportRequest[ 'startTime' ],
@@ -84,11 +84,11 @@ class WMSHistoryPlotter( BasePlotter ):
     return S_OK( { 'data' : dataDict, 'granularity' : granularity } )
 
   def _plotNumberOfReschedules( self, reportRequest, plotInfo, filename ):
-    """
-    It creates the plot.
-    :param dict reportRequest plot attributes
-    :param dict plotInfo contains all the data which are used to create the plot
-    :param str filename
+    """It creates the plot.
+
+    :param dict reportRequest: plot attributes
+    :param dict plotInfo: contains all the data which are used to create the plot
+    :param str filename:
     :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
     metadata = {'title' : 'Reschedules by %s' % reportRequest[ 'grouping' ],
@@ -108,10 +108,10 @@ class WMSHistoryPlotter( BasePlotter ):
                                           metadata = metadata )
 
   def _reportAverageNumberOfJobs( self, reportRequest ):
-    """
-    It is used to retrieve the data from the database.
-    :param dict reportRequest contains attributes used to create the plot.
-    :return S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length 
+    """It is used to retrieve the data from the database.
+
+    :param dict reportRequest: contains attributes used to create the plot.
+    :return: S_OK or S_ERROR {'data':value1, 'granularity':value2} value1 is a dictionary, value2 is the bucket length
     """
     selectFields = ['Jobs']
                            
@@ -126,11 +126,11 @@ class WMSHistoryPlotter( BasePlotter ):
     return S_OK( { 'data' : dataDict  } )
 
   def _plotAverageNumberOfJobs( self, reportRequest, plotInfo, filename ):
-    """
-    It creates the plot.
-    :param dict reportRequest plot attributes
-    :param dict plotInfo contains all the data which are used to create the plot
-    :param str filename
+    """It creates the plot.
+
+    :param dict reportRequest: plot attributes
+    :param dict plotInfo: contains all the data which are used to create the plot
+    :param str filename:
     :return S_OK or S_ERROR { 'plot' : value1, 'thumbnail' : value2 } value1 and value2 are TRUE/FALSE
     """
     metadata = {'title' : 'Average Number of Jobs by %s' % reportRequest[ 'grouping' ],

--- a/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -47,6 +47,7 @@ class AgentConfigError( Exception ):
   """ misconfiguration error """
   def __init__( self, msg ):
     """ ctor
+
     :param str msg: error string
     """
     Exception.__init__( self )

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -328,7 +328,8 @@ class Request( object ):
   def delayNextExecution( self, deltaTime ):
     """This helper sets the NotBefore attribute in deltaTime minutes
        in the future
-       :param deltaTime : time in minutes before next execution
+
+       :param deltaTime: time in minutes before next execution
     """
     now = datetime.datetime.utcnow().replace( microsecond = 0 )
     extraDelay = datetime.timedelta( minutes = deltaTime )

--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -894,7 +894,7 @@ class RequestDB( object ):
     """ read request id for given name
         if the name is not unique, an error is returned
 
-    :param requestName : name of the request
+    :param requestName: name of the request
     """
     session = self.DBSession()
 

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -188,9 +188,9 @@ class ReqManagerHandler(RequestHandler):
   @classmethod
   def export_getBulkRequests(cls, numberOfRequest, assigned):
     """ Get a request of given type from the database
-        :param numberOfRequest : size of the bulk (default 10)
 
-        :return S_OK( {Failed : message, Successful : list of Request.toJSON()} )
+        :param numberOfRequest: size of the bulk (default 10)
+        :return: S_OK( {Failed : message, Successful : list of Request.toJSON()} )
     """
     getRequests = cls.__requestDB.getBulkRequests(
         numberOfRequest=numberOfRequest, assigned=assigned)
@@ -263,8 +263,8 @@ class ReqManagerHandler(RequestHandler):
         The key can be any field from the RequestTable. or "Type",
         which will be interpreted as 'Operation.Type'
 
-        :param groupingAttribute : attribute used for grouping
-        :param selectDict : selection criteria
+        :param groupingAttribute: attribute used for grouping
+        :param selectDict: selection criteria
     """
 
     return cls.__requestDB.getRequestCountersWeb(groupingAttribute, selectDict)

--- a/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -237,6 +237,7 @@ class ReqProxyHandler(RequestHandler):
 
   def export_listCacheDir(self):
     """List the content of the Cache directory
+
         :returns: list of file
     """
     cacheDir = self.cacheDir()

--- a/ResourceStatusSystem/Client/ResourceStatus.py
+++ b/ResourceStatusSystem/Client/ResourceStatus.py
@@ -311,8 +311,8 @@ class ResourceStatus(object):
   def isStorageElementAlwaysBanned(self, seName, statusType):
     """ Checks if the AlwaysBanned policy is applied to the SE given as parameter
 
-    :param seName : string, name of the SE
-    :param statusType : ReadAcces, WriteAccess, RemoveAccess, CheckAccess
+    :param seName: string, name of the SE
+    :param statusType: ReadAcces, WriteAccess, RemoveAccess, CheckAccess
 
     :returns: S_OK(True/False)
     """

--- a/Resources/Catalog/FCConditionParser.py
+++ b/Resources/Catalog/FCConditionParser.py
@@ -58,14 +58,6 @@ class FCConditionParser(object):
   # Binary operator base class
   class _BoolBinOp( object ):
     """ Abstract object to represent a binary operator
-
-           :param token: the token matching a binary operator
-                         it is a list with only one element which itself is a list
-                         [ [ Arg1, Operator, Arg2] ]
-                         The arguments themselves can be of any type, but they need to
-                         provide an "eval" method that takes \*\*kwargs as input,
-                         and return a boolean
-
     """
 
     reprsymbol = None  # Sign to represent the boolean operation
@@ -76,6 +68,12 @@ class FCConditionParser(object):
 
     def __init__( self, token ):
       """
+      :param token: the token matching a binary operator
+                    it is a list with only one element which itself is a list
+                    [ [ Arg1, Operator, Arg2] ]
+                    The arguments themselves can be of any type, but they need to
+                    provide an "eval" method that takes \*\*kwargs as input,
+                    and return a boolean
       """
 
       # Keep the two arguments
@@ -114,19 +112,16 @@ class FCConditionParser(object):
 
   class _BoolNot( object ):
     """ Represents the "not" unitary operator
-
-    :param t: the token matching a unitary operator
-              it is a list with only one element which itself is a list
-              [ [ !, Arg1] ]
-              The argument itself can be of any type, but it needs to
-              provide an "eval" method that takes \*\*kwargs as input,
-              and return a boolean
-
     """
 
     def __init__( self, t ):
       """
-
+      :param t: the token matching a unitary operator
+                it is a list with only one element which itself is a list
+                [ [ !, Arg1] ]
+                The argument itself can be of any type, but it needs to
+                provide an "eval" method that takes \*\*kwargs as input,
+                and return a boolean
       """
 
       # We just keep the argument

--- a/Resources/Catalog/FileCatalogClientBase.py
+++ b/Resources/Catalog/FileCatalogClientBase.py
@@ -68,6 +68,7 @@ class FileCatalogClientBase( Client ):
   @classmethod
   def hasCatalogMethod( cls, methodName ):
     """ Check of a method with the given name is implemented
+
     :param str methodName: the name of the method to check
     :return: boolean Flag True if the method is implemented
     """

--- a/Resources/Catalog/TSCatalogClient.py
+++ b/Resources/Catalog/TSCatalogClient.py
@@ -47,7 +47,8 @@ class TSCatalogClient( FileCatalogClientBase ):
 
   def setMetadata( self, path, metadatadict ):
     """ Set metadata parameter for the given path
-        :return Successful/Failed dict.
+
+        :return: Successful/Failed dict.
     """
     rpcClient = self._getRPC()
     return rpcClient.setMetadata( path, metadatadict )

--- a/Resources/MessageQueue/MQConnectionManager.py
+++ b/Resources/MessageQueue/MQConnectionManager.py
@@ -123,6 +123,7 @@ class MQConnectionManager( object ):
 
   def getConnector( self, mqConnection ):
     """ Function returns MQConnector assigned to the mqURI.
+
     Args:
       mqConnection(str): connection name.
     Returns:

--- a/Resources/MessageQueue/MQConnector.py
+++ b/Resources/MessageQueue/MQConnector.py
@@ -90,6 +90,7 @@ class MQConnector( object ):
   def disconnect( self, parameters = None ):
     """
     Disconnects from the message queue server
+
     :param dict parameters: dictionary with additional parameters if any
     :return: S_OK/S_ERROR
     """
@@ -98,6 +99,7 @@ class MQConnector( object ):
   def subscribe( self, parameters = None ):
     """
     Subscribes to the message queue server
+
     :param dict parameters: dictionary with additional parameters if any
     :return: S_OK/S_ERROR
     """
@@ -107,6 +109,7 @@ class MQConnector( object ):
   def unsubscribe( self, parameters = None ):
     """
     Subscribes to the message queue server
+
     :param dict parameters: dictionary with additional parameters if any
     :return: S_OK/S_ERROR
     """

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -232,6 +232,7 @@ class StompListener (stomp.ConnectionListener):
   def on_message(self, headers, body):
     """
     Function called upon receiving a message
+
     :param dict headers: message headers
     :param json body: message body
     """

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -117,9 +117,9 @@ class GFAL2_StorageBase(StorageBase):
 
     :param self: self reference
     :param str path: path or list of paths to be checked
-    :returns Failed dictionary: {pfn : error message}
-             Successful dictionary: {pfn : bool}
-             S_ERROR in case of argument problems
+    :returns: Failed dictionary: {pfn : error message}
+              Successful dictionary: {pfn : bool}
+              S_ERROR in case of argument problems
     """
     res = checkArgumentFormat(path)
     if not res['OK']:
@@ -182,9 +182,9 @@ class GFAL2_StorageBase(StorageBase):
 
     :param self: self reference
     :param str: path or list of paths to be checked ( 'srm://...')
-    :returns Failed dict: {path : error message}
-             Successful dict: {path : bool}
-             S_ERROR in case of argument problems
+    :returns: Failed dict: {path : error message}
+              Successful dict: {path : bool}
+              S_ERROR in case of argument problems
 
     """
     res = checkArgumentFormat(path)
@@ -380,9 +380,9 @@ class GFAL2_StorageBase(StorageBase):
     :param self: self reference
     :param str path: path (or list of paths) on storage (srm://...)
     :param localPath: destination folder. Default is from current directory
-    :returns Successful dict: {path : size}
-             Failed dict: {path : errorMessage}
-             S_ERROR in case of argument problems
+    :returns: Successful dict: {path : size}
+              Failed dict: {path : errorMessage}
+              S_ERROR in case of argument problems
     """
 
     res = checkArgumentFormat(path)
@@ -846,9 +846,9 @@ class GFAL2_StorageBase(StorageBase):
     :param str path: path of list of paths to be pinned
     :param int lifetime: pinning time in seconds (default 24h)
 
-    :return successful dict {url : token},
-            failed dict {url : message}
-            S_ERROR in case of argument problems
+    :return: successful dict {url : token},
+             failed dict {url : message}
+             S_ERROR in case of argument problems
     """
 
     res = checkArgumentFormat(path)
@@ -904,9 +904,9 @@ class GFAL2_StorageBase(StorageBase):
                      Just as you can pass an empty token string and a directory as pfn which then releases all the files in the directory
                      an its subdirectories
 
-    :return successful dict {url : token},
-            failed dict {url : message}
-            S_ERROR in case of argument problems
+    :return: successful dict {url : token},
+             failed dict {url : message}
+             S_ERROR in case of argument problems
     """
     res = checkArgumentFormat(path)
     if not res['OK']:
@@ -1032,7 +1032,7 @@ class GFAL2_StorageBase(StorageBase):
 
     :param self: self reference
     :param time: unix time
-    :return Date in following format: 2014-10-29 14:32:10
+    :return: Date in following format: 2014-10-29 14:32:10
     """
     return datetime.datetime.fromtimestamp(time).strftime('%Y-%m-%d %H:%M:%S')
 

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -553,7 +553,7 @@ class StorageElementItem(object):
   def getStorageParameters(self, plugin=None, protocol=None):
     """ Get plugin specific options
 
-      :param plugin : plugin we are interested in
+      :param plugin: plugin we are interested in
       :param protocol: protocol we are interested in
 
       Either plugin or protocol can be defined, not both, but at least one of them
@@ -612,7 +612,7 @@ class StorageElementItem(object):
         :param sourceSE: storageElement instance of the sourceSE
         :param protocols: ordered protocol restriction list
 
-        :return:dictionnary Successful/Failed with pair (src, dest) urls
+        :return: dictionnary Successful/Failed with pair (src, dest) urls
     """
     log = self.log.getSubLogger('generateTransferURLsBetweenSEs')
 
@@ -711,7 +711,7 @@ class StorageElementItem(object):
         between the sourceSE and ourselves. If protocols is given,
         the chosen protocol has to be among those
 
-        :param sourceSE : storageElement instance of the sourceSE
+        :param sourceSE: storageElement instance of the sourceSE
         :param protocols: ordered protocol restriction list
 
         :return: a list protocols that fits the needs, or None
@@ -798,7 +798,7 @@ class StorageElementItem(object):
   def getLFNFromURL(self, urls):
     """ Get the LFN from the PFNS .
 
-        :param lfn : input lfn or lfns (list/dict)
+        :param lfn: input lfn or lfns (list/dict)
 
     """
     result = checkArgumentFormat(urls)
@@ -871,9 +871,9 @@ class StorageElementItem(object):
     """ Generates a dictionary (url : lfn ), where the url are constructed
         from the lfn using the constructURLFromLFN method of the storage plugins.
 
-        :param: lfns : dictionary {lfn:whatever}
+        :param lfns: dictionary {lfn:whatever}
 
-        :returns dictionary {constructed url : lfn}
+        :returns: dictionary {constructed url : lfn}
     """
     log = self.log.getSubLogger("__generateURLDict")
     log.verbose("generating url dict for %s lfn in %s." % (len(lfns), self.name))
@@ -1043,11 +1043,11 @@ class StorageElementItem(object):
     """ Forward the call to each storage in turn until one works.
         The method to be executed is stored in self.methodName
 
-        :param lfn : string, list or dictionary
-        :param *args : variable amount of non-keyword arguments. SHOULD BE EMPTY
-        :param **kwargs : keyword arguments
+        :param lfn: string, list or dictionary
+        :param *args: variable amount of non-keyword arguments. SHOULD BE EMPTY
+        :param **kwargs: keyword arguments
 
-        :returns S_OK( { 'Failed': {lfn : reason} , 'Successful': {lfn : value} } )
+        :returns: S_OK( { 'Failed': {lfn : reason} , 'Successful': {lfn : value} } )
                 The Failed dict contains the lfn only if the operation failed on all the storages
                 The Successful dict contains the value returned by the successful storages.
 
@@ -1202,11 +1202,11 @@ class StorageElementItem(object):
     """
         Generates a DataOperation accounting if needs to be, and adds it to the DataStore client cache
 
-        :param lfns : list of lfns on which we attempted the operation
-        :param startDate : datetime, start of the operation
-        :param elapsedTime : time (seconds) the operation took
-        :param storageParameters : the parameters of the plugins used to perform the operation
-        :param callRes : the return of the method call, S_OK or S_ERROR
+        :param lfns: list of lfns on which we attempted the operation
+        :param startDate: datetime, start of the operation
+        :param elapsedTime: time (seconds) the operation took
+        :param storageParameters: the parameters of the plugins used to perform the operation
+        :param callRes: the return of the method call, S_OK or S_ERROR
 
         The operation is generated with the OperationType "se.methodName"
         The TransferSize and TransferTotal for directory methods actually take into

--- a/WorkloadManagementSystem/DB/ElasticJobDB.py
+++ b/WorkloadManagementSystem/DB/ElasticJobDB.py
@@ -39,7 +39,7 @@ class ElasticJobDB(DB):
     :param int jobID: Job ID
     :param list paramList: list of parameters to be returned
 
-    :return : dict with all Job Parameter values
+    :return: dict with all Job Parameter values
     """
 
     self.log.debug('JobDB.getParameters: Getting Parameters for job %s' % jobID)
@@ -93,7 +93,7 @@ class ElasticJobDB(DB):
     :param string attribute: Attribute
     :param list paramList: list of parameters to be returned
 
-    :return : dict with all Job Parameter and Attribute values
+    :return: dict with all Job Parameter and Attribute values
     """
 
     self.log.debug('JobDB.getParameters: Getting Parameters for job %s' % jobID)
@@ -152,7 +152,7 @@ class ElasticJobDB(DB):
     :param basestring key: Name
     :param keyword value: value
 
-    :return : S_OK/S_ERROR
+    :return: S_OK/S_ERROR
     """
 
     attributesDict = {"jobGroup": "00000000", "owner": 'Unknown', "proxy": None, "subTime": None, "runTime": None}

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -437,7 +437,7 @@ class JobDB(DB):
     :param self: self reference
     :param int jobID: Job ID
 
-    :return : dict with all Job Status values/empty dict if matching job not found
+    :return: dict with all Job Status values/empty dict if matching job not found
     """
 
     jobStatusNames = ['Status', 'MinorStatus', 'ApplicationStatus']
@@ -656,7 +656,7 @@ class JobDB(DB):
         :param bool update: optional flag to update the job LastUpdateTime stamp
         :param str myDate: optional time stamp for the LastUpdateTime attribute
 
-        :return : S_OK/S_ERROR
+        :return: S_OK/S_ERROR
     """
 
     if attrName not in self.jobAttributeNames:
@@ -697,7 +697,7 @@ class JobDB(DB):
         :param bool update: optional flag to update the job LastUpdateTime stamp
         :param str myDate: optional time stamp for the LastUpdateTime attribute
 
-        :return : S_OK/S_ERROR
+        :return: S_OK/S_ERROR
     """
 
     jobIDList = jobID


### PR DESCRIPTION
Add a check for the `:param` and `:return` in the html of the code documentation

Fix the formatting of these in the docstrings.

- [x] Check after the last merges