### PR TITLE
[v6r21]  Allow both Tag and Tags option in the job JDL

### DIFF
--- a/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -390,6 +390,8 @@ class JobScheduling(OptimizerExecutor):
         tagList.append("MultiProcessor")
     if "Tags" in jobManifest:
       tagList.extend(jobManifest.getOption("Tags", []))
+    if "Tag" in jobManifest:
+      tagList.extend(jobManifest.getOption("Tag", []))
     if tagList:
 
       jobManifest.setOption("Tags", ", ".join(tagList))


### PR DESCRIPTION
  In the job JDL users are often confused in how to specify tags - either with the Tag ot Tags option (the correct way so far is Tags even if there is a single tag). This PR makes both ways possible

BEGINRELEASENOTES

*WMS
CHANGE: JobScheduling - allow both Tag and Tags option in the job JDL

ENDRELEASENOTES
