### PR TITLE
[v7r0] Changes and fixes for pilot wrappers

### DIFF
--- a/ConfigurationSystem/ConfigTemplate.cfg
+++ b/ConfigurationSystem/ConfigTemplate.cfg
@@ -4,7 +4,7 @@ Services
   {
     HandlerPath = DIRAC/ConfigurationSystem/Service/ConfigurationHandler.py
     Port = 9135
-    UpdatePilotCStoJSONFile = False
+    UpdatePilotCStoJSONFile = True
     Authorization
     {
       Default = authenticated

--- a/ConfigurationSystem/Service/ConfigurationHandler.py
+++ b/ConfigurationSystem/Service/ConfigurationHandler.py
@@ -60,7 +60,7 @@ class ConfigurationHandler(RequestHandler):
       return res
 
     # Check the flag for updating the pilot 3 JSON file
-    updatePilotCStoJSONFileFlag = self.srv_getCSOption('UpdatePilotCStoJSONFile', False)
+    updatePilotCStoJSONFileFlag = self.srv_getCSOption('UpdatePilotCStoJSONFile', True)
     if updatePilotCStoJSONFileFlag and gServiceInterface.isMaster():
       if gPilotSynchronizer is None:
         try:

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -144,20 +144,37 @@ logger.info("But first unpacking pilot files")
 # Getting the pilot files
 logger.info("Getting the pilot files from %(location)s")
 
-# Getting the json file
-rJson = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.json')
-with open('pilot.json', 'wb') as pj:
-  pj.write(rJson.read())
-  pj.close()
+# Getting the json file and the tar file
+try:
+  # needs to distinguish versions prior to or after 2.7.9
+  if sys.version_info >= (2, 7, 9):
+    import ssl
+    context = ssl._create_unverified_context()
+    rJson = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.json',
+                            timeout=10,
+                            context=context)
+    rTar = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.tar',
+                            timeout=10,
+                            context=context)
+  else:
+    rJson = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.json',
+                            timeout=10)
+    rTar = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.tar',
+                            timeout=10)
+  except urllib2.URLError:
+    print('%(location)s unreacheable')
 
-# Getting the tar file
-rTar = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.tar')
-with open('pilot.tar', 'wb') as pt:
-  pt.write(rTar.read())
-  pt.close()
-with tarfile.open('pilot.tar', 'r') as pt:
-  pt.extractall()
-  pt.close()
+pj = open('pilot.json', 'wb') pj:
+pj.write(rJson.read())
+pj.close()
+
+pt = open('pilot.tar', 'wb') pt:
+pt.write(rTar.read())
+pt.close()
+
+pt = tarfile.open('pilot.tar', 'r'):
+pt.extractall()
+pt.close()
 """ % {'location': location}
 
   localPilot += """

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -166,15 +166,15 @@ try:
 except urllib2.URLError:
   print('%(location)s unreacheable')
 
-pj = open('pilot.json', 'wb') pj:
+pj = open('pilot.json', 'wb')
 pj.write(rJson.read())
 pj.close()
 
-pt = open('pilot.tar', 'wb') pt:
+pt = open('pilot.tar', 'wb')
 pt.write(rTar.read())
 pt.close()
 
-pt = tarfile.open('pilot.tar', 'r'):
+pt = tarfile.open('pilot.tar', 'r')
 pt.extractall()
 pt.close()
 """ % {'location': location}

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -32,7 +32,6 @@ import base64
 import bz2
 import logging
 import time
-import urllib2
 import tarfile
 
 # setting up the logging
@@ -156,26 +155,35 @@ for loc in location:
   # Getting the json file and the tar file
   try:
 
+    # urllib is different between python 2 and 3
+    if sys.version_info < (3,):
+      from urllib2 import urlopen as url_library_urlopen
+      from urllib2 import URLError as url_library_URLError
+    else:
+      from urllib.request import urlopen as url_library_urlopen
+      from urllib.error import URLError as url_library_URLError
+
+
     # needs to distinguish versions prior to or after 2.7.9
     if sys.version_info >= (2, 7, 9):
       import ssl
       context = ssl._create_unverified_context()
-      rJson = urllib2.urlopen('https://' + loc + '/pilot/pilot.json',
-                              timeout=10,
-                              context=context)
-      rTar = urllib2.urlopen('https://' + loc + '/pilot/pilot.tar',
-                              timeout=10,
-                              context=context)
+      rJson = url_library_urlopen('https://' + loc + '/pilot/pilot.json',
+                                  timeout=10,
+                                  context=context)
+      rTar = url_library_urlopen('https://' + loc + '/pilot/pilot.tar',
+                                 timeout=10,
+                                 context=context)
       break
 
     else:
-      rJson = urllib2.urlopen('https://' + loc + '/pilot/pilot.json',
-                              timeout=10)
-      rTar = urllib2.urlopen('https://' + loc + '/pilot/pilot.tar',
-                              timeout=10)
+      rJson = url_library_urlopen('https://' + loc + '/pilot/pilot.json',
+                                  timeout=10)
+      rTar = url_library_urlopen('https://' + loc + '/pilot/pilot.tar',
+                                 timeout=10)
       break
 
-  except urllib2.URLError:
+  except url_library_URLError:
     print('%%s unreacheable' %% loc)
 
 pj = open('pilot.json', 'wb')

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -96,8 +96,8 @@ def pilotWrapperScript(pilotFilesCompressedEncodedDict=None,
     envVariables = {}
 
   compressedString = ""
-  for pfName, encodedPf in pilotFilesCompressedEncodedDict.items():  # are there some pilot files to unpack?
-                                                                     # then we create the unpacking string
+  # are there some pilot files to unpack? Then we create the unpacking string
+  for pfName, encodedPf in pilotFilesCompressedEncodedDict.items():
     compressedString += """
 try:
   with open('%(pfName)s', 'w') as fd:

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -49,7 +49,7 @@ logger.addHandler(screen_handler)
 # just logging the environment as first thing
 print('===========================================================')
 logger.debug('Environment of execution host\\n')
