### PR TITLE
[integration] Implement Multi-VO File Catalog Metadata Handling

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
@@ -1,0 +1,17 @@
+""" DIRAC Multi VO FileCatalog plugin class to manage directory metadata for multiple VO.
+"""
+from __future__ import division
+
+__RCSID__ = "$Id$"
+
+from DIRAC.DataManagementSystem.DB.FileCatalogComponents.DirectoryMetadata.DirectoryMetadata import DirectoryMetadata
+from DIRAC.DataManagementSystem.DB.FileCatalogComponents.MultiVOMetaNameMixIn import MultiVOMetaNameMixIn
+
+
+class MultiVODirectoryMetadata(MultiVOMetaNameMixIn, DirectoryMetadata):
+  """
+  MULti-VO FileCatalog plugin implementation.
+  """
+
+  def __init__(self, database=None):
+    super(MultiVODirectoryMetadata, self).__init__(database=database)

--- a/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/MultiVOFileMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/MultiVOFileMetadata.py
@@ -1,0 +1,17 @@
+""" DIRAC Multi VO FileCatalog plugin class to manage file metadata for multiple VO.
+"""
+from __future__ import division
+
+__RCSID__ = "$Id$"
+
+from DIRAC.DataManagementSystem.DB.FileCatalogComponents.FileMetadata.FileMetadata import FileMetadata
+from DIRAC.DataManagementSystem.DB.FileCatalogComponents.MultiVOMetaNameMixIn import MultiVOMetaNameMixIn
+
+
+class MultiVOFileMetadata(MultiVOMetaNameMixIn, FileMetadata):
+  """
+  MULti-VO FileCatalog plugin implementation.
+  """
+
+  def __init__(self, database=None):
+    super(MultiVOFileMetadata, self).__init__(database=database)

--- a/DataManagementSystem/DB/FileCatalogComponents/MetaNameMixIn.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/MetaNameMixIn.py
@@ -1,0 +1,41 @@
+""" DIRAC base MixIn class to manage file metadata and directory names.
+"""
+from __future__ import division
+
+
+class MetaNameMixIn(object):
+
+  def getMetaName(self, meta, credDict):
+    """
+    Return a metadata name based on client supplied meta name and client credentials
+    For the base class it just returns the name passed in.
+    This method is a pass-through and is meant to be overwritten by derived classes.
+
+    :param meta:  meta name
+    :param credDict: client credentials
+    :return: meta name
+    """
+
+    return meta
+
+  def getMetaNameSuffix(self, credDict):
+    """
+    Get meta name suffix based on client credentials. The method is needed to be able
+    to return metadata w/o a suffix to the client.
+    This method is a pass-through and is meant to be overwritten by derived classes.
+
+    :param credDict: client credentials
+    :return: the suffix. And empty string for a base class.
+    """
+
+    return ''
+
+  def stripSuffix(self, metaDict, credDict):
+    """
+    Strip suffix pass through, just return the metadata dictionary.
+
+    :param metaDict: meta dictionary to modify.
+    :param credDict: credential dictionary.
+    :return: unchanged metaDict
+    """
+    return metaDict

--- a/DataManagementSystem/DB/FileCatalogComponents/MultiVOMetaNameMixIn.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/MultiVOMetaNameMixIn.py
@@ -33,7 +33,7 @@ class MultiVOMetaNameMixIn(MetaNameMixIn):
     :return: VO specific suffix
     """
     vo = Registry.getGroupOption(credDict['group'], 'VO')
-    return '_' + vo.replace('-', '_')
+    return '_' + vo.replace('-', '_').replace('.','')
 
   def stripSuffix(self, metaDict, credDict):
     """

--- a/DataManagementSystem/DB/FileCatalogComponents/MultiVOMetaNameMixIn.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/MultiVOMetaNameMixIn.py
@@ -1,0 +1,50 @@
+""" DIRAC Multi VO MixIn class to manage file metadata and directory for multiple VO.
+"""
+from __future__ import division
+
+__RCSID__ = "$Id$"
+
+from DIRAC.DataManagementSystem.DB.FileCatalogComponents.MetaNameMixIn import MetaNameMixIn
+from DIRAC.ConfigurationSystem.Client.Helpers import Registry
+
+
+class MultiVOMetaNameMixIn(MetaNameMixIn):
+  """
+  MULti-VO MetaName MixIn implementation.
+  """
+
+  def getMetaName(self, meta, credDict):
+    """
+    Return a fully-qualified metadata name based on client-suplied metadata name and
+    client credentials. User VO is added to the metadata passed in.
+
+    :param meta: metadata name
+    :param credDict: client credentials
+    :return: fully-qualified metadata name
+    """
+
+    return meta + self.getMetaNameSuffix(credDict)
+
+  def getMetaNameSuffix(self, credDict):
+    """
+    Get a VO specific suffix from user credentials.
+
+    :param credDict: user credentials
+    :return: VO specific suffix
+    """
+    vo = Registry.getGroupOption(credDict['group'], 'VO')
+    return '_' + vo.replace('-', '_')
+
+  def stripSuffix(self, metaDict, credDict):
+    """
+    Strip the suffix from all keys which contain it, removing all other keys.
+
+    :param metaDict: original dict
+    :param credDict: user credential dictionary
+    :return: a new dict with modified keys
+    """
+
+    suffix = self.getMetaNameSuffix(credDict)
+    smetaDict = {key.rsplit(suffix, 1)[0]: value for key, value in metaDict.iteritems()
+                 if key.endswith(suffix)}
+    return smetaDict

