### PR TITLE
[v6r21] No default SubmitPool in a job description

### DIFF
--- a/Interfaces/scripts/dirac-admin-get-site-mask.py
+++ b/Interfaces/scripts/dirac-admin-get-site-mask.py
@@ -25,7 +25,7 @@ diracAdmin = DiracAdmin()
 
 gLogger.setLevel('ALWAYS')
 
-result = diracAdmin.getSiteMask(printOutput=True)
+result = diracAdmin.getSiteMask(printOutput=True, status="Active")
 if result['OK']:
   DIRACExit( 0 )
 else:

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -1211,12 +1211,6 @@ class JobDB(DB):
     classAdJob.insertAttributeString('OwnerDN', ownerDN)
     classAdJob.insertAttributeString('OwnerGroup', ownerGroup)
 
-    submitPools = getGroupOption(ownerGroup, "SubmitPools")
-    if not submitPools and vo:
-      submitPools = getVOOption(vo, 'SubmitPools')
-    if submitPools and not classAdJob.lookupAttribute('SubmitPools'):
-      classAdJob.insertAttributeString('SubmitPools', submitPools)
-
     if vo:
       classAdJob.insertAttributeString('VirtualOrganization', vo)
 


### PR DESCRIPTION
We used to use SubmitPool job parameter in multi-VO installations to allow pilots submitted for a given VO to distinguish jobs coming from this same VO. Now pilots are using explicit VO name when presenting CE description to the Matcher to achieve the same goal. So, setting the default SubmitPool value for the job description is no more needed and actually complicates the matching logic. It is suppressed in this PR.

BEGINRELEASENOTES

*WorkloadManagementSystem
CHANGE: JobDB.py - do not add default SubmitPool parameter to a job description
FIX: dirac-admin-get-site-mask - show only sites in Active state

ENDRELEASENOTES