-for key, val in os.environ.iteritems():
+for key, val in os.environ.items():
   logger.debug(key + '=' + val)
 print('===========================================================', end='\\n')
 
@@ -96,8 +96,8 @@ def pilotWrapperScript(pilotFilesCompressedEncodedDict=None,
     envVariables = {}
 
   compressedString = ""
-  for pfName, encodedPf in pilotFilesCompressedEncodedDict.iteritems():  # are there some pilot files to unpack?
-                                                                         # then we create the unpacking string
+  for pfName, encodedPf in pilotFilesCompressedEncodedDict.items():  # are there some pilot files to unpack?
+                                                                     # then we create the unpacking string
     compressedString += """
 try:
   with open('%(pfName)s', 'w') as fd:
@@ -111,7 +111,7 @@ except BaseException as x:
        'pfName': pfName}
 
   envVariablesString = ""
-  for name, value in envVariables.iteritems():  # are there some environment variables to add?
+  for name, value in envVariables.items():  # are there some environment variables to add?
     envVariablesString += """
 os.environ[\"%(name)s\"]=\"%(value)s\"
 """ % {'name': name,

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -52,7 +52,7 @@ print('===========================================================')
 logger.debug('Environment of execution host\\n')
 for key, val in os.environ.iteritems():
   logger.debug(key + '=' + val)
-print('===========================================================', end='\n')
+print('===========================================================', end='\\n')
 
 # putting ourselves in the right directory
 pilotExecDir = '%(pilotExecDir)s'
@@ -163,8 +163,8 @@ try:
                             timeout=10)
     rTar = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.tar',
                             timeout=10)
-  except urllib2.URLError:
-    print('%(location)s unreacheable')
+except urllib2.URLError:
+  print('%(location)s unreacheable')
 
 pj = open('pilot.json', 'wb') pj:
 pj.write(rJson.read())

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -21,6 +21,8 @@ pilotWrapperContent = """#!/bin/bash
 /usr/bin/env python << EOF
 
 # imports
+from __future__ import print_function
+
 import os
 import stat
 import tempfile
@@ -46,11 +48,11 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(screen_handler)
 
 # just logging the environment as first thing
-print '==========================================================='
+print('===========================================================')
 logger.debug('Environment of execution host\\n')
 for key, val in os.environ.iteritems():
   logger.debug(key + '=' + val)
-print '===========================================================\\n'
+print('===========================================================', end='\n')
 
 # putting ourselves in the right directory
 pilotExecDir = '%(pilotExecDir)s'
@@ -103,7 +105,7 @@ try:
     fd.write(bz2.decompress(base64.b64decode(\"\"\"%(encodedPf)s\"\"\")))
   os.chmod('%(pfName)s', stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 except BaseException as x:
-  print >> sys.stderr, x
+  print(x, file=sys.stderr)
   shutil.rmtree(pilotWorkingDirectory)
   sys.exit(-1)
 """ % {'encodedPf': encodedPf,

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -146,25 +146,37 @@ logger.info("But first unpacking pilot files")
 # Getting the pilot files
 logger.info("Getting the pilot files from %(location)s")
 
-# Getting the json file and the tar file
-try:
-  # needs to distinguish versions prior to or after 2.7.9
-  if sys.version_info >= (2, 7, 9):
-    import ssl
-    context = ssl._create_unverified_context()
-    rJson = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.json',
-                            timeout=10,
-                            context=context)
-    rTar = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.tar',
-                            timeout=10,
-                            context=context)
-  else:
-    rJson = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.json',
-                            timeout=10)
-    rTar = urllib2.urlopen('https://' + '%(location)s' + '/pilot/pilot.tar',
-                            timeout=10)
-except urllib2.URLError:
-  print('%(location)s unreacheable')
+location = '%(location)s'.replace(' ', '').split(',')
+
+import random
+random.shuffle(location)
+
+# we try from the available locations
+for loc in location:
+  # Getting the json file and the tar file
+  try:
+
+    # needs to distinguish versions prior to or after 2.7.9
+    if sys.version_info >= (2, 7, 9):
+      import ssl
+      context = ssl._create_unverified_context()
+      rJson = urllib2.urlopen('https://' + loc + '/pilot/pilot.json',
+                              timeout=10,
+                              context=context)
+      rTar = urllib2.urlopen('https://' + loc + '/pilot/pilot.tar',
+                              timeout=10,
+                              context=context)
+      break
+
+    else:
+      rJson = urllib2.urlopen('https://' + loc + '/pilot/pilot.json',
+                              timeout=10)
+      rTar = urllib2.urlopen('https://' + loc + '/pilot/pilot.tar',
+                              timeout=10)
+      break
+
+  except urllib2.URLError:
+    print('%%s unreacheable' %% loc)
 
 pj = open('pilot.json', 'wb')
 pj.write(rJson.read())

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -47,11 +47,11 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(screen_handler)
 
 # just logging the environment as first thing
-print('===========================================================')
+logger.debug('===========================================================')
 logger.debug('Environment of execution host\\n')
 for key, val in os.environ.items():
   logger.debug(key + '=' + val)
-print('===========================================================', end='\\n')
+logger.debug('===========================================================\\n')
 
 # putting ourselves in the right directory
 pilotExecDir = '%(pilotExecDir)s'
@@ -105,6 +105,7 @@ try:
   os.chmod('%(pfName)s', stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 except BaseException as x:
   print(x, file=sys.stderr)
+  logger.error(x)
   shutil.rmtree(pilotWorkingDirectory)
   sys.exit(-1)
 """ % {'encodedPf': encodedPf,
@@ -184,7 +185,13 @@ for loc in location:
       break
 
   except url_library_URLError:
-    print('%%s unreacheable' %% loc)
+    print('%%s unreacheable' %% loc, file=sys.stderr)
+    logger.error('%%s unreacheable' %% loc)
+
+else:
+  print("None of the locations of the pilot files is reachable", file=sys.stderr)
+  logger.error("None of the locations of the pilot files is reachable")
+  sys.exit(-1)
 
 pj = open('pilot.json', 'wb')
 pj.write(rJson.read())

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/Configuration/Services/Server/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Systems/Configuration/Services/Server/index.rst
@@ -13,8 +13,8 @@ In this subsection the Server service is configured. The attributes are showed i
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 | *Port*                             | Port where the service is responding       | Port = 9135                                                             |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
-| *UpdatePilotCStoJSONFile*          | Optional flag to enable if you want that   | UpdatePilotCStoJSONFile = True                                          |
-|                                    | the configuration on the pilot is dumped   | Default is False                                                        |
+| *UpdatePilotCStoJSONFile*          | Optional flag to disable the dumping of    | UpdatePilotCStoJSONFile = False                                         |
+|                                    | the configuration on the pilot             | Default is True                                                         |
 |                                    | in a JSON file and uploaded to a webserver |                                                                         |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 | *Authorization*                    | Subsection to configure authorization over | Authorization                                                           |

--- a/docs/source/AdministratorGuide/Configuration/ExampleConfig.rst
+++ b/docs/source/AdministratorGuide/Configuration/ExampleConfig.rst
@@ -297,7 +297,7 @@ Below is a complete example configuration with anotations for some sections::
         {
           HandlerPath = DIRAC/ConfigurationSystem/Service/ConfigurationHandler.py
           Port = 9135
-          UpdatePilotCStoJSONFile = False
+          UpdatePilotCStoJSONFile = True
           Authorization
           {
             Default = authenticated

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -18,14 +18,15 @@ The ``pilot.json`` file is created starting from information found in the Config
 
 The pilot wrapper (the script that starts the pilot, which is effectively equivalent to what SiteDirectors send)
 expects to find and download such a ``pilot.json`` file from a known location, or a set of them.
-Such a location can be, for example, exposed via *https://* by the DIRAC WebApp webserver. Other protocols (including *file://*) are possible.
+Such a location should be exposed via *https://* by, for example, the DIRAC WebApp webserver.
+
+The (list of) location(s) has to be added in the Operations option *Pilot/pilotFileServer*.
+If more than one location is used, add them as a list.
+We suggest to add at least the URL of the DIRAC WebApp webserver, but multiple locations are also possible, and advised.
 
 The pilot.json file is always kept in sync with the content of the Configuration Service.
 At every configuration update, the pilot.json file content will also be updated.
 
-Also the Operations option *Pilot/<...>/pilotFileServer* should be set to the webserver(s) chosen for the upload.
-If more than one location is used, add them as a list.
-We suggest to use simply the DIRAC webserver, but multiple locations are also possible, and advised.
 
 If you use the DIRAC webserver please
 
@@ -45,12 +46,15 @@ Other options that can be set also in the Operations part of the CS include:
 |                                    |                                            | The value above is the default                                          |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 | *pilotVORepo*                      | Pointer to git repository of VO DIRAC      | pilotVORepo = https://github.com/MyDIRAC/VOPilot.git                    |
-|                                    | extension of pilot                         |                                                                         |
+|                                    | extension of pilot.                        |                                                                         |
+|                                    | This option is needed in case you have an  |                                                                         |
+|                                    | extension of the pilot                     |                                                                         |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 | *pilotScriptsPath*                 | Path to the code, inside the Git repository| pilotScriptsPath = Pilot                                                |
 |                                    |                                            | This value is the default                                               |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 | *pilotScriptsVOPath*               | Path to the code, inside the Git repository| pilotScriptsVOPath = VOPilot                                            |
+|                                    | of the pilot extension                     |                                                                         |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 
 
@@ -60,6 +64,8 @@ Starting the old Pilot 2 via SiteDirectors
 Since DIRAC v7r0, SiteDirectors will send by default "pilots3".
 To still send Pilot 2 type of pilots, the Pilot3 flag should be set explicitely to False
 (see :mod:`~DIRAC.WorkloadManagementSystem.Agent.SiteDirector`).
+
+It should be anyway noted that "Pilot 2" are not maintained anymore, and that their code will be removed in a future version of DIRAC.
 
 
 Pilot logging

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -1,8 +1,8 @@
 .. _pilot3:
 
-=============
-DIRAC Pilot 3
-=============
+==============
+DIRAC pilots 3
+==============
 
 All concepts defined for Pilot2 are valid also for Pilot3. There are anyway some differences for what regards their usage.
 
@@ -54,21 +54,12 @@ Other options that can be set also in the Operations part of the CS include:
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 
 
-Starting Pilot3 via SiteDirectors
-==================================
+Starting the old Pilot 2 via SiteDirectors
+==========================================
 
-.. versionadded:: v6r20
-
-  Since DIRAC v6r20, SiteDirectors can send "pilot2" or "pilot3". Pilot2 is the default,
-  but the "Pilot3=True" flag can be used for sending Pilot3 files instead, see the documentation
-  for the :mod:`~DIRAC.WorkloadManagementSystem.Agent.SiteDirector`.
-
-.. versionchanged:: v7r0
-
-  The default is now to send Pilot3. Pilot2 can be enabled by setting the SiteDirector option Pilot3 to False::
-
-    Pilot3=False
-
+Since DIRAC v7r0, SiteDirectors will send by default "pilots3".
+To still send Pilot 2 type of pilots, the Pilot3 flag should be set explicitely to False
+(see :mod:`~DIRAC.WorkloadManagementSystem.Agent.SiteDirector`).
 
 
 Pilot logging

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -16,17 +16,19 @@ Bootstrap
 Pilot3 needs a JSON file for bootstrapping. We simply call this file the ``pilot.json`` file.
 The ``pilot.json`` file is created starting from information found in the Configuration Service.
 
-The pilot wrapper (the script that starts the pilot, which is effectively equivalent to what SiteDirectors send) expects
-to find (download) such a ``pilot.json`` file from a known location, which can be for example exposed by the DIRAC
-WebApp webserver.
+The pilot wrapper (the script that starts the pilot, which is effectively equivalent to what SiteDirectors send)
+expects to find (download) such pilot.json file from a known location, or a set of them.
+Such location can be, for example, exposed via *https://* by the DIRAC WebApp webserver. Other protocols (including *file://*) are possible.
 
 The ``pilot.json`` file is therefore always kept in sync with the content of the Configuration Service.
 From DIRAC v6r20, there is the possibility to set the option *UpdatePilotCStoJSONFile* to True in the configuration of
 the Configuration/Server service (please see :ref:`ConfigurationServer` for detais). If this option is set,
 at every configuration update, the ``pilot.json`` file content will also be updated (if necessary).
 
-If *UpdatePilotCStoJSONFile* is True, then also the Operations option *Pilot/<...>/pilotFileServer* should be set to the webserver chosen for the upload.
-We suggest to use simply the DIRAC webserver.
+If *UpdatePilotCStoJSONFile* is True, then also the Operations option *Pilot/<...>/pilotFileServer*
+should be set to the webserver(s) chosen for the upload.
+If more than one location are used, add them as a list.
+We suggest to use simply the DIRAC webserver, but multiple locations are also possible, and advised.
 
 If you use the DIRAC webserver please
 

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -20,13 +20,10 @@ The pilot wrapper (the script that starts the pilot, which is effectively equiva
 expects to find (download) such pilot.json file from a known location, or a set of them.
 Such location can be, for example, exposed via *https://* by the DIRAC WebApp webserver. Other protocols (including *file://*) are possible.
 
-The ``pilot.json`` file is therefore always kept in sync with the content of the Configuration Service.
-From DIRAC v6r20, there is the possibility to set the option *UpdatePilotCStoJSONFile* to True in the configuration of
-the Configuration/Server service (please see :ref:`ConfigurationServer` for detais). If this option is set,
-at every configuration update, the ``pilot.json`` file content will also be updated (if necessary).
+The pilot.json file is therefore always kept in sync with the content of the Configuration Service.
+At every configuration update, the pilot.json file content will also be updated (if necessary).
 
-If *UpdatePilotCStoJSONFile* is True, then also the Operations option *Pilot/<...>/pilotFileServer*
-should be set to the webserver(s) chosen for the upload.
+Also the Operations option *Pilot/<...>/pilotFileServer* should be set to the webserver(s) chosen for the upload.
 If more than one location are used, add them as a list.
 We suggest to use simply the DIRAC webserver, but multiple locations are also possible, and advised.
 

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -21,10 +21,10 @@ expects to find and download such a ``pilot.json`` file from a known location, o
 Such a location can be, for example, exposed via *https://* by the DIRAC WebApp webserver. Other protocols (including *file://*) are possible.
 
 The pilot.json file is always kept in sync with the content of the Configuration Service.
-At every configuration update, the pilot.json file content will also be updated (if necessary).
+At every configuration update, the pilot.json file content will also be updated.
 
 Also the Operations option *Pilot/<...>/pilotFileServer* should be set to the webserver(s) chosen for the upload.
-If more than one location are used, add them as a list.
+If more than one location is used, add them as a list.
 We suggest to use simply the DIRAC webserver, but multiple locations are also possible, and advised.
 
 If you use the DIRAC webserver please

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -17,10 +17,10 @@ Pilot3 needs a JSON file for bootstrapping. We simply call this file the ``pilot
 The ``pilot.json`` file is created starting from information found in the Configuration Service.
 
 The pilot wrapper (the script that starts the pilot, which is effectively equivalent to what SiteDirectors send)
-expects to find (download) such pilot.json file from a known location, or a set of them.
-Such location can be, for example, exposed via *https://* by the DIRAC WebApp webserver. Other protocols (including *file://*) are possible.
+expects to find and download such a ``pilot.json`` file from a known location, or a set of them.
+Such a location can be, for example, exposed via *https://* by the DIRAC WebApp webserver. Other protocols (including *file://*) are possible.
 
-The pilot.json file is therefore always kept in sync with the content of the Configuration Service.
+The pilot.json file is always kept in sync with the content of the Configuration Service.
 At every configuration update, the pilot.json file content will also be updated (if necessary).
 
 Also the Operations option *Pilot/<...>/pilotFileServer* should be set to the webserver(s) chosen for the upload.

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
@@ -19,6 +19,7 @@ What's a DIRAC Pilot
 ====================
 
 First of all, a definition:
+
 - A *pilot* is what creates the possibility to run jobs on a worker node. Or, in other words:
 - a script that, at a minimum, setup (VO)DIRAC, sets the local DIRAC configuration, launches the an entity for matching jobs (e.g. the JobAgent)
 
@@ -37,7 +38,7 @@ A pilot has, at a minimum, to:
 A pilot has to run on each and every computing resource type, provided that:
 
 - Python 2.6+ on the WN
-- It is an OS onto which we can install DIRAC
+- It is an OS onto which we can install a DIRAC client (basically: SLC6 or CentOS7)
 
 The same pilot script can be used everywhere.
 
@@ -57,9 +58,10 @@ Definitions that help understanding what's a pilot
 - *pilot wrapper*: a script that wraps the pilot script with conditions for running the pilot script itself (maybe multiple times).
 - *pilot job*: a pilot wrapper sent to a computing element (e.g. CREAM, ARC).
 
-The *pilot* is a "standardized" piece of code. The *pilot wrapper* is not.
+The *pilot* is a "standardized" piece of code. The *pilot wrapper* might not be standardized.
 
-An agent like the "SiteDirector" encapsulates the *pilot* in a *pilot wrapper*, then sends it to a Computing Element as a *pilot job*.
+The "SiteDirector" agent encapsulates the *pilot* in a *pilot wrapper*, then sends it to a Computing Element as a *pilot job*.
+
 But, if you don't have the possibility to send a pilot job (e.g. the case of a Virtual Machine in a cloud),
 you can still find a way to start the pilot script by encapsulating it in a pilot wrapper that will be started at boot time,
 e.g. by supplying the proper contextualization to the VM.
@@ -75,31 +77,29 @@ The following CS section is used for administering the DIRAC pilots::
 These parameters will be interpreted by the WorkloadManagementSystem/SiteDirector agents, and by the WorkloadManagementSystem/Matcher.
 They can also be accessed by other services/agents, e.g. for syncing purposes.
 
-Inside this section, you should define the following options, and give them a meaningful value (here, an example is give)::
+Inside this section, you should define the following options, and give them a meaningful value (here, an example is given)::
 
    # Needed by the SiteDirector:
-   Version = v6r20p14 #Version to install. Add the version of your extension if you have one.
-   Project = myVO #Your project name: this will end up in the /LocalSite/ReleaseProject option of the pilot cfg, and will be used at matching time
-   Extensions = myVO #The DIRAC extension (if any)
-   Installation = mycfg.cfg #For an optional configuration file, used by the installation script.
+   Version = v6r20p14  # DIRAC version(s)
+   Project = myVO  # Your project name: this will end up in the /LocalSite/ReleaseProject option of the pilot cfg, and will be used at matching time
+   Extensions = myVO # The DIRAC extension (if any)
+   Installation = mycfg.cfg # For an optional configuration file, used by the installation script.
    # For the Matcher
-   CheckVersion = False #True by default, if false any version would be accepted at matching level (this is a check done by the WorkloadManagementSystem/Matcher service).
+   CheckVersion = False # True by default, if false any version would be accepted at matching level (this is a check done by the WorkloadManagementSystem/Matcher service).
 
-When the *CheckVersion* option is "True", the version checking done at the Matcher level will be strict,
-which means that pilots running different versions from those listed in the *Versions* option will refuse to match any job.
-There is anyway the possibility to list more than one version in *Versions*; in this case, all of them will be accepted by the Matcher,
-and in this case the pilot will install the first in this list (e.g. if Version=v6r20p14,v6r20p13 then pilots will install version v6r20p14)
+Further details:
+
+- *Version* is the version of DIRAC that the pilots will install. Add the version of your DIRAC extension if you have one. A list of versions can also be added here, meaning that all these versions will be accepted by the Matcher (see below), while only the first in the list will be the one used by the pilots for knowing which DIRAC version to install (e.g. if Version=v7r0p2,v7r0p1 then pilots will install version v7r0p2)
+- *Project* is, normally, the same as *Extensions*
+- When the *CheckVersion* option is "True", the version checking done at the Matcher level will be strict, which means that pilots running different versions from those listed in the *Versions* option will refuse to match any job. There is anyway the possibility to list more than one version in *Versions*; in this case, all of them will be accepted by the Matcher.
 
 
 
 Pilot Commands
 ==============
 
-The system works with "commands", as explained in the RFC 18. Any command can be added.
-If your command is executed before the "InstallDIRAC" command, pay attention that DIRAC functionalities won't be available.
-
-Beware that, to send pilot jobs containing a specific list of commands using the SiteDirector agents,
-you'll need a SiteDirector extension.
+The system works with "commands", as explained in the `RFC 18 <https://github.com/DIRACGrid/DIRAC/wiki/Pilots-2.0:-generic,-configurable-pilots>`_.
+Any command can be added. If your command is executed before the "InstallDIRAC" command, pay attention that DIRAC functionalities won't be available.
 
 Basically, pilot commands are an implementation of the command pattern.
 Commands define a toolbox of pilot capabilities available to the pilot script. Each command implements one function, like:
@@ -110,10 +110,10 @@ Commands define a toolbox of pilot capabilities available to the pilot script. E
 - Configure (VO)DIRAC
 - In fact, there are several configuration commands
 - Configure CPU capabilities
-- the famous “dirac-wms-cpu-normalization”
+- Run the *dirac-wms-cpu-normalization* script, which calculates the CPU power of the node
 - Run the JobAgent
 
-A custom list of commands can be specified using the --commands option,
+A custom list of commands can be specified using the *--commands* option to the pilot, or set in the Pilots' configuration,
 but if nothing is selected then the following list will be run::
 
    'GetPilotVersion', 'CheckWorkerNode', 'InstallDIRAC', 'ConfigureBasics', 'CheckCECapabilities',
@@ -155,17 +155,16 @@ and possibly extend, in case you want to send/start pilots that don't know befor
 In this case, you have to provide a json file freely accessible that contains the pilot version.
 This is tipically the case for VMs in IAAS and IAAC.
 
-The files to consider are in https://github.com/DIRACGrid/DIRAC/blob/master/WorkloadManagementSystem/PilotAgent
-for Pilot2, while the so-called "Pilot3" files are in the dedicated repository at https://github.com/DIRACGrid/Pilot/.
+The files to consider are in https://github.com/DIRACGrid/Pilot
 
 The main file in which you should look is dirac-pilot.py
 that also contains a good explanation on how the system works.
 
 You have to provide in this case a pilot wrapper script (which can be written in bash, for example) that will start your pilot script
 with the proper environment. If you are on a cloud site, often contextualization of your virtual machine is done by supplying
-a script like the following: https://gitlab.cern.ch/mcnab/temp-diracpilot/raw/master/user_data (this one is an example from LHCb)
+a script like the following: https://github.com/DIRACGrid/Pilot/blob/master/Pilot/user_data_vm
 
-A simpler example is the following::
+A simpler example using the LHCbPilot extension follows::
 
   #!/bin/sh
   #
@@ -226,6 +225,9 @@ A simpler example is the following::
   DIRAC_PILOT='https://lhcb-portal-dirac.cern.ch/pilot/dirac-pilot.py'
   DIRAC_PILOT_TOOLS='https://lhcb-portal-dirac.cern.ch/pilot/pilotTools.py'
   DIRAC_PILOT_COMMANDS='https://lhcb-portal-dirac.cern.ch/pilot/pilotCommands.py'
+  DIRAC_PILOT_LOGGER='https://lhcb-portal-dirac.cern.ch/pilot/PilotLogger.py'
+  DIRAC_PILOT_LOGGERTOOLS='https://lhcb-portal-dirac.cern.ch/pilot/PilotLoggerTools.py'
+  DIRAC_PILOT_MESSAGESENDER='https://lhcb-portal-dirac.cern.ch/pilot/MessageSender.py'
   LHCbDIRAC_PILOT_COMMANDS='https://lhcb-portal-dirac.cern.ch/pilot/LHCbPilotCommands.py'
 
   #
@@ -234,6 +236,9 @@ A simpler example is the following::
   wget --no-check-certificate -O dirac-pilot.py $DIRAC_PILOT
   wget --no-check-certificate -O pilotTools.py $DIRAC_PILOT_TOOLS
   wget --no-check-certificate -O pilotCommands.py $DIRAC_PILOT_COMMANDS
+  wget --no-check-certificate -O PilotLogger.py $DIRAC_PILOT_LOGGER
+  wget --no-check-certificate -O PilotLoggerTools.py $DIRAC_PILOT_LOGGERTOOLS
+  wget --no-check-certificate -O MessageSender.py $DIRAC_PILOT_MESSAGESENDER
   wget --no-check-certificate -O LHCbPilotCommands.py $LHCbDIRAC_PILOT_COMMANDS
 
   #run the dirac-pilot script

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
@@ -4,6 +4,9 @@
 DIRAC pilots
 ========================
 
+.. meta::
+   :keywords: Pilots3, Pilot3, Pilot
+
 This page describes what are DIRAC pilots, and how they work.
 To know how to develop DIRAC pilots, please refer to the Developers documentation
 

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# This is a test that:
+# - gets the (DIRAC-free) PilotWrapper.py (that should be in input)
+# - use its functions to generate a pilot wrapper
+# - starts it
+#
+# It should be executed for different versions of python, e.g.:
+# - 2.5.x
+# - 2.7.x (x < 9)
+# - 2.7.x (x >= 9)
+# (- 3.6.x)
+
+from __future__ import print_function
+
+import sys
+import urllib2
+import os
+import time
+import base64
+import bz2
+
+# gets the (DIRAC-free) PilotWrapper.py, and dirac-install.py
+
+if sys.version_info >= (2, 7, 9):
+  import ssl
+  context = ssl._create_unverified_context()
+  rf = urllib2.urlopen(sys.argv[1],
+                       context=context)
+  di = urllib2.urlopen('https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py',
+                       context=context)
+else:
+  rf = urllib2.urlopen(sys.argv[1])
+  di = urllib2.urlopen('https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py')
+
+with open('PilotWrapper.py', 'wb') as pj:
+  pj.write(rf.read())
+  pj.close()  # for python 2.6
+with open('dirac-install.py', 'wb') as pj:
+  pj.write(di.read())
+  pj.close()  # for python 2.6
+
+
+# use its functions to generate a pilot wrapper
+time.sleep(1)
+from PilotWrapper import pilotWrapperScript
+
+diracInstall = os.path.join(os.getcwd(), 'dirac-install.py')
+with open(diracInstall, "r") as fd:
+  diracInstall = fd.read()
+diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9))
+
+res = pilotWrapperScript(
+    pilotFilesCompressedEncodedDict={'dirac-install.py': diracInstallEncoded},
+    pilotOptions="-c 123 --foo bar",
+    location='lbcertifdirac7.cern.ch:8443')
+
+with open('pilot-wrapper.sh', 'wb') as pj:
+  pj.write(res)
+
+# now start it
+
+os.system("sh pilot-wrapper.sh")

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -60,7 +60,7 @@ diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9))
 res = pilotWrapperScript(
     pilotFilesCompressedEncodedDict={'dirac-install.py': diracInstallEncoded},
     pilotOptions="--commands CheckWorkerNode,InstallDIRAC --setup=DIRAC-Certification --debug",
-    location='lbcertifdirac7.cern.ch:8443')
+    location='lbcertifdirac7.cern.ch:8443,wrong.cern.ch')
 
 with open('pilot-wrapper.sh', 'wb') as pj:
   pj.write(res)

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -10,6 +10,16 @@
 # - 2.7.x (x < 9)
 # - 2.7.x (x >= 9)
 # (- 3.6.x)
+#
+#
+# Invoke this with:
+#
+# python Test_GenerateAndExecutePilotWrapper.py url://to_PilotWrapper.py
+# (and in this case it will download dirac-install.py from github)
+# or
+# python Test_GenerateAndExecutePilotWrapper.py url://to_PilotWrapper.py url://to_dirac-install.py
+#
+
 
 from __future__ import print_function
 
@@ -50,7 +60,8 @@ with open('dirac-install.py', 'wb') as pj:
 
 # use its functions to generate a pilot wrapper
 time.sleep(1)
-from PilotWrapper import pilotWrapperScript
+# by now this will be in the local dir
+from PilotWrapper import pilotWrapperScript  # pylint: disable=import-error
 
 diracInstall = os.path.join(os.getcwd(), 'dirac-install.py')
 with open(diracInstall, "r") as fd:

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -33,13 +33,13 @@ import bz2
 
 # urllib is different between python 2 and 3
 if sys.version_info < (3,):
-  from urllib2 import urlopen as url_library_urlopen
+  from urllib2 import urlopen as url_library_urlopen  # pylint: disable=import-error
 else:
-  from urllib.request import urlopen as url_library_urlopen
+  from urllib.request import urlopen as url_library_urlopen  # pylint: disable=no-name-in-module
 
 
 if sys.version_info >= (2, 7, 9):
-  import ssl
+  import ssl  # pylint: disable=import-error
   context = ssl._create_unverified_context()
   rf = url_library_urlopen(sys.argv[1],
                            context=context)
@@ -74,7 +74,7 @@ from PilotWrapper import pilotWrapperScript  # pylint: disable=import-error
 diracInstall = os.path.join(os.getcwd(), 'dirac-install.py')
 with open(diracInstall, "r") as fd:
   diracInstall = fd.read()
-if sys.version_info < (3,):
+if sys.version_info >= (3,):
   diracInstallEncoded = base64.b64encode(bz2.compress(bytes(diracInstall, 'UTF-8'), 9))
 else:
   diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9))

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -6,7 +6,7 @@
 # - starts it
 #
 # It should be executed for different versions of python, e.g.:
-# - 2.5.x
+# - 2.6.x
 # - 2.7.x (x < 9)
 # - 2.7.x (x >= 9)
 # (- 3.6.x)
@@ -27,11 +27,18 @@ if sys.version_info >= (2, 7, 9):
   context = ssl._create_unverified_context()
   rf = urllib2.urlopen(sys.argv[1],
                        context=context)
-  di = urllib2.urlopen('https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py',
-                       context=context)
+  try:  # dirac-install.py location from the args, if provided
+    di = urllib2.urlopen(sys.argv[2],
+                         context=context)
+  except IndexError:
+    di = urllib2.urlopen('https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py',
+                         context=context)
 else:
   rf = urllib2.urlopen(sys.argv[1])
-  di = urllib2.urlopen('https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py')
+  try:  # dirac-install.py location from the args, if provided
+    di = urllib2.urlopen(sys.argv[2])
+  except IndexError:
+    di = urllib2.urlopen('https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py')
 
 with open('PilotWrapper.py', 'wb') as pj:
   pj.write(rf.read())
@@ -52,7 +59,7 @@ diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9))
 
 res = pilotWrapperScript(
     pilotFilesCompressedEncodedDict={'dirac-install.py': diracInstallEncoded},
-    pilotOptions="-c 123 --foo bar",
+    pilotOptions="--commands CheckWorkerNode,InstallDIRAC --setup=DIRAC-Certification --debug",
     location='lbcertifdirac7.cern.ch:8443')
 
 with open('pilot-wrapper.sh', 'wb') as pj:

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -24,31 +24,39 @@
 from __future__ import print_function
 
 import sys
-import urllib2
 import os
 import time
 import base64
 import bz2
 
-# gets the (DIRAC-free) PilotWrapper.py, and dirac-install.py
+# 1) gets the (DIRAC-free) PilotWrapper.py, and dirac-install.py
+
+# urllib is different between python 2 and 3
+if sys.version_info < (3,):
+  from urllib2 import urlopen as url_library_urlopen
+else:
+  from urllib.request import urlopen as url_library_urlopen
+
 
 if sys.version_info >= (2, 7, 9):
   import ssl
   context = ssl._create_unverified_context()
-  rf = urllib2.urlopen(sys.argv[1],
-                       context=context)
+  rf = url_library_urlopen(sys.argv[1],
+                           context=context)
   try:  # dirac-install.py location from the args, if provided
-    di = urllib2.urlopen(sys.argv[2],
-                         context=context)
+    di = url_library_urlopen(sys.argv[2],
+                             context=context)
   except IndexError:
-    di = urllib2.urlopen('https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py',
-                         context=context)
+    di_loc = 'https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py'
+    di = url_library_urlopen(di_loc,
+                             context=context)
 else:
-  rf = urllib2.urlopen(sys.argv[1])
+  rf = url_library_urlopen(sys.argv[1])
   try:  # dirac-install.py location from the args, if provided
-    di = urllib2.urlopen(sys.argv[2])
+    di = url_library_urlopen(sys.argv[2])
   except IndexError:
-    di = urllib2.urlopen('https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py')
+    di_loc = 'https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py'
+    di = url_library_urlopen(di_loc)
 
 with open('PilotWrapper.py', 'wb') as pj:
   pj.write(rf.read())
@@ -58,7 +66,7 @@ with open('dirac-install.py', 'wb') as pj:
   pj.close()  # for python 2.6
 
 
-# use its functions to generate a pilot wrapper
+# 2)  use its functions to generate a pilot wrapper
 time.sleep(1)
 # by now this will be in the local dir
 from PilotWrapper import pilotWrapperScript  # pylint: disable=import-error
@@ -76,6 +84,6 @@ res = pilotWrapperScript(
 with open('pilot-wrapper.sh', 'wb') as pj:
   pj.write(res)
 
-# now start it
+# 3) now start it
 
 os.system("sh pilot-wrapper.sh")

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -74,7 +74,10 @@ from PilotWrapper import pilotWrapperScript  # pylint: disable=import-error
 diracInstall = os.path.join(os.getcwd(), 'dirac-install.py')
 with open(diracInstall, "r") as fd:
   diracInstall = fd.read()
-diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9))
+if sys.version_info < (3,):
+  diracInstallEncoded = base64.b64encode(bz2.compress(bytes(diracInstall, 'UTF-8'), 9))
+else:
+  diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9))
 
 res = pilotWrapperScript(
     pilotFilesCompressedEncodedDict={'dirac-install.py': diracInstallEncoded},

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -35,7 +35,7 @@ import bz2
 if sys.version_info < (3,):
   from urllib2 import urlopen as url_library_urlopen  # pylint: disable=import-error
 else:
-  from urllib.request import urlopen as url_library_urlopen  # pylint: disable=no-name-in-module
+  from urllib.request import urlopen as url_library_urlopen  # pylint: disable=import-error,no-name-in-module
 
 
 if sys.version_info >= (2, 7, 9):


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
NEW: PilotWrapper can get the Pilot files from a list of locations
CHANGE: PilotWrapper is compatible with several python versions

*test
NEW: added a test for PilotWrapper

*docs
CHANGE: Pilot 3 is the default

ENDRELEASENOTES