--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -488,12 +488,13 @@ class FileCatalogHandler(RequestHandler):
   types_getMetadataFields = []
 
   def export_getMetadataFields(self):
-    """ Get all the metadata fields
+    """ Get all the metadata fields.
     """
-    resultDir = gFileCatalogDB.dmeta.getMetadataFields(self.getRemoteCredentials())
+    resultDir = gFileCatalogDB.dmeta.getMetadataFields(self.getRemoteCredentials(), stripVO=True)
     if not resultDir['OK']:
       return resultDir
-    resultFile = gFileCatalogDB.fmeta.getFileMetadataFields(self.getRemoteCredentials())
+
+    resultFile = gFileCatalogDB.fmeta.getFileMetadataFields(self.getRemoteCredentials(), stripVO=True)
     if not resultFile['OK']:
       return resultFile
 
@@ -524,16 +525,17 @@ class FileCatalogHandler(RequestHandler):
   types_getDirectoryUserMetadata = [StringTypes]
 
   def export_getDirectoryUserMetadata(self, path):
-    """ Get all the metadata valid for the given directory path
+    """ Get all the metadata valid for the given directory path.
     """
-    return gFileCatalogDB.dmeta.getDirectoryMetadata(path, self.getRemoteCredentials())
+    return gFileCatalogDB.dmeta.getDirectoryMetadata(path, self.getRemoteCredentials(), stripVO=True)
+    # code below breaks client-side checks
 
   types_getFileUserMetadata = [StringTypes]
 
   def export_getFileUserMetadata(self, path):
