### PR TITLE
[WIP] [v6r21] Fix for transformation-replication script

### DIFF
--- a/TransformationSystem/Utilities/ReplicationTransformation.py
+++ b/TransformationSystem/Utilities/ReplicationTransformation.py
@@ -11,7 +11,7 @@ def createDataTransformation(flavour, targetSE, sourceSE,
                              metaKey, metaValue,
                              extraData=None, extraname='',
                              groupSize=1,
-                             plugin='Broadcast',
+                             plugin=None,
                              tGroup=None,
                              tBody=None,
                              enable=False,
@@ -41,6 +41,12 @@ def createDataTransformation(flavour, targetSE, sourceSE,
 
   if isinstance(targetSE, basestring):
     targetSE = [targetSE]
+
+  if sourceSE and plugin is None:
+    plugin = 'Broadcast'
+  if plugin is None:
+    plugin = 'Standard'
+  gLogger.debug('Using plugin: %r' % plugin)
 
   if flavour not in ('Replication', 'Moving'):
     return S_ERROR('Unsupported flavour %s' % flavour)

--- a/TransformationSystem/test/Test_replicationTransformation.py
+++ b/TransformationSystem/test/Test_replicationTransformation.py
@@ -43,7 +43,7 @@ class TestMoving(unittest.TestCase):
   def tearDown(self):
     pass
 
-  def test_createRepl_1(self):
+  def test_createRepl_Broadcast(self):
     """ test creating transformation """
     tSE = "Target-SRM"
     sSE = "Source-SRM"
@@ -56,6 +56,23 @@ class TestMoving(unittest.TestCase):
             patch("%s.TransformationClient" % module_name, new=self.tMock):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=True)
     self.assertTrue(ret['OK'], ret.get('Message', ""))
+    self.assertEqual(ret['Value'].getPlugin().get('Value'), 'Broadcast')
+
+  def test_createRepl_Standard(self):
+    """ test creating transformation """
+    tSE = 'Target-SRM'
+    sSE = ''
+    prodID = 12345
+    module_name = 'DIRAC.TransformationSystem.Utilities.ReplicationTransformation'
+    trmodule = 'DIRAC.TransformationSystem.Client.Transformation.Transformation'
+    with patch(trmodule + '.getTransformation', new=Mock(return_value=S_OK({}))), \
+            patch(trmodule + '.addTransformation', new=Mock(return_value=S_OK())), \
+            patch(trmodule + '._Transformation__setSE', new=Mock(return_value=S_OK())), \
+            patch('%s.TransformationClient' % module_name, new=self.tMock):
+      ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=True)
+    self.assertTrue(ret['OK'], ret.get('Message', ''))
+    self.assertEqual(ret['Value'].getPlugin().get('Value'), 'Standard')
+
 
   def test_createRepl_Dry(self):
     """ test creating transformation """
@@ -84,6 +101,21 @@ class TestMoving(unittest.TestCase):
             patch("%s.TransformationClient" % module_name, new=self.tMock):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, extraname="extraName", enable=True)
     self.assertTrue(ret['OK'], ret.get('Message', ""))
+
+  def test_createRepl_BadFlavour(self):
+    """ test creating transformation """
+    tSE = "Target-SRM"
+    sSE = "Source-SRM"
+    prodID = 12345
+    module_name = "DIRAC.TransformationSystem.Utilities.ReplicationTransformation"
+    trmodule = "DIRAC.TransformationSystem.Client.Transformation.Transformation"
+    with patch(trmodule + ".getTransformation", new=Mock(return_value=S_OK({}))), \
+            patch(trmodule + ".addTransformation", new=Mock(return_value=S_OK())), \
+            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())), \
+            patch("%s.TransformationClient" % module_name, new=self.tMock):
+      ret = createDataTransformation('Smelly', tSE, sSE, 'prodID', prodID, extraname="extraName", enable=True)
+    self.assertFalse(ret['OK'], ret.get('Message', ""))
+    self.assertIn('Unsupported flavour', ret['Message'])
 
   def test_createRepl_SEFail_1(self):
     """ test creating transformation """


### PR DESCRIPTION

BEGINRELEASENOTES

*TS
FIX: The dirac-transformation-replication script will now create valid transformations given only the required arguments. Instead of the 'Broadcast' plugin, the 'Standard' plugin is created if not SourceSE is given. If a value for the plugin argument is given, that will be used.

ENDRELEASENOTES
