### PR TITLE
[v7r0] Hackathon fix for tests

### DIFF
--- a/tests/Workflow/Integration/Test_UserJobs.py
+++ b/tests/Workflow/Integration/Test_UserJobs.py
@@ -30,13 +30,14 @@ class UserJobTestCase(IntegrationTest):
 
     self.d = Dirac()
 
+    integration_test_dir = '/DIRAC/tests/Workflow/Integration'
     try:
-      self.exeScriptLocation = find_all('exe-script.py', rootPath, '/DIRAC/tests/Workflow/Integration')[0]
-      self.helloWorld = find_all("helloWorld.py", rootPath, '/DIRAC/tests/Workflow/Integration')[0]
+      self.exeScriptLocation = find_all('exe-script.py', rootPath, integration_test_dir)[0]
+      self.helloWorld = find_all("helloWorld.py", rootPath, integration_test_dir)[0]
       self.mpExe = find_all('mpTest.py', rootPath, '/DIRAC/tests/Utilities')[0]
     except IndexError:  # we are in Jenkins
-      self.exeScriptLocation = find_all('exe-script.py', os.environ['WORKSPACE'], '/DIRAC/tests/Workflow/Integration')[0]
-      self.helloWorld = find_all("helloWorld.py", os.environ['WORKSPACE'], '/DIRAC/tests/Workflow/Integration')[0]
+      self.exeScriptLocation = find_all('exe-script.py', os.environ['WORKSPACE'], integration_test_dir)[0]
+      self.helloWorld = find_all("helloWorld.py", os.environ['WORKSPACE'], integration_test_dir)[0]
       self.mpExe = find_all('mpTest.py', os.environ['WORKSPACE'], '/DIRAC/tests/Utilities')[0]
 
     gLogger.setLevel('DEBUG')

--- a/tests/Workflow/Integration/Test_UserJobs.py
+++ b/tests/Workflow/Integration/Test_UserJobs.py
@@ -31,12 +31,12 @@ class UserJobTestCase(IntegrationTest):
     self.d = Dirac()
 
     try:
-      self.exeScriptLocation = find_all('exe-script.py', rootPath, '/DIRAC/tests/Workflow')[0]
-      self.helloWorld = find_all("helloWorld.py", rootPath, '/DIRAC/tests/Workflow')[0]
+      self.exeScriptLocation = find_all('exe-script.py', rootPath, '/DIRAC/tests/Workflow/Integration')[0]
+      self.helloWorld = find_all("helloWorld.py", rootPath, '/DIRAC/tests/Workflow/Integration')[0]
       self.mpExe = find_all('mpTest.py', rootPath, '/DIRAC/tests/Utilities')[0]
     except IndexError:  # we are in Jenkins
-      self.exeScriptLocation = find_all('exe-script.py', os.environ['WORKSPACE'], '/DIRAC/tests/Workflow')[0]
-      self.helloWorld = find_all("helloWorld.py", os.environ['WORKSPACE'], '/DIRAC/tests/Workflow')[0]
+      self.exeScriptLocation = find_all('exe-script.py', os.environ['WORKSPACE'], '/DIRAC/tests/Workflow/Integration')[0]
+      self.helloWorld = find_all("helloWorld.py", os.environ['WORKSPACE'], '/DIRAC/tests/Workflow/Integration')[0]
       self.mpExe = find_all('mpTest.py', os.environ['WORKSPACE'], '/DIRAC/tests/Utilities')[0]
 
     gLogger.setLevel('DEBUG')


### PR DESCRIPTION
The user jobs script uses `tests/Workflow/Regression/helloWorld.py` instead of `tests/Workflow/Integration/helloWorld.py` in Jenkins.

Fixes: https://jenkins-dirac.web.cern.ch/blue/organizations/jenkins/Pilot3_CVM4_pipeline/detail/Pilot3_CVM4_pipeline/8/pipeline/35/