### PR TITLE
[v7] Create data queries before transformation is created

### DIFF
--- a/TransformationSystem/Client/Transformation.py
+++ b/TransformationSystem/Client/Transformation.py
@@ -1,4 +1,6 @@
-""" A generic client for creating transformations
+"""A generic client for creating and managing transformations.
+
+See the information about transformation parameters below.
 """
 
 from __future__ import print_function

--- a/TransformationSystem/Client/Transformation.py
+++ b/TransformationSystem/Client/Transformation.py
@@ -56,6 +56,12 @@ class Transformation(API):
                         'Body': '',
                         'MaxNumberOfTasks': 0,
                         'EventsPerTask': 0}
+
+    # the metaquery parameters are neither part of the transformation parameters nor the additional parameters, so
+    # special treatment is necessary
+    self.inputMetaQuery = None
+    self.outputMetaQuery = None
+
     self.ops = Operations()
     self.supportedPlugins = self.ops.getValue('Transformations/AllowedPlugins',
                                               ['Broadcast', 'Standard', 'BySize', 'ByShare'])
@@ -131,6 +137,20 @@ class Transformation(API):
         if not isinstance(val, (basestring, int, long, float, list, tuple, dict)):
           raise TypeError("Cannot encode %r, in json" % (val))
       return self.__setParam(json.dumps(body))
+
+  def setInputMetaQuery(self, query):
+    """Set the input meta query.
+
+    :param dict query: dictionary to use for input meta query
+    """
+    self.inputMetaQuery = query
+
+  def setOutputMetaQuery(self, query):
+    """Set the output meta query.
+
+    :param dict query: dictionary to use for output meta query
+    """
+    self.outputMetaQuery = query
 
   def __setSE(self, seParam, seList):
     if isinstance(seList, basestring):
@@ -471,6 +491,13 @@ class Transformation(API):
 
   #############################################################################
   def addTransformation(self, addFiles=True, printOutput=False):
+    """Add transformation to the transformation system.
+
+    Sets all parameters currently assigned to the transformation.
+
+    :param bool addFiles: if True, immediately perform input data query
+    :param bool printOutput: if True, print information about transformation
+    """
     res = self._checkCreation()
     if not res['OK']:
       return self._errorReport(res, 'Failed transformation sanity check')
@@ -491,7 +518,10 @@ class Transformation(API):
                                              body=self.paramValues['Body'],
                                              maxTasks=self.paramValues['MaxNumberOfTasks'],
                                              eventsPerTask=self.paramValues['EventsPerTask'],
-                                             addFiles=addFiles)
+                                             addFiles=addFiles,
+                                             inputMetaQuery=self.inputMetaQuery,
+                                             outputMetaQuery=self.outputMetaQuery,
+                                             )
     if not res['OK']:
       if printOutput:
         self._prettyPrint(res)

--- a/TransformationSystem/Utilities/ReplicationTransformation.py
+++ b/TransformationSystem/Utilities/ReplicationTransformation.py
@@ -3,7 +3,6 @@ Utilities to create replication transformations
 """
 
 from DIRAC.TransformationSystem.Client.Transformation import Transformation
-from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 from DIRAC import gLogger, S_OK, S_ERROR
 
 
@@ -70,6 +69,7 @@ def createDataTransformation(flavour, targetSE, sourceSE,
                }[flavour] if tBody is None else tBody
 
   trans.setBody(transBody)
+  trans.setInputMetaQuery(metadata)
 
   if sourceSE:
     res = trans.setSourceSE(sourceSE)
