### PR TITLE
[v6r21] restoring the job status to Running after hearbeat

### DIFF
--- a/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -327,18 +327,18 @@ class JobStateUpdateHandler(RequestHandler):
       self.log.warn('Failed to set the heart beat data', 'for job %d ' % int(jobID))
 
     # Restore the Running status if necessary
-    # result = jobDB.getJobAttributes(jobID,['Status'])
-    # if not result['OK']:
-    #  return result
+    result = jobDB.getJobAttributes(jobID, ['Status'])
+    if not result['OK']:
+     return result
 
-    # if not result['Value']:
-    #  return S_ERROR('Job %d not found' % jobID)
+    if not result['Value']:
+     return S_ERROR('Job %d not found' % jobID)
 
-    # status = result['Value']['Status']
-    # if status == "Stalled" or status == "Matched":
-    #  result = jobDB.setJobAttribute(jobID,'Status','Running',True)
-    #  if not result['OK']:
-    #    self.log.warn('Failed to restore the job status to Running')
+    status = result['Value']['Status']
+    if status == "Stalled" or status == "Matched":
+     result = jobDB.setJobAttribute(jobID, 'Status', 'Running', True)
+     if not result['OK']:
+       self.log.warn('Failed to restore the job status to Running')
 
     jobMessageDict = {}
     result = jobDB.getJobCommand(int(jobID))


### PR DESCRIPTION
I simply de-commented some lines, which have been commented 10+ years ago. If anyone can shed some light on why they were commented, please let me know. I guess it was a "temporary measure" for performance reasons.

BEGINRELEASENOTES

*WMS
CHANGE: restoring the job status to Running after hearbeat

ENDRELEASENOTES
