### PR TITLE
[v6r21] Update of the MQ documentation and standarize CS MQ section 

### DIFF
--- a/AccountingSystem/Agent/test/Test_NetworkAgent.py
+++ b/AccountingSystem/Agent/test/Test_NetworkAgent.py
@@ -9,8 +9,8 @@ from mock.mock import MagicMock
 
 __RCSID__ = "$Id$"
 
-MQURI1 = 'mq.dirac.net::Topic::perfsonar.summary.packet-loss-rate'
-MQURI2 = 'mq.dirac.net::Queue::perfsonar.summary.histogram-owdelay'
+MQURI1 = 'mq.dirac.net::Topics::perfsonar.summary.packet-loss-rate'
+MQURI2 = 'mq.dirac.net::Queues::perfsonar.summary.histogram-owdelay'
 
 ROOT_PATH = '/Resources/Sites'
 SITE1 = 'LCG.Dirac.net'

--- a/FrameworkSystem/private/standardLogging/Handler/MessageQueueHandler.py
+++ b/FrameworkSystem/private/standardLogging/Handler/MessageQueueHandler.py
@@ -27,7 +27,7 @@ class MessageQueueHandler(logging.Handler):
     Initialization of the MessageQueueHandler.
 
     :params queue: string representing the queue identifier in the configuration.
-                   example: "mardirac3.in2p3.fr::Queue::TestQueue"
+                   example: "mardirac3.in2p3.fr::Queues::TestQueue"
     """
     super(MessageQueueHandler, self).__init__()
     self.producer = None

--- a/MonitoringSystem/Client/MonitoringReporter.py
+++ b/MonitoringSystem/Client/MonitoringReporter.py
@@ -58,7 +58,7 @@ class MonitoringReporter(object):
     else:
       return retVal
 
-    result = createConsumer("Monitoring::Queue::%s" % self.__failoverQueueName)
+    result = createConsumer("Monitoring::Queues::%s" % self.__failoverQueueName)
     if not result['OK']:
       gLogger.error("Fail to create Consumer: %s" % result['Message'])
       return S_ERROR("Fail to create Consumer: %s" % result['Message'])
@@ -165,7 +165,7 @@ class MonitoringReporter(object):
       MQProducer or None:
     """
     mqProducer = None
-    result = createProducer("Monitoring::Queue::%s" % self.__failoverQueueName)
+    result = createProducer("Monitoring::Queues::%s" % self.__failoverQueueName)
     if not result['OK']:
       gLogger.warn("Fail to create Producer:", result['Message'])
     else:

--- a/Resources/MessageQueue/MQCommunication.py
+++ b/Resources/MessageQueue/MQCommunication.py
@@ -21,7 +21,7 @@ def createConsumer(mqURI, callback=generateDefaultCallback()):
   Args:
     mqURI(str):Pseudo URI identifing MQ service. It has the following format
               mqConnection::DestinationType::DestinationName
-              e.g. blabla.cern.ch::Queue::MyQueue1
+              e.g. blabla.cern.ch::Queues::MyQueue1
     callback: callback function that can be used to process the incoming messages
 
   Returns:
@@ -45,7 +45,7 @@ def createProducer(mqURI):
   Args:
     mqURI(str):Pseudo URI identifing MQ service. It has the following format
               mqConnection::DestinationType::DestinationName
-              e.g. blabla.cern.ch::Queue::MyQueue1
+              e.g. blabla.cern.ch::Queues::MyQueue1
   Returns:
     S_OK/S_ERROR: with the producer object in S_OK.
   """
@@ -65,7 +65,7 @@ def _setupConnection(mqURI, mType):
   Args:
     mqURI(str):Pseudo URI identifing the MQ service. It has the following format:
               mqConnection::DestinationType::DestinationName
-              e.g. blabla.cern.ch::Queue::MyQueue1
+              e.g. blabla.cern.ch::Queues::MyQueue1
     mType(str): 'consumer' or 'producer'
   Returns:
     S_OK/S_ERROR: with the value of the messenger Id ( e.g. 'consumer4' ) in S_OK.

--- a/Resources/MessageQueue/MQConnectionManager.py
+++ b/Resources/MessageQueue/MQConnectionManager.py
@@ -6,9 +6,9 @@
     producer/consumer communication. Example structure::
 
       {
-        mardirac3.in2p3.fr: {'MQConnector':StompConnector, 'destinations':{'/queues/test1':['consumer1', 'producer1'],
-                                                                           '/queues/test2':['consumer1', 'producer1']}},
-        blabal.cern.ch:     {'MQConnector':None,           'destinations':{'/queues/test2':['consumer2', 'producer2',]}}
+        mardirac3.in2p3.fr: {'MQConnector':StompConnector, 'destinations':{'/queue/test1':['consumer1', 'producer1'],
+                                                                           '/queue/test2':['consumer1', 'producer1']}},
+        blabal.cern.ch:     {'MQConnector':None,           'destinations':{'/queue/test2':['consumer2', 'producer2',]}}
       }
 """
 
@@ -176,7 +176,7 @@ class MQConnectionManager( object ):
 
     Returns:
       S_OK or S_ERROR: with the list of strings in the pseudo-path format e.g.
-            ['blabla.cern.ch/queues/test1/consumer1','blabal.cern.ch/topics/test2/producer2']
+            ['blabla.cern.ch/queue/test1/consumer1','blabal.cern.ch/topic/test2/producer2']
     """
     self.lock.acquire()
     try:
@@ -248,7 +248,7 @@ class MQConnectionManager( object ):
     Args:
       mqConnection(str): message queue connection name.
     Returns:
-      dict: of form {'/queues/queue1':['producer1','consumer2']} or {}
+      dict: of form {'/queue/queue1':['producer1','consumer2']} or {}
     """
     return self.__getConnection( mqConnection ).get( "destinations", {} )
 
@@ -256,7 +256,7 @@ class MQConnectionManager( object ):
     """ Function returns list of messengers for given connection and given destination.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
     Returns:
       list: of form ['producer1','consumer2'] or []
     """
@@ -266,7 +266,7 @@ class MQConnectionManager( object ):
     """ Function returns list of messnager for given connection, destination and type.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
       messengerType(str): 'consumer' or 'producer'
     Returns:
       list: of form ['producer1','producer2'], ['consumer8', 'consumer20'] or []
@@ -295,7 +295,7 @@ class MQConnectionManager( object ):
   def __getAllMessengersInfo( self ):
     """ Function returns list of all messengers in the pseudo-path format.
     Returns:
-      list: of form ['blabla.cern.ch/queues/myQueue1/producer1','bibi.in2p3.fr/topics/myTopic331/consumer3'] or []
+      list: of form ['blabla.cern.ch/queue/myQueue1/producer1','bibi.in2p3.fr/topic/myTopic331/consumer3'] or []
     """
     output = lambda connection,dest,messenger: str( connection )+str( dest )+'/'+ str( messenger )
     return [output( c, d, m ) for c in self.__connectionStorage.keys() for d in self.__getDestinations( c )  for m in self.__getMessengersId( c, d )]
@@ -313,7 +313,7 @@ class MQConnectionManager( object ):
     """ Function checks if given destination(queue or topic) exists in the connection storage.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
     Returns:
       bool:
     """
@@ -323,7 +323,7 @@ class MQConnectionManager( object ):
     """ Function checks if given messenger(producer or consumer) exists in the connection storage.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
       messengerId(str): messenger name e.g. 'consumer1', 'producer4' .
     Returns:
       bool:
@@ -335,7 +335,7 @@ class MQConnectionManager( object ):
         If connection or/and destination do not exist, they are created as well.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
       messengerId(str): messenger name e.g. 'consumer1', 'producer4'.
     Returns:
       bool: True if messenger is added or False if the messenger already exists.
@@ -356,7 +356,7 @@ class MQConnectionManager( object ):
         If it is the last messenger in given destination and/or connection they are removed as well..
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
       messengerId(str): messenger name e.g. 'consumer1', 'producer4'.
     Returns:
       bool: True if messenger is removed or False if the messenger was not in the storage.

--- a/Resources/MessageQueue/MQConnectionManager.py
+++ b/Resources/MessageQueue/MQConnectionManager.py
@@ -6,9 +6,9 @@
     producer/consumer communication. Example structure::
 
       {
-        mardirac3.in2p3.fr: {'MQConnector':StompConnector, 'destinations':{'/queue/test1':['consumer1', 'producer1'],
-                                                                           '/queue/test2':['consumer1', 'producer1']}},
-        blabal.cern.ch:     {'MQConnector':None,           'destinations':{'/queue/test2':['consumer2', 'producer2',]}}
+        mardirac3.in2p3.fr: {'MQConnector':StompConnector, 'destinations':{'/queues/test1':['consumer1', 'producer1'],
+                                                                           '/queues/test2':['consumer1', 'producer1']}},
+        blabal.cern.ch:     {'MQConnector':None,           'destinations':{'/queues/test2':['consumer2', 'producer2',]}}
       }
 """
 
@@ -176,7 +176,7 @@ class MQConnectionManager( object ):
 
     Returns:
       S_OK or S_ERROR: with the list of strings in the pseudo-path format e.g.
-            ['blabla.cern.ch/queue/test1/consumer1','blabal.cern.ch/topic/test2/producer2']
+            ['blabla.cern.ch/queues/test1/consumer1','blabal.cern.ch/topics/test2/producer2']
     """
     self.lock.acquire()
     try:
@@ -248,7 +248,7 @@ class MQConnectionManager( object ):
     Args:
       mqConnection(str): message queue connection name.
     Returns:
-      dict: of form {'/queue/queue1':['producer1','consumer2']} or {}
+      dict: of form {'/queues/queue1':['producer1','consumer2']} or {}
     """
     return self.__getConnection( mqConnection ).get( "destinations", {} )
 
@@ -256,7 +256,7 @@ class MQConnectionManager( object ):
     """ Function returns list of messengers for given connection and given destination.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
     Returns:
       list: of form ['producer1','consumer2'] or []
     """
@@ -266,7 +266,7 @@ class MQConnectionManager( object ):
     """ Function returns list of messnager for given connection, destination and type.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
       messengerType(str): 'consumer' or 'producer'
     Returns:
       list: of form ['producer1','producer2'], ['consumer8', 'consumer20'] or []
@@ -295,7 +295,7 @@ class MQConnectionManager( object ):
   def __getAllMessengersInfo( self ):
     """ Function returns list of all messengers in the pseudo-path format.
     Returns:
-      list: of form ['blabla.cern.ch/queue/myQueue1/producer1','bibi.in2p3.fr/topic/myTopic331/consumer3'] or []
+      list: of form ['blabla.cern.ch/queues/myQueue1/producer1','bibi.in2p3.fr/topics/myTopic331/consumer3'] or []
     """
     output = lambda connection,dest,messenger: str( connection )+str( dest )+'/'+ str( messenger )
     return [output( c, d, m ) for c in self.__connectionStorage.keys() for d in self.__getDestinations( c )  for m in self.__getMessengersId( c, d )]
@@ -313,7 +313,7 @@ class MQConnectionManager( object ):
     """ Function checks if given destination(queue or topic) exists in the connection storage.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
     Returns:
       bool:
     """
@@ -323,7 +323,7 @@ class MQConnectionManager( object ):
     """ Function checks if given messenger(producer or consumer) exists in the connection storage.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
       messengerId(str): messenger name e.g. 'consumer1', 'producer4' .
     Returns:
       bool:
@@ -335,7 +335,7 @@ class MQConnectionManager( object ):
         If connection or/and destination do not exist, they are created as well.
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
       messengerId(str): messenger name e.g. 'consumer1', 'producer4'.
     Returns:
       bool: True if messenger is added or False if the messenger already exists.
@@ -356,7 +356,7 @@ class MQConnectionManager( object ):
         If it is the last messenger in given destination and/or connection they are removed as well..
     Args:
       mqConnection(str): message queue connection name.
-      mqDestination(str): message queue or topic name e.g. '/queue/myQueue1' .
+      mqDestination(str): message queue or topic name e.g. '/queues/myQueue1' .
       messengerId(str): messenger name e.g. 'consumer1', 'producer4'.
     Returns:
       bool: True if messenger is removed or False if the messenger was not in the storage.

--- a/Resources/MessageQueue/Utilities.py
+++ b/Resources/MessageQueue/Utilities.py
@@ -14,7 +14,7 @@ def getMQParamsFromCS(mqURI):
   Args:
     mqURI(str):Pseudo URI identifing the MQ service. It has the following format:
               mqConnection::DestinationType::DestinationName
-              e.g. blabla.cern.ch::Queue::MyQueue1
+              e.g. blabla.cern.ch::Queues::MyQueue1
     mType(str): 'consumer' or 'producer'
   Returns:
     S_OK(param_dicts) or S_ERROR
@@ -37,7 +37,7 @@ def getMQParamsFromCS(mqURI):
       mqDestinationPath = path
 
   # set-up internal parameter depending on the destination type
-  tmp = mqDestinationPath.split('Queue')[0].split('Topic')
+  tmp = mqDestinationPath.split('Queues')[0].split('Topics')
   servicePath = tmp[0]
   serviceDict = {}
   if len(tmp) > 1:
@@ -91,7 +91,7 @@ def generateDefaultCallback():
   Args:
     mqURI(str):Pseudo URI identifing MQ connection. It has the following format
               mqConnection::DestinationType::DestinationName
-              e.g. blabla.cern.ch::Queue::MyQueue1
+              e.g. blabla.cern.ch::Queues::MyQueue1
   Returns:
     object: callback function
   """

--- a/Resources/MessageQueue/Utilities.py
+++ b/Resources/MessageQueue/Utilities.py
@@ -71,6 +71,8 @@ def getDestinationName(mqURI):
 
 def getDestinationAddress(mqURI):
   mqType, mqName = mqURI.split("::")[-2:]
+  # We remove the trailing 's to change from Queues to Queue
+  mqType = mqType.rstrip('s')
   return "/" + mqType.lower() + "/" + mqName
 
 

