### PR TITLE
[v7r1] Make the client version known to services

### DIFF
--- a/Core/DISET/RequestHandler.py
+++ b/Core/DISET/RequestHandler.py
@@ -557,6 +557,9 @@ class RequestHandler(object):
       return ('Unknown yet', )
     return self.serviceInfoDict['actionTuple']
 
+  def srv_getClientVersion(self):
+    return self.serviceInfoDict.get("clientVersion")
+
   @classmethod
   def srv_getURL(cls):
     return cls.__srvInfoDict['URL']

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -523,7 +523,8 @@ and this is thread %s
       return self.__initStatus
     stConnectionInfo = ((self.__URLTuple[3], self.setup, self.vo),
                         action,
-                        self.__extraCredentials)
+                        self.__extraCredentials,
+                        DIRAC.version)
 
     # Send the connection info and get the answer back
     retVal = transport.sendData(S_OK(stConnectionInfo))

--- a/Core/DISET/private/Service.py
+++ b/Core/DISET/private/Service.py
@@ -487,6 +487,8 @@ class Service(object):
     clientTransport = self._transportPool.get(trid)
     if clientTransport:
       clientParams['clientAddress'] = clientTransport.getRemoteAddress()
+    if len(proposalTuple) > 3:
+      clientParams['clientVersion'] = proposalTuple[3]
     # Generate handler dict with per client info
     handlerInitDict = dict(self._serviceInfoDict)
     for key in clientParams:

--- a/Core/DISET/private/Service.py
+++ b/Core/DISET/private/Service.py
@@ -475,6 +475,11 @@ class Service(object):
   def _instantiateHandler(self, trid, proposalTuple=None):
     """
     Generate an instance of the handler for a given service
+
+    :param int trid: transprot ID
+    :param tuple proposalTuple: tuple describing the proposed action
+
+    :return: S_OK/S_ERROR, Value is the handler object
     """
     # Generate the client params
     clientParams = {'serviceStartTime': self._startTime}
@@ -487,6 +492,7 @@ class Service(object):
     clientTransport = self._transportPool.get(trid)
     if clientTransport:
       clientParams['clientAddress'] = clientTransport.getRemoteAddress()
+    # The 4th element is the client version if available
     if len(proposalTuple) > 3:
       clientParams['clientVersion'] = proposalTuple[3]
     # Generate handler dict with per client info

--- a/Core/DISET/private/Service.py
+++ b/Core/DISET/private/Service.py
@@ -476,7 +476,7 @@ class Service(object):
     """
     Generate an instance of the handler for a given service
 
-    :param int trid: transprot ID
+    :param int trid: transport ID
     :param tuple proposalTuple: tuple describing the proposed action
 
     :return: S_OK/S_ERROR, Value is the handler object


### PR DESCRIPTION
This PR makes the DIRAC version of the client to be available to service. This will allow, for example, meaningful error message in case of client/service version incompatibility.

BEGINRELEASENOTES

*Core
NEW: DISET - pass the client DIRAC version as part of the request description structure

ENDRELEASENOTES
