### PR TITLE
[V6r20] dfc docstrings

### DIFF
--- a/Resources/Catalog/Utilities.py
+++ b/Resources/Catalog/Utilities.py
@@ -9,6 +9,7 @@ __RCSID__ = "$Id$"
 
 import os
 import errno
+import functools
 
 from DIRAC import S_OK, S_ERROR
 
@@ -67,6 +68,7 @@ def checkArgumentFormat( path, generateMap = False ):
 def checkCatalogArguments( f ):
   """ Decorator to check arguments of FileCatalog calls in the clients
   """
+  @functools.wraps(f)
   def processWithCheckingArguments(*args, **kwargs):
 
     checkFlag = kwargs.pop( 'LFNChecking', True )

--- a/docs/source/AdministratorGuide/DIRACSites/ComputingElements/index.rst
+++ b/docs/source/AdministratorGuide/DIRACSites/ComputingElements/index.rst
@@ -98,7 +98,7 @@ This is the general structure in which specific CE descriptions are inserted.
 The CE configuration is part of the general DIRAC configuration
 It can be placed in the general Configuration Service or in the local configuration of the DIRAC installation.
 
-Additional info can be found :ref:`here <resourcesComputing>`__.
+Additional info can be found :ref:`here <resourcesComputing>`.
 
 Some CE parameters are confidential, e.g.
 password of the account used for the SSH tunnel access to a site. The confidential parameters

--- a/docs/source/AdministratorGuide/DIRACSites/StorageElements/index.rst
+++ b/docs/source/AdministratorGuide/DIRACSites/StorageElements/index.rst
@@ -9,4 +9,4 @@ For instance a different base path or a different SRM Space Token for different 
 
 In general the SE name is a logical name and not a hostname.
 
-Detailed information about SEs can be found :ref:`here <resourcesStorageElement>`__.
+Detailed information about SEs can be found :ref:`here <resourcesStorageElement>`.


### PR DESCRIPTION

BEGINRELEASENOTES

*DMS
FIX: `FileCatalogClient` now properly forwards function docstrings through `checkCatalogArguments` decorator, fixes #3927 
CHANGE: `Resources.Catalog.Utilities`: use functool_wraps in `checkCatalogArguments` 


ENDRELEASENOTES
