### PR TITLE
[v6r20]Fix fts3 space token for non srm storage

### DIFF
--- a/DataManagementSystem/Client/FTS3Job.py
+++ b/DataManagementSystem/Client/FTS3Job.py
@@ -4,6 +4,7 @@ __RCSID__ = "$Id $"
 
 
 import datetime
+import errno
 
 # Requires at least version 3.3.3
 import fts3.rest.client.easy as fts3
@@ -15,6 +16,7 @@ from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
+from DIRAC.Core.Utilities.DErrno import cmpError
 
 from DIRAC.DataManagementSystem.private.FTS3Utilities import FTS3Serializable
 from DIRAC.DataManagementSystem.Client.FTS3File import FTS3File
@@ -145,7 +147,7 @@ class FTS3Job(FTS3Serializable):
 
         :param seName name of the storageElement
 
-        :returns space token
+        :returns space token. If there is no SpaceToken defined, returns None
     """
     seToken = None
     if seName:
@@ -153,6 +155,11 @@ class FTS3Job(FTS3Serializable):
 
       res = seObj.getStorageParameters(protocol='srm')
       if not res['OK']:
+        # If there is no SRM protocol, we do not specify
+        # the space token
+        if cmpError(res, errno.ENOPROTOOPT):
+          return S_OK(None)
+
         return res
 
       seToken = res["Value"].get("SpaceToken")

--- a/DataManagementSystem/Client/FTS3Operation.py
+++ b/DataManagementSystem/Client/FTS3Operation.py
@@ -4,6 +4,7 @@ from sqlalchemy import orm
 
 from DIRAC.DataManagementSystem.Client.FTS3Job import FTS3Job
 from DIRAC.DataManagementSystem.private import FTS3Utilities
+from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
@@ -457,6 +458,8 @@ class FTS3TransferOperation(FTS3Operation):
     request = res['Value']['request']
     operation = res['Value']['operation']
 
+    registrationProtocols = DMSHelpers(vo=self._vo).getRegistrationProtocols()
+
     log.info("will create %s 'RegisterReplica' operations" % len(ftsFilesByTarget))
 
     for target, ftsFileList in ftsFilesByTarget.iteritems():
@@ -479,7 +482,7 @@ class FTS3TransferOperation(FTS3Operation):
         # TODO: are we really ever going to change type... ?
         opFile.ChecksumType = 'ADLER32'
         opFile.Size = ftsFile.size
-        res = returnSingleResult(targetSE.getURL(ftsFile.lfn, protocol='srm'))
+        res = returnSingleResult(targetSE.getURL(ftsFile.lfn, protocol=registrationProtocols))
 
         # This should never happen !
         if not res["OK"]:

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -581,7 +581,7 @@ class StorageElementItem(object):
 
     errStr = "Requested plugin or protocol not available."
     log.debug(errStr, "%s for %s" % (reqStr, self.name))
-    return S_ERROR(errStr)
+    return S_ERROR(errno.ENOPROTOOPT, errStr)
 
   def __getAllProtocols(self, protoType):
     """ Returns the list of all protocols for Input or Output


### PR DESCRIPTION
This were the small pieces missing to have transfers going to/from non SRM storage to work. They are used as hotfix in LHCb for ECHO storage. 

BEGINRELEASENOTES

*DMS
FIX: FTS3: remove the hardcoded srm protocol for registration
FIX: FTS3: return an empty spacetoken if SRM is not available

*Resources
NEW: SE: return a standard error in case the requested protocol is not available

ENDRELEASENOTES
