### PR TITLE
[v7r0] M2Crypto: bug fixes

### DIFF
--- a/Core/DISET/private/Transports/SSL/M2Utils.py
+++ b/Core/DISET/private/Transports/SSL/M2Utils.py
@@ -97,7 +97,7 @@ def getM2SSLContext(ctx=None, **kwargs):
   # Set peer verification
   if kwargs.get('skipCACheck', False):
     # Don't validate peer, but still request creds
-    ctx.set_verify(SSL.verify_fail_if_no_peer_cert, VERIFY_DEPTH)
+    ctx.set_verify(SSL.verify_none, VERIFY_DEPTH)
   else:
     # Do validate peer
     ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, VERIFY_DEPTH)

--- a/Core/Security/m2crypto/X509Chain.py
+++ b/Core/Security/m2crypto/X509Chain.py
@@ -859,13 +859,12 @@ class X509Chain(object):
     retVal = self.dumpAllToString()
     if not retVal['OK']:
       return retVal
-
     pemData = retVal['Value']
     try:
       if not filename:
         fd, filename = tempfile.mkstemp()
       else:
-        fd = file(filename, "w")
+        fd = os.open(filename, os.O_RDWR | os.O_CREAT)
 
       os.write(fd, pemData)
       os.close(fd)

--- a/FrameworkSystem/scripts/dirac-proxy-init.py
+++ b/FrameworkSystem/scripts/dirac-proxy-init.py
@@ -132,7 +132,9 @@ class ProxyInit(object):
 
     gLogger.notice("Added VOMS attribute %s" % vomsAttr)
     chain = resultVomsAttributes['Value']
-    chain.dumpAllToFile(self.__proxyGenerated)
+    retDump = chain.dumpAllToFile(self.__proxyGenerated)
+    if not retDump['OK']:
+      return retDump
     return S_OK()
 
   def createProxy(self):


### PR DESCRIPTION
BEGINRELEASENOTES
*CORE
FIX: Fix M2Crypto implementation for SkipCAChecks=True, needed when running dirac-configure for the first time
FIX: Fix in M2Crypto.X509Chain.dumpAllToFile: written proxy file was empty

ENDRELEASENOTES

1)

https://github.com/DIRACGrid/DIRAC/blob/c3994972b4fac0b09a60a530bff6bc303261a7ab/Core/DISET/private/Transports/SSL/pygsi/SocketInfo.py#L241-L251
vs
https://github.com/DIRACGrid/DIRAC/blob/c3994972b4fac0b09a60a530bff6bc303261a7ab/Core/DISET/private/Transports/SSL/M2Utils.py#L98-L103


2) `os.write` does not take a file object, but needs a file descriptor returned by os.open