### PR TITLE
[v6r22] use CAs for uploading the pilot files

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -379,7 +379,7 @@ class PilotCStoJSONSynchronizer(object):
       
     resp = requests.post('https://%s/DIRAC/upload' % self.pilotFileServer,
                          data=data,
-                         verify = casFile,
+                         verify=casFile,
                          cert=self.certAndKeyLocation)
 
     if resp.status_code != 200:

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -367,7 +367,7 @@ class PilotCStoJSONSynchronizer(object):
       with open(pilotScript, "rb") as psf:
         script = psf.read()
       data = {'filename': filename, 'data': script}
-    
+
     bd = BundleDeliveryClient()
     retVal = bd.getCAs()
     casFile = None
@@ -376,7 +376,7 @@ class PilotCStoJSONSynchronizer(object):
       casFile = certifi.where()
     else:
       casFile = retVal['Value']
-      
+
     resp = requests.post('https://%s/DIRAC/upload' % self.pilotFileServer,
                          data=data,
                          verify=casFile,


### PR DESCRIPTION

BEGINRELEASENOTES

*WorkloadManagement
FIX: use CAs to upload the pilot files to a dedicated web server using requests 

ENDRELEASENOTES
