### PR TITLE
[v6r20] Convert maxNumberOfProcessors to int

### DIFF
--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -483,7 +483,7 @@ class PilotParams( object ):
       elif o == '-p' or o == '--platform':
         self.platform = v
       elif o == '-m' or o == '--maxNumberOfProcessors':
-        self.maxNumberOfProcessors = v
+        self.maxNumberOfProcessors = int( v )
       elif o == '-D' or o == '--disk':
         try:
           self.minDiskSpace = int( v )


### PR DESCRIPTION
Hi,

Here is the backport of #4091 to v6r20... I guess I should have just targeted it at this branch in the first place.

Regards,
Simon


BEGINRELEASENOTES
*WorkloadManagement
FIX: Ensure maxNumberOfProcessors is an int
ENDRELEASENOTES
