### PR TITLE
[v6r21] broadcast without sourceSE

### DIFF
--- a/TransformationSystem/Agent/test/Test_Plugins.py
+++ b/TransformationSystem/Agent/test/Test_Plugins.py
@@ -5,18 +5,17 @@
 # line-too-long
 
 # imports
-import unittest
+import pytest
 import importlib
 from mock import MagicMock
 
 from DIRAC.DataManagementSystem.Client.test.mock_DM import dm_mock
 from DIRAC.Resources.Catalog.test.mock_FC import fc_mock
 
-from DIRAC import gLogger
+from DIRAC import gLogger, S_OK
 
-# sut
 from DIRAC.TransformationSystem.Agent.TransformationPlugin import TransformationPlugin
-
+from DIRAC.TransformationSystem.Client import Utilities
 
 paramsBase = {'AgentType': 'Automatic',
               'DerivedProduction': '0',
@@ -44,111 +43,141 @@ data = {'/this/is/at.1': ['SE1'],
         '/this/is/at_4': ['SE4']}
 
 
-class PluginsTestCase(unittest.TestCase):
-  """ Base class for the Agents test cases
-  """
-
-  def setUp(self):
-    self.mockTC = MagicMock()
-    self.tPlugin = importlib.import_module(
-        'DIRAC.TransformationSystem.Agent.TransformationPlugin')
-    self.tPlugin.TransformationClient = self.mockTC
-    self.tPlugin.DataManager = dm_mock
-    self.tPlugin.FileCatalog = fc_mock
-
-    self.util = importlib.import_module('DIRAC.TransformationSystem.Client.Utilities')
-    self.util.FileCatalog = fc_mock
-    self.util.StorageElement = MagicMock()
-
-    self.maxDiff = None
-
-    gLogger.setLevel('DEBUG')
-
-  def tearDown(self):
-    #     sys.modules.pop( 'DIRAC.Core.Base.AgentModule' )
-    #     sys.modules.pop( 'DIRAC.TransformationSystem.Agent.TransformationAgent' )
-    pass
+@pytest.fixture
+def setup(mocker):
+  tpName = 'DIRAC.TransformationSystem.Agent.TransformationPlugin'
+  tuName = 'DIRAC.TransformationSystem.Client.Utilities'
+  mocker.patch(tpName + '.TransformationClient', new=MagicMock('tClient'))
+  mocker.patch(tpName + '.TransformationPlugin._getSiteForSE', return_value=S_OK([]))
+  mocker.patch(tuName + '.DataManager', new=dm_mock)
+  mocker.patch(tuName + '.FileCatalog', new=fc_mock)
+  mocker.patch(tuName + '.StorageElement', new=MagicMock('SEMock'))
+  gLogger.setLevel('DEBUG')
 
 
-class PluginsBaseSuccess(PluginsTestCase):
-
-  def test__Standard_G10(self):
-    #   # no input data, active
-    params = dict(paramsBase)
-    params['GroupSize'] = 10L
-    pluginStandard = TransformationPlugin('Standard')
-    pluginStandard.setParameters(params)
-    res = pluginStandard.run()
-    self.assertTrue(res['OK'])
-    self.assertEqual(res['Value'], [])
-
-  def test__Standard_Data_G10(self):
-    # input data, active
-    params = dict(paramsBase)
-    params['GroupSize'] = 10L
-    pluginStandard = TransformationPlugin('Standard')
-    pluginStandard.setParameters(params)
-    pluginStandard.setInputData(data)
-    res = pluginStandard.run()
-    self.assertTrue(res['OK'])
-    self.assertEqual(res['Value'], [])
-
-  def test__Standard_Flush_G10(self):
-    # input data, flush
-    pluginStandard = TransformationPlugin('Standard')
-    params = dict(paramsBase)
-    params['GroupSize'] = 10L
-    params['Status'] = 'Flush'
-    pluginStandard.setParameters(params)
-    pluginStandard.setInputData(data)
-    res = pluginStandard.run()
-    sortedData = [('SE1', ['/this/is/at.1']),
-                  ('SE1,SE2', ['/this/is/also/at.12', '/this/is/at.12']),
-                  ('SE1,SE2,SE3', ['/this/is/at_123']),
-                  ('SE2', ['/this/is/als/at.2', '/this/is/at.2']),
-                  ('SE2,SE3', ['/this/is/at_23']),
-                  ('SE4', ['/this/is/at_4'])]
-    self.assertTrue(res['OK'])
-    self.assertEqual(res['Value'], sortedData)
-
-  def test__Standard_G1(self):
-    # no input data, active
-    pluginStandard = TransformationPlugin('Standard')
-    pluginStandard.setParameters(paramsBase)
-    res = pluginStandard.run()
-    self.assertTrue(res['OK'])
-    self.assertEqual(res['Value'], [])
-
-  def test__Standard_Data_G1(self):
-    # input data, active
-    pluginStandard = TransformationPlugin('Standard')
-    pluginStandard.setParameters(paramsBase)
-    pluginStandard.setInputData(data)
-    res = pluginStandard.run()
-    self.assertTrue(res['OK'])
-    sortedData = sorted([(",".join(SEs), [lfn]) for lfn, SEs in data.iteritems()])
-    self.assertEqual(res['Value'], sortedData)
-
-  def test__Standard_Flush_G1(self):
-    # input data, flush
-    pluginStandard = TransformationPlugin('Standard')
-    params = dict(paramsBase)
-    params['Status'] = 'Flush'
-    pluginStandard.setParameters(params)
-    pluginStandard.setInputData(data)
-    res = pluginStandard.run()
-    sortedData = sorted([(",".join(SEs), [lfn]) for lfn, SEs in data.iteritems()])
-    self.assertTrue(res['OK'])
-    self.assertEqual(res['Value'], sortedData)
-
-#############################################################################
-# Test Suite run
-#############################################################################
+def test__Standard_G10(setup):
+  """Test StandardPlugin: no input data, active."""
+  params = dict(paramsBase)
+  params['GroupSize'] = 10L
+  pluginStandard = TransformationPlugin('Standard')
+  pluginStandard.setParameters(params)
+  res = pluginStandard.run()
+  assert res['OK']
+  # no data
+  assert res['Value'] == []
 
 
-if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase(PluginsTestCase)
-  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(PluginsBaseSuccess))
-  testResult = unittest.TextTestRunner(verbosity=2).run(suite)
+def test__Standard_Data_G10(setup):
+  """Test StandardPlugin: input data, active."""
+  params = dict(paramsBase)
+  params['GroupSize'] = 10L
+  pluginStandard = TransformationPlugin('Standard')
+  pluginStandard.setParameters(params)
+  pluginStandard.setInputData(data)
+  res = pluginStandard.run()
+  assert res['OK']
+  # data less than 10
+  assert res['Value'] == []
 
-# EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#
+
+def test__Standard_Flush_G10(setup):
+  """Test StandardPlugin: input data, flush."""
+  pluginStandard = TransformationPlugin('Standard')
+  params = dict(paramsBase)
+  params['GroupSize'] = 10L
+  params['Status'] = 'Flush'
+  pluginStandard.setParameters(params)
+  pluginStandard.setInputData(data)
+  res = pluginStandard.run()
+  sortedData = [('SE1', ['/this/is/at.1']),
+                ('SE1,SE2', ['/this/is/also/at.12', '/this/is/at.12']),
+                ('SE1,SE2,SE3', ['/this/is/at_123']),
+                ('SE2', ['/this/is/als/at.2', '/this/is/at.2']),
+                ('SE2,SE3', ['/this/is/at_23']),
+                ('SE4', ['/this/is/at_4'])]
+  assert res['OK']
+  assert res['Value'] == sortedData
+
+
+def test__Standard_G1(setup):
+  """Test StandardPlugin: not input data, active."""
+  pluginStandard = TransformationPlugin('Standard')
+  pluginStandard.setParameters(paramsBase)
+  res = pluginStandard.run()
+  assert res['OK']
+  assert res['Value'] == []
+
+
+def test__Standard_Data_G1(setup):
+  """Test StandardPlugin: input data, active."""
+  pluginStandard = TransformationPlugin('Standard')
+  pluginStandard.setParameters(paramsBase)
+  pluginStandard.setInputData(data)
+  res = pluginStandard.run()
+  assert res['OK']
+  sortedData = sorted([(",".join(SEs), [lfn]) for lfn, SEs in data.iteritems()])
+  assert res['Value'], sortedData
+
+
+def test__Standard_Flush_G1(setup):
+  """Test StandardPlugin: input data, flush."""
+  pluginStandard = TransformationPlugin('Standard')
+  params = dict(paramsBase)
+  params['Status'] = 'Flush'
+  pluginStandard.setParameters(params)
+  pluginStandard.setInputData(data)
+  res = pluginStandard.run()
+  sortedData = sorted([(",".join(SEs), [lfn]) for lfn, SEs in data.iteritems()])
+  assert res['OK']
+  assert res['Value'] == sortedData
+
+
+def test__Broadcast_Active_G1(setup):
+  """Test BroadcastPlugin: input data, Active"""
+  thePlugin = TransformationPlugin('Broadcast')
+  params = dict(paramsBase)
+  params['Status'] = 'Active'
+  params['SourceSE'] = 'SE1'
+  params['TargetSE'] = 'SE2'
+  thePlugin.setParameters(params)
+  thePlugin.setInputData(data)
+  res = thePlugin.run()
+  # sort returned values by first lfn in LFNs
+  sortedReturn = [(SE, lfns) for SE, lfns in sorted(res['Value'], key=lambda t: t[1][0])]
+  # sort data by lfn
+  expected = [('SE2', [lfn]) for lfn, SEs in sorted(data.iteritems(), key=lambda t: t[0]) if 'SE1' in SEs]
+  assert res['OK']
+  assert sortedReturn == expected
+
+
+def test__Broadcast_Active_G10(setup):
+  """Test BroadcastPlugin: input data, Active"""
+  thePlugin = TransformationPlugin('Broadcast')
+  params = dict(paramsBase)
+  params['Status'] = 'Active'
+  params['SourceSE'] = "['SE1']"
+  params['TargetSE'] = ['SE2']
+  params['GroupSize'] = 10
+  thePlugin.setParameters(params)
+  thePlugin.setInputData(data)
+  res = thePlugin.run()
+  assert res['OK']
+  assert res['Value'] == []
+
+
+def test__Broadcast_Active_G1_NoSource(setup):
+  """Test BroadcastPlugin: input data, Active, noSource"""
+  thePlugin = TransformationPlugin('Broadcast')
+  params = dict(paramsBase)
+  params['Status'] = 'Active'
+  params['TargetSE'] = ['SE2']
+  params['GroupSize'] = 1
+  thePlugin.setParameters(params)
+  thePlugin.setInputData(data)
+  res = thePlugin.run()
+  # sort returned values by first lfn in LFNs
+  sortedReturn = [(SE, lfns) for SE, lfns in sorted(res['Value'], key=lambda t: t[1][0])]
+  # sort data by lfn
+  expected = [('SE2', [lfn]) for lfn, _SEs in sorted(data.iteritems(), key=lambda t: t[0])]
+  assert res['OK']
+  assert sortedReturn == expected

