### PR TITLE
[v6r21] Specify CAPath when using requests

### DIFF
--- a/Core/LCG/GOCDBClient.py
+++ b/Core/LCG/GOCDBClient.py
@@ -15,7 +15,7 @@ from xml.dom import minidom
 import requests
 
 from DIRAC import S_OK, S_ERROR, gLogger
-
+from DIRAC.Core.Security.Locations import getCAsLocation
 
 def _parseSingleElement(element, attributes=None):
   """
@@ -222,9 +222,11 @@ class GOCDBClient(object):
     if ongoing:
       params += '&ongoing_only=yes'
 
+    caPath = getCAsLocation()
+
     try:
       response = requests.get(
-          'https://goc.egi.eu/gocdbpi/public/?method=get_downtime&topentity=' + params)
+          'https://goc.egi.eu/gocdbpi/public/?method=get_downtime&topentity=' + params, verify=caPath)
       response.raise_for_status()
     except requests.exceptions.RequestException as e:
       return S_ERROR("Error %s" % e)
@@ -279,7 +281,8 @@ class GOCDBClient(object):
         gocdb_ep = gocdb_ep + "&topentity=" + entity
     gocdb_ep = gocdb_ep + when + gocdbpi_startDate + "&scope="
 
-    dtPage = requests.get(gocdb_ep)
+    caPath = getCAsLocation()
+    dtPage = requests.get(gocdb_ep, verify=caPath)
 
     dt = dtPage.text
 
@@ -304,7 +307,8 @@ class GOCDBClient(object):
     gocdb_ep = "https://goc.egi.eu/gocdbpi/public/?method=get_service_endpoint&" \
         + granularity + '=' + entity
 
-    service_endpoint_page = requests.get(gocdb_ep)
+    caPath = getCAsLocation()
+    service_endpoint_page = requests.get(gocdb_ep, verify=caPath)
 
     return service_endpoint_page.text
 

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2036,8 +2036,7 @@ def createBashrc():
           certDir = '%s/etc/grid-security/certificates' % proPath
       lines.extend(['# CAs path for SSL verification',
                     'export X509_CERT_DIR=%s' % certDir,
-                    'export SSL_CERT_DIR=%s' % certDir,
-                    'export REQUESTS_CA_BUNDLE=%s' % certDir])
+                    'export SSL_CERT_DIR=%s' % certDir])
 
       lines.append(
           'export X509_VOMS_DIR=%s' %
@@ -2155,8 +2154,7 @@ def createCshrc():
           certDir = '%s/etc/grid-security/certificates' % proPath
       lines.extend(['# CAs path for SSL verification',
                     'setenv X509_CERT_DIR %s' % certDir,
-                    'setenv SSL_CERT_DIR %s' % certDir,
-                    'setenv REQUESTS_CA_BUNDLE %s' % certDir])
+                    'setenv SSL_CERT_DIR %s' % certDir])
 
       lines.append(
           'setenv X509_VOMS_DIR %s' %
@@ -2323,8 +2321,7 @@ def createBashrcForDiracOS():
           certDir = '%s/etc/grid-security/certificates' % proPath
       lines.extend(['# CAs path for SSL verification',
                     'export X509_CERT_DIR=%s' % certDir,
-                    'export SSL_CERT_DIR=%s' % certDir,
-                    'export REQUESTS_CA_BUNDLE=%s' % certDir])
+                    'export SSL_CERT_DIR=%s' % certDir])
 
       lines.append(
           'export X509_VOMS_DIR=%s' %

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -205,15 +205,19 @@ def getPilotFiles(pilotFilesDir=None, pilotFilesLocation=None):
   shutil.rmtree(pilotFilesDir)  # make sure it's empty
   os.mkdir(pilotFilesDir)
 
+  # Default value is True such that if this value is
+  # not defined, we use the system CAs with requests
+  caPath = os.environ.get('X509_CERT_DIR', True)
+
   # getting the pilot files
   if pilotFilesLocation.startswith('http'):
-    res = requests.get(pilotFilesLocation)
+    res = requests.get(pilotFilesLocation, verify=caPath)
     if res.status_code != 200:
       raise IOError(res.text)
     fileObj = StringIO(res.content)
     tar = tarfile.open(fileobj=fileObj)
 
-    res = requests.get(os.path.join(os.path.dirname(pilotFilesLocation), 'pilot.json'))
+    res = requests.get(os.path.join(os.path.dirname(pilotFilesLocation), 'pilot.json'), verify=caPath)
     if res.status_code != 200:
       raise IOError(res.text)
     jsonCFG = res.json()


### PR DESCRIPTION
Our users reported issues using standard tools like pip because we define `REQUESTS_CA_BUNDLE` in the generated bashrc. I think it is fair that this kind of settings should not "sweat out" of DIRAC. 
We could overcome this either by setting `os.environ['REQUESTS_CA_BUNDLE']` in the `__init__.py`, or by crafting `Sessions` or by just specifying the CA path when calling requests. Given that there was already an occurrence of the later one in the code, I just propagated it everywhere (also, this allows importing DIRAC's API with other standard tools).

I also removed the REQUESTS_CA_BUNDLE definition from the bashrc.

It might be that we once bump into the same issue with `SSL_CERT_DIR`.

When moving to https, it will be anyway cleaner to wrap all that in a Session object once for all. 

@fstagni I suspect that this deserves to run the pilot tests, since it impacts the pilot fetching what it needs in the pilotWrapper no ?  

BEGINRELEASENOTES
*Core
CHANGE: dirac-install does not define REQUESTS_CA_BUNDLE in the bashrc anymore
CHANGE: specify the ca location when calling requests

*WMS
CHANGE: specify the ca location when calling requests
ENDRELEASENOTES
