### PR TITLE
[v6r21] Dirac API returns directory LFN metadata

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1227,7 +1227,8 @@ class Dirac(API):
     return self.getLfnMetadata(lfns, printOutput=printOutput)
 
   def getLfnMetadata(self, lfns, printOutput=False):
-    """Obtain replica metadata from file catalogue client. Input LFN(s) can be string or list.
+    """Obtain replica metadata from file catalogue client.
+       Input LFN(s) can be string or list. LFN(s) can be either files or directories
 
        Example usage:
 
@@ -1249,19 +1250,32 @@ class Dirac(API):
 
     fc = FileCatalog()
     start = time.time()
-    repsResult = fc.getFileMetadata(lfns)
+    fileResult = fc.getFileMetadata(lfns)
     timing = time.time() - start
     self.log.info('Metadata Lookup Time: %.2f seconds ' % (timing))
-    self.log.verbose(repsResult)
-    if not repsResult['OK']:
+    self.log.verbose(fileResult)
+    if not fileResult['OK']:
       self.log.warn('Failed to retrieve file metadata from the catalogue')
-      self.log.warn(repsResult['Message'])
-      return repsResult
+      self.log.warn(fileResult['Message'])
+      return fileResult
+
+    repsResult = fileResult['Value']
+    if repsResult['Failed']:
+      # Some entries can be directories
+      dirs = repsResult['Failed'].keys()
+      dirResult = fc.getDirectoryMetadata(dirs)
+      if not dirResult['OK']:
+        self.log.warn('Failed to retrieve directory metadata from the catalogue')
+        self.log.warn(dirResult['Message'])
+        return dirResult
+      for dir in dirResult['Value']['Successful']:
+        repsResult['Successful'][dir] = dirResult['Value']['Successful'][dir]
+        repsResult['Failed'].pop(dir)
 
     if printOutput:
-      print self.pPrint.pformat(repsResult['Value'])
+      print self.pPrint.pformat(repsResult)
 
-    return repsResult
+    return S_OK(repsResult)
 
   #############################################################################
   def addFile(self, lfn, fullPath, diracSE, fileGuid=None, printOutput=False):

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1255,8 +1255,7 @@ class Dirac(API):
     self.log.info('Metadata Lookup Time: %.2f seconds ' % (timing))
     self.log.verbose(fileResult)
     if not fileResult['OK']:
-      self.log.warn('Failed to retrieve file metadata from the catalogue')
-      self.log.warn(fileResult['Message'])
+      self.log.warn('Failed to retrieve file metadata from the catalogue', fileResult['Message'])
       return fileResult
 
     repsResult = fileResult['Value']
@@ -1268,9 +1267,9 @@ class Dirac(API):
         self.log.warn('Failed to retrieve directory metadata from the catalogue')
         self.log.warn(dirResult['Message'])
         return dirResult
-      for dir in dirResult['Value']['Successful']:
-        repsResult['Successful'][dir] = dirResult['Value']['Successful'][dir]
-        repsResult['Failed'].pop(dir)
+      for directory in dirResult['Value']['Successful']:
+        repsResult['Successful'][directory] = dirResult['Value']['Successful'][directory]
+        repsResult['Failed'].pop(directory)
 
     if printOutput:
       print self.pPrint.pformat(repsResult)


### PR DESCRIPTION
This is a PR to fix issue #3955 

BEGINRELEASENOTES

*Interfaces
CHANGE: Dirac.py - getLFNMetadata returns result for both file and directory LFNs

ENDRELEASENOTES
