### PR TITLE
[v7r0]  Add version restrictions to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,13 +23,14 @@ m2crypto
 numpy>=1.10.1
 pexpect>=4.0.1
 psutil>=4.2.0
-pyasn1
+pyasn1>0.4.1
 pyasn1_modules
 Pygments>=1.5
 pylint>=1.6.5
 pyparsing>=2.0.6
 pytest>=3.6
-pytest-cov>=2.2.0
+coverage===4.0.3
+pytest-cov===2.4.0
 pytest-mock
 python-coveralls
 pytz>=2015.7


### PR DESCRIPTION
I tried to prepare a new virtual env for DIRAC. In order to complete the installation with success I had to add some version restriction at the requirements.txt modules. The exact versions were shown at the errors produced by pip.

OS: openSuse 42.3
python: 2.7.13

References: #3984

BEGINRELEASENOTES
Update the requirements.txt to contain version restrictions at some modules.

Please follow the template:
CHANGE: installing modules from requirements.txt produced version compatibility errors. I updated the file in order to make module installation on a new virtualenv succeed. 

ENDRELEASENOTES
