### PR TITLE
[v6r20] recursive removal of log directories explicite

### DIFF
--- a/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -402,7 +402,7 @@ class TransformationCleaningAgent(AgentModule):
     :param str directory: folder name
     """
     self.log.verbose("Removing log files found in the directory %s" % directory)
-    res = returnSingleResult(StorageElement(self.logSE).removeDirectory(directory))
+    res = returnSingleResult(StorageElement(self.logSE).removeDirectory(directory, recursive=True))
     if not res['OK']:
       self.log.error("Failed to remove log files", res['Message'])
       return res


### PR DESCRIPTION
When the LogSE is a DIRAC storage, the removal of a directory is always recursive. It is not true for the other SEs. 

BEGINRELEASENOTES
*TS
CHANGE: make the recursive removal of the log directory explicit in the TransformationCleaningAgent
ENDRELEASENOTES
