### PR TITLE
[v6r21] dirac-deploy-scripts can generate symlink

### DIFF
--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -3,7 +3,7 @@
 Deploy all scripts and extensions
 Options:
  * --symlink: this will create symlinks instead of wrappers
- * <python path>: you can specify the folder where your pythin installation should be fetched from
+ * <python path>: you can specify the folder where your python installation should be fetched from
                   to replace the shebang
 """
 __RCSID__ = "$Id$"

--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -20,14 +20,14 @@ DEBUG = False
 
 moduleSuffix = "DIRAC"
 gDefaultPerms = stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
-excludeMask = [ '__init__.py' ]
-simpleCopyMask = [ os.path.basename( __file__ ),
-                   'dirac-compile-externals.py',
-                   'dirac-install.py',
-                   'dirac-platform.py',
-                   'dirac_compile_externals.py',
-                   'dirac_install.py',
-                   'dirac_platform.py']
+excludeMask = ['__init__.py']
+simpleCopyMask = [os.path.basename(__file__),
+                  'dirac-compile-externals.py',
+                  'dirac-install.py',
+                  'dirac-platform.py',
+                  'dirac_compile_externals.py',
+                  'dirac_install.py',
+                  'dirac_platform.py']
 
 wrapperTemplate = """#!$PYTHONLOCATION$
 #
@@ -87,9 +87,9 @@ else:
 
 # Python interpreter location can be specified as an argument
 pythonLocation = "/usr/bin/env python"
-if len( sys.argv ) == 2:
-  pythonLocation = os.path.join( sys.argv[1], 'bin', 'python' )
-wrapperTemplate = wrapperTemplate.replace( '$PYTHONLOCATION$', pythonLocation )
+if len(sys.argv) == 2:
+  pythonLocation = os.path.join(sys.argv[1], 'bin', 'python')
+wrapperTemplate = wrapperTemplate.replace('$PYTHONLOCATION$', pythonLocation)
 
 # On the newest MacOS the DYLD_LIBRARY_PATH variable is not passed to the shell of
 # the os.system() due to System Integrity Protection feature
