### PR TITLE
[v6r22] Pilot wrapper for pilot3: download files at runtime

### DIFF
--- a/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
+++ b/WorkloadManagementSystem/Agent/MultiProcessorSiteDirector.py
@@ -59,7 +59,7 @@ class MultiProcessorSiteDirector(SiteDirector):
 
     return S_OK()
 
-  def submitJobs(self):
+  def submitPilots(self):
     """ Go through defined computing elements and submit jobs if necessary
     """
 

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -119,7 +119,7 @@ class SiteDirector(AgentModule):
     self.sendAccounting = True
 
     self.pilot3 = False
-    self.pilotFiles = []
+    self.pilotFiles = []  # files whose content will be compressed and sent together with the pilot wrapper
 
     self.siteClient = None
     self.rssClient = None
@@ -272,12 +272,8 @@ class SiteDirector(AgentModule):
     self.firstPass = False
 
     # which files to send in the pilotWrapper?
-    if self.pilot3:
-      # this is a standard location, as done by the PilotCS2JSONSynchronizer
-      pilotFilesLocation = os.path.join(Operations().getValue("Pilot/pilotFileServer"), 'pilot/pilot.tar')
-      self.pilotFiles = getPilotFiles(pilotFilesDir=self.am_getWorkDirectory(),
-                                      pilotFilesLocation=pilotFilesLocation)
-    else:
+    if not self.pilot3:
+      # If it's pilot 3, nothing will be sent: the wrapper will get them all
       self.pilotFiles = DIRAC_MODULES + [DIRAC_PILOT]
 
     return S_OK()

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -478,7 +478,7 @@ class SiteDirector(AgentModule):
     # From here on we assume we are going to (try to) submit some pilots
     self.log.debug("Going to try to submit some pilots")
 
-    self.log.verbose("Queues treated", "%s" % ','.join(self.queueDict))
+    self.log.verbose("Queues treated", ','.join(self.queueDict))
 
     self.totalSubmittedPilots = 0
 
@@ -487,7 +487,7 @@ class SiteDirector(AgentModule):
 
     for queueName, queueDictionary in queueDictItems:
       # now submitting to the single queues
-      self.log.verbose("Evaluating queue", "%s" % queueName)
+      self.log.verbose("Evaluating queue", queueName)
 
       # are we going to submit pilots to this specific queue?
       if not self._allowedToSubmit(queueName, anySite, jobSites, testSites):

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -40,7 +40,7 @@ from DIRAC.WorkloadManagementSystem.Client.MatcherClient import MatcherClient
 from DIRAC.WorkloadManagementSystem.Client.ServerUtils import pilotAgentsDB
 from DIRAC.WorkloadManagementSystem.Service.WMSUtilities import getGridEnv
 from DIRAC.WorkloadManagementSystem.private.ConfigHelper import findGenericPilotCredentials
-from DIRAC.WorkloadManagementSystem.Utilities.PilotWrapper import pilotWrapperScript, getPilotFiles,\
+from DIRAC.WorkloadManagementSystem.Utilities.PilotWrapper import pilotWrapperScript, \
     _writePilotWrapperFile, getPilotFilesCompressedEncodedDict
 from DIRAC.Resources.Computing.ComputingElementFactory import ComputingElementFactory
 from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
@@ -1170,10 +1170,14 @@ class SiteDirector(AgentModule):
     except BaseException as be:
       self.log.exception("Exception during pilot modules files compression", lException=be)
 
+    location = ''
+    if self.pilot3:
+      location = Operations().getValue("Pilot/pilotFileServer")
     localPilot = pilotWrapperScript(pilotFilesCompressedEncodedDict=pilotFilesCompressedEncodedDict,
                                     pilotOptions=pilotOptions,
                                     pilotExecDir=pilotExecDir,
-                                    envVariables=envVariables)
+                                    envVariables=envVariables,
+                                    location=location)
 
     return _writePilotWrapperFile(workingDirectory=workingDirectory, localPilot=localPilot)
 

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -4,7 +4,6 @@
 
     The main client of this module is the SiteDirector, that invokes the functions here more or less like this::
 
