### PR TITLE
[v6r21] FTS3DB.getActiveJobs: get those non-finished jobs that were monitored…

### DIFF
--- a/DataManagementSystem/DB/FTS3DB.py
+++ b/DataManagementSystem/DB/FTS3DB.py
@@ -293,7 +293,7 @@ class FTS3DB(object):
       if jobAssignmentTag:
         ftsJobsQuery = ftsJobsQuery.with_for_update()
 
-      ftsJobsQuery = ftsJobsQuery.order_by(FTS3Job.lastMonitor.desc())
+      ftsJobsQuery = ftsJobsQuery.order_by(FTS3Job.lastMonitor.asc())
       ftsJobsQuery = ftsJobsQuery.limit(limit)
 
       ftsJobs = ftsJobsQuery.all()


### PR DESCRIPTION
… the longest while ago



BEGINRELEASENOTES

*DMS
CHANGE: FTS3DB: getActiveJobs, those jobs are now selected that have been monitored the longest time ago. Ensure better cycling through FTS Jobs

ENDRELEASENOTES
