### PR TITLE
[v6r21] MessageQueue log backends is now set to VERBOSE instead of DEBUG

### DIFF
--- a/Resources/LogBackends/MessageQueueBackend.py
+++ b/Resources/LogBackends/MessageQueueBackend.py
@@ -5,6 +5,7 @@ Message Queue wrapper
 __RCSID__ = "$Id$"
 
 from DIRAC.FrameworkSystem.private.standardLogging.Handler.MessageQueueHandler import MessageQueueHandler
+from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
 from DIRAC.Resources.LogBackends.AbstractBackend import AbstractBackend
 from DIRAC.FrameworkSystem.private.standardLogging.Formatter.JsonFormatter import JsonFormatter
 
@@ -35,6 +36,7 @@ class MessageQueueBackend(AbstractBackend):
     if parameters is not None:
       self.__queue = parameters.get("MsgQueue", self.__queue)
     self._handler = MessageQueueHandler(self.__queue)
+    self._handler.setLevel(LogLevels.VERBOSE)
 
   def setLevel(self, level):
     """


### PR DESCRIPTION
Debug is so full of crap that it just makes centralized logging useless. 
This is a good incentive to review a bit the logging. I will update the log messages/levels in the coming weeks/months, based on the logs I will collect.



BEGINRELEASENOTES

*Resources
CHANGE: MessageQueue log backends is now set to VERBOSE instead of DEBUG
ENDRELEASENOTES
