### PR TITLE
[v6r21] Ensure maxNumberOfProcessors is int

### DIFF
--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -483,7 +483,7 @@ class PilotParams( object ):
       elif o == '-p' or o == '--platform':
         self.platform = v
       elif o == '-m' or o == '--maxNumberOfProcessors':
-        self.maxNumberOfProcessors = v
+        self.maxNumberOfProcessors = int( v )
       elif o == '-D' or o == '--disk':
         try:
           self.minDiskSpace = int( v )


### PR DESCRIPTION
Hi,

We discovered a bug where maxNumberOfProcessors is a string, which breaks a min() statement later on in the code (resulting in the number of procs being uncapped). This patch simply converts it to an int to resolve the bug. Would it be possible to backport it to v6r20 as well?

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Ensure maxNumberOfProcessors is an int
ENDRELEASENOTES
