### PR TITLE
[v6r21] getDiracModules method is no longer exists use the class member instead

### DIFF
--- a/Core/scripts/dirac-distribution.py
+++ b/Core/scripts/dirac-distribution.py
@@ -186,7 +186,7 @@ class DistributionMaker:
       if 'Web' in modName:  # we have to compile WebApp and also its extension.
         if modName != 'WebAppDIRAC' and modName != "Web":  # it means we have an extension!
           # Note: the old portal called Web
-          modules = self.relConf.getDiracModules()
+          modules = self.relConf.diracBaseModules
           webData = modules.get("WebAppDIRAC", None)
           if webData:
             dctArgs.append("-e '%s'" % webData.get("Version"))


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: getDiracModules is removed, class member is used instead.

ENDRELEASENOTES
