### PR TITLE
[v6r21] Fix symlink creations in deploy-script

### DIFF
--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -191,7 +191,7 @@ for rootModule in listDir:
         if os.path.exists(fakeScriptPath):
           os.remove(fakeScriptPath)
         # Create the symlink
-        os.symlink(os.path.abspath(scriptPath), fakeScriptPath)
+        os.symlink(os.path.join(rootPath, scriptPath), fakeScriptPath)
       else:
         with open(fakeScriptPath, "w") as fd:
           fd.write(wrapperTemplate.replace('$SCRIPTLOCATION$', scriptPath))


### PR DESCRIPTION
Stupid mistake 
BEGINRELEASENOTES
*Core
FIX: correct symlinks in dirac-deploy

ENDRELEASENOTES
