### PR TITLE
[v6r22] plugin to get SE occupancy

### DIFF
--- a/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/Resources/Storage/GFAL2_SRM2Storage.py
@@ -184,6 +184,9 @@ class GFAL2_SRM2Storage(GFAL2_StorageBase):
       Out of the results, we keep totalsize, guaranteedsize, and unusedsize all in B.
     """
 
+    if self.protocolParameters['SpaceToken'] == '':
+      return super(GFAL2_SRM2Storage, self).getOccupancy(*parms, **kws)
+
     # Gfal2 extended parameter name to query the space token occupancy
     spaceTokenAttr = 'spacetoken.description?%s' % self.protocolParameters['SpaceToken']
     # gfal2 can take any srm url as a base.

--- a/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
+++ b/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
@@ -1,0 +1,27 @@
+import os
+
+from DIRAC import gLogger, gConfig
+from DIRAC import S_OK, S_ERROR
+from DIRAC.Core.Utilities.Grid import ldapsearchBDII
+
+
+class BDIIOccupancy(object):
+  def __init__(self):
+    self.host = 'lcg-bdii.cern.ch:2170'
+    if 'LCG_GFAL_INFOSYS' in os.environ:
+      self.host = os.environ['LCG_GFAL_INFOSYS']
+
+  def getOccupancy(self, sePlugin):
+    sTokenDict = {'Total': 0, 'Free': 0}
+    bdiiAttr = ['GlueSATotalOnlineSize', 'GlueSAFreeOnlineSize']
+    filt = "(&(GlueSAAccessControlBaseRule=VO:%s)" % sePlugin.voName
+    filt += "(GlueChunkKey=GlueSEUniqueID=%s))" % sePlugin.protocolParameters['Host']
+    ret = ldapsearchBDII(filt, bdiiAttr, host=self.host)
+    if not ret['OK']:
+      return ret
+    if len(ret['Value']) > 0:
+      if 'attr' in ret['Value'][0]:
+        attr = ret['Value'][0]['attr']
+        sTokenDict['Total'] = float(attr.get(bdiiAttr[0], 0)) * 1024 * 1024 * 1024
+        sTokenDict['Free'] = float(attr.get(bdiiAttr[1], 0)) * 1024 * 1024 * 1024
+    return S_OK(sTokenDict)

--- a/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
+++ b/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
@@ -39,9 +39,9 @@ class BDIIOccupancy(object):
     ret = ldapsearchBDII(filt, BDIIAttr, host=self.bdii)
     if not ret['OK']:
       return ret
-    if len(ret['Value']) > 0:
-      if 'attr' in ret['Value'][0]:
-        attr = ret['Value'][0]['attr']
+    for value in ret['Value']:
+      if 'attr' in value:
+        attr = value['attr']
         sTokenDict['Total'] = float(attr.get(BDIIAttr[0], 0)) * 1024 * 1024 * 1024
         sTokenDict['Free'] = float(attr.get(BDIIAttr[1], 0)) * 1024 * 1024 * 1024
     return S_OK(sTokenDict)

--- a/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
+++ b/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
@@ -1,3 +1,9 @@
+"""
+  Defines the plugin to take storage space information given by BDII
+"""
+
+__RCSID__ = "$Id$"
+
 import os
 
 from DIRAC import gLogger, gConfig
@@ -6,6 +12,11 @@ from DIRAC.Core.Utilities.Grid import ldapsearchBDII
 
 
 class BDIIOccupancy(object):
+  """ .. class:: BDIIOccupancy
+
+  Occupancy plugin to return the space information given by BDII
+  Assuming the protocol is SRM
+  """
   def __init__(self, se):
     # flag to show initalization status of the plugin
     self.isUsable = False

--- a/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
+++ b/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
@@ -7,13 +7,15 @@ from DIRAC.Core.Utilities.Grid import ldapsearchBDII
 
 class BDIIOccupancy(object):
   def __init__(self, se):
+    # flag to show initalization status of the plugin
     self.isUsable = False
     self.log = se.log.getSubLogger('BDIIOccupancy')
+    # BDII host to query
     self.bdii = 'lcg-bdii.cern.ch:2170'
     if 'LCG_GFAL_INFOSYS' in os.environ:
       self.bdii = os.environ['LCG_GFAL_INFOSYS']
     self.vo = se.vo
-    # assume the SE speaks SRM
+    # assume given SE speaks SRM
     ret = se.getStorageParameters(protocol='srm')
     if not ret['OK']:
       self.log.error(ret['Message'])
@@ -25,6 +27,11 @@ class BDIIOccupancy(object):
     self.isUsable = True
 
   def getOccupancy(self):
+    """ Returns the space information given by BDII
+        Total and Free space are taken from GlueSATotalOnlineSize and GlueSAFreeOnlineSize, respectively.
+
+        :returns: S_OK with dict (keys: Total, Free)
+    """
     sTokenDict = {'Total': 0, 'Free': 0}
     BDIIAttr = ['GlueSATotalOnlineSize', 'GlueSAFreeOnlineSize']
 

--- a/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
+++ b/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
@@ -19,7 +19,6 @@ class BDIIOccupancy(object):
   """
   def __init__(self, se):
     # flag to show initalization status of the plugin
