### PR TITLE
[v6r21][POLEMIC] dirac-deploy-scripts uses symlink

### DIFF
--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -129,7 +129,7 @@ if not rootPath:
   sys.exit( 1 )
 
 targetScriptsPath = os.path.join( rootPath, "scripts" )
-pythonScriptRE = re.compile( "(.*/)*([a-z]+-[a-zA-Z0-9-]+|[a-z]+_[a-zA-Z0-9_]+|d[a-zA-Z0-9-]+).py" )
+pythonScriptRE = re.compile( "(.*/)*([a-z]+-[a-zA-Z0-9-]+|[a-z]+_[a-zA-Z0-9_]+|d[a-zA-Z0-9-]+).py$" )
 print "Scripts will be deployed at %s" % targetScriptsPath
 
 if not os.path.isdir( targetScriptsPath ):

--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -20,76 +20,78 @@ DEBUG = False
 
 moduleSuffix = "DIRAC"
 gDefaultPerms = stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
-excludeMask = [ '__init__.py' ]
-simpleCopyMask = [ os.path.basename( __file__ ),
-                   'dirac-compile-externals.py',
-                   'dirac-install.py',
-                   'dirac-platform.py',
-                   'dirac_compile_externals.py',
-                   'dirac_install.py',
-                   'dirac_platform.py']
+excludeMask = ['__init__.py']
+simpleCopyMask = [os.path.basename(__file__),
+                  'dirac-compile-externals.py',
+                  'dirac-install.py',
+                  'dirac-platform.py',
+                  'dirac_compile_externals.py',
+                  'dirac_install.py',
+                  'dirac_platform.py']
 
-def lookForScriptsInPath( basePath, rootModule ):
-  isScriptsDir = os.path.split( rootModule )[1] == "scripts"
+
+def lookForScriptsInPath(basePath, rootModule):
+  isScriptsDir = os.path.split(rootModule)[1] == "scripts"
   scriptFiles = []
-  for entry in os.listdir( basePath ):
-    absEntry = os.path.join( basePath, entry )
-    if os.path.isdir( absEntry ):
-      scriptFiles.extend( lookForScriptsInPath( absEntry, os.path.join( rootModule, entry ) ) )
-    elif isScriptsDir and os.path.isfile( absEntry ):
-      scriptFiles.append( ( os.path.join( rootModule, entry ), entry ) )
+  for entry in os.listdir(basePath):
+    absEntry = os.path.join(basePath, entry)
+    if os.path.isdir(absEntry):
+      scriptFiles.extend(lookForScriptsInPath(absEntry, os.path.join(rootModule, entry)))
+    elif isScriptsDir and os.path.isfile(absEntry):
+      scriptFiles.append((os.path.join(rootModule, entry), entry))
   return scriptFiles
 
-def findDIRACRoot( path ):
-  dirContents = os.listdir( path )
-  if 'DIRAC' in dirContents and os.path.isdir( os.path.join( path, 'DIRAC' ) ):
+
+def findDIRACRoot(path):
+  dirContents = os.listdir(path)
+  if 'DIRAC' in dirContents and os.path.isdir(os.path.join(path, 'DIRAC')):
     return path
-  parentPath = os.path.dirname( path )
-  if parentPath == path or len( parentPath ) == 1:
+  parentPath = os.path.dirname(path)
+  if parentPath == path or len(parentPath) == 1:
     return False
-  return findDIRACRoot( os.path.dirname( path ) )
+  return findDIRACRoot(os.path.dirname(path))
 
 
-rootPath = findDIRACRoot( os.path.dirname( os.path.realpath( __file__ ) ) )
+rootPath = findDIRACRoot(os.path.dirname(os.path.realpath(__file__)))
 if not rootPath:
   print "Error: Cannot find DIRAC root!"
-  sys.exit( 1 )
+  sys.exit(1)
 
-targetScriptsPath = os.path.join( rootPath, "scripts" )
-pythonScriptRE = re.compile( "(.*/)*([a-z]+-[a-zA-Z0-9-]+|[a-z]+_[a-zA-Z0-9_]+|d[a-zA-Z0-9-]+).py$" )
+targetScriptsPath = os.path.join(rootPath, "scripts")
+pythonScriptRE = re.compile("(.*/)*([a-z]+-[a-zA-Z0-9-]+|[a-z]+_[a-zA-Z0-9_]+|d[a-zA-Z0-9-]+).py$")
 print "Scripts will be deployed at %s" % targetScriptsPath
 
