### PR TITLE
[v6r21] TransformationCleaningAgent: don't return error if log directory does not exist

### DIFF
--- a/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -21,6 +21,7 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Utilities.Proxy import executeWithUserProxy
+from DIRAC.Core.Utilities.DErrno import cmpError
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Resources.Catalog.FileCatalogClient import FileCatalogClient
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
@@ -357,7 +358,7 @@ class TransformationCleaningAgent(AgentModule):
     self.log.verbose("Removing log files found in the directory %s" % directory)
     res = returnSingleResult(StorageElement(self.logSE).removeDirectory(directory, recursive=True))
     if not res['OK']:
-      if os.strerror(errno.ENOENT) in res['Message']:
+      if cmpError(res, errno.ENOENT):  # No such file or directory
         self.log.warn("Transformation log directory does not exist", directory)
         return S_OK()
       self.log.error("Failed to remove log files", res['Message'])

--- a/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -13,7 +13,8 @@ __RCSID__ = "$Id$"
 # # imports
 import re
 import ast
-import os.path
+import os
+import errno
 from datetime import datetime, timedelta
 # # from DIRAC
 from DIRAC import S_OK, S_ERROR
@@ -356,6 +357,9 @@ class TransformationCleaningAgent(AgentModule):
     self.log.verbose("Removing log files found in the directory %s" % directory)
     res = returnSingleResult(StorageElement(self.logSE).removeDirectory(directory, recursive=True))
     if not res['OK']:
+      if os.strerror(errno.ENOENT) in res['Message']:
+        self.log.warn("Transformation log directory does not exist", directory)
+        return S_OK()
       self.log.error("Failed to remove log files", res['Message'])
       return res
     self.log.info("Successfully removed transformation log directory")


### PR DESCRIPTION

BEGINRELEASENOTES

*TS
FIX: TransformationCleaningAgent: don't return error if log directory does not exist

ENDRELEASENOTES