@@ -89,12 +89,6 @@ def createDataTransformation(flavour, targetSE, sourceSE,
   gLogger.verbose(res)
   trans.setStatus('Active')
   trans.setAgentType('Automatic')
-  currtrans = trans.getTransformationID()['Value']
-  client = TransformationClient()
-  # res = client.createTransformationInputDataQuery(currtrans, metadata)
-  res = client.createTransformationMetaQuery(currtrans, metadata, 'Input')
-  if not res['OK']:
-    return res
 
   gLogger.always("Successfully created replication transformation")
   return S_OK(trans)

--- a/TransformationSystem/test/Test_replicationTransformation.py
+++ b/TransformationSystem/test/Test_replicationTransformation.py
@@ -49,27 +49,24 @@ class TestMoving(unittest.TestCase):
     tSE = "Target-SRM"
     sSE = "Source-SRM"
     prodID = 12345
-    module_name = "DIRAC.TransformationSystem.Utilities.ReplicationTransformation"
     trmodule = "DIRAC.TransformationSystem.Client.Transformation.Transformation"
     with patch(trmodule + ".getTransformation", new=Mock(return_value=S_OK({}))), \
             patch(trmodule + ".addTransformation", new=Mock(return_value=S_OK())), \
-            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())), \
-            patch("%s.TransformationClient" % module_name, new=self.tMock):
+            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=True)
     self.assertTrue(ret['OK'], ret.get('Message', ""))
     self.assertEqual(ret['Value'].getPlugin().get('Value'), 'Broadcast')
+    self.assertEqual(ret['Value'].inputMetaQuery, {'prodID': prodID})
 
   def test_createRepl_NoSource(self):
     """ test creating transformation """
     tSE = 'Target-SRM'
     sSE = ''
     prodID = 12345
-    module_name = 'DIRAC.TransformationSystem.Utilities.ReplicationTransformation'
     trmodule = 'DIRAC.TransformationSystem.Client.Transformation.Transformation'
     with patch(trmodule + '.getTransformation', new=Mock(return_value=S_OK({}))), \
             patch(trmodule + '.addTransformation', new=Mock(return_value=S_OK())), \
-            patch(trmodule + '._Transformation__setSE', new=Mock(return_value=S_OK())), \
-            patch('%s.TransformationClient' % module_name, new=self.tMock):
+            patch(trmodule + '._Transformation__setSE', new=Mock(return_value=S_OK())):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=True)
     self.assertTrue(ret['OK'], ret.get('Message', ''))
     self.assertEqual(ret['Value'].getPlugin().get('Value'), 'Broadcast')
@@ -80,12 +77,10 @@ class TestMoving(unittest.TestCase):
     tSE = "Target-SRM"
     sSE = "Source-SRM"
     prodID = 12345
-    module_name = "DIRAC.TransformationSystem.Utilities.ReplicationTransformation"
     trmodule = "DIRAC.TransformationSystem.Client.Transformation.Transformation"
     with patch(trmodule + ".getTransformation", new=Mock(return_value=S_OK({}))), \
             patch(trmodule + ".addTransformation", new=Mock(return_value=S_OK())), \
-            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())), \
-            patch("%s.TransformationClient" % module_name, new=self.tMock):
+            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=False, extraData={})
     self.assertTrue(ret['OK'], ret.get('Message', ""))
 
@@ -94,12 +89,10 @@ class TestMoving(unittest.TestCase):
     tSE = "Target-SRM"
     sSE = "Source-SRM"
     prodID = 12345
-    module_name = "DIRAC.TransformationSystem.Utilities.ReplicationTransformation"
     trmodule = "DIRAC.TransformationSystem.Client.Transformation.Transformation"
     with patch(trmodule + ".getTransformation", new=Mock(return_value=S_OK({}))), \
             patch(trmodule + ".addTransformation", new=Mock(return_value=S_OK())), \
-            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())), \
-            patch("%s.TransformationClient" % module_name, new=self.tMock):
+            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, extraname="extraName", enable=True)
     self.assertTrue(ret['OK'], ret.get('Message', ""))
 
@@ -108,12 +101,10 @@ class TestMoving(unittest.TestCase):
     tSE = "Target-SRM"
     sSE = "Source-SRM"
     prodID = 12345