--- a/TransformationSystem/Client/Utilities.py
+++ b/TransformationSystem/Client/Utilities.py
@@ -447,6 +447,21 @@ class PluginUtilities(object):
       targetSEs = []
     return (targetSEs + list(sameSEs)) if not local else targetSEs
 
+  @staticmethod
+  def seParamtoList(inputParam):
+    """Transform ``inputParam`` to list.
+
+    :param inputParam: can be string, list, or string representation of list
+    :returns: list
+    """
+    if not inputParam:
+      return []
+    if inputParam.count('['):
+      return eval(inputParam)  # pylint: disable=eval-used
+    elif isinstance(inputParam, list):
+      return inputParam
+    return [inputParam]
+
 
 def getFileGroups(fileReplicas, groupSE=True):
   """

--- a/TransformationSystem/Utilities/ReplicationTransformation.py
+++ b/TransformationSystem/Utilities/ReplicationTransformation.py
@@ -11,7 +11,7 @@ def createDataTransformation(flavour, targetSE, sourceSE,
                              metaKey, metaValue,
                              extraData=None, extraname='',
                              groupSize=1,
-                             plugin=None,
+                             plugin='Broadcast',
                              tGroup=None,
                              tBody=None,
                              enable=False,
@@ -42,10 +42,6 @@ def createDataTransformation(flavour, targetSE, sourceSE,
   if isinstance(targetSE, basestring):
     targetSE = [targetSE]
 
-  if sourceSE and plugin is None:
-    plugin = 'Broadcast'
-  if plugin is None:
-    plugin = 'Standard'
   gLogger.debug('Using plugin: %r' % plugin)
 
   if flavour not in ('Replication', 'Moving'):

--- a/TransformationSystem/test/Test_replicationTransformation.py
+++ b/TransformationSystem/test/Test_replicationTransformation.py
@@ -58,7 +58,7 @@ class TestMoving(unittest.TestCase):
     self.assertTrue(ret['OK'], ret.get('Message', ""))
     self.assertEqual(ret['Value'].getPlugin().get('Value'), 'Broadcast')
 
-  def test_createRepl_Standard(self):
+  def test_createRepl_NoSource(self):
     """ test creating transformation """
     tSE = 'Target-SRM'
     sSE = ''
@@ -71,7 +71,7 @@ class TestMoving(unittest.TestCase):
             patch('%s.TransformationClient' % module_name, new=self.tMock):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=True)
     self.assertTrue(ret['OK'], ret.get('Message', ''))
-    self.assertEqual(ret['Value'].getPlugin().get('Value'), 'Standard')
+    self.assertEqual(ret['Value'].getPlugin().get('Value'), 'Broadcast')
 
 
   def test_createRepl_Dry(self):

--- a/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
+++ b/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
@@ -53,7 +53,7 @@ Then we create the list of LFNs we just uploaded::
 The easiest way to create a transformation to replicate files is by using the
 :doc:`/AdministratorGuide/CommandReference/dirac-transformation-replication` command::
 
-  [diracuser@dirac-tuto ~]$ dirac-transformation-replication 0 StorageElementTwo --Plugin Broadcast --Enable --SourceSEs StorageElementOne
+  [diracuser@dirac-tuto ~]$ dirac-transformation-replication 0 StorageElementTwo --Plugin Broadcast --Enable
   Created transformation NNN
   Successfully created replication transformation
 
@@ -118,7 +118,7 @@ script that creates a removal transformation:
     myTrans.setGroupSize(groupSize)
 
     # the transformation plugin defines which input files are treated, and how they are grouped, for example
-    plugin = 'Standard'
+    plugin = 'Broadcast'
     myTrans.setPlugin(plugin)
 
     # the 'body' of the transformation, defines a list of Request Operations
@@ -235,7 +235,7 @@ We can also use the command ``dirac-dms-find-lfns`` to search for files with giv
 
 Now we create a transformation, which uses the metadata to pick up the files::
 
- [diracuser@dirac-tuto ~]$  dirac-transformation-replication 2 StorageElementTwo --Plugin=Broadcast --Enable --SourceSEs StorageElementOne
+ [diracuser@dirac-tuto ~]$  dirac-transformation-replication 2 StorageElementTwo --Plugin=Broadcast --Enable
  Created transformation LLL
  Successfully created replication transformation
 


### PR DESCRIPTION

BEGINRELEASENOTES

*TS
CHANGE: the Broadcast TransformationPlugin no longer requires a SourceSE to be set. If it is set, the behaviour is unchanged
CHANGE: dirac-transformation-replication: change default pluging back to Broadcast (reverts #4066)

ENDRELEASENOTES
