### PR TITLE
[WIP] Remove race condition from StompMQConnector

### DIFF
--- a/Resources/MessageQueue/StompMQConnector.py
+++ b/Resources/MessageQueue/StompMQConnector.py
@@ -197,10 +197,12 @@ class StompMQConnector(MQConnector):
     fail = False
     self.lock.acquire()
     try:
+      isActiveCallbackOld = False
       connection = next(iter(self.connections.itervalues()), None)
       if connection:
         listener = connection.get_listener('ReconnectListener')
         if listener:
+          isActiveCallbackOld = listener.isActiveCallback
           listener.isActiveCallback = False
 
       for connection in self.connections.itervalues():
@@ -214,7 +216,7 @@ class StompMQConnector(MQConnector):
       if connection:
         listener = connection.get_listener('ReconnectListener')
         if listener:
-          listener.isActiveCallback = True
+          listener.isActiveCallback = isActiveCallbackOld
       self.lock.release()
 
     if fail:


### PR DESCRIPTION
Add lock mecanism to StomMQConnector
Also, add isActiveCallback field to ReconnectListener and reset it
in disconnect method.

BEGINRELEASENOTES
*Resources/MessageQueue
FIX: With multiple brokers scenario the call of producer close() function can lead to race conditions. This fix adds the lock and also desactivates the reconnect procedure when the disconnect() function is called.
ENDRELEASENOTES