--- a/Resources/MessageQueue/test/Test_MQConnectionManager.py
+++ b/Resources/MessageQueue/test/Test_MQConnectionManager.py
@@ -15,10 +15,10 @@ class TestMQConnectionManager( unittest.TestCase ):
   def setUp( self ):
     self.maxDiff = None  # To show full difference between structures in  case of error
     dest = {}
-    dest.update({'/queues/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4']})
-    dest.update({'/queues/test2': ['producer2', 'consumer1', 'consumer2']})
-    dest.update({'/topics/test1': ['producer1']})
-    dest4 = {'/queues/test3': ['producer1', 'consumer2','consumer3','consumer4']}
+    dest.update({'/queue/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4']})
+    dest.update({'/queue/test2': ['producer2', 'consumer1', 'consumer2']})
+    dest.update({'/topic/test1': ['producer1']})
+    dest4 = {'/queue/test3': ['producer1', 'consumer2','consumer3','consumer4']}
     conn1 = {'MQConnector':'TestConnector1', 'destinations':dest}
     conn2 = {'MQConnector':'TestConnector2', 'destinations':dest4}
     storage = {'mardirac3.in2p3.fr':conn1, 'testdir.blabla.ch':conn2}
@@ -35,26 +35,26 @@ class TestMQConnectionStorageFunctions_connectionExists( TestMQConnectionManager
 
 class TestMQConnectionStorageFunctions_destinationExists( TestMQConnectionManager ):
   def test_success( self ):
-    self.assertTrue(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr',  '/queues/test1'))
+    self.assertTrue(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr',  '/queue/test1'))
   def test_failure( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__destinationExists( 'nonexisting', '/queues/test1'))
+    self.assertFalse(self.mgr._MQConnectionManager__destinationExists( 'nonexisting', '/queue/test1'))
   def test_failure2( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr', '/queues/nonexisting'))
+    self.assertFalse(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr', '/queue/nonexisting'))
 
 class TestMQConnectionStorageFunctions_messengerExists( TestMQConnectionManager ):
   def test_success( self ):
-    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queues/test1','consumer2' ))
-    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queues/test1','producer4' ))
+    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queue/test1','consumer2' ))
+    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queue/test1','producer4' ))
   def test_failure( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__messengerExists('noexisting',  '/queues/test1','producer4' ))
+    self.assertFalse(self.mgr._MQConnectionManager__messengerExists('noexisting',  '/queue/test1','producer4' ))
   def test_failure2( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queues/nonexisting','producer4'))
+    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queue/nonexisting','producer4'))
   def test_failure3( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queues/test1','producer10'))
+    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queue/test1','producer10'))
 
 class TestMQConnectionStorageFunctions_getConnection( TestMQConnectionManager ):
   def test_success( self ):
-    expectedConn = {'MQConnector':'TestConnector2', 'destinations':{'/queues/test3': ['producer1', 'consumer2','consumer3','consumer4']}}
+    expectedConn = {'MQConnector':'TestConnector2', 'destinations':{'/queue/test3': ['producer1', 'consumer2','consumer3','consumer4']}}
     self.assertEqual(self.mgr._MQConnectionManager__getConnection('testdir.blabla.ch'),expectedConn)
   def test_failure( self ):
     self.assertEqual(self.mgr._MQConnectionManager__getConnection('nonexisiting'), {})
@@ -79,9 +79,9 @@ class TestMQConnectionStorageFunctions_setConnector( TestMQConnectionManager ):
 
 class TestMQConnectionStorageFunctions_getDestinations( TestMQConnectionManager ):
   def test_success( self ):
-    expectedDests ={'/queues/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4'],
-                    '/queues/test2': ['producer2', 'consumer1', 'consumer2'],
-                    '/topics/test1': ['producer1']}
+    expectedDests ={'/queue/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4'],
+                    '/queue/test2': ['producer2', 'consumer1', 'consumer2'],
+                    '/topic/test1': ['producer1']}
     self.assertEqual(self.mgr._MQConnectionManager__getDestinations('mardirac3.in2p3.fr'),expectedDests)
   def test_failure( self ):
     self.assertEqual(self.mgr._MQConnectionManager__getDestinations('nonexisiting'), {})
@@ -89,36 +89,36 @@ class TestMQConnectionStorageFunctions_getDestinations( TestMQConnectionManager 
 class TestMQConnectionStorageFunctions_getMessengersId( TestMQConnectionManager ):
   def test_success( self ):
     expectedMess =['producer4', 'consumer1', 'consumer2', 'consumer4']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queues/test1'),expectedMess)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queue/test1'),expectedMess)
   def test_success2( self ):
     expectedMess2 =['producer2', 'consumer1', 'consumer2']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queues/test2'),expectedMess2)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queue/test2'),expectedMess2)
   def test_failure( self ):
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('nonexisiting', '/queues/test2'), [])
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('nonexisiting', '/queue/test2'), [])
   def test_failure2( self ):
     self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', 'nonexisiting'), [])
 
 class TestMQConnectionStorageFunctions_getMessengersIdWithType( TestMQConnectionManager ):
   def test_success( self ):
     expectedMess =['producer4']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queues/test1', 'producer'),expectedMess)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test1', 'producer'),expectedMess)
   def test_success2( self ):
     expectedMess2 =['producer2']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queues/test2', 'producer'),expectedMess2)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test2', 'producer'),expectedMess2)
   def test_success3( self ):
     expectedMess =[ 'consumer1', 'consumer2', 'consumer4']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queues/test1', 'consumer'),expectedMess)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test1', 'consumer'),expectedMess)
   def test_success4( self ):
     expectedMess2 =['consumer1', 'consumer2']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queues/test2', 'consumer'),expectedMess2)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test2', 'consumer'),expectedMess2)
   def test_failure( self ):
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('nonexisiting', '/queues/test2', 'producer'), [])
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('nonexisiting', '/queue/test2', 'producer'), [])
   def test_failure2( self ):
     self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', 'nonexisiting', 'producer'), [])
 
 class TestMQConnectionStorageFunctions_getAllMessengersInfo( TestMQConnectionManager ):
   def test_success( self ):
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
 class TestMQConnectionStorageFunctions_getAllMessengersId( TestMQConnectionManager ):
@@ -136,71 +136,71 @@ class TestMQConnectionStorageFunctions_getAllMessengersIdWithType( TestMQConnect
 
 class TestMQConnectionStorageFunctions_addMessenger( TestMQConnectionManager ):
   def test_success( self ):
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer1', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queues/test1', 'producer1'))
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer1', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queue/test1', 'producer1'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_success2( self ):
     # new queue
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test5/producer8', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queues/test5', 'producer8'))
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test5/producer8', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queue/test5', 'producer8'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_success3( self ):
     # new connection
-    expectedOutput= ['mytest.is.the.best/queues/test10/producer24', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queues/test10', 'producer24'))
+    expectedOutput= ['mytest.is.the.best/queue/test10/producer24', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queue/test10', 'producer24'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
   def test_success4( self ):
     #  two times
-    expectedOutput= ['mytest.is.the.best/queues/test10/producer2', 'mytest.is.the.best/queues/test10/producer24', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queues/test10', 'producer24'))
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queues/test10', 'producer2'))
+    expectedOutput= ['mytest.is.the.best/queue/test10/producer2', 'mytest.is.the.best/queue/test10/producer24', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queue/test10', 'producer24'))
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queue/test10', 'producer2'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_failure( self ):
     # messenger already exists
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
-    self.assertFalse(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queues/test1', 'producer4'))
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    self.assertFalse(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queue/test1', 'producer4'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
 class TestMQConnectionStorageFunctions_removeMessenger( TestMQConnectionManager ):
   def test_success( self ):
-    expectedOutput= [ 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/queues/test1', 'producer4'))
+    expectedOutput= [ 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/queue/test1', 'producer4'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_success2( self ):
-    #remove whole destination /topics/test1 cause only one element
-    expectedOutput= [ 'mardirac3.in2p3.fr/queues/test1/producer4','mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2','testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/topics/test1', 'producer1'))
+    #remove whole destination /topic/test1 cause only one element
+    expectedOutput= [ 'mardirac3.in2p3.fr/queue/test1/producer4','mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2','testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/topic/test1', 'producer1'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_success3( self ):
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1']
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1']
     #remove whole connection
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'producer1'))
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'consumer2'))
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'consumer3'))
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'consumer4'))
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'producer1'))
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'consumer2'))
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'consumer3'))
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'consumer4'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
                                            
   def test_failure( self ):                
     #remove nonexisting messenger          
-    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'producer10'))
+    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'producer10'))
   def test_failure2( self ):
     #remove nonexisting destination
-    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/nonexisting', 'producer1'))
+    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/nonexisting', 'producer1'))
   def test_failure3( self ):
     #remove nonexisting connection
-    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('nonexisting', '/queues/test103', 'producer1'))
+    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('nonexisting', '/queue/test103', 'producer1'))
 
 class TestMQConnectionManager_addNewmessenger( TestMQConnectionManager ):
   def test_success( self ):
     result = self.mgr.addNewMessenger(mqURI = "mardirac3.in2p3.fr::Queues::test1", messengerType = "producer"  )
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'producer5')
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer5', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
@@ -219,7 +219,7 @@ class TestMQConnectionManager_addNewmessenger( TestMQConnectionManager ):
     result = self.mgr.addNewMessenger(mqURI = "noexisting.blabla.ch::Queues::test3", messengerType = "consumer"  )
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
-    expectedOutput= ['noexisting.blabla.ch/queues/test3/consumer5', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    expectedOutput= ['noexisting.blabla.ch/queue/test3/consumer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
@@ -229,7 +229,7 @@ class TestMQConnectionManager_startConnection( TestMQConnectionManager ):
     result = self.mgr.startConnection(mqURI = "mardirac3.in2p3.fr::Queues::test1", params ={}, messengerType = "producer")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'producer5')
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer5', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
@@ -240,7 +240,7 @@ class TestMQConnectionManager_startConnection( TestMQConnectionManager ):
     result = self.mgr.startConnection(mqURI = "noexisting.blabla.ch::Queues::test3", params={}, messengerType = "consumer"  )
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
-    expectedOutput= ['noexisting.blabla.ch/queues/test3/consumer5', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    expectedOutput= ['noexisting.blabla.ch/queue/test3/consumer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
     result = self.mgr.getConnector('noexisting.blabla.ch')
@@ -251,14 +251,14 @@ class TestMQConnectionManager_stopConnection( TestMQConnectionManager ):
   def test_success( self ):
     result = self.mgr.stopConnection(mqURI = "mardirac3.in2p3.fr::Queues::test1", messengerId = "producer4")
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
   def test_success2( self ):
     result = self.mgr.stopConnection(mqURI = "mardirac3.in2p3.fr::Topics::test1", messengerId = "producer1")
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
@@ -275,7 +275,7 @@ class TestMQConnectionManager_stopConnection( TestMQConnectionManager ):
     self.assertTrue(result['OK'])
     result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queues::test3", messengerId = "consumer4")
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1']
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
@@ -293,7 +293,7 @@ class TestMQConnectionManager_getAllMessengers( TestMQConnectionManager ):
   def test_success( self ):
     result = self.mgr.getAllMessengers()
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 

--- a/Resources/MessageQueue/test/Test_MQConnectionManager.py
+++ b/Resources/MessageQueue/test/Test_MQConnectionManager.py
@@ -15,10 +15,10 @@ class TestMQConnectionManager( unittest.TestCase ):
   def setUp( self ):
     self.maxDiff = None  # To show full difference between structures in  case of error
     dest = {}
-    dest.update({'/queue/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4']})
-    dest.update({'/queue/test2': ['producer2', 'consumer1', 'consumer2']})
-    dest.update({'/topic/test1': ['producer1']})
-    dest4 = {'/queue/test3': ['producer1', 'consumer2','consumer3','consumer4']}
+    dest.update({'/queues/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4']})
+    dest.update({'/queues/test2': ['producer2', 'consumer1', 'consumer2']})
+    dest.update({'/topics/test1': ['producer1']})
+    dest4 = {'/queues/test3': ['producer1', 'consumer2','consumer3','consumer4']}
     conn1 = {'MQConnector':'TestConnector1', 'destinations':dest}
     conn2 = {'MQConnector':'TestConnector2', 'destinations':dest4}
     storage = {'mardirac3.in2p3.fr':conn1, 'testdir.blabla.ch':conn2}
@@ -35,26 +35,26 @@ class TestMQConnectionStorageFunctions_connectionExists( TestMQConnectionManager
 
 class TestMQConnectionStorageFunctions_destinationExists( TestMQConnectionManager ):
   def test_success( self ):
-    self.assertTrue(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr',  '/queue/test1'))
+    self.assertTrue(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr',  '/queues/test1'))
   def test_failure( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__destinationExists( 'nonexisting', '/queue/test1'))
+    self.assertFalse(self.mgr._MQConnectionManager__destinationExists( 'nonexisting', '/queues/test1'))
   def test_failure2( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr', '/queue/nonexisting'))
+    self.assertFalse(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr', '/queues/nonexisting'))
 
 class TestMQConnectionStorageFunctions_messengerExists( TestMQConnectionManager ):
   def test_success( self ):
-    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queue/test1','consumer2' ))
-    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queue/test1','producer4' ))
+    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queues/test1','consumer2' ))
+    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queues/test1','producer4' ))
   def test_failure( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__messengerExists('noexisting',  '/queue/test1','producer4' ))
+    self.assertFalse(self.mgr._MQConnectionManager__messengerExists('noexisting',  '/queues/test1','producer4' ))
   def test_failure2( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queue/nonexisting','producer4'))
+    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queues/nonexisting','producer4'))
   def test_failure3( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queue/test1','producer10'))
+    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queues/test1','producer10'))
 
 class TestMQConnectionStorageFunctions_getConnection( TestMQConnectionManager ):
   def test_success( self ):
-    expectedConn = {'MQConnector':'TestConnector2', 'destinations':{'/queue/test3': ['producer1', 'consumer2','consumer3','consumer4']}}
+    expectedConn = {'MQConnector':'TestConnector2', 'destinations':{'/queues/test3': ['producer1', 'consumer2','consumer3','consumer4']}}
     self.assertEqual(self.mgr._MQConnectionManager__getConnection('testdir.blabla.ch'),expectedConn)
   def test_failure( self ):
     self.assertEqual(self.mgr._MQConnectionManager__getConnection('nonexisiting'), {})
@@ -79,9 +79,9 @@ class TestMQConnectionStorageFunctions_setConnector( TestMQConnectionManager ):
 
 class TestMQConnectionStorageFunctions_getDestinations( TestMQConnectionManager ):
   def test_success( self ):
-    expectedDests ={'/queue/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4'],
-                    '/queue/test2': ['producer2', 'consumer1', 'consumer2'],
-                    '/topic/test1': ['producer1']}
+    expectedDests ={'/queues/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4'],
+                    '/queues/test2': ['producer2', 'consumer1', 'consumer2'],
+                    '/topics/test1': ['producer1']}
     self.assertEqual(self.mgr._MQConnectionManager__getDestinations('mardirac3.in2p3.fr'),expectedDests)
   def test_failure( self ):
     self.assertEqual(self.mgr._MQConnectionManager__getDestinations('nonexisiting'), {})
@@ -89,36 +89,36 @@ class TestMQConnectionStorageFunctions_getDestinations( TestMQConnectionManager 
 class TestMQConnectionStorageFunctions_getMessengersId( TestMQConnectionManager ):
   def test_success( self ):
     expectedMess =['producer4', 'consumer1', 'consumer2', 'consumer4']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queue/test1'),expectedMess)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queues/test1'),expectedMess)
   def test_success2( self ):
     expectedMess2 =['producer2', 'consumer1', 'consumer2']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queue/test2'),expectedMess2)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queues/test2'),expectedMess2)
   def test_failure( self ):
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('nonexisiting', '/queue/test2'), [])
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('nonexisiting', '/queues/test2'), [])
   def test_failure2( self ):
     self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', 'nonexisiting'), [])
 
 class TestMQConnectionStorageFunctions_getMessengersIdWithType( TestMQConnectionManager ):
   def test_success( self ):
     expectedMess =['producer4']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test1', 'producer'),expectedMess)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queues/test1', 'producer'),expectedMess)
   def test_success2( self ):
     expectedMess2 =['producer2']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test2', 'producer'),expectedMess2)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queues/test2', 'producer'),expectedMess2)
   def test_success3( self ):
     expectedMess =[ 'consumer1', 'consumer2', 'consumer4']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test1', 'consumer'),expectedMess)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queues/test1', 'consumer'),expectedMess)
   def test_success4( self ):
     expectedMess2 =['consumer1', 'consumer2']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test2', 'consumer'),expectedMess2)
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queues/test2', 'consumer'),expectedMess2)
   def test_failure( self ):
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('nonexisiting', '/queue/test2', 'producer'), [])
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('nonexisiting', '/queues/test2', 'producer'), [])
   def test_failure2( self ):
     self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', 'nonexisiting', 'producer'), [])
 
 class TestMQConnectionStorageFunctions_getAllMessengersInfo( TestMQConnectionManager ):
   def test_success( self ):
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
 class TestMQConnectionStorageFunctions_getAllMessengersId( TestMQConnectionManager ):
