### PR TITLE
[v6r21] Add option to limit StageMonitoringAgent to certain storage plugins

### DIFF
--- a/StorageManagementSystem/Agent/StageMonitorAgent.py
+++ b/StorageManagementSystem/Agent/StageMonitorAgent.py
@@ -1,3 +1,15 @@
+"""StageMonitorAgent
+
+This agents queries the storage element about staging requests, to see if files are staged or not.
+
+.. literalinclude:: ../ConfigTemplate.cfg
+  :start-after: ##BEGIN StageMonitorAgent
+  :end-before: ##END
+  :caption: StageMonitorAgent options
+  :dedent: 2
+
+"""
+
 __RCSID__ = "$Id$"
 
 from DIRAC import gLogger, S_OK, S_ERROR, siteName
@@ -21,6 +33,7 @@ class StageMonitorAgent( AgentModule ):
     # /Operations/Shifter/DataManager
     # the shifterProxy option in the Configuration can be used to change this default.
     self.am_setOption( 'shifterProxy', 'DataManager' )
+    self.storagePlugins = self.am_getOption('StoragePlugins', [])
 
     return S_OK()
 
@@ -73,7 +86,7 @@ class StageMonitorAgent( AgentModule ):
     oAccounting = DataOperation()
     oAccounting.setStartTime()
 
-    res = StorageElement( storageElement ).getFileMetadata( lfnRepIDs )
+    res = StorageElement(storageElement, plugins=self.storagePlugins).getFileMetadata(lfnRepIDs)
     if not res['OK']:
       gLogger.error( "StageMonitor.__monitorStorageElementStageRequests: Completely failed to monitor stage requests for replicas.", res['Message'] )
       return

--- a/StorageManagementSystem/ConfigTemplate.cfg
+++ b/StorageManagementSystem/ConfigTemplate.cfg
@@ -11,10 +11,14 @@ Services
 }
 Agents
 {
+  ##BEGIN StageMonitorAgent
   StageMonitorAgent
   {
     PollingTime = 120
+    # only use these Plugins to query StorageElements. All if empty
+    StoragePlugins =
   }
+  ##END
   StageRequestAgent
   {
     PollingTime = 120


### PR DESCRIPTION

We have two access protocols defined for castor, SRM and XROOT, in case the SMS SMA contacts castor via XROOT the files were always considered to be staged. This PR adds an option to limit the plugins used to GFAL2_SRM2, for example, or a list of plugins.

This feature depends on #4078 

BEGINRELEASENOTES

*SMS
NEW: StageMonitorAgent: new option StoragePlugins to limit the protocols used to contact storagelements for staged files.

ENDRELEASENOTES
