### PR TITLE
[v6r20] patch send mail client/service

### DIFF
--- a/FrameworkSystem/Client/NotificationClient.py
+++ b/FrameworkSystem/Client/NotificationClient.py
@@ -11,10 +11,11 @@ from DIRAC.Core.Utilities.Mail import Mail
 
 class NotificationClient(Client):
 
-  def __init__(self):
+  def __init__(self, **kwargs):
     """ Notification Client constructor
     """
     self.log = gLogger.getSubLogger('NotificationClient')
+    Client.__init__(self, **kwargs)
     self.setServer('Framework/Notification')
 
   def sendMail(self, addresses, subject, body,

--- a/FrameworkSystem/Service/NotificationHandler.py
+++ b/FrameworkSystem/Service/NotificationHandler.py
@@ -70,7 +70,7 @@ class NotificationHandler( RequestHandler ):
     gLogger.verbose( 'Received signal to send the following mail to %s:\nSubject = %s\n%s' % ( address, subject, body ) )
     eMail = Mail()
     notificationSection = PathFinder.getServiceSection( "Framework/Notification" )
-    csSection = notificationSection + '/SMTPServer'
+    csSection = notificationSection + '/SMTP'
     eMail._smtpHost = gConfig.getValue( '%s/Host' % csSection )
     eMail._smtpPort = gConfig.getValue( '%s/Port' % csSection )
     eMail._smtpLogin = gConfig.getValue( '%s/Login' % csSection )


### PR DESCRIPTION
Fixed AttributeError: 'function' object has no attribute 'setdefault'

BEGINRELEASENOTES

*FrameworkSystem/Client/NotificationClient.py
FIX: Added **kwargs argument

*FrameworkSystem/Service/NotificationHandler.py
FIX: Changed SMTPServer to SMTP

ENDRELEASENOTES