### PR TITLE
[v6r20] Add possiblity to make the use of deprecated functions/class raise an exception

### DIFF
--- a/Core/Utilities/Decorators.py
+++ b/Core/Utilities/Decorators.py
@@ -1,6 +1,7 @@
 """ Decorators for DIRAC.
 """
 
+import os
 import inspect
 import functools
 import traceback
@@ -11,6 +12,9 @@ def deprecated( reason, onlyOnce=False ):
   """ A decorator to mark a class or function as deprecated.
       This will cause a warnings to be generated in the usual log if the item
       is used (instantiated or called).
+
+      If the environment variable ``DIRAC_DEPRECATED_FAIL`` is set to a non-empty value, an exception will be
+      raised when the function or class is used.
 
       The decorator can be used before as class or function, giving a reason,
       for example:
@@ -24,6 +28,7 @@ def deprecated( reason, onlyOnce=False ):
 
       @deprecated( "Use otherClass instead", onlyOnce=True )
       class MyOldClass:
+
 
       Parameters
       ----------
@@ -70,6 +75,9 @@ def deprecated( reason, onlyOnce=False ):
           the constructor/function/method.
           All arguments are passed through to the target function.
       """
+      # fail calling the function if environment variable is set
+      if os.environ.get("DIRAC_DEPRECATED_FAIL", None):
+        raise NotImplementedError("ERROR: using deprecated function or class: %s" % reason)
       # Get the details of the deprecated object
       if clsName:
         objName = clsName

--- a/Core/Utilities/Decorators.py
+++ b/Core/Utilities/Decorators.py
@@ -10,6 +10,7 @@ __RCSID__ = "$Id$"
 
 def deprecated( reason, onlyOnce=False ):
   """ A decorator to mark a class or function as deprecated.
+
       This will cause a warnings to be generated in the usual log if the item
       is used (instantiated or called).
 
@@ -17,23 +18,23 @@ def deprecated( reason, onlyOnce=False ):
       raised when the function or class is used.
 
       The decorator can be used before as class or function, giving a reason,
-      for example:
-      @deprecated( "Use functionTwo instead" )
-      def functionOne( ... ):
+      for example::
 
-      If onlyOnce is set to true then the warning will only be generated on the
+        @deprecated("Use functionTwo instead")
+        def functionOne(...):
+
+      If `onlyOnce` is set to true then the warning will only be generated on the
       first call or creation of the item. This is useful for things that are
       likely to get called repeatedly (to prevent generating massive log files);
-      for example:
+      for example::
 
-      @deprecated( "Use otherClass instead", onlyOnce=True )
-      class MyOldClass:
-
+        @deprecated("Use otherClass instead", onlyOnce=True)
+        class MyOldClass:
 
       Parameters
       ----------
       reason : str
-        Message to display to the user when the deperated item is used. This should specify
+        Message to display to the user when the deprecated item is used. This should specify
         what should be used instead.
       onlyOnce : bool
         If set, the deprecation warning will only be displayed on the first use.
@@ -44,7 +45,6 @@ def deprecated( reason, onlyOnce=False ):
         A double-function wrapper around the decorated object as required by the python
         interpreter.
   """
-
   def decFunc( func, clsName=None ):
     """ Inner function generator.
         Returns a function which wraps the given "func" function,


### PR DESCRIPTION
With this option tests fail when they access a deprecated function, making it possible to automatically track down the usage.


BEGINRELEASENOTES

*CORE
NEW: When the environment variable DIRAC_DEPRECATED_FAIL is set to a non-empty value, the use of deprecated functions will raise a NotImplementError exception

ENDRELEASENOTES
