### PR TITLE
[v6r20] Core.Base.Script: fix exception for scriptName in tests

### DIFF
--- a/Core/Base/Script.py
+++ b/Core/Base/Script.py
@@ -27,6 +27,7 @@ if caller != '__main__':
       break
     i += 1
 
+i = 0 if i == len(sys.argv) else i
 scriptName = os.path.basename(sys.argv[i]).replace('.py', '')
 localCfg.firstOptionIndex = i + 1
 


### PR DESCRIPTION
If the loop prior to this change doesn't find the script name an exception is guaranteed. This breaks our tests.

related to #3885

BEGINRELEASENOTES

*Core
FIX: Core.Base.Script: Fix exception on import, when the caller module was not like anything on the command line arguments

ENDRELEASENOTES
