### PR TITLE
[v6r20] DFC: fix the sePrefix default return value

### DIFF
--- a/Resources/Catalog/FileCatalogClient.py
+++ b/Resources/Catalog/FileCatalogClient.py
@@ -121,10 +121,10 @@ class FileCatalogClient(FileCatalogClientBase):
           # The PFN was not returned, construct it on the fly
           # For some VO's the prefix can be non-standard
           voPrefix = seDict.get("VOPrefix", {}).get(se, {}).get(vo)
-          sePrefix = seDict.get(se)
+          sePrefix = seDict.get(se, '')
           prefix = voPrefix if voPrefix else sePrefix
-          if prefix:
-            lfnDict['Successful'][lfn][se] = prefix + lfn
+
+          lfnDict['Successful'][lfn][se] = prefix + lfn
 
     return S_OK(lfnDict)
 


### PR DESCRIPTION
Fixes https://github.com/DIRACGrid/DIRAC/issues/3828
The Integration tests are working again with this PR

BEGINRELEASENOTES
*DMS
FIX: restore correct default value for the SEPrefix in the FileCatalogClient
ENDRELEASENOTES
