### PR TITLE
[v6r20] web compiler support for extjs6

### DIFF
--- a/FrameworkSystem/Client/WebAppCompiler.py
+++ b/FrameworkSystem/Client/WebAppCompiler.py
@@ -133,7 +133,6 @@ class WebAppCompiler(object):
         env[k] = os.environ[k]
         os.environ.pop(k)
     gLogger.verbose("Command is: %s" % " ".join(cmd))
-    print "Command is: %s" % " ".join(cmd)
     try:
       result = subprocess.call(cmd)
     except OSError as e:
@@ -256,10 +255,8 @@ class WebAppCompiler(object):
 
     try:
       os.unlink(inFile)
-    except IOError as e:
-      print e
+    except IOError:
       pass
-
     for staticPath in self.__staticPaths:
       gLogger.notice("Looing into %s" % staticPath)
       extDirectoryContent = os.listdir(staticPath)


### PR DESCRIPTION

BEGINRELEASENOTES
*FrameworkSystem
FIX: add extjs6 support to the web compiler
ENDRELEASENOTES
