### PR TITLE
[v6r21] codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,9 @@
 comment: off
 
 ignore:
-  - ".*/[Tt]ests/.*"
-  - ".*/[Tt]est/.*"
   - "^docs"
   - "^container"
+  - "^tests"
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,8 @@
 comment: off
 
 ignore:
+  - ".*/[Tt]ests/.*"
+  - ".*/[Tt]est/.*"
   - "^docs"
   - "^container"
   - "^tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,6 @@ coverage:
   status:
     project:
       default:
-        unittest:
         threshold: 0.03
     patch:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,17 @@
 comment: off
+
+ignore:
+  - ".*/[Tt]ests/.*"
+  - ".*/[Tt]est/.*"
+  - "^docs"
+  - "^container"
+
+coverage:
+  status:
+    project:
+      default:
+        unittest:
+        threshold: 0.03
+    patch:
+      default:
+        target: 0


### PR DESCRIPTION
This sets the target coverage diff for the "patch" check to 0 and adds a threshold of 0.03 for the "project" coverage to allow random fluctuations in the diff (caused by calls to "random" in functions that are tested?).

(Also fixes a syntax error in the yaml compared to that of the integration branch.)
