### PR TITLE
[v6r21] Fix in dirac.cfg

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -285,7 +285,8 @@ Resources
        RemoveAccess = True # Allowed for Remove if no RSS enabled
        OccupancyLFN = /lhcb/storageDetails.json # Json containing occupancy details
        SpaceReservation = LHCb-EOS # Space reservation name if any. Concept like SpaceToken
-       GFAL2_SRM2 # Protocol section, see  # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Storages/index.html#available-protocol-plugins
+       # Protocol section, see  # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Storages/index.html#available-protocol-plugins
+       GFAL2_SRM2
        {
          Host = srm-eoslhcb.cern.ch
          Port = 8443


### PR DESCRIPTION
The CFG parsing fails when there is a comment in a section title.
This breaks building the documentation