### PR TITLE
[v6r20] Add site name configuration for singularity

### DIFF
--- a/Resources/Computing/SingularityComputingElement.py
+++ b/Resources/Computing/SingularityComputingElement.py
@@ -135,6 +135,7 @@ class SingularityComputingElement(ComputingElement):
       cfgOpts.append("-S '%s'" % setup)
     csServers = gConfig.getValue("/DIRAC/Configuration/Servers", [])
     cfgOpts.append("-C '%s'" % ','.join(csServers))
+    cfgOpts.append("-n '%s'" % DIRAC.siteName())
     return ' '.join(cfgOpts)
 
   def __createWorkArea(self, proxy, jobDesc, log, logLevel):


### PR DESCRIPTION
We found that the site using singularity does not appear in the accounting, while two other site names show up as 'DIRAC.Client.cn' and 'DIRAC.Client.uk'.
This happens because the dirac installation inside singularity does not have a site name configuration.
Then the job wrapper running inside singularity is also not able to report the correct site name.

Here it is added as the dirac-configure argument.

BEGINRELEASENOTES

*Resources
FIX: Add site name configuration for the dirac installation inside singularity CE

ENDRELEASENOTES
