### PR TITLE
[v6r22] extension can take DIRACOS from DIRAC

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -741,12 +741,12 @@ class ReleaseConfig(object):
       return S_OK(sourceUrl)
     return S_ERROR("Don't know how to find the installation tarballs for project %s" % project)
 
-  def getDiracOsLocation(self, project=None, diracosFromDIRAC=False):
+  def getDiracOsLocation(self, project=None, diracosDefault=False):
     """
     Returns the location of the DIRAC os binary for a given project for example: LHCb or DIRAC, etc...
 
     :param str project: the name of the project
-    :param bool diracosFromDIRAC: where to take diracos
+    :param bool diracosDefault: flag to take diracos distribution from the default location
 
     :return: the location of the tar balls
     """
@@ -754,7 +754,7 @@ class ReleaseConfig(object):
       project = 'DIRAC'
 
     diracOsLoc = "Projects/%s/DIRACOS" % self.projectName
-    if not diracosFromDIRAC and self.globalDefaults.isOption(diracOsLoc):
+    if not diracosDefault and self.globalDefaults.isOption(diracOsLoc):
       # use from the VO specific configuration file
       location = self.globalDefaults.get(diracOsLoc, "")
     else:
@@ -2316,9 +2316,17 @@ def installDiracOS(releaseConfig):
   else:
     # if ":" is not present in diracos name, we take the diracos tarball from vanilla DIRAC location
     if diracos.lower() == 'diracos':
-      tarsURL = releaseConfig.getDiracOsLocation(diracosFromDIRAC=True)['Value']
+      retVal = releaseConfig.getDiracOsLocation(diracosDefault=True)
+      if retVal['OK']:
+        tarsURL = retVal['Value']
+      else:
+        logERROR(retVal['Message'])
     else:
-      tarsURL = releaseConfig.getDiracOsLocation()['Value']
+      retVal = releaseConfig.getDiracOsLocation()
+      if retVal['OK']:
+        tarsURL = retVal['Value']
+      else:
+        logERROR(retVal['Message'])
   if not tarsURL:
     tarsURL = releaseConfig.getTarsLocation('DIRAC')['Value']
     logWARN("DIRACOS location is not specified using %s" % tarsURL)

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2313,7 +2313,7 @@ def installDiracOS(releaseConfig):
     tarsURL = cliParams.installSource
   else:
     # if : is not exists in diracos version, we use diracos from DIRAC
-    if diracos == 'diracos':      
+    if diracos == 'diracos':    
       tarsURL = releaseConfig.getDiracOsLocation(diracOSFromDIRAC=True)['Value']
     else:
       tarsURL = releaseConfig.getDiracOsLocation()['Value']

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2313,7 +2313,7 @@ def installDiracOS(releaseConfig):
     tarsURL = cliParams.installSource
   else:
     # if : is not exists in diracos version, we use diracos from DIRAC
-    if diracos == 'diracos':    
+    if diracos == 'diracos':
       tarsURL = releaseConfig.getDiracOsLocation(diracOSFromDIRAC=True)['Value']
     else:
       tarsURL = releaseConfig.getDiracOsLocation()['Value']

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -741,17 +741,18 @@ class ReleaseConfig(object):
       return S_OK(sourceUrl)
     return S_ERROR("Don't know how to find the installation tarballs for project %s" % project)
 
-  def getDiracOsLocation(self, project=None):
+  def getDiracOsLocation(self, project=None, diracOSFromDIRAC=False):
     """
     Returns the location of the DIRAC os binary for a given project for example: LHCb or DIRAC, etc...
 
     :param str project: the name of the project
+    :param bool diracOSFromDIRAC: where to take diracos
     """
     if project is None:
       project = 'DIRAC'
 
     diracOsLoc = "Projects/%s/DIRACOS" % self.projectName
-    if self.globalDefaults.isOption(diracOsLoc):
+    if not diracOSFromDIRAC and self.globalDefaults.isOption(diracOsLoc):
       # use from the VO specific configuration file
       location = self.globalDefaults.get(diracOsLoc, "")
     else:
@@ -2311,7 +2312,11 @@ def installDiracOS(releaseConfig):
   if cliParams.installSource:
     tarsURL = cliParams.installSource
   else:
-    tarsURL = releaseConfig.getDiracOsLocation()['Value']
+    # if : is not exists in diracos version, we use diracos from DIRAC
+    if diracos == 'diracos':      
+      tarsURL = releaseConfig.getDiracOsLocation(diracOSFromDIRAC=True)['Value']
+    else:
+      tarsURL = releaseConfig.getDiracOsLocation()['Value']
   if not tarsURL:
     tarsURL = releaseConfig.getTarsLocation('DIRAC')['Value']
     logWARN("DIRACOS location is not specified using %s" % tarsURL)

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -741,18 +741,20 @@ class ReleaseConfig(object):
       return S_OK(sourceUrl)
     return S_ERROR("Don't know how to find the installation tarballs for project %s" % project)
 
-  def getDiracOsLocation(self, project=None, diracOSFromDIRAC=False):
+  def getDiracOsLocation(self, project=None, diracOSfromDIRAC=False):
     """
     Returns the location of the DIRAC os binary for a given project for example: LHCb or DIRAC, etc...
 
     :param str project: the name of the project
-    :param bool diracOSFromDIRAC: where to take diracos
+    :param bool diracOSfromDIRAC: where to take diracos
+
+    :return: the location of the tar balls
     """
     if project is None:
       project = 'DIRAC'
 
     diracOsLoc = "Projects/%s/DIRACOS" % self.projectName
-    if not diracOSFromDIRAC and self.globalDefaults.isOption(diracOsLoc):
+    if not diracOSfromDIRAC and self.globalDefaults.isOption(diracOsLoc):
       # use from the VO specific configuration file
       location = self.globalDefaults.get(diracOsLoc, "")
     else:
@@ -2312,9 +2314,9 @@ def installDiracOS(releaseConfig):
   if cliParams.installSource:
     tarsURL = cliParams.installSource
   else:
-    # if : is not exists in diracos version, we use diracos from DIRAC
-    if diracos == 'diracos':
-      tarsURL = releaseConfig.getDiracOsLocation(diracOSFromDIRAC=True)['Value']
+    # if ":" is not present in diracos name, we take the diracos tarball from vanilla DIRAC location
+    if diracos.lower() == 'diracos':
+      tarsURL = releaseConfig.getDiracOsLocation(diracOSfromDIRAC=True)['Value']
     else:
       tarsURL = releaseConfig.getDiracOsLocation()['Value']
   if not tarsURL:

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -741,12 +741,12 @@ class ReleaseConfig(object):
       return S_OK(sourceUrl)
     return S_ERROR("Don't know how to find the installation tarballs for project %s" % project)
 
-  def getDiracOsLocation(self, project=None, diracOSfromDIRAC=False):
+  def getDiracOsLocation(self, project=None, diracosFromDIRAC=False):
     """
     Returns the location of the DIRAC os binary for a given project for example: LHCb or DIRAC, etc...
 
     :param str project: the name of the project
-    :param bool diracOSfromDIRAC: where to take diracos
+    :param bool diracosFromDIRAC: where to take diracos
 
     :return: the location of the tar balls
     """
@@ -754,7 +754,7 @@ class ReleaseConfig(object):
       project = 'DIRAC'
 
     diracOsLoc = "Projects/%s/DIRACOS" % self.projectName
-    if not diracOSfromDIRAC and self.globalDefaults.isOption(diracOsLoc):
+    if not diracosFromDIRAC and self.globalDefaults.isOption(diracOsLoc):
       # use from the VO specific configuration file
       location = self.globalDefaults.get(diracOsLoc, "")
     else:
@@ -2316,7 +2316,7 @@ def installDiracOS(releaseConfig):
   else:
     # if ":" is not present in diracos name, we take the diracos tarball from vanilla DIRAC location
     if diracos.lower() == 'diracos':
-      tarsURL = releaseConfig.getDiracOsLocation(diracOSfromDIRAC=True)['Value']
+      tarsURL = releaseConfig.getDiracOsLocation(diracosFromDIRAC=True)['Value']
     else:
       tarsURL = releaseConfig.getDiracOsLocation()['Value']
   if not tarsURL:


### PR DESCRIPTION
It is required by #4197

BEGINRELEASENOTES

*Core
CHANGE: A VO with diracos extension, must be able to install the main diracos from DIRAC repository. 

ENDRELEASENOTES