-if not os.path.isdir( targetScriptsPath ):
-  os.mkdir( targetScriptsPath )
+if not os.path.isdir(targetScriptsPath):
+  os.mkdir(targetScriptsPath)
 
 
 # DIRAC scripts need to be treated first, so that its scripts
 # can be overwritten by the extensions
-listDir = os.listdir( rootPath )
+listDir = os.listdir(rootPath)
 if 'DIRAC' in listDir:  # should always be true...
-  listDir.remove( 'DIRAC' )
-  listDir.insert( 0, 'DIRAC' )
+  listDir.remove('DIRAC')
+  listDir.insert(0, 'DIRAC')
 
 for rootModule in listDir:
-  modulePath = os.path.join( rootPath, rootModule )
-  if not os.path.isdir( modulePath ):
+  modulePath = os.path.join(rootPath, rootModule)
+  if not os.path.isdir(modulePath):
     continue
-  extSuffixPos = rootModule.find( moduleSuffix )
-  if extSuffixPos == -1 or extSuffixPos != len( rootModule ) - len( moduleSuffix ):
+  extSuffixPos = rootModule.find(moduleSuffix)
+  if extSuffixPos == -1 or extSuffixPos != len(rootModule) - len(moduleSuffix):
     continue
   print "Inspecting %s module" % rootModule
-  scripts = lookForScriptsInPath( modulePath, rootModule )
+  scripts = lookForScriptsInPath(modulePath, rootModule)
   for script in scripts:
     scriptPath = script[0]
     scriptName = script[1]
     if scriptName in excludeMask:
       continue
-    scriptLen = len( scriptName )
-    if scriptName not in simpleCopyMask and pythonScriptRE.match( scriptName ):
-      newScriptName = scriptName[:-3].replace( '_', '-' )
+    scriptLen = len(scriptName)
+    if scriptName not in simpleCopyMask and pythonScriptRE.match(scriptName):
+      newScriptName = scriptName[:-3].replace('_', '-')
       if DEBUG:
-        print " Wrapping %s as %s" % ( scriptName, newScriptName )
-      fakeScriptPath = os.path.join( targetScriptsPath, newScriptName )
+        print " Wrapping %s as %s" % (scriptName, newScriptName)
+      fakeScriptPath = os.path.join(targetScriptsPath, newScriptName)
 
       # We may overwrite already existing links (in extension for example)
       # os.symlink will not allow that, so remove the existing first
@@ -98,23 +100,23 @@ for rootModule in listDir:
       # Create the symlink
       os.symlink(os.path.abspath(scriptPath), fakeScriptPath)
 
-      os.chmod( fakeScriptPath, gDefaultPerms )
+      os.chmod(fakeScriptPath, gDefaultPerms)
     else:
       if DEBUG:
         print " Copying %s" % scriptName
-      shutil.copy( os.path.join( rootPath, scriptPath ), targetScriptsPath )
-      copyPath = os.path.join( targetScriptsPath, scriptName )
+      shutil.copy(os.path.join(rootPath, scriptPath), targetScriptsPath)
+      copyPath = os.path.join(targetScriptsPath, scriptName)
       if platform.system() == 'Darwin':
-        with open( copyPath, 'r+' ) as script:
+        with open(copyPath, 'r+') as script:
           scriptStr = script.read()
-          script.seek( 0 )
-      os.chmod( copyPath, gDefaultPerms )
-      cLen = len( copyPath )
-      reFound = pythonScriptRE.match( copyPath )
+          script.seek(0)
+      os.chmod(copyPath, gDefaultPerms)
+      cLen = len(copyPath)
+      reFound = pythonScriptRE.match(copyPath)
       if reFound:
-        pathList = list( reFound.groups() )
-        pathList[-1] = pathList[-1].replace( '_', '-' )
-        destPath = "".join( pathList )
+        pathList = list(reFound.groups())
+        pathList[-1] = pathList[-1].replace('_', '-')
+        destPath = "".join(pathList)
         if DEBUG:
-          print " Renaming %s as %s" % ( copyPath, destPath )
-        os.rename( copyPath, destPath )
+          print " Renaming %s as %s" % (copyPath, destPath)
+        os.rename(copyPath, destPath)


### PR DESCRIPTION
It seems to me that this python wrapper that dirac-deploy-script currently creates is totally useless. 
This PR keeps the same logic for exploring, finding and renaming the scripts, but just does a symlink. 
I've put the autoformat in a separate commit to ease the comments 

BEGINRELEASENOTES

*Core
FIX: dirac-deploy-scripts uses correct regex to find scripts
CHANGE: dirac-deploy-scripts uses symplink instead of wrapper

ENDRELEASENOTES