@@ -136,100 +136,100 @@ class TestMQConnectionStorageFunctions_getAllMessengersIdWithType( TestMQConnect
 
 class TestMQConnectionStorageFunctions_addMessenger( TestMQConnectionManager ):
   def test_success( self ):
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer1', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queue/test1', 'producer1'))
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer1', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queues/test1', 'producer1'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_success2( self ):
     # new queue
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test5/producer8', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queue/test5', 'producer8'))
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test5/producer8', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queues/test5', 'producer8'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_success3( self ):
     # new connection
-    expectedOutput= ['mytest.is.the.best/queue/test10/producer24', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queue/test10', 'producer24'))
+    expectedOutput= ['mytest.is.the.best/queues/test10/producer24', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queues/test10', 'producer24'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
   def test_success4( self ):
     #  two times
-    expectedOutput= ['mytest.is.the.best/queue/test10/producer2', 'mytest.is.the.best/queue/test10/producer24', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queue/test10', 'producer24'))
-    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queue/test10', 'producer2'))
+    expectedOutput= ['mytest.is.the.best/queues/test10/producer2', 'mytest.is.the.best/queues/test10/producer24', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queues/test10', 'producer24'))
+    self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queues/test10', 'producer2'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_failure( self ):
     # messenger already exists
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
-    self.assertFalse(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queue/test1', 'producer4'))
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    self.assertFalse(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queues/test1', 'producer4'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
 class TestMQConnectionStorageFunctions_removeMessenger( TestMQConnectionManager ):
   def test_success( self ):
-    expectedOutput= [ 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/queue/test1', 'producer4'))
+    expectedOutput= [ 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/queues/test1', 'producer4'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_success2( self ):
-    #remove whole destination /topic/test1 cause only one element
-    expectedOutput= [ 'mardirac3.in2p3.fr/queue/test1/producer4','mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2','testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/topic/test1', 'producer1'))
+    #remove whole destination /topics/test1 cause only one element
+    expectedOutput= [ 'mardirac3.in2p3.fr/queues/test1/producer4','mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2','testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/topics/test1', 'producer1'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
 
   def test_success3( self ):
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1']
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1']
     #remove whole connection
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'producer1'))
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'consumer2'))
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'consumer3'))
-    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'consumer4'))
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'producer1'))
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'consumer2'))
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'consumer3'))
+    self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'consumer4'))
     self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
                                            
   def test_failure( self ):                
     #remove nonexisting messenger          
-    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'producer10'))
+    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/test3', 'producer10'))
   def test_failure2( self ):
     #remove nonexisting destination
-    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/nonexisting', 'producer1'))
+    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queues/nonexisting', 'producer1'))
   def test_failure3( self ):
     #remove nonexisting connection
-    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('nonexisting', '/queue/test103', 'producer1'))
+    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('nonexisting', '/queues/test103', 'producer1'))
 
 class TestMQConnectionManager_addNewmessenger( TestMQConnectionManager ):
   def test_success( self ):
-    result = self.mgr.addNewMessenger(mqURI = "mardirac3.in2p3.fr::Queue::test1", messengerType = "producer"  )
+    result = self.mgr.addNewMessenger(mqURI = "mardirac3.in2p3.fr::Queues::test1", messengerType = "producer"  )
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'producer5')
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer5', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
   def test_success2( self ):
-    result = self.mgr.addNewMessenger(mqURI = "mardirac3.in2p3.fr::Topic::test1", messengerType = "consumer"  )
+    result = self.mgr.addNewMessenger(mqURI = "mardirac3.in2p3.fr::Topics::test1", messengerType = "consumer"  )
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
 
   def test_success3( self ):
-    result = self.mgr.addNewMessenger(mqURI = "testdir.blabla.ch::Queue::test3", messengerType = "consumer"  )
+    result = self.mgr.addNewMessenger(mqURI = "testdir.blabla.ch::Queues::test3", messengerType = "consumer"  )
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
 
   def test_success4( self ):
     #connection does not exist
-    result = self.mgr.addNewMessenger(mqURI = "noexisting.blabla.ch::Queue::test3", messengerType = "consumer"  )
+    result = self.mgr.addNewMessenger(mqURI = "noexisting.blabla.ch::Queues::test3", messengerType = "consumer"  )
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
-    expectedOutput= ['noexisting.blabla.ch/queue/test3/consumer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput= ['noexisting.blabla.ch/queues/test3/consumer5', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
 class TestMQConnectionManager_startConnection( TestMQConnectionManager ):
   def test_success( self ):
     #existing connection
-    result = self.mgr.startConnection(mqURI = "mardirac3.in2p3.fr::Queue::test1", params ={}, messengerType = "producer")
+    result = self.mgr.startConnection(mqURI = "mardirac3.in2p3.fr::Queues::test1", params ={}, messengerType = "producer")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'producer5')
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer5', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
@@ -237,10 +237,10 @@ class TestMQConnectionManager_startConnection( TestMQConnectionManager ):
   def test_success2( self, mock_createConnectorAndConnect):
     #connection does not exist
     mock_createConnectorAndConnect.return_value = S_OK('MyConnector')
