### PR TITLE
[WIP][integration -- later?] python 2/3 compatibilities

### DIFF
--- a/AccountingSystem/Agent/NetworkAgent.py
+++ b/AccountingSystem/Agent/NetworkAgent.py
@@ -102,7 +102,7 @@ class NetworkAgent (AgentModule):
       return S_ERROR('Unable to fetch perfSONAR endpoints from CS.')
 
     tmpDict = {}
-    for path, value in result['Value'].iteritems():
+    for path, value in result['Value'].items():  # can be an iterator
       if value == 'True':
         elements = path.split('/')
         diracName = elements[4]

--- a/AccountingSystem/Client/AccountingCLI.py
+++ b/AccountingSystem/Client/AccountingCLI.py
@@ -6,9 +6,12 @@ DIRAC Accounting DataStore Service
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+
 __RCSID__ = "$Id$"
 
 import sys
+
+from builtins import input
 
 from DIRAC import gLogger
 from DIRAC.Core.Base.CLI import CLI, colorize
@@ -200,7 +203,7 @@ class AccountingCLI(CLI):
         gLogger.error("No type name specified")
         return
       while True:
-        choice = raw_input(
+        choice = input(
             "Are you completely sure you want to delete type %s and all it's data? yes/no [no]: " %
             typeName)
         choice = choice.lower()

--- a/AccountingSystem/Client/DataStoreClient.py
+++ b/AccountingSystem/Client/DataStoreClient.py
@@ -3,8 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/AccountingSystem/Client/DataStoreClient.py
+++ b/AccountingSystem/Client/DataStoreClient.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 import time

--- a/AccountingSystem/Client/ReportsClient.py
+++ b/AccountingSystem/Client/ReportsClient.py
@@ -8,6 +8,8 @@ __RCSID__ = "$Id$"
 
 import tempfile
 
+from io import open
+
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Base.Client import Client
 from DIRAC.Core.DISET.TransferClient import TransferClient

--- a/AccountingSystem/Service/DataStoreHandler.py
+++ b/AccountingSystem/Service/DataStoreHandler.py
@@ -13,8 +13,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+__RCSID__ = "$Id$"
 
 import datetime
+import six
 
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.AccountingSystem.DB.MultiAccountingDB import MultiAccountingDB
@@ -23,8 +25,6 @@ from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
 from DIRAC.Core.Utilities import Time
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.Core.DISET.RPCClient import RPCClient
-
-__RCSID__ = "$Id$"
 
 
 class DataStoreHandler(RequestHandler):
@@ -47,7 +47,7 @@ class DataStoreHandler(RequestHandler):
       gThreadScheduler.addPeriodicTask(60, cls.__acDB.loadPendingRecords)  # pylint: disable=no-member
     return S_OK()
 
-  types_registerType = [basestring, list, list, list]
+  types_registerType = [six.string_types, list, list, list]
 
   def export_registerType(self, typeName, definitionKeyFields, definitionAccountingFields, bucketsLength):
     """
@@ -71,7 +71,7 @@ class DataStoreHandler(RequestHandler):
       return S_ERROR("Error while registering type:\n %s" % "\n ".join(errorsList))
     return S_OK()
 
-  types_setBucketsLength = [basestring, list]
+  types_setBucketsLength = [six.string_types, list]
 
   def export_setBucketsLength(self, typeName, bucketsLength):
     """
@@ -91,7 +91,7 @@ class DataStoreHandler(RequestHandler):
       return S_ERROR("Error while changing bucketsLength type:\n %s" % "\n ".join(errorsList))
     return S_OK()
 
-  types_regenerateBuckets = [basestring]
+  types_regenerateBuckets = [six.string_types]
 
   def export_regenerateBuckets(self, typeName):
     """
@@ -119,7 +119,7 @@ class DataStoreHandler(RequestHandler):
     """
     return self.__acDB.getRegisteredTypes()  # pylint: disable=no-member
 
-  types_deleteType = [basestring]
+  types_deleteType = [six.string_types]
 
   def export_deleteType(self, typeName):
     """
@@ -138,7 +138,7 @@ class DataStoreHandler(RequestHandler):
       return S_ERROR("Error while deleting type:\n %s" % "\n ".join(errorsList))
     return S_OK()
 
-  types_commit = [basestring, datetime.datetime, datetime.datetime, list]
+  types_commit = [six.string_types, datetime.datetime, datetime.datetime, list]
 
   def export_commit(self, typeName, startTime, endTime, valuesList):
     """
@@ -161,7 +161,7 @@ class DataStoreHandler(RequestHandler):
       Add a record for a type
     """
     setup = self.serviceInfoDict['clientSetup']
-    expectedTypes = [basestring, datetime.datetime, datetime.datetime, list]
+    expectedTypes = [six.string_types, datetime.datetime, datetime.datetime, list]
     for entry in entriesList:
       if len(entry) != 4:
         return S_ERROR("Invalid records")
@@ -193,7 +193,7 @@ class DataStoreHandler(RequestHandler):
 
     return RPCClient('Accounting/DataStoreMaster').compactDB()
 
-  types_remove = [basestring, datetime.datetime, datetime.datetime, list]
+  types_remove = [six.string_types, datetime.datetime, datetime.datetime, list]
 
   def export_remove(self, typeName, startTime, endTime, valuesList):
     """
@@ -216,11 +216,11 @@ class DataStoreHandler(RequestHandler):
       Remove a record for a type
     """
     setup = self.serviceInfoDict['clientSetup']
-    expectedTypes = [basestring, datetime.datetime, datetime.datetime, list]
+    expectedTypes = [six.string_types, datetime.datetime, datetime.datetime, list]
     for entry in entriesList:
       if len(entry) != 4:
         return S_ERROR("Invalid records")
-      for i in xrange(len(entry)):
+      for i, _ in enumerate(entry):
         if not isinstance(entry[i], expectedTypes[i]):
           return S_ERROR("%s field in the records should be %s" % (i, expectedTypes[i]))
     ok = 0

--- a/AccountingSystem/Service/ReportGeneratorHandler.py
+++ b/AccountingSystem/Service/ReportGeneratorHandler.py
@@ -18,6 +18,8 @@ import six
 import os
 import datetime
 
+from io import open
+
 from DIRAC import S_OK, S_ERROR, rootPath, gConfig, gLogger
 from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.Core.Utilities import Time

--- a/AccountingSystem/private/Plotters/NetworkPlotter.py
+++ b/AccountingSystem/private/Plotters/NetworkPlotter.py
@@ -56,8 +56,8 @@ class NetworkPlotter(BaseReporter):
   def _plotPacketLossRate(self, reportRequest, plotInfo, filename):
 
     # prepare custom scale (10,20,...,100)
-    scale_data = dict(zip(range(0, 101), range(100, -1, -1)))
-    scale_ticks = range(0, 101, 10)
+    scale_data = dict(zip(list(range(0, 101)), list(range(100, -1, -1))))
+    scale_ticks = list(range(0, 101, 10))
 
     metadata = {'title': 'Packet loss rate by %s' % reportRequest['grouping'],
                 'starttime': reportRequest['startTime'],
@@ -101,12 +101,12 @@ class NetworkPlotter(BaseReporter):
 
     # prepare custom scale (1..10, 100)
     boundaries = list(np.arange(0, 10, 0.1))
-    boundaries.extend(range(10, 110, 10))
+    boundaries.extend(list(range(10, 110, 10)))
     values = list(np.arange(100, 0, -1))
     values.extend([0] * 10)
 
     scale_data = dict(zip(boundaries, values))
-    scale_ticks = range(0, 11)
+    scale_ticks = list(range(0, 11))
     scale_ticks.append(100)
 
     metadata = {'title': 'Magnified packet loss rate by %s' % reportRequest['grouping'],

--- a/AccountingSystem/private/Plotters/PilotPlotter.py
+++ b/AccountingSystem/private/Plotters/PilotPlotter.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from DIRAC import S_OK
 from DIRAC.AccountingSystem.Client.Types.Pilot import Pilot

--- a/AccountingSystem/scripts/dirac-accounting-decode-fileid.py
+++ b/AccountingSystem/scripts/dirac-accounting-decode-fileid.py
@@ -9,12 +9,16 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 __RCSID__ = "$Id$"
 
 import pprint
 import sys
-import urlparse
 import cgi
+
+from six.moves.urllib.parse import urlparse
+
 from DIRAC import gLogger
 from DIRAC.Core.Base import Script
 from DIRAC.Core.Utilities.Plotting.FileCoding import extractRequestFromFileId
@@ -30,7 +34,7 @@ fileIds = Script.getPositionalArgs()
 
 for fileId in fileIds:
   # Try to find if it's a url
-  parseRes = urlparse.urlparse(fileId)
+  parseRes = urlparse(fileId)
   if parseRes.query:
     queryRes = cgi.parse_qs(parseRes.query)
     if 'file' in queryRes:

--- a/ConfigurationSystem/Client/CSCLI.py
+++ b/ConfigurationSystem/Client/CSCLI.py
@@ -6,11 +6,14 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+
 import sys
 import atexit
 import os
 import readline
+
 import six
+from builtins import input
 
 from DIRAC import gLogger
 
@@ -243,7 +246,7 @@ class CSCLI(CLI):
         return
       if not self.modifiedData:
         while True:
-          choice = raw_input("Data has not been modified, do you still want to upload changes? yes/no [no]: ")
+          choice = input("Data has not been modified, do you still want to upload changes? yes/no [no]: ")
           choice = choice.lower()
           if choice in ("yes", "y"):
             break
@@ -251,7 +254,7 @@ class CSCLI(CLI):
             print("Commit aborted")
             return
 
-      choice = raw_input("Do you really want to send changes to server? yes/no [no]: ")
+      choice = input("Do you really want to send changes to server? yes/no [no]: ")
       choice = choice.lower()
       if choice in ("yes", "y"):
         print("Uploading changes to %s (It may take some seconds)..." % self.masterURL)
@@ -305,7 +308,7 @@ class CSCLI(CLI):
         print("Must specify option to delete")
         return
       optionPath = argsList[0].strip()
-      choice = raw_input("Are you sure you want to delete %s? yes/no [no]: " % optionPath)
+      choice = input("Are you sure you want to delete %s? yes/no [no]: " % optionPath)
       choice = choice.lower()
       if choice in ("yes", "y", "true"):
         if self.modificator.removeOption(optionPath):
@@ -329,7 +332,7 @@ class CSCLI(CLI):
         print("Must specify section to delete")
         return
       section = argsList[0].strip()
-      choice = raw_input("Are you sure you want to delete %s? yes/no [no]: " % section)
+      choice = input("Are you sure you want to delete %s? yes/no [no]: " % section)
       choice = choice.lower()
       if choice in ("yes", "y", "true"):
         if self.modificator.removeSection(section):
@@ -502,7 +505,7 @@ class CSCLI(CLI):
         print("What version to rollback?")
         return
       version = " ".join(argsList[0:2])
-      choice = raw_input("Do you really want to rollback to version %s? yes/no [no]: " % version)
+      choice = input("Do you really want to rollback to version %s? yes/no [no]: " % version)
       choice = choice.lower()
       if choice in ("yes", "y"):
         response = self.modificator.rollbackToVersion(version)
@@ -521,7 +524,7 @@ class CSCLI(CLI):
     Usage: diffWithServer
     """
     try:
-      choice = raw_input("Do you want to merge with server configuration? yes/no [no]: ")
+      choice = input("Do you want to merge with server configuration? yes/no [no]: ")
       choice = choice.lower()
       if choice in ("yes", "y"):
         retVal = self.modificator.mergeWithServer()

--- a/ConfigurationSystem/Client/CSShellCLI.py
+++ b/ConfigurationSystem/Client/CSShellCLI.py
@@ -4,14 +4,17 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+
 __RCSID__ = "$Id$"
 
 import cmd
 import os
 
-from DIRAC.Core.Base.CLI import CLI, colorize
+from builtins import input
+
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 from DIRAC.ConfigurationSystem.private.Modificator import Modificator
+from DIRAC.Core.Base.CLI import CLI, colorize
 from DIRAC.Core.DISET.RPCClient import RPCClient
 
 
@@ -72,7 +75,7 @@ class CSShellCLI(CLI):
   def do_disconnect(self, _line):
     """Disconnect from CS"""
     if self.connected and self.dirty:
-      res = raw_input("Do you want to commit your changes into the CS ? [y/N] ")
+      res = input("Do you want to commit your changes into the CS ? [y/N] ")
       if res.lower() in ["y", "yes"]:
         self.do_commit("")
 

--- a/ConfigurationSystem/Client/Helpers/CSGlobals.py
+++ b/ConfigurationSystem/Client/Helpers/CSGlobals.py
@@ -8,14 +8,17 @@ Some Helper functions to retrieve common location from the CS
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+
 __RCSID__ = "$Id$"
 
 import imp
+import six
+
 from DIRAC.Core.Utilities.DIRACSingleton import DIRACSingleton
 
 
+@six.add_metaclass(DIRACSingleton)
 class Extensions(object):
-  __metaclass__ = DIRACSingleton
 
   def __init__(self):
     self.__modules = {}

--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -72,11 +72,13 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import six
-import thread
+import threading
 import os
 from diraccfg import CFG
+
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.Core.Utilities import LockRing
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry, CSGlobals
@@ -156,7 +158,7 @@ class Operations(object):
     finally:
       try:
         Operations.__cacheLock.release()
-      except thread.error:
+      except threading.ThreadError:
         pass
 
   @deprecated("unused")

--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -6,10 +6,10 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
-import urlparse
 from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
 
 import six
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath

--- a/ConfigurationSystem/Client/LocalConfiguration.py
+++ b/ConfigurationSystem/Client/LocalConfiguration.py
@@ -10,6 +10,8 @@ import sys
 import os
 import getopt
 
+from io import open
+
 import DIRAC
 from DIRAC import gLogger
 from DIRAC import S_OK, S_ERROR

--- a/ConfigurationSystem/Client/PathFinder.py
+++ b/ConfigurationSystem/Client/PathFinder.py
@@ -3,8 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/ConfigurationSystem/Client/PathFinder.py
+++ b/ConfigurationSystem/Client/PathFinder.py
@@ -4,9 +4,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
-import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC.Core.Utilities import List
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
@@ -110,8 +112,8 @@ def getServiceURL(serviceName, serviceTuple=False, setup=False):
   # This can only happen if there is only one server defined
   if ',' not in url:
 
-    urlParse = urlparse.urlparse(url)
-    server, port = urlParse.netloc.split(':')
+    urlParsed = urlparse(url)
+    server, port = urlParsed.netloc.split(':')
     mainUrlsList = []
 
     if server == '$MAINSERVERS$':
@@ -123,8 +125,8 @@ def getServiceURL(serviceName, serviceTuple=False, setup=False):
         raise Exception("No Main servers defined")
 
       for srv in mainServers:
-        mainUrlsList.append(urlparse.ParseResult(scheme=urlParse.scheme, netloc=':'.join([srv, port]),
-                                                 path=urlParse.path, params='', query='', fragment='').geturl())
+        mainUrlsList.append(urlparse.ParseResult(scheme=urlParsed.scheme, netloc=':'.join([srv, port]),
+                                                 path=urlParsed.path, params='', query='', fragment='').geturl())
       return ','.join(mainUrlsList)
 
   if len(url.split("/")) < 5:

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -12,12 +12,15 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 
 import re
 import socket
-from urlparse import urlparse
+
+from builtins import str
+from six.moves.urllib.parse import urlparse
 
 import six
 

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -18,11 +18,9 @@ __RCSID__ = "$Id$"
 
 import re
 import socket
-
-from builtins import str
-from six.moves.urllib.parse import urlparse
-
 import six
+
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath

--- a/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -6,17 +6,21 @@ from __future__ import print_function
 
 import os
 import unittest
+
+from io import open
 from diraccfg import CFG
+
 from DIRAC.ConfigurationSystem.Client.PathFinder import getComponentSection, getServiceFailoverURL, getServiceURL
 from DIRAC.ConfigurationSystem.private.ConfigurationClient import ConfigurationClient
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 
 
-class TestPathFinder( unittest.TestCase ):
-  def setUp( self ):
-    #Creating test configuration file
+class TestPathFinder(unittest.TestCase):
+
+  def setUp(self):
+    # Creating test configuration file
     self.testCfgFileName = 'test.cfg'
-    cfgContent='''
+    cfgContent = '''
     DIRAC
     {
       Setup=TestSetup
@@ -55,67 +59,72 @@ class TestPathFinder( unittest.TestCase ):
     '''
     with open(self.testCfgFileName, 'w') as f:
       f.write(cfgContent)
-    gConfig = ConfigurationClient(fileToLoadList = [self.testCfgFileName])  #we replace the configuration by our own one.
-    self.setup = gConfig.getValue( '/DIRAC/Setup', '' )
-    self.wm = gConfig.getValue('DIRAC/Setups/' + self.setup +'/WorkloadManagement', '')
-  def tearDown( self ):
+    # we replace the configuration by our own one.
+    gConfig = ConfigurationClient(fileToLoadList=[self.testCfgFileName])
+    self.setup = gConfig.getValue('/DIRAC/Setup', '')
+    self.wm = gConfig.getValue('DIRAC/Setups/' + self.setup + '/WorkloadManagement', '')
+
+  def tearDown(self):
     try:
       os.remove(self.testCfgFileName)
     except OSError:
       pass
     # SUPER UGLY: one must recreate the CFG objects of gConfigurationData
     # not to conflict with other tests that might be using a local dirac.cfg
-    gConfigurationData.localCFG=CFG()
-    gConfigurationData.remoteCFG=CFG()
-    gConfigurationData.mergedCFG=CFG()
+    gConfigurationData.localCFG = CFG()
+    gConfigurationData.remoteCFG = CFG()
+    gConfigurationData.mergedCFG = CFG()
     gConfigurationData.generateNewVersion()
 
-class TestGetComponentSection( TestPathFinder ):
 
-  def test_success( self ):
-    result = getComponentSection('WorkloadManagement/SandboxStoreHandler',False, False,'Services')
+class TestGetComponentSection(TestPathFinder):
+
+  def test_success(self):
+    result = getComponentSection('WorkloadManagement/SandboxStoreHandler', False, False, 'Services')
     correctResult = '/Systems/WorkloadManagement/' + self.wm + '/Services/SandboxStoreHandler'
     self.assertEqual(result, correctResult)
 
-  def test_sucessComponentStringDoesNotExist( self ):
+  def test_sucessComponentStringDoesNotExist(self):
     """ tricky case one could expect that if entity string is wrong
         than some kind of error will be returned, but it is not the case
     """
-    result = getComponentSection('WorkloadManagement/SimpleLogConsumer',False, False,'NonRonsumersNon')
+    result = getComponentSection('WorkloadManagement/SimpleLogConsumer', False, False, 'NonRonsumersNon')
     correctResult = '/Systems/WorkloadManagement/' + self.wm + '/NonRonsumersNon/SimpleLogConsumer'
     self.assertEqual(result, correctResult)
 
-class TestURLs( TestPathFinder ):
 
-  def test_getServiceURLSimple( self ):
+class TestURLs(TestPathFinder):
+
+  def test_getServiceURLSimple(self):
     """Fetching a URL defined normally"""
     result = getServiceURL('WorkloadManagement/Service1')
     correctResult = 'dips://server1:1234/WorkloadManagement/Service1'
 
     self.assertEqual(result, correctResult)
 
-  def test_getServiceMainURL( self ):
+  def test_getServiceMainURL(self):
     """Fetching a URL referencing the MainServers"""
     result = getServiceURL('WorkloadManagement/Service2')
     correctResult = 'dips://gw1:5678/WorkloadManagement/Service2,dips://gw2:5678/WorkloadManagement/Service2'
     self.assertEqual(result, correctResult)
 
-  def test_getServiceFailoverURLNonExisting( self ):
+  def test_getServiceFailoverURLNonExisting(self):
     """Fetching a FailoverURL not defined"""
     result = getServiceFailoverURL('WorkloadManagement/Service1')
     correctResult = ''
 
     self.assertEqual(result, correctResult)
 
-  def test_getServiceFailoverURL( self ):
+  def test_getServiceFailoverURL(self):
     """Fetching a FailoverURL"""
     result = getServiceFailoverURL('WorkloadManagement/Service2')
     correctResult = 'dips://failover1:5678/WorkloadManagement/Service2'
     self.assertEqual(result, correctResult)
 
-if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestPathFinder )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestGetComponentSection ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestURLs ) )
 
-  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
+if __name__ == '__main__':
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestPathFinder)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestGetComponentSection))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestURLs))
+
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/ConfigurationSystem/private/ConfigurationData.py
+++ b/ConfigurationSystem/private/ConfigurationData.py
@@ -320,7 +320,7 @@ class ConfigurationData(object):
   def dumpLocalCFGToFile(self, fileName):
     try:
       with open(fileName, "w") as fd:
-        fd.write(str(self.localCFG))
+        fd.write(self.localCFG)
       gLogger.verbose("Configuration file dumped", "'%s'" % fileName)
     except IOError:
       gLogger.error("Can't dump cfg file", "'%s'" % fileName)
@@ -335,7 +335,7 @@ class ConfigurationData(object):
 
   def dumpRemoteCFGToFile(self, fileName):
     with open(fileName, "w") as fd:
-      fd.write(str(self.remoteCFG))
+      fd.write(self.remoteCFG)
 
   def __backupCurrentConfiguration(self, backupName):
     configurationFilename = "%s.cfg" % self.getName()
@@ -359,7 +359,7 @@ class ConfigurationData(object):
     configurationFile = os.path.join(DIRAC.rootPath, "etc", "%s.cfg" % self.getName())
     try:
       with open(configurationFile, "w") as fd:
-        fd.write(str(self.remoteCFG))
+        fd.write(self.remoteCFG)
     except Exception as e:
       gLogger.fatal("Cannot write new configuration to disk!",
                     "file %s exception %s" % (configurationFile, repr(e)))

--- a/ConfigurationSystem/private/ConfigurationData.py
+++ b/ConfigurationSystem/private/ConfigurationData.py
@@ -4,11 +4,15 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
+
 import os.path
 import zlib
 import zipfile
-import thread
+import threading
 import time
+from io import open
+
 import DIRAC
 
 from diraccfg import CFG
@@ -397,7 +401,7 @@ class ConfigurationData(object):
     self.runningThreadsNumber += 1
     try:
       self.threadingLock.release()
-    except thread.error:
+    except threading.ThreadError:
       pass
 
   def dangerZoneEnd(self, returnValue=None):
@@ -409,6 +413,6 @@ class ConfigurationData(object):
     self.runningThreadsNumber -= 1
     try:
       self.threadingLock.release()
-    except thread.error:
+    except threading.ThreadError:
       pass
     return returnValue

--- a/ConfigurationSystem/private/Refresher.py
+++ b/ConfigurationSystem/private/Refresher.py
@@ -5,12 +5,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 import threading
-import thread
 import time
 import random
+
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 from DIRAC.ConfigurationSystem.Client.PathFinder import getGatewayURLs
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
@@ -82,7 +84,7 @@ class Refresher(threading.Thread):
     finally:
       try:
         self.__triggeredRefreshLock.release()
-      except thread.error:
+      except threading.ThreadError:
         pass
     # Launch the refresh
     thd = threading.Thread(target=self.__refreshInThread)

--- a/ConfigurationSystem/private/Refresher.py
+++ b/ConfigurationSystem/private/Refresher.py
@@ -4,8 +4,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -9,8 +9,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -10,13 +10,17 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 import signal
 import re
 import os
 import shlex
-from urlparse import urlparse
+
+from builtins import input
+from six.moves.urllib.parse import urlparse
 
 from DIRAC.Core.Base import Script
 from DIRAC import gLogger, exit as DIRACExit, S_OK
@@ -107,7 +111,7 @@ def checkUnusedCEs():
     gLogger.notice('No new resources available, exiting')
     DIRACExit(0)
 
-  inp = raw_input("\nDo you want to add sites ? [default=yes] [yes|no]: ")
+  inp = input("\nDo you want to add sites ? [default=yes] [yes|no]: ")
   inp = inp.strip()
   if not inp and inp.lower().startswith('n'):
     gLogger.notice('Nothing else to be done, exiting')
@@ -133,7 +137,7 @@ def checkUnusedCEs():
     result = getDIRACSiteName(site)
     if not result['OK']:
       gLogger.notice('\nThe site %s is not yet in the CS, give it a name' % site)
-      diracSite = raw_input('[help|skip|<domain>.<name>.%s]: ' % country)
+      diracSite = input('[help|skip|<domain>.<name>.%s]: ' % country)
       if diracSite.lower() == "skip":
         continue
       if diracSite.lower() == "help":
@@ -142,7 +146,7 @@ def checkUnusedCEs():
           if k != "CEs":
             gLogger.notice('%s\t%s' % (k, v))
         gLogger.notice('\nEnter DIRAC site name in the form <domain>.<name>.%s\n' % country)
-        diracSite = raw_input('[<domain>.<name>.%s]: ' % country)
+        diracSite = input('[<domain>.<name>.%s]: ' % country)
       try:
         _, _, _ = diracSite.split('.')
       except ValueError:
@@ -164,7 +168,7 @@ def checkUnusedCEs():
       for diracSite in diracSites:
         if ce in addedCEs:
           continue
-        yn = raw_input("Add CE %s of type %s to %s? [default yes] [yes|no]: " % (ce, ceType, diracSite))
+        yn = input("Add CE %s of type %s to %s? [default yes] [yes|no]: " % (ce, ceType, diracSite))
         if yn == '' or yn.lower() == 'y':
           newCEs.setdefault(diracSite, [])
           newCEs[diracSite].append(ce)
@@ -174,7 +178,7 @@ def checkUnusedCEs():
       if diracSite in newCEs:
         cmd = "dirac-admin-add-site %s %s %s" % (diracSite, site, ' '.join(newCEs[diracSite]))
         gLogger.notice("\nNew site/CEs will be added with command:\n%s" % cmd)
-        yn = raw_input("Add it ? [default yes] [yes|no]: ")
+        yn = input("Add it ? [default yes] [yes|no]: ")
         if not (yn == '' or yn.lower() == 'y'):
           continue
 
@@ -184,7 +188,7 @@ def checkUnusedCEs():
           result = systemCall(0, shlex.split(cmd))
           if not result['OK']:
             gLogger.error('Error while executing dirac-admin-add-site command')
-            yn = raw_input("Do you want to continue ? [default no] [yes|no]: ")
+            yn = input("Do you want to continue ? [default no] [yes|no]: ")
             if yn == '' or yn.lower().startswith('n'):
               if sitesAdded:
                 gLogger.notice('CEs were added at the following sites:')
@@ -195,7 +199,7 @@ def checkUnusedCEs():
             exitStatus, stdData, errData = result['Value']
             if exitStatus:
               gLogger.error('Error while executing dirac-admin-add-site command\n', '\n'.join([stdData, errData]))
-              yn = raw_input("Do you want to continue ? [default no] [yes|no]: ")
+              yn = input("Do you want to continue ? [default no] [yes|no]: ")
               if yn == '' or yn.lower().startswith('n'):
                 if sitesAdded:
                   gLogger.notice('CEs were added at the following sites:')
@@ -239,7 +243,7 @@ def updateCS(changeSet):
       else:
         csAPI.modifyValue(cfgPath(section, option), new_value)
 
-    yn = raw_input('Do you want to commit changes to CS ? [default yes] [yes|no]: ')
+    yn = input('Do you want to commit changes to CS ? [default yes] [yes|no]: ')
     if yn == '' or yn.lower().startswith('y'):
       result = csAPI.commit()
       if not result['OK']:
@@ -295,7 +299,7 @@ def checkUnusedSEs():
         gLogger.notice('Consider adding site %s to the DIRAC CS' % site)
         continue
       diracSites = result['Value']
-      yn = raw_input(
+      yn = input(
           '\nDo you want to add new SRM SE %s at site(s) %s ? default yes [yes|no]: ' %
           (gridSE, str(diracSites)))
       if not yn or yn.lower().startswith('y'):
@@ -304,7 +308,7 @@ def checkUnusedSEs():
           for i, s in enumerate(diracSites):
             prompt += '\n[%d] %s' % (i, s)
           prompt += '\nEnter your choice number: '
-          inp = raw_input(prompt)
+          inp = input(prompt)
           try:
             ind = int(inp)
           except BaseException:
@@ -316,7 +320,7 @@ def checkUnusedSEs():
 
         domain, siteName, country = diracSite.split('.')
         recName = '%s-disk' % siteName
-        inp = raw_input('Give a DIRAC name to the grid SE %s, default %s : ' % (gridSE, recName))
+        inp = input('Give a DIRAC name to the grid SE %s, default %s : ' % (gridSE, recName))
         diracSEName = inp
         if not inp:
           diracSEName = recName
@@ -357,7 +361,7 @@ def checkUnusedSEs():
         changeList = sorted(changeSet)
         for entry in changeList:
           gLogger.notice(entry)
-        yn = raw_input('Do you want to add new SE %s ? default yes [yes|no]: ' % diracSEName)
+        yn = input('Do you want to add new SE %s ? default yes [yes|no]: ' % diracSEName)
         if not yn or yn.lower().startswith('y'):
           changeSetFull = changeSetFull.union(changeSet)
 
@@ -379,7 +383,7 @@ def checkUnusedSEs():
     for section, option, value in changeList:
       csAPI.setOption(cfgPath(section, option), value)
 
-    yn = raw_input('New SE data is accumulated\n Do you want to commit changes to CS ? default yes [yes|no]: ')
+    yn = input('New SE data is accumulated\n Do you want to commit changes to CS ? default yes [yes|no]: ')
     if not yn or yn.lower().startswith('y'):
       result = csAPI.commit()
       if not result['OK']:
@@ -431,23 +435,23 @@ if __name__ == "__main__":
   vo = getVOOption(vo, 'VOMSName', vo)
 
   if doCEs:
-    yn = raw_input('Do you want to check/add new sites to CS ? [default yes] [yes|no]: ')
+    yn = input('Do you want to check/add new sites to CS ? [default yes] [yes|no]: ')
     yn = yn.strip()
     if yn == '' or yn.lower().startswith('y'):
       checkUnusedCEs()
 
-    yn = raw_input('Do you want to update CE details in the CS ? [default yes] [yes|no]: ')
+    yn = input('Do you want to update CE details in the CS ? [default yes] [yes|no]: ')
     yn = yn.strip()
     if yn == '' or yn.lower().startswith('y'):
       updateSites()
 
   if doSEs:
-    yn = raw_input('Do you want to check/add new storage elements to CS ? [default yes] [yes|no]: ')
+    yn = input('Do you want to check/add new storage elements to CS ? [default yes] [yes|no]: ')
     yn = yn.strip()
     if yn == '' or yn.lower().startswith('y'):
       result = checkUnusedSEs()
 
-    yn = raw_input('Do you want to update SE details in the CS ? [default yes] [yes|no]: ')
+    yn = input('Do you want to update SE details in the CS ? [default yes] [yes|no]: ')
     yn = yn.strip()
     if yn == '' or yn.lower().startswith('y'):
       updateSEs()

--- a/Core/Base/Client.py
+++ b/Core/Base/Client.py
@@ -5,8 +5,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/Core/Base/Client.py
+++ b/Core/Base/Client.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 import ast

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -417,7 +417,7 @@ class BaseClient(object):
     """
     if not self.__initStatus['OK']:
       return self.__initStatus
-    cThID = threading.get_ident()
+    cThID = threading._get_ident()
     if not self.__allowedThreadID:
       self.__allowedThreadID = cThID
     elif cThID != self.__allowedThreadID:

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -417,7 +417,7 @@ class BaseClient(object):
     """
     if not self.__initStatus['OK']:
       return self.__initStatus
-    cThID = threading.ident
+    cThID = threading.get_ident()
     if not self.__allowedThreadID:
       self.__allowedThreadID = cThID
     elif cThID != self.__allowedThreadID:

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -4,12 +4,14 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 
 import six
 import time
-import thread
+import threading
+
 import DIRAC
 from DIRAC.Core.DISET.private.Protocols import gProtocolDict
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
@@ -415,7 +417,7 @@ class BaseClient(object):
     """
     if not self.__initStatus['OK']:
       return self.__initStatus
-    cThID = thread.get_ident()
+    cThID = threading.ident
     if not self.__allowedThreadID:
       self.__allowedThreadID = cThID
     elif cThID != self.__allowedThreadID:

--- a/Core/DISET/private/InnerRPCClient.py
+++ b/Core/DISET/private/InnerRPCClient.py
@@ -3,9 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import str
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/Core/DISET/private/InnerRPCClient.py
+++ b/Core/DISET/private/InnerRPCClient.py
@@ -4,6 +4,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import str
+
 __RCSID__ = "$Id$"
 
 from DIRAC.Core.DISET.private.BaseClient import BaseClient

--- a/Core/DISET/private/Transports/BaseTransport.py
+++ b/Core/DISET/private/Transports/BaseTransport.py
@@ -20,8 +20,7 @@ Client <- Service        : Close
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/Core/DISET/private/Transports/BaseTransport.py
+++ b/Core/DISET/private/Transports/BaseTransport.py
@@ -21,11 +21,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 import time
 import select
-import cStringIO
+from io import BytesIO
 from hashlib import md5
 
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK
@@ -235,7 +237,7 @@ class BaseTransport(object):
         self.byteStream = pkgData[pkgSize:]
       else:
         # If we still need to read stuff
-        pkgMem = cStringIO.StringIO()
+        pkgMem = BytesIO()
         pkgMem.write(pkgData)
         # Receive while there's still data to be received
         while readSize < pkgSize:

--- a/Core/Utilities/DAG.py
+++ b/Core/Utilities/DAG.py
@@ -5,11 +5,15 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
-import copy
-from DIRAC import gLogger
 
 __RCSID__ = "$Id $"
+
+import copy
+from six import itervalues, iteritems
+
+from DIRAC import gLogger
 
 
 class DAG(object):
@@ -50,7 +54,7 @@ class DAG(object):
       gLogger.error("Missing node to where the edge lands")
       return
 
-    for node, toNodes in self.graph.iteritems():
+    for node, toNodes in iteritems(self.graph):
       # This is clearly not enough to assure that it's really acyclic...
       if toNode == node and fromNode in toNodes:
         gLogger.error("Can't insert this edge")
@@ -61,7 +65,7 @@ class DAG(object):
     """ Return a list of index nodes
     """
     notIndexNodes = set()
-    for depNodes in self.graph.itervalues():
+    for depNodes in itervalues(self.graph):
       [notIndexNodes.add(depNode) for depNode in depNodes]
     indexNodes = list(set(self.graph.keys()) - notIndexNodes)
     return [unHashNode(inu) for inu in indexNodes]

--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -1,4 +1,3 @@
-# $HeadURL$
 """
 Encoding and decoding for dirac, Ids:
  i -> int
@@ -15,14 +14,13 @@ Encoding and decoding for dirac, Ids:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
+
 __RCSID__ = "$Id$"
 
-from past.builtins import long
 import six
-import types
 import datetime
 import os
-
 import functools
 import inspect
 import traceback
@@ -221,7 +219,7 @@ def decodeInt(data, i):
   return (value, end + 1)
 
 
-g_dEncodeFunctions[types.IntType] = encodeInt
+g_dEncodeFunctions[int] = encodeInt  # FIXME: put int... but this should desappear!!!
 g_dDecodeFunctions["i"] = decodeInt
 
 
@@ -241,7 +239,7 @@ def decodeLong(data, i):
   return (value, end + 1)
 
 
-g_dEncodeFunctions[types.LongType] = encodeLong
+g_dEncodeFunctions[int] = encodeLong
 g_dDecodeFunctions["I"] = decodeLong
 
 
@@ -265,7 +263,7 @@ def decodeFloat(data, i):
   return (value, end + 1)
 
 
-g_dEncodeFunctions[types.FloatType] = encodeFloat
+g_dEncodeFunctions[float] = encodeFloat
 g_dDecodeFunctions["f"] = decodeFloat
 
 
@@ -287,7 +285,7 @@ def decodeBool(data, i):
     return (True, i + 2)
 
 
-g_dEncodeFunctions[types.BooleanType] = encodeBool
+g_dEncodeFunctions[bool] = encodeBool
 g_dDecodeFunctions["b"] = decodeBool
 
 
@@ -306,7 +304,7 @@ def decodeString(data, i):
   return (data[colon: end], end)
 
 
-g_dEncodeFunctions[types.StringType] = encodeString
+g_dEncodeFunctions[str] = encodeString
 g_dDecodeFunctions["s"] = decodeString
 
 
@@ -326,8 +324,10 @@ def decodeUnicode(data, i):
   end = colon + value
   return (unicode(data[colon: end], 'utf-8'), end)
 
+#  g_dEncodeFunctions[types.UnicodeType] = encodeUnicode  # FIXME: Unicode and python 3
 
-g_dEncodeFunctions[types.UnicodeType] = encodeUnicode
+
+g_dEncodeFunctions[str] = encodeUnicode
 g_dDecodeFunctions["u"] = decodeUnicode
 
 
@@ -391,7 +391,7 @@ def decodeNone(_data, i):
   return (None, i + 1)
 
 
-g_dEncodeFunctions[types.NoneType] = encodeNone
+g_dEncodeFunctions[type(None)] = encodeNone
 g_dDecodeFunctions['n'] = decodeNone
 
 
@@ -415,7 +415,7 @@ def decodeList(data, i):
   return(oL, i + 1)
 
 
-g_dEncodeFunctions[types.ListType] = encodeList
+g_dEncodeFunctions[list] = encodeList
 g_dDecodeFunctions["l"] = decodeList
 
 
@@ -441,7 +441,7 @@ def decodeTuple(data, i):
   return (tuple(oL), i)
 
 
-g_dEncodeFunctions[types.TupleType] = encodeTuple
+g_dEncodeFunctions[tuple] = encodeTuple
 g_dDecodeFunctions["t"] = decodeTuple
 
 
@@ -477,7 +477,7 @@ def decodeDict(data, i):
   return (oD, i + 1)
 
 
-g_dEncodeFunctions[types.DictType] = encodeDict
+g_dEncodeFunctions[dict] = encodeDict
 g_dDecodeFunctions["d"] = decodeDict
 
 

--- a/Core/Utilities/LockRing.py
+++ b/Core/Utilities/LockRing.py
@@ -2,10 +2,11 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
+
 import random
 import time
 import threading
-import thread
 from hashlib import md5
 
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK
@@ -21,10 +22,10 @@ class LockRing(object):
     self.__events = {}
 
   def __genName(self, container):
-    name = md5(str(time.time() + random.random())).hexdigest()
+    name = md5(str(time.time() + random.random()).encode('utf-8')).hexdigest()
     retries = 10
     while name in container and retries:
-      name = md5(str(time.time() + random.random())).hexdigest()
+      name = md5(str(time.time() + random.random()).encode('utf-8')).hexdigest()
       retries -= 1
     return name
 
@@ -73,7 +74,7 @@ class LockRing(object):
     for lockName in self.__locks.keys():
       try:
         self.__locks[lockName].release()
-      except (RuntimeError, thread.error, KeyError):
+      except (RuntimeError, threading.ThreadError, KeyError):
         pass
 
   def _setAllEvents(self):

--- a/Core/Utilities/Network.py
+++ b/Core/Utilities/Network.py
@@ -5,15 +5,17 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 __RCSID__ = "$Id$"
 
 import socket
-import urlparse
 import os
 import struct
 import array
 import fcntl
 import platform
+from six.moves.urllib.parse import urlparse
 
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 
@@ -57,7 +59,7 @@ def getFQDN():
 
 
 def splitURL(url):
-  o = urlparse.urlparse(url)
+  o = urlparse(url)
   if o.scheme == "":
     return S_ERROR("'%s' URL is missing protocol" % url)
   path = o.path

--- a/Core/Utilities/Pfn.py
+++ b/Core/Utilities/Pfn.py
@@ -1,5 +1,3 @@
-# $HeadURL$
-
 """
 :mod: Pfn
 
@@ -13,14 +11,16 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
-__RCSID__ = "$Id:$"
+__RCSID__ = "$Id$"
 
 # # imports
 import os
+from six.moves.urllib.parse import urlparse
+
 # # from DIRAC
 from DIRAC import S_OK, S_ERROR, gLogger
-import urlparse
 
 
 def pfnunparse(pfnDict, srmSpecific=True):
@@ -217,7 +217,7 @@ def default_pfnparse(pfn):
   pfnDict = dict.fromkeys(["Protocol", "Host", "Port", "WSUrl", "Path", "FileName"], "")
   try:
 
-    parse = urlparse.urlparse(pfn)
+    parse = urlparse(pfn)
     pfnDict['Protocol'] = parse.scheme
     if ':' in parse.netloc:
       pfnDict['Host'], pfnDict['Port'] = parse.netloc.split(':')

--- a/Core/Utilities/ReturnValues.py
+++ b/Core/Utilities/ReturnValues.py
@@ -8,8 +8,10 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import six
+
 import traceback
 from DIRAC.Core.Utilities.DErrno import strerror
 

--- a/Core/Utilities/ThreadScheduler.py
+++ b/Core/Utilities/ThreadScheduler.py
@@ -3,10 +3,10 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 
-from past.builtins import long
 import hashlib
 import threading
 import time
@@ -45,7 +45,8 @@ class ThreadScheduler(object):
             'func': taskFunc,
             'args': taskArgs,
             }
-    md.update(str(task))
+    res = str(task).encode('utf-8')
+    md.update(res)
     taskId = md.hexdigest()
     if taskId in self.__taskDict:
       return S_ERROR("Task %s is already added" % taskId)

--- a/Core/Utilities/Time.py
+++ b/Core/Utilities/Time.py
@@ -28,10 +28,12 @@ if a give datetime is in the defined interval.
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
+
 import time as nativetime
 import datetime
-from types import StringTypes
 import sys
+import time as nativetime
 
 __RCSID__ = "$Id$"
 
@@ -194,46 +196,33 @@ def fromString(myDate=None):
   See notice on toString method
   On Error, return None
   """
-  if StringTypes.__contains__(type(myDate)):
-    if myDate.find(' ') > 0:
-      dateTimeTuple = myDate.split(' ')
-      dateTuple = dateTimeTuple[0].split('-')
+  if myDate.find(' ') > 0:
+    dateTimeTuple = myDate.split(' ')
+    dateTuple = dateTimeTuple[0].split('-')
+    try:
+      return (datetime.datetime(year=dateTuple[0],
+                                month=dateTuple[1],
+                                day=dateTuple[2]) +
+              fromString(dateTimeTuple[1]))
+      # return dt.combine( fromString( dateTimeTuple[0] ),
+      #                                   fromString( dateTimeTuple[1] ) )
+    except BaseException:
       try:
-        return (datetime.datetime(year=dateTuple[0],
-                                  month=dateTuple[1],
-                                  day=dateTuple[2]) +
+        return (datetime.datetime(year=int(dateTuple[0]),
+                                  month=int(dateTuple[1]),
+                                  day=int(dateTuple[2])) +
                 fromString(dateTimeTuple[1]))
         # return dt.combine( fromString( dateTimeTuple[0] ),
         #                                   fromString( dateTimeTuple[1] ) )
-      except BaseException:
+      except Exception:
         try:
-          return (datetime.datetime(year=int(dateTuple[0]),
-                                    month=int(dateTuple[1]),
-                                    day=int(dateTuple[2])) +
-                  fromString(dateTimeTuple[1]))
-        except ValueError:
-          return None
-        # return dt.combine( fromString( dateTimeTuple[0] ),
-        #                                   fromString( dateTimeTuple[1] ) )
-    elif myDate.find(':') > 0:
-      timeTuple = myDate.replace('.', ':').split(':')
-      try:
-        if len(timeTuple) == 4:
           return datetime.timedelta(hours=int(timeTuple[0]),
                                     minutes=int(timeTuple[1]),
                                     seconds=int(timeTuple[2]),
-                                    microseconds=int(timeTuple[3]))
-        elif len(timeTuple) == 3:
-          try:
-            return datetime.timedelta(hours=int(timeTuple[0]),
-                                      minutes=int(timeTuple[1]),
-                                      seconds=int(timeTuple[2]),
-                                      microseconds=0)
-          except ValueError:
-            return None
-        else:
+                                    microseconds=0)
+        except ValueError:
           return None
-      except BaseException:
+      except Exception:
         return None
     elif myDate.find('-') > 0:
       dateTuple = myDate.split('-')
@@ -241,8 +230,14 @@ def fromString(myDate=None):
         return datetime.date(int(dateTuple[0]), int(dateTuple[1]), int(dateTuple[2]))
       except BaseException:
         return None
-
-  return None
+    except BaseException:
+      return None
+  elif myDate.find('-') > 0:
+    dateTuple = myDate.split('-')
+    try:
+      return datetime.date(int(dateTuple[0]), int(dateTuple[1]), int(dateTuple[2]))
+    except BaseException:
+      return None
 
 
 class timeInterval:
@@ -259,8 +254,7 @@ class timeInterval:
        If not properly initialized an error flag is set, and subsequent calls
        to any method will return None
     """
-    if (not isinstance(initialDateTime, _dateTimeType) or
-            not isinstance(intervalTimeDelta, _timeType)):
+    if (not isinstance(initialDateTime, _dateTimeType) or not isinstance(intervalTimeDelta, _timeType)):
       self.__error = True
       return None
     self.__error = False

--- a/Core/Utilities/Time.py
+++ b/Core/Utilities/Time.py
@@ -33,7 +33,6 @@ from __future__ import unicode_literals
 import time as nativetime
 import datetime
 import sys
-import time as nativetime
 
 __RCSID__ = "$Id$"
 
@@ -202,19 +201,27 @@ def fromString(myDate=None):
     try:
       return (datetime.datetime(year=dateTuple[0],
                                 month=dateTuple[1],
-                                day=dateTuple[2]) +
-              fromString(dateTimeTuple[1]))
+                                day=dateTuple[2]) + fromString(dateTimeTuple[1]))
       # return dt.combine( fromString( dateTimeTuple[0] ),
       #                                   fromString( dateTimeTuple[1] ) )
-    except BaseException:
+    except Exception:
       try:
         return (datetime.datetime(year=int(dateTuple[0]),
                                   month=int(dateTuple[1]),
-                                  day=int(dateTuple[2])) +
-                fromString(dateTimeTuple[1]))
+                                  day=int(dateTuple[2])) + fromString(dateTimeTuple[1]))
+      except ValueError:
+        return None
         # return dt.combine( fromString( dateTimeTuple[0] ),
         #                                   fromString( dateTimeTuple[1] ) )
-      except Exception:
+  elif myDate.find(':') > 0:
+    timeTuple = myDate.replace('.', ':').split(':')
+    try:
+      if len(timeTuple) == 4:
+        return datetime.timedelta(hours=int(timeTuple[0]),
+                                  minutes=int(timeTuple[1]),
+                                  seconds=int(timeTuple[2]),
+                                  microseconds=int(timeTuple[3]))
+      elif len(timeTuple) == 3:
         try:
           return datetime.timedelta(hours=int(timeTuple[0]),
                                     minutes=int(timeTuple[1]),
@@ -222,21 +229,15 @@ def fromString(myDate=None):
                                     microseconds=0)
         except ValueError:
           return None
-      except Exception:
+      else:
         return None
-    elif myDate.find('-') > 0:
-      dateTuple = myDate.split('-')
-      try:
-        return datetime.date(int(dateTuple[0]), int(dateTuple[1]), int(dateTuple[2]))
-      except BaseException:
-        return None
-    except BaseException:
+    except Exception:
       return None
   elif myDate.find('-') > 0:
     dateTuple = myDate.split('-')
     try:
       return datetime.date(int(dateTuple[0]), int(dateTuple[1]), int(dateTuple[2]))
-    except BaseException:
+    except Exception:
       return None
 
 

--- a/Core/Utilities/test/Test_Encode.py
+++ b/Core/Utilities/test/Test_Encode.py
@@ -9,9 +9,7 @@ On the other hand, it can serialize some objects, while DISET cannot.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 
 import datetime

--- a/Core/Utilities/test/Test_Encode.py
+++ b/Core/Utilities/test/Test_Encode.py
@@ -11,10 +11,14 @@ from __future__ import division
 from __future__ import print_function
 
 
-from string import printable
+from __future__ import absolute_import, print_function, unicode_literals
+
+
 import datetime
 import sys
+from string import printable
 
+from six import itervalues
 
 from DIRAC.Core.Utilities.DEncode import encode as disetEncode, decode as disetDecode, g_dEncodeFunctions
 from DIRAC.Core.Utilities.JEncode import encode as jsonEncode, decode as jsonDecode, JSerializable
@@ -99,7 +103,7 @@ def test_everyBaseTypeIsTested():
   """
   current_module = sys.modules[__name__]
 
-  for encodeFunc in g_dEncodeFunctions.itervalues():
+  for encodeFunc in itervalues(g_dEncodeFunctions):
     testFuncName = ('test_BaseType_%s' % encodeFunc.__name__).replace('encode', '')
     getattr(current_module, testFuncName)
 

--- a/DataManagementSystem/Agent/RequestOperations/RemoveReplica.py
+++ b/DataManagementSystem/Agent/RequestOperations/RemoveReplica.py
@@ -1,5 +1,4 @@
 ########################################################################
-# $HeadURL $
 # File: RemoveReplica.py
 # Author: Krzysztof.Ciba@NOSPAMgmail.com
 # Date: 2013/03/25 07:45:06
@@ -20,6 +19,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id $"
 
@@ -31,11 +31,12 @@ __RCSID__ = "$Id $"
 
 # # imports
 import os
+from six import itervalues, iteritems
+
 # # from DIRAC
 from DIRAC import S_OK
 from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.DataManagementSystem.Agent.RequestOperations.DMSRequestOperationsBase import DMSRequestOperationsBase
-
 from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
 
 ########################################################################
@@ -184,16 +185,16 @@ class RemoveReplica(DMSRequestOperationsBase):
     :param str targetSE: target SE name
     """
     # Clear the error
-    for opFile in toRemoveDict.itervalues():
+    for opFile in itervalues(toRemoveDict):
       opFile.Error = ''
     removeReplicas = self.dm.removeReplica(targetSE, toRemoveDict.keys())
     if not removeReplicas["OK"]:
-      for opFile in toRemoveDict.itervalues():
+      for opFile in itervalues(toRemoveDict):
         opFile.Error = removeReplicas["Message"]
       return removeReplicas
     removeReplicas = removeReplicas["Value"]
     # # filter out failed
-    for lfn, opFile in toRemoveDict.iteritems():
+    for lfn, opFile in iteritems(toRemoveDict):
       if lfn in removeReplicas["Failed"]:
         errorReason = str(removeReplicas['Failed'][lfn])
         # If the reason is that the file does not exist,

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -11,6 +11,8 @@ This module consists of DataManager and related classes.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 
 # # imports
 import six
@@ -19,7 +21,6 @@ import fnmatch
 import os
 import time
 import errno
-import six
 
 # # from DIRAC
 import DIRAC

--- a/FrameworkSystem/Client/MonitoringClient.py
+++ b/FrameworkSystem/Client/MonitoringClient.py
@@ -5,10 +5,11 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 __RCSID__ = "$Id"
 
 import time
-
 import six
 
 import DIRAC
@@ -272,7 +273,8 @@ class MonitoringClient(object):
       raise MonitoringClientActivityNotDefined("You must register activity %s before adding marks to it" % name)
       # raise Exception( "You must register activity %s before adding marks to it" % name )
     if not isinstance(value, self.__validMonitoringValues):
-      raise MonitoringClientActivityValueTypeError("Activity '%s' value's type (%s) is not valid" % (name, type(value)))
+      raise MonitoringClientActivityValueTypeError("Activity '%s' value's type (%s) is not valid" % (name,
+                                                                                                     type(value)))
       # raise Exception( "Value's type %s is not valid" % value )
     self.activitiesLock.acquire()
     try:
@@ -472,7 +474,7 @@ class MonitoringClient(object):
         return False
       condVal = condDict[key]
       componentVal = component[key]
-      if type(condVal) in (list, tuple):
+      if isinstance(condVal, (list, tuple)):
         if componentVal not in condVal:
           return False
       else:

--- a/FrameworkSystem/private/standardLogging/Logging.py
+++ b/FrameworkSystem/private/standardLogging/Logging.py
@@ -5,10 +5,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 import logging
 import os
+from six import itervalues
 
 from DIRAC import S_ERROR
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
@@ -144,7 +147,7 @@ class Logging(object):
       self._options[optionName] = value
 
       # propagate in the children
-      for child in self._children.itervalues():
+      for child in itervalues(self._children):
         child._setOption(optionName, value, directCall=False)  # pylint: disable=protected-access
       # update the format to apply the option change
       self._generateBackendFormat()
@@ -259,7 +262,7 @@ class Logging(object):
         self._lockOptions.release()
 
       # propagate in the children
-      for child in self._children.itervalues():
+      for child in itervalues(self._children):
         child._setLevel(level, directCall=False)  # pylint: disable=protected-access
     finally:
       self._lockLevel.release()

--- a/FrameworkSystem/private/standardLogging/Logging.py
+++ b/FrameworkSystem/private/standardLogging/Logging.py
@@ -4,8 +4,7 @@ Logging
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/FrameworkSystem/private/standardLogging/Message.py
+++ b/FrameworkSystem/private/standardLogging/Message.py
@@ -7,6 +7,8 @@ from __future__ import division
 from __future__ import print_function
 
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 from DIRAC.Core.Utilities import Time
@@ -21,7 +23,7 @@ def tupleToMessage(varTuple):
 class Message:
 
   def __init__(self, systemName, level, time, msgText, variableText, frameInfo, subSystemName=''):
-    import thread
+    import threading
     self.systemName = systemName
     self.level = level
     self.time = time
@@ -29,7 +31,7 @@ class Message:
     self.variableText = str(variableText)
     self.frameInfo = frameInfo
     self.subSystemName = subSystemName
-    self.threadId = thread.get_ident()
+    self.threadId = threading.ident
 
   def getName(self):
     return self.systemName

--- a/FrameworkSystem/private/standardLogging/Message.py
+++ b/FrameworkSystem/private/standardLogging/Message.py
@@ -31,7 +31,7 @@ class Message:
     self.variableText = str(variableText)
     self.frameInfo = frameInfo
     self.subSystemName = subSystemName
-    self.threadId = threading.ident
+    self.threadId = threading.get_ident()
 
   def getName(self):
     return self.systemName

--- a/FrameworkSystem/private/standardLogging/Message.py
+++ b/FrameworkSystem/private/standardLogging/Message.py
@@ -31,7 +31,7 @@ class Message:
     self.variableText = str(variableText)
     self.frameInfo = frameInfo
     self.subSystemName = subSystemName
-    self.threadId = threading.get_ident()
+    self.threadId = threading._get_ident()
 
   def getName(self):
     return self.systemName

--- a/FrameworkSystem/private/standardLogging/test/Test_DisplayOptions.py
+++ b/FrameworkSystem/private/standardLogging/test/Test_DisplayOptions.py
@@ -61,7 +61,7 @@ class Test_DisplayOptions(Test_Logging):
 
     logstring1 = cleaningLog(self.buffer.getvalue())
 
-    self.assertIn(str(threading.get_ident()), logstring1)
+    self.assertIn(str(threading._get_ident()), logstring1)
     self.buffer.truncate(0)
 
   def test_02setShowThreadIDsHeaders(self):
@@ -97,7 +97,7 @@ class Test_DisplayOptions(Test_Logging):
 
     logstring1 = cleaningLog(self.buffer.getvalue())
 
-    self.assertIn(str(threading.get_ident()), logstring1)
+    self.assertIn(str(threading._get_ident()), logstring1)
     self.buffer.truncate(0)
 
   def test_03setSubLogShowHeaders(self):

--- a/FrameworkSystem/private/standardLogging/test/Test_DisplayOptions.py
+++ b/FrameworkSystem/private/standardLogging/test/Test_DisplayOptions.py
@@ -61,7 +61,7 @@ class Test_DisplayOptions(Test_Logging):
 
     logstring1 = cleaningLog(self.buffer.getvalue())
 
-    self.assertIn(str(threading.ident), logstring1)
+    self.assertIn(str(threading.get_ident()), logstring1)
     self.buffer.truncate(0)
 
   def test_02setShowThreadIDsHeaders(self):
@@ -97,7 +97,7 @@ class Test_DisplayOptions(Test_Logging):
 
     logstring1 = cleaningLog(self.buffer.getvalue())
 
-    self.assertIn(str(threading.ident), logstring1)
+    self.assertIn(str(threading.get_ident()), logstring1)
     self.buffer.truncate(0)
 
   def test_03setSubLogShowHeaders(self):

--- a/FrameworkSystem/private/standardLogging/test/Test_DisplayOptions.py
+++ b/FrameworkSystem/private/standardLogging/test/Test_DisplayOptions.py
@@ -5,10 +5,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 import unittest
-import thread
+import threading
 
 from DIRAC.FrameworkSystem.private.standardLogging.test.TestLoggingBase import Test_Logging, gLogger, cleaningLog
 
@@ -59,7 +61,7 @@ class Test_DisplayOptions(Test_Logging):
 
     logstring1 = cleaningLog(self.buffer.getvalue())
 
-    self.assertIn(str(thread.get_ident()), logstring1)
+    self.assertIn(str(threading.ident), logstring1)
     self.buffer.truncate(0)
 
   def test_02setShowThreadIDsHeaders(self):
@@ -95,7 +97,7 @@ class Test_DisplayOptions(Test_Logging):
 
     logstring1 = cleaningLog(self.buffer.getvalue())
 
-    self.assertIn(str(thread.get_ident()), logstring1)
+    self.assertIn(str(threading.ident), logstring1)
     self.buffer.truncate(0)
 
   def test_03setSubLogShowHeaders(self):

--- a/FrameworkSystem/private/standardLogging/test/Test_DisplayOptions.py
+++ b/FrameworkSystem/private/standardLogging/test/Test_DisplayOptions.py
@@ -4,8 +4,7 @@ Test Display Options
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/MonitoringSystem/Client/ServerUtils.py
+++ b/MonitoringSystem/Client/ServerUtils.py
@@ -5,8 +5,7 @@ It always try to insert the records directly. In case of failure the monitoring 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/MonitoringSystem/Client/ServerUtils.py
+++ b/MonitoringSystem/Client/ServerUtils.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 

--- a/RequestManagementSystem/Client/File.py
+++ b/RequestManagementSystem/Client/File.py
@@ -13,8 +13,11 @@ operation file
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 # Disable invalid names warning
 # pylint: disable=invalid-name
+
 
 __RCSID__ = "$Id$"
 

--- a/RequestManagementSystem/Client/Operation.py
+++ b/RequestManagementSystem/Client/Operation.py
@@ -14,11 +14,10 @@ Operation implementation
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 # Disable invalid names warning
 # pylint: disable=invalid-name
-
-from __future__ import absolute_import, print_function, unicode_literals
-from builtins import str
 
 __RCSID__ = "$Id$"
 

--- a/RequestManagementSystem/Client/Operation.py
+++ b/RequestManagementSystem/Client/Operation.py
@@ -16,6 +16,10 @@ from __future__ import division
 from __future__ import print_function
 # Disable invalid names warning
 # pylint: disable=invalid-name
+
+from __future__ import absolute_import, print_function, unicode_literals
+from builtins import str
+
 __RCSID__ = "$Id$"
 
 import datetime

--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import six
 import os

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -13,8 +13,11 @@ request implementation
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 # Disable invalid names warning
 # pylint: disable=invalid-name
+
+
 __RCSID__ = "$Id$"
 
 

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -17,7 +17,6 @@ from __future__ import unicode_literals
 # Disable invalid names warning
 # pylint: disable=invalid-name
 
-
 __RCSID__ = "$Id$"
 
 

--- a/ResourceStatusSystem/Command/VOBOXAvailabilityCommand.py
+++ b/ResourceStatusSystem/Command/VOBOXAvailabilityCommand.py
@@ -7,7 +7,9 @@ from __future__ import print_function
 # FIXME: NOT Usable ATM
 # missing doNew, doCache, doMaster
 
-import urlparse
+from __future__ import absolute_import, print_function, unicode_literals
+
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.DISET.RPCClient import RPCClient
@@ -45,7 +47,7 @@ class VOBOXAvailabilityCommand(Command):
 
     ##
 
-    parsed = urlparse.urlparse(serviceURL)
+    parsed = urlparse(serviceURL)
     site = parsed[1].split(':')[0]
 
     try:

--- a/ResourceStatusSystem/Command/VOBOXAvailabilityCommand.py
+++ b/ResourceStatusSystem/Command/VOBOXAvailabilityCommand.py
@@ -3,11 +3,10 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 # FIXME: NOT Usable ATM
 # missing doNew, doCache, doMaster
-
-from __future__ import absolute_import, print_function, unicode_literals
 
 from six.moves.urllib.parse import urlparse
 

--- a/Resources/Computing/BOINCComputingElement.py
+++ b/Resources/Computing/BOINCComputingElement.py
@@ -9,6 +9,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
+
 __RCSID__ = "$Id$"
 
 import os
@@ -16,7 +18,7 @@ import bz2
 import base64
 import tempfile
 
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement
 from DIRAC import S_OK, S_ERROR, gLogger

--- a/Resources/Computing/LocalComputingElement.py
+++ b/Resources/Computing/LocalComputingElement.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import stat
@@ -15,7 +16,7 @@ import shutil
 import tempfile
 import getpass
 import errno
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC import gConfig

--- a/Resources/Computing/SSHBatchComputingElement.py
+++ b/Resources/Computing/SSHBatchComputingElement.py
@@ -18,6 +18,7 @@ import six
 import os
 import socket
 import stat
+
 from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR

--- a/Resources/Computing/SSHBatchComputingElement.py
+++ b/Resources/Computing/SSHBatchComputingElement.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 
@@ -17,7 +18,7 @@ import six
 import os
 import socket
 import stat
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC import rootPath

--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 
@@ -18,7 +19,7 @@ import json
 import stat
 import shutil
 import errno
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC import rootPath

--- a/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/Resources/Storage/GFAL2_XROOTStorage.py
@@ -10,6 +10,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 import os
 
 # from DIRAC

--- a/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/Resources/Storage/GFAL2_XROOTStorage.py
@@ -9,8 +9,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 import os
 

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -3,8 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 # # custom duty
 

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 # # custom duty
 
 import six

--- a/Resources/Storage/test/Test_StorageElement.py
+++ b/Resources/Storage/test/Test_StorageElement.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 import os
 import tempfile
 import mock

--- a/Resources/Storage/test/Test_StorageElement.py
+++ b/Resources/Storage/test/Test_StorageElement.py
@@ -3,8 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 import os
 import tempfile

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/WorkloadManagementSystem/Agent/JobCleaningAgent.py
+++ b/WorkloadManagementSystem/Agent/JobCleaningAgent.py
@@ -28,6 +28,8 @@ than 0.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 __RCSID__ = "$Id$"
 
 import time

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
@@ -5,6 +5,8 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 import pytest
 from mock import MagicMock
 

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_JobCleaningAgent.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_JobCleaningAgent.py
@@ -5,6 +5,8 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ unicode_literals
+
 import pytest
 from mock import MagicMock
 

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_JobCleaningAgent.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_JobCleaningAgent.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from __future__ unicode_literals
+from __future__ import unicode_literals
 
 import pytest
 from mock import MagicMock

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_PilotStatusAgent.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_PilotStatusAgent.py
@@ -5,6 +5,8 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 import pytest
 from mock import MagicMock
 

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
@@ -3,8 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 # pylint: disable=protected-access
 

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 # pylint: disable=protected-access
 
 # imports

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
@@ -5,6 +5,8 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 from mock import MagicMock
 
 # DIRAC Components

--- a/WorkloadManagementSystem/Client/JobReport.py
+++ b/WorkloadManagementSystem/Client/JobReport.py
@@ -6,6 +6,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
+
 __RCSID__ = "$Id$"
 
 from DIRAC import S_OK, S_ERROR, gLogger

--- a/WorkloadManagementSystem/Client/JobStateUpdateClient.py
+++ b/WorkloadManagementSystem/Client/JobStateUpdateClient.py
@@ -3,6 +3,8 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
+
 from DIRAC.Core.Base.Client import Client, createClient
 
 

--- a/WorkloadManagementSystem/Client/ServerUtils.py
+++ b/WorkloadManagementSystem/Client/ServerUtils.py
@@ -11,8 +11,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import unicode_literals
 
 __RCSID__ = "$Id$"
 

--- a/WorkloadManagementSystem/Client/ServerUtils.py
+++ b/WorkloadManagementSystem/Client/ServerUtils.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import absolute_import, print_function, unicode_literals
+
 __RCSID__ = "$Id$"
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -104,7 +104,7 @@ if preVersion:
 
 # Check of python version
 
-__pythonMajorVersion = ("2", )
+__pythonMajorVersion = ("2", "3")
 __pythonMinorVersion = ("7")
 
 pythonVersion = pyPlatform.python_version_tuple()

--- a/tests/Utilities/mpTest.py
+++ b/tests/Utilities/mpTest.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
 
 from multiprocessing import Process, Queue, current_process
 

--- a/tests/Utilities/mpTest.py
+++ b/tests/Utilities/mpTest.py
@@ -43,5 +43,6 @@ def main():
 
   print(r1 + r2 + r3 + r4)  # pylint: disable=print-statement
 
+
 if __name__ == '__main__':
   main()

--- a/tests/Utilities/mpTest.py
+++ b/tests/Utilities/mpTest.py
@@ -44,6 +44,5 @@ def main():
 
   print(r1 + r2 + r3 + r4)  # pylint: disable=print-statement
 
-
 if __name__ == '__main__':
   main()

--- a/tests/Utilities/testJobDefinitions.py
+++ b/tests/Utilities/testJobDefinitions.py
@@ -6,6 +6,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import unicode_literals
+
 import os
 
 from DIRAC import rootPath

--- a/tests/py3CheckDirs.txt
+++ b/tests/py3CheckDirs.txt
@@ -1,0 +1,2 @@
+AccountingSystem/
+ConfigurationSystem/Client/


### PR DESCRIPTION
A bunch of python 2/3 compatibilities. After these changes I could do `import DIRAC` within python 3.7.

A couple things:
- MySQL-python is not python 3 compatible, so I used https://pypi.org/project/mysqlclient/ which seems like the best option. Didn't really try it fully though.
- fts3-rest: I couldn't find a Python 3 version, but maybe simply it's not on pypi.