### PR TITLE
[v6r22] Added option for LocalCEType (for pilot 3)

### DIFF
--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -75,7 +75,7 @@ class JobAgent(AgentModule):
     self.am_setOption('MonitoringEnabled', False)
     self.am_setOption('MaxCycles', loops)
 
-    ceType = self.am_getOption('CEType', 'InProcess')
+    ceType = self.am_getOption('CEType', self.ceName)
     localCE = gConfig.getValue('/LocalSite/LocalCE', '')
     if localCE:
       self.log.info('Defining CE from local configuration', '= %s' % localCE)

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -170,7 +170,7 @@ class PilotCStoJSONSynchronizer(object):
             pilotDict['CEs'][ce] = {'Site': site, 'GridCEType': ceType}
 
           if localCEType is not None:
-            pilotDict['CEs'][ce] = {'Site': site, 'LocalCEType': ceType}
+            pilotDict['CEs'][ce] = {'Site': site, 'LocalCEType': localCEType}
 
     defaultSetup = gConfig.getValue('/DIRAC/DefaultSetup')
     if defaultSetup:

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -165,12 +165,13 @@ class PilotCStoJSONSynchronizer(object):
 
           if ceType is None:
             # Skip but log it
-            self.log.error('CE has no option CEType! - skipping', ce + ' at ' + site)
+            self.log.error('CE has no option CEType!', ce + ' at ' + site)
+            pilotDict['CEs'][ce] = {'Site': site}
           else:
             pilotDict['CEs'][ce] = {'Site': site, 'GridCEType': ceType}
 
           if localCEType is not None:
-            pilotDict['CEs'][ce] = {'Site': site, 'LocalCEType': localCEType}
+            pilotDict['CEs'][ce].setDefault('LocalCEType', localCEType)
 
     defaultSetup = gConfig.getValue('/DIRAC/DefaultSetup')
     if defaultSetup:

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -161,12 +161,16 @@ class PilotCStoJSONSynchronizer(object):
 
         for ce in ceList['Value']:
           ceType = gConfig.getValue('/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/CEType')
+          localCEType = gConfig.getValue('/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/LocalCEType')
 
           if ceType is None:
             # Skip but log it
             self.log.error('CE has no option CEType! - skipping', ce + ' at ' + site)
           else:
             pilotDict['CEs'][ce] = {'Site': site, 'GridCEType': ceType}
+
+          if localCEType is not None:
+            pilotDict['CEs'][ce] = {'Site': site, 'LocalCEType': ceType}
 
     defaultSetup = gConfig.getValue('/DIRAC/DefaultSetup')
     if defaultSetup:

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
@@ -47,7 +47,9 @@ This sub-subsection specify the attributes of each particular CE of the site. Mu
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/architecture*                       | CE architecture                                             | architecture = x86_64          |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
-| *<CE_NAME>/CEType*                             | Type of CE, can take values as LCG or CREAM                 | CEType = LCG                   |
+| *<CE_NAME>/CEType*                             | Type of CE, can take values as LCG or CREAM                 | CEType = ARC                   |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/LocalCEType*                        | Type of Local CE, normally empty. Defaul = "InProcess"      | CEType = Pool                  |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/OS*                                 | CE operating system in a DIRAC format                       | OS = ScientificLinux_Boron_5.3 |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
@@ -148,6 +150,7 @@ An example for this session follows::
             SI00 = 0
             Pilot = False
             CEType = HTCondorCE
+            LocalCEType = Pool
             SubmissionMode = Direct
             Queues
             {

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
@@ -49,7 +49,7 @@ This sub-subsection specify the attributes of each particular CE of the site. Mu
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/CEType*                             | Type of CE, can take values as LCG or CREAM                 | CEType = ARC                   |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
-| *<CE_NAME>/LocalCEType*                        | Type of Local CE, normally empty. Defaul = "InProcess"      | CEType = Pool                  |
+| *<CE_NAME>/LocalCEType*                        | Type of Local CE, normally empty. Default = "InProcess"     | LocalCEType = Pool             |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | *<CE_NAME>/OS*                                 | CE operating system in a DIRAC format                       | OS = ScientificLinux_Boron_5.3 |
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+


### PR DESCRIPTION
This PR adds an option for specifying the LocalCEType (which by default is "InProcess"). This option will be interpreted by the Pilot3 (PR in https://github.com/DIRACGrid/Pilot/pull/83) and the idea is basically to specify the "Pool"ComputingElement, with HPC or anyway CEs for large WNs in mind.


BEGINRELEASENOTES

*WMS
NEW: added option for specifying a LocalCEType (which by default is "InProcess")

ENDRELEASENOTES
