### PR TITLE
[v6r21] a logic bug in counting numberOfTasks

### DIFF
--- a/TransformationSystem/Agent/MCExtensionAgent.py
+++ b/TransformationSystem/Agent/MCExtensionAgent.py
@@ -93,7 +93,7 @@ class MCExtensionAgent( AgentModule ):
     done = statusDict.get( 'Done', 0 )
     failed = statusDict.get( 'Failed', 0 )
     waiting = statusDict.get( 'Waiting', 0 )
-    total = statusDict.get( 'Created', 0 )
+    total = statusDict.get( 'TotalCreated', 0 )
     # If the failure rate is higher than acceptable
     if ( total != 0 ) and ( ( 100.0 * float( failed ) / float( total ) ) > self.maxFailRate ):
       return 0

--- a/TransformationSystem/Agent/MCExtensionAgent.py
+++ b/TransformationSystem/Agent/MCExtensionAgent.py
@@ -93,7 +93,7 @@ class MCExtensionAgent( AgentModule ):
     done = statusDict.get( 'Done', 0 )
     failed = statusDict.get( 'Failed', 0 )
     waiting = statusDict.get( 'Waiting', 0 )
-    total = statusDict.get( 'TotalCreated', 0 )
+    total = statusDict.get('TotalCreated', 0)
     # If the failure rate is higher than acceptable
     if ( total != 0 ) and ( ( 100.0 * float( failed ) / float( total ) ) > self.maxFailRate ):
       return 0


### PR DESCRIPTION
MCExtension has a logic bug in the code when counting "numberOfTasks = maxTasks - ( total - failed )", total should be "totalcreated" instead of just "created"
original: total = statusDict.get( 'Created', 0 )
modified: total = statusDict.get( 'TotalCreated', 0 )
After changed, the "MaxNumberOfTasks" can correctly limit the number of jobs 

created.

BEGINRELEASENOTES

*Transformation
FIX: fixed a logic bug in counting numberOfTasks in MCExtension which is expected 

to limit the total number of tasks for MC transformations

ENDRELEASENOTES
