### PR TITLE
[v6r21] Add DN list from lhcb_pilot group to json file

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -184,7 +184,8 @@ class PilotCStoJSONSynchronizer(object):
       usersInGroup = usersString.split(',')
       DNs = [gConfig.getValue('/Registry/Users/' + user + '/DN') for user in usersInGroup]
       return S_OK(DNs)
-    except AttributeError:
+    except AttributeError as ae:
+      gLogger.exception("Error occured while getting the DNs", lException=ae)
       return S_ERROR('Some error occured while getting the DNs.')
 
   def _getPilotOptionsPerSetup(self, setup, pilotDict):

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -177,6 +177,7 @@ class PilotCStoJSONSynchronizer(object):
 
   def _getDNs(self, certGroupName):
     '''Returns DN list of users in given group.
+
     :param certGroupName: name of the group.
     :returns: S_OK with the list of DNs if successful, S_ERROR otherwise'''
     try:

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -36,7 +36,7 @@ class PilotCStoJSONSynchronizer(object):
     """ c'tor
         Just setting defaults
     """
-    self.pilotCertGroupName = 'Pilot'
+    self.pilotCertGroupName = 'lhcb_pilot'
     self.jsonFile = 'pilot.json'  # default filename of the pilot json file
 
     # domain name of the web server used to upload the pilot json file and the pilot scripts

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -255,7 +255,7 @@ class PilotCStoJSONSynchronizer(object):
           return queueOptionRes
         queuesDict[queue] = queueOptionRes['Value']
       pilotDict['Setups'][setup]['Logging']['Queues'] = queuesDict
-      print (pilotDict)
+      print(pilotDict)
 
   def _syncScripts(self):
     """Clone the pilot scripts from the repository and upload them to the web server

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -170,20 +170,6 @@ class PilotCStoJSONSynchronizer(object):
 
     return pilotDict
 
-  def _getDNs(self, certGroupName):
-    '''Returns DN list of users in given group.
-
-    :param certGroupName: name of the group.
-    :returns: S_OK with the list of DNs if successful, S_ERROR otherwise'''
-    try:
-      usersString = gConfig.getValue('/Registry/Groups/' + certGroupName + '/Users')
-      usersInGroup = usersString.split(',')
-      DNs = [gConfig.getValue('/Registry/Users/' + user + '/DN') for user in usersInGroup]
-      return S_OK(DNs)
-    except AttributeError as ae:
-      gLogger.exception("Error occured while getting the DNs", lException=ae)
-      return S_ERROR('Some error occured while getting the DNs.')
-
   def _getPilotOptionsPerSetup(self, setup, pilotDict):
     """ Given a setup, returns its pilot options in a dictionary
     """

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -255,7 +255,6 @@ class PilotCStoJSONSynchronizer(object):
           return queueOptionRes
         queuesDict[queue] = queueOptionRes['Value']
       pilotDict['Setups'][setup]['Logging']['Queues'] = queuesDict
-      print(pilotDict)
 
   def _syncScripts(self):
     """Clone the pilot scripts from the repository and upload them to the web server

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -119,26 +119,7 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     res = synchroniser.sync()
     self.assertTrue(res['OK'])
 
-
-class Test_PilotCStoJSONSynchronizer_getDNs(PilotCStoJSONSynchronizerTestCase):
-
-  def test_success(self):
-    synchroniser = PilotCStoJSONSynchronizer()
-    res = synchroniser._getDNs('lhcb_pilot')
-    self.assertTrue(res['OK'])
-    DNs = res['Value']
-    expected = ['/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=ttester/CN=696969/CN=Thomas Tester',
-                '/DC=ch/DC=voodo/OU=Organic Units/OU=Users/CN=franekbolek/CN=111122/CN=Franek Bolek']
-    self.assertEqual(sorted(expected), sorted(DNs))
-
-  def test_failure(self):
-    synchroniser = PilotCStoJSONSynchronizer()
-    res = synchroniser._getDNs('nonExistingGroup')
-    self.assertFalse(res['OK'])
-
-
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase(PilotCStoJSONSynchronizerTestCase)
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_PilotCStoJSONSynchronizer_sync))
-  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_PilotCStoJSONSynchronizer_getDNs))
   testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -50,6 +50,13 @@ class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
     Operations{
       Defaults
       {
+        Pilot
+        {
+          Project = LHCb
+          GenericPilotDN = /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=romanov/CN=427293/CN=Vladimir Romanovskiy
+          GenericPilotGroup = lhcb_pilot
+        }
+
         MainServers = gw1, gw2
       }
     }