-    result = self.mgr.startConnection(mqURI = "noexisting.blabla.ch::Queue::test3", params={}, messengerType = "consumer"  )
+    result = self.mgr.startConnection(mqURI = "noexisting.blabla.ch::Queues::test3", params={}, messengerType = "consumer"  )
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
-    expectedOutput= ['noexisting.blabla.ch/queue/test3/consumer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput= ['noexisting.blabla.ch/queues/test3/consumer5', 'mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
     result = self.mgr.getConnector('noexisting.blabla.ch')
@@ -249,16 +249,16 @@ class TestMQConnectionManager_startConnection( TestMQConnectionManager ):
 
 class TestMQConnectionManager_stopConnection( TestMQConnectionManager ):
   def test_success( self ):
-    result = self.mgr.stopConnection(mqURI = "mardirac3.in2p3.fr::Queue::test1", messengerId = "producer4")
+    result = self.mgr.stopConnection(mqURI = "mardirac3.in2p3.fr::Queues::test1", messengerId = "producer4")
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
   def test_success2( self ):
-    result = self.mgr.stopConnection(mqURI = "mardirac3.in2p3.fr::Topic::test1", messengerId = "producer1")
+    result = self.mgr.stopConnection(mqURI = "mardirac3.in2p3.fr::Topics::test1", messengerId = "producer1")
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
@@ -267,15 +267,15 @@ class TestMQConnectionManager_stopConnection( TestMQConnectionManager ):
   def test_success3( self, mock_disconnect, mock_unsubscribe ):
     mock_disconnect.return_value = S_OK()
     mock_unsubscribe.return_value = S_OK()
-    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queue::test3", messengerId = "consumer3")
+    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queues::test3", messengerId = "consumer3")
     self.assertTrue(result['OK'])
-    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queue::test3", messengerId = "producer1")
+    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queues::test3", messengerId = "producer1")
     self.assertTrue(result['OK'])
-    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queue::test3", messengerId = "consumer2")
+    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queues::test3", messengerId = "consumer2")
     self.assertTrue(result['OK'])
-    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queue::test3", messengerId = "consumer4")
+    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queues::test3", messengerId = "consumer4")
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1']
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 
@@ -293,7 +293,7 @@ class TestMQConnectionManager_getAllMessengers( TestMQConnectionManager ):
   def test_success( self ):
     result = self.mgr.getAllMessengers()
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput= ['mardirac3.in2p3.fr/queues/test1/producer4', 'mardirac3.in2p3.fr/queues/test1/consumer1', 'mardirac3.in2p3.fr/queues/test1/consumer2', 'mardirac3.in2p3.fr/queues/test1/consumer4', 'mardirac3.in2p3.fr/queues/test2/producer2', 'mardirac3.in2p3.fr/queues/test2/consumer1', 'mardirac3.in2p3.fr/queues/test2/consumer2', 'mardirac3.in2p3.fr/topics/test1/producer1', 'testdir.blabla.ch/queues/test3/producer1', 'testdir.blabla.ch/queues/test3/consumer2', 'testdir.blabla.ch/queues/test3/consumer3', 'testdir.blabla.ch/queues/test3/consumer4']
     result = self.mgr.getAllMessengers()
     self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
 

--- a/Resources/MessageQueue/test/Test_MQConnectionManager.py
+++ b/Resources/MessageQueue/test/Test_MQConnectionManager.py
@@ -2,8 +2,8 @@
    Also, test of internal functions for mq connection storage.
 """
 
-## ignore use of __functions, _functions
-#pylint: disable=no-member, protected-access
+# ignore use of __functions, _functions
+# pylint: disable=no-member, protected-access
 
 import unittest
 import mock
@@ -11,321 +11,613 @@ from DIRAC import S_OK
 from DIRAC.Resources.MessageQueue.MQConnectionManager import MQConnectionManager
 
 
-class TestMQConnectionManager( unittest.TestCase ):
-  def setUp( self ):
+class TestMQConnectionManager(unittest.TestCase):
+  def setUp(self):
     self.maxDiff = None  # To show full difference between structures in  case of error
     dest = {}
     dest.update({'/queue/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4']})
     dest.update({'/queue/test2': ['producer2', 'consumer1', 'consumer2']})
     dest.update({'/topic/test1': ['producer1']})
-    dest4 = {'/queue/test3': ['producer1', 'consumer2','consumer3','consumer4']}
-    conn1 = {'MQConnector':'TestConnector1', 'destinations':dest}
-    conn2 = {'MQConnector':'TestConnector2', 'destinations':dest4}
-    storage = {'mardirac3.in2p3.fr':conn1, 'testdir.blabla.ch':conn2}
-    self.mgr = MQConnectionManager(connectionStorage = storage)
+    dest4 = {'/queue/test3': ['producer1', 'consumer2', 'consumer3', 'consumer4']}
+    conn1 = {'MQConnector': 'TestConnector1', 'destinations': dest}
+    conn2 = {'MQConnector': 'TestConnector2', 'destinations': dest4}
+    storage = {'mardirac3.in2p3.fr': conn1, 'testdir.blabla.ch': conn2}
+    self.mgr = MQConnectionManager(connectionStorage=storage)
 
-  def tearDown( self ):
+  def tearDown(self):
     pass
 
-class TestMQConnectionStorageFunctions_connectionExists( TestMQConnectionManager ):
-  def test_success( self ):
-    self.assertTrue(self.mgr._MQConnectionManager__connectionExists( 'mardirac3.in2p3.fr'))
-  def test_failure( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__connectionExists( 'nonexisting'))
 
-class TestMQConnectionStorageFunctions_destinationExists( TestMQConnectionManager ):
-  def test_success( self ):
-    self.assertTrue(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr',  '/queue/test1'))
-  def test_failure( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__destinationExists( 'nonexisting', '/queue/test1'))
-  def test_failure2( self ):
+class TestMQConnectionStorageFunctions_connectionExists(TestMQConnectionManager):
+  def test_success(self):
+    self.assertTrue(self.mgr._MQConnectionManager__connectionExists('mardirac3.in2p3.fr'))
+
+  def test_failure(self):
+    self.assertFalse(self.mgr._MQConnectionManager__connectionExists('nonexisting'))
+
+
+class TestMQConnectionStorageFunctions_destinationExists(TestMQConnectionManager):
+  def test_success(self):
+    self.assertTrue(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr', '/queue/test1'))
+
+  def test_failure(self):
+    self.assertFalse(self.mgr._MQConnectionManager__destinationExists('nonexisting', '/queue/test1'))
+
+  def test_failure2(self):
     self.assertFalse(self.mgr._MQConnectionManager__destinationExists('mardirac3.in2p3.fr', '/queue/nonexisting'))
 
-class TestMQConnectionStorageFunctions_messengerExists( TestMQConnectionManager ):
-  def test_success( self ):
-    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queue/test1','consumer2' ))
-    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr',  '/queue/test1','producer4' ))
-  def test_failure( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__messengerExists('noexisting',  '/queue/test1','producer4' ))
-  def test_failure2( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queue/nonexisting','producer4'))
-  def test_failure3( self ):
-    self.assertFalse(self.mgr._MQConnectionManager__messengerExists( 'mardirac3.in2p3.fr', '/queue/test1','producer10'))
 
-class TestMQConnectionStorageFunctions_getConnection( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedConn = {'MQConnector':'TestConnector2', 'destinations':{'/queue/test3': ['producer1', 'consumer2','consumer3','consumer4']}}
-    self.assertEqual(self.mgr._MQConnectionManager__getConnection('testdir.blabla.ch'),expectedConn)
-  def test_failure( self ):
+class TestMQConnectionStorageFunctions_messengerExists(TestMQConnectionManager):
+  def test_success(self):
+    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr', '/queue/test1', 'consumer2'))
+    self.assertTrue(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr', '/queue/test1', 'producer4'))
+
+  def test_failure(self):
+    self.assertFalse(self.mgr._MQConnectionManager__messengerExists('noexisting', '/queue/test1', 'producer4'))
+
+  def test_failure2(self):
+    self.assertFalse(self.mgr._MQConnectionManager__messengerExists(
+        'mardirac3.in2p3.fr', '/queue/nonexisting', 'producer4'))
+
+  def test_failure3(self):
+    self.assertFalse(self.mgr._MQConnectionManager__messengerExists('mardirac3.in2p3.fr', '/queue/test1', 'producer10'))
+
+
+class TestMQConnectionStorageFunctions_getConnection(TestMQConnectionManager):
+  def test_success(self):
+    expectedConn = {'MQConnector': 'TestConnector2', 'destinations': {
+        '/queue/test3': ['producer1', 'consumer2', 'consumer3', 'consumer4']}}
+    self.assertEqual(self.mgr._MQConnectionManager__getConnection('testdir.blabla.ch'), expectedConn)
+
+  def test_failure(self):
     self.assertEqual(self.mgr._MQConnectionManager__getConnection('nonexisiting'), {})
 
-class TestMQConnectionStorageFunctions_getAllConnections( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedOutput = ['testdir.blabla.ch','mardirac3.in2p3.fr']
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllConnections()),sorted(expectedOutput))
 
-class TestMQConnectionStorageFunctions_getConnector( TestMQConnectionManager ):
-  def test_success( self ):
-    self.assertEqual(self.mgr._MQConnectionManager__getConnector('testdir.blabla.ch'),'TestConnector2')
-  def test_failure( self ):
+class TestMQConnectionStorageFunctions_getAllConnections(TestMQConnectionManager):
+  def test_success(self):
+    expectedOutput = ['testdir.blabla.ch', 'mardirac3.in2p3.fr']
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllConnections()), sorted(expectedOutput))
+
+
+class TestMQConnectionStorageFunctions_getConnector(TestMQConnectionManager):
+  def test_success(self):
+    self.assertEqual(self.mgr._MQConnectionManager__getConnector('testdir.blabla.ch'), 'TestConnector2')
+
+  def test_failure(self):
     self.assertIsNone(self.mgr._MQConnectionManager__getConnector('nonexisiting'))
 
-class TestMQConnectionStorageFunctions_setConnector( TestMQConnectionManager ):
-  def test_success( self ):
+
+class TestMQConnectionStorageFunctions_setConnector(TestMQConnectionManager):
+  def test_success(self):
     self.assertTrue(self.mgr._MQConnectionManager__setConnector('testdir.blabla.ch', 'TestConnector5'))
-    self.assertEqual(self.mgr._MQConnectionManager__getConnector('testdir.blabla.ch'),'TestConnector5')
-  def test_failure( self ):
+    self.assertEqual(self.mgr._MQConnectionManager__getConnector('testdir.blabla.ch'), 'TestConnector5')
+
+  def test_failure(self):
     self.assertFalse(self.mgr._MQConnectionManager__setConnector('nonexisiting', 'TestConnector3'))
 
-class TestMQConnectionStorageFunctions_getDestinations( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedDests ={'/queue/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4'],
-                    '/queue/test2': ['producer2', 'consumer1', 'consumer2'],
-                    '/topic/test1': ['producer1']}
-    self.assertEqual(self.mgr._MQConnectionManager__getDestinations('mardirac3.in2p3.fr'),expectedDests)
-  def test_failure( self ):
+
+class TestMQConnectionStorageFunctions_getDestinations(TestMQConnectionManager):
+  def test_success(self):
+    expectedDests = {'/queue/test1': ['producer4', 'consumer1', 'consumer2', 'consumer4'],
+                     '/queue/test2': ['producer2', 'consumer1', 'consumer2'],
+                     '/topic/test1': ['producer1']}
+    self.assertEqual(self.mgr._MQConnectionManager__getDestinations('mardirac3.in2p3.fr'), expectedDests)
+
+  def test_failure(self):
     self.assertEqual(self.mgr._MQConnectionManager__getDestinations('nonexisiting'), {})
 
-class TestMQConnectionStorageFunctions_getMessengersId( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedMess =['producer4', 'consumer1', 'consumer2', 'consumer4']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queue/test1'),expectedMess)
-  def test_success2( self ):
-    expectedMess2 =['producer2', 'consumer1', 'consumer2']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queue/test2'),expectedMess2)
-  def test_failure( self ):
+
+class TestMQConnectionStorageFunctions_getMessengersId(TestMQConnectionManager):
+  def test_success(self):
+    expectedMess = ['producer4', 'consumer1', 'consumer2', 'consumer4']
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', '/queue/test1'), expectedMess)
+
+  def test_success2(self):
+    expectedMess2 = ['producer2', 'consumer1', 'consumer2']
+    self.assertEqual(
+        self.mgr._MQConnectionManager__getMessengersId(
+            'mardirac3.in2p3.fr',
+            '/queue/test2'),
+        expectedMess2)
+
+  def test_failure(self):
     self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('nonexisiting', '/queue/test2'), [])
-  def test_failure2( self ):
+
+  def test_failure2(self):
     self.assertEqual(self.mgr._MQConnectionManager__getMessengersId('mardirac3.in2p3.fr', 'nonexisiting'), [])
 
-class TestMQConnectionStorageFunctions_getMessengersIdWithType( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedMess =['producer4']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test1', 'producer'),expectedMess)
-  def test_success2( self ):
-    expectedMess2 =['producer2']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test2', 'producer'),expectedMess2)
-  def test_success3( self ):
-    expectedMess =[ 'consumer1', 'consumer2', 'consumer4']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test1', 'consumer'),expectedMess)
-  def test_success4( self ):
-    expectedMess2 =['consumer1', 'consumer2']
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', '/queue/test2', 'consumer'),expectedMess2)
-  def test_failure( self ):
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('nonexisiting', '/queue/test2', 'producer'), [])
-  def test_failure2( self ):
-    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType('mardirac3.in2p3.fr', 'nonexisiting', 'producer'), [])
 
-class TestMQConnectionStorageFunctions_getAllMessengersInfo( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
+class TestMQConnectionStorageFunctions_getMessengersIdWithType(TestMQConnectionManager):
+  def test_success(self):
+    expectedMess = ['producer4']
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType(
+        'mardirac3.in2p3.fr', '/queue/test1', 'producer'), expectedMess)
 
-class TestMQConnectionStorageFunctions_getAllMessengersId( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedOutput= ['producer4', 'consumer1', 'consumer2', 'consumer4', 'producer2', 'consumer1', 'consumer2', 'producer1', 'producer1', 'consumer2', 'consumer3', 'consumer4']
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersId()),sorted(expectedOutput))
+  def test_success2(self):
+    expectedMess2 = ['producer2']
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType(
+        'mardirac3.in2p3.fr', '/queue/test2', 'producer'), expectedMess2)
 
-class TestMQConnectionStorageFunctions_getAllMessengersIdWithType( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedOutput= ['consumer1', 'consumer2', 'consumer4', 'consumer1', 'consumer2','consumer2', 'consumer3', 'consumer4']
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersIdWithType('consumer')),sorted(expectedOutput))
-    expectedOutput= ['producer4', 'producer2', 'producer1', 'producer1']
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersIdWithType('producer')),sorted(expectedOutput))
+  def test_success3(self):
+    expectedMess = ['consumer1', 'consumer2', 'consumer4']
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType(
+        'mardirac3.in2p3.fr', '/queue/test1', 'consumer'), expectedMess)
+
+  def test_success4(self):
+    expectedMess2 = ['consumer1', 'consumer2']
+    self.assertEqual(self.mgr._MQConnectionManager__getMessengersIdWithType(
+        'mardirac3.in2p3.fr', '/queue/test2', 'consumer'), expectedMess2)
+
+  def test_failure(self):
+    self.assertEqual(
+        self.mgr._MQConnectionManager__getMessengersIdWithType(
+            'nonexisiting', '/queue/test2', 'producer'), [])
+
+  def test_failure2(self):
+    self.assertEqual(
+        self.mgr._MQConnectionManager__getMessengersIdWithType(
+            'mardirac3.in2p3.fr',
+            'nonexisiting',
+            'producer'),
+        [])
 
 
-class TestMQConnectionStorageFunctions_addMessenger( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer1', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+class TestMQConnectionStorageFunctions_getAllMessengersInfo(TestMQConnectionManager):
+  def test_success(self):
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()), sorted(expectedOutput))
+
+
+class TestMQConnectionStorageFunctions_getAllMessengersId(TestMQConnectionManager):
+  def test_success(self):
+    expectedOutput = [
+        'producer4',
+        'consumer1',
+        'consumer2',
+        'consumer4',
+        'producer2',
+        'consumer1',
+        'consumer2',
+        'producer1',
+        'producer1',
+        'consumer2',
+        'consumer3',
+        'consumer4']
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersId()), sorted(expectedOutput))
+
+
+class TestMQConnectionStorageFunctions_getAllMessengersIdWithType(TestMQConnectionManager):
+  def test_success(self):
+    expectedOutput = [
+        'consumer1',
+        'consumer2',
+        'consumer4',
+        'consumer1',
+        'consumer2',
+        'consumer2',
+        'consumer3',
+        'consumer4']
+    self.assertEqual(
+        sorted(
+            self.mgr._MQConnectionManager__getAllMessengersIdWithType('consumer')),
+        sorted(expectedOutput))
+    expectedOutput = ['producer4', 'producer2', 'producer1', 'producer1']
+    self.assertEqual(
+        sorted(
+            self.mgr._MQConnectionManager__getAllMessengersIdWithType('producer')),
+        sorted(expectedOutput))
+
+
+class TestMQConnectionStorageFunctions_addMessenger(TestMQConnectionManager):
+  def test_success(self):
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer1',
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queue/test1', 'producer1'))
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()), sorted(expectedOutput))
 
-  def test_success2( self ):
+  def test_success2(self):
     # new queue
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test5/producer8', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test5/producer8',
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queue/test5', 'producer8'))
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()), sorted(expectedOutput))
 
-  def test_success3( self ):
+  def test_success3(self):
     # new connection
-    expectedOutput= ['mytest.is.the.best/queue/test10/producer24', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'mytest.is.the.best/queue/test10/producer24',
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queue/test10', 'producer24'))
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
-  def test_success4( self ):
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()), sorted(expectedOutput))
+
+  def test_success4(self):
     #  two times
-    expectedOutput= ['mytest.is.the.best/queue/test10/producer2', 'mytest.is.the.best/queue/test10/producer24', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'mytest.is.the.best/queue/test10/producer2',
+        'mytest.is.the.best/queue/test10/producer24',
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queue/test10', 'producer24'))
     self.assertTrue(self.mgr._MQConnectionManager__addMessenger('mytest.is.the.best', '/queue/test10', 'producer2'))
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()), sorted(expectedOutput))
 
-  def test_failure( self ):
+  def test_failure(self):
     # messenger already exists
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     self.assertFalse(self.mgr._MQConnectionManager__addMessenger('mardirac3.in2p3.fr', '/queue/test1', 'producer4'))
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()), sorted(expectedOutput))
 
-class TestMQConnectionStorageFunctions_removeMessenger( TestMQConnectionManager ):
-  def test_success( self ):
-    expectedOutput= [ 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+
+class TestMQConnectionStorageFunctions_removeMessenger(TestMQConnectionManager):
+  def test_success(self):
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/queue/test1', 'producer4'))
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()), sorted(expectedOutput))
 
-  def test_success2( self ):
-    #remove whole destination /topic/test1 cause only one element
-    expectedOutput= [ 'mardirac3.in2p3.fr/queue/test1/producer4','mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2','testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+  def test_success2(self):
+    # remove whole destination /topic/test1 cause only one element
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('mardirac3.in2p3.fr', '/topic/test1', 'producer1'))
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()), sorted(expectedOutput))
 
-  def test_success3( self ):
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1']
-    #remove whole connection
+  def test_success3(self):
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1']
+    # remove whole connection
     self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'producer1'))
     self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'consumer2'))
     self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'consumer3'))
     self.assertTrue(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'consumer4'))
-    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()),sorted(expectedOutput))
-                                           
-  def test_failure( self ):                
-    #remove nonexisting messenger          
+    self.assertEqual(sorted(self.mgr._MQConnectionManager__getAllMessengersInfo()), sorted(expectedOutput))
+
+  def test_failure(self):
+    # remove nonexisting messenger
     self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/test3', 'producer10'))
-  def test_failure2( self ):
-    #remove nonexisting destination
-    self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('testdir.blabla.ch', '/queue/nonexisting', 'producer1'))
-  def test_failure3( self ):
-    #remove nonexisting connection
+
+  def test_failure2(self):
+    # remove nonexisting destination
+    self.assertFalse(
+        self.mgr._MQConnectionManager__removeMessenger(
+            'testdir.blabla.ch',
+            '/queue/nonexisting',
+            'producer1'))
+
+  def test_failure3(self):
+    # remove nonexisting connection
     self.assertFalse(self.mgr._MQConnectionManager__removeMessenger('nonexisting', '/queue/test103', 'producer1'))
 
-class TestMQConnectionManager_addNewmessenger( TestMQConnectionManager ):
-  def test_success( self ):
-    result = self.mgr.addNewMessenger(mqURI = "mardirac3.in2p3.fr::Queues::test1", messengerType = "producer"  )
+
+class TestMQConnectionManager_addNewmessenger(TestMQConnectionManager):
+  def test_success(self):
+    result = self.mgr.addNewMessenger(mqURI="mardirac3.in2p3.fr::Queues::test1", messengerType="producer")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'producer5')
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer5',
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
-    self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
+    self.assertEqual(sorted(result['Value']), sorted(expectedOutput))
 
-  def test_success2( self ):
-    result = self.mgr.addNewMessenger(mqURI = "mardirac3.in2p3.fr::Topics::test1", messengerType = "consumer"  )
+  def test_success2(self):
+    result = self.mgr.addNewMessenger(mqURI="mardirac3.in2p3.fr::Topics::test1", messengerType="consumer")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
 
-  def test_success3( self ):
-    result = self.mgr.addNewMessenger(mqURI = "testdir.blabla.ch::Queues::test3", messengerType = "consumer"  )
+  def test_success3(self):
+    result = self.mgr.addNewMessenger(mqURI="testdir.blabla.ch::Queues::test3", messengerType="consumer")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
 
-  def test_success4( self ):
-    #connection does not exist
-    result = self.mgr.addNewMessenger(mqURI = "noexisting.blabla.ch::Queues::test3", messengerType = "consumer"  )
+  def test_success4(self):
+    # connection does not exist
+    result = self.mgr.addNewMessenger(mqURI="noexisting.blabla.ch::Queues::test3", messengerType="consumer")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
-    expectedOutput= ['noexisting.blabla.ch/queue/test3/consumer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'noexisting.blabla.ch/queue/test3/consumer5',
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
-    self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
+    self.assertEqual(sorted(result['Value']), sorted(expectedOutput))
 
-class TestMQConnectionManager_startConnection( TestMQConnectionManager ):
-  def test_success( self ):
-    #existing connection
-    result = self.mgr.startConnection(mqURI = "mardirac3.in2p3.fr::Queues::test1", params ={}, messengerType = "producer")
+
+class TestMQConnectionManager_startConnection(TestMQConnectionManager):
+  def test_success(self):
+    # existing connection
+    result = self.mgr.startConnection(mqURI="mardirac3.in2p3.fr::Queues::test1", params={}, messengerType="producer")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'producer5')
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer5',
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
-    self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
+    self.assertEqual(sorted(result['Value']), sorted(expectedOutput))
 
   @mock.patch('DIRAC.Resources.MessageQueue.MQConnectionManager.MQConnectionManager.createConnectorAndConnect')
-  def test_success2( self, mock_createConnectorAndConnect):
-    #connection does not exist
+  def test_success2(self, mock_createConnectorAndConnect):
+    # connection does not exist
     mock_createConnectorAndConnect.return_value = S_OK('MyConnector')
-    result = self.mgr.startConnection(mqURI = "noexisting.blabla.ch::Queues::test3", params={}, messengerType = "consumer"  )
+    result = self.mgr.startConnection(mqURI="noexisting.blabla.ch::Queues::test3", params={}, messengerType="consumer")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], 'consumer5')
-    expectedOutput= ['noexisting.blabla.ch/queue/test3/consumer5', 'mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'noexisting.blabla.ch/queue/test3/consumer5',
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
-    self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
+    self.assertEqual(sorted(result['Value']), sorted(expectedOutput))
     result = self.mgr.getConnector('noexisting.blabla.ch')
     self.assertEqual(result['Value'], 'MyConnector')
 
 
-class TestMQConnectionManager_stopConnection( TestMQConnectionManager ):
-  def test_success( self ):
-    result = self.mgr.stopConnection(mqURI = "mardirac3.in2p3.fr::Queues::test1", messengerId = "producer4")
+class TestMQConnectionManager_stopConnection(TestMQConnectionManager):
+  def test_success(self):
+    result = self.mgr.stopConnection(mqURI="mardirac3.in2p3.fr::Queues::test1", messengerId="producer4")
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
-    self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
+    self.assertEqual(sorted(result['Value']), sorted(expectedOutput))
 
-  def test_success2( self ):
-    result = self.mgr.stopConnection(mqURI = "mardirac3.in2p3.fr::Topics::test1", messengerId = "producer1")
+  def test_success2(self):
+    result = self.mgr.stopConnection(mqURI="mardirac3.in2p3.fr::Topics::test1", messengerId="producer1")
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
-    self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
+    self.assertEqual(sorted(result['Value']), sorted(expectedOutput))
 
   @mock.patch('DIRAC.Resources.MessageQueue.MQConnectionManager.MQConnectionManager.unsubscribe')
   @mock.patch('DIRAC.Resources.MessageQueue.MQConnectionManager.MQConnectionManager.disconnect')
-  def test_success3( self, mock_disconnect, mock_unsubscribe ):
+  def test_success3(self, mock_disconnect, mock_unsubscribe):
     mock_disconnect.return_value = S_OK()
     mock_unsubscribe.return_value = S_OK()
-    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queues::test3", messengerId = "consumer3")
+    result = self.mgr.stopConnection(mqURI="testdir.blabla.ch::Queues::test3", messengerId="consumer3")
     self.assertTrue(result['OK'])
-    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queues::test3", messengerId = "producer1")
+    result = self.mgr.stopConnection(mqURI="testdir.blabla.ch::Queues::test3", messengerId="producer1")
     self.assertTrue(result['OK'])
-    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queues::test3", messengerId = "consumer2")
+    result = self.mgr.stopConnection(mqURI="testdir.blabla.ch::Queues::test3", messengerId="consumer2")
     self.assertTrue(result['OK'])
-    result = self.mgr.stopConnection(mqURI = "testdir.blabla.ch::Queues::test3", messengerId = "consumer4")
+    result = self.mgr.stopConnection(mqURI="testdir.blabla.ch::Queues::test3", messengerId="consumer4")
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1']
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1']
     result = self.mgr.getAllMessengers()
-    self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
+    self.assertEqual(sorted(result['Value']), sorted(expectedOutput))
 
-class TestMQConnectionManager_removeAllConnections( TestMQConnectionManager ):
+
+class TestMQConnectionManager_removeAllConnections(TestMQConnectionManager):
   @mock.patch('DIRAC.Resources.MessageQueue.MQConnectionManager.MQConnectionManager.disconnect')
-  def test_success( self, mock_disconnect):
+  def test_success(self, mock_disconnect):
     mock_disconnect.return_value = S_OK()
     result = self.mgr.removeAllConnections()
     self.assertTrue(result['OK'])
-    expectedOutput= []
+    expectedOutput = []
     result = self.mgr.getAllMessengers()
-    self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
+    self.assertEqual(sorted(result['Value']), sorted(expectedOutput))
 
-class TestMQConnectionManager_getAllMessengers( TestMQConnectionManager ):
-  def test_success( self ):
+
+class TestMQConnectionManager_getAllMessengers(TestMQConnectionManager):
+  def test_success(self):
     result = self.mgr.getAllMessengers()
     self.assertTrue(result['OK'])
-    expectedOutput= ['mardirac3.in2p3.fr/queue/test1/producer4', 'mardirac3.in2p3.fr/queue/test1/consumer1', 'mardirac3.in2p3.fr/queue/test1/consumer2', 'mardirac3.in2p3.fr/queue/test1/consumer4', 'mardirac3.in2p3.fr/queue/test2/producer2', 'mardirac3.in2p3.fr/queue/test2/consumer1', 'mardirac3.in2p3.fr/queue/test2/consumer2', 'mardirac3.in2p3.fr/topic/test1/producer1', 'testdir.blabla.ch/queue/test3/producer1', 'testdir.blabla.ch/queue/test3/consumer2', 'testdir.blabla.ch/queue/test3/consumer3', 'testdir.blabla.ch/queue/test3/consumer4']
+    expectedOutput = [
+        'mardirac3.in2p3.fr/queue/test1/producer4',
+        'mardirac3.in2p3.fr/queue/test1/consumer1',
+        'mardirac3.in2p3.fr/queue/test1/consumer2',
+        'mardirac3.in2p3.fr/queue/test1/consumer4',
+        'mardirac3.in2p3.fr/queue/test2/producer2',
+        'mardirac3.in2p3.fr/queue/test2/consumer1',
+        'mardirac3.in2p3.fr/queue/test2/consumer2',
+        'mardirac3.in2p3.fr/topic/test1/producer1',
+        'testdir.blabla.ch/queue/test3/producer1',
+        'testdir.blabla.ch/queue/test3/consumer2',
+        'testdir.blabla.ch/queue/test3/consumer3',
+        'testdir.blabla.ch/queue/test3/consumer4']
     result = self.mgr.getAllMessengers()
-    self.assertEqual(sorted(result['Value']),sorted(expectedOutput))
+    self.assertEqual(sorted(result['Value']), sorted(expectedOutput))
 
-class TestMQConnectionManager_getConnector( TestMQConnectionManager ):
-  def test_success( self ):
+
+class TestMQConnectionManager_getConnector(TestMQConnectionManager):
+  def test_success(self):
     result = self.mgr.getConnector('mardirac3.in2p3.fr')
     self.assertTrue(result['OK'])
-  def test_failure( self ):
+
+  def test_failure(self):
     result = self.mgr.getConnector('nonexistent.in2p3.fr')
     self.assertEqual(result['Message'], 'Failed to get the MQConnector!')
 
+
 if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionManager )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionManager_addNewmessenger ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionManager_startConnection ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionManager_stopConnection ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionManager_removeAllConnections ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionManager_getAllMessengers ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionManager_getConnector ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_connectionExists ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_destinationExists ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_messengerExists ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_getConnection ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_getAllConnections ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_getConnector ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_setConnector ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_getDestinations ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_getMessengersId ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_getMessengersIdWithType ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_addMessenger ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_removeMessenger ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_getAllMessengersInfo) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_getAllMessengersId) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConnectionStorageFunctions_getAllMessengersIdWithType) )
-  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionManager)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionManager_addNewmessenger))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionManager_startConnection))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionManager_stopConnection))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionManager_removeAllConnections))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionManager_getAllMessengers))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionManager_getConnector))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_connectionExists))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_destinationExists))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_messengerExists))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_getConnection))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_getAllConnections))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_getConnector))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_setConnector))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_getDestinations))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_getMessengersId))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(
+      TestMQConnectionStorageFunctions_getMessengersIdWithType))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_addMessenger))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_removeMessenger))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_getAllMessengersInfo))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConnectionStorageFunctions_getAllMessengersId))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(
+      TestMQConnectionStorageFunctions_getAllMessengersIdWithType))
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Resources/MessageQueue/test/Test_MQConsumer.py
+++ b/Resources/MessageQueue/test/Test_MQConsumer.py
@@ -7,72 +7,89 @@ from DIRAC.Resources.MessageQueue.MQConsumer import MQConsumer
 from DIRAC.Resources.MessageQueue.MQConnectionManager import MQConnectionManager
 from DIRAC.Resources.MessageQueue.MQConnector import MQConnector
 
-class FakeMQConnector( MQConnector ):
-  def __init__( self, params={} ):
-    super( FakeMQConnector, self ).__init__()
+
+class FakeMQConnector(MQConnector):
+  def __init__(self, params={}):
+    super(FakeMQConnector, self).__init__()
+
   def disconnect(self):
     return S_OK("FakeMQConnection disconnecting")
-  def get(self, destination = ''):
-    return "FakeMQConnection getting message"
-  def subscribe( self, parameters = None):
-    return S_OK( 'Subscription successful' )
-  def unsubscribe(self, parameters):
-    return S_OK( 'Unsubscription successful' )
 
-class TestMQConsumer( unittest.TestCase ):
-  def setUp( self ):
+  def get(self, destination=''):
+    return "FakeMQConnection getting message"
+
+  def subscribe(self, parameters=None):
+    return S_OK('Subscription successful')
+
+  def unsubscribe(self, parameters):
+    return S_OK('Unsubscription successful')
+
+
+class TestMQConsumer(unittest.TestCase):
+  def setUp(self):
     self.maxDiff = None  # To show full difference between structures in  case of error
     dest = {}
     dest.update({'/queue/FakeQueue': ['consumer4', 'consumer2']})
-    dest4 = {'/queue/test3': ['consumer1', 'consumer2','consumer3','consumer4']}
-    conn1 = {'MQConnector':FakeMQConnector(), 'destinations':dest}
-    conn2 = {'MQConnector':FakeMQConnector(), 'destinations':dest4}
-    storage = {'fake.cern.ch':conn1, 'testdir.blabla.ch':conn2}
-    self.myManager = MQConnectionManager(connectionStorage = storage)
-  def tearDown( self ):
+    dest4 = {'/queue/test3': ['consumer1', 'consumer2', 'consumer3', 'consumer4']}
+    conn1 = {'MQConnector': FakeMQConnector(), 'destinations': dest}
+    conn2 = {'MQConnector': FakeMQConnector(), 'destinations': dest4}
+    storage = {'fake.cern.ch': conn1, 'testdir.blabla.ch': conn2}
+    self.myManager = MQConnectionManager(connectionStorage=storage)
+
+  def tearDown(self):
     pass
-class TestMQConsumer_get( TestMQConsumer):
-  def test_failure( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId = 'consumer1')
+
+
+class TestMQConsumer_get(TestMQConsumer):
+  def test_failure(self):
+    consumer = MQConsumer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", consumerId='consumer1')
     result = consumer.get()
     self.assertFalse(result['OK'])
     self.assertEqual(result['Message'], 'No messages ( 1141 : No messages in queue)')
 
-  def test_sucess( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "bad.cern.ch::Queues::FakeQueue", consumerId = 'consumer1')
+  def test_sucess(self):
+    consumer = MQConsumer(mqManager=self.myManager, mqURI="bad.cern.ch::Queues::FakeQueue", consumerId='consumer1')
     result = consumer.get()
     self.assertFalse(result['OK'])
 
-class TestMQConsumer_close( TestMQConsumer):
-  def test_success( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId ='consumer4')
+
+class TestMQConsumer_close(TestMQConsumer):
+  def test_success(self):
+    consumer = MQConsumer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", consumerId='consumer4')
     result = consumer.close()
     self.assertTrue(result['OK'])
 
-  def test_failure( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId ='consumer4')
+  def test_failure(self):
+    consumer = MQConsumer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", consumerId='consumer4')
     result = consumer.close()
     self.assertTrue(result['OK'])
     result = consumer.close()
     self.assertFalse(result['OK'])
-    self.assertEqual(result['Message'], 'MQ connection failure ( 1142 : Failed to stop the connection!The messenger consumer4 does not exist!)')
+    self.assertEqual(
+        result['Message'],
+        'MQ connection failure ( 1142 : Failed to stop the connection!The messenger consumer4 does not exist!)')
 
-  def test_failure2( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId ='consumer4')
-    consumer2 = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId ='consumer2')
+  def test_failure2(self):
+    consumer = MQConsumer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", consumerId='consumer4')
+    consumer2 = MQConsumer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", consumerId='consumer2')
     result = consumer.close()
     self.assertTrue(result['OK'])
     result = consumer.close()
     self.assertFalse(result['OK'])
-    self.assertEqual(result['Message'], 'MQ connection failure ( 1142 : Failed to stop the connection!The messenger consumer4 does not exist!)')
+    self.assertEqual(
+        result['Message'],
+        'MQ connection failure ( 1142 : Failed to stop the connection!The messenger consumer4 does not exist!)')
     result = consumer2.close()
     self.assertTrue(result['OK'])
     result = consumer2.close()
     self.assertFalse(result['OK'])
-    self.assertEqual(result['Message'], 'MQ connection failure ( 1142 : Failed to stop the connection!The messenger consumer2 does not exist!)')
+    self.assertEqual(
+        result['Message'],
+        'MQ connection failure ( 1142 : Failed to stop the connection!The messenger consumer2 does not exist!)')
+
 
 if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConsumer )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConsumer_get))
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQConsumer_close))
-  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConsumer)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConsumer_get))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQConsumer_close))
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Resources/MessageQueue/test/Test_MQConsumer.py
+++ b/Resources/MessageQueue/test/Test_MQConsumer.py
@@ -23,8 +23,8 @@ class TestMQConsumer( unittest.TestCase ):
   def setUp( self ):
     self.maxDiff = None  # To show full difference between structures in  case of error
     dest = {}
-    dest.update({'/queues/FakeQueue': ['consumer4', 'consumer2']})
-    dest4 = {'/queues/test3': ['consumer1', 'consumer2','consumer3','consumer4']}
+    dest.update({'/queue/FakeQueue': ['consumer4', 'consumer2']})
+    dest4 = {'/queue/test3': ['consumer1', 'consumer2','consumer3','consumer4']}
     conn1 = {'MQConnector':FakeMQConnector(), 'destinations':dest}
     conn2 = {'MQConnector':FakeMQConnector(), 'destinations':dest4}
     storage = {'fake.cern.ch':conn1, 'testdir.blabla.ch':conn2}

--- a/Resources/MessageQueue/test/Test_MQConsumer.py
+++ b/Resources/MessageQueue/test/Test_MQConsumer.py
@@ -23,8 +23,8 @@ class TestMQConsumer( unittest.TestCase ):
   def setUp( self ):
     self.maxDiff = None  # To show full difference between structures in  case of error
     dest = {}
-    dest.update({'/queue/FakeQueue': ['consumer4', 'consumer2']})
-    dest4 = {'/queue/test3': ['consumer1', 'consumer2','consumer3','consumer4']}
+    dest.update({'/queues/FakeQueue': ['consumer4', 'consumer2']})
+    dest4 = {'/queues/test3': ['consumer1', 'consumer2','consumer3','consumer4']}
     conn1 = {'MQConnector':FakeMQConnector(), 'destinations':dest}
     conn2 = {'MQConnector':FakeMQConnector(), 'destinations':dest4}
     storage = {'fake.cern.ch':conn1, 'testdir.blabla.ch':conn2}
@@ -33,24 +33,24 @@ class TestMQConsumer( unittest.TestCase ):
     pass
 class TestMQConsumer_get( TestMQConsumer):
   def test_failure( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", consumerId = 'consumer1')
+    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId = 'consumer1')
     result = consumer.get()
     self.assertFalse(result['OK'])
     self.assertEqual(result['Message'], 'No messages ( 1141 : No messages in queue)')
 
   def test_sucess( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "bad.cern.ch::Queue::FakeQueue", consumerId = 'consumer1')
+    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "bad.cern.ch::Queues::FakeQueue", consumerId = 'consumer1')
     result = consumer.get()
     self.assertFalse(result['OK'])
 
 class TestMQConsumer_close( TestMQConsumer):
   def test_success( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", consumerId ='consumer4')
+    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId ='consumer4')
     result = consumer.close()
     self.assertTrue(result['OK'])
 
   def test_failure( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", consumerId ='consumer4')
+    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId ='consumer4')
     result = consumer.close()
     self.assertTrue(result['OK'])
     result = consumer.close()
@@ -58,8 +58,8 @@ class TestMQConsumer_close( TestMQConsumer):
     self.assertEqual(result['Message'], 'MQ connection failure ( 1142 : Failed to stop the connection!The messenger consumer4 does not exist!)')
 
   def test_failure2( self ):
-    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", consumerId ='consumer4')
-    consumer2 = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", consumerId ='consumer2')
+    consumer = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId ='consumer4')
+    consumer2 = MQConsumer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", consumerId ='consumer2')
     result = consumer.close()
     self.assertTrue(result['OK'])
     result = consumer.close()

--- a/Resources/MessageQueue/test/Test_MQProducer.py
+++ b/Resources/MessageQueue/test/Test_MQProducer.py
@@ -21,8 +21,8 @@ class TestMQProducer( unittest.TestCase ):
   def setUp( self ):
     self.maxDiff = None  # To show full difference between structures in  case of error
     dest = {}
-    dest.update({'/queues/FakeQueue': ['producer4', 'producer2']})
-    dest4 = {'/queues/test3': ['producer1', 'consumer2','consumer3','consumer4']}
+    dest.update({'/queue/FakeQueue': ['producer4', 'producer2']})
+    dest4 = {'/queue/test3': ['producer1', 'consumer2','consumer3','consumer4']}
     conn1 = {'MQConnector':FakeMQConnector(), 'destinations':dest}
     conn2 = {'MQConnector':FakeMQConnector(), 'destinations':dest4}
     storage = {'fake.cern.ch':conn1, 'testdir.blabla.ch':conn2}

--- a/Resources/MessageQueue/test/Test_MQProducer.py
+++ b/Resources/MessageQueue/test/Test_MQProducer.py
@@ -7,77 +7,93 @@ from DIRAC.Resources.MessageQueue.MQProducer import MQProducer
 from DIRAC.Resources.MessageQueue.MQConnectionManager import MQConnectionManager
 from DIRAC.Resources.MessageQueue.MQConnector import MQConnector
 
-class FakeMQConnector( MQConnector ):
-  def __init__( self, params={} ):
-    super( FakeMQConnector, self ).__init__()
+
+class FakeMQConnector(MQConnector):
+  def __init__(self, params={}):
+    super(FakeMQConnector, self).__init__()
+
   def disconnect(self):
     return S_OK("FakeMQConnection disconnecting")
-  def get(self, destination = ''):
+
+  def get(self, destination=''):
     return "FakeMQConnection getting message"
-  def put(self, message, parameters = None ):
+
+  def put(self, message, parameters=None):
     return S_OK("FakeMQConnection sending message: " + str(message))
 
-class TestMQProducer( unittest.TestCase ):
-  def setUp( self ):
+
+class TestMQProducer(unittest.TestCase):
+  def setUp(self):
     self.maxDiff = None  # To show full difference between structures in  case of error
     dest = {}
     dest.update({'/queue/FakeQueue': ['producer4', 'producer2']})
-    dest4 = {'/queue/test3': ['producer1', 'consumer2','consumer3','consumer4']}
-    conn1 = {'MQConnector':FakeMQConnector(), 'destinations':dest}
-    conn2 = {'MQConnector':FakeMQConnector(), 'destinations':dest4}
-    storage = {'fake.cern.ch':conn1, 'testdir.blabla.ch':conn2}
-    self.myManager = MQConnectionManager(connectionStorage = storage)
-  def tearDown( self ):
+    dest4 = {'/queue/test3': ['producer1', 'consumer2', 'consumer3', 'consumer4']}
+    conn1 = {'MQConnector': FakeMQConnector(), 'destinations': dest}
+    conn2 = {'MQConnector': FakeMQConnector(), 'destinations': dest4}
+    storage = {'fake.cern.ch': conn1, 'testdir.blabla.ch': conn2}
+    self.myManager = MQConnectionManager(connectionStorage=storage)
+
+  def tearDown(self):
     pass
-class TestMQProducer_put( TestMQProducer):
-  def test_success( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId = 'producer4')
+
+
+class TestMQProducer_put(TestMQProducer):
+  def test_success(self):
+    producer = MQProducer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", producerId='producer4')
     result = producer.put("wow!")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], "FakeMQConnection sending message: wow!")
 
-  def test_failure( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "bad.cern.ch::Queues::FakeQueue", producerId = 'producer4')
+  def test_failure(self):
+    producer = MQProducer(mqManager=self.myManager, mqURI="bad.cern.ch::Queues::FakeQueue", producerId='producer4')
     result = producer.put("wow!")
     self.assertFalse(result['OK'])
 
-class TestMQProducer_close( TestMQProducer):
-  def test_success( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId ='producer4')
+
+class TestMQProducer_close(TestMQProducer):
+  def test_success(self):
+    producer = MQProducer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", producerId='producer4')
     result = producer.close()
     self.assertTrue(result['OK'])
-    #producer is still able to sent cause the connection is still active (producer2 is connected)
+    # producer is still able to sent cause the connection is still active (producer2 is connected)
     result = producer.put("wow!")
     self.assertTrue(result['OK'])
 
-  def test_failure( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId ='producer4')
+  def test_failure(self):
+    producer = MQProducer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", producerId='producer4')
     result = producer.close()
     self.assertTrue(result['OK'])
     result = producer.close()
     self.assertFalse(result['OK'])
-    self.assertEqual(result['Message'], 'MQ connection failure ( 1142 : Failed to stop the connection!The messenger producer4 does not exist!)')
+    self.assertEqual(
+        result['Message'],
+        'MQ connection failure ( 1142 : Failed to stop the connection!The messenger producer4 does not exist!)')
 
-  def test_failure2( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId ='producer4')
-    producer2 = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId ='producer2')
+  def test_failure2(self):
+    producer = MQProducer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", producerId='producer4')
+    producer2 = MQProducer(mqManager=self.myManager, mqURI="fake.cern.ch::Queues::FakeQueue", producerId='producer2')
     result = producer.close()
     self.assertTrue(result['OK'])
     result = producer.close()
     self.assertFalse(result['OK'])
-    self.assertEqual(result['Message'], 'MQ connection failure ( 1142 : Failed to stop the connection!The messenger producer4 does not exist!)')
+    self.assertEqual(
+        result['Message'],
+        'MQ connection failure ( 1142 : Failed to stop the connection!The messenger producer4 does not exist!)')
     result = producer2.close()
     self.assertTrue(result['OK'])
     result = producer2.close()
     self.assertFalse(result['OK'])
-    self.assertEqual(result['Message'], 'MQ connection failure ( 1142 : Failed to stop the connection!The messenger producer2 does not exist!)')
-    #connection does not exist so put will not work
+    self.assertEqual(
+        result['Message'],
+        'MQ connection failure ( 1142 : Failed to stop the connection!The messenger producer2 does not exist!)')
+    # connection does not exist so put will not work
     result = producer.put("wow!")
     self.assertFalse(result['OK'])
     self.assertEqual(result['Message'], 'Failed to get the MQConnector!')
 
+
 if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestMQProducer )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQProducer_put))
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestMQProducer_close))
-  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestMQProducer)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQProducer_put))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestMQProducer_close))
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Resources/MessageQueue/test/Test_MQProducer.py
+++ b/Resources/MessageQueue/test/Test_MQProducer.py
@@ -21,8 +21,8 @@ class TestMQProducer( unittest.TestCase ):
   def setUp( self ):
     self.maxDiff = None  # To show full difference between structures in  case of error
     dest = {}
-    dest.update({'/queue/FakeQueue': ['producer4', 'producer2']})
-    dest4 = {'/queue/test3': ['producer1', 'consumer2','consumer3','consumer4']}
+    dest.update({'/queues/FakeQueue': ['producer4', 'producer2']})
+    dest4 = {'/queues/test3': ['producer1', 'consumer2','consumer3','consumer4']}
     conn1 = {'MQConnector':FakeMQConnector(), 'destinations':dest}
     conn2 = {'MQConnector':FakeMQConnector(), 'destinations':dest4}
     storage = {'fake.cern.ch':conn1, 'testdir.blabla.ch':conn2}
@@ -31,19 +31,19 @@ class TestMQProducer( unittest.TestCase ):
     pass
 class TestMQProducer_put( TestMQProducer):
   def test_success( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", producerId = 'producer4')
+    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId = 'producer4')
     result = producer.put("wow!")
     self.assertTrue(result['OK'])
     self.assertEqual(result['Value'], "FakeMQConnection sending message: wow!")
 
   def test_failure( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "bad.cern.ch::Queue::FakeQueue", producerId = 'producer4')
+    producer = MQProducer(mqManager = self.myManager, mqURI  = "bad.cern.ch::Queues::FakeQueue", producerId = 'producer4')
     result = producer.put("wow!")
     self.assertFalse(result['OK'])
 
 class TestMQProducer_close( TestMQProducer):
   def test_success( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", producerId ='producer4')
+    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId ='producer4')
     result = producer.close()
     self.assertTrue(result['OK'])
     #producer is still able to sent cause the connection is still active (producer2 is connected)
@@ -51,7 +51,7 @@ class TestMQProducer_close( TestMQProducer):
     self.assertTrue(result['OK'])
 
   def test_failure( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", producerId ='producer4')
+    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId ='producer4')
     result = producer.close()
     self.assertTrue(result['OK'])
     result = producer.close()
@@ -59,8 +59,8 @@ class TestMQProducer_close( TestMQProducer):
     self.assertEqual(result['Message'], 'MQ connection failure ( 1142 : Failed to stop the connection!The messenger producer4 does not exist!)')
 
   def test_failure2( self ):
-    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", producerId ='producer4')
-    producer2 = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queue::FakeQueue", producerId ='producer2')
+    producer = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId ='producer4')
+    producer2 = MQProducer(mqManager = self.myManager, mqURI  = "fake.cern.ch::Queues::FakeQueue", producerId ='producer2')
     result = producer.close()
     self.assertTrue(result['OK'])
     result = producer.close()

--- a/Resources/MessageQueue/test/Test_MQ_Utilities.py
+++ b/Resources/MessageQueue/test/Test_MQ_Utilities.py
@@ -141,6 +141,21 @@ class Test_getMQParamFromCSSuccessTestCase( unittest.TestCase ):
     with self.assertRaises( KeyError ):
       result['Value']['Queue']
 
+  def test_getMQService( self ):
+    self.assertEqual(module.getMQService("bblabl.ch::Topics::MyTopic") , "bblabl.ch")
+    self.assertEqual(module.getMQService("bblabl.ch::Queues::MyQueue") , "bblabl.ch")
+
+  def test_getDestinationType( self ):
+    self.assertEqual(module.getDestinationType("bblabl.ch::Topics::MyTopic") , "Topics")
+    self.assertEqual(module.getDestinationType("bblabl.ch::Queues::MyQueue") , "Queues")
+
+  def test_getDestinationName( self ):
+    self.assertEqual(module.getDestinationName("bblabl.ch::Topics::MyTopic") , "MyTopic")
+    self.assertEqual(module.getDestinationName("bblabl.ch::Queues::MyQueue") , "MyQueue")
+
+  def test_getDestinationAddress( self ):
+    self.assertEqual(module.getDestinationAddress("bblabl.ch::Topics::MyTopic") , "/topic/MyTopic")
+    self.assertEqual(module.getDestinationAddress("bblabl.ch::Queues::MyQueue") , "/queue/MyQueue")
 
 class Test_getMQParamFromCSFailureTestCase( unittest.TestCase ):
   """ Test class to check known failure scenarios.

--- a/Resources/MessageQueue/test/Test_MQ_Utilities.py
+++ b/Resources/MessageQueue/test/Test_MQ_Utilities.py
@@ -17,35 +17,35 @@ QUEUE_TYPE = 'Queue'
 TOPIC_TYPE = 'Topic'
 QUEUE_NAME = 'Test'
 
-CS_MQSERVICE_OPTIONS = { 'Host': MQSERVICE_NAME }
-CS_QUEUE_OPTIONS = { 'Acknowledgement': True }
+CS_MQSERVICE_OPTIONS = {'Host': MQSERVICE_NAME}
+CS_QUEUE_OPTIONS = {'Acknowledgement': True}
 
 QUEUE_CONFIG = \
-{
-  '%s/%s/Queues/%s' % ( ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME ): None,
-  '%s/%s/Queues/%s/Acknowledgement' % ( ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME ): True
-}
+    {
+        '%s/%s/Queues/%s' % (ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME): None,
+        '%s/%s/Queues/%s/Acknowledgement' % (ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME): True
+    }
 
 TOPIC_CONFIG = \
-{
-  '%s/%s/Topics/%s' % ( ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME ): None,
-  '%s/%s/Topics/%s/Acknowledgement' % ( ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME ): True
-}
+    {
+        '%s/%s/Topics/%s' % (ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME): None,
+        '%s/%s/Topics/%s/Acknowledgement' % (ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME): True
+    }
 
 SIMILAR_QUEUE_CONFIG = QUEUE_CONFIG.copy()
 SIMILAR_QUEUE_CONFIG.update(
-{
-  '%s/%s/Queues/%s1' % ( ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME ): None,
-  '%s/%s/Queues/%s1/Acknowledgement' % ( ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME ): True,
-})
+    {
+        '%s/%s/Queues/%s1' % (ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME): None,
+        '%s/%s/Queues/%s1/Acknowledgement' % (ROOT_PATH, MQSERVICE_NAME, QUEUE_NAME): True,
+    })
 
 DIFFERENT_MQSERVICE_NAME = 'different-mq.dirac.net'
 AMBIGIOUS_QUEUE_CONFIG = QUEUE_CONFIG.copy()
 AMBIGIOUS_QUEUE_CONFIG.update(
-{
-  '%s/%s/Queues/%s' % ( ROOT_PATH, DIFFERENT_MQSERVICE_NAME, QUEUE_NAME ): None,
-  '%s/%s/Queues/%s/Acknowledgement' % ( ROOT_PATH, DIFFERENT_MQSERVICE_NAME, QUEUE_NAME ): True,
-} )
+    {
+        '%s/%s/Queues/%s' % (ROOT_PATH, DIFFERENT_MQSERVICE_NAME, QUEUE_NAME): None,
+        '%s/%s/Queues/%s/Acknowledgement' % (ROOT_PATH, DIFFERENT_MQSERVICE_NAME, QUEUE_NAME): True,
+    })
 
 """
 Used CS example:
@@ -93,7 +93,8 @@ Resources
 }
 """
 