-    module_name = "DIRAC.TransformationSystem.Utilities.ReplicationTransformation"
     trmodule = "DIRAC.TransformationSystem.Client.Transformation.Transformation"
     with patch(trmodule + ".getTransformation", new=Mock(return_value=S_OK({}))), \
             patch(trmodule + ".addTransformation", new=Mock(return_value=S_OK())), \
-            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())), \
-            patch("%s.TransformationClient" % module_name, new=self.tMock):
+            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())):
       ret = createDataTransformation('Smelly', tSE, sSE, 'prodID', prodID, extraname="extraName", enable=True)
     self.assertFalse(ret['OK'], ret.get('Message', ""))
     self.assertIn('Unsupported flavour', ret['Message'])
@@ -123,12 +114,10 @@ class TestMoving(unittest.TestCase):
     tSE = "Target-SRM"
     sSE = "Source-SRM"
     prodID = 12345
-    module_name = "DIRAC.TransformationSystem.Utilities.ReplicationTransformation"
     trmodule = "DIRAC.TransformationSystem.Client.Transformation.Transformation"
     with patch(trmodule + ".getTransformation", new=Mock(return_value=S_OK({}))), \
             patch(trmodule + ".addTransformation", new=Mock(return_value=S_OK())), \
-            patch(trmodule + "._Transformation__setSE", new=Mock(side_effect=(S_OK(), S_ERROR()))), \
-            patch("%s.TransformationClient" % module_name, new=self.tMock):
+            patch(trmodule + "._Transformation__setSE", new=Mock(side_effect=(S_OK(), S_ERROR()))):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=True)
     self.assertFalse(ret['OK'], str(ret))
     self.assertIn("TargetSE not valid", ret['Message'])
@@ -138,12 +127,10 @@ class TestMoving(unittest.TestCase):
     tSE = "Target-SRM"
     sSE = "Source-SRM"
     prodID = 12345
-    module_name = "DIRAC.TransformationSystem.Utilities.ReplicationTransformation"
     trmodule = "DIRAC.TransformationSystem.Client.Transformation.Transformation"
     with patch(trmodule + ".getTransformation", new=Mock(return_value=S_OK({}))), \
             patch(trmodule + ".addTransformation", new=Mock(return_value=S_OK())), \
-            patch(trmodule + "._Transformation__setSE", new=Mock(side_effect=(S_ERROR(), S_ERROR()))), \
-            patch("%s.TransformationClient" % module_name, new=self.tMock):
+            patch(trmodule + "._Transformation__setSE", new=Mock(side_effect=(S_ERROR(), S_ERROR()))):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=True)
     self.assertFalse(ret['OK'], str(ret))
     self.assertIn("SourceSE not valid", ret['Message'])
@@ -153,12 +140,10 @@ class TestMoving(unittest.TestCase):
     tSE = "Target-SRM"
     sSE = "Source-SRM"
     prodID = 12345
-    module_name = "DIRAC.TransformationSystem.Utilities.ReplicationTransformation"
     trmodule = "DIRAC.TransformationSystem.Client.Transformation.Transformation"
     with patch(trmodule + ".getTransformation", new=Mock(return_value=S_OK({}))), \
             patch(trmodule + ".addTransformation", new=Mock(return_value=S_ERROR("Cannot add Trafo"))), \
-            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())), \
-            patch("%s.TransformationClient" % module_name, new=self.tMock):
+            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=True)
     self.assertFalse(ret['OK'], str(ret))
     self.assertIn("Cannot add Trafo", ret['Message'])
@@ -168,18 +153,13 @@ class TestMoving(unittest.TestCase):
     tSE = "Target-SRM"
     sSE = "Source-SRM"
     prodID = 12345
-    # self.tClientMock.createTransformationInputDataQuery.return_value = S_ERROR("Failed to create IDQ")
-    self.tClientMock.createTransformationMetaQuery.return_value = S_ERROR("Failed to create IDQ")
-
-    module_name = "DIRAC.TransformationSystem.Utilities.ReplicationTransformation"
     trmodule = "DIRAC.TransformationSystem.Client.Transformation.Transformation"
     with patch(trmodule + ".getTransformation", new=Mock(return_value=S_OK({}))), \