@@ -111,7 +118,6 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     synchroniser = PilotCStoJSONSynchronizer()
     res = synchroniser.sync()
     self.assertTrue(res['OK'])
-
 
 class Test_PilotCStoJSONSynchronizer_getDNs(PilotCStoJSONSynchronizerTestCase):
 

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -119,6 +119,7 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     res = synchroniser.sync()
     self.assertTrue(res['OK'])
 
+
 class Test_PilotCStoJSONSynchronizer_getDNs(PilotCStoJSONSynchronizerTestCase):
 
   def test_success(self):

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -1,0 +1,30 @@
+""" This is a test of the creation of the json dump file
+"""
+
+import unittest
+
+from DIRAC.WorkloadManagementSystem.Utilities.PilotCStoJSONSynchronizer import PilotCStoJSONSynchronizer
+
+
+class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
+  """ Base class for the PilotCStoJSONSynchronizer test cases
+  """
+
+  def setUp(self):
+    pass
+
+  def tearDown(self):
+    pass
+
+
+class Test_PilotCStoJSONSynchronizer_getDNs(PilotCStoJSONSynchronizerTestCase):
+
+  def test_succes(self):
+    # res = pilotWrapperScript()
+    pass
+
+
+if __name__ == '__main__':
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(PilotCStoJSONSynchronizerTestCase)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_PilotCStoJSONSynchronizer_getDNs))
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -119,6 +119,7 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     res = synchroniser.sync()
     self.assertTrue(res['OK'])
 
+
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase(PilotCStoJSONSynchronizerTestCase)
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_PilotCStoJSONSynchronizer_sync))

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -53,8 +53,8 @@ class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
         Pilot
         {
           Project = LHCb
-          GenericPilotDN = /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=romanov/CN=427293/CN=Vladimir Romanovskiy
-          GenericPilotGroup = lhcb_pilot
+          GenericPilotDN = /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=doe/CN=111213/CN=Joe Doe
+          GenericPilotGroup = xxx_pilot
         }
 
         MainServers = gw1, gw2

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -2,8 +2,12 @@
 """
 
 import unittest
+import os
 
 from DIRAC.WorkloadManagementSystem.Utilities.PilotCStoJSONSynchronizer import PilotCStoJSONSynchronizer
+from DIRAC.ConfigurationSystem.private.ConfigurationClient import ConfigurationClient
+from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
+from DIRAC.Core.Utilities.CFG import CFG
 
 
 class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
@@ -11,20 +15,123 @@ class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
   """
 
   def setUp(self):
-    pass
+    # Creating test configuration file
+    self.testCfgFileName = 'test.cfg'
+    cfgContent = '''
+    DIRAC
+    {
+      Setup=TestSetup
+      Setups
+      {
+        TestSetup
+        {
+          WorkloadManagement=MyWM
+        }
+      }
+    }
+    Systems
+    {
+      WorkloadManagement
+      {
+        MyWM
+        {
+          URLs
+          {
+            Service1 = dips://server1:1234/WorkloadManagement/Service1
+            Service2 = dips://$MAINSERVERS$:5678/WorkloadManagement/Service2
+          }
+          FailoverURLs
+          {
+            Service2 = dips://failover1:5678/WorkloadManagement/Service2
+          }
+        }
+      }
+    }
+    Operations{
+      Defaults
+      {
+        MainServers = gw1, gw2
+      }
+    }
+    Registry
+    {
+      Users
+      {
+        ttester
+        {
+          DN = /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=ttester/CN=696969/CN=Thomas Tester
+          CA = /DC=ch/DC=cern/CN=CERN Grid Certification Authority
+          Email = thomas.tester@cern.ch
+        }
+        franekbolek
+        {
+          DN = /DC=ch/DC=voodo/OU=Organic Units/OU=Users/CN=franekbolek/CN=111122/CN=Franek Bolek
+          CA = /DC=ch/DC=voodo/CN=Voodo Grid Certification Authority
+          Email = franek.bolek@voodo.pl
+        }
+      }
+      Groups
+      {
+        lhcb_pilot
+        {
+          #@@-host - /DC=ch/DC=voodo/OU=computers/CN=brabra.voodo.pl
+          Users = franekbolek
+          Users += ttester
+          Properties = GenericPilot
+          Properties += LimitedDelegation
+          VOMSRole = /lhcb/Role=pilot
+          #@@-ggg@diracAdmin - 2015-07-07 13:40:55
+          VO = lhcb
+        }
+      }
+    }
+    '''
+    with open(self.testCfgFileName, 'w') as f:
+      f.write(cfgContent)
+    gConfig = ConfigurationClient(fileToLoadList=[self.testCfgFileName])  # we replace the configuration by our own one.
+    self.setup = gConfig.getValue('/DIRAC/Setup', '')
+    self.wm = gConfig.getValue('DIRAC/Setups/' + self.setup + '/WorkloadManagement', '')
 
   def tearDown(self):
-    pass
+    try:
+      os.remove(self.testCfgFileName)
+    except OSError:
+      pass
+    # SUPER UGLY: one must recreate the CFG objects of gConfigurationData
+    # not to conflict with other tests that might be using a local dirac.cfg
+    gConfigurationData.localCFG = CFG()
+    gConfigurationData.remoteCFG = CFG()
+    gConfigurationData.mergedCFG = CFG()
+    gConfigurationData.generateNewVersion()
+
+
+class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
+
+  def test_success(self):
+    synchroniser = PilotCStoJSONSynchronizer()
+    res = synchroniser.sync()
+    self.assertTrue(res['OK'])
 
 
 class Test_PilotCStoJSONSynchronizer_getDNs(PilotCStoJSONSynchronizerTestCase):
 
-  def test_succes(self):
-    # res = pilotWrapperScript()
-    pass
+  def test_success(self):
+    synchroniser = PilotCStoJSONSynchronizer()
+    res = synchroniser._getDNs('lhcb_pilot')
+    self.assertTrue(res['OK'])
+    DNs = res['Value']
+    expected = ['/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=ttester/CN=696969/CN=Thomas Tester',
+                '/DC=ch/DC=voodo/OU=Organic Units/OU=Users/CN=franekbolek/CN=111122/CN=Franek Bolek']
+    self.assertEqual(sorted(expected), sorted(DNs))
+
+  def test_failure(self):
+    synchroniser = PilotCStoJSONSynchronizer()
+    res = synchroniser._getDNs('nonExistingGroup')
+    self.assertFalse(res['OK'])
 
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase(PilotCStoJSONSynchronizerTestCase)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_PilotCStoJSONSynchronizer_sync))
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(Test_PilotCStoJSONSynchronizer_getDNs))
   testResult = unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION

BEGINRELEASENOTES
WorkloadManagementSystem
CHANGE: Modification of utility function PilotCStoJSONSynchronizer. The modification allows to add information to created json file about the DNs fields of users belonging to 'lhcb_pilot' group. This information is needed for the second level authorization used in the Pilot Logger architecture. 
Also, some basic unit tests are added.

ENDRELEASENOTES
