### PR TITLE
[v6r21] use the proper release

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1126,7 +1126,7 @@ class ReleaseConfig(object):
         for release in self.prjRelCFG['DIRAC']:
           logWARN("Getting DIRACOS version from DIRAC %s!" % release)
           diracOSVersion = self.prjRelCFG['DIRAC'][release].get(
-              "Releases/%s/DIRACOS" % cliParams.release, diracOSVersion)
+              "Releases/%s/DIRACOS" % release, diracOSVersion)
     except KeyError:
       pass
     return diracOSVersion


### PR DESCRIPTION

BEGINRELEASENOTES

*CORE
FIX: if the DIRACOS version is not given then use the proper release version
ENDRELEASENOTES