-class Test_getMQParamFromCSSuccessTestCase( unittest.TestCase ):
+
+class Test_getMQParamFromCSSuccessTestCase(unittest.TestCase):
   """ Test class to check success scenarios.
   """
 
@@ -104,101 +105,105 @@ class Test_getMQParamFromCSSuccessTestCase( unittest.TestCase ):
     module.gConfig = MagicMock()
 
     module.gConfig.getOptionsDict.side_effect = [
-                                                  {'OK': True, 'Value': CS_MQSERVICE_OPTIONS},
-                                                  {'OK': True, 'Value': CS_QUEUE_OPTIONS}
-                                                ]
-  def test_getQueue( self ):
+        {'OK': True, 'Value': CS_MQSERVICE_OPTIONS},
+        {'OK': True, 'Value': CS_QUEUE_OPTIONS}
+    ]
+
+  def test_getQueue(self):
 
     module.gConfig.getConfigurationTree.return_value = {'OK': True, 'Value': QUEUE_CONFIG}
 
     # check returned value
-    result = module.getMQParamsFromCS(mqURI = MQSERVICE_NAME+"::" +QUEUE_TYPE+ "::"+ QUEUE_NAME )
-    self.assertTrue( result['OK'] )
+    result = module.getMQParamsFromCS(mqURI=MQSERVICE_NAME + "::" + QUEUE_TYPE + "::" + QUEUE_NAME)
+    self.assertTrue(result['OK'])
 
     # check queue parameters
