### PR TITLE
[v6r21] fixes for dirac-dms-clean-directory

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata.py
@@ -835,6 +835,8 @@ class DirectoryMetadata:
   def removeMetadataForDirectory(self, dirList, credDict):
     """ Remove all the metadata for the given directory list
     """
+    if not dirList:
+      return S_OK({'Successful': {}, 'Failed': {}})
 
     failed = {}
     successful = {}

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
@@ -530,6 +530,8 @@ class DirectoryTreeBase:
           return S_OK(resultDict)
         else:
           pDir = os.path.dirname(path)
+          if not pDir:
+            return S_ERROR('Illegal Path')
           result = self.getDirectoryPermissions(pDir, credDict)
           return result
       else:

--- a/DataManagementSystem/scripts/dirac-dms-clean-directory.py
+++ b/DataManagementSystem/scripts/dirac-dms-clean-directory.py
@@ -1,42 +1,50 @@
 #! /usr/bin/env python
-########################################################################
-# $HeadURL: $
-########################################################################
-__RCSID__ = "$Id:  $"
+__RCSID__ = "$Id$"
 
-from DIRAC           import exit as DIRACExit, gLogger
+import os
+import sys
+
+from DIRAC import exit as DIRACExit, gLogger
 from DIRAC.Core.Base import Script
 
-Script.setUsageMessage( """
+Script.setUsageMessage("""
 Clean the given directory or a list of directories by removing it and all the
 contained files and subdirectories from the physical storage and from the
 file catalogs.
 
 Usage:
-   %s <lfn | fileContainingLfns> <SE> <status>
-""" % Script.scriptName )
+   %s <LFN_Directory | fileContainingLFN_Directories>
+""" % Script.scriptName)
 
 Script.parseCommandLine()
-import os, sys
 
 args = Script.getPositionalArgs()
-if len( args ) < 1:
+if len(args) != 1:
   Script.showHelp()
-  DIRACExit( -1 )
-else:
-  inputFileName = args[0]
+  DIRACExit(-1)
 
-if os.path.exists( inputFileName ):
-  lfns = [lfn.strip().split()[0] for lfn in sorted( open( inputFileName, 'r' ).read().splitlines() )]
+inputFileName = args[0]
+
+if os.path.exists(inputFileName):
+  lfns = [lfn.strip().split()[0] for lfn in sorted(open(inputFileName, 'r').read().splitlines())]
 else:
   lfns = [inputFileName]
 
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 dm = DataManager()
+retVal = 0
 for lfn in [lfn for lfn in lfns if lfn]:
-  print "Cleaning directory %s ... " % lfn
-  result = dm.cleanLogicalDirectory( lfn )
-  if result['OK']:
-    print 'OK'
+  gLogger.notice("Cleaning directory %r ... " % lfn)
+  result = dm.cleanLogicalDirectory(lfn)
+  if not result['OK']:
+    gLogger.error('Failed to clean directory', result['Message'])
+    retVal = -1
   else:
-    print "ERROR: %s" % result['Message']
+    if not result['Value']['Failed']:
+      gLogger.notice('OK')
+    else:
+      for folder, message in result['Value']['Failed'].items():
+        gLogger.error('Failed to clean folder', "%r: %s" % (folder, message))
+        retVal = -1
+
+  DIRACExit(retVal)


### PR DESCRIPTION

BEGINRELEASENOTES

*DMS
FIX: ``dirac-dms-clean-directory`` correct usage message for list of arguments
FIX: ``dirac-dms-clean-directory`` now properly prints error messages
FIX: ``dirac-dms-clean-directory`` will now also clean empty directories
FIX: ``FileCatalog.DirectoryMetadata``: prevent error when removeMetadataDirectory is called on empty list of directories, triggered when calling removeDirectory on non-existing directory
FIX: ``FileCatalog.DirectoryTreeBase``: prevent maximum recursion depth exception when calling remove directory with illegal path


ENDRELEASENOTES
