### PR TITLE
[v6r22] SE: do not disable Session reuse in GridFTP anymore

### DIFF
--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -75,9 +75,6 @@ class GFAL2_StorageBase(StorageBase):
     # by default turn off BDII checks
     self.ctx.set_opt_boolean("BDII", "ENABLE", False)
 
-    # FIXME: Avoid caching because of a bug in globus (https://its.cern.ch/jira/browse/DMC-853)
-    self.ctx.set_opt_boolean("GRIDFTP PLUGIN", "SESSION_REUSE", False)
-
     # Enable IPV6 for gsiftp
     self.ctx.set_opt_boolean("GRIDFTP PLUGIN", "IPV6", True)
 


### PR DESCRIPTION
The use of this cache was disabled at the time because of a bug (specific globus + specific dCache). The bug is now fixed. We should revert to the previous behavior because this "hacK" hurts very much removals (in particular RAL Echo)
For references:
https://github.com/globus/globus-toolkit/issues/57
https://github.com/dCache/dcache/issues/4830
https://github.com/gridcf/gct/issues/81

BEGINRELEASENOTES

*Resources
FIX: re-allow the use of the gsiftp cache in the SE

ENDRELEASENOTES
