### PR TITLE
[v6r21] Tests: add a test to check that we can copy API classes

### DIFF
--- a/Core/test/Test_API.py
+++ b/Core/test/Test_API.py
@@ -1,0 +1,12 @@
+"""Test the API class."""
+
+import copy
+
+from DIRAC.Core.Base.API import API
+
+
+def test_deepcopy():
+  """Ensure we can copy the API classes."""
+  instance_A = API()
+  instance_B = copy.deepcopy(instance_A)
+  assert instance_B.log


### PR DESCRIPTION
For #3968 
The test will fail if the getstate/setstate are removed