### PR TITLE
[v6r21] Adapt the SpaceToken SRM concept to non SRM storage

### DIFF
--- a/Core/Utilities/List.py
+++ b/Core/Utilities/List.py
@@ -5,6 +5,7 @@
 __RCSID__ = "$Id$"
 
 import random
+import sys
 random.seed()
 
 
@@ -125,3 +126,18 @@ def breakListIntoChunks(aList, chunkSize):
   if isinstance(aList, (set, dict, tuple)):
     aList = list(aList)
   return [chunk for chunk in getChunk(aList, chunkSize)]
+
+
+def getIndexInList(anItem, aList):
+  """ Return the index of the element x in the list l
+      or sys.maxint if it does not exist
+
+      :param anItem: element to look for
+      :param list aList: list to look into
+
+      :return: the index or sys.maxint
+  """
+  try:
+    return aList.index(anItem)
+  except ValueError:
+    return sys.maxsize

--- a/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
+++ b/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
@@ -84,10 +84,12 @@ class FreeDiskSpaceCommand(Command):
     occupancy = occupancyResult['Value']
     free = occupancy['Free']
     total = occupancy['Total']
+    spaceReservation = occupancy.get('SpaceReservation', '')
 
     results = {'Endpoint': endpointResult['Value'],
                'Free': free,
                'Total': total,
+               'SpaceReservation': spaceReservation,
                'ElementName': elementName}
     result = self._storeCommand(results)
     if not result['OK']:

--- a/ResourceStatusSystem/Utilities/CSHelpers.py
+++ b/ResourceStatusSystem/Utilities/CSHelpers.py
@@ -219,7 +219,16 @@ def getSEHost(seName):
 
 
 def getStorageElementEndpoint(seName):
-  """ Get endpoint as combination of host, port, wsurl
+  """ Get one endpoint of a StorageElement
+
+      Like all the rest of the methods here, they will need to adapt to an SRM free world.
+      This is planned for a future version. See https://github.com/DIRACGrid/DIRAC/issues/3908
+
+      :param seName: name of the storage element
+
+      :returns: for historical reasons, if the protocol is SRM, you get  'httpg://host:port/WSUrl'
+                For other protocols, you get :py:meth:`~DIRAC.Resources.Storage.StorageBase.StorageBase.getEndpoint`
+
   """
   seParameters = _getSEParameters(seName)
   if not seParameters['OK']:
@@ -237,7 +246,7 @@ def getStorageElementEndpoint(seName):
       url = url.replace('?SFN=', '')
       return S_OK(url)
   else:
-    return S_OK(seParameters['Value']['URLBase'])
+    return S_OK(seParameters['Value']['Endpoint'])
 
   return S_ERROR((host, port, wsurl))
 

--- a/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/Resources/Storage/GFAL2_SRM2Storage.py
@@ -212,5 +212,6 @@ class GFAL2_SRM2Storage(GFAL2_StorageBase):
 
     sTokenDict['Total'] = float(occupancyDict.get('totalsize', '0'))
     sTokenDict['Free'] = float(occupancyDict.get('unusedsize', '0'))
+    sTokenDict['SpaceReservation'] = self.protocolParameters['SpaceToken']
 
     return S_OK(sTokenDict)

--- a/Resources/Storage/StorageBase.py
+++ b/Resources/Storage/StorageBase.py
@@ -113,6 +113,8 @@ class StorageBase(object):
     parameterDict["StorageName"] = self.name
     parameterDict["PluginName"] = self.pluginName
     parameterDict['URLBase'] = self.getURLBase().get('Value', '')
+    parameterDict['Endpoint'] = self.getEndpoint().get('Value', '')
+
     return parameterDict
 
   def exists(self, *parms, **kws):
@@ -282,6 +284,18 @@ class StorageBase(object):
     urlDict = dict(self.protocolParameters)
     if not withWSUrl:
       urlDict['WSUrl'] = ''
+    return pfnunparse(urlDict, srmSpecific=self.srmSpecificParse)
+
+  def getEndpoint(self):
+    """ This will get endpoint of the storage. It basically is the same as :py:meth:`getURLBase`
+        but without the basePath
+
+    :returns: 'proto://hostname<:port>'
+
+    """
+    urlDict = dict(self.protocolParameters)
+    # We remove the basePath
+    urlDict['Path'] = ''
     return pfnunparse(urlDict, srmSpecific=self.srmSpecificParse)
 
   def isURL(self, path):

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -19,6 +19,7 @@ from functools import reduce
 from DIRAC import gLogger, gConfig, siteName
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Utilities.File import convertSizeUnits
+from DIRAC.Core.Utilities.List import getIndexInList
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR, returnSingleResult
 from DIRAC.Resources.Storage.StorageFactory import StorageFactory
 from DIRAC.Core.Utilities.Pfn import pfnparse
@@ -670,13 +671,13 @@ class StorageElementItem(object):
     # even if both can provide xroot
     sourceSEStorages = sorted(
         sourceSE.storages,
-        key=lambda x: self.__getIndexInList(
+        key=lambda x: getIndexInList(
             x.getParameters()['Protocol'],
             commonProtocols))
 
     selfStorages = sorted(
         self.storages,
-        key=lambda x: self.__getIndexInList(
+        key=lambda x: getIndexInList(
             x.getParameters()['Protocol'],
             commonProtocols))
 
@@ -795,7 +796,7 @@ class StorageElementItem(object):
       protocolList = list(protocols)
       commonProtocols = sorted(
           commonProtocols & set(protocolList),
-          key=lambda x: self.__getIndexInList(
+          key=lambda x: getIndexInList(
               x,
               protocolList))
 
@@ -967,21 +968,6 @@ class StorageElementItem(object):
 #     res['Failed'] = failed
     return res
 
-  @staticmethod
-  def __getIndexInList(x, l):
-    """ Return the index of the element x in the list l
-        or sys.maxint if it does not exist
-
-        :param x: element to look for
-        :param l: list to look int
-
-        :return: the index or sys.maxint
-    """
-    try:
-      return l.index(x)
-    except ValueError:
-      return sys.maxsize
-
   def __filterPlugins(self, methodName, protocols=None, inputProtocol=None):
     """ Determine the list of plugins that
         can be used for a particular action
@@ -1030,7 +1016,7 @@ class StorageElementItem(object):
 
       # The closest list for "OK" methods is the AccessProtocol preference, so we sort based on that
       pluginsToUse.sort(
-          key=lambda x: self.__getIndexInList(
+          key=lambda x: getIndexInList(
               x.protocolParameters['Protocol'],
               self.localAccessProtocolList))
       log.debug("Plugins to be used for %s: %s" %
@@ -1079,7 +1065,7 @@ class StorageElementItem(object):
 
     # sort the plugins according to the lists in the CS
     pluginsToUse.sort(
-        key=lambda x: self.__getIndexInList(
+        key=lambda x: getIndexInList(
             x.protocolParameters['Protocol'],
             allowedProtocols))
 

--- a/dirac.cfg
+++ b/dirac.cfg
@@ -283,6 +283,8 @@ Resources
        WriteAccess = True # Allowed for Write if no RSS enabled
        CheckAccess = True # Allowed for Check if no RSS enabled
        RemoveAccess = True # Allowed for Remove if no RSS enabled
+       OccupancyLFN = /lhcb/storageDetails.json # Json containing occupancy details
+       SpaceReservation = LHCb-EOS # Space reservation name if any. Concept like SpaceToken
        GFAL2_SRM2 # Protocol section, see  # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Storages/index.html#available-protocol-plugins
        {
          Host = srm-eoslhcb.cern.ch

--- a/docs/source/AdministratorGuide/Resources/Storage/index.rst
+++ b/docs/source/AdministratorGuide/Resources/Storage/index.rst
@@ -11,6 +11,7 @@ DIRAC provides an abstraction of a SE interface that allows to access different 
     CERN-USER
     {
       OccupancyLFN = /lhcb/spaceReport.json
+      SpaceReservation = LHCb_USER
       ReadAccess = Active
       WriteAccess = Active
       AccessProtocol.1
@@ -43,16 +44,17 @@ DIRAC provides an abstraction of a SE interface that allows to access different 
 
 Configuration options are:
 
-* `BackendType`: just used for information. No internal use at the moment
-* `SEType`: Can be `T0D1` or `T1D0` or `T1D1`. it is used to asses whether the SE is a tape SE or not. If the digit after `T` is `1`, then it is a tape.
-* `UseCatalogURL`: default `False`. If `True`, use the url stored in the catalog instead of regenerating it
-* `ChecksumType`: default `ADLER32`. NOT ACTIVE !
-* `Alias`: when set to the name of another storage element, it instanciates the other SE instead.
-* `ReadAccess`: default `True`. Allowed for Read if no RSS enabled (:ref:`activateRSS`)
-* `WriteAccess`: default `True`. Allowed for Write if no RSS enabled
-* `CheckAccess`: default `True`. Allowed for Check if no RSS enabled
-* `RemoveAccess`: default `True`. Allowed for Remove if no RSS enabled
-* `OccupancyLFN`: default (`/<vo>/occupancy.json`). LFN where the json file containing the space reporting is to be found
+* ``BackendType``: just used for information. No internal use at the moment
+* ``SEType``: Can be `T0D1` or `T1D0` or `T1D1`. it is used to asses whether the SE is a tape SE or not. If the digit after `T` is `1`, then it is a tape.
+* ``UseCatalogURL``: default `False`. If `True`, use the url stored in the catalog instead of regenerating it
+* ``ChecksumType``: default `ADLER32`. NOT ACTIVE !
+* ``Alias``: when set to the name of another storage element, it instanciates the other SE instead.
+* ``ReadAccess``: default `True`. Allowed for Read if no RSS enabled (:ref:`activateRSS`)
+* ``WriteAccess``: default `True`. Allowed for Write if no RSS enabled
+* ``CheckAccess``: default `True`. Allowed for Check if no RSS enabled
+* ``RemoveAccess``: default `True`. Allowed for Remove if no RSS enabled
+* ``OccupancyLFN``: default (`/<vo>/occupancy.json`). LFN where the json file containing the space reporting is to be found
+* ``SpaceReservation``: just a name of a zone of the physical storage which can have some space reserved. Extends the SRM ``SpaceToken`` concept.
 
 VO specific paths
 -----------------
@@ -237,6 +239,8 @@ For example::
    }
 
 The LFN of this file is by default `/<vo>/occupancy.json`, but can be overwritten with the `OccupancyLFN` option of the SE.
+
+The ``SpaceReservation`` option allows to specify a physical zone of the storage which would have space reservation (for example ``LHCb_USER``, ``LHCb_PROD``, etc). It extends the concept of ``SpaceToken`` that SRM has. This option is only used if the StoragePlugin does not return itself a ``SpaceReservation`` value.
 
 
 Multi Protocol


### PR DESCRIPTION
The idea of this PR is to port the concept of `SpaceToken` SRM has to non SRM protocol. This came out from discussions with many people, including @fstagni @iueda @hmiyake 
@hmiyake will soon propose a PR with more changes regarding getOccupancy.
We realized that such a concept is needed for being able to perform accounting properly. 
This PR basically adds a `SpaceReservation` value to the return of `StorageElement.getOccupancy`. This value is:
* either returned by the StoragePlugin (SRM returns its SpaceToken, but it can be read in the json file)
* or read from the CS in the SE definition

One other change consists in what is returned by `CSHelper.getStorageElementEndpoint`. it was very inconsistent up to now, and it still is. But in the case of non srm protocol, this method now returns the endpoint,  and not the endpoint+basePath (consistent with what SRM does already now). This allows us to regroup the SE that are in fact the same underlying storage. There is still a lot of work to be done on that module to be completely SRM compatible. I've updated https://github.com/DIRACGrid/DIRAC/issues/3908 accordingly after discussion with @fstagni 

BEGINRELEASENOTES

*Core
NEW: getIndexInList utility in List.py

*Resources
NEW: add a SpaceReservation concept to storages
NEW: add a getEndpoint method to StorageBase 

*RSS
CHANGE: CSHelpers.getStorageElementEndpoint returns the endpoint or non srm protocol
CHANGE: add the SpaceReservation to the FreeDiskSpaceCommand result


ENDRELEASENOTES
