### PR TITLE
[v6r22]  fixing commit id for extensions

### DIFF
--- a/Core/scripts/dirac-create-distribution-tarball.py
+++ b/Core/scripts/dirac-create-distribution-tarball.py
@@ -296,7 +296,7 @@ class TarModuleCreator(object):
                 continue
               toReplace = po2.stdout.read().strip()
               toReplace = "".join(i for i in toReplace if ord(i) < 128)
-              fileContents = fileContents.replace(keyWord, toReplace)
+              fileContents = fileContents.replace(keyWord, toReplace, 1)
 
           with open(objPath, "w") as fd:
             fd.write(fileContents)


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: $Id$ keyword must be replaced only at the beginning of the file.

ENDRELEASENOTES
