### PR TITLE
[v6r21] Standardize sizes returned by StoragePlugins in Bytes

### DIFF
--- a/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/Resources/Storage/GFAL2_SRM2Storage.py
@@ -181,7 +181,7 @@ class GFAL2_SRM2Storage(GFAL2_StorageBase):
       https://its.cern.ch/jira/browse/DMC-977
 
       It queries the srm interface for a given space token.
-      Out of the results, we keep totalsize, guaranteedsize, and unusedsize all in MB.
+      Out of the results, we keep totalsize, guaranteedsize, and unusedsize all in B.
     """
 
     # Gfal2 extended parameter name to query the space token occupancy
@@ -210,7 +210,7 @@ class GFAL2_SRM2Storage(GFAL2_StorageBase):
 
     sTokenDict = {}
 
-    sTokenDict['Total'] = float(occupancyDict.get('totalsize', '0')) / 1e6
-    sTokenDict['Free'] = float(occupancyDict.get('unusedsize', '0')) / 1e6
+    sTokenDict['Total'] = float(occupancyDict.get('totalsize', '0'))
+    sTokenDict['Free'] = float(occupancyDict.get('unusedsize', '0'))
 
     return S_OK(sTokenDict)

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -370,7 +370,7 @@ class StorageElementItem(object):
         It loops over the different Storage Plugins to query it.
 
         :params occupancyLFN: (named param) LFN where to find the space reporting json file on the storage
-                              The json file should contain the Free and Total space in MB.
+                              The json file should contain the Free and Total space in B.
                               If not specified, the default path will be </vo/occupancy.json>
 
         :returns: S_OK with dict (keys: Total, Free)
@@ -393,7 +393,7 @@ class StorageElementItem(object):
     # Try all of the storages one by one
     for storage in filteredPlugins:
 
-      # The result of the plugin is always in MB
+      # The result of the plugin is always in B
       res = storage.getOccupancy(**kwargs)
       if res['OK']:
         occupancyDict = res['Value']
@@ -403,9 +403,10 @@ class StorageElementItem(object):
           log.verbose("Missing mandatory parameters", mandatoryParams - set(occupancyDict))
           continue
 
-        if unit != 'MB':
+        # Since plugins return Bytes, we do not need to convert if that's what we want
+        if unit != 'B':
           for space in ['Total', 'Free']:
-            convertedSpace = convertSizeUnits(occupancyDict[space], 'MB', unit)
+            convertedSpace = convertSizeUnits(occupancyDict[space], 'B', unit)
             # If we have a conversion error, we go to the next plugin
             if convertedSpace == -sys.maxsize:
               log.verbose(

--- a/docs/source/AdministratorGuide/Resources/Storage/index.rst
+++ b/docs/source/AdministratorGuide/Resources/Storage/index.rst
@@ -228,7 +228,7 @@ Several methods allow to know how much space is left on a storage, depending on 
 * any other: a generic implementation has been made in order to retrieve a JSON file containing the necessary information.
 
 A WLCG working group is trying to standardize the space reporting. So a standard will probably emerge soon (before 2053).
-For the time being, we shall consider that the JSON file will contain a dictionary with keys `Total` and `Free` in MB.
+For the time being, we shall consider that the JSON file will contain a dictionary with keys `Total` and `Free` in Bytes.
 For example::
 
    {


### PR DESCRIPTION
Up to now, we were in a mixed situation: some places use power of 1024 while others (in fact, just SRM) relied on power of 1000 for sizes. 
This PR aims at making things uniform: all in power of 1024, but still with the existing name (i.e. `MB` and not `MiB`).
The only impact I expect from that is that the values stored in RSS for SRM storages will be smaller.
But up to now, we were in a mixed state, so better to smooth it out.
One thing to note is that the genius of WLCG talking pledges are using power of 1000... 

BEGINRELEASENOTES

*Resources
CHANGE: Standardize sizes returned by StoragePlugins in Bytes

*DMS
CHANGE: DIP handler internally uses bytes instead of MB

ENDRELEASENOTES
