### PR TITLE
[v6r21] JobDB.getAttributesForJobList: return S_ERROR if unknown attribute is requested

### DIFF
--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -127,6 +127,9 @@ class JobDB(DB):
     if not jobIDList:
       return S_OK({})
     if attrList:
+      missingAttr = [repr(x) for x in attrList if x not in self.jobAttributeNames]
+      if missingAttr:
+        return S_ERROR("JobDB.getAttributesForJobList: Unknown Attribute(s): %s" % ", ".join(missingAttr))
       attrNames = ','.join(str(x) for x in attrList if x in self.jobAttributeNames)
       attr_tmp_list = attrList
     else:


### PR DESCRIPTION


BEGINRELEASENOTES

*WMS
FIX: JobDB.getAttributesForJobList: Return S_ERROR if unknown attributes are requested. Instead of potentially returning garbage a clear error message is returned.

ENDRELEASENOTES

If the user provided `attrList` contains an attribute name that is not defined 
Line 130 will filter it out.
But in line 147 the original `attrList` (via `attr_temp_list`) is used to construct the return dictionary, which leads to a shift in the `attrname` to value dictionary (unless the unknown attribute was last in the list).

As the list of attributes doesn't change (it is the list of columns in the JobDB), it doesn't make sense to silently ignore this problem and return "None" or "UNKNOWN ATTRIBUTE" as the dictionary values for the unknown attributes.

https://github.com/DIRACGrid/DIRAC/blob/a45fddce5366c1af75faabf0c382469e37070def/WorkloadManagementSystem/DB/JobDB.py#L129-L147
