### PR TITLE
v6r20] ReplicationTransformation.createDataTransformation: return the transformation object when successful

### DIFF
--- a/TransformationSystem/Utilities/ReplicationTransformation.py
+++ b/TransformationSystem/Utilities/ReplicationTransformation.py
@@ -31,7 +31,7 @@ def createDataTransformation(flavour, targetSE, sourceSE,
   :param str tGroup: transformation group to set
   :param tBody: transformation body to set
   :param bool enable: if true submit the transformation, otherwise dry run
-  :returns: S_OK, S_ERROR
+  :returns: S_OK (with the transformation object, if successfully added), S_ERROR
   """
   metadata = {metaKey: metaValue}
   if isinstance(extraData, dict):
@@ -94,4 +94,4 @@ def createDataTransformation(flavour, targetSE, sourceSE,
     return res
 
   gLogger.always("Successfully created replication transformation")
-  return S_OK()
+  return S_OK(trans)


### PR DESCRIPTION

BEGINRELEASENOTES

*TS
CHANGE:  ReplicationTransformation.createDataTransformation: returns S_OK with the transformation object when it was successfully added, instead of S_OK(None)

ENDRELEASENOTES
