### PR TITLE
[v6r21] fix dirac os detection

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1822,7 +1822,8 @@ def loadConfiguration():
     except BaseException:
       pass
 
-  if not cliParams.diracOS and os.path.exists("%s/diracos" % cliParams.targetPath):
+  # If we are running an update, DIRACOS will be set in the environment
+  if not cliParams.diracOS and 'DIRACOS' in os.environ:
     logWARN("Forcing to install DIRACOS, because it is already installed!")
     cliParams.diracOS = True
 


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: better way of detecting whether DIRACOS was already installed 

ENDRELEASENOTES