-    self.assertEqual( result['Value']['Queue'], QUEUE_NAME )
-    self.assertEqual( result['Value']['Host'], MQSERVICE_NAME )
-    self.assertTrue( result['Value']['Acknowledgement'] )
+    self.assertEqual(result['Value']['Queue'], QUEUE_NAME)
+    self.assertEqual(result['Value']['Host'], MQSERVICE_NAME)
+    self.assertTrue(result['Value']['Acknowledgement'])
 
-    with self.assertRaises( KeyError ):
+    with self.assertRaises(KeyError):
       result['Value']['Topic']
 
-  def test_getTopic( self ):
-    """ Try to get a topic 
+  def test_getTopic(self):
+    """ Try to get a topic
     """
     module.gConfig.getConfigurationTree.return_value = {'OK': True, 'Value': TOPIC_CONFIG}
 
     # check returned value
-    TOPIC_NAME=QUEUE_NAME
-    result = module.getMQParamsFromCS(mqURI = MQSERVICE_NAME+"::" +TOPIC_TYPE+ "::"+ TOPIC_NAME )
-    self.assertTrue( result['OK'] )
+    TOPIC_NAME = QUEUE_NAME
+    result = module.getMQParamsFromCS(mqURI=MQSERVICE_NAME + "::" + TOPIC_TYPE + "::" + TOPIC_NAME)
+    self.assertTrue(result['OK'])
 
     # check topic parameters
-    self.assertEqual( result['Value']['Topic'], TOPIC_NAME )
-    self.assertEqual( result['Value']['Host'], MQSERVICE_NAME )
-    self.assertTrue( result['Value']['Acknowledgement'] )
+    self.assertEqual(result['Value']['Topic'], TOPIC_NAME)
+    self.assertEqual(result['Value']['Host'], MQSERVICE_NAME)
+    self.assertTrue(result['Value']['Acknowledgement'])
 
-    with self.assertRaises( KeyError ):
+    with self.assertRaises(KeyError):
       result['Value']['Queue']
 
-  def test_getMQService( self ):
-    self.assertEqual(module.getMQService("bblabl.ch::Topics::MyTopic") , "bblabl.ch")
-    self.assertEqual(module.getMQService("bblabl.ch::Queues::MyQueue") , "bblabl.ch")
+  def test_getMQService(self):
+    self.assertEqual(module.getMQService("bblabl.ch::Topics::MyTopic"), "bblabl.ch")
+    self.assertEqual(module.getMQService("bblabl.ch::Queues::MyQueue"), "bblabl.ch")
 
-  def test_getDestinationType( self ):
-    self.assertEqual(module.getDestinationType("bblabl.ch::Topics::MyTopic") , "Topics")
-    self.assertEqual(module.getDestinationType("bblabl.ch::Queues::MyQueue") , "Queues")
+  def test_getDestinationType(self):
+    self.assertEqual(module.getDestinationType("bblabl.ch::Topics::MyTopic"), "Topics")
+    self.assertEqual(module.getDestinationType("bblabl.ch::Queues::MyQueue"), "Queues")
 
-  def test_getDestinationName( self ):
-    self.assertEqual(module.getDestinationName("bblabl.ch::Topics::MyTopic") , "MyTopic")
-    self.assertEqual(module.getDestinationName("bblabl.ch::Queues::MyQueue") , "MyQueue")
+  def test_getDestinationName(self):
+    self.assertEqual(module.getDestinationName("bblabl.ch::Topics::MyTopic"), "MyTopic")
+    self.assertEqual(module.getDestinationName("bblabl.ch::Queues::MyQueue"), "MyQueue")
 
-  def test_getDestinationAddress( self ):
-    self.assertEqual(module.getDestinationAddress("bblabl.ch::Topics::MyTopic") , "/topic/MyTopic")
-    self.assertEqual(module.getDestinationAddress("bblabl.ch::Queues::MyQueue") , "/queue/MyQueue")
+  def test_getDestinationAddress(self):
+    self.assertEqual(module.getDestinationAddress("bblabl.ch::Topics::MyTopic"), "/topic/MyTopic")
+    self.assertEqual(module.getDestinationAddress("bblabl.ch::Queues::MyQueue"), "/queue/MyQueue")
 
-class Test_getMQParamFromCSFailureTestCase( unittest.TestCase ):
+
+class Test_getMQParamFromCSFailureTestCase(unittest.TestCase):
   """ Test class to check known failure scenarios.
   """
 
-  def setUp( self ):
+  def setUp(self):
 
     # external dependencies
     module.CSAPI = MagicMock()
     module.gConfig = MagicMock()
 
-  def test_getQueueByInvalidName( self ):
+  def test_getQueueByInvalidName(self):
     """ Try to get a queue by invalid names
     """
 
     module.gConfig.getConfigurationTree.return_value = {'OK': True, 'Value': {}}
 
     # try different possibilities
-    result = module.getMQParamsFromCS( '%s' % QUEUE_NAME )
-    self.assertFalse( result['OK'] )
-    
-    result = module.getMQParamsFromCS( mqURI = MQSERVICE_NAME+"::" +QUEUE_TYPE+ "::"+ "InvalidName" )
-    self.assertFalse( result['OK'] )
+    result = module.getMQParamsFromCS('%s' % QUEUE_NAME)
+    self.assertFalse(result['OK'])
 
-    result = module.getMQParamsFromCS( '%s::' % MQSERVICE_NAME )
-    self.assertFalse( result['OK'] )
+    result = module.getMQParamsFromCS(mqURI=MQSERVICE_NAME + "::" + QUEUE_TYPE + "::" + "InvalidName")
+    self.assertFalse(result['OK'])
 
-    result = module.getMQParamsFromCS( '%s::%s' % ( MQSERVICE_NAME, QUEUE_NAME ) )
-    self.assertFalse( result['OK'] )
+    result = module.getMQParamsFromCS('%s::' % MQSERVICE_NAME)
+    self.assertFalse(result['OK'])
 
-class Test_generateDefaultCallbackTestCase( unittest.TestCase ):
+    result = module.getMQParamsFromCS('%s::%s' % (MQSERVICE_NAME, QUEUE_NAME))
+    self.assertFalse(result['OK'])
+
+
+class Test_generateDefaultCallbackTestCase(unittest.TestCase):
   """ Check default callback behaviour.
   """
-  def test_EmptyMessage( self ):
+
+  def test_EmptyMessage(self):
     myCallback = module.generateDefaultCallback()
     self.assertRaises(Queue.Empty, myCallback.get)
 
-  def test_putOneGetOneMessage( self ):
+  def test_putOneGetOneMessage(self):
     myCallback = module.generateDefaultCallback()
     myCallback("", "test message")
     self.assertEqual(myCallback.get(), "test message")
 
-  def test_severalMessages( self ):
+  def test_severalMessages(self):
     myCallback = module.generateDefaultCallback()
     myCallback("", "test message1")
     myCallback("", "test message2")
@@ -209,8 +214,8 @@ class Test_generateDefaultCallbackTestCase( unittest.TestCase ):
     self.assertEqual(myCallback.get(), "test message3")
     self.assertEqual(myCallback.get(), "test message4")
     self.assertRaises(Queue.Empty, myCallback.get)
-  
-  def test_twoDifferentCallbacks( self ):
+
+  def test_twoDifferentCallbacks(self):
     myCallback = module.generateDefaultCallback()
     myCallback2 = module.generateDefaultCallback()
     myCallback("", "test message")
@@ -220,8 +225,9 @@ class Test_generateDefaultCallbackTestCase( unittest.TestCase ):
     self.assertEqual(myCallback2.get(), "test message2")
     self.assertRaises(Queue.Empty, myCallback2.get)
 
+
 if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( Test_getMQParamFromCSSuccessTestCase )
-  suite.addTests( unittest.defaultTestLoader.loadTestsFromTestCase( Test_getMQParamFromCSFailureTestCase ) )
-  suite.addTests( unittest.defaultTestLoader.loadTestsFromTestCase( Test_generateDefaultCallbackTestCase ) )
-  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(Test_getMQParamFromCSSuccessTestCase)
+  suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(Test_getMQParamFromCSFailureTestCase))
+  suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(Test_generateDefaultCallbackTestCase))
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Resources/MessageQueue/test/Test_MQ_Utilities.py
+++ b/Resources/MessageQueue/test/Test_MQ_Utilities.py
@@ -93,7 +93,7 @@ Resources
 }
 """
 
