### PR TITLE
[v6r21] Fix version of Ubuntu on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: trusty
 language: python
 python:
   - "2.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # From repo
-git+https://:@gitlab.cern.ch:8443/fts/fts-rest.git#egg=fts3
+fts3-rest
 git+https://github.com/DIRACGrid/pyGSI.git#egg=GSI
 
 # From pypi


### PR DESCRIPTION
Travis can run python tests on different versions of Ubuntu: xenial, trusty or precise. At present it switches between them, based on load and this results in slightly different testing behavior. This PR fixes the test environment to trusty 14.04 LTS, we can run only on this version due to fts3/pycurl requirements.

Please merge ASAP to v6r22 and integration.
