### PR TITLE
[v7r0] fix xroot proxy cache

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2154,6 +2154,10 @@ def createBashrc():
       # Add the lines required for ARC CE support
       lines.extend(['# ARC Computing Element',
                     'export ARC_PLUGIN_PATH=$DIRACLIB/arc'])
+
+      # Add the lines required for fork support for xrootd
+      lines.extend(['# Fork support for xrootd',
+                    'export XRD_RUNFORKHANDLER=1'])
       lines.append('')
       f = open(bashrcFile, 'w')
       f.write('\n'.join(lines))
@@ -2250,6 +2254,11 @@ def createCshrc():
       # Add the lines required for ARC CE support
       lines.extend(['# ARC Computing Element',
                     'setenv ARC_PLUGIN_PATH $DIRACLIB/arc'])
+
+      # Add the lines required for fork support for xrootd
+      lines.extend(['# Fork support for xrootd',
+                    'setenv XRD_RUNFORKHANDLER 1'])
+
       lines.append('')
       f = open(cshrcFile, 'w')
       f.write('\n'.join(lines))
@@ -2433,6 +2442,11 @@ def createBashrcForDiracOS():
       # Note: eventually this line should disappear as already set by diracosrc
       lines.extend(['# ARC Computing Element',
                     'export ARC_PLUGIN_PATH=$DIRACOS/usr/lib64/arc'])
+
+      # Add the lines required for fork support for xrootd
+      lines.extend(['# Fork support for xrootd',
+                    'export XRD_RUNFORKHANDLER=1'])
+
       lines.append('')
       with open(bashrcFile, 'w') as f:
         f.write('\n'.join(lines))

--- a/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/Resources/Storage/GFAL2_XROOTStorage.py
@@ -46,7 +46,7 @@ class GFAL2_XROOTStorage(GFAL2_StorageBase):
     super(GFAL2_XROOTStorage, self).__init__(storageName, parameters)
     self.srmSpecificParse = False
 
-    self.log = LOG.getSubLogger("GFAL2_XROOTStorage")
+    self.log = LOG.getSubLogger(storageName)
 
     self.pluginName = 'GFAL2_XROOT'
 

--- a/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/Resources/Storage/GFAL2_XROOTStorage.py
@@ -13,23 +13,24 @@ import os
 from DIRAC import gLogger
 from DIRAC.Resources.Storage.GFAL2_StorageBase import GFAL2_StorageBase
 from DIRAC.Core.Utilities.Pfn import pfnparse, pfnunparse
+from DIRAC.Core.Security.Locations import getProxyLocation
 
-class GFAL2_XROOTStorage( GFAL2_StorageBase ):
+LOG = gLogger.getSubLogger(__name__)
+
+
+class GFAL2_XROOTStorage(GFAL2_StorageBase):
   """ .. class:: GFAL2_XROOTStorage
 
   Xroot interface to StorageElement using gfal2
   """
 
-
   _INPUT_PROTOCOLS = ['file', 'root']
   _OUTPUT_PROTOCOLS = ['root']
 
-
-
   PROTOCOL_PARAMETERS = GFAL2_StorageBase.PROTOCOL_PARAMETERS + ['SvcClass']
-  DYNAMIC_OPTIONS = { 'SvcClass' : 'svcClass'}
+  DYNAMIC_OPTIONS = {'SvcClass': 'svcClass'}
 
-  def __init__( self, storageName, parameters ):
+  def __init__(self, storageName, parameters):
     """ c'tor
 
     :param self: self reference
@@ -42,10 +43,10 @@ class GFAL2_XROOTStorage( GFAL2_StorageBase ):
     :param str wspath: location of SRM on :host:
     """
     # # init base class
-    super( GFAL2_XROOTStorage, self ).__init__( storageName, parameters )
+    super(GFAL2_XROOTStorage, self).__init__(storageName, parameters)
     self.srmSpecificParse = False
 
-    self.log = gLogger.getSubLogger( "GFAL2_XROOTStorage", True )
+    self.log = LOG.getSubLogger("GFAL2_XROOTStorage")
 
     self.pluginName = 'GFAL2_XROOT'
 
@@ -62,7 +63,7 @@ class GFAL2_XROOTStorage( GFAL2_StorageBase ):
     if 'XrdSecPROTOCOL' not in os.environ:
       os.environ['XrdSecPROTOCOL'] = 'gsi,unix'
 
-  def __addDoubleSlash( self, res ):
+  def __addDoubleSlash(self, res):
     """ Utilities to add the double slash between the host(:port) and the path
 
         :param res: DIRAC return structure which contains an URL if S_OK
@@ -71,21 +72,42 @@ class GFAL2_XROOTStorage( GFAL2_StorageBase ):
     if not res['OK']:
       return res
     url = res['Value']
-    res = pfnparse( url, srmSpecific = self.srmSpecificParse )
+    res = pfnparse(url, srmSpecific=self.srmSpecificParse)
     if not res['OK']:
       return res
     urlDict = res['Value']
     urlDict['Path'] = '/' + urlDict['Path']
-    return pfnunparse( urlDict, srmSpecific = self.srmSpecificParse )
 
-  def getURLBase( self, withWSUrl = False ):
-    """ Overwrite to add the double slash """
-    return self.__addDoubleSlash( super( GFAL2_XROOTStorage, self ).getURLBase( withWSUrl = withWSUrl ) )
+    # Now, that's one heck of a disgusting hack
+    # xrootd client is a bit faulty when managing
+    # the connection cache, and ends up reusing an
+    # existing connection for different users (security flaw...)
+    # they have fixed it (to some extent starting from xrootd 4.10)
+    # (https://github.com/xrootd/xrootd/issues/976)
+    # BUT. They still can't consume properly the information when
+    # the identity is passed in the url (root://url?gsiusrpxy=/tmp/myproxy)
+    # So we apply a trick here which is to specify the proxy filename as a virtual user
+    # This has no consequence (developer's own words), but to distinguish between users
+    # Another ticket has been opened for that https://github.com/xrootd/xrootd/issues/992
 
-  def constructURLFromLFN( self, lfn, withWSUrl = False ):
-    """ Overwrite to add the double slash """
-    return self.__addDoubleSlash( super( GFAL2_XROOTStorage, self ).constructURLFromLFN( lfn = lfn, withWSUrl = withWSUrl ) )
+    try:
+      proxyLoc = getProxyLocation()
+      if proxyLoc:
+        proxyLoc = os.path.basename(proxyLoc)
+        urlDict['Host'] = '%s@%s' % (proxyLoc, urlDict['Host'])
+    except Exception as e:
+      self.log.warn("Exception trying to add virtual user in the url", repr(e))
 
-  def getCurrentURL( self, fileName ):
+    return pfnunparse(urlDict, srmSpecific=self.srmSpecificParse)
+
+  def getURLBase(self, withWSUrl=False):
     """ Overwrite to add the double slash """
-    return self.__addDoubleSlash( super( GFAL2_XROOTStorage, self ).getCurrentURL( fileName ) )
+    return self.__addDoubleSlash(super(GFAL2_XROOTStorage, self).getURLBase(withWSUrl=withWSUrl))
+
+  def constructURLFromLFN(self, lfn, withWSUrl=False):
+    """ Overwrite to add the double slash """
+    return self.__addDoubleSlash(super(GFAL2_XROOTStorage, self).constructURLFromLFN(lfn=lfn, withWSUrl=withWSUrl))
+
+  def getCurrentURL(self, fileName):
+    """ Overwrite to add the double slash """
+    return self.__addDoubleSlash(super(GFAL2_XROOTStorage, self).getCurrentURL(fileName))


### PR DESCRIPTION
In order for the fix to be fully efficient, we will need xroot 4.10
This should fix some permission denied problems we are getting. Details are in the code comments.

@andresailer  this is the fix we discussed a while ago.

This was tested as hotfix on the REA in LHCb. 

BEGINRELEASENOTES
*Core
NEW: dirac-install defines XRD_RUNFORKHANDLER environment variable

*Resources
FIX: add proxy location as a virtual user for xroot urls

ENDRELEASENOTES