-    self.isUsable = False
     self.log = se.log.getSubLogger('BDIIOccupancy')
     # BDII host to query
     self.bdii = 'lcg-bdii.cern.ch:2170'
@@ -29,15 +28,12 @@ class BDIIOccupancy(object):
     # assume given SE speaks SRM
     ret = se.getStorageParameters(protocol='srm')
     if not ret['OK']:
-      self.log.error(ret['Message'])
-      return
+      raise RuntimeError(ret['Message'])
     if 'Host' not in ret['Value']:
-      self.log.error('No Host is found from StorageParameters')
-      return
+      raise RuntimeError('No Host is found from StorageParameters')
     self.host = ret['Value']['Host']
-    self.isUsable = True
 
-  def getOccupancy(self):
+  def getOccupancy(self, **kwargs):
     """ Returns the space information given by BDII
         Total and Free space are taken from GlueSATotalOnlineSize and GlueSAFreeOnlineSize, respectively.
 

--- a/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
+++ b/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
@@ -6,22 +6,35 @@ from DIRAC.Core.Utilities.Grid import ldapsearchBDII
 
 
 class BDIIOccupancy(object):
-  def __init__(self):
-    self.host = 'lcg-bdii.cern.ch:2170'
+  def __init__(self, se):
+    self.isUsable = False
+    self.log = se.log.getSubLogger('BDIIOccupancy')
+    self.bdii = 'lcg-bdii.cern.ch:2170'
     if 'LCG_GFAL_INFOSYS' in os.environ:
-      self.host = os.environ['LCG_GFAL_INFOSYS']
+      self.bdii = os.environ['LCG_GFAL_INFOSYS']
+    self.vo = se.vo
+    # assume the SE speaks SRM
+    ret = se.getStorageParameters(protocol='srm')
+    if not ret['OK']:
+      self.log.error(ret['Message'])
+      return
+    if 'Host' not in ret['Value']:
+      self.log.error('No Host is found from StorageParameters')
+      return
+    self.host = ret['Value']['Host']
+    self.isUsable = True
 
-  def getOccupancy(self, sePlugin):
+  def getOccupancy(self):
     sTokenDict = {'Total': 0, 'Free': 0}
-    bdiiAttr = ['GlueSATotalOnlineSize', 'GlueSAFreeOnlineSize']
-    filt = "(&(GlueSAAccessControlBaseRule=VO:%s)" % sePlugin.voName
-    filt += "(GlueChunkKey=GlueSEUniqueID=%s))" % sePlugin.protocolParameters['Host']
-    ret = ldapsearchBDII(filt, bdiiAttr, host=self.host)
+    BDIIAttr = ['GlueSATotalOnlineSize', 'GlueSAFreeOnlineSize']
+
+    filt = "(&(GlueSAAccessControlBaseRule=VO:%s)(GlueChunkKey=GlueSEUniqueID=%s))" % (self.vo, self.host)
+    ret = ldapsearchBDII(filt, BDIIAttr, host=self.bdii)
     if not ret['OK']:
       return ret
     if len(ret['Value']) > 0:
       if 'attr' in ret['Value'][0]:
         attr = ret['Value'][0]['attr']
-        sTokenDict['Total'] = float(attr.get(bdiiAttr[0], 0)) * 1024 * 1024 * 1024
-        sTokenDict['Free'] = float(attr.get(bdiiAttr[1], 0)) * 1024 * 1024 * 1024
+        sTokenDict['Total'] = float(attr.get(BDIIAttr[0], 0)) * 1024 * 1024 * 1024
+        sTokenDict['Free'] = float(attr.get(BDIIAttr[1], 0)) * 1024 * 1024 * 1024
     return S_OK(sTokenDict)

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -410,7 +410,7 @@ class StorageElementItem(object):
           occupancyDict = res['Value']
           result = self.checkOccupancy(occupancyDict, unit)
           if result['OK']:
-            return result['Value']
+            return result
 
     # Try all of the storages one by one
     for storage in filteredPlugins:
@@ -426,15 +426,15 @@ class StorageElementItem(object):
 
         if 'SpaceReservation' not in occupancyDict:
           occupancyDict['SpaceReservation'] = self.options.get('SpaceReservation')
-        return res
+        return S_OK(occupancyDict)
 
     return S_ERROR("Could not retrieve the occupancy from any plugin")
 
   def checkOccupancy(self, occupancyDict, unit):
     """ Validate occupancy dict given by getOccupancy
 
-      :param occupancyDict: occupancy given by occupancy or storage plugins
-      :param unit: inherited from getOccupancy
+      :param dict occupancyDict: occupancy given by occupancy or storage plugins
+      :param str unit: Any of ( 'B', 'kB', 'MB', 'GB', 'TB', 'PB')
 
       :returns: S_OK with updated occupancyDict
     """

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -385,9 +385,6 @@ class StorageElementItem(object):
     """
     log = self.log.getSubLogger('getOccupancy', True)
 