@@ -102,87 +102,89 @@ else:
 sys.exit( os.system('python "%s"%s' % ( DiracScript, args )  ) / 256 )
 """
 
-def lookForScriptsInPath( basePath, rootModule ):
-  isScriptsDir = os.path.split( rootModule )[1] == "scripts"
+
+def lookForScriptsInPath(basePath, rootModule):
+  isScriptsDir = os.path.split(rootModule)[1] == "scripts"
   scriptFiles = []
-  for entry in os.listdir( basePath ):
-    absEntry = os.path.join( basePath, entry )
-    if os.path.isdir( absEntry ):
-      scriptFiles.extend( lookForScriptsInPath( absEntry, os.path.join( rootModule, entry ) ) )
-    elif isScriptsDir and os.path.isfile( absEntry ):
-      scriptFiles.append( ( os.path.join( rootModule, entry ), entry ) )
+  for entry in os.listdir(basePath):
+    absEntry = os.path.join(basePath, entry)
+    if os.path.isdir(absEntry):
+      scriptFiles.extend(lookForScriptsInPath(absEntry, os.path.join(rootModule, entry)))
+    elif isScriptsDir and os.path.isfile(absEntry):
+      scriptFiles.append((os.path.join(rootModule, entry), entry))
   return scriptFiles
 
-def findDIRACRoot( path ):
-  dirContents = os.listdir( path )
-  if 'DIRAC' in dirContents and os.path.isdir( os.path.join( path, 'DIRAC' ) ):
+
+def findDIRACRoot(path):
+  dirContents = os.listdir(path)
+  if 'DIRAC' in dirContents and os.path.isdir(os.path.join(path, 'DIRAC')):
     return path
-  parentPath = os.path.dirname( path )
-  if parentPath == path or len( parentPath ) == 1:
+  parentPath = os.path.dirname(path)
+  if parentPath == path or len(parentPath) == 1:
     return False
-  return findDIRACRoot( os.path.dirname( path ) )
+  return findDIRACRoot(os.path.dirname(path))
 
 
-rootPath = findDIRACRoot( os.path.dirname( os.path.realpath( __file__ ) ) )
+rootPath = findDIRACRoot(os.path.dirname(os.path.realpath(__file__)))
 if not rootPath:
   print "Error: Cannot find DIRAC root!"
-  sys.exit( 1 )
+  sys.exit(1)
 
-targetScriptsPath = os.path.join( rootPath, "scripts" )
-pythonScriptRE = re.compile( "(.*/)*([a-z]+-[a-zA-Z0-9-]+|[a-z]+_[a-zA-Z0-9_]+|d[a-zA-Z0-9-]+).py" )
+targetScriptsPath = os.path.join(rootPath, "scripts")
+pythonScriptRE = re.compile("(.*/)*([a-z]+-[a-zA-Z0-9-]+|[a-z]+_[a-zA-Z0-9_]+|d[a-zA-Z0-9-]+).py")
 print "Scripts will be deployed at %s" % targetScriptsPath
 
-if not os.path.isdir( targetScriptsPath ):
-  os.mkdir( targetScriptsPath )
+if not os.path.isdir(targetScriptsPath):
+  os.mkdir(targetScriptsPath)
 
 
 # DIRAC scripts need to be treated first, so that its scripts
 # can be overwritten by the extensions
-listDir = os.listdir( rootPath )
+listDir = os.listdir(rootPath)
 if 'DIRAC' in listDir:  # should always be true...
-  listDir.remove( 'DIRAC' )
-  listDir.insert( 0, 'DIRAC' )
+  listDir.remove('DIRAC')
+  listDir.insert(0, 'DIRAC')
 
 for rootModule in listDir:
-  modulePath = os.path.join( rootPath, rootModule )
-  if not os.path.isdir( modulePath ):
+  modulePath = os.path.join(rootPath, rootModule)
+  if not os.path.isdir(modulePath):
     continue
-  extSuffixPos = rootModule.find( moduleSuffix )
-  if extSuffixPos == -1 or extSuffixPos != len( rootModule ) - len( moduleSuffix ):
+  extSuffixPos = rootModule.find(moduleSuffix)
+  if extSuffixPos == -1 or extSuffixPos != len(rootModule) - len(moduleSuffix):
     continue
   print "Inspecting %s module" % rootModule
-  scripts = lookForScriptsInPath( modulePath, rootModule )
+  scripts = lookForScriptsInPath(modulePath, rootModule)
   for script in scripts:
     scriptPath = script[0]
     scriptName = script[1]
     if scriptName in excludeMask:
       continue
-    scriptLen = len( scriptName )
-    if scriptName not in simpleCopyMask and pythonScriptRE.match( scriptName ):
-      newScriptName = scriptName[:-3].replace( '_', '-' )
+    scriptLen = len(scriptName)
+    if scriptName not in simpleCopyMask and pythonScriptRE.match(scriptName):
+      newScriptName = scriptName[:-3].replace('_', '-')
       if DEBUG:
-        print " Wrapping %s as %s" % ( scriptName, newScriptName )
-      fakeScriptPath = os.path.join( targetScriptsPath, newScriptName )
-      with open( fakeScriptPath, "w" ) as fd:
-        fd.write( wrapperTemplate.replace( '$SCRIPTLOCATION$', scriptPath ) )
-      os.chmod( fakeScriptPath, gDefaultPerms )
+        print " Wrapping %s as %s" % (scriptName, newScriptName)
+      fakeScriptPath = os.path.join(targetScriptsPath, newScriptName)
+      with open(fakeScriptPath, "w") as fd:
+        fd.write(wrapperTemplate.replace('$SCRIPTLOCATION$', scriptPath))
+      os.chmod(fakeScriptPath, gDefaultPerms)
     else:
       if DEBUG:
         print " Copying %s" % scriptName
-      shutil.copy( os.path.join( rootPath, scriptPath ), targetScriptsPath )
-      copyPath = os.path.join( targetScriptsPath, scriptName )
+      shutil.copy(os.path.join(rootPath, scriptPath), targetScriptsPath)
+      copyPath = os.path.join(targetScriptsPath, scriptName)
       if platform.system() == 'Darwin':
-        with open( copyPath, 'r+' ) as script:
+        with open(copyPath, 'r+') as script:
           scriptStr = script.read()
-          script.seek( 0 )
-          script.write( scriptStr.replace( '/usr/bin/env python', pythonLocation ) )
-      os.chmod( copyPath, gDefaultPerms )
-      cLen = len( copyPath )
-      reFound = pythonScriptRE.match( copyPath )
+          script.seek(0)
+          script.write(scriptStr.replace('/usr/bin/env python', pythonLocation))
+      os.chmod(copyPath, gDefaultPerms)
+      cLen = len(copyPath)
+      reFound = pythonScriptRE.match(copyPath)
       if reFound:
-        pathList = list( reFound.groups() )
-        pathList[-1] = pathList[-1].replace( '_', '-' )
-        destPath = "".join( pathList )
+        pathList = list(reFound.groups())
+        pathList[-1] = pathList[-1].replace('_', '-')
+        destPath = "".join(pathList)
         if DEBUG:
-          print " Renaming %s as %s" % ( copyPath, destPath )
-        os.rename( copyPath, destPath )
+          print " Renaming %s as %s" % (copyPath, destPath)
+        os.rename(copyPath, destPath)

--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -131,7 +131,7 @@ if not rootPath:
   sys.exit(1)
 
 targetScriptsPath = os.path.join(rootPath, "scripts")
-pythonScriptRE = re.compile("(.*/)*([a-z]+-[a-zA-Z0-9-]+|[a-z]+_[a-zA-Z0-9_]+|d[a-zA-Z0-9-]+).py")
+pythonScriptRE = re.compile("(.*/)*([a-z]+-[a-zA-Z0-9-]+|[a-z]+_[a-zA-Z0-9_]+|d[a-zA-Z0-9-]+).py$")
 print "Scripts will be deployed at %s" % targetScriptsPath
 
 if not os.path.isdir(targetScriptsPath):

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -196,6 +196,7 @@ class Params(object):
     self.externalVersion = ""
     self.cleanPYTHONPATH = False
     self.createLink = False
+    self.scriptSymlink = False
 
 
 cliParams = Params()
@@ -1657,7 +1658,8 @@ cmdOpts = (('r:', 'release=', 'Release version to install'),
            ('x:', 'external=', 'external version'),
            ('  ', 'cleanPYTHONPATH', 'Only use the DIRAC PYTHONPATH (for pilots installation)'),
            ('  ', 'createLink', 'create version symbolic link from the versions directory. This is equivalent to the \
-           following command: ln -s /opt/dirac/versions/vArBpC vArBpC')
+           following command: ln -s /opt/dirac/versions/vArBpC vArBpC'),
+           ('  ', 'scriptSymlink', 'Symlink the scripts instead of creating wrapper')
            )
 
 
@@ -1803,6 +1805,8 @@ def loadConfiguration():
       cliParams.cleanPYTHONPATH = True
     elif o == '--createLink':
       cliParams.createLink = True
+    elif o == '--scriptSymlink':
+      cliParams.scriptSymlink = True
 
   if not cliParams.release and not cliParams.modules:
     logERROR("Missing release to install")
@@ -2532,6 +2536,11 @@ if __name__ == "__main__":
                                  "scripts", "dirac_deploy_scripts.py")
     if os.path.isfile(ddeLocation):
       cmd = ddeLocation
+
+      # if specified, create symlink instead of wrapper.
+      if cliParams.scriptSymlink:
+        cmd += ' --symlink'
+
       # In MacOS /usr/bin/env does not find python in the $PATH, passing binary path
       # as an argument to the dirac-deploy-scripts
       if not cliParams.platform:
@@ -2540,6 +2549,7 @@ if __name__ == "__main__":
         binaryPath = os.path.join(cliParams.targetPath, cliParams.platform)
         logNOTICE("For MacOS (Darwin) use explicit binary path %s" % binaryPath)
         cmd += ' %s' % binaryPath
+
       os.system(cmd)
     else:
       logDEBUG("No dirac-deploy-scripts found. This doesn't look good")


### PR DESCRIPTION
Replaces https://github.com/DIRACGrid/DIRAC/pull/4039

BEGINRELEASENOTES
*Core
FIX: dirac-deploy-scripts uses correct regex to find scripts
NEW: dirac-deploy-scripts can use symplink instead of wrapper


ENDRELEASENOTES
