### PR TITLE
[v6r21] DictCache: prevent AttributeError exception in __del__ function when …

### DIFF
--- a/Core/Utilities/DictCache.py
+++ b/Core/Utilities/DictCache.py
@@ -247,4 +247,7 @@ class DictCache(object):
     """
     self.purgeAll(useLock=False)
     del self.__lock
-    del self.__cache
+    if self.__threadLocal:
+      del self.__threadLocalCache
+    else:
+      del self.__sharedCache


### PR DESCRIPTION
…deleting property

This line in the `__del__` function of DictCache causes exceptions when scripts are exiting, for example, but worse cases can happen, I guess...

https://github.com/DIRACGrid/DIRAC/blob/3df550dd90f850cd9cd40b5e9930ffe16982b2e2/Core/Utilities/DictCache.py#L250

```
Exception AttributeError: "can't delete attribute" in <bound method DictCache.__del__ of <DIRAC.Core.Utilities.DictCache.DictCache object at 0x7efe59325810>> ignored
```
As `__cache` is now a `@property` on can no longer `del` it, instead del one or the other

BEGINRELEASENOTES
*Core
FIX: DictCache: Fix exception upon __delete__

ENDRELEASENOTES