-class _getMQParamFromCSSuccessTestCase( unittest.TestCase ):
+class Test_getMQParamFromCSSuccessTestCase( unittest.TestCase ):
   """ Test class to check success scenarios.
   """
 
@@ -142,7 +142,7 @@ class _getMQParamFromCSSuccessTestCase( unittest.TestCase ):
       result['Value']['Queue']
 
 
-class _getMQParamFromCSFailureTestCase( unittest.TestCase ):
+class Test_getMQParamFromCSFailureTestCase( unittest.TestCase ):
   """ Test class to check known failure scenarios.
   """
 
@@ -171,7 +171,7 @@ class _getMQParamFromCSFailureTestCase( unittest.TestCase ):
     result = module.getMQParamsFromCS( '%s::%s' % ( MQSERVICE_NAME, QUEUE_NAME ) )
     self.assertFalse( result['OK'] )
 
-class _generateDefaultCallbackTestCase( unittest.TestCase ):
+class Test_generateDefaultCallbackTestCase( unittest.TestCase ):
   """ Check default callback behaviour.
   """
   def test_EmptyMessage( self ):
@@ -206,7 +206,7 @@ class _generateDefaultCallbackTestCase( unittest.TestCase ):
     self.assertRaises(Queue.Empty, myCallback2.get)
 
 if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( _getMQParamFromCSSuccessTestCase )
