### PR TITLE
[v6r21][WIP]Add some tutorials

### DIFF
--- a/Core/scripts/install_site.sh
+++ b/Core/scripts/install_site.sh
@@ -31,6 +31,10 @@ do
     DEBUG='-o LogLevel=DEBUG'
   ;;
 
+  -o | --dirac-os )
+    USE_DIRACOS='--dirac-os'
+  ;;
+
   -v | --version )
     switch=$1
     shift
@@ -62,7 +66,7 @@ installDir=`grep TargetPath $installCfg | grep -v '#' | cut -d '=' -f 2 | sed -e
 mkdir -p $installDir || exit
 #
 
-python dirac-install -t server $installCfg
+python dirac-install -t server $USE_DIRACOS $installCfg
 source $installDir/bashrc
 dirac-configure $installCfg $DEBUG
 dirac-setup-site $DEBUG

--- a/docs/source/AdministratorGuide/Authentication/index.rst
+++ b/docs/source/AdministratorGuide/Authentication/index.rst
@@ -1,3 +1,5 @@
+.. _manageAuthNAndAuthZ:
+
 Manage authentification and authorizations
 ==========================================
 

--- a/docs/source/AdministratorGuide/Resources/Catalog/index.rst
+++ b/docs/source/AdministratorGuide/Resources/Catalog/index.rst
@@ -44,14 +44,9 @@ For example::
       {
         FileCatalog
         {
-          AccessType = Read-Write
-          Status = Active
-          Master = True
         }
         BookkeepingDB
         {
-          AccessType = Write
-          Status = Active
           CatalogURL = Bookkeeping/BookkeepingManager
         }
       }
@@ -69,6 +64,25 @@ Then, each catalog should have a few (case-sensitive) options defined:
 * `Status`: (default `Active`). If anything else than `Active`, the catalog will not be used
 * `AccessType`: `Read`/`Write`/`Read-Write`. No default, must be defined. This defines if the catalog is read-only, write only or both.
 * `Master`: see :ref:`masterCatalog`
+
+For example::
+
+
+   Catalogs
+   {
+
+      FileCatalog
+      {
+        AccessType = Read-Write
+        Status = Active
+        Master = True
+      }
+      BookkeepingDB
+      {
+        AccessType = Write
+        Status = Active
+      }
+   }
 
 .. _masterCatalog:
 

--- a/docs/source/AdministratorGuide/Resources/Catalog/index.rst
+++ b/docs/source/AdministratorGuide/Resources/Catalog/index.rst
@@ -45,6 +45,8 @@ For example::
         FileCatalog
         {
         }
+        # This is not in DIRAC, just
+        # another catalog
         BookkeepingDB
         {
           CatalogURL = Bookkeeping/BookkeepingManager
@@ -77,6 +79,8 @@ For example::
         Status = Active
         Master = True
       }
+      # This is not in DIRAC, just
+      # another catalog
       BookkeepingDB
       {
         AccessType = Write

--- a/docs/source/AdministratorGuide/Systems/Transformation/index.rst
+++ b/docs/source/AdministratorGuide/Systems/Transformation/index.rst
@@ -1,3 +1,5 @@
+.. _adminTS:
+
 =====================
 Transformation System
 =====================
@@ -221,7 +223,7 @@ TransformationAgent plugins
 TaskManager plugins
 -------------------
 
-By default the standard plugin (BySE) sets job's destination depending on the location of its input data. 
+By default the standard plugin (BySE) sets job's destination depending on the location of its input data.
 
 One possibility is represented by the **ByJobType** TaskManager plugin,
 that allows to specify different rules for site destinations for each JobType.
@@ -309,7 +311,7 @@ In order to use the ByJobType plugin, one has to:
   * Sections under "JobTypeMapping" correspond to the different JobTypes one may want to define, *e.g.*: DataReprocessing, Merge, etc.
   * For each JobType one has to define:
 
-    * "Exclude": the list of sites that will be removed as destination sites ("ALL" for all sites). 
+    * "Exclude": the list of sites that will be removed as destination sites ("ALL" for all sites).
     * Optionally one may redefine the "AutoAddedSites" (including setting it empty)
     * "Allow": the list of 'helpers', specifying sites helping another site.
 

--- a/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
+++ b/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
@@ -1,0 +1,765 @@
+====================
+Basic Tutorial setup
+====================
+
+Tutorial goal
+=============
+
+The aim of the tutorial is to have a self contained DIRAC setup. You will be guided through the whole installation process both of the server part and the client part.
+By the end of the tutorial, you will have:
+
+  * a Configuration service, to server other servers and clients
+  * a ComponentMonitoring service to keep track of other services and agents installed
+  * a SystemAdministrator service to manage the DIRAC installation in the future
+  * the WebApp, to allow for web interface access
+
+The setup you will have at the end is the base for all the other tutorials.
+
+
+Basic requirements
+==================
+
+We here assume that you have at your disposition a fresh SLC6 64bits installation. If you don't, we recommend installing a virtual machine. Instr uctions for installing SLC6 can be found `here <http://linux.web.cern.ch/linux/scientific6/docs/install.shtml>`_
+
+In this tutorial, we will use a freshly installed SLC6 x86_64 virtual machine, with all the default options, except the hostname being `dirac-tuto`.
+
+Machine setup
+=============
+
+This section is to be executed as `root` user.
+
+Make sure that the machine can address itself using the 'dirac-tuto` alias. Modify the `/etc/host` file as such::
+
+  127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4 dirac-tuto
+  ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6 dirac-tuto
+
+
+-------------
+Install runit
+-------------
+
+The next step is to install `runit`, which is responsible for supervising DIRAC processes
+
+First, install the `RPM <http://diracproject.web.cern.ch/diracproject/rpm/runit-2.1.2-1.el6.x86_64.rpm>`_::
+
+    [root@dirac-tuto ~]# yum install -y http://diracproject.web.cern.ch/diracproject/rpm/runit-2.1.2-1.el6.x86_64.rpm
+    Loaded plugins: changelog, kernel-module, protectbase, refresh-packagekit, security, tsflags,
+                  : versionlock
+    Setting up Install Process
+    runit-2.1.2-1.el6.x86_64.rpm                                              | 611 kB     00:00
+    Examining /var/tmp/yum-root-uyeABW/runit-2.1.2-1.el6.x86_64.rpm: runit-2.1.2-1.el6.x86_64
+    Marking /var/tmp/yum-root-uyeABW/runit-2.1.2-1.el6.x86_64.rpm to be installed
+    161 packages excluded due to repository protections
+    Resolving Dependencies
+    --> Running transaction check
+    ---> Package runit.x86_64 0:2.1.2-1.el6 will be installed
+    --> Finished Dependency Resolution
+    Beginning Kernel Module Plugin
+    Finished Kernel Module Plugin
+
+    Dependencies Resolved
+
+    =================================================================================================
+    Package        Arch            Version                 Repository                          Size
+    =================================================================================================
+    Installing:
+    runit          x86_64          2.1.2-1.el6             /runit-2.1.2-1.el6.x86_64          1.7 M
+
+    Transaction Summary
+    =================================================================================================
+    Install       1 Package(s)
+
+    Total size: 1.7 M
+    Installed size: 1.7 M
+    Downloading Packages:
+    Running rpm_check_debug
+    Running Transaction Test
+    Transaction Test Succeeded
+    Running Transaction
+      Installing : runit-2.1.2-1.el6.x86_64                                                      1/1
+    runsvdir start/running, process 7257
+      Verifying  : runit-2.1.2-1.el6.x86_64                                                      1/1
+
+    Installed:
+      runit.x86_64 0:2.1.2-1.el6
+
+    Complete!
+
+
+Next, edit the `/etc/init/runsvdir.conf` file to point to the future DIRAC installation as such::
+
+  # for runit - manage /usr/sbin/runsvdir-start
+  start on runlevel [2345]
+  stop on runlevel [^2345]
+  normal exit 0 111
+  respawn
+  exec /opt/dirac/sbin/runsvdir-start
+
+Finally, create the directory `/opt/dirac/sbin`::
+
+  mkdir -p /opt/dirac/sbin
+
+and the file `/opt/dirac/sbin/runsvdir-start` with the following content::
+
+  cd /opt/dirac
+  RUNSVCTRL='/sbin/runsvctrl'
+  chpst -u dirac $RUNSVCTRL d /opt/dirac/startup/*
+  killall runsv svlogd
+  RUNSVDIR='/sbin/runsvdir'
+  exec chpst -u dirac $RUNSVDIR -P /opt/dirac/startup 'log:  DIRAC runsv'
+
+make it executable::
+
+  chmod +x /opt/dirac/sbin/runsvdir-start
+
+
+and restart `runsvdir`::
+
+  restart runsvdir
+
+
+-------------
+Install MySQL
+-------------
+
+First of all, remove the existing (outdated) installation::
+
+   yum remove -y $(rpm -qa | grep -i mysql | paste -sd ' ')
+
+
+Install all the necessary RPMs for MySQL 5.6::
+
+  yum install -y https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-devel-5.6.43-1.el6.x86_64.rpm https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-server-5.6.43-1.el6.x86_64.rpm https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-client-5.6.43-1.el6.x86_64.rpm
+
+Setup the root password::
+
+  [root@dirac-tuto ~]# mysqld_safe --skip-grant-tables &
+  [1] 8840
+  [root@dirac-tuto ~]# 190410 16:11:21 mysqld_safe Logging to '/var/lib/mysql/dirac-tuto.err'.
+  190410 16:11:21 mysqld_safe Starting mysqld daemon with databases from /var/lib/mysql
+
+  [root@dirac-tuto ~]# mysql -u root
+  Welcome to the MySQL monitor.  Commands end with ; or \g.
+  Your MySQL connection id is 1
+  Server version: 5.6.43 MySQL Community Server (GPL)
+
+  Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+
+  Oracle is a registered trademark of Oracle Corporation and/or its
+  affiliates. Other names may be trademarks of their respective
+  owners.
+
+  Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+  mysql> FLUSH PRIVILEGES;
+  Query OK, 0 rows affected (0.00 sec)
+
+
+  mysql> SET PASSWORD FOR 'root'@'localhost' = PASSWORD('password');
+  Query OK, 0 rows affected (0.00 sec)
+
+  mysql> FLUSH PRIVILEGES;
+  Query OK, 0 rows affected (0.00 sec)
+
+  mysql> quit
+  Bye
+
+  [root@dirac-tuto ~]# service mysql stop
+  Shutting down MySQL..190410 16:12:52 mysqld_safe mysqld from pid file /var/lib/mysql/dirac-tuto.pid ended
+                                                            [  OK  ]
+  [1]+  Done                    mysqld_safe --skip-grant-tables
+  [root@dirac-tuto ~]# service mysql start
+  Starting MySQL.
+
+
+-----------------------
+Create the `dirac` user
+-----------------------
+
+The user that will run the server will be `dirac`. You can set a password for that user::
+
+  adduser -s /bin/bash -d /home/dirac dirac
+  passwd dirac
+
+
+All files bellow `/opt/dirac/` should belong to this user::
+
+  chown -R dirac:dirac /opt/dirac/
+
+
+
+Server installation
+===================
+
+This section is to be executed as `dirac` user
+
+------------------
+CA and certificate
+------------------
+
+DIRAC relies on TLS for securing its connections and for authorization and authentication. Since we are using a self contained installation, we will be using our own CA. There are a bunch of utilities that we will be using to generate the necessary files.
+
+First of all, download the utilities from the DIRAC repository::
+
+  mkdir ~/caUtilities/ && cd ~/caUtilities/
+  curl -O -L https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/tests/Jenkins/utilities.sh
+  curl -O -L https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/tests/Jenkins/config/ci/openssl_config_ca.cnf
+  curl -O -L https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/tests/Jenkins/config/ci/openssl_config_host.cnf
+  curl -O -L https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/tests/Jenkins/config/ci/openssl_config_user.cnf
+
+We then will generate the CA, the host certificate, and the client certificate that will be used by our client later. First, we create a subshell, and source the tools to be able to call the functions::
+
+  bash
+  export SERVERINSTALLDIR=/opt/dirac
+  export CI_CONFIG=~/caUtilities/
+  source utilities.sh
+
+
+Then we generate the CA::
+
+  [dirac@dirac-tuto caUtilities]$ generateCA
+  ==> [generateCA]
+  Generating RSA private key, 2048 bit long modulus
+  .............+++
+  ...............+++
+  e is 65537 (0x10001)
+
+Now generate a host certificate, valid for 1 year::
+
+  [dirac@dirac-tuto ca]$ generateCertificates 365
+  ==> [generateCertificates]
+  Using configuration from /opt/dirac/etc/grid-security/ca/openssl_config_ca.cnf
+  Check that the request matches the signature
+  Signature ok
+  Certificate Details:
+          Serial Number: 4096 (0x1000)
+          Validity
+              Not Before: Apr 10 14:47:38 2019 GMT
+              Not After : Apr  9 14:47:38 2020 GMT
+          Subject:
+              countryName               = ch
+              organizationName          = DIRAC
+              organizationalUnitName    = DIRAC CI
+              commonName                = dirac-tuto
+              emailAddress              = lhcb-dirac-ci@cern.ch
+          X509v3 extensions:
+              X509v3 Basic Constraints:
+                  CA:FALSE
+              Netscape Comment:
+                  OpenSSL Generated Server Certificate
+              X509v3 Subject Key Identifier:
+                  85:90:F4:7D:6E:31:50:F7:3E:53:7E:0B:B3:22:D5:5C:37:D4:D0:5A
+              X509v3 Authority Key Identifier:
+                  keyid:33:F0:C8:60:6D:6B:52:BD:E9:A7:FA:57:27:72:5A:5D:7E:43:12:ED
+                  DirName:/O=DIRAC CI/CN=DIRAC CI Signing Certification Authority
+                  serial:88:B1:7A:54:17:8C:00:13
+
+              X509v3 Key Usage: critical
+                  Digital Signature, Key Encipherment
+              X509v3 Extended Key Usage:
+                  TLS Web Server Authentication, TLS Web Client Authentication
+              X509v3 Subject Alternative Name:
+                  DNS:dirac-tuto, DNS:localhost
+  Certificate is to be certified until Apr  9 14:47:38 2020 GMT (365 days)
+
+  Write out database with 1 new entries
+  Data Base Updated
+
+
+Finally, generate the client certificate for later, also valid one year::
+
+  [dirac@dirac-tuto grid-security]$ generateUserCredentials 365
+  ==> [generateUserCredentials]
+  Generating RSA private key, 2048 bit long modulus
+  ................................................................................+++
+  ...........................................................................................................................................+++
+  e is 65537 (0x10001)
+  Using configuration from /opt/dirac/etc/grid-security/ca/openssl_config_ca.cnf
+  Check that the request matches the signature
+  Signature ok
+  Certificate Details:
+          Serial Number: 4097 (0x1001)
+          Validity
+              Not Before: Apr 10 14:48:31 2019 GMT
+              Not After : Apr  9 14:48:31 2020 GMT
+          Subject:
+              countryName               = ch
+              organizationName          = DIRAC
+              organizationalUnitName    = DIRAC CI
+              commonName                = ciuser
+              emailAddress              = lhcb-dirac-ci@cern.ch
+          X509v3 extensions:
+              X509v3 Basic Constraints:
+                  CA:FALSE
+              X509v3 Subject Key Identifier:
+                  98:BB:F0:A8:96:4F:80:C8:3E:21:60:5E:FD:17:4E:34:97:EF:31:17
+              X509v3 Authority Key Identifier:
+                  keyid:33:F0:C8:60:6D:6B:52:BD:E9:A7:FA:57:27:72:5A:5D:7E:43:12:ED
+
+              X509v3 Key Usage: critical
+                  Digital Signature, Non Repudiation, Key Encipherment
+              X509v3 Extended Key Usage:
+                  TLS Web Client Authentication
+              Netscape Comment:
+                  OpenSSL Generated Client Certificate
+  Certificate is to be certified until Apr  9 14:48:31 2020 GMT (365 days)
+
+  Write out database with 1 new entries
+  Data Base Updated
+
+To finish, time to exit the subshell::
+
+  exit
+
+
+At this point, you should find:
+
+ * The CA in `/opt/dirac/etc/grid-security/certificates`::
+
+    [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/certificates/
+    855f710d.0  ca.cert.pem
+
+ * The host certificate (`hostcert.pem`) and key (`hostkey.pem`) in `/opt/dirac/etc/grid-security`::
+
+    [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/
+    ca  certificates  hostcert.pem  hostkey.pem  openssl_config_host.cnf  request.csr.pem
+
+ * The user credentials for later in `/opt/dirac/user/`::
+
+    [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/user/
+    client.key  client.pem  client.req  openssl_config_user.cnf
+
+--------------------
+Install DIRAC Server
+--------------------
+
+This section is to be run as dirac user.
+
+We will install DIRAC v6r21 with DIRACOS.
+
+First, download the installer, and make it executable::
+
+  mkdir ~/DIRAC && cd ~/DIRAC
+  curl -O -L https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/install_site.sh
+  chmod +x install_site.sh
+
+
+`install_site.sh` requires a configuration file to tell it what and how to install. Create a file called `installation.cfg` with the following content::
+
+  LocalInstallation
+  {
+    #  DIRAC release version to install
+    Release = v6r21p2
+    #  Installation type
+    InstallType = server
+    #  Each DIRAC update will be installed in a separate directory, not overriding the previous ones
+    UseVersionsDir = yes
+    #  The directory of the DIRAC software installation
+    TargetPath = /opt/dirac
+    #  Install the WebApp extension
+    Extensions = WebApp
+
+    # Name of the VO we will use
+    VirtualOrganization = tutoVO
+    # Name of the site or host
+    SiteName = dirac-tuto
+    # Setup name
+    Setup = MyDIRAC-Production
+    #  Default name of system instances
+    InstanceName = Production
+    #  Flag to skip download of CAs
+    SkipCADownload = yes
+    #  Flag to use the server certificates
+    UseServerCertificate = yes
+
+    # Name of the Admin user (from the user certificate we created )
+    AdminUserName = ciuser
+    # DN of the Admin user certificate (from the user certificate we created)
+    AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+    AdminUserEmail= adminUser@cern.ch
+    # Name of the Admin group
+    AdminGroupName = dirac_admin
+
+    # DN of the host certificate (from the host certificate we created)
+    HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=dirac-tuto/emailAddress=lhcb-dirac-ci@cern.ch
+    # Define the Configuration Server as Master
+    ConfigurationMaster = yes
+
+    # List of DataBases to be installed (what's here is a list for a basic installation)
+    Databases = InstalledComponentsDB
+    Databases += ResourceStatusDB
+
+    #  List of Services to be installed (what's here is a list for a basic installation)
+    Services  = Configuration/Server
+    Services += Framework/ComponentMonitoring
+    Services += Framework/SystemAdministrator
+    #  Flag determining whether the Web Portal will be installed
+    WebPortal = yes
+    WebApp = yes
+
+    Database
+    {
+      #  User name used to connect the DB server
+      User = Dirac
+      #  Password for database user access
+      Password = Dirac
+      #  Password for root DB user
+      RootPwd = password
+      #  location of DB server
+      Host = localhost
+    }
+  }
+
+
+And then run it::
+
+
+  [dirac@dirac-tuto DIRAC]$ ./install_site.sh --dirac-os install.cfg
+  --2019-04-11 08:51:21--  https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/dirac-install.py
+  Resolving github.com... 140.82.118.4, 140.82.118.3
+  Connecting to github.com|140.82.118.4|:443... connected.
+  HTTP request sent, awaiting response... 302 Found
+
+
+  [...]
+
+
+  Status of installed components:
+
+    Name                          Runit Uptime PID
+  =================================================
+  1 Web_WebApp                    Run        4 24338
+  2 Configuration_Server          Run       53 24142
+  3 Framework_ComponentMonitoring Run       36 24207
+  4 Framework_SystemAdministrator Run       20 24247
+
+
+You can verify that the components are running::
+
+  [dirac@dirac-tuto DIRAC]$ runsvstat /opt/dirac/startup/*
+  /opt/dirac/startup/Configuration_Server: run (pid 24142) 288 seconds
+  /opt/dirac/startup/Framework_ComponentMonitoring: run (pid 24207) 271 seconds
+  /opt/dirac/startup/Framework_SystemAdministrator: run (pid 24247) 255 seconds
+  /opt/dirac/startup/Web_WebApp: run (pid 24338) 239 seconds
+
+
+The logs are to be found in `/opt/dirac/runit/`, grouped by component.
+
+The installation created the file `/opt/dirac/etc/dirac.cfg`. The content is the same as the `installation.cfg`, with the addition of the following::
+
+  DIRAC
+  {
+    Setup = MyDIRAC-Production
+    VirtualOrganization = tutoVO
+    Extensions = WebApp
+    Security
+    {
+    }
+    Setups
+    {
+      MyDIRAC-Production
+      {
+        Configuration = Production
+        Framework = Production
+      }
+    }
+    Configuration
+    {
+      Master = yes
+      Name = MyDIRAC-Production
+      Servers = dips://dirac-tuto:9135/Configuration/Server
+    }
+  }
+  LocalSite
+  {
+    Site = dirac-tuto
+  }
+  Systems
+  {
+    Databases
+    {
+      User = Dirac
+      Password = Dirac
+      Host = localhost
+      Port = 3306
+    }
+    NoSQLDatabases
+    {
+      Host = dirac-tuto
+      Port = 9200
+    }
+  }
+
+This part is used as configuration for all your services and agents that you will run. It contains two important information:
+* The database credentials
+* The address of the configuration server: `Servers = dips://dirac-tuto:9135/Configuration/Server`
+
+The Configuration service will serve the content of the file `/opt/dirac/etc/MyDIRAC-Production.cfg` to every client, be it a service, an agent, a job, or an interactive client. The content looks like such::
+
+  DIRAC
+  {
+    Extensions = WebApp
+    VirtualOrganization = tutoVO
+    Configuration
+    {
+      Name = MyDIRAC-Production
+      Version = 2019-04-11 06:52:18.414086
+      MasterServer = dips://dirac-tuto:9135/Configuration/Server
+    }
+    Setups
+    {
+      MyDIRAC-Production
+      {
+        Configuration = Production
+        Framework = Production
+      }
+    }
+  }
+  Registry
+  {
+    Users
+    {
+      ciuser
+      {
+        DN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+        Email = adminUser@cern.ch
+      }
+    }
+    Groups
+    {
+      dirac_user
+      {
+        Users = ciuser
+        Properties = NormalUser
+      }
+      dirac_admin
+      {
+        Users = ciuser
+        Properties = AlarmsManagement
+        Properties += ServiceAdministrator
+        Properties += CSAdministrator
+        Properties += JobAdministrator
+        Properties += FullDelegation
+        Properties += ProxyManagement
+        Properties += Operator
+      }
+    }
+    Hosts
+    {
+      dirac-tuto
+      {
+        DN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=dirac-tuto/emailAddress=lhcb-dirac-ci@cern.ch
+        Properties = TrustedHost
+        Properties += CSAdministrator
+        Properties += JobAdministrator
+        Properties += FullDelegation
+        Properties += ProxyManagement
+        Properties += Operator
+      }
+    }
+    DefaultGroup = dirac_user
+  }
+  Operations
+  {
+    Defaults
+    {
+      EMail
+      {
+        Production = adminUser@cern.ch
+        Logging = adminUser@cern.ch
+      }
+    }
+  }
+  WebApp
+  {
+    Access
+    {
+      upload = TrustedHost
+    }
+  }
+  Systems
+  {
+    Framework
+    {
+      Production
+      {
+        Services
+        {
+          ComponentMonitoring
+          {
+            Port = 9190
+            Authorization
+            {
+              Default = ServiceAdministrator
+              componentExists = authenticated
+              getComponents = authenticated
+              hostExists = authenticated
+              getHosts = authenticated
+              installationExists = authenticated
+              getInstallations = authenticated
+              updateLog = Operator
+            }
+          }
+          SystemAdministrator
+          {
+            Port = 9162
+            Authorization
+            {
+              Default = ServiceAdministrator
+              storeHostInfo = Operator
+            }
+          }
+        }
+        URLs
+        {
+          ComponentMonitoring = dips://dirac-tuto:9190/Framework/ComponentMonitoring
+          SystemAdministrator = dips://dirac-tuto:9162/Framework/SystemAdministrator
+        }
+        FailoverURLs
+        {
+        }
+        Databases
+        {
+          InstalledComponentsDB
+          {
+            DBName = InstalledComponentsDB
+            Host = localhost
+            Port = 3306
+          }
+        }
+      }
+    }
+  }
+
+
+This configuration will be used for example by Services in order to:
+* know their configuration (for example the `ComponentMonitoring` Service will use everything under `Systems/Framework/Production/Services/ComponentMonitoring` )
+* Identify host and persons (`Registry` section)
+
+Or by clients to get the URLs of given services (for example `ComponentMonitoring = dips://dirac-tuto:9190/Framework/ComponentMonitoring`)
+
+Since this configuration is given as a whole to every client, you understand why no database credentials are in this file. Services and Agents running on the machine will have their configuration as a merge of what is served by the Configuration service and the `/opt/dirac/etc/dirac.cfg`, and thus have access to these private information.
+
+The file `/opt/dirac/bashrc` is to be sourced whenever you want to use the server installation.
+
+Client installation
+===================
+
+Now we will create another linux account `diracuser` and another installation to be used as client
+
+--------------------
+Setup client session
+--------------------
+
+This section has to be ran as `root`
+
+First, create an account, and add in its `~/.globus/` directory the user certificate you created earlier::
+
+  adduser -s /bin/bash -d /home/diracuser diracuser
+  passwd diracuser
+  mkdir ~diracuser/.globus/
+  cp /opt/dirac/user/client.pem ~diracuser/.globus/usercert.pem
+  cp /opt/dirac/user/client.key ~diracuser/.globus/userkey.pem
+  chown -R diracuser:diracuser ~diracuser/.globus/
+
+
+--------------------
+Install DIRAC client
+--------------------
+
+This section has to be ran as `diracuser`
+
+We will do the installation in the `~/DIRAC` directory. For a client, the configuration is really minimal, so we will just install the code and its dependencies.
+First, create the structure, and download the installer::
+
+  mkdir ~/DIRAC && cd ~/DIRAC
+  curl -O -L https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/dirac-install.py
+  chmod +x dirac-install.py
+
+
+Now we trigger the installation, with the same version as the server::
+
+  [diracuser@dirac-tuto DIRAC]$ ./dirac-install.py -r v6r21 --dirac-os
+  2019-04-11 14:46:41 UTC dirac-install [NOTICE]  Processing installation requirements
+  2019-04-11 14:46:41 UTC dirac-install [NOTICE]  Destination path for installation is /home/diracuser/DIRAC
+  2019-04-11 14:46:41 UTC dirac-install [NOTICE]  Discovering modules to install
+  2019-04-11 14:46:41 UTC dirac-install [NOTICE]  Installing modules...
+  2019-04-11 14:46:41 UTC dirac-install [NOTICE]  Installing DIRAC:v6r21
+  2019-04-11 14:46:41 UTC dirac-install [NOTICE]  Retrieving http://diracproject.web.cern.ch/diracproject/tars/DIRAC-v6r21.tar.gz
+  2019-04-11 14:46:41 UTC dirac-install [NOTICE]  Retrieving http://diracproject.web.cern.ch/diracproject/tars/DIRAC-v6r21.md5
+  2019-04-11 14:46:42 UTC dirac-install [NOTICE]  Deploying scripts...
+  Scripts will be deployed at /home/diracuser/DIRAC/scripts
+  Inspecting DIRAC module
+  2019-04-11 14:46:42 UTC dirac-install [NOTICE]  Installing DIRAC OS ...
+  2019-04-11 14:46:42 UTC dirac-install [NOTICE]  Retrieving https://diracos.web.cern.ch/diracos/releases/diracos-1.0.0.tar.gz
+  .........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................2019-04-11 14:46:46 UTC dirac-install [NOTICE]  Retrieving https://diracos.web.cern.ch/diracos/releases/diracos-1.0.0.md5
+  2019-04-11 14:47:02 UTC dirac-install [NOTICE]  Fixing externals paths...
+  2019-04-11 14:47:02 UTC dirac-install [NOTICE]  Running externals post install...
+  2019-04-11 14:47:02 UTC dirac-install [NOTICE]  Creating /home/diracuser/DIRAC/bashrc
+  2019-04-11 14:47:02 UTC dirac-install [NOTICE]  Defaults written to defaults-DIRAC.cfg
+  2019-04-11 14:47:02 UTC dirac-install [NOTICE]  Executing /home/diracuser/DIRAC/scripts/dirac-externals-requirements...
+  2019-04-11 14:47:03 UTC dirac-install [NOTICE]  DIRAC properly installed
+
+You will notice that among other things, the installation created a `~/DIRAC/bashrc` file. This file must be sourced whenever you want to use dirac client.
+
+In principle, your system administrator will have managed the CA for you. In this specific case, since we have our own CA, we will just link the client installation CA with the server one::
+
+  mkdir -p ~/DIRAC/etc/grid-security/
+  ln -s /opt/dirac/etc/grid-security/certificates/ ~/DIRAC/etc/grid-security/certificates
+
+The last step is to configure the client to talk to the proper configuration service. This is easily done by creating a `~/.dirac.cfg` file with the following content::
+
+  DIRAC
+  {
+    Setup = MyDIRAC-Production
+    Configuration
+    {
+      Servers = dips://dirac-tuto:9135/Configuration/Server
+    }
+  }
+
+You should now be able to get a proxy::
+
+  [diracuser@dirac-tuto DIRAC]$ source ~/DIRAC/bashrc
+  [diracuser@dirac-tuto DIRAC]$ dirac-proxy-init
+  Generating proxy...
+  Proxy generated:
+  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=460648814
+  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  timeleft     : 23:59:59
+  DIRAC group  : dirac_user
+  rfc          : True
+  path         : /tmp/x509up_u501
+  username     : ciuser
+  properties   : NormalUser
+
+
+And you can observe that the Configuration Service has served the client::
+
+  [diracuser@dirac-tuto DIRAC]$ grep ciuser /opt/dirac/runit/Configuration/Server/log/current
+  2019-04-11 14:54:10 UTC Configuration/Server NOTICE: Executing action ([::1]:33394)[dirac_user:ciuser] RPC/getCompressedDataIfNewer(<masked>)
+  2019-04-11 14:54:10 UTC Configuration/Server NOTICE: Returning response ([::1]:33394)[dirac_user:ciuser] (0.00 secs) OK
+
+--------------
+Use the WebApp
+--------------
+
+This section is to be executed as `diracuser`.
+
+First you need to convert your user certificate into a `p12` format (you will be prompt for a password, you can leave it empty)::
+
+  cd ~/.globus/
+  openssl pkcs12 -export -out certificate.p12 -inkey userkey.pem -in usercert.pem
+
+This will create the file `~/.globus/certificate.p12`.
+
+Use your favorite browser, and add this certificate.
+
+You should be able to access the WebApp using the following address `https://localhost:8443/DIRAC/`
+
+
+Conclusion
+==========
+
+We have seen how to install a DIRAC server and client using a personal CA, and how to access the WebApp. Starting from here, you will be able to extend on further tutorials.

--- a/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
+++ b/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
@@ -303,7 +303,7 @@ We will install DIRAC v6r21 with DIRACOS.
 
 First, download the installer, and make it executable::
 
-  mkdir ~/DIRAC && cd ~/DIRAC
+  mkdir ~/DiracInstallation && cd ~/DiracInstallation
   curl -O -L https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/install_site.sh
   chmod +x install_site.sh
 
@@ -635,10 +635,10 @@ Install DIRAC client
 
 This section has to be ran as ``diracuser``
 
-We will do the installation in the ``~/DIRAC`` directory. For a client, the configuration is really minimal, so we will just install the code and its dependencies.
+We will do the installation in the ``~/DiracInstallation`` directory. For a client, the configuration is really minimal, so we will just install the code and its dependencies.
 First, create the structure, and download the installer::
 
-  mkdir ~/DIRAC && cd ~/DIRAC
+  mkdir ~/DiracInstallation && cd ~/DiracInstallation
   curl -O -L https://github.com/DIRACGrid/DIRAC/raw/integration/Core/scripts/dirac-install.py
   chmod +x dirac-install.py
 
@@ -666,14 +666,14 @@ Now we trigger the installation, with the same version as the server::
   2019-04-11 14:47:02 UTC dirac-install [NOTICE]  Executing /home/diracuser/DIRAC/scripts/dirac-externals-requirements...
   2019-04-11 14:47:03 UTC dirac-install [NOTICE]  DIRAC properly installed
 
-You will notice that among other things, the installation created a ``~/DIRAC/bashrc`` file. This file must be sourced whenever you want to use dirac client.
+You will notice that among other things, the installation created a ``~/DiracInstallation/bashrc`` file. This file must be sourced whenever you want to use dirac client.
 
 In principle, your system administrator will have managed the CA for you. In this specific case, since we have our own CA, we will just link the client installation CA with the server one::
 
-  mkdir -p ~/DIRAC/etc/grid-security/
-  ln -s /opt/dirac/etc/grid-security/certificates/ ~/DIRAC/etc/grid-security/certificates
+  mkdir -p ~/DiracInstallation/etc/grid-security/
+  ln -s /opt/dirac/etc/grid-security/certificates/ ~/DiracInstallation/etc/grid-security/certificates
 
-The last step is to configure the client to talk to the proper configuration service. This is easily done by creating a ``~/DIRAC/etc/dirac.cfg`` file with the following content::
+The last step is to configure the client to talk to the proper configuration service. This is easily done by creating a ``~/DiracInstallation/etc/dirac.cfg`` file with the following content::
 
   DIRAC
   {
@@ -686,7 +686,7 @@ The last step is to configure the client to talk to the proper configuration ser
 
 You should now be able to get a proxy::
 
-  [diracuser@dirac-tuto DIRAC]$ source ~/DIRAC/bashrc
+  [diracuser@dirac-tuto DIRAC]$ source ~/DiracInstallation/bashrc
   [diracuser@dirac-tuto DIRAC]$ dirac-proxy-init
   Generating proxy...
   Proxy generated:

--- a/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
+++ b/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
@@ -10,10 +10,10 @@ Tutorial goal
 The aim of the tutorial is to have a self contained DIRAC setup. You will be guided through the whole installation process both of the server part and the client part.
 By the end of the tutorial, you will have:
 
-  * a Configuration service, to server other servers and clients
-  * a ComponentMonitoring service to keep track of other services and agents installed
-  * a SystemAdministrator service to manage the DIRAC installation in the future
-  * the WebApp, to allow for web interface access
+* a Configuration service, to serve other servers and clients
+* a ComponentMonitoring service to keep track of other services and agents installed
+* a SystemAdministrator service to manage the DIRAC installation in the future
+* the WebApp, to allow for web interface access
 
 The setup you will have at the end is the base for all the other tutorials.
 
@@ -21,16 +21,16 @@ The setup you will have at the end is the base for all the other tutorials.
 Basic requirements
 ==================
 
-We here assume that you have at your disposition a fresh SLC6 64bits installation. If you don't, we recommend installing a virtual machine. Instr uctions for installing SLC6 can be found `here <http://linux.web.cern.ch/linux/scientific6/docs/install.shtml>`_
+We assume that you have at your disposition a fresh SLC6 64bit installation. If you don't, we recommend installing a virtual machine. Instructions for installing SLC6 can be found `here <http://linux.web.cern.ch/linux/scientific6/docs/install.shtml>`_
 
-In this tutorial, we will use a freshly installed SLC6 x86_64 virtual machine, with all the default options, except the hostname being `dirac-tuto`.
+In this tutorial, we will use a freshly installed SLC6 x86_64 virtual machine, with all the default options, except the hostname being ``dirac-tuto``.
 
 Machine setup
 =============
 
-This section is to be executed as `root` user.
+This section is to be executed as ``root`` user.
 
-Make sure that the machine can address itself using the 'dirac-tuto` alias. Modify the `/etc/host` file as such::
+Make sure that the machine can address itself using the ``dirac-tuto`` alias. Modify the ``/etc/host`` file as such::
 
   127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4 dirac-tuto
   ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6 dirac-tuto
@@ -40,7 +40,7 @@ Make sure that the machine can address itself using the 'dirac-tuto` alias. Modi
 Install runit
 -------------
 
-The next step is to install `runit`, which is responsible for supervising DIRAC processes
+The next step is to install ``runit``, which is responsible for supervising DIRAC processes
 
 First, install the `RPM <http://diracproject.web.cern.ch/diracproject/rpm/runit-2.1.2-1.el6.x86_64.rpm>`_::
 
@@ -49,7 +49,7 @@ First, install the `RPM <http://diracproject.web.cern.ch/diracproject/rpm/runit-
 
 
 
-Next, edit the `/etc/init/runsvdir.conf` file to point to the future DIRAC installation as such::
+Next, edit the ``/etc/init/runsvdir.conf`` file to point to the future DIRAC installation as such::
 
   # for runit - manage /usr/sbin/runsvdir-start
   start on runlevel [2345]
@@ -58,11 +58,11 @@ Next, edit the `/etc/init/runsvdir.conf` file to point to the future DIRAC insta
   respawn
   exec /opt/dirac/sbin/runsvdir-start
 
-Finally, create the directory `/opt/dirac/sbin`::
+Finally, create the directory ``/opt/dirac/sbin``::
 
   mkdir -p /opt/dirac/sbin
 
-and the file `/opt/dirac/sbin/runsvdir-start` with the following content::
+and the file ``/opt/dirac/sbin/runsvdir-start`` with the following content::
 
   cd /opt/dirac
   RUNSVCTRL='/sbin/runsvctrl'
@@ -76,7 +76,7 @@ make it executable::
   chmod +x /opt/dirac/sbin/runsvdir-start
 
 
-and restart `runsvdir`::
+and restart ``runsvdir``::
 
   restart runsvdir
 
@@ -137,16 +137,16 @@ Setup the root password::
 
 
 -----------------------
-Create the `dirac` user
+Create the ``dirac`` user
 -----------------------
 
-The user that will run the server will be `dirac`. You can set a password for that user::
+The user that will run the server will be ``dirac``. You can set a password for that user::
 
   adduser -s /bin/bash -d /home/dirac dirac
   passwd dirac
 
 
-All files bellow `/opt/dirac/` should belong to this user::
+All files bellow ``/opt/dirac/`` should belong to this user::
 
   chown -R dirac:dirac /opt/dirac/
 
@@ -155,7 +155,7 @@ All files bellow `/opt/dirac/` should belong to this user::
 Server installation
 ===================
 
-This section is to be executed as `dirac` user
+This section is to be executed as ``dirac`` user
 
 ------------------
 CA and certificate
@@ -278,20 +278,20 @@ To finish, time to exit the subshell::
 
 At this point, you should find:
 
- * The CA in `/opt/dirac/etc/grid-security/certificates`::
+* The CA in ``/opt/dirac/etc/grid-security/certificates``::
 
-    [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/certificates/
-    855f710d.0  ca.cert.pem
+  [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/certificates/
+  855f710d.0  ca.cert.pem
 
- * The host certificate (`hostcert.pem`) and key (`hostkey.pem`) in `/opt/dirac/etc/grid-security`::
+* The host certificate (``hostcert.pem``) and key (``hostkey.pem``) in ``/opt/dirac/etc/grid-security``::
 
-    [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/
-    ca  certificates  hostcert.pem  hostkey.pem  openssl_config_host.cnf  request.csr.pem
+  [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/
+  ca  certificates  hostcert.pem  hostkey.pem  openssl_config_host.cnf  request.csr.pem
 
- * The user credentials for later in `/opt/dirac/user/`::
+* The user credentials for later in ``/opt/dirac/user/``::
 
-    [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/user/
-    client.key  client.pem  client.req  openssl_config_user.cnf
+  [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/user/
+  client.key  client.pem  client.req  openssl_config_user.cnf
 
 --------------------
 Install DIRAC Server
@@ -308,7 +308,7 @@ First, download the installer, and make it executable::
   chmod +x install_site.sh
 
 
-`install_site.sh` requires a configuration file to tell it what and how to install. Create a file called `installation.cfg` with the following content::
+``install_site.sh`` requires a configuration file to tell it what and how to install. Create a file called ``installation.cfg`` with the following content::
 
   LocalInstallation
   {
@@ -407,9 +407,9 @@ You can verify that the components are running::
   /opt/dirac/startup/Web_WebApp: run (pid 24338) 239 seconds
 
 
-The logs are to be found in `/opt/dirac/runit/`, grouped by component.
+The logs are to be found in ``/opt/dirac/runit/``, grouped by component.
 
-The installation created the file `/opt/dirac/etc/dirac.cfg`. The content is the same as the `installation.cfg`, with the addition of the following::
+The installation created the file ``/opt/dirac/etc/dirac.cfg``. The content is the same as the ``installation.cfg``, with the addition of the following::
 
   DIRAC
   {
@@ -457,9 +457,9 @@ The installation created the file `/opt/dirac/etc/dirac.cfg`. The content is the
 This part is used as configuration for all your services and agents that you will run. It contains two important information:
 
 * The database credentials
-* The address of the configuration server: `Servers = dips://dirac-tuto:9135/Configuration/Server`
+* The address of the configuration server: ``Servers = dips://dirac-tuto:9135/Configuration/Server``
 
-The Configuration service will serve the content of the file `/opt/dirac/etc/MyDIRAC-Production.cfg` to every client, be it a service, an agent, a job, or an interactive client. The content looks like such::
+The Configuration service will serve the content of the file ``/opt/dirac/etc/MyDIRAC-Production.cfg`` to every client, be it a service, an agent, a job, or an interactive client. The content looks like such::
 
   DIRAC
   {
@@ -599,27 +599,27 @@ The Configuration service will serve the content of the file `/opt/dirac/etc/MyD
 
 This configuration will be used for example by Services in order to:
 
-* know their configuration (for example the `ComponentMonitoring` Service will use everything under `Systems/Framework/Production/Services/ComponentMonitoring` )
-* Identify host and persons (`Registry` section)
+* know their configuration (for example the ``ComponentMonitoring`` Service will use everything under ``Systems/Framework/Production/Services/ComponentMonitoring`` )
+* Identify host and persons (``Registry`` section)
 
-Or by clients to get the URLs of given services (for example `ComponentMonitoring = dips://dirac-tuto:9190/Framework/ComponentMonitoring`)
+Or by clients to get the URLs of given services (for example ``ComponentMonitoring = dips://dirac-tuto:9190/Framework/ComponentMonitoring``)
 
-Since this configuration is given as a whole to every client, you understand why no database credentials are in this file. Services and Agents running on the machine will have their configuration as a merge of what is served by the Configuration service and the `/opt/dirac/etc/dirac.cfg`, and thus have access to these private information.
+Since this configuration is given as a whole to every client, you understand why no database credentials are in this file. Services and Agents running on the machine will have their configuration as a merge of what is served by the Configuration service and the ``/opt/dirac/etc/dirac.cfg``, and thus have access to these private information.
 
-The file `/opt/dirac/bashrc` is to be sourced whenever you want to use the server installation.
+The file ``/opt/dirac/bashrc`` is to be sourced whenever you want to use the server installation.
 
 Client installation
 ===================
 
-Now we will create another linux account `diracuser` and another installation to be used as client
+Now we will create another linux account ``diracuser`` and another installation to be used as client
 
 --------------------
 Setup client session
 --------------------
 
-This section has to be ran as `root`
+This section has to be ran as ``root``
 
-First, create an account, and add in its `~/.globus/` directory the user certificate you created earlier::
+First, create an account, and add in its ``~/.globus/`` directory the user certificate you created earlier::
 
   adduser -s /bin/bash -d /home/diracuser diracuser
   passwd diracuser
@@ -633,9 +633,9 @@ First, create an account, and add in its `~/.globus/` directory the user certifi
 Install DIRAC client
 --------------------
 
-This section has to be ran as `diracuser`
+This section has to be ran as ``diracuser``
 
-We will do the installation in the `~/DIRAC` directory. For a client, the configuration is really minimal, so we will just install the code and its dependencies.
+We will do the installation in the ``~/DIRAC`` directory. For a client, the configuration is really minimal, so we will just install the code and its dependencies.
 First, create the structure, and download the installer::
 
   mkdir ~/DIRAC && cd ~/DIRAC
@@ -666,14 +666,14 @@ Now we trigger the installation, with the same version as the server::
   2019-04-11 14:47:02 UTC dirac-install [NOTICE]  Executing /home/diracuser/DIRAC/scripts/dirac-externals-requirements...
   2019-04-11 14:47:03 UTC dirac-install [NOTICE]  DIRAC properly installed
 
-You will notice that among other things, the installation created a `~/DIRAC/bashrc` file. This file must be sourced whenever you want to use dirac client.
+You will notice that among other things, the installation created a ``~/DIRAC/bashrc`` file. This file must be sourced whenever you want to use dirac client.
 
 In principle, your system administrator will have managed the CA for you. In this specific case, since we have our own CA, we will just link the client installation CA with the server one::
 
   mkdir -p ~/DIRAC/etc/grid-security/
   ln -s /opt/dirac/etc/grid-security/certificates/ ~/DIRAC/etc/grid-security/certificates
 
-The last step is to configure the client to talk to the proper configuration service. This is easily done by creating a `~/DIRAC/etc/dirac.cfg` file with the following content::
+The last step is to configure the client to talk to the proper configuration service. This is easily done by creating a ``~/DIRAC/etc/dirac.cfg`` file with the following content::
 
   DIRAC
   {
@@ -711,18 +711,18 @@ And you can observe that the Configuration Service has served the client::
 Use the WebApp
 --------------
 
-This section is to be executed as `diracuser`.
+This section is to be executed as ``diracuser``.
 
-First you need to convert your user certificate into a `p12` format (you will be prompt for a password, you can leave it empty)::
+First you need to convert your user certificate into a ``p12`` format (you will be prompt for a password, you can leave it empty)::
 
   cd ~/.globus/
   openssl pkcs12 -export -out certificate.p12 -inkey userkey.pem -in usercert.pem
 
-This will create the file `~/.globus/certificate.p12`.
+This will create the file ``~/.globus/certificate.p12``.
 
 Use your favorite browser, and add this certificate.
 
-You should be able to access the WebApp using the following address `https://localhost:8443/DIRAC/`
+You should be able to access the WebApp using the following address ``https://localhost:8443/DIRAC/``
 
 
 Conclusion

--- a/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
+++ b/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
@@ -1,3 +1,5 @@
+.. _tuto_basic_setup:
+
 ====================
 Basic Tutorial setup
 ====================
@@ -88,9 +90,10 @@ First of all, remove the existing (outdated) installation::
    yum remove -y $(rpm -qa | grep -i mysql | paste -sd ' ')
 
 
-Install all the necessary RPMs for MySQL 5.6::
+Install all the necessary RPMs for MySQL 5.7::
 
-  yum install -y https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-devel-5.6.43-1.el6.x86_64.rpm https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-server-5.6.43-1.el6.x86_64.rpm https://dev.mysql.com/get/Downloads/MySQL-5.6/MySQL-client-5.6.43-1.el6.x86_64.rpm
+  yum install -y https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-community-devel-5.7.25-1.el6.x86_64.rpm https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-community-server-5.7.25-1.el6.x86_64.rpm https://dev.mysqlom/get/Downloads/MySQL-5.7/mysql-community-client-5.7.25-1.el6.x86_64.rpm  https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-community-libs-5.7.25-1.el6.x86_64.rpm https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-community-common-5.7.25-1.el6.x86_64.rpm
+
 
 Setup the root password::
 
@@ -125,11 +128,11 @@ Setup the root password::
   mysql> quit
   Bye
 
-  [root@dirac-tuto ~]# service mysql stop
+  [root@dirac-tuto ~]# service mysqld stop
   Shutting down MySQL..190410 16:12:52 mysqld_safe mysqld from pid file /var/lib/mysql/dirac-tuto.pid ended
                                                             [  OK  ]
   [1]+  Done                    mysqld_safe --skip-grant-tables
-  [root@dirac-tuto ~]# service mysql start
+  [root@dirac-tuto ~]# service mysqld start
   Starting MySQL.
 
 
@@ -670,7 +673,7 @@ In principle, your system administrator will have managed the CA for you. In thi
   mkdir -p ~/DIRAC/etc/grid-security/
   ln -s /opt/dirac/etc/grid-security/certificates/ ~/DIRAC/etc/grid-security/certificates
 
-The last step is to configure the client to talk to the proper configuration service. This is easily done by creating a `~/.dirac.cfg` file with the following content::
+The last step is to configure the client to talk to the proper configuration service. This is easily done by creating a `~/DIRAC/etc/dirac.cfg` file with the following content::
 
   DIRAC
   {

--- a/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
+++ b/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
@@ -42,48 +42,9 @@ The next step is to install `runit`, which is responsible for supervising DIRAC 
 
 First, install the `RPM <http://diracproject.web.cern.ch/diracproject/rpm/runit-2.1.2-1.el6.x86_64.rpm>`_::
 
-    [root@dirac-tuto ~]# yum install -y http://diracproject.web.cern.ch/diracproject/rpm/runit-2.1.2-1.el6.x86_64.rpm
-    Loaded plugins: changelog, kernel-module, protectbase, refresh-packagekit, security, tsflags,
-                  : versionlock
-    Setting up Install Process
-    runit-2.1.2-1.el6.x86_64.rpm                                              | 611 kB     00:00
-    Examining /var/tmp/yum-root-uyeABW/runit-2.1.2-1.el6.x86_64.rpm: runit-2.1.2-1.el6.x86_64
-    Marking /var/tmp/yum-root-uyeABW/runit-2.1.2-1.el6.x86_64.rpm to be installed
-    161 packages excluded due to repository protections
-    Resolving Dependencies
-    --> Running transaction check
-    ---> Package runit.x86_64 0:2.1.2-1.el6 will be installed
-    --> Finished Dependency Resolution
-    Beginning Kernel Module Plugin
-    Finished Kernel Module Plugin
+  yum install -y http://diracproject.web.cern.ch/diracproject/rpm/runit-2.1.2-1.el6.x86_64.rpm
 
-    Dependencies Resolved
 
-    =================================================================================================
-    Package        Arch            Version                 Repository                          Size
-    =================================================================================================
-    Installing:
-    runit          x86_64          2.1.2-1.el6             /runit-2.1.2-1.el6.x86_64          1.7 M
-
-    Transaction Summary
-    =================================================================================================
-    Install       1 Package(s)
-
-    Total size: 1.7 M
-    Installed size: 1.7 M
-    Downloading Packages:
-    Running rpm_check_debug
-    Running Transaction Test
-    Transaction Test Succeeded
-    Running Transaction
-      Installing : runit-2.1.2-1.el6.x86_64                                                      1/1
-    runsvdir start/running, process 7257
-      Verifying  : runit-2.1.2-1.el6.x86_64                                                      1/1
-
-    Installed:
-      runit.x86_64 0:2.1.2-1.el6
-
-    Complete!
 
 
 Next, edit the `/etc/init/runsvdir.conf` file to point to the future DIRAC installation as such::
@@ -349,7 +310,7 @@ First, download the installer, and make it executable::
   LocalInstallation
   {
     #  DIRAC release version to install
-    Release = v6r21p2
+    Release = v6r21p3
     #  Installation type
     InstallType = server
     #  Each DIRAC update will be installed in a separate directory, not overriding the previous ones
@@ -491,6 +452,7 @@ The installation created the file `/opt/dirac/etc/dirac.cfg`. The content is the
   }
 
 This part is used as configuration for all your services and agents that you will run. It contains two important information:
+
 * The database credentials
 * The address of the configuration server: `Servers = dips://dirac-tuto:9135/Configuration/Server`
 
@@ -633,6 +595,7 @@ The Configuration service will serve the content of the file `/opt/dirac/etc/MyD
 
 
 This configuration will be used for example by Services in order to:
+
 * know their configuration (for example the `ComponentMonitoring` Service will use everything under `Systems/Framework/Production/Services/ComponentMonitoring` )
 * Identify host and persons (`Registry` section)
 

--- a/docs/source/AdministratorGuide/Tutorials/diracSE.rst
+++ b/docs/source/AdministratorGuide/Tutorials/diracSE.rst
@@ -128,7 +128,7 @@ This file uploads `/tmp/dummy.txt` on the StorageElement, list the directory and
   Listing directory
   {'OK': True, 'Value': {'Successful': {'/tutoVO': {'Files': {'myFirstFile.txt': {'Accessible': True, 'Migrated': 0, 'Unavailable': 0, 'Lost': 0, 'Exists': True, 'Cached': 1, 'Checksum': '166203b7', 'Mode': 420, 'File': True, 'Directory': True, 'TimeStamps': (1555342476, 1555342476, 1555342476), 'Type': 'File', 'Size': 10}}, 'SubDirs': {}}}, 'Failed': {}}}
   Getting file
-  {'OK': True, 'Value': {'Successful': {}, 'Failed': {'/tutoVO/myFirstFile.txt': "/tmp/donwloaded.txt/myFirstFile.txt can't be opened"}}}
+  {'OK': True, 'Value': {'Successful': {'/tutoVO/myFirstFile.txt': 10}, 'Failed': {}}}
   Removing file
   {'OK': True, 'Value': {'Successful': {'/tutoVO/myFirstFile.txt': True}, 'Failed': {}}}
   Listing directory
@@ -138,3 +138,43 @@ This file uploads `/tmp/dummy.txt` on the StorageElement, list the directory and
 Note: you might be getting the following message if you have no Accounting system. you can safely ignore it::
 
   Error sending accounting record Cannot get URL for Accounting/DataStore in setup MyDIRAC-Production: RuntimeError('Option /DIRAC/Setups/MyDIRAC-Production/Accounting is not defined',)
+
+
+Adding a second DIRAC SE
+========================
+
+It is often interesting to have a second SE.
+
+As `dirac` user, create a new directory::
+
+  mkdir /opt/dirac/storageElementTwo/
+
+Now the rest is to be installed with `diracuser` and a proxy with `dirac_admin` group.
+
+We need another StorageElement service. However, it has to have a different name than the first one, so we will just call this service `StorageElementTwo`::
+
+  [diracuser@dirac-tuto ~]$ dirac-admin-sysadmin-cli --host dirac-tuto
+  Pinging dirac-tuto...
+  [dirac-tuto]> install service DataManagement StorageElementTwo -m StorageElement -p Port=9147
+  Loading configuration template /home/diracuser/DIRAC/DIRAC/DataManagementSystem/ConfigTemplate.cfg
+  Adding to CS service DataManagement/StorageElementTwo
+  service DataManagement_StorageElementTwo is installed, runit status: Run
+
+
+Using the WebApp, add the new StorageElement definition in the `/Resources/StorageElements` section::
+
+  StorageElementTwo
+  {
+    BackendType = DISET
+    DIP
+    {
+      Host = dirac-tuto
+      Port = 9147
+      Protocol = dips
+      Path = /DataManagement/StorageElementTwo
+      Access = remote
+    }
+  }
+
+
+In order to test it, just re-use `/tmp/testSE.py`, replacing `StorageElementOne` with `StorageElementTwo`

--- a/docs/source/AdministratorGuide/Tutorials/diracSE.rst
+++ b/docs/source/AdministratorGuide/Tutorials/diracSE.rst
@@ -1,0 +1,140 @@
+.. _tuto_install_dirac_se:
+
+===============================
+Install a DIRAC Storage Element
+===============================
+
+Pre-requisite
+=============
+
+You should have a machine setup as described in :ref:`tuto_basic_setup`, and be able to install dirac components. For simple interaction with the StorageElement using `dirac-dms-*` commands, you should also have a working FileCatalog.
+
+
+Tutorial goal
+=============
+
+The aim of the tutorial is to do a step by step guide to install a DIRAC StorageElement. By the end of the tutorial, you will be able to have a fully functional storage element that can be addressed like any other storage.
+
+
+Machine setup
+=============
+
+This section is to be executed as `dirac` user.
+
+We will simply create a folder where the files will be stored::
+
+  mkdir /opt/dirac/storageElementOne/
+
+
+Installing the service
+======================
+
+This section is to be executed as `diracuser` user, with `dirac_admin` proxy (reminder: `dirac-proxy-init -g dirac_admin).
+
+Install the StorageElement service using `dirac-admin-sysadmin-cli`::
+
+  [diracuser@dirac-tuto ~]$ dirac-admin-sysadmin-cli --host dirac-tuto
+  [dirac-tuto]> add instance DataManagement Production
+  Adding DataManagement system as Production self.instance for MyDIRAC-Production self.setup to dirac.cfg and CS
+  DataManagement system instance Production added successfully
+  [dirac-tuto]> install service DataManagement StorageElement
+  Loading configuration template /home/diracuser/DIRAC/DIRAC/DataManagementSystem/ConfigTemplate.cfg
+  Adding to CS service DataManagement/StorageElement
+  service DataManagement_StorageElement is installed, runit status: Run
+  [dirac-tuto]> quit
+
+From the web interface, change the configuration of the StorageElement you just installed to point to the folder you created earlier::
+
+  Systems/DataManagement/Production/StorageElement/BasePath = /opt/dirac/storageElementOne/
+
+And restart the service::
+
+  [diracuser@dirac-tuto ~]$ dirac-admin-sysadmin-cli --host dirac-tuto
+  [dirac-tuto]> restart DataManagement StorageElement
+
+  DataManagement_StorageElement started successfully, runit status:
+
+  ('   DataManagement_StorageElement', ':', 'Run')
+
+
+You now have a Service offering grid like storage. However, you still need to declare a StorageElement for it to be usable within DIRAC.
+
+
+Adding the StorageElement
+=========================
+
+You need to add a StorageElement in the `Resources/StorageElements` section.  Using the WebApp, just add the following::
+
+  StorageElementOne
+  {
+    BackendType = DISET
+    DIP
+    {
+      Host = dirac-tuto
+      Port = 9148
+      Protocol = dips
+      Path = /DataManagement/StorageElement
+      Access = remote
+    }
+  }
+
+
+You now have a storage that you can address as `StorageElementOne` in all the dirac commands or in your code.
+
+
+Test it
+=======
+
+Create a dummy file::
+
+  echo "dummyFile" > /tmp/dummy.txt
+
+Now create a file called `/tmp/testSE.py`, with the following content::
+
+  from DIRAC.Core.Base.Script import parseCommandLine
+  parseCommandLine()
+
+  localFile = '/tmp/dummy.txt'
+  lfn = '/tutoVO/myFirstFile.txt'
+
+  from DIRAC.Resources.Storage.StorageElement import StorageElement
+
+
+  se = StorageElement('StorageElementOne')
+
+  print "Putting file"
+  print se.putFile({lfn: localFile})
+
+  print "Listing directory"
+  print se.listDirectory('/tutoVO')
+
+  print "Getting file"
+  print se.getFile(lfn, '/tmp/donwloaded.txt')
+
+  print "Removing file"
+  print se.removeFile(lfn)
+
+  print "Listing directory"
+  print se.listDirectory('/tutoVO')
+
+
+
+
+This file uploads `/tmp/dummy.txt` on the StorageElement, list the directory and removes it. The output should be something like that::
+
+  [diracuser@dirac-tuto ~]$ python /tmp/testSE.py
+  Putting file
+  {'OK': True, 'Value': {'Successful': {'/tutoVO/myFirstFile.txt': 10}, 'Failed': {}}}
+  Listing directory
+  {'OK': True, 'Value': {'Successful': {'/tutoVO': {'Files': {'myFirstFile.txt': {'Accessible': True, 'Migrated': 0, 'Unavailable': 0, 'Lost': 0, 'Exists': True, 'Cached': 1, 'Checksum': '166203b7', 'Mode': 420, 'File': True, 'Directory': True, 'TimeStamps': (1555342476, 1555342476, 1555342476), 'Type': 'File', 'Size': 10}}, 'SubDirs': {}}}, 'Failed': {}}}
+  Getting file
+  {'OK': True, 'Value': {'Successful': {}, 'Failed': {'/tutoVO/myFirstFile.txt': "/tmp/donwloaded.txt/myFirstFile.txt can't be opened"}}}
+  Removing file
+  {'OK': True, 'Value': {'Successful': {'/tutoVO/myFirstFile.txt': True}, 'Failed': {}}}
+  Listing directory
+  {'OK': True, 'Value': {'Successful': {'/tutoVO': {'Files': {}, 'SubDirs': {}}}, 'Failed': {}}}
+
+
+Note: you might be getting the following message if you have no Accounting system. you can safely ignore it::
+
+  Error sending accounting record Cannot get URL for Accounting/DataStore in setup MyDIRAC-Production: RuntimeError('Option /DIRAC/Setups/MyDIRAC-Production/Accounting is not defined',)

--- a/docs/source/AdministratorGuide/Tutorials/diracSE.rst
+++ b/docs/source/AdministratorGuide/Tutorials/diracSE.rst
@@ -7,7 +7,7 @@ Install a DIRAC Storage Element
 Pre-requisite
 =============
 
-You should have a machine setup as described in :ref:`tuto_basic_setup`, and be able to install dirac components. For simple interaction with the StorageElement using `dirac-dms-*` commands, you should also have a working FileCatalog.
+You should have a machine setup as described in :ref:`tuto_basic_setup`, and be able to install dirac components. For simple interaction with the StorageElement using ``dirac-dms-*`` commands, you should also have a working FileCatalog.
 
 
 Tutorial goal
@@ -19,7 +19,7 @@ The aim of the tutorial is to do a step by step guide to install a DIRAC Storage
 Machine setup
 =============
 
-This section is to be executed as `dirac` user.
+This section is to be executed as ``dirac`` user.
 
 We will simply create a folder where the files will be stored::
 
@@ -29,9 +29,9 @@ We will simply create a folder where the files will be stored::
 Installing the service
 ======================
 
-This section is to be executed as `diracuser` user, with `dirac_admin` proxy (reminder: `dirac-proxy-init -g dirac_admin).
+This section is to be executed as ``diracuser`` user, with ``dirac_admin`` proxy (reminder: ``dirac-proxy-init -g dirac_admin``).
 
-Install the StorageElement service using `dirac-admin-sysadmin-cli`::
+Install the StorageElement service using ``dirac-admin-sysadmin-cli``::
 
   [diracuser@dirac-tuto ~]$ dirac-admin-sysadmin-cli --host dirac-tuto
   [dirac-tuto]> add instance DataManagement Production
@@ -63,7 +63,7 @@ You now have a Service offering grid like storage. However, you still need to de
 Adding the StorageElement
 =========================
 
-You need to add a StorageElement in the `Resources/StorageElements` section.  Using the WebApp, just add the following::
+You need to add a StorageElement in the ``Resources/StorageElements`` section.  Using the WebApp, just add the following::
 
   StorageElementOne
   {
@@ -79,7 +79,7 @@ You need to add a StorageElement in the `Resources/StorageElements` section.  Us
   }
 
 
-You now have a storage that you can address as `StorageElementOne` in all the dirac commands or in your code.
+You now have a storage element that you can address as ``StorageElementOne`` in all the dirac commands or in your code.
 
 
 Test it
@@ -89,7 +89,7 @@ Create a dummy file::
 
   echo "dummyFile" > /tmp/dummy.txt
 
-Now create a file called `/tmp/testSE.py`, with the following content::
+Now create a file called ``/tmp/testSE.py``, with the following content::
 
   from DIRAC.Core.Base.Script import parseCommandLine
   parseCommandLine()
@@ -120,7 +120,7 @@ Now create a file called `/tmp/testSE.py`, with the following content::
 
 
 
-This file uploads `/tmp/dummy.txt` on the StorageElement, list the directory and removes it. The output should be something like that::
+This file uploads ``/tmp/dummy.txt`` on the StorageElement, list the directory and removes it. The output should be something like that::
 
   [diracuser@dirac-tuto ~]$ python /tmp/testSE.py
   Putting file
@@ -135,9 +135,9 @@ This file uploads `/tmp/dummy.txt` on the StorageElement, list the directory and
   {'OK': True, 'Value': {'Successful': {'/tutoVO': {'Files': {}, 'SubDirs': {}}}, 'Failed': {}}}
 
 
-Note: you might be getting the following message if you have no Accounting system. you can safely ignore it::
+.. note:: you might be getting the following message if you have no Accounting system. you can safely ignore it::
 
-  Error sending accounting record Cannot get URL for Accounting/DataStore in setup MyDIRAC-Production: RuntimeError('Option /DIRAC/Setups/MyDIRAC-Production/Accounting is not defined',)
+    Error sending accounting record Cannot get URL for Accounting/DataStore in setup MyDIRAC-Production: RuntimeError('Option /DIRAC/Setups/MyDIRAC-Production/Accounting is not defined',)
 
 
 Adding a second DIRAC SE
@@ -145,13 +145,13 @@ Adding a second DIRAC SE
 
 It is often interesting to have a second SE.
 
-As `dirac` user, create a new directory::
+As ``dirac`` user, create a new directory::
 
   mkdir /opt/dirac/storageElementTwo/
 
-Now the rest is to be installed with `diracuser` and a proxy with `dirac_admin` group.
+Now the rest is to be installed with ``diracuser`` and a proxy with ``dirac_admin`` group.
 
-We need another StorageElement service. However, it has to have a different name than the first one, so we will just call this service `StorageElementTwo`::
+We need another StorageElement service. However, it has to have a different name than the first one, so we will just call this service ``StorageElementTwo``::
 
   [diracuser@dirac-tuto ~]$ dirac-admin-sysadmin-cli --host dirac-tuto
   Pinging dirac-tuto...
@@ -161,7 +161,7 @@ We need another StorageElement service. However, it has to have a different name
   service DataManagement_StorageElementTwo is installed, runit status: Run
 
 
-Using the WebApp, add the new StorageElement definition in the `/Resources/StorageElements` section::
+Using the WebApp, add the new StorageElement definition in the ``/Resources/StorageElements`` section::
 
   StorageElementTwo
   {
@@ -177,4 +177,4 @@ Using the WebApp, add the new StorageElement definition in the `/Resources/Stora
   }
 
 
-In order to test it, just re-use `/tmp/testSE.py`, replacing `StorageElementOne` with `StorageElementTwo`
+In order to test it, just re-use ``/tmp/testSE.py``, replacing ``StorageElementOne`` with ``StorageElementTwo``

--- a/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
+++ b/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
@@ -10,10 +10,10 @@ Pre-requisite
 
 You should:
 
- * have a machine setup as described in :ref:`tuto_basic_setup`
- * have installed a DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
- * have installed the DFC using the tutorial (:ref:`tuto_install_dfc`).
- * be able to install dirac components
+* have a machine setup as described in :ref:`tuto_basic_setup`
+* have installed a DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
+* have installed the DFC using the tutorial (:ref:`tuto_install_dfc`).
+* be able to install dirac components
 
 
 Tutorial goal
@@ -22,9 +22,9 @@ Tutorial goal
 The aim of the tutorial is to demonstrate how large scale data management operations (removals, replications, etc) can be achieved using the Transformation System.
 By the end of the tutorial, you will be able to:
 
-  * Submit simple transformation for manipulating a given list of files
-  * Have transformations automatically fed thanks to metadata
-  * Write your own plugin for TransformationSystem
+* Submit simple transformation for manipulating a given list of files
+* Have transformations automatically fed thanks to metadata
+* Write your own plugin for TransformationSystem
 
 
 More links
@@ -36,9 +36,9 @@ More links
 Installing the RequestManagementSystem
 ======================================
 
-This section is to be performed as `diracuser` with a proxy in `dirac_admin` group.
+This section is to be performed as ``diracuser`` with a proxy in ``dirac_admin`` group.
 
 In order to have asynchronous operations handled in DIRAC, you need to have the RequestManagementSystem installed. For it to be functional, you need at least:
 
-  * The ReqManager: the service interfacing this system
-  * The RequestExecutingAgent: the agent performing the operations
+* The ReqManager: the service interfacing this system
+* The RequestExecutingAgent: the agent performing the operations

--- a/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
+++ b/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
@@ -1,0 +1,44 @@
+===============================================================
+Doing large scale DataManagement with the Transformation System
+===============================================================
+
+Pre-requisite
+=============
+
+Pre-requisite
+=============
+
+You should:
+
+ * have a machine setup as described in :ref:`tuto_basic_setup`
+ * have installed a DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
+ * have installed the DFC using the tutorial (:ref:`tuto_install_dfc`).
+ * be able to install dirac components
+
+
+Tutorial goal
+=============
+
+The aim of the tutorial is to demonstrate how large scale data management operations (removals, replications, etc) can be achieved using the Transformation System.
+By the end of the tutorial, you will be able to:
+
+  * Submit simple transformation for manipulating a given list of files
+  * Have transformations automatically fed thanks to metadata
+  * Write your own plugin for TransformationSystem
+
+
+More links
+==========
+
+* RequestManagementSystem documentation: :ref:`requestManagementSystem`
+
+
+Installing the RequestManagementSystem
+======================================
+
+This section is to be performed as `diracuser` with a proxy in `dirac_admin` group.
+
+In order to have asynchronous operations handled in DIRAC, you need to have the RequestManagementSystem installed. For it to be functional, you need at least:
+
+  * The ReqManager: the service interfacing this system
+  * The RequestExecutingAgent: the agent performing the operations

--- a/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
+++ b/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
@@ -11,9 +11,10 @@ Pre-requisite
 You should:
 
 * have a machine setup as described in :ref:`tuto_basic_setup`
-* have installed a DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
+* have installed two DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
 * have installed the DFC using the tutorial (:ref:`tuto_install_dfc`).
-* be able to install dirac components
+* have followed the tutorial on identity management (:ref:`tuto_managing_identities`)
+* have installed the RMS using the tutorial (:ref:`tuto_install_rms`)
 
 
 Tutorial goal
@@ -30,7 +31,7 @@ By the end of the tutorial, you will be able to:
 More links
 ==========
 
-* RequestManagementSystem documentation: :ref:`requestManagementSystem`
+* :ref:`adminTS`
 
 
 Installing the RequestManagementSystem

--- a/docs/source/AdministratorGuide/Tutorials/index.rst
+++ b/docs/source/AdministratorGuide/Tutorials/index.rst
@@ -11,6 +11,7 @@ Each of this tutorial is a step by step guide.
    :numbered:
 
    basicTutoSetup
+   managingIdentities
    diracSE
    installDFC
    installRMS

--- a/docs/source/AdministratorGuide/Tutorials/index.rst
+++ b/docs/source/AdministratorGuide/Tutorials/index.rst
@@ -13,4 +13,5 @@ Each of this tutorial is a step by step guide.
    basicTutoSetup
    diracSE.rst
    installDFC.rst
+   installRMS.rst
    dmsWithTs.rst

--- a/docs/source/AdministratorGuide/Tutorials/index.rst
+++ b/docs/source/AdministratorGuide/Tutorials/index.rst
@@ -11,3 +11,6 @@ Each of this tutorial is a step by step guide.
    :numbered:
 
    basicTutoSetup
+   diracSE.rst
+   installDFC.rst
+   dmsWithTs.rst

--- a/docs/source/AdministratorGuide/Tutorials/index.rst
+++ b/docs/source/AdministratorGuide/Tutorials/index.rst
@@ -1,0 +1,13 @@
+.. _dirac-admin-tutorials:
+
+=============================
+DIRAC Administrator tutorials
+=============================
+
+Each of this tutorial is a step by step guide.
+
+.. toctree::
+   :maxdepth: 1
+   :numbered:
+
+   basicTutoSetup

--- a/docs/source/AdministratorGuide/Tutorials/index.rst
+++ b/docs/source/AdministratorGuide/Tutorials/index.rst
@@ -11,7 +11,7 @@ Each of this tutorial is a step by step guide.
    :numbered:
 
    basicTutoSetup
-   diracSE.rst
-   installDFC.rst
-   installRMS.rst
-   dmsWithTs.rst
+   diracSE
+   installDFC
+   installRMS
+   dmsWithTs

--- a/docs/source/AdministratorGuide/Tutorials/installDFC.rst
+++ b/docs/source/AdministratorGuide/Tutorials/installDFC.rst
@@ -9,9 +9,9 @@ Pre-requisite
 
 You should:
 
- * have a machine setup as described in :ref:`tuto_basic_setup`
- * be able to install dirac components
- * have installed a DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
+* have a machine setup as described in :ref:`tuto_basic_setup`
+* be able to install dirac components
+* have installed a DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
 
 Tutorial goal
 =============
@@ -24,14 +24,14 @@ More links
 
 More information can be found at the following places:
 
- * Introduction to DataManagement: :ref:`data-management-system`
- * Catalog resource definition :ref:`resourcesCatalog`
- * How-to datamanagement for user :ref:`howto_user_dms`
+* Introduction to DataManagement: :ref:`data-management-system`
+* Catalog resource definition :ref:`resourcesCatalog`
+* How-to datamanagement for user :ref:`howto_user_dms`
 
 Installing the DFC
 ==================
 
-This section is to be executed as `diracuser` with a proxy with `dirac_admin` group.
+This section is to be executed as ``diracuser`` with a proxy with ``dirac_admin`` group.
 
 The DFC is no different than any other DIRAC service with a database. The installation step are thus very simple::
 
@@ -51,20 +51,20 @@ Adding the FileCatalog resource
 
 In order to be used as a FileCatalog by clients, the DFC needs to be declared. This happens in two places:
 
- * `/Resources/FileCatalogs/`: in this section, you define how to access the catalog
- * `/Operations/Defaults/Services/Catalogs/`: in this section, you define how to use the catalog (for example read/write)
+* ``/Resources/FileCatalogs/``: in this section, you define how to access the catalog
+* ``/Operations/Defaults/Services/Catalogs/``: in this section, you define how to use the catalog (for example read/write)
 
 
-Since we have only one catalog, we will use it as `Read-Write` and as `Master`.
+Since we have only one catalog, we will use it as ``Read-Write`` and as ``Master``.
 
-Using the WebApp, add the following in `/Resources/FileCatalogs/` (all options to defaults)::
+Using the WebApp, add the following in ``/Resources/FileCatalogs/`` (all options to defaults)::
 
     FileCatalog
     {
     }
 
 
-Using the WebApp, add the following in `/Operations/Defaults/Services/Catalogs`::
+Using the WebApp, add the following in ``/Operations/Defaults/Services/Catalogs``::
 
   FileCatalog
   {
@@ -78,7 +78,7 @@ From this moment onward, the catalog is totally usable.
 Test the catalog
 ================
 
-Since we have a StorageElement at our disposal, we can use the standard `dirac-dms-*` script.
+Since we have a StorageElement at our disposal, we can use the standard ``dirac-dms-*`` script.
 
 First, let us create a file and then "put it on the grid"::
 
@@ -90,7 +90,7 @@ First, let us create a file and then "put it on the grid"::
   Successfully uploaded file to StorageElementOne
 
 
-Now, let's check it's replicas and metadata::
+Now, let's check its replicas and metadata::
 
   [diracuser@dirac-tuto ~]$ dirac-dms-lfn-replicas /tutoVO/user/c/ciuser/world.txt
   LFN                             StorageElement    URL

--- a/docs/source/AdministratorGuide/Tutorials/installDFC.rst
+++ b/docs/source/AdministratorGuide/Tutorials/installDFC.rst
@@ -1,3 +1,5 @@
+.. _tuto_install_dfc:
+
 =================================
 Installing the DIRAC File Catalog
 =================================

--- a/docs/source/AdministratorGuide/Tutorials/installDFC.rst
+++ b/docs/source/AdministratorGuide/Tutorials/installDFC.rst
@@ -1,0 +1,128 @@
+=================================
+Installing the DIRAC File Catalog
+=================================
+
+Pre-requisite
+=============
+
+You should:
+
+ * have a machine setup as described in :ref:`tuto_basic_setup`
+ * be able to install dirac components
+ * have installed a DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
+
+Tutorial goal
+=============
+
+The aim of the tutorial is to install the DIRAC FileCatalog (DFC)
+By the end of the tutorial, you will be able to do all sort of simple Data Management operations.
+
+More links
+==========
+
+More information can be found at the following places:
+
+ * Introduction to DataManagement: :ref:`data-management-system`
+ * Catalog resource definition :ref:`resourcesCatalog`
+ * How-to datamanagement for user :ref:`howto_user_dms`
+
+Installing the DFC
+==================
+
+This section is to be executed as `diracuser` with a proxy with `dirac_admin` group.
+
+The DFC is no different than any other DIRAC service with a database. The installation step are thus very simple::
+
+  [diracuser@dirac-tuto ~]$ dirac-admin-sysadmin-cli --host dirac-tuto
+  Pinging dirac-tuto...
+  [dirac-tuto]> install db FileCatalogDB
+  Adding to CS DataManagement/FileCatalogDB
+  Database FileCatalogDB from DIRAC/DataManagementSystem installed successfully
+  [dirac-tuto]> install service DataManagement FileCatalog
+  Loading configuration template /home/diracuser/DIRAC/DIRAC/DataManagementSystem/ConfigTemplate.cfg
+  Adding to CS service DataManagement/FileCatalog
+  service DataManagement_FileCatalog is installed, runit status: Run
+
+
+Adding the FileCatalog resource
+===============================
+
+In order to be used as a FileCatalog by clients, the DFC needs to be declared. This happens in two places:
+
+ * `/Resources/FileCatalogs/`: in this section, you define how to access the catalog
+ * `/Operations/Defaults/Services/Catalogs/`: in this section, you define how to use the catalog (for example read/write)
+
+
+Since we have only one catalog, we will use it as `Read-Write` and as `Master`.
+
+Using the WebApp, add the following in `/Resources/FileCatalogs/` (all options to defaults)::
+
+    FileCatalog
+    {
+    }
+
+
+Using the WebApp, add the following in `/Operations/Defaults/Services/Catalogs`::
+
+  FileCatalog
+  {
+    AccessType = Read-Write
+    Status = Active
+    Master = True
+  }
+
+From this moment onward, the catalog is totally usable.
+
+Test the catalog
+================
+
+Since we have a StorageElement at our disposal, we can use the standard `dirac-dms-*` script.
+
+First, let us create a file and then "put it on the grid"::
+
+
+  [diracuser@dirac-tuto ~]$ echo "Hello" > /tmp/world.txt
+  [diracuser@dirac-tuto ~]$ dirac-dms-add-file /tutoVO/user/c/ciuser/world.txt /tmp/world.txt StorageElementOne
+
+  Uploading /tutoVO/user/c/ciuser/world.txt
+  Successfully uploaded file to StorageElementOne
+
+
+Now, let's check it's replicas and metadata::
+
+  [diracuser@dirac-tuto ~]$ dirac-dms-lfn-replicas /tutoVO/user/c/ciuser/world.txt
+  LFN                             StorageElement    URL
+  =====================================================
+  /tutoVO/user/c/ciuser/world.txt StorageElementOne dips://dirac-tuto:9148/DataManagement/StorageElement/tutoVO/user/c/ciuser/world.txt
+
+  [diracuser@dirac-tuto ~]$ dirac-dms-lfn-metadata /tutoVO/user/c/ciuser/world.txt
+  {'Failed': {},
+  'Successful': {'/tutoVO/user/c/ciuser/world.txt': {'Checksum': '078b01ff',
+                                                      'ChecksumType': 'Adler32',
+                                                      'CreationDate': datetime.datetime(2019, 4, 16, 9, 5, 58),
+                                                      'FileID': 1L,
+                                                      'GID': 1,
+                                                      'GUID': '09F7E02F-1290-BE21-1DA7-07A266F153B3',
+                                                      'Mode': 509,
+                                                      'ModificationDate': datetime.datetime(2019, 4, 16, 9, 5, 58),
+                                                      'Owner': 'ciuser',
+                                                      'OwnerGroup': 'dirac_admin',
+                                                      'Size': 6L,
+                                                      'Status': 'AprioriGood',
+                                                      'UID': 1}}}
+
+Note that these metadata are those registered in the catalog (which hopefully should match the physical one !)
+
+We can also check all the user files that belong to us on the grid::
+
+  [diracuser@dirac-tuto ~]$ dirac-dms-user-lfns
+  Will search for files in /tutoVO/user/c/ciuser
+  /tutoVO/user/c/ciuser: 1 files, 0 sub-directories
+  1 matched files have been put in tutoVO-user-c-ciuser.lfns
+  [diracuser@dirac-tuto ~]$ cat tutoVO-user-c-ciuser.lfns
+  /tutoVO/user/c/ciuser/world.txt
+
+Finally, let's remove the file::
+
+  [diracuser@dirac-tuto ~]$ dirac-dms-remove-files /tutoVO/user/c/ciuser/world.txt
+  Successfully removed 1 files

--- a/docs/source/AdministratorGuide/Tutorials/installRMS.rst
+++ b/docs/source/AdministratorGuide/Tutorials/installRMS.rst
@@ -9,25 +9,125 @@ Pre-requisite
 
 You should:
 
- * have a machine setup as described in :ref:`tuto_basic_setup`
- * be able to install dirac components
- * have installed a DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
- *
+* have a machine setup as described in :ref:`tuto_basic_setup`
+* be able to install dirac components
+* have installed two DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
+* have installed the DFC (:ref:`tuto_install_dfc`)
+* have followed the tutorial on identity management (:ref:`tuto_managing_identities`)
 
 Tutorial goal
 =============
 
-The aim of the tutorial is to install the DIRAC FileCatalog (DFC)
-By the end of the tutorial, you will be able to do all sort of simple Data Management operations.
+The aim of the tutorial is to install the RequestManagement system components and to use it to perform a simple replication of file.
 
 More links
 ==========
 
 More information can be found at the following places:
 
- * Introduction to DataManagement: :ref:`data-management-system`
- * Catalog resource definition :ref:`resourcesCatalog`
- * How-to datamanagement for user :ref:`howto_user_dms`
+* :ref:`data-management-system`
+* :ref:`requestManagementSystem`
 
-Installing the DFC
+Installing the RMS
 ==================
+
+This section is to be executed as ``diracuser`` with a proxy with ``dirac_admin`` group.
+
+The RMS needs the ``ReqManager`` service and the ``RequestExecutingAgent`` to work (you may want to add the ``CleanReqDBAgent`` if you scale...).
+
+The RMS is no different than any other DIRAC system. The installation step are thus very simple::
+
+  [diracuser@dirac-tuto ~]$ dirac-admin-sysadmin-cli --host dirac-tuto
+  Pinging dirac-tuto...
+  [dirac-tuto]> add instance RequestManagement Production
+  Adding RequestManagement system as Production self.instance for MyDIRAC-Production self.setup to dirac.cfg and CS
+  RequestManagement system instance Production added successfully
+  [dirac-tuto]> install db ReqDB
+  MySQL root password:
+  Adding to CS RequestManagement/ReqDB
+  Database ReqDB from DIRAC/RequestManagementSystem installed successfully
+  [dirac-tuto]> install service RequestManagement ReqManager
+  Loading configuration template /home/diracuser/DiracInstallation/DIRAC/RequestManagementSystem/ConfigTemplate.cfg
+  Adding to CS service RequestManagement/ReqManager
+  service RequestManagement_ReqManager is installed, runit status: Run
+  [dirac-tuto]> install agent RequestManagement RequestExecutingAgent
+  Loading configuration template /home/diracuser/DiracInstallation/DIRAC/RequestManagementSystem/ConfigTemplate.cfg
+  Adding to CS agent RequestManagement/RequestExecutingAgent
+  agent RequestManagement_RequestExecutingAgent is installed, runit status: Run
+  [dirac-tuto]> quit
+
+
+By default, the installation of the ``RequestExecutingAgent`` will configure it with a whole bunch of default Operations possible. You can see that in the Agent configuration in ``/Systems/RequestManagement/Production/Agents/RequestExecutingAgent/OperationHandlers``
+
+
+Testing the RMS
+===============
+
+This section is to be executed with a proxy with `dirac_user` group.
+
+The test we are going to do consists in transferring a file from one storage element to another, using the RequestExecutingAgent.
+
+First, let's add a file::
+
+  [diracuser@dirac-tuto ~]$ echo "My Test File" > /tmp/myTestFile.txt
+  [diracuser@dirac-tuto ~]$ dirac-dms-add-file /tutoVO/user/c/ciuser/myTestFile.txt /tmp/myTestFile.txt StorageElementOne
+
+  Uploading /tutoVO/user/c/ciuser/myTestFile.txt
+  Successfully uploaded file to StorageElementOne
+
+
+We can see that our file is indeed in the ``StorageElementOne``::
+
+  [diracuser@dirac-tuto ~]$ dirac-dms-lfn-replicas /tutoVO/user/c/ciuser/myTestFile.txt
+  LFN                                  StorageElement    URL
+  ==========================================================
+  /tutoVO/user/c/ciuser/myTestFile.txt StorageElementOne dips://dirac-tuto:9148/DataManagement/StorageElement/tutoVO/user/c/ciuser/myTestFile.txt
+
+Let's replicate it to ``StorageElementTwo`` using the RMS::
+
+  [diracuser@dirac-tuto ~]$ dirac-dms-replicate-and-register-request myFirstRequest /tutoVO/user/c/ciuser/myTestFile.txt StorageElementTwo
+  Request 'myFirstRequest' has been put to ReqDB for execution.
+  RequestID(s): 8
+  You can monitor requests' status using command: 'dirac-rms-request <requestName/ID>'
+
+
+The Request has a name (``myFirstRequest``) that we chose, but also an ID, returned by the system (here ````). The ID is guaranteed to be unique, while the name is not, so it is recommended to use the ID when you interact with the RMS. You can see the status of your Request, using its name or ID::
+
+  [diracuser@dirac-tuto ~]$ dirac-rms-request myFirstRequest
+  Request name='myFirstRequest' ID=8 Status='Waiting'
+  Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:05, NotBefore 2019-04-23 14:37:05
+  Owner: '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch', Group: dirac_data
+    [0] Operation Type='ReplicateAndRegister' ID=8 Order=0 Status='Waiting'
+        TargetSE: StorageElementTwo - Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:05
+      [01] ID=2 LFN='/tutoVO/user/c/ciuser/myTestFile.txt' Status='Waiting' Checksum='1e750431'
+
+  [diracuser@dirac-tuto ~]$ dirac-rms-request 8
+  Request name='myFirstRequest' ID=8 Status='Waiting'
+  Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:05, NotBefore 2019-04-23 14:37:05
+  Owner: '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch', Group: dirac_data
+    [0] Operation Type='ReplicateAndRegister' ID=8 Order=0 Status='Waiting'
+        TargetSE: StorageElementTwo - Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:05
+      [01] ID=2 LFN='/tutoVO/user/c/ciuser/myTestFile.txt' Status='Waiting' Checksum='1e750431'
+
+
+You can here clearly see that the Request consists of one ``ReplicateAndRegister`` operation (which does what it says) targeting the LFN ``/tutoVO/user/c/ciuser/myTestFile.txt``. The RequestExecutingAgent will pick up the request and execute it. And shortly you should be able to see it done::
+
+  [diracuser@dirac-tuto ~]$ dirac-rms-request 8
+  Request name='myFirstRequest' ID=8 Status='Done'
+  Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:29, NotBefore 2019-04-23 14:37:05
+  Owner: '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch', Group: dirac_data
+    [0] Operation Type='ReplicateAndRegister' ID=8 Order=0 Status='Done'
+        TargetSE: StorageElementTwo - Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:29
+      [01] ID=2 LFN='/tutoVO/user/c/ciuser/myTestFile.txt' Status='Done' Checksum='1e750431'
+
+  [diracuser@dirac-tuto ~]$ dirac-dms-lfn-replicas /tutoVO/user/c/ciuser/myTestFile.txt
+  LFN                                  StorageElement    URL
+  ==========================================================
+  /tutoVO/user/c/ciuser/myTestFile.txt StorageElementTwo dips://dirac-tuto:9147/DataManagement/StorageElementTwo/tutoVO/user/c/ciuser/myTestFile.txt
+                                      StorageElementOne dips://dirac-tuto:9148/DataManagement/StorageElement/tutoVO/user/c/ciuser/myTestFile.txt
+
+
+Conclusion
+==========
+
+You now have an RMS in place, which is the base for all the asynchronous operations in DIRAC. This is used for big scale operations, failover, or even more !

--- a/docs/source/AdministratorGuide/Tutorials/installRMS.rst
+++ b/docs/source/AdministratorGuide/Tutorials/installRMS.rst
@@ -1,0 +1,33 @@
+.. _tuto_install_rms:
+
+=======================================
+Installing the RequestManagement System
+=======================================
+
+Pre-requisite
+=============
+
+You should:
+
+ * have a machine setup as described in :ref:`tuto_basic_setup`
+ * be able to install dirac components
+ * have installed a DIRAC SE using the tutorial (:ref:`tuto_install_dirac_se`).
+ *
+
+Tutorial goal
+=============
+
+The aim of the tutorial is to install the DIRAC FileCatalog (DFC)
+By the end of the tutorial, you will be able to do all sort of simple Data Management operations.
+
+More links
+==========
+
+More information can be found at the following places:
+
+ * Introduction to DataManagement: :ref:`data-management-system`
+ * Catalog resource definition :ref:`resourcesCatalog`
+ * How-to datamanagement for user :ref:`howto_user_dms`
+
+Installing the DFC
+==================

--- a/docs/source/AdministratorGuide/Tutorials/managingIdentities.rst
+++ b/docs/source/AdministratorGuide/Tutorials/managingIdentities.rst
@@ -1,0 +1,142 @@
+.. _tuto_managing_identities:
+
+===================
+Managing identities
+===================
+
+Pre-requisite
+=============
+
+You should:
+
+* have a machine setup as described in :ref:`tuto_basic_setup`
+* be able to install dirac components
+
+
+Tutorial goal
+=============
+
+Very quickly when using DIRAC, you will need to manage identities of people and their proxies. This is done with the ``ProxyManager`` service and with several configuration options.
+In this tutorial, we will install the ``ProxyManager``, create a new group, and define some ``Shifter``.
+
+
+Further reading
+===============
+
+* :ref:`compAuthNAndAutZ`
+* :ref:`manageAuthNAndAuthZ`
+
+Installing the ``ProxyManager``
+===============================
+
+This section is to be performed as ``diracuser`` with ``dirac_admin`` group proxy.
+
+The ``ProxyManager`` will host delegated proxies of the users. As any other service, it is very easy to install::
+
+  [dirac-tuto]> install db ProxyDB
+  MySQL root password:
+  Adding to CS Framework/ProxyDB
+  Database ProxyDB from DIRAC/FrameworkSystem installed successfully
+  [dirac-tuto]> install service Framework ProxyManager
+  Loading configuration template /home/diracuser/DiracInstallation/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+  Adding to CS service Framework/ProxyManager
+  service Framework_ProxyManager is installed, runit status: Run
+
+
+
+.. note:: The ProxyDB contains sensitive information. For production environment, it is recommended that you keep this in a separate database with different credentials and strict access control.
+
+
+Testing the ``ProxyManager``
+============================
+
+The simplest way to test it is to upload your user proxy::
+
+  [diracuser@dirac-tuto ~]$ dirac-proxy-init -U
+  Generating proxy...
+  Uploading proxy for dirac_user...
+  Proxy generated:
+  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=6045995638
+  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  timeleft     : 23:59:59
+  DIRAC group  : dirac_user
+  rfc          : True
+  path         : /tmp/x509up_u501
+  username     : ciuser
+  properties   : NormalUser
+
+  Proxies uploaded:
+  DN                                                                     | Group      | Until (GMT)
+  /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch | dirac_user | 2020/04/09 14:43
+
+As you can see, the proxyDB now contains a delegated proxy for the ``ciuser`` with the group ``dirac_user``.
+
+If you use a proxy with the ``ProxyManagement`` permission, like the ``dirac_admin`` group has, you can retrieve proxies stored in the DB::
+
+  [diracuser@dirac-tuto ~]$ dirac-proxy-init -g dirac_admin
+  Generating proxy...
+  Proxy generated:
+  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=5472309786
+  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  timeleft     : 23:59:59
+  DIRAC group  : dirac_admin
+  rfc          : True
+  path         : /tmp/x509up_u501
+  username     : ciuser
+  properties   : AlarmsManagement, ServiceAdministrator, CSAdministrator, JobAdministrator, FullDelegation, ProxyManagement, Operator
+  [diracuser@dirac-tuto ~]$ dirac-admin-get-proxy ciuser dirac_user
+  Proxy downloaded to /home/diracuser/proxy.ciuser.dirac_user
+
+
+Adding a new group
+==================
+
+Groups are useful to manage permissions and separate activities. For example, we will create a new group ``dirac_data``, and decide to use that group for all the data centrally managed.
+
+Using the ``Configuration Manager`` application in the WebApp, create a new section ``dirac_data`` in ``/Registry/Groups``::
+
+  Users = ciuser
+  Properties = NormalUser
+  AutoUploadProxy = True
+
+You should now be able to get a proxy belonging to the `dirac_data` group that will be automatically uploaded::
+
+  [diracuser@dirac-tuto ~]$ dirac-proxy-init -g dirac_data
+  Generating proxy...
+  Uploading proxy for dirac_data...
+  Proxy generated:
+  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=6009266000
+  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  timeleft     : 23:59:59
+  DIRAC group  : dirac_data
+  rfc          : True
+  path         : /tmp/x509up_u501
+  username     : ciuser
+  properties   : NormalUser
+
+  Proxies uploaded:
+  DN                                                                     | Group      | Until (GMT)
+  /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch | dirac_data | 2020/04/09 14:43
+  /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch | dirac_user | 2020/04/09 14:43
+
+
+.. note:: if you get ``Unauthorized query ( 1111 : Unauthorized query)``, it means the ProxyManager has not yet updated its internal configuration. Just restart it to save time, or wait.
+
+
+Adding a Shifter
+================
+
+``Shifter`` is basically a role, to which you associate a given proxy, for example ``DataManager`` (it could be anything). You can then tell your Components to use the ``DataManager`` identity to perform certain operations (at random: data management operations ? :-) ).
+
+Using the ``Configuration Manager`` application in the WebApp, create a new section ``Shifter`` in ``/Operations/Defaults``::
+
+  DataManager
+  {
+    User = ciuser
+    Group = dirac_data
+  }
+
+You can now force any agent (don't, unless you know what you are doing) to use a proxy instead of the host certificate by specifying the ``shifterProxy`` option.

--- a/docs/source/AdministratorGuide/index.rst
+++ b/docs/source/AdministratorGuide/index.rst
@@ -27,3 +27,4 @@ This administration documentation refers to the "Core" DIRAC project.
    MultiVO/index
    CommandReference/index
    scalingAndLimitations
+   Tutorials/index

--- a/docs/source/DeveloperGuide/Internals/Core/componentsAuthNandAuthZ.rst
+++ b/docs/source/DeveloperGuide/Internals/Core/componentsAuthNandAuthZ.rst
@@ -1,3 +1,5 @@
+.. _compAuthNAndAutZ:
+
 ===========================================
 Components authentication and authorization
 ===========================================
@@ -50,9 +52,9 @@ When a client calls a service, he needs to be identified. If a client opens a co
 	{
 		'DN': '/C=ch/O=DIRAC/[...]',
 		'group': 'devGroup',
-		'CN': u'ciuser', 
-		'x509Chain': <X509Chain 2 certs [...][...]>, 
-		'isLimitedProxy': False, 
+		'CN': u'ciuser',
+		'x509Chain': <X509Chain 2 certs [...][...]>,
+		'isLimitedProxy': False,
 		'isProxy': True
 	}
 
@@ -72,7 +74,7 @@ AuthManager.authQuery() returns boolean so it is easy to use, you just have to p
 	# credDict came from BaseTransport.getConnectingCredentials()
 	# hardcodedMethodAuth is optional
 
-To determine if a query can be authorized or not the AuthManager extract valid properties for a given method. 
+To determine if a query can be authorized or not the AuthManager extract valid properties for a given method.
 First AuthManager try to get it from gConfig, then try to get it from hardcoded list (hardcodedMethodAuth) in your service and if nothing was found get default properties from gConfig.
 
 AuthManager also extract properties from user with credential dictionary and configuration system to check if properties matches. So you don't have to extract properties by yourself, but if needed you can use :py:class:`DIRAC.Core.Security.CS.getPropertiesForGroup()`

--- a/docs/source/UserGuide/HowTo/DataManagement/index.rst
+++ b/docs/source/UserGuide/HowTo/DataManagement/index.rst
@@ -1,3 +1,5 @@
+.. _howto_user_dms:
+
 ==============
 DataManagement
 ==============


### PR DESCRIPTION
This PR will contain the necessary things for the DMS + TS tutorial.
@andresailer @fstagni @atsareg please take a peek


The first tutorial is the setup of an installation for basic server + client, with WebApp and local CA. It is very largely inspired by the existing guides, except that no choice is given to the user (as a tutorial should be). 
You can see it here: https://chaen-dirac.readthedocs.io/en/rel-v6r21_tuto_tsdms/AdministratorGuide/Tutorials/basicTutoSetup.html


**This installation should be the base for all future tutorials**

More will come, do not merge yet please

BEGINRELEASENOTES

*Core
NEW: install_site supports DIRACOS

*Docs
NEW: basic server and client tutorial
NEW: DIRAC SE tutorial
NEW: DFC tutorial

ENDRELEASENOTES
