### PR TITLE
[v6r21] Add argument to SandboxStoreClient to allow using the service

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1698,7 +1698,7 @@ class Dirac(API):
 
     # New download
     result = SandboxStoreClient(smdb=False,
-                                useCertificates=self.useCertificates,).downloadSandboxForJob(jobID,
+                                useCertificates=self.useCertificates).downloadSandboxForJob(jobID,
                                                                                              'Output',
                                                                                              dirPath,
                                                                                              inMemory=False,

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1646,9 +1646,12 @@ class Dirac(API):
     try:
       os.mkdir(dirPath)
     except Exception as x:
-      return self._errorReport(str(x), 'Could not create directory in %s' % (dirPath))
+      return self._errorReport(repr(x), 'Could not create directory in %s' % (dirPath))
 
-    result = SandboxStoreClient(useCertificates=self.useCertificates).downloadSandboxForJob(jobID, 'Input', dirPath)
+    result = SandboxStoreClient(smdb=False,
+                                useCertificates=self.useCertificates).downloadSandboxForJob(jobID,
+                                                                                            'Input',
+                                                                                            dirPath)
     if not result['OK']:
       self.log.warn(result['Message'])
     else:
@@ -1694,9 +1697,12 @@ class Dirac(API):
     mkDir(dirPath)
 
     # New download
-    result = SandboxStoreClient(useCertificates=self.useCertificates).downloadSandboxForJob(jobID, 'Output', dirPath,
-                                                                                            inMemory=False,
-                                                                                            unpack=unpack)
+    result = SandboxStoreClient(smdb=False,
+                                useCertificates=self.useCertificates,).downloadSandboxForJob(jobID,
+                                                                                             'Output',
+                                                                                             dirPath,
+                                                                                             inMemory=False,
+                                                                                             unpack=unpack)
     if result['OK']:
       self.log.info('Files retrieved and extracted in %s' % (dirPath))
       if self.jobRepo:

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1699,10 +1699,10 @@ class Dirac(API):
     # New download
     result = SandboxStoreClient(smdb=False,
                                 useCertificates=self.useCertificates).downloadSandboxForJob(jobID,
-                                                                                             'Output',
-                                                                                             dirPath,
-                                                                                             inMemory=False,
-                                                                                             unpack=unpack)
+                                                                                            'Output',
+                                                                                            dirPath,
+                                                                                            inMemory=False,
+                                                                                            unpack=unpack)
     if result['OK']:
       self.log.info('Files retrieved and extracted in %s' % (dirPath))
       if self.jobRepo:

--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -27,13 +27,14 @@ class SandboxStoreClient(object):
   __validSandboxTypes = ('Input', 'Output')
   __smdb = None
 
-  def __init__(self, rpcClient=None, transferClient=None, **kwargs):
+  def __init__(self, rpcClient=None, transferClient=None, smdb=None, **kwargs):
 
     self.__serviceName = "WorkloadManagement/SandboxStore"
     self.__rpcClient = rpcClient
     self.__transferClient = transferClient
     self.__kwargs = kwargs
     self.__vo = None
+    SandboxStoreClient.__smdb = smdb
     if 'delegatedGroup' in kwargs:
       self.__vo = getVOForGroup(kwargs['delegatedGroup'])
     if SandboxStoreClient.__smdb is None:


### PR DESCRIPTION

BEGINRELEASENOTES
*WMS
CHANGE: Add an argument to the constructor of SandboxStoreClient for using in scripts that cannot use the DB directly
ENDRELEASENOTES
