### PR TITLE
[v7r0] better doc strings

### DIFF
--- a/Core/Base/Client.py
+++ b/Core/Base/Client.py
@@ -120,6 +120,7 @@ def createClient(serviceName):
   def genFunc(funcName, arguments, handlerClassPath, doc):
     """Create a function with *funcName* taking *arguments*."""
     doc = '' if doc is None else doc
+    funcDocString = '%s(%s, **kwargs)\n' % (funcName, ', '.join(arguments))
     # do not describe self or cls in the parameter description
     if arguments and arguments[0] in ('self', 'cls'):
       arguments = arguments[1:]
@@ -133,7 +134,8 @@ def createClient(serviceName):
       def func(self, **kwargs):  # pylint: disable=missing-docstring
         self.call = funcName
         return self.executeRPC(**kwargs)
-    func.__doc__ = doc + "\n\nAutomatically created for the service function :func:`~%s.export_%s`" % \
+    func.__doc__ = funcDocString + doc + \
+        "\n\nAutomatically created for the service function :func:`~%s.export_%s`" % \
         (handlerClassPath, funcName)
     parameterDoc = ''
     # add description for parameters, if that is not already done for the docstring of function in the service

--- a/Core/Utilities/Decorators.py
+++ b/Core/Utilities/Decorators.py
@@ -71,6 +71,11 @@ def deprecated(reason, onlyOnce=False):
 
     decFunc.warningEn = True
 
+    if func.__doc__ is None:
+      func.__doc__ = '\n\n**Deprecated**: ' + reason
+    else:
+      func.__doc__ += '\n\n**Deprecated**: ' + reason
+
     @functools.wraps(func)
     def innerFunc(*args, **kwargs):
       """ Prints a suitable deprectaion notice and calls


### PR DESCRIPTION

If the first line of a docstring looks like a function signature, sphinx uses that instead of what is defined in python. We can use this to properly create the function signatures in the automatically created client functions.

http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_docstring_signature



BEGINRELEASENOTES

*Docs
CHANGE: Automatically added client functions now display proper argument names in the function siganture instead of just "*args"
CHANGE: Functions decorated with the deprecated decorator will now mention this in their docstring

ENDRELEASENOTES
