### PR TITLE
[v6r21] Minor WMS fixes

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -974,6 +974,7 @@ class SiteDirector(AgentModule):
         else:
           maxWaitingJobs = int(self.queueDict[queue]['ParametersDict'].get('MaxWaitingJobs', 10))
           maxTotalJobs = int(self.queueDict[queue]['ParametersDict'].get('MaxTotalJobs', 10))
+          waitingToRunningRatio = float(self.queueDict[queue]['ParametersDict'].get('WaitingToRunningRatio', 0.0))
           waitingJobs = 0
           totalJobs = 0
           if jobIDList:
@@ -990,6 +991,8 @@ class SiteDirector(AgentModule):
               runningJobs = totalJobs - waitingJobs
               self.log.info("PilotAgentsDB report(%s_%s): Wait=%d, Run=%d, Max=%d" %
                             (ceName, queueName, waitingJobs, runningJobs, maxTotalJobs))
+              maxWaitingJobs = int(max(maxWaitingJobs, runningJobs * waitingToRunningRatio))
+
           totalSlots = min((maxTotalJobs - totalJobs), (maxWaitingJobs - waitingJobs))
           self.queueSlots[queue]['AvailableSlots'] = max(totalSlots, 0)
 

--- a/WorkloadManagementSystem/Client/Matcher.py
+++ b/WorkloadManagementSystem/Client/Matcher.py
@@ -311,11 +311,12 @@ class Matcher(object):
         vo = resourceDict.get('VirtualOrganization', '')
       else:
         vo = Registry.getVOForGroup(credDict['group'])
-      result = Registry.getGroupsForVO(vo)
-      if result['OK']:
-        resourceDict['OwnerGroup'] = result['Value']
-      else:
-        raise RuntimeError(result['Message'])
+      if 'OwnerGroup' not in resourceDict:
+        result = Registry.getGroupsForVO(vo)
+        if result['OK']:
+          resourceDict['OwnerGroup'] = result['Value']
+        else:
+          raise RuntimeError(result['Message'])
     else:
       # If it's a private pilot, the DN has to be the same
       if Properties.PILOT in credDict['properties']:


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: SiteDirector - restore the logic of limiting the number of pilots to submit due to the  WaitingToRunningRatio option
FIX: Matcher - if a pilot presents OwnerGroup parameter in its description, this is interpreted as a pilot requirement to jobs and should not be overriden. 

ENDRELEASENOTES
