### PR TITLE
[v6r21] MQ: randomzied the broker list when putting message

### DIFF
--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -3,6 +3,7 @@ Class for management of Stomp MQ connections, e.g. RabbitMQ
 """
 
 import json
+import random
 import os
 import socket
 import stomp
@@ -107,7 +108,12 @@ class StompMQConnector(MQConnector):
     """
     destination = parameters.get('destination', '')
     error = False
-    for connection in self.connections.itervalues():
+
+    # Randomize the brokers to spread the load
+    randConn = self.connections.values()
+    random.shuffle(randConn)
+
+    for connection in randConn:
       try:
         if isinstance(message, (list, set, tuple)):
           for msg in message:


### PR DESCRIPTION
In order to benefit from having several broker behind an alias, randomize the connection list
It is already running as a hotfix in LHCb

BEGINRELEASENOTES
*Resources
CHANGE: MQ: randomzied the broker list when putting message
ENDRELEASENOTES
