### PR TITLE
[v6r20] FTS3: speedup by using subqueries for the Jobs table

### DIFF
--- a/DataManagementSystem/DB/FTS3DB.py
+++ b/DataManagementSystem/DB/FTS3DB.py
@@ -111,7 +111,10 @@ fts3Operation_mapper = mapper(FTS3Operation, fts3OperationTable,
                               ),
                                   'ftsJobs': relationship(
                                   FTS3Job,
-                                  lazy='joined',  # Immediately load the entirety of the object
+                                  lazy='subquery',  # Immediately load the entirety of the object,
+                                                    # but use a subquery to do it
+                                                    # This is to avoid the cartesian product between the three tables.
+                                                    # https://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#subquery-eager-loading
                                   cascade='all, delete-orphan',  # if a File is removed from the list,
                                   # remove it from the DB
                                   passive_deletes=True,  # used together with cascade='all, delete-orphan'


### PR DESCRIPTION
Now that's a cool one :-)
In order to optimize the queries done to retrieve FTS3Operations, FTS3Jobs and FTS3Files, I changed the loading type between Operations and Jobs. It is now done using a subquery. The net result is that some queries that were taking many minutes because of the cardinality now takes 2 seconds.
It is running as hotfix in LHCb 

BEGINRELEASENOTES

*DMS
CHANGE: FTS3: speedup by using subqueries for the Jobs table

ENDRELEASENOTES
