### PR TITLE
[v6r21] JobSanity agent must return the number of input data

### DIFF
--- a/Core/scripts/dirac-distribution.py
+++ b/Core/scripts/dirac-distribution.py
@@ -221,7 +221,7 @@ class DistributionMaker:
     return S_OK()
 
   def getAvailableExternals(self):
-    packagesURL = "http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/installSource/tars.list"
+    packagesURL = "http://diracproject.web.cern.ch/diracproject/tars/tars.list"
     try:
       remoteFile = urllib2.urlopen(packagesURL)
     except urllib2.URLError:

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -4,14 +4,14 @@ The main DIRAC installer script. It can be used to install the main DIRAC softwa
 modules, web, rest etc. and DIRAC extensions.
 
 In order to deploy DIRAC you have to provide: globalDefaultsURL, which is by default:
-"http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/globalDefaults.cfg", but it can be
+"http://diracproject.web.cern.ch/diracproject/configs/globalDefaults.cfg", but it can be
 in the local file system in a separate directory. The content of this file is the following::
 
   Installations
   {
     DIRAC
     {
-       DefaultsLocation = http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/defaultsDIRAC.cfg
+       DefaultsLocation =  http://diracproject.web.cern.ch/diracproject/dirac.cfg
        LocalInstallation
        {
         PythonVersion = 27
@@ -19,7 +19,7 @@ in the local file system in a separate directory. The content of this file is th
        # in case you have a DIRAC extension
        LHCb
       {
-      DefaultsLocation = http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/defaults/lhcb.cfg
+      DefaultsLocation = http://lhcb-rpm.web.cern.ch/lhcb-rpm/lhcbdirac/lhcb.cfg
       }
     }
   }
@@ -27,18 +27,18 @@ in the local file system in a separate directory. The content of this file is th
   {
     DIRAC
     {
-      DefaultsLocation = http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/defaults/dirac.cfg
+      DefaultsLocation =  http://diracproject.web.cern.ch/diracproject/dirac.cfg
     }
     # in case you have a DIRAC extension
     LHCb
     {
-      DefaultsLocation = http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/defaults/lhcb.cfg
+      DefaultsLocation = http://lhcb-rpm.web.cern.ch/lhcb-rpm/lhcbdirac/lhcb.cfg
     }
   }
 
 the DefaultsLocation for example::
 
-  DefaultsLocation = http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/defaults/dirac.cfg
+  DefaultsLocation = http://diracproject.web.cern.ch/diracproject/dirac.cfg
 
 must contain a minimal configuration. The following options must be in this
 file::
@@ -493,7 +493,7 @@ class ReleaseConfig(object):
     if globalDefaultsURL:
       self.globalDefaultsURL = globalDefaultsURL
     else:
-      self.globalDefaultsURL = "http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/globalDefaults.cfg"
+      self.globalDefaultsURL = "http://diracproject.web.cern.ch/diracproject/configs/globalDefaults.cfg"
     self.globalDefaults = ReleaseConfig.CFG()
     self.loadedCfgs = []
     self.prjDepends = {}

--- a/WorkloadManagementSystem/Executor/JobSanity.py
+++ b/WorkloadManagementSystem/Executor/JobSanity.py
@@ -104,6 +104,7 @@ class JobSanity(OptimizerExecutor):
       maxLFNs = self.ex_getOption('MaxInputDataPerJob', 100)
       if len(data) > maxLFNs:
         return S_ERROR("Exceeded Maximum Dataset Limit (%s)" % maxLFNs)
+    return S_OK(len(data))
 
   def checkInputSandbox(self, jobState, manifest):
     """The number of input sandbox files, as specified in the job

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -390,7 +390,7 @@ class PilotParams( object ):
     self.architectureScript = 'dirac-platform'
     self.certsLocation = '%s/etc/grid-security' % self.workingDir
     self.pilotCFGFile = 'pilot.json'
-    self.pilotCFGFileLocation = 'http://lhcbproject.web.cern.ch/lhcbproject/dist/DIRAC3/defaults/'
+    self.pilotCFGFileLocation = 'http://diracproject.web.cern.ch/diracproject/configs/'
 
     # Parameters that can be determined at runtime only
     self.queueParameters = {}  # from CE description


### PR DESCRIPTION
BEGINRELEASENOTES
*WorkloadManagement
FIX:JobSanity agent must return the number of input data
*Core
CHANGE: Use EOS for installing DIRAC software
ENDRELEASENOTES