### PR TITLE
[v6r21] MQ disconnect only producers

### DIFF
--- a/Resources/MessageQueue/MQConnector.py
+++ b/Resources/MessageQueue/MQConnector.py
@@ -66,7 +66,7 @@ class MQConnector( object ):
     """
     if not parameters:
       parameters = {}
-    self.parameters = parameters.copy()
+    self.parameters = parameters
 
   def setupConnection( self, parameters = None ):
     """

--- a/Resources/MessageQueue/MQConnector.py
+++ b/Resources/MessageQueue/MQConnector.py
@@ -64,6 +64,9 @@ class MQConnector( object ):
   def __init__( self, parameters = None ):
     """ Standard constructor
     """
+    if not parameters:
+      parameters = {}
+    self.parameters = parameters.copy()
 
   def setupConnection( self, parameters = None ):
     """

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -98,7 +98,7 @@ class StompMQConnector(MQConnector):
     try:
       # Get IP addresses of brokers and ignoring two first returned arguments which are hostname and aliaslist.
       _, _, ip_addresses = socket.gethostbyname_ex(host)
-      self.log.info('Broker name resolved,  to %s IP(s)' % len(ip_addresses))
+      self.log.info('Broker name resolved', 'to %s IP(s)' % len(ip_addresses))
 
       for ip in ip_addresses:
         connectionArgs.update({'host_and_ports': [(ip, int(port))]})

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -99,14 +99,13 @@ class StompMQConnector(MQConnector):
         return S_ERROR(EMQCONN, 'Invalid SSL version provided: %s' % sslVersion)
 
     try:
-      # Get IP addresses of brokers and ignore two first return arguments which are hostname and aliaslist.
+      # Get IP addresses of brokers and ignoring two first returned arguments which are hostname and aliaslist.
       _, _, ip_addresses = socket.gethostbyname_ex(host)
-      self.log.info('Broker name resolves to %s IP(s)' % len(ip_addresses))
+      self.log.info('Broker name resolved,  to %s IP(s)' % len(ip_addresses))
 
       for ip in ip_addresses:
         connectionArgs.update({'host_and_ports': [(ip, int(port))]})
-        print "checking connectionArgs"
-        print connectionArgs
+        self.log.debug("Connection args: %s" % str(connectionArgs))
         self.connections[ip] = stomp.Connection(**connectionArgs)
 
     except Exception as e:

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -45,11 +45,11 @@ class StompMQConnector(MQConnector):
       gLogger.enableLogsFromExternalLibs()
 
   def setupConnection(self, parameters=None):
-    #"""
-    # Establishes a new connection to a Stomp server, e.g. RabbitMQ
-    #:param dict parameters: dictionary with additional MQ parameters if any
-    #:return: S_OK/S_ERROR
-    #"""
+    """
+     Establishes a new connection to a Stomp server, e.g. RabbitMQ
+    :param dict parameters: dictionary with additional MQ parameters if any
+    :return: S_OK/S_ERROR
+    """
 
     if parameters is not None:
       self.parameters.update(parameters)
@@ -91,10 +91,10 @@ class StompMQConnector(MQConnector):
           hostcert = paths[0]
           hostkey = paths[1]
         connectionArgs.update({
-          'use_ssl': True,
-          'ssl_version': sslVersion,
-          'ssl_key_file': hostkey,
-          'ssl_cert_file': hostcert})
+                              'use_ssl': True,
+                              'ssl_version': sslVersion,
+                              'ssl_key_file': hostkey,
+                              'ssl_cert_file': hostcert})
       else:
         return S_ERROR(EMQCONN, 'Invalid SSL version provided: %s' % sslVersion)
 

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -159,7 +159,7 @@ class StompMQConnector(MQConnector):
         try:
           connection.get_listener('ReconnectListener')
         except KeyError:
-          listener = ReconnectListener( self.reconnect)
+          listener = ReconnectListener(self.reconnect)
           connection.set_listener('ReconnectListener', listener)
 
         if connection.is_connected():
@@ -206,7 +206,7 @@ class StompMQConnector(MQConnector):
     fail = False
     for connection in self.connections.itervalues():
       try:
-        listener = StompListener(callback, acknowledgement, connection, mId, self.reconnect)
+        listener = StompListener(callback, acknowledgement, connection, mId)
         connection.set_listener('StompListener', listener)
         connection.subscribe(destination=dest,
                              id=mId,
@@ -263,7 +263,7 @@ class StompListener (stomp.ConnectionListener):
   Internal listener class responsible for handling new messages and errors.
   """
 
-  def __init__(self, callback, ack, connection, messengerId, callbackOnDisconnected=None):
+  def __init__(self, callback, ack, connection, messengerId):
     """
     Initializes the internal listener object
 
@@ -280,7 +280,6 @@ class StompListener (stomp.ConnectionListener):
     self.ack = ack
     self.mId = messengerId
     self.connection = connection
-    self.callbackOnDisconnected = callbackOnDisconnected
 
   def on_message(self, headers, body):
     """

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -23,11 +23,11 @@ class StompMQConnector(MQConnector):
   # Setting for the reconnection handling by stomp interface.
   # See e.g. the description of Transport class in
   # https://github.com/jasonrbriggs/stomp.py/blob/master/stomp/transport.py
-  RECONNECT_SLEEP_INITIAL = 1 # [s]  Initial delay before reattempting to establish a connection.
-  RECONNECT_SLEEP_INCREASE = 0.5 # Factor by which sleep delay is increased 0.5 means increase by 50%.
-  RECONNECT_SLEEP_MAX = 120 # [s] The maximum delay that can be reached independent of increasing procedure.
-  RECONNECT_SLEEP_JITTER =  0.1 # Random factor to add. 0.1 means a random number from 0 to 10% of the current time.
-  RECONNECT_ATTEMPTS_MAX = 1e4 # Maximum attempts to reconnect.
+  RECONNECT_SLEEP_INITIAL = 1  # [s]  Initial delay before reattempting to establish a connection.
+  RECONNECT_SLEEP_INCREASE = 0.5  # Factor by which sleep delay is increased 0.5 means increase by 50%.
+  RECONNECT_SLEEP_MAX = 120  # [s] The maximum delay that can be reached independent of increasing procedure.
+  RECONNECT_SLEEP_JITTER = 0.1  # Random factor to add. 0.1 means a random number from 0 to 10% of the current time.
+  RECONNECT_ATTEMPTS_MAX = 1e4  # Maximum attempts to reconnect.
 
   PORT = 61613
 
@@ -36,7 +36,7 @@ class StompMQConnector(MQConnector):
     """
     super(StompMQConnector, self).__init__()
     if not parameters:
-      parameters={}
+      parameters = {}
     self.parameters = parameters.copy()
     self.log = gLogger.getSubLogger(self.__class__.__name__)
     self.connections = {}
@@ -72,14 +72,13 @@ class StompMQConnector(MQConnector):
     hostcert = self.parameters.get('HostCertificate')
     hostkey = self.parameters.get('HostKey')
 
-    connectionArgs = { 'vhost':vhost,
-                      'keepalive':True, 
-                      'reconnect_sleep_initial' :reconnectSleepInitial,
-                      'reconnect_sleep_increase' : reconnectSleepIncrease ,
-                      'reconnect_sleep_max' :reconnectSleepMax, 
-                      'reconnect_sleep_jitter' :reconnectSleepJitter, 
-                      'reconnect_attempts_max' : reconnectAttemptsMax }
-
+    connectionArgs = {'vhost': vhost,
+                      'keepalive': True,
+                      'reconnect_sleep_initial': reconnectSleepInitial,
+                      'reconnect_sleep_increase': reconnectSleepIncrease,
+                      'reconnect_sleep_max': reconnectSleepMax,
+                      'reconnect_sleep_jitter': reconnectSleepJitter,
+                      'reconnect_attempts_max': reconnectAttemptsMax}
 
     if sslVersion is not None:
       if sslVersion == 'TLSv1':
@@ -91,21 +90,21 @@ class StompMQConnector(MQConnector):
             return S_ERROR('Could not find a certificate!')
           hostcert = paths[0]
           hostkey = paths[1]
-        connectionArgs.update({ 
-              'use_ssl':True,
-              'ssl_version':sslVersion,
-              'ssl_key_file':hostkey,
-              'ssl_cert_file':hostcert})
+        connectionArgs.update({
+          'use_ssl': True,
+          'ssl_version': sslVersion,
+          'ssl_key_file': hostkey,
+          'ssl_cert_file': hostcert})
       else:
         return S_ERROR(EMQCONN, 'Invalid SSL version provided: %s' % sslVersion)
 
     try:
       # Get IP addresses of brokers and ignore two first return arguments which are hostname and aliaslist.
-      _,_,ip_addresses = socket.gethostbyname_ex(host)
+      _, _, ip_addresses = socket.gethostbyname_ex(host)
       self.log.info('Broker name resolves to %s IP(s)' % len(ip_addresses))
 
       for ip in ip_addresses:
-        connectionArgs.update({'host_and_ports':[(ip, int(port))]})
+        connectionArgs.update({'host_and_ports': [(ip, int(port))]})
         print "checking connectionArgs"
         print connectionArgs
         self.connections[ip] = stomp.Connection(**connectionArgs)
@@ -160,10 +159,9 @@ class StompMQConnector(MQConnector):
       except Exception as e:
         self.log.error('Failed to connect: %s' % e)
 
-    if connected:
-      return S_OK("Connected to %s" % host)
-    else:
+    if not connected:
       return S_ERROR(EMQCONN, "Failed to connect to  %s" % host)
+    return S_OK("Connected to %s" % host)
 
   def disconnect(self, parameters=None):
     """
@@ -179,8 +177,7 @@ class StompMQConnector(MQConnector):
 
     if fail:
       return S_ERROR(EMQUKN, 'Failed to disconnect from at least one broker')
-    else:
-      return S_OK('Successfully disconnected from all brokers')
+    return S_OK('Successfully disconnected from all brokers')
 
   def subscribe(self, parameters=None):
     mId = parameters.get('messengerId', '')
@@ -219,8 +216,7 @@ class StompMQConnector(MQConnector):
 
     if fail:
       return S_ERROR(EMQUKN, 'Failed to unsubscribe from at least one destination')
-    else:
-      return S_OK('Successfully unsubscribed from all destinations')
+    return S_OK('Successfully unsubscribed from all destinations')
 
 
 class StompListener (stomp.ConnectionListener):
@@ -234,7 +230,7 @@ class StompListener (stomp.ConnectionListener):
 
     :param func callback: a defaultCallback compatible function
     :param bool ack: if set to true an acknowledgement will be send back to the sender
-    :param str messengerId: messenger identifier sent with acknowledgement messages. 
+    :param str messengerId: messenger identifier sent with acknowledgement messages.
 
     """
 

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -44,8 +44,11 @@ class StompMQConnector(MQConnector):
   def setupConnection(self, parameters=None):
     """
      Establishes a new connection to a Stomp server, e.g. RabbitMQ
-    :param dict parameters: dictionary with additional MQ parameters if any
-    :return: S_OK/S_ERROR
+
+    Args:
+      parameters(dict): dictionary with additional MQ parameters if any.
+    Returns:
+      S_OK/S_ERROR
     """
 
     if parameters is not None:
@@ -120,8 +123,9 @@ class StompMQConnector(MQConnector):
     """
     Sends a message to the queue
     message contains the body of the message
-
-    :param str message: string or any json encodable structure
+    Args:
+      message(str): string or any json encodable structure.
+      parameters(dict): parameters with 'destination' key defined.
     """
     destination = parameters.get('destination', '')
     error = False
@@ -241,7 +245,8 @@ class ReconnectListener (stomp.ConnectionListener):
   def __init__(self, callback=None):
     """
     Initializes the internal listener object
-    :param func callback: a function called when disconnection happens
+    Args:
+      callback: a function called when disconnection happens.
     """
 
     self.log = gLogger.getSubLogger('ReconnectListener')
@@ -265,11 +270,10 @@ class StompListener (stomp.ConnectionListener):
   def __init__(self, callback, ack, connection, messengerId):
     """
     Initializes the internal listener object
-
-    :param func callback: a defaultCallback compatible function
-    :param bool ack: if set to true an acknowledgement will be send back to the sender
-    :param str messengerId: messenger identifier sent with acknowledgement messages.
-
+    Args:
+      callback: a defaultCallback compatible function.
+      ack(bool): if set to true an acknowledgement will be send back to the sender.
+      messengerId(str): messenger identifier sent with acknowledgement messages.
     """
 
     self.log = gLogger.getSubLogger('StompListener')
@@ -283,8 +287,9 @@ class StompListener (stomp.ConnectionListener):
   def on_message(self, headers, body):
     """
     Function called upon receiving a message
-    :param dict headers: message headers
-    :param json body: message body
+    Args:
+      headers(dict): message headers.
+      body(json): message body.
     """
     result = self.callback(headers, json.loads(body))
     if self.ack:
@@ -295,5 +300,8 @@ class StompListener (stomp.ConnectionListener):
 
   def on_error(self, headers, message):
     """ Function called when an error happens
+    Args:
+      headers(dict): message headers.
+      body(json): message body.
     """
     self.log.error(message)

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -35,9 +35,6 @@ class StompMQConnector(MQConnector):
     """ Standard constructor
     """
     super(StompMQConnector, self).__init__()
-    if not parameters:
-      parameters = {}
-    self.parameters = parameters.copy()
     self.log = gLogger.getSubLogger(self.__class__.__name__)
     self.connections = {}
 

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -80,6 +80,7 @@ class StompMQConnector(MQConnector):
                       'reconnect_sleep_jitter': reconnectSleepJitter,
                       'reconnect_attempts_max': reconnectAttemptsMax}
 
+    # We use ssl credentials and not user-password.
     if sslVersion is not None:
       if sslVersion == 'TLSv1':
         sslVersion = ssl.PROTOCOL_TLSv1
@@ -156,14 +157,13 @@ class StompMQConnector(MQConnector):
     connected = False
     for ip, connection in self.connections.iteritems():
       try:
-        connection.start()
-        connection.connect(username=user, passcode=password)
-        time.sleep(1)
         listener = connection.get_listener('ReconnectListener')
         if listener is None:
           listener = ReconnectListener(self.reconnect)
           connection.set_listener('ReconnectListener', listener)
-
+        connection.start()
+        connection.connect(username=user, passcode=password)
+        time.sleep(1)
         if connection.is_connected():
           self.log.info("Connected to %s:%s" % (ip, port))
           connected = True

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -98,7 +98,6 @@ class StompMQConnector(MQConnector):
       else:
         return S_ERROR(EMQCONN, 'Invalid SSL version provided: %s' % sslVersion)
 
-
     try:
       # Get IP addresses of brokers and ignoring two first returned arguments which are hostname and aliaslist.
       _, _, ip_addresses = socket.gethostbyname_ex(host)
@@ -161,7 +160,7 @@ class StompMQConnector(MQConnector):
         connection.connect(username=user, passcode=password)
         time.sleep(1)
         listener = connection.get_listener('ReconnectListener')
-        if listener is None: 
+        if listener is None:
           listener = ReconnectListener(self.reconnect)
           connection.set_listener('ReconnectListener', listener)
 
@@ -237,6 +236,7 @@ class StompMQConnector(MQConnector):
       return S_ERROR(EMQUKN, 'Failed to unsubscribe from at least one destination')
     return S_OK('Successfully unsubscribed from all destinations')
 
+
 class ReconnectListener (stomp.ConnectionListener):
   """
   Internal listener class responsible for reconnecting in case of disconnection.
@@ -261,6 +261,7 @@ class ReconnectListener (stomp.ConnectionListener):
         self.callback()
     except Exception as e:
       self.log.error("Unexpected error while calling reconnect callback: %s" % e)
+
 
 class StompListener (stomp.ConnectionListener):
   """

--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -111,7 +111,7 @@ class StompMQConnector(MQConnector):
     return S_OK('Setup successful')
 
   def reconnect(self):
-    res = self.connect()
+    res = self.connect(self.parameters)
     if not res:
       return S_ERROR(EMQCONN, "Failed to reconnect")
     return S_OK('Reconnection successful')
@@ -156,9 +156,8 @@ class StompMQConnector(MQConnector):
         connection.start()
         connection.connect(username=user, passcode=password)
         time.sleep(1)
-        try:
-          connection.get_listener('ReconnectListener')
-        except KeyError:
+        listener = connection.get_listener('ReconnectListener')
+        if listener is None: 
           listener = ReconnectListener(self.reconnect)
           connection.set_listener('ReconnectListener', listener)
 

--- a/Resources/MessageQueue/test/Test_StompMQConnection.py
+++ b/Resources/MessageQueue/test/Test_StompMQConnection.py
@@ -23,14 +23,14 @@ MESSENGERID = 'Producer1'
 
 PARAMETERS = \
     {
-        'Host': HOST,
-        'Port': PORT,
-        'VHost': VHOST,
-        'User': USER,
-        'Password': PASSWORD,
-        'Queue': QUEUE,
-        'Topic': TOPIC,
-        'Acknowledgement': ACKNOWLEDGEMENT
+      'Host': HOST,
+      'Port': PORT,
+      'VHost': VHOST,
+      'User': USER,
+      'Password': PASSWORD,
+      'Queue': QUEUE,
+      'Topic': TOPIC,
+      'Acknowledgement': ACKNOWLEDGEMENT
     }
 
 SSL_VERSION = 'TLSv1'
@@ -39,9 +39,9 @@ HOSTKEY = '/etc/hostkey.pem'
 
 SSL_PARAMETERS = PARAMETERS.copy()
 SSL_PARAMETERS.update({
-    'SSLVersion': SSL_VERSION,
-    'HostCertificate': HOSTCERT,
-    'HostKey': HOSTKEY
+  'SSLVersion': SSL_VERSION,
+  'HostCertificate': HOSTCERT,
+  'HostKey': HOSTKEY
 })
 del SSL_PARAMETERS['Queue']
 
@@ -99,17 +99,17 @@ class StompMQConnectorSuccessTestCase(unittest.TestCase):
     self.assertEqual(sorted(self.mqConnector.parameters), sorted(PARAMETERS))
 
     # check calls
-    connectionArgs = { 'vhost':VHOST, 
-                      'keepalive':True, 
-                      'reconnect_sleep_initial' :1,
+    connectionArgs = {'vhost': VHOST,
+                      'keepalive': True,
+                      'reconnect_sleep_initial': 1,
                       'reconnect_sleep_increase': 0.5,
-                      'reconnect_sleep_max': 120, 
-                      'reconnect_sleep_jitter' :0.1, 
-                      'reconnect_attempts_max' :1e4,  
-                      'host_and_ports':[(IP1, int(PORT))]
-                    }
+                      'reconnect_sleep_max': 120,
+                      'reconnect_sleep_jitter': 0.1,
+                      'reconnect_attempts_max': 1e4,
+                      'host_and_ports': [(IP1, int(PORT))]
+                     }
     module.stomp.Connection.assert_any_call(**connectionArgs)
-    connectionArgs.update({'host_and_ports':[(IP2, int(PORT))]})
+    connectionArgs.update({'host_and_ports': [(IP2, int(PORT))]})
     module.stomp.Connection.assert_any_call(**connectionArgs)
 
     result = self.mqConnector.connect()
@@ -125,23 +125,22 @@ class StompMQConnectorSuccessTestCase(unittest.TestCase):
       self.assertIsNotNone(self.mqConnector.connections[ip])
 
     # check calls
-    connectionArgs = { 'vhost':VHOST, 
-                      'keepalive':True, 
-                      'reconnect_sleep_initial' :1,
+    connectionArgs = {'vhost': VHOST,
+                      'keepalive': True,
+                      'reconnect_sleep_initial': 1,
                       'reconnect_sleep_increase': 0.5,
-                      'reconnect_sleep_max': 120, 
-                      'reconnect_sleep_jitter' :0.1, 
-                      'reconnect_attempts_max' :1e4,  
-                      'use_ssl':True,
-                      'ssl_version':module.ssl.PROTOCOL_TLSv1,
-                      'ssl_key_file':HOSTKEY,
-                      'ssl_cert_file':HOSTCERT, 
-                      'host_and_ports':[(IP1, int(PORT))]
-                    }
-
+                      'reconnect_sleep_max': 120,
+                      'reconnect_sleep_jitter': 0.1,
+                      'reconnect_attempts_max': 1e4,
+                      'use_ssl': True,
+                      'ssl_version': module.ssl.PROTOCOL_TLSv1,
+                      'ssl_key_file': HOSTKEY,
+                      'ssl_cert_file': HOSTCERT,
+                      'host_and_ports': [(IP1, int(PORT))]
+                     }
 
     module.stomp.Connection.assert_any_call(**connectionArgs)
-    connectionArgs.update({'host_and_ports':[(IP2, int(PORT))]})
+    connectionArgs.update({'host_and_ports': [(IP2, int(PORT))]})
     module.stomp.Connection.assert_any_call(**connectionArgs)
 
     result = self.mqConnector.connect()

--- a/Resources/MessageQueue/test/Test_StompMQConnection.py
+++ b/Resources/MessageQueue/test/Test_StompMQConnection.py
@@ -22,16 +22,14 @@ ACKNOWLEDGEMENT = 'True'
 MESSENGERID = 'Producer1'
 
 PARAMETERS = \
-    {
-      'Host': HOST,
-      'Port': PORT,
-      'VHost': VHOST,
-      'User': USER,
-      'Password': PASSWORD,
-      'Queue': QUEUE,
-      'Topic': TOPIC,
-      'Acknowledgement': ACKNOWLEDGEMENT
-    }
+    {'Host': HOST,
+     'Port': PORT,
+     'VHost': VHOST,
+     'User': USER,
+     'Password': PASSWORD,
+     'Queue': QUEUE,
+     'Topic': TOPIC,
+     'Acknowledgement': ACKNOWLEDGEMENT}
 
 SSL_VERSION = 'TLSv1'
 HOSTCERT = '/etc/hostcert.pem'
@@ -39,9 +37,9 @@ HOSTKEY = '/etc/hostkey.pem'
 
 SSL_PARAMETERS = PARAMETERS.copy()
 SSL_PARAMETERS.update({
-  'SSLVersion': SSL_VERSION,
-  'HostCertificate': HOSTCERT,
-  'HostKey': HOSTKEY
+    'SSLVersion': SSL_VERSION,
+    'HostCertificate': HOSTCERT,
+    'HostKey': HOSTKEY
 })
 del SSL_PARAMETERS['Queue']
 
@@ -99,15 +97,15 @@ class StompMQConnectorSuccessTestCase(unittest.TestCase):
     self.assertEqual(sorted(self.mqConnector.parameters), sorted(PARAMETERS))
 
     # check calls
-    connectionArgs = {'vhost': VHOST,
-                      'keepalive': True,
-                      'reconnect_sleep_initial': 1,
-                      'reconnect_sleep_increase': 0.5,
-                      'reconnect_sleep_max': 120,
-                      'reconnect_sleep_jitter': 0.1,
-                      'reconnect_attempts_max': 1e4,
-                      'host_and_ports': [(IP1, int(PORT))]
-                     }
+    connectionArgs = {
+        'vhost': VHOST,
+        'keepalive': True,
+        'reconnect_sleep_initial': 1,
+        'reconnect_sleep_increase': 0.5,
+        'reconnect_sleep_max': 120,
+        'reconnect_sleep_jitter': 0.1,
+        'reconnect_attempts_max': 1e4,
+        'host_and_ports': [(IP1, int(PORT))]}
     module.stomp.Connection.assert_any_call(**connectionArgs)
     connectionArgs.update({'host_and_ports': [(IP2, int(PORT))]})
     module.stomp.Connection.assert_any_call(**connectionArgs)
@@ -136,8 +134,7 @@ class StompMQConnectorSuccessTestCase(unittest.TestCase):
                       'ssl_version': module.ssl.PROTOCOL_TLSv1,
                       'ssl_key_file': HOSTKEY,
                       'ssl_cert_file': HOSTCERT,
-                      'host_and_ports': [(IP1, int(PORT))]
-                     }
+                      'host_and_ports': [(IP1, int(PORT))]}
 
     module.stomp.Connection.assert_any_call(**connectionArgs)
     connectionArgs.update({'host_and_ports': [(IP2, int(PORT))]})

--- a/Resources/MessageQueue/test/Test_StompMQConnection.py
+++ b/Resources/MessageQueue/test/Test_StompMQConnection.py
@@ -103,8 +103,9 @@ class StompMQConnectorSuccessTestCase(unittest.TestCase):
                       'keepalive':True, 
                       'reconnect_sleep_initial' :1,
                       'reconnect_sleep_increase': 0.5,
+                      'reconnect_sleep_max': 120, 
                       'reconnect_sleep_jitter' :0.1, 
-                      'reconnect_attempts_max' :1e6,  
+                      'reconnect_attempts_max' :1e4,  
                       'host_and_ports':[(IP1, int(PORT))]
                     }
     module.stomp.Connection.assert_any_call(**connectionArgs)
@@ -128,8 +129,9 @@ class StompMQConnectorSuccessTestCase(unittest.TestCase):
                       'keepalive':True, 
                       'reconnect_sleep_initial' :1,
                       'reconnect_sleep_increase': 0.5,
+                      'reconnect_sleep_max': 120, 
                       'reconnect_sleep_jitter' :0.1, 
-                      'reconnect_attempts_max' :1e6,  
+                      'reconnect_attempts_max' :1e4,  
                       'use_ssl':True,
                       'ssl_version':module.ssl.PROTOCOL_TLSv1,
                       'ssl_key_file':HOSTKEY,

--- a/Resources/MessageQueue/test/Test_StompMQConnection.py
+++ b/Resources/MessageQueue/test/Test_StompMQConnection.py
@@ -99,15 +99,17 @@ class StompMQConnectorSuccessTestCase(unittest.TestCase):
     self.assertEqual(sorted(self.mqConnector.parameters), sorted(PARAMETERS))
 
     # check calls
-    module.stomp.Connection.assert_any_call([(IP1, int(PORT))],
-                                            vhost=VHOST,
-                                            keepalive=True
-                                            )
-
-    module.stomp.Connection.assert_any_call([(IP2, int(PORT))],
-                                            vhost=VHOST,
-                                            keepalive=True
-                                            )
+    connectionArgs = { 'vhost':VHOST, 
+                      'keepalive':True, 
+                      'reconnect_sleep_initial' :1,
+                      'reconnect_sleep_increase': 0.5,
+                      'reconnect_sleep_jitter' :0.1, 
+                      'reconnect_attempts_max' :1e6,  
+                      'host_and_ports':[(IP1, int(PORT))]
+                    }
+    module.stomp.Connection.assert_any_call(**connectionArgs)
+    connectionArgs.update({'host_and_ports':[(IP2, int(PORT))]})
+    module.stomp.Connection.assert_any_call(**connectionArgs)
 
     result = self.mqConnector.connect()
     self.assertTrue(result['OK'])
@@ -122,23 +124,23 @@ class StompMQConnectorSuccessTestCase(unittest.TestCase):
       self.assertIsNotNone(self.mqConnector.connections[ip])
 
     # check calls
-    module.stomp.Connection.assert_any_call([(IP1, int(PORT))],
-                                            use_ssl=True,
-                                            ssl_version=module.ssl.PROTOCOL_TLSv1,
-                                            ssl_key_file=HOSTKEY,
-                                            ssl_cert_file=HOSTCERT,
-                                            vhost=VHOST,
-                                            keepalive=True
-                                            )
+    connectionArgs = { 'vhost':VHOST, 
+                      'keepalive':True, 
+                      'reconnect_sleep_initial' :1,
+                      'reconnect_sleep_increase': 0.5,
+                      'reconnect_sleep_jitter' :0.1, 
+                      'reconnect_attempts_max' :1e6,  
+                      'use_ssl':True,
+                      'ssl_version':module.ssl.PROTOCOL_TLSv1,
+                      'ssl_key_file':HOSTKEY,
+                      'ssl_cert_file':HOSTCERT, 
+                      'host_and_ports':[(IP1, int(PORT))]
+                    }
 
-    module.stomp.Connection.assert_any_call([(IP2, int(PORT))],
-                                            use_ssl=True,
-                                            ssl_version=module.ssl.PROTOCOL_TLSv1,
-                                            ssl_key_file=HOSTKEY,
-                                            ssl_cert_file=HOSTCERT,
-                                            vhost=VHOST,
-                                            keepalive=True
-                                            )
+
+    module.stomp.Connection.assert_any_call(**connectionArgs)
+    connectionArgs.update({'host_and_ports':[(IP2, int(PORT))]})
+    module.stomp.Connection.assert_any_call(**connectionArgs)
 
     result = self.mqConnector.connect()
     self.assertTrue(result['OK'])


### PR DESCRIPTION
Solving part of the issue presented in #3986 
When MQ server is restarted, the clients are blocked. This fix add a dedicated listener ReconnectListener which in case of the disconnection tries to reconnect to the server.
The set of options such as number of trials, interval time etc  are provided. To reconnect the internal 
stomp.py connect mechanism is used.
The  current solution solves the producer case. Separate patch will be prepared for the consumer case. This needs more refactorization due to the handling of subscription after the disconnection occurs.

As byproduct, the handling of stomp.exception.NotConnectedException which could be raised  inside StompMQConnector subscribe() method, has been added. The exception is  handled  and it is transformed into a standard S_ERROR. 

Integration tests done:

Scenario I:
1.Server is unavailable
2.Producer wants to connect and  send a message. Producer will try to reconnect.
3.Server goes up
4.Producer connects and sends the message

Scenario II:
1.Producer is connected. 
2.Server goes down. Producer is trying to reconnect
3.Server goes up. Producer connects and can send message. 


BEGINRELEASENOTES

*Resources
FIX: Resources/MessageQueue: add a dedicated listener ReconnectListener

ENDRELEASENOTES