-        pilotFiles = getPilotFiles()
         pilotFilesCompressedEncodedDict = getPilotFilesCompressedEncodedDict(pilotFiles)
         localPilot = pilotWrapperScript(pilotFilesCompressedEncodedDict,
                                         pilotOptions,
@@ -16,73 +15,13 @@
 import os
 import tempfile
 import shutil
-import tarfile
 import json
 import base64
 import bz2
 
-from cStringIO import StringIO
-
 import requests
 
-
-def pilotWrapperScript(pilotFilesCompressedEncodedDict=None,
-                       pilotOptions='',
-                       pilotExecDir='',
-                       envVariables=None):
-  """ Returns the content of the pilot wrapper script.
-
-      The pilot wrapper script is a bash script that invokes the system python. Linux only.
-
-     :param pilotFilesCompressedEncodedDict: this is a possible dict of name:compressed+encoded content files.
-                        the proxy can be part of this, and of course the pilot files
-     :type pilotFilesCompressedEncodedDict: dict
-     :param pilotOptions: options with which to start the pilot
-     :type pilotOptions: basestring
-     :param pilotExecDir: pilot execution directory
-     :type pilotExecDir: basestring
-
-     :returns: content of the pilot wrapper
-     :rtype: basestring
-  """
-
-  if pilotFilesCompressedEncodedDict is None:
-    pilotFilesCompressedEncodedDict = {}
-
-  if envVariables is None:
-    envVariables = {}
-
-  mString = ""
-  for pfName, encodedPf in pilotFilesCompressedEncodedDict.iteritems():  # are there some pilot files to unpack?
-                                                                         # then we create the unpacking string
-    mString += """
-try:
-  with open('%(pfName)s', 'w') as fd:
-    fd.write(bz2.decompress(base64.b64decode(\"\"\"%(encodedPf)s\"\"\")))
-  os.chmod('%(pfName)s', stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
-except BaseException as x:
-  print >> sys.stderr, x
-  shutil.rmtree(pilotWorkingDirectory)
-  sys.exit(-1)
-""" % {'encodedPf': encodedPf,
-       'pfName': pfName}
-
-  envVariablesString = ""
-  for name, value in envVariables.iteritems():  # are there some environment variables to add?
-    envVariablesString += """
-os.environ[\"%(name)s\"]=\"%(value)s\"
-""" % {'name': name,
-       'value': value}
-
-  mString = mString + envVariablesString
-
-  # add X509_USER_PROXY to etablish pilot env in Cluster WNs
-  if 'proxy' in pilotFilesCompressedEncodedDict:
-    mString += """
-os.environ['X509_USER_PROXY'] = os.path.join(pilotWorkingDirectory, 'proxy')
-"""
-
-  localPilot = """#!/bin/bash
+pilotWrapperContent = """#!/bin/bash
 /usr/bin/env python << EOF
 
 # imports
@@ -123,13 +62,83 @@ pilotWorkingDirectory = tempfile.mkdtemp(suffix='pilot', prefix='DIRAC_', dir=pi
 pilotWorkingDirectory = os.path.realpath(pilotWorkingDirectory)
 os.chdir(pilotWorkingDirectory)
 logger.info("Launching dirac-pilot script from %%s" %%os.getcwd())
+"""
 
+
+def pilotWrapperScript(pilotFilesCompressedEncodedDict=None,
+                       pilotOptions='',
+                       pilotExecDir='',
+                       envVariables=None):
+  """ Returns the content of the pilot wrapper script.
+
+      The pilot wrapper script is a bash script that invokes the system python. Linux only.
+
+     :param pilotFilesCompressedEncodedDict: this is a possible dict of name:compressed+encoded content files.
+                        the proxy can be part of this, and of course the pilot files
+     :type pilotFilesCompressedEncodedDict: dict
+     :param pilotOptions: options with which to start the pilot
+     :type pilotOptions: basestring
+     :param pilotExecDir: pilot execution directory
+     :type pilotExecDir: basestring
+
+     :returns: content of the pilot wrapper
+     :rtype: basestring
+  """
+
+  if pilotFilesCompressedEncodedDict is None:
+    pilotFilesCompressedEncodedDict = {}
+
+  if envVariables is None:
+    envVariables = {}
+
+  compressedString = ""
+  for pfName, encodedPf in pilotFilesCompressedEncodedDict.iteritems():  # are there some pilot files to unpack?
+                                                                         # then we create the unpacking string
+    compressedString += """
+try:
+  with open('%(pfName)s', 'w') as fd:
+    fd.write(bz2.decompress(base64.b64decode(\"\"\"%(encodedPf)s\"\"\")))
+  os.chmod('%(pfName)s', stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+except BaseException as x:
+  print >> sys.stderr, x
+  shutil.rmtree(pilotWorkingDirectory)
+  sys.exit(-1)
+""" % {'encodedPf': encodedPf,
+       'pfName': pfName}
+
+  envVariablesString = ""
+  for name, value in envVariables.iteritems():  # are there some environment variables to add?
+    envVariablesString += """
+os.environ[\"%(name)s\"]=\"%(value)s\"
+""" % {'name': name,
+       'value': value}
+
+  # add X509_USER_PROXY to etablish pilot env in Cluster WNs
+  if 'proxy' in pilotFilesCompressedEncodedDict:
+    envVariablesString += """
+os.environ['X509_USER_PROXY'] = os.path.join(pilotWorkingDirectory, 'proxy')
+"""
+
+  # now building the actual pilot wrapper
+
+  localPilot = pilotWrapperContent % {'pilotExecDir': pilotExecDir}
+
+  if compressedString:
+    localPilot += """
 # unpacking lines
 logger.info("But first unpacking pilot files")
-%(mString)s
+%s
+""" % compressedString
 
+  if envVariablesString:
+    localPilot += """
+# Modifying the environment
+%s
+""" % envVariablesString
+
+  localPilot += """
 # now finally launching the pilot script (which should be called dirac-pilot.py)
-cmd = "python dirac-pilot.py %(pilotOptions)s"
+cmd = "python dirac-pilot.py %s"
 logger.info('Executing: %%s' %% cmd)
 sys.stdout.flush()
 os.system(cmd)
@@ -138,9 +147,7 @@ os.system(cmd)
 shutil.rmtree(pilotWorkingDirectory)
 
 EOF
-""" % {'mString': mString,
-       'pilotOptions': pilotOptions,
-       'pilotExecDir': pilotExecDir}
+""" % pilotOptions
 
   return localPilot
 
@@ -149,10 +156,10 @@ def getPilotFilesCompressedEncodedDict(pilotFiles, proxy=None):
   """ this function will return the dictionary of pilot files names : encodedCompressedContent
       that we are going to send
 
-     :param pilotFiles: list of pilot files
+     :param pilotFiles: list of pilot files (list of location on the disk)
      :type pilotFiles: list
-     :param proxy: proxy
-     :type proxy: basestring
+     :param proxy: the proxy to send
+     :type proxy: X509Chain
   """
   pilotFilesCompressedEncodedDict = {}
 
@@ -185,52 +192,3 @@ def _writePilotWrapperFile(workingDirectory=None, localPilot=''):
   with os.fdopen(fd, 'w') as pilotWrapper:
     pilotWrapper.write(localPilot)
   return name
-
-
-def getPilotFiles(pilotFilesDir=None, pilotFilesLocation=None):
-  """ get the pilot files to be sent in a local directory (this is for pilot3 files)
-
-     :param pilotFilesDir: the directory where to store the pilot files
-     :type pilotFilesDir: basestring
-     :param pilotFilesLocation: URL from where to the pilot files
-     :type pilotFilesLocation: basestring
-
-     :returns: list of pilot files (full path)
-     :rtype: list
-  """
-
-  if pilotFilesDir is None:
-    pilotFilesDir = os.getcwd()
-
-  shutil.rmtree(pilotFilesDir)  # make sure it's empty
-  os.mkdir(pilotFilesDir)
-
-  # Default value is True such that if this value is
-  # not defined, we use the system CAs with requests
-  caPath = os.environ.get('X509_CERT_DIR', True)
-
-  # getting the pilot files
-  if pilotFilesLocation.startswith('http'):
-    res = requests.get(pilotFilesLocation, verify=caPath)
-    if res.status_code != 200:
-      raise IOError(res.text)
-    fileObj = StringIO(res.content)
-    tar = tarfile.open(fileobj=fileObj)
-
-    res = requests.get(os.path.join(os.path.dirname(pilotFilesLocation), 'pilot.json'), verify=caPath)
-    if res.status_code != 200:
-      raise IOError(res.text)
-    jsonCFG = res.json()
-  else:  # maybe it's just a local file
-    tar = tarfile.open(os.path.basename(pilotFilesLocation))
-
-  tar.extractall(pilotFilesDir)
-  with open(os.path.join(pilotFilesDir, 'pilot.json'), 'w') as fd:
-    json.dump(jsonCFG, fd)
-
-  # excluding some files that might got in
-  pilotFiles = [pf for pf in os.listdir(pilotFilesDir) if pf not in ['__init__.py', 'dirac-install.py']]
-  pilotFiles = [pf for pf in pilotFiles if pf.endswith('.py') or pf.endswith('.json')]
-  pilotFiles = [os.path.join(pilotFilesDir, pf) for pf in pilotFiles]
-
-  return pilotFiles

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
@@ -7,99 +7,74 @@ import os
 import base64
 import bz2
 
-import unittest
-
 from DIRAC.WorkloadManagementSystem.Utilities.PilotWrapper import pilotWrapperScript
 
 
-class PilotWrapperTestCase(unittest.TestCase):
-  """ Base class for the Agents test cases
+def test_scriptEmpty():
+  """ test script creation
+  """
+  res = pilotWrapperScript()
+
+  assert 'cmd = "python dirac-pilot.py "' in res
+  assert 'os.environ["someName"]="someValue"' not in res
+
+
+def test_scriptoptions():
+  """ test script creation
   """
 
-  def setUp(self):
-    pass
+  res = pilotWrapperScript(
+      pilotFilesCompressedEncodedDict={'dirac-install.py': 'someContentOfDiracInstall',
+                                       'someOther.py': 'someOtherContent'},
+      pilotOptions="-c 123 --foo bar")
 
-  def tearDown(self):
-    pass
-
-
-class PilotWrapperTestCaseCreation(PilotWrapperTestCase):
-
-  def test_scriptEmpty(self):
-    """ test script creation
-    """
-    res = pilotWrapperScript()
-
-    self.assertTrue('cmd = "python dirac-pilot.py "' in res)
-    self.assertTrue('os.environ["someName"]="someValue"' not in res)
-
-  def test_scriptoptions(self):
-    """ test script creation
-    """
-
-    res = pilotWrapperScript(
-        pilotFilesCompressedEncodedDict={'dirac-install.py': 'someContentOfDiracInstall',
-                                         'someOther.py': 'someOtherContent'},
-        pilotOptions="-c 123 --foo bar")
-
-    self.assertTrue("with open('dirac-install.py', 'w') as fd:" in res)
-    self.assertTrue('os.environ["someName"]="someValue"' not in res)
-
-  def test_scriptReal(self):
-    """ test script creation
-    """
-    diracInstall = os.path.join(os.getcwd(), 'Core/scripts/dirac-install.py')
-    with open(diracInstall, "r") as fd:
-      diracInstall = fd.read()
-    diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9))
-
-    diracPilot = os.path.join(os.getcwd(), 'WorkloadManagementSystem/PilotAgent/dirac-pilot.py')
-    with open(diracPilot, "r") as fd:
-      diracPilot = fd.read()
-    diracPilotEncoded = base64.b64encode(bz2.compress(diracPilot, 9))
-
-    diracPilotTools = os.path.join(os.getcwd(), 'WorkloadManagementSystem/PilotAgent/pilotTools.py')
-    with open(diracPilotTools, "r") as fd:
-      diracPilotTools = fd.read()
-    diracPilotToolsEncoded = base64.b64encode(bz2.compress(diracPilotTools, 9))
-
-    diracPilotCommands = os.path.join(os.getcwd(), 'WorkloadManagementSystem/PilotAgent/pilotCommands.py')
-    with open(diracPilotCommands, "r") as fd:
-      diracPilotCommands = fd.read()
-    diracPilotCommandsEncoded = base64.b64encode(bz2.compress(diracPilotCommands, 9))
-
-    res = pilotWrapperScript(
-        pilotFilesCompressedEncodedDict={'dirac-install.py': diracInstallEncoded,
-                                         'dirac-pilot.py': diracPilotEncoded,
-                                         'pilotTools.py': diracPilotToolsEncoded,
-                                         'pilotCommands.py': diracPilotCommandsEncoded},
-        pilotOptions="-c 123 --foo bar")
-
-    self.assertTrue("with open('dirac-pilot.py', 'w') as fd:" in res)
-    self.assertTrue("with open('dirac-install.py', 'w') as fd:" in res)
-    self.assertTrue('os.environ["someName"]="someValue"' not in res)
-
-  def test_scriptWithEnvVars(self):
-    """ test script creation
-    """
-    res = pilotWrapperScript(
-        pilotFilesCompressedEncodedDict={'dirac-install.py': 'someContentOfDiracInstall',
-                                         'someOther.py': 'someOtherContent'},
-        pilotOptions="-c 123 --foo bar",
-        envVariables={'someName': 'someValue',
-                      'someMore': 'oneMore'})
-
-    self.assertTrue('os.environ["someName"]="someValue"' in res)
+  assert "with open('dirac-install.py', 'w') as fd:" in res
+  assert 'os.environ["someName"]="someValue"' not in res
 
 
-#############################################################################
-# Test Suite run
-#############################################################################
+def test_scriptReal():
+  """ test script creation
+  """
+  diracInstall = os.path.join(os.getcwd(), 'Core/scripts/dirac-install.py')
+  with open(diracInstall, "r") as fd:
+    diracInstall = fd.read()
+  diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9))
+
+  diracPilot = os.path.join(os.getcwd(), 'WorkloadManagementSystem/PilotAgent/dirac-pilot.py')
+  with open(diracPilot, "r") as fd:
+    diracPilot = fd.read()
+  diracPilotEncoded = base64.b64encode(bz2.compress(diracPilot, 9))
+
+  diracPilotTools = os.path.join(os.getcwd(), 'WorkloadManagementSystem/PilotAgent/pilotTools.py')
+  with open(diracPilotTools, "r") as fd:
+    diracPilotTools = fd.read()
+  diracPilotToolsEncoded = base64.b64encode(bz2.compress(diracPilotTools, 9))
+
+  diracPilotCommands = os.path.join(os.getcwd(), 'WorkloadManagementSystem/PilotAgent/pilotCommands.py')
+  with open(diracPilotCommands, "r") as fd:
+    diracPilotCommands = fd.read()
+  diracPilotCommandsEncoded = base64.b64encode(bz2.compress(diracPilotCommands, 9))
+
+  res = pilotWrapperScript(
+      pilotFilesCompressedEncodedDict={'dirac-install.py': diracInstallEncoded,
+                                       'dirac-pilot.py': diracPilotEncoded,
+                                       'pilotTools.py': diracPilotToolsEncoded,
+                                       'pilotCommands.py': diracPilotCommandsEncoded},
+      pilotOptions="-c 123 --foo bar")
+
+  assert "with open('dirac-pilot.py', 'w') as fd:" in res
+  assert "with open('dirac-install.py', 'w') as fd:" in res
+  assert 'os.environ["someName"]="someValue"' not in res
 
 
-if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase(PilotWrapperTestCase)
-  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(PilotWrapperTestCaseCreation))
-  testResult = unittest.TextTestRunner(verbosity=2).run(suite)
+def test_scriptWithEnvVars():
+  """ test script creation
+  """
+  res = pilotWrapperScript(
+      pilotFilesCompressedEncodedDict={'dirac-install.py': 'someContentOfDiracInstall',
+                                       'someOther.py': 'someOtherContent'},
+      pilotOptions="-c 123 --foo bar",
+      envVariables={'someName': 'someValue',
+                    'someMore': 'oneMore'})
 
-# EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#
+  assert 'os.environ["someName"]="someValue"' in res

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
@@ -78,3 +78,17 @@ def test_scriptWithEnvVars():
                     'someMore': 'oneMore'})
 
   assert 'os.environ["someName"]="someValue"' in res
+
+
+def test_scriptPilot3():
+  """ test script creation
+  """
+  res = pilotWrapperScript(
+      pilotFilesCompressedEncodedDict={'proxy': 'thisIsSomeProxy'},
+      pilotOptions="-c 123 --foo bar",
+      envVariables={'someName': 'someValue',
+                    'someMore': 'oneMore'},
+      location='lhcb-portal.cern.ch')
+
+  assert 'os.environ["someName"]="someValue"' in res
+  assert 'lhcb-portal.cern.ch' in res

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,13 @@ git+https://:@gitlab.cern.ch:8443/fts/fts-rest.git#egg=fts3
 git+https://github.com/DIRACGrid/pyGSI.git#egg=GSI
 
 # From pypi
+M2Crypto==0.32
 autopep8==1.3.3
 certifi
-CMRESHandler>=1.0.0b4
 coverage
 codecov
-elasticsearch-dsl>=2.0.0
+elasticsearch-dsl~=6.3.1
+CMRESHandler>=1.0.0b4
 funcsigs
 futures
 GitPython>=2.1.0


### PR DESCRIPTION
I modified the pilot wrapper so that it now makes different things depending if it's pilot 2 (still the default) or pilot 3. For pilot 2 nothing changes. For pilot 3 the input files (.py and .json) will be downloaded at run time. This may be improved with time.

@atsareg : VMDIRAC should maybe invoke the method `pilotWrapperScript` in the PilotWrapper.py module to get pilot wrapper to be used there. I think what's used in VMDIRAC is https://github.com/DIRACGrid/VMDIRAC/blob/integration/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot and IIUC it's pilot 2.


BEGINRELEASENOTES

*WMS
CHANGE: Pilot wrapper for pilot3: download files at runtime

ENDRELEASENOTES