-            patch(trmodule + ".addTransformation", new=Mock(return_value=S_OK())), \
-            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())), \
-            patch("%s.TransformationClient" % module_name, new=self.tMock):
+            patch(trmodule + ".addTransformation", new=Mock(return_value=S_ERROR('Failed to add IMQ'))), \
+            patch(trmodule + "._Transformation__setSE", new=Mock(return_value=S_OK())):
       ret = createDataTransformation('Moving', tSE, sSE, 'prodID', prodID, enable=True)
     self.assertFalse(ret['OK'], str(ret))
-    self.assertIn("Failed to create IDQ", ret['Message'])
+    self.assertIn("Failed to add IMQ", ret['Message'])
 
 
 class TestParams(unittest.TestCase):

--- a/docs/diracdoctools/CustomizedDocs/CustomTransformation.py
+++ b/docs/diracdoctools/CustomizedDocs/CustomTransformation.py
@@ -1,0 +1,37 @@
+"""Additional docstring for the DErrno module."""
+
+import textwrap
+
+MODULE = 'DIRAC.TransformationSystem.Client.Transformation'
+
+
+class CustomTransformation(object):  # pylint: disable=too-few-public-methods
+  """Add the ERRNO constants to the docstring automatically."""
+
+  def __init__(self):
+    """Create a string containing restructured text documentation for all the special tranformation parameters
+
+    :param str module: full path to the module
+    :param bool replace: wether to replace the full docstring or not
+       if you replace it completely add the automodule commands etc.!
+    """
+    self.module = MODULE
+    self.replace = False
+    self.doc_string = ''
+    # Fill the docstring addition with what we want to add
+    self.doc_string += textwrap.dedent("""
+                                       Transformation Parameters
+                                       -------------------------
+
+                                       Any parameter with ``ParameterName`` can be set for a transformation with a call
+                                       to ``setParameterName(parameterValue)``.
+
+                                       The following parameters have a special meaning
+                                       """)
+    from DIRAC.TransformationSystem.Client.Transformation import Transformation
+    trans = Transformation()
+    for paramName in sorted(trans.paramTypes):
+      self.doc_string += '\n``%s``:\n    Default value: %r' % (paramName, trans.paramValues[paramName])
+
+
+CUSTOMIZED_DOCSTRINGS[MODULE] = CustomTransformation()  # pylint: disable=undefined-variable

--- a/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
+++ b/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
@@ -261,19 +261,17 @@ To add the metadata query functionality to our ``createRemoval.py`` script from 
 of lines
 
 .. code-block:: python
-   :lineno-start: 61
+   :lineno-start: 44
 
-   from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
-   metadata = {'TransformationID': 2}
-   res = TransformationClient().createTransformationInputDataQuery(transID, metadata)
-   gLogger.notice('Added input data query', res)
+   metaQuery = {'TransformationID': 2}
+   myTrans.setInputDataQuery(metaQuery)
+
    ...
 
 Adapt the script by inserting the lines and changing the ``uniqueIdentifier`` and execute it::
 
   [diracuser@dirac-tuto ~]$ python createRemoval.py
   Created transformation JJJ
-  Added input data query {'OK': True, 'rpcStub': (('Transformation/TransformationManager', {'skipCACheck': False, 'keepAliveLapse': 150, 'timeout': 120}), 'createTransformationInputDataQuery', (JJJL, {'TransformationID': 2})), 'Value': 1L}
   Created RemoveReplica transformation: JJJL
 
 Conclusion


### PR DESCRIPTION

BEGINRELEASENOTES

*TS
NEW: InputDataQuery and OutputDataQuery parameters can be set for Transformations before they are added to the transformation system. Solves #4071 

ENDRELEASENOTES