-  suite.addTests( unittest.defaultTestLoader.loadTestsFromTestCase( _getMQParamFromCSFailureTestCase ) )
-  suite.addTests( unittest.defaultTestLoader.loadTestsFromTestCase( _generateDefaultCallbackTestCase ) )
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase( Test_getMQParamFromCSSuccessTestCase )
+  suite.addTests( unittest.defaultTestLoader.loadTestsFromTestCase( Test_getMQParamFromCSFailureTestCase ) )
+  suite.addTests( unittest.defaultTestLoader.loadTestsFromTestCase( Test_generateDefaultCallbackTestCase ) )
   testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )

--- a/docs/source/AdministratorGuide/DIRACSites/MessageQueues/index.rst
+++ b/docs/source/AdministratorGuide/DIRACSites/MessageQueues/index.rst
@@ -66,11 +66,11 @@ like described in :ref:`development_use_mq`, for example::
    from DIRAC.Resources.MessageQueue.MQCommunication import createProducer
    from DIRAC.Resources.MessageQueue.MQCommunication import createConsumer
 
-   result = createProducer( "mardirac3.in2p3.fr::Queue::TestQueue" )
+   result = createProducer( "mardirac3.in2p3.fr::Queues::TestQueue" )
    if result['OK']:
       producer = result['Value']
 
-   result = createConsumer( "mardirac3.in2p3.fr::Queue::TestQueue" )
+   result = createConsumer( "mardirac3.in2p3.fr::Queues::TestQueue" )
    if result['OK']:
       consumer = result['Value']
 

--- a/docs/source/AdministratorGuide/DIRACSites/MessageQueues/index.rst
+++ b/docs/source/AdministratorGuide/DIRACSites/MessageQueues/index.rst
@@ -6,8 +6,23 @@ Message Queues
 
 Message Queues are services for passing messages between DIRAC components.
 These services are not part necessarily of the DIRAC software and are provided
-by third parties. Access to the services is done via logical Queues (or Topics) which are
-described in the *Resources* section of the DIRAC configuration.
+by third parties. Access to the services is done via logical Queues (or Topics).
+Queues and Topics are two popular variation of the MQ communication model.
+In the first case, the messages from the queue are typically delivered to the subscribed
+consumers one by one. One message will be received by exactly one consumer.
+If no consumer is available, then the messages are stored in the queue. Many consumers connected
+to the same queue can be used for the load balancing purposes.
+The topic architecture can be see as implementation of the publish-subscribe pattern. The messages
+are typically grouped in categories (e.g. by assigning the label called topic), and consumers
+subscribe to chosen topics. When the message becomes available, it is send to all
+subscribed consumers.
+Detailed implementation of Topic/Queue mechanism can differ dependent e.g. MQ broker used.
+
+The available implementation of the Message Queue uses Stomp protocol.
+All the Stomp-dependent details are encapsulated in StompMQConnector class,
+which extends the generic MQConnector class. 
+It is possible to provide a self-defined connector by extending the 
+MQConnector class.
 
 A commented example of the Message Queues configuration is provided below.
 Each option value is representing its default value::
@@ -80,4 +95,21 @@ like described in :ref:`development_use_mq`, for example::
      message = result['Value']
 
 
-In order not to spam the logs, the log output of Stomp is always silence, unless the environment variable `DIRAC_DEBUG_STOMP` is set to any value
+In order not to spam the logs, the log output of Stomp is always silence, unless the environment variable `DIRAC_DEBUG_STOMP` is set to any value.
+
+====================================
+Message Queue nomenclature in DIRAC
+====================================
+
+* MQ - Message Queue System e.g. RabbitMQ
+* mqMessenger - processes that send or receive messages to/from the MQ system.
+  We define two types of messengers: consumer (MQConsumer class) and producer (MQProducer class).
+* mqDestination is the endpoint of MQ systems. We define two kind of destinations: Queue or Topic.
+  which correspond  to two type of communication schemes between MQ and consumers/producers.
+* mqService - unique identifier that characterises an MQ resource in the DIRAC CS. mqService can have one or more topics and/or queues assigned.
+* mqConnection: authenticated link between an MQ and one or more producers or/and consumers. The link can be characterised by mqService.
+* mqURI - pseudo URI identifier that univocally identifies the destination.
+  It has the following format mqService::mqDestinationType::mqDestination name e.g."mardirac3.in2p3.fr::Queues::TestQueue" or
+  "mardirac3.in2p3.fr::Topics::TestTopic".
+* mqType - type of the MQ communication protocol e.g. Stomp.
+* MQConnector - provides abstract interface to communicate with a given MQ system. It can be specialized e.g.  StompMQConnector.

--- a/docs/source/DeveloperGuide/AddingNewComponents/Resources/MessageQueues/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/Resources/MessageQueues/index.rst
@@ -12,7 +12,7 @@ messages which are arbitrary json structures. The *MQProducer* objects are used 
 
    from DIRAC.Resources.MessageQueue.MQCommunication import createProducer
 
-   result = createProducer( "mardirac3.in2p3.fr::Queue::TestQueue" )
+   result = createProducer( "mardirac3.in2p3.fr::Queues::TestQueue" )
    if result['OK']:
       producer = result['Value']
    # Publish a message which is an arbitrary json structure
@@ -25,7 +25,7 @@ These objects can request messages explicitly:
 
    from DIRAC.Resources.MessageQueue.MQCommunication import createConsumer
 
-   result = createConsumer( "mardirac3.in2p3.fr::Queue::TestQueue" )
+   result = createConsumer( "mardirac3.in2p3.fr::Queues::TestQueue" )
    if result['OK']:
       consumer = result['Value']
    result = consumer.get( message )
@@ -42,14 +42,14 @@ when new messages will arrive:
   def myCallback( headers, message ):
     <function implementation>
 
-   result = createConsumer( "mardirac3.in2p3.fr::Queue::TestQueue", callback = myCallback )
+   result = createConsumer( "mardirac3.in2p3.fr::Queues::TestQueue", callback = myCallback )
    if result['OK']:
       consumer = result['Value']
 
 
 The destination name (queue or topic) in the consumer/producer instantiation must be given as
-fully qualified name like "mardirac3.in2p3.fr::Queue::TestQueue" or
-"mardirac3.in2p3.fr::Topic::TestTopic".
+fully qualified name like "mardirac3.in2p3.fr::Queues::TestQueue" or
+"mardirac3.in2p3.fr::Topics::TestTopic".
 
 ====================================
 Message Queue nomenclature in DIRAC
@@ -63,7 +63,7 @@ Message Queue nomenclature in DIRAC
 * mqService - unique identifier that characterises an MQ resource in the DIRAC CS. mqService can have one or more topics and/or queues assigned.
 * mqConnection: authenticated link between an MQ and one or more producers or/and consumers. The link can be characterised by mqService.
 * mqURI - pseudo URI identifier that univocally identifies the destination.
-  It has the following format mqService::mqDestinationType::mqDestination name e.g."mardirac3.in2p3.fr::Queue::TestQueue" or
-  "mardirac3.in2p3.fr::Topic::TestTopic".
+  It has the following format mqService::mqDestinationType::mqDestination name e.g."mardirac3.in2p3.fr::Queues::TestQueue" or
+  "mardirac3.in2p3.fr::Topics::TestTopic".
 * mqType - type of the MQ communication protocol e.g. Stomp.
 * MQConnector - provides abstract interface to communicate with a given MQ system. It can be specialized e.g.  StompMQConnector.

--- a/docs/source/DeveloperGuide/AddingNewComponents/Resources/MessageQueues/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/Resources/MessageQueues/index.rst
@@ -50,20 +50,3 @@ when new messages will arrive:
 The destination name (queue or topic) in the consumer/producer instantiation must be given as
 fully qualified name like "mardirac3.in2p3.fr::Queues::TestQueue" or
 "mardirac3.in2p3.fr::Topics::TestTopic".
-
-====================================
-Message Queue nomenclature in DIRAC
-====================================
-
-* MQ - Message Queue System e.g. RabbitMQ
-* mqMessenger - processes that send or receive messages to/from the MQ system.
-  We define two types of messengers: consumer (MQConsumer class) and producer (MQProducer class).
-* mqDestination is the endpoint of MQ systems. We define two kind of destinations: Queue or Topic.
-  which correspond  to two type of communication schemes between MQ and consumers/producers.
-* mqService - unique identifier that characterises an MQ resource in the DIRAC CS. mqService can have one or more topics and/or queues assigned.
-* mqConnection: authenticated link between an MQ and one or more producers or/and consumers. The link can be characterised by mqService.
-* mqURI - pseudo URI identifier that univocally identifies the destination.
-  It has the following format mqService::mqDestinationType::mqDestination name e.g."mardirac3.in2p3.fr::Queues::TestQueue" or
-  "mardirac3.in2p3.fr::Topics::TestTopic".
-* mqType - type of the MQ communication protocol e.g. Stomp.
-* MQConnector - provides abstract interface to communicate with a given MQ system. It can be specialized e.g.  StompMQConnector.

--- a/docs/source/DeveloperGuide/AddingNewComponents/Utilities/gLogger/Backends/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/Utilities/gLogger/Backends/index.rst
@@ -107,6 +107,6 @@ MsgQueue represents a MessageQueue resources from DIRAC under this form:
 
 ::
 
-  mardirac3.in2p3.fr::Queue::TestQueue
+  mardirac3.in2p3.fr::Queues::TestQueue
 
 You will find more details about these resources in the :ref:`configuration_message_queues` section.


### PR DESCRIPTION
Change the way of defining identifier  format for MQ resources. The middle part  of mqURI is plural instead of singular to be conformed with the currently used  section naming in CS.  After changes the accepted values are  'Topics' or 'Queues'.

Examples:
Before: blablba.cern.ch::Topic::test1
Now: blablba.cern.ch::Topics::test1
Before: blablba.cern.ch::Queue::myQueue1
Now: blablba.cern.ch::Queues:myQueue1

Also, the section explaining Topic/Queue concept has been added.

BEGINRELEASENOTES

*Resources/MessageQueue
CHANGE: change the way of defining identifier  format for MQ resources: accepted values are  'Topics' or 'Queues'.

ENDRELEASENOTES