-    # Mandatory parameters
-    mandatoryParams = set(['Total', 'Free'])
-
     if 'occupancyLFN' not in kwargs:
       occupancyLFN = self.options.get('OccupancyLFN')
       if not occupancyLFN:
@@ -399,8 +396,8 @@ class StorageElementItem(object):
     if not filteredPlugins:
       return S_ERROR(errno.EPROTONOSUPPORT, "No storage plugins to query the occupancy")
 
-    occupancyPlugin = self.options.get('OccupancyPlugin')
     # Call occupancy plugin if requested
+    occupancyPlugin = self.options.get('OccupancyPlugin')
     if occupancyPlugin:
       res = ObjectLoader().loadObject(occupancyPlugin)
       if not res['OK']:
@@ -411,7 +408,7 @@ class StorageElementItem(object):
         res = occupancyPlugin.getOccupancy()
         if res['OK']:
           occupancyDict = res['Value']
-          result = self.checkOccupancy(occupancyDict, mandatoryParams, unit)
+          result = self.checkOccupancy(occupancyDict, unit)
           if result['OK']:
             return result['Value']
 
@@ -422,7 +419,7 @@ class StorageElementItem(object):
       res = storage.getOccupancy(**kwargs)
       if res['OK']:
         occupancyDict = res['Value']
-        result = self.checkOccupancy(occupancyDict, mandatoryParams, unit)
+        result = self.checkOccupancy(occupancyDict, unit)
         if not result['OK']:
           continue
         occupancyDict = result['Value']
@@ -433,8 +430,18 @@ class StorageElementItem(object):
 
     return S_ERROR("Could not retrieve the occupancy from any plugin")
 
-  def checkOccupancy(self, occupancyDict, mandatoryParams, unit):
+  def checkOccupancy(self, occupancyDict, unit):
+    """ Validate occupancy dict given by getOccupancy
+
+      :param occupancyDict: occupancy given by occupancy or storage plugins
+      :param unit: inherited from getOccupancy
+
+      :returns: S_OK with updated occupancyDict
+    """
     log = self.log.getSubLogger('checkOccupancy', True)
+
+    # Mandatory parameters
+    mandatoryParams = set(['Total', 'Free'])
     # Make sure all the mandatory parameters are present
     if set(occupancyDict) & mandatoryParams != mandatoryParams:
 

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -406,14 +406,12 @@ class StorageElementItem(object):
       try:
         occupancyPlugin = res['Value'](self)
         res = occupancyPlugin.getOccupancy(**kwargs)
-        if res['OK']:
-          occupancyDict = res['Value']
-          result = self.checkOccupancy(occupancyDict, unit)
-          if result['OK']:
-            return result
-          log.warn('Occupancy plugin failed: %s' % str(result['Message']))
+        if not res['OK']:
+          return res
+        occupancyDict = res['Value']
+        return self.checkOccupancy(occupancyDict, unit)
       except Exception as e:
-        log.warn('Occupancy plugin failed: %s' % str(e))
+        return S_ERROR('Occupancy plugin failed: %s' % str(e))
 
     # Try all of the storages one by one
     for storage in filteredPlugins:

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -403,14 +403,17 @@ class StorageElementItem(object):
       if not res['OK']:
         return S_ERROR(errno.EPROTONOSUPPORT, 'Failed to load occupancy plugin %s' % occupancyPlugin)
       log.verbose('Use occupancy plugin %s' % occupancyPlugin)
-      occupancyPlugin = res['Value'](self)
-      if occupancyPlugin.isUsable:
-        res = occupancyPlugin.getOccupancy()
+      try:
+        occupancyPlugin = res['Value'](self)
+        res = occupancyPlugin.getOccupancy(**kwargs)
         if res['OK']:
           occupancyDict = res['Value']
           result = self.checkOccupancy(occupancyDict, unit)
           if result['OK']:
             return result
+          log.warn('Occupancy plugin failed: %s' % str(result['Message']))
+      except Exception as e:
+        log.warn('Occupancy plugin failed: %s' % str(e))
 
     # Try all of the storages one by one
     for storage in filteredPlugins:


### PR DESCRIPTION
This PR proposes to add a plugin mechanism to StorageElement.getOccupancy().
If "OccupancyPlugin" is found from a SE configuration, specified occupancy plugin is called before built-in getOccupancy() of each SE plugin.
As a working sample, add plugin to retrieve the occupancy from BDII.
Additionally enable for GFAL2_SRM2Storage.getOccupancy() to go back parent function if SpaceToken is not given.

This is replacement of #4109 which incorporated unrelated commits

BEGINRELEASENOTES

*Resources
NEW: enable to get SE occupancy from plugin
NEW: add occupancy plugin to retrieve the info from BDII
CHANGE: GFAL2_SRM2Storage.getOccupancy() calls parent if SpaceToken is not given

ENDRELEASENOTES