### PR TITLE
[v6r20] fix dead slave exception and consider ArchiveSE in closerSEs

### DIFF
--- a/ConfigurationSystem/private/ServiceInterface.py
+++ b/ConfigurationSystem/private/ServiceInterface.py
@@ -99,7 +99,7 @@ class ServiceInterface(threading.Thread):
     gLogger.info("Checking status of slave servers")
     iGraceTime = gConfigurationData.getSlavesGraceTime()
     bModifiedSlaveServers = False
-    for sSlaveURL in self.dAliveSlaveServers:
+    for sSlaveURL in self.dAliveSlaveServers.keys():
       if time.time() - self.dAliveSlaveServers[sSlaveURL] > iGraceTime:
         gLogger.info("Found dead slave", sSlaveURL)
         del self.dAliveSlaveServers[sSlaveURL]

--- a/TransformationSystem/Client/Utilities.py
+++ b/TransformationSystem/Client/Utilities.py
@@ -435,7 +435,7 @@ class PluginUtilities(object):
     if targetSEs:
       # Some SEs are left, look for sites
       existingSites = [self.dmsHelper.getLocalSiteForSE(se).get('Value')
-                       for se in existingSEs if not self.dmsHelper.isSEArchive(se)]
+                       for se in existingSEs]
       existingSites = set([site for site in existingSites if site])
       closeSEs = set([se for se in targetSEs
                       if self.dmsHelper.getLocalSiteForSE(se).get('Value') in existingSites])


### PR DESCRIPTION
Regarding the exception in the CS, it looks like that, and was introduced here https://github.com/DIRACGrid/DIRAC/commit/806114f82b95313f0c9fe3dff245c4dbecc3e0ca
```
2018-11-22 21:12:40 UTC Configuration/Server INFO: Found dead slave dips://lbvobox100.cern.ch:9135/Configuration/Server
Exception in thread Thread-5:
Traceback (most recent call last):
  File "/opt/dirac/pro/Linux_x86_64_glibc-2.12/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/opt/dirac/pro/DIRAC/ConfigurationSystem/private/ServiceInterface.py", line 172, in run
    self.__checkSlavesStatus()
  File "/opt/dirac/pro/DIRAC/ConfigurationSystem/private/ServiceInterface.py", line 102, in __checkSlavesStatus
    for sSlaveURL in self.dAliveSlaveServers:
RuntimeError: dictionary changed size during iterat
```

BEGINRELEASENOTES

*CS
FIX: Fix exception when removing dead slave

*TS
NEW: do not remove archive SEs when looking at closerSE

ENDRELEASENOTES
