### PR TITLE
[v7r0] Add a default DIRACOS version to the integration branch -- Merge order: 1

### DIFF
--- a/releases.cfg
+++ b/releases.cfg
@@ -17,6 +17,7 @@ Releases
   {
     Modules = DIRAC, Web, VMDIRAC
     Externals = v6r6p3
+    DIRACOS = master
   }
   v7r0-pre9
   {


### PR DESCRIPTION
@andresailer which system should I put for the release note ?
@atsareg @zmathe can you please check ?


BEGINRELEASENOTES

*Core
NEW: Default DIRACOS version for the integration branch

ENDRELEASENOTES
