### PR TITLE
[v6r21] fix documentation warnings

### DIFF
--- a/docs/source/AdministratorGuide/CommandReference/index.rst
+++ b/docs/source/AdministratorGuide/CommandReference/index.rst
@@ -138,7 +138,6 @@ User convenience:
 .. toctree::
     :maxdepth: 2
     
-    dirac-accounting-report-cli
     dirac-accounting-decode-fileid
     dirac-cert-convert.sh
     dirac-myproxy-upload

--- a/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
+++ b/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
@@ -141,9 +141,9 @@ Setup the root password::
   Starting MySQL.
 
 
------------------------
+-------------------------
 Create the ``dirac`` user
------------------------
+-------------------------
 
 The user that will run the server will be ``dirac``. You can set a password for that user::
 

--- a/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
+++ b/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
@@ -285,18 +285,18 @@ At this point, you should find:
 
 * The CA in ``/opt/dirac/etc/grid-security/certificates``::
 
-  [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/certificates/
-  855f710d.0  ca.cert.pem
+    [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/certificates/
+    855f710d.0  ca.cert.pem
 
 * The host certificate (``hostcert.pem``) and key (``hostkey.pem``) in ``/opt/dirac/etc/grid-security``::
 
-  [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/
-  ca  certificates  hostcert.pem  hostkey.pem  openssl_config_host.cnf  request.csr.pem
+    [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/etc/grid-security/
+    ca  certificates  hostcert.pem  hostkey.pem  openssl_config_host.cnf  request.csr.pem
 
 * The user credentials for later in ``/opt/dirac/user/``::
 
-  [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/user/
-  client.key  client.pem  client.req  openssl_config_user.cnf
+    [dirac@dirac-tuto caUtilities]$ ls /opt/dirac/user/
+    client.key  client.pem  client.req  openssl_config_user.cnf
 
 --------------------
 Install DIRAC Server

--- a/docs/source/AdministratorGuide/Tutorials/diracSE.rst
+++ b/docs/source/AdministratorGuide/Tutorials/diracSE.rst
@@ -142,9 +142,11 @@ This file uploads ``/tmp/dummy.txt`` on the StorageElement, list the directory a
   {'OK': True, 'Value': {'Successful': {'/tutoVO': {'Files': {}, 'SubDirs': {}}}, 'Failed': {}}}
 
 
-.. note:: you might be getting the following message if you have no Accounting system. you can safely ignore it::
+.. note::
 
-    Error sending accounting record Cannot get URL for Accounting/DataStore in setup MyDIRAC-Production: RuntimeError('Option /DIRAC/Setups/MyDIRAC-Production/Accounting is not defined',)
+   You might be getting the following message if you have no Accounting system. You can safely ignore it::
+
+     Error sending accounting record Cannot get URL for Accounting/DataStore in setup MyDIRAC-Production\: RuntimeError('Option /DIRAC/Setups/MyDIRAC-Production/Accounting is not defined',)
 
 
 Adding a second DIRAC SE

--- a/docs/source/AdministratorGuide/Tutorials/installRMS.rst
+++ b/docs/source/AdministratorGuide/Tutorials/installRMS.rst
@@ -91,7 +91,7 @@ Let's replicate it to ``StorageElementTwo`` using the RMS::
   You can monitor requests' status using command: 'dirac-rms-request <requestName/ID>'
 
 
-The Request has a name (``myFirstRequest``) that we chose, but also an ID, returned by the system (here ````). The ID is guaranteed to be unique, while the name is not, so it is recommended to use the ID when you interact with the RMS. You can see the status of your Request, using its name or ID::
+The Request has a name (``myFirstRequest``) that we chose, but also an ID, returned by the system (here ``8``). The ID is guaranteed to be unique, while the name is not, so it is recommended to use the ID when you interact with the RMS. You can see the status of your Request, using its name or ID::
 
   [diracuser@dirac-tuto ~]$ dirac-rms-request myFirstRequest
   Request name='myFirstRequest' ID=8 Status='Waiting'


### PR DESCRIPTION
Just fixing some warnings that make the docs test in integration fail, but were introduced in v6r21
```
docs/source/AdministratorGuide/CommandReference/index.rst:135: WARNING: toctree contains reference to nonexisting document u'AdministratorGuide/CommandReference/dirac-accounting-report-cli'
docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst:144: WARNING: Title overline too short.

-----------------------
Create the ``dirac`` user
-----------------------
docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst:289: WARNING: Inconsistent literal block quoting.
docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst:294: WARNING: Inconsistent literal block quoting.
docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst:299: WARNING: Inconsistent literal block quoting.
docs/source/AdministratorGuide/Tutorials/diracSE.rst:147: WARNING: Literal block expected; none found.
docs/source/AdministratorGuide/Tutorials/installRMS.rst:94: WARNING: Inline literal start-string without end-string.
docs/source/AdministratorGuide/Tutorials/installRMS.rst:94: WARNING: Inline literal start-string without end-string.
```