### PR TITLE
[v6r21] AccountingDB.insertRecordThroughQueue: fix zeroK

### DIFF
--- a/AccountingSystem/DB/AccountingDB.py
+++ b/AccountingSystem/DB/AccountingDB.py
@@ -622,7 +622,7 @@ class AccountingDB(DB):
     if typeName not in self.dbCatalog:
       return S_ERROR("Type %s has not been defined in the db" % typeName)
     result = self.__insertInQueueTable(typeName, startTime, endTime, valuesList)
-    if not result['0K']:
+    if not result['OK']:
       return result
 
     return S_OK()


### PR DESCRIPTION
I don't think this function is actually called anywhere, or there should have been exceptions showing up, but I stumbled across this...

BEGINRELEASENOTES

*Accounting
FIX:  In AccountingDB.insertRecordThroughQueue fix bad dictionary key "0K"

ENDRELEASENOTES
