### PR TITLE
[v7r0] use DIRACOS when externals are not defined

### DIFF
--- a/Core/scripts/dirac-distribution.py
+++ b/Core/scripts/dirac-distribution.py
@@ -248,7 +248,7 @@ class DistributionMaker:
     return True
 
   def tarExternals(self, releaseVersion):
-    externalsVersion = self.relConf.getExtenalsVersion(releaseVersion)
+    externalsVersion = self.relConf.getExternalsVersion(releaseVersion)
     platform = Platform.getPlatformString()
     availableExternals = self.getAvailableExternals()
 

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1093,7 +1093,7 @@ class ReleaseConfig(object):
       return S_OK((False, modTpl[0]))
     return S_OK((modTpl[0], modTpl[1]))
 
-  def getExtenalsVersion(self, release=None):
+  def getExternalsVersion(self, release=None):
     """
     It returns the version of DIRAC Externals. If it is not provided,
     uses the default cfg
@@ -1894,7 +1894,7 @@ def installExternals(releaseConfig):
   if not releaseConfig:
     externalsVersion = cliParams.externalVersion
   else:
-    externalsVersion = releaseConfig.getExtenalsVersion()
+    externalsVersion = releaseConfig.getExternalsVersion()
   if not externalsVersion:
     res = installDiracOS(releaseConfig)
     if res:

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1896,6 +1896,9 @@ def installExternals(releaseConfig):
   else:
     externalsVersion = releaseConfig.getExtenalsVersion()
   if not externalsVersion:
+    res = installDiracOS(releaseConfig)
+    if res:
+      return True
     logERROR("No externals defined")
     return False
 

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1896,9 +1896,6 @@ def installExternals(releaseConfig):
   else:
     externalsVersion = releaseConfig.getExternalsVersion()
   if not externalsVersion:
-    res = installDiracOS(releaseConfig)
-    if res:
-      return True
     logERROR("No externals defined")
     return False
 
@@ -2410,6 +2407,7 @@ def createBashrcForDiracOS():
 
   return True
 
+
 def checkoutFromGit(moduleName, sourceURL, tagVersion, destinationDir=None):
   """
   This method checkout a given tag from a git repository.
@@ -2562,7 +2560,8 @@ if __name__ == "__main__":
   else:
     logNOTICE("Skipping installing DIRAC")
 
-  if cliParams.diracOS:
+  # we install with DIRACOS from v7rX DIRAC release
+  if cliParams.diracOS or int(releaseConfig.prjRelCFG['DIRAC'].keys()[0][1]) > 6:
     logNOTICE("Installing DIRAC OS %s..." % cliParams.diracOSVersion)
     if not installDiracOS(releaseConfig):
       sys.exit(1)


### PR DESCRIPTION
This is almost a hack: dirac-install.py will try to install with DIRACOS when:
- the "--dirac-os" flag is not set
- there's no external version specified, which is the case for v7r0-pre17 and everything that will come later.

We can't change much else because it would change the logic for installing older versions. If you have other suggestions, please fire!

BEGINRELEASENOTES

*Core
CHANGE: dirac-install.py will use DIRACOS when externals are not defined

ENDRELEASENOTES
