### PR TITLE
[v7r0] Logger: make sure sVarMsg is always a string

### DIFF
--- a/FrameworkSystem/private/standardLogging/Logging.py
+++ b/FrameworkSystem/private/standardLogging/Logging.py
@@ -415,7 +415,7 @@ class Logging(object):
       # extras attributes are not camel case because log record attributes are
       # not either.
       extra = {'componentname': self._componentName,
-               'varmessage': sVarMsg,
+               'varmessage': str(sVarMsg),
                'spacer': '' if not sVarMsg else ' ',
                'customname': self._customName}
       self._logger.log(level, "%s", sMsg, exc_info=exc_info, extra=extra)


### PR DESCRIPTION
In order to avoid a lot of issues with the centralized logging, make sure the variable message is always a string

BEGINRELEASENOTES

*Framework
CHANGE: make sure sVarMsg in Logger is always a string

ENDRELEASENOTES