### PR TITLE
[v6r21]  fix fts duplicate transfer (and fix Script.py)

### DIFF
--- a/Core/Base/Script.py
+++ b/Core/Base/Script.py
@@ -34,7 +34,8 @@ if caller != '__main__':
   gLogger.debug("Called from module", caller)
   # Loop over until one of the argument is the caller, that is the DIRAC script
   for arg in sys.argv:
-    # if the form is "pytest test-dirac-do-something.py::class::method", we need to isolate the test-dirac-do-something.py
+    # if the form is "pytest test-dirac-do-something.py::class::method", we
+    # need to isolate the test-dirac-do-something.py
     arg = arg.split('::')[0]
     if os.path.basename(arg).replace('.py', '') == caller.split('.')[-1]:
       break

--- a/Core/Base/Script.py
+++ b/Core/Base/Script.py
@@ -43,7 +43,7 @@ if caller != '__main__':
 
 # If we reached the end, assume the caller is the first argument
 i = 0 if i == len(sys.argv) else i
-# Same thing here, get ride of the pytest specific class:meth options
+# Same thing here, get rid of the pytest specific class:meth options
 scriptName = os.path.basename(sys.argv[i].split('::')[0]).replace('.py', '')
 # The first argument DIRAC should parse is the next one
 localCfg.firstOptionIndex = i + 1

--- a/Core/Base/Script.py
+++ b/Core/Base/Script.py
@@ -18,19 +18,34 @@ localCfg = LocalConfiguration()
 
 caller = inspect.currentframe().f_back.f_globals['__name__']
 
+
+# There are several ways to call DIRAC scripts:
+# * dirac-do-something
+# * dirac-do-something.py
+# * python dirac-do-something.py
+# * pytest test-dirac-do-something.py
+# * pytest --option test-dirac-do-something.py
+# * pytest test-dirac-do-something.py::class::method
+# The following lines attempt to keep only what is necessary to DIRAC, leaving the rest to pytest or whatever is before
+
 i = 0
 if caller != '__main__':
   # This is for the case when, for example, you run a DIRAC script from within pytest
   gLogger.debug("Called from module", caller)
+  # Loop over until one of the argument is the caller, that is the DIRAC script
   for arg in sys.argv:
+    # if the form is "pytest test-dirac-do-something.py::class::method", we need to isolate the test-dirac-do-something.py
+    arg = arg.split('::')[0]
     if os.path.basename(arg).replace('.py', '') == caller.split('.')[-1]:
       break
     i += 1
 
+# If we reached the end, assume the caller is the first argument
 i = 0 if i == len(sys.argv) else i
-scriptName = os.path.basename(sys.argv[i]).replace('.py', '')
+# Same thing here, get ride of the pytest specific class:meth options
+scriptName = os.path.basename(sys.argv[i].split('::')[0]).replace('.py', '')
+# The first argument DIRAC should parse is the next one
 localCfg.firstOptionIndex = i + 1
-
 gIsAlreadyInitialized = False
 
 

--- a/DataManagementSystem/Agent/FTS3Agent.py
+++ b/DataManagementSystem/Agent/FTS3Agent.py
@@ -213,7 +213,9 @@ class FTS3Agent(AgentModule):
       # { fileID : { Status, Error } }
       filesStatus = res['Value']
 
-      res = self.fts3db.updateFileStatus(filesStatus)
+      # Specify the job ftsGUID to make sure we do not overwrite
+      # status of files already taken by newer jobs
+      res = self.fts3db.updateFileStatus(filesStatus, ftsGUID=ftsJob.ftsGUID)
 
       if not res['OK']:
         log.error("Error updating file fts status", "%s, %s" % (ftsJob.ftsGUID, res))

--- a/DataManagementSystem/Client/FTS3Client.py
+++ b/DataManagementSystem/Client/FTS3Client.py
@@ -63,12 +63,13 @@ class FTS3Client(Client):
     except Exception as e:
       return S_ERROR("Exception when decoding the active jobs json %s" % e)
 
-  def updateFileStatus(self, fileStatusDict, **kwargs):
+  def updateFileStatus(self, fileStatusDict, ftsGUID=None, **kwargs):
     """ Update the file ftsStatus and error
-       :param fileStatusDict : { fileID : { status , error } }
+       :param fileStatusDict : { fileID : { status , error, ftsGUID } }
+       :param ftsGUID: if specified, only update the files having a matchign ftsGUID
     """
 
-    return self._getRPC(**kwargs).updateFileStatus(fileStatusDict)
+    return self._getRPC(**kwargs).updateFileStatus(fileStatusDict, ftsGUID)
 
   def updateJobStatus(self, jobStatusDict, **kwargs):
     """ Update the job Status and error

--- a/DataManagementSystem/Client/FTS3File.py
+++ b/DataManagementSystem/Client/FTS3File.py
@@ -37,7 +37,7 @@ class FTS3File(FTS3Serializable):
   INIT_STATE = 'New'
 
   _attrToSerialize = ['fileID', 'operationID', 'status', 'attempt', 'creationTime',
-                      'lastUpdate', 'rmsFileID', 'checksum', 'size', 'lfn', 'error', 'targetSE']
+                      'lastUpdate', 'rmsFileID', 'checksum', 'size', 'lfn', 'error', 'targetSE', 'ftsGUID']
 
   def __init__(self):
 
@@ -57,6 +57,9 @@ class FTS3File(FTS3Serializable):
     self.error = None
 
     self.targetSE = None
+
+    # Place holder for the latest job taking care of this file
+    self.ftsGUID = None
 
   @staticmethod
   def fromRMSFile(rmsFile, targetSE):

--- a/DataManagementSystem/DB/FTS3DB.py
+++ b/DataManagementSystem/DB/FTS3DB.py
@@ -332,8 +332,8 @@ class FTS3DB(object):
 
        :param fileStatusDict : { fileID : { status , error, ftsGUID } }
        :param ftsGUID: If specified, only update the rows where the ftsGUID matches this value.
-                       This avoids two jobs handling teh same file one after another to step on each other foot.
-                       Note that for the moment it is a optional parameters, but it may turn mandatory soon.
+                       This avoids two jobs handling the same file one after another to step on each other foot.
+                       Note that for the moment it is an optional parameter, but it may turn mandatory soon.
 
     """
 

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -103,12 +103,13 @@ class FTS3ManagerHandler(RequestHandler):
   types_updateFileStatus = [dict]
 
   @classmethod
-  def export_updateFileStatus(cls, fileStatusDict):
+  def export_updateFileStatus(cls, fileStatusDict, ftsGUID):
     """ Update the file ftsStatus and error
        :param fileStatusDict : { fileID : { status , error } }
+       :param ftsGUID: (not mandatory) If specified, only update the rows where the ftsGUID matches this value.
     """
 
-    return cls.fts3db.updateFileStatus(fileStatusDict)
+    return cls.fts3db.updateFileStatus(fileStatusDict, ftsGUID)
 
   types_updateJobStatus = [dict]
 

--- a/tests/Integration/DataManagementSystem/Test_Client_FTS3.py
+++ b/tests/Integration/DataManagementSystem/Test_Client_FTS3.py
@@ -191,7 +191,7 @@ class TestClientFTS3(unittest.TestCase):
         File1 fails, File2 is still ongoing.
         We submit Job2 for File1.
         Job1 is monitored again, and we update again File1 to failed (because it is so in Job1)
-        A Job3 would be created for File1, dispite Job2 still runing on it.
+        A Job3 would be created for File1, despite Job2 still running on it.
     """
     op = self.generateOperation('Transfer', 2, ['Target1'])
 

--- a/tests/Integration/DataManagementSystem/Test_Client_FTS3.py
+++ b/tests/Integration/DataManagementSystem/Test_Client_FTS3.py
@@ -182,6 +182,181 @@ class TestClientFTS3(unittest.TestCase):
     for attr in ['ftsGUID', 'ftsServer', 'username', 'userGroup']:
       self.assertTrue(getattr(job1, attr) == getattr(job2, attr))
 
+  def test_03_job_monitoring_racecondition(self):
+    """ We used to have a race condition resulting in duplicated transfers for a file.
+        This test reproduces the race condition.
+
+        The scenario is as follow. Operation has two files File1 and File2.
+        Job1 is submitted for File1 and File2.
+        File1 fails, File2 is still ongoing.
+        We submit Job2 for File1.
+        Job1 is monitored again, and we update again File1 to failed (because it is so in Job1)
+        A Job3 would be created for File1, dispite Job2 still runing on it.
+    """
+    op = self.generateOperation('Transfer', 2, ['Target1'])
+
+    job1 = FTS3Job()
+    job1.ftsGUID = '03-racecondition-job1'
+    job1.ftsServer = 'fts3'
+
+    job1.username = "Pink"
+    job1.userGroup = "Floyd"
+
+    op.ftsJobs.append(job1)
+
+    res = self.client.persistOperation(op)
+    opID = res['Value']
+
+    # Get back the operation to update all the IDs
+    res = self.client.getOperation(opID)
+    op = res['Value']
+
+    fileIds = []
+    for ftsFile in op.ftsFiles:
+      fileIds.append(ftsFile.fileID)
+
+    file1ID = min(fileIds)
+    file2ID = max(fileIds)
+
+    # Now we monitor Job1, and find that the first file has failed, the second is still ongoing
+    fileStatusDict = {file1ID: {'status': 'Failed', 'error': 'Someone made a boo-boo'},
+                      file2ID: {'status': 'Staging'}
+                      }
+
+    res = self.client.updateFileStatus(fileStatusDict)
+    self.assertTrue(res['OK'])
+
+    # We would then submit a second job
+    job2 = FTS3Job()
+    job2.ftsGUID = '03-racecondition-job2'
+    job2.ftsServer = 'fts3'
+
+    job2.username = "Pink"
+    job2.userGroup = "Floyd"
+
+    op.ftsJobs.append(job2)
+    res = self.client.persistOperation(op)
+
+    # Now we monitor Job2 & Job1 (in this order)
+    fileStatusDictJob2 = {file1ID: {'status': 'Staging'},
+                          }
+    res = self.client.updateFileStatus(fileStatusDictJob2)
+    self.assertTrue(res['OK'])
+
+    # And in Job1, File1 is (and will remain) failed, while File2 is still ongoing
+    fileStatusDictJob1 = {file1ID: {'status': 'Failed', 'error': 'Someone made a boo-boo'},
+                          file2ID: {'status': 'Staging'}
+                          }
+    res = self.client.updateFileStatus(fileStatusDictJob1)
+    self.assertTrue(res['OK'])
+
+    # And now this is the problem, because If we check whether this operation still has
+    # files to submit, it will tell me yes, while all the files are being taken care of
+    res = self.client.getOperation(opID)
+    op = res['Value']
+
+    # isTotallyProcessed does not return S_OK struct
+    filesToSubmit = op._getFilesToSubmit()
+    self.assertEquals(filesToSubmit, [op.ftsFiles[0]])
+
+  def test_04_job_monitoring_solve_racecondition(self):
+    """ We used to have a race condition resulting in duplicated transfers for a file.
+        This test reproduces the race condition to make sure it is fixed.
+        This test makes sure that the update only happens on files concerned by the job
+
+        The scenario is as follow. Operation has two files File1 and File2.
+        Job1 is submitted for File1 and File2.
+        File1 fails, File2 is still ongoing.
+        We submit Job2 for File1.
+        Job1 is monitored again, and we update again File1 to failed (because it is so in Job1)
+        A Job3 would be created for File1, dispite Job2 still runing on it.
+    """
+    op = self.generateOperation('Transfer', 2, ['Target1'])
+
+    job1 = FTS3Job()
+    job1GUID = '04-racecondition-job1'
+    job1.ftsGUID = job1GUID
+    job1.ftsServer = 'fts3'
+
+    job1.username = "Pink"
+    job1.userGroup = "Floyd"
+
+    op.ftsJobs.append(job1)
+
+    # Now, when submitting the job, we specify the ftsGUID to which files are
+    # assigned
+    for ftsFile in op.ftsFiles:
+      ftsFile.ftsGUID = job1GUID
+
+    res = self.client.persistOperation(op)
+    opID = res['Value']
+
+    # Get back the operation to update all the IDs
+    res = self.client.getOperation(opID)
+    op = res['Value']
+
+    fileIds = []
+    for ftsFile in op.ftsFiles:
+      fileIds.append(ftsFile.fileID)
+
+    # Arbitrarilly decide that File1 has the smalled fileID
+    file1ID = min(fileIds)
+    file2ID = max(fileIds)
+
+    # Now we monitor Job1, and find that the first file has failed, the second is still ongoing
+    # And since File1 is in an FTS final status, we set its ftsGUID to None
+    fileStatusDict = {file1ID: {'status': 'Failed', 'error': 'Someone made a boo-boo', 'ftsGUID': None},
+                      file2ID: {'status': 'Staging'}
+                      }
+
+    # And when updating, take care of specifying that you are updating for a given GUID
+    res = self.client.updateFileStatus(fileStatusDict, ftsGUID=job1GUID)
+    self.assertTrue(res['OK'])
+
+    # We would then submit a second job
+    job2 = FTS3Job()
+    job2GUID = '04-racecondition-job2'
+    job2.ftsGUID = job2GUID
+    job2.ftsServer = 'fts3'
+
+    job2.username = "Pink"
+    job2.userGroup = "Floyd"
+
+    op.ftsJobs.append(job2)
+
+    # And do not forget to add the new FTSGUID to File1
+    # assigned
+    for ftsFile in op.ftsFiles:
+      if ftsFile.fileID == file1ID:
+        ftsFile.ftsGUID = job2GUID
+
+    res = self.client.persistOperation(op)
+
+    # Now we monitor Job2 & Job1 (in this order)
+    fileStatusDictJob2 = {file1ID: {'status': 'Staging'},
+                          }
+
+    # Again specify the GUID
+    res = self.client.updateFileStatus(fileStatusDictJob2, ftsGUID=job2GUID)
+    self.assertTrue(res['OK'])
+
+    # And in Job1, File1 is (and will remain) failed, while File2 is still ongoing
+    fileStatusDictJob1 = {file1ID: {'status': 'Failed', 'error': 'Someone made a boo-boo'},
+                          file2ID: {'status': 'Staging'}
+                          }
+
+    # And thanks to specifying the job GUID, File1 should not be touched !
+    res = self.client.updateFileStatus(fileStatusDictJob1, ftsGUID=job1GUID)
+    self.assertTrue(res['OK'])
+
+    # And hopefully now there shouldn't be any file to submit
+    res = self.client.getOperation(opID)
+    op = res['Value']
+
+    # isTotallyProcessed does not return S_OK struct
+    filesToSubmit = op._getFilesToSubmit()
+    self.assertEquals(filesToSubmit, [])
+
   def _perf(self):
 
     db = FTS3DB()


### PR DESCRIPTION
So, there is a bug in the logic in the new FTS system, which might result in duplicate transfers. This is of course not good. This PR fixes it a priori, but unfortunately requires a table change.

The duplicate transfers happen like that:
* Operation has two files File1 and File2.
* Job1 is submitted for File1 and File2.
* File1 fails, File2 is still ongoing.
* We submit Job2 for File1.
* Job1 is monitored again, and we update again File1 to failed (because it is so in Job1)
* A Job3 would be created for File1, despite Job2 still running on it.

The idea of the fix is as follow:
* we add an `ftsGUID` attribute to the FTSFile, initialized to None.
* when submitting a job for that file, we set the ftsGUID to the value of the job we just submitted.  
* when the job is monitored, if the transfer for that file is in an fts final state (Done, Cancel, Failed), we set the ftsGUID to None
* when the status of files are updated after the monitoring of the job, we specify the GUID of the job in the query, such that only the files with this specific GUID are updated. 

@andresailer  please check it carefully. And if you still have your setup to test it, I would love that ! 
@phicharp you may have comments as well.

If we are happy with this solution, I will provide instruction and script to update the database.

PS: I also added a fix for Script.py

BEGINRELEASENOTES

*DMS
FIX: Fixes FTS3 duplicate transfers

*Core
FIX: allow Script.py to accommodate specific test calls with pytest

ENDRELEASENOTES