-    """ Get all the metadata valid for the given file
+    """ Get all the metadata valid for the given file.
     """
-    return gFileCatalogDB.fmeta.getFileUserMetadata(path, self.getRemoteCredentials())
+    return gFileCatalogDB.fmeta.getFileUserMetadata(path, self.getRemoteCredentials(), stripVO=True)
 
   types_findDirectoriesByMetadata = [DictType]
 

--- a/tests/Integration/DataManagementSystem/Test_UserMetadata.py
+++ b/tests/Integration/DataManagementSystem/Test_UserMetadata.py
@@ -1,0 +1,138 @@
+"""
+Test of multi-VO user metadata handling. Assumes a running Dirac instance with the (master?) FileCatalog
+"""
+from __future__ import division
+
+import unittest
+import os
+import sys
+import os.path
+
+from DIRAC.Core.Base.Script import parseCommandLine
+
+parseCommandLine()
+
+from DIRAC.Interfaces.API.Dirac import Dirac
+from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
+
+
+def random_dd(outfile, size_mb):
+  import os
+  with open(outfile, 'w') as f:
+    for i in range(int(size_mb * 2**20 / 512)):
+      f.write(os.urandom(512))
+
+
+class TestUserMetadataTestCase(unittest.TestCase):
+  def setUp(self):
+    self.dirac = Dirac()
+    self.fc = FileCatalog()
+
+    self.lfn5 = '/gridpp/user/m/martynia/FC_test/test_file_10MB_v5.bin'
+    self.dir5 = os.path.dirname(self.lfn5)
+    # local file, for now:
+    self.fullPath = 'test_file_10MB.bin'
+    random_dd(self.fullPath, 10)
+    diracSE = 'UKI-LT2-IC-HEP-disk'
+    # add a replica
+    result = self.dirac.addFile(self.lfn5, self.fullPath, diracSE)
+    self.assertTrue(result['OK'])
+
+  def tearDown(self):
+    # meta index -r
+    result = self.fc.deleteMetadataField('JMMetaInt6')
+    # delete a sole replica: dirac-dms-remove-files
+    result = self.dirac.removeFile(self.lfn5)
+    self.assertTrue(result['OK'])
+    os.remove(self.fullPath)
+
+
+class testMetadata(TestUserMetadataTestCase):
+  def test_AddQueryRemove(self):
+    result = self.dirac.getLfnMetadata(self.lfn5)
+    self.assertTrue(result['OK'])
+    self.assertTrue(self.lfn5 in result['Value']['Successful'])
+    self.assertEqual(result['Value']['Failed'], {})
+
+    # meta index -f
+    result = self.fc.addMetadataField('JMMetaInt6', 'INT', metaType='-f')
+    self.assertTrue(result['OK'])
+    self.assertNotEqual(result['Value'], 'Already exists')
+    self.assertTrue(result['Value'].startswith('Added new metadata:'))
+
+    # meta index -d
+    result = self.fc.addMetadataField('JMTestDirectory6', 'INT', metaType='-d')
+    self.assertTrue(result['OK'])
+    self.assertNotEqual(result['Value'], 'Already exists')
+    self.assertTrue(result['Value'].startswith('Added new metadata:'))
+
+    # meta show
+    result = self.fc.getMetadataFields()
+    self.assertTrue(result['OK'])
+    self.assertDictContainsSubset({'JMMetaInt6': 'INT'}, result['Value']['FileMetaFields'])
+    self.assertDictContainsSubset({'JMTestDirectory6': 'INT'}, result['Value']['DirectoryMetaFields'])
+
+    # meta set
+    metaDict6 = {'JMMetaInt6': 13}
+    result = self.fc.setMetadata(self.lfn5, metaDict6)
+    self.assertTrue(result['OK'])
+
+    metaDirDict6 = {'JMTestDirectory6': 126}
+    result = self.fc.setMetadata(self.dir5, metaDirDict6)
+    self.assertTrue(result['OK'])
+
+    # find
+    result = self.fc.findFilesByMetadata(metaDict6)
+    self.assertTrue(result['OK'])
+    self.assertIn(self.lfn5, result['Value'])
+
+    # find
+    metaDirDict = {'JMTestDirectory6': 126}
+    result = self.fc.findDirectoriesByMetadata(metaDirDict, path='/')
+    self.assertTrue(result['OK'])
+    self.assertIn(self.dir5, result['Value'].values())
+
+    # API call only
+    result = self.fc.getFileUserMetadata(self.lfn5)
+    self.assertTrue(result['OK'])
+    self.assertDictContainsSubset({'JMMetaInt6': 13}, result['Value'])
+    # file: return  enclosing directory
+    result = self.fc.getDirectoryUserMetadata(self.lfn5)
+    self.assertTrue(result['OK'])
+    self.assertDictContainsSubset({'JMTestDirectory6': 126}, result['Value'])
+    # directory only
+    result = self.fc.getDirectoryUserMetadata(self.dir5)
+    self.assertTrue(result['OK'])
+    self.assertDictContainsSubset({'JMTestDirectory6': 126}, result['Value'])
+    # replicas
+    # metaDict6={'JMMetaInt6':13}
+    # result = self.fc.getReplicasByMetadata(metaDict, path='/')
+    # print result
+    # self.assertTrue(result['OK'])
+    #
+    # meta remove lfn5  JMMetaInt6
+    path = self.lfn5
+    metadata = ['JMMetaInt6']
+    metaDict = {path: metadata}
+    result = self.fc.removeMetadata(metaDict)
+    self.assertTrue(result['OK'])
+
+    # meta index -r JMMetaInt6
+    result = self.fc.deleteMetadataField('JMMetaInt6')
+    self.assertTrue(result['OK'])
+
+    result = self.fc.deleteMetadataField('JMTestDirectory6')
+    self.assertTrue(result['OK'])
+
+  @unittest.expectedFailure
+  def test_ReplicasByMetadata(self):
+    metaDict6 = {'JMMetaInt6': 13}
+    result = self.fc.getReplicasByMetadata(metaDict6, path='/')
+    self.assertTrue(result['OK'])
+
+
+if __name__ == '__main__':
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestUserMetadataTestCase)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(testMetadata))
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)
+  sys.exit(not testResult.wasSuccessful())


### PR DESCRIPTION
BEGINRELEASENOTES
The idea of the update is to allow to store user metadata in a VO dependant way. For indexed
metadata a SQL table name, which normally holds a meta name as a suffix, is now extended to include w VO suffix. This way each VO writes to their own SQL table. 
The [DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata.py](url) and 
[DataManagementSystem/DB/FileCatalogComponents/FileMetadata.py](url) now contain a "hook" which, when overwritten in a derived class generates a required VO-specific tbale name suffix.
ENDRELEASENOTES
