### PR TITLE
v6r21 -----  fix bashrc creation in case of diracos

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1791,7 +1791,7 @@ def loadConfiguration():
     elif o in ('-x', '--external'):
       cliParams.externalVersion = v
     elif o == '--cleanPYTHONPATH':
-      cliParams.cleanPYTHONPATH = True  
+      cliParams.cleanPYTHONPATH = True
 
   if not cliParams.release and not cliParams.modules:
     logERROR("Missing release to install")
@@ -2301,6 +2301,7 @@ def createBashrcForDiracOS():
       lines = ['# DIRAC bashrc file, used by service and agent run scripts to set environment',
                'export PYTHONUNBUFFERED=yes',
                'export PYTHONOPTIMIZE=x',
+               '[ -z "$DIRACOS" ] && export DIRACOS=%s/diracos' % proPath,
                '. %s/diracos/diracosrc' % proPath]
       if 'HOME' in os.environ:
         lines.append('[ -z "$HOME" ] && export HOME=%s' % os.environ['HOME'])
@@ -2331,8 +2332,6 @@ def createBashrcForDiracOS():
           [
               '# Some DIRAC locations',
               '[ -z "$DIRAC" ] && export DIRAC=%s' %
-              proPath,
-              '[ -z "$DIRACOS" ] && export DIRACOS=%s/diracos' %
               proPath,
               'export DIRACSCRIPTS=%s' %
               os.path.join(
@@ -2388,6 +2387,7 @@ def createBashrcForDiracOS():
     return False
 
   return True
+
 
 def checkoutFromGit(moduleName, sourceURL, tagVersion, destinationDir=None):
   """


### PR DESCRIPTION
BEGINRELEASENOTES

*CORE
FIX: set DIRACOS environment variable before souring diracosrc
ENDRELEASENOTES
