### PR TITLE
[v7r1] Synchronize service after the CS update

### DIFF
--- a/ConfigurationSystem/Client/CSAPI.py
+++ b/ConfigurationSystem/Client/CSAPI.py
@@ -11,7 +11,6 @@ from DIRAC.Core.Security import Locations
 from DIRAC.ConfigurationSystem.private.Modificator import Modificator
 from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
-from DIRAC.Core.DISET.RPCClient import RPCClient
 
 __RCSID__ = "$Id$"
 

--- a/ConfigurationSystem/Client/CSAPI.py
+++ b/ConfigurationSystem/Client/CSAPI.py
@@ -778,5 +778,3 @@ class CSAPI(object):
     """
 
     return self.__rpcClient.forceGlobalConfigurationUpdate()
-
-

--- a/ConfigurationSystem/Client/CSAPI.py
+++ b/ConfigurationSystem/Client/CSAPI.py
@@ -11,6 +11,7 @@ from DIRAC.Core.Security import Locations
 from DIRAC.ConfigurationSystem.private.Modificator import Modificator
 from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC.Core.DISET.RPCClient import RPCClient
 
 __RCSID__ = "$Id$"
 
@@ -768,3 +769,14 @@ class CSAPI(object):
     for line in diffData:
       if line[0] in ('+', '-'):
         gLogger.notice(line)
+
+  def forceGlobalConfigurationUpdate(self):
+    """
+    Force global update of configuration on all the registered services
+
+    :return: S_OK/S_ERROR
+    """
+
+    return self.__rpcClient.forceGlobalConfigurationUpdate()
+
+

--- a/ConfigurationSystem/ConfigTemplate.cfg
+++ b/ConfigurationSystem/ConfigTemplate.cfg
@@ -12,6 +12,7 @@ Services
       rollbackToVersion = CSAdministrator
       getVersionContents = ServiceAdministrator
       getVersionContents += CSAdministrator
+      forceGlobalConfigurationUpdate = CSAdministrator
     }
   }
 }

--- a/ConfigurationSystem/Service/ConfigurationHandler.py
+++ b/ConfigurationSystem/Service/ConfigurationHandler.py
@@ -7,6 +7,7 @@ from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.private.ServiceInterface import ServiceInterface
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.Utilities import DErrno
+from DIRAC.Core.Security.Properties import CS_ADMINISTRATOR
 
 gServiceInterface = None
 gPilotSynchronizer = None
@@ -76,6 +77,7 @@ class ConfigurationHandler(RequestHandler):
     return res
 
   types_forceGlobalConfigurationUpdate = []
+  auth_forceGlobalConfigurationUpdate = [CS_ADMINISTRATOR]
 
   def export_forceGlobalConfigurationUpdate(self):
     """

--- a/ConfigurationSystem/Service/ConfigurationHandler.py
+++ b/ConfigurationSystem/Service/ConfigurationHandler.py
@@ -65,7 +65,7 @@ class ConfigurationHandler(RequestHandler):
       if gPilotSynchronizer is None:
         try:
           # This import is only needed for the Master CS service, making it conditional avoids
-          # dependency on the git client preinstalled on all the servers running CS slaves
+          # dependency on the git client pre-installed on all the servers running CS slaves
           from DIRAC.WorkloadManagementSystem.Utilities.PilotCStoJSONSynchronizer import PilotCStoJSONSynchronizer
         except ImportError as exc:
           self.log.exception("Failed to import PilotCStoJSONSynchronizer", repr(exc))
@@ -74,6 +74,16 @@ class ConfigurationHandler(RequestHandler):
       return gPilotSynchronizer.sync()
 
     return res
+
+  types_forceGlobalConfigurationUpdate = []
+
+  def export_forceGlobalConfigurationUpdate(self):
+    """
+    Attempt to request all the configured services to update their configuration
+
+    :return: S_OK, Value Successful/Failed dict with service URLs
+    """
+    return gServiceInterface.forceGlobalUpdate()
 
   types_writeEnabled = []
 

--- a/ConfigurationSystem/private/ConfigurationData.py
+++ b/ConfigurationSystem/private/ConfigurationData.py
@@ -251,6 +251,13 @@ class ConfigurationData(object):
     else:
       return True
 
+  def getAutoSlaveSync(self):
+    value = self.extractOptionFromCFG("%s/AutoSlaveSync" % self.configurationPath, self.localCFG)
+    if value and value.lower() in ("no", "false", "n"):
+      return False
+    else:
+      return True
+
   def getServers(self):
     return list(self.remoteServerList)
 

--- a/ConfigurationSystem/private/ServiceInterface.py
+++ b/ConfigurationSystem/private/ServiceInterface.py
@@ -186,7 +186,7 @@ class ServiceInterface(threading.Thread):
     """
     gLogger.info("Updating services configuration")
     # Get URLs of all the services except for Configuration services
-    cfg = gConfigurationData.remoteCFG['Systems'].getAsDict()
+    cfg = gConfigurationData.remoteCFG.getAsDict()['Systems']
     urlSet = set()
     for system_ in cfg:
       for instance in cfg[system_]:

--- a/ConfigurationSystem/private/ServiceInterface.py
+++ b/ConfigurationSystem/private/ServiceInterface.py
@@ -21,6 +21,7 @@ from DIRAC.Core.DISET.RPCClient import RPCClient
 from DIRAC.Core.Utilities.ThreadPool import ThreadPool
 from DIRAC.Core.Security.Locations import getHostCertificateAndKeyLocation
 
+
 class ServiceInterface(threading.Thread):
 
   def __init__(self, sURL):
@@ -39,7 +40,7 @@ class ServiceInterface(threading.Thread):
       self.dAliveSlaveServers = {}
       self.__launchCheckSlaves()
 
-    self.__updateResultDict = {"Successful":{}, "Failed": {}}
+    self.__updateResultDict = {"Successful": {}, "Failed": {}}
 
   def isMaster(self):
     return gConfigurationData.isMaster()
@@ -170,7 +171,7 @@ class ServiceInterface(threading.Thread):
     """
     gLogger.info("Updating configuration on slave servers")
     iGraceTime = gConfigurationData.getSlavesGraceTime()
-    self.__updateResultDict = {"Successful":{}, "Failed": {}}
+    self.__updateResultDict = {"Successful": {}, "Failed": {}}
     urlSet = set()
     for slaveURL in self.dAliveSlaveServers:
       if time.time() - self.dAliveSlaveServers[slaveURL] <= iGraceTime:
@@ -190,7 +191,7 @@ class ServiceInterface(threading.Thread):
     for system_ in cfg:
       for instance in cfg[system_]:
         for url in cfg[system_][instance]['URLs']:
-          urlSet = urlSet.union(set([u.strip() for u in cfg[system_][instance]['URLs'][url].split(',') \
+          urlSet = urlSet.union(set([u.strip() for u in cfg[system_][instance]['URLs'][url].split(',')
                                      if 'Configuration/Server' not in u]))
     return self.__updateServiceConfiguration(urlSet)
 

--- a/ConfigurationSystem/private/ServiceInterface.py
+++ b/ConfigurationSystem/private/ServiceInterface.py
@@ -190,7 +190,7 @@ class ServiceInterface(threading.Thread):
     for system_ in cfg:
       for instance in cfg[system_]:
         for url in cfg[system_][instance]['URLs']:
-          urlSet = urlSet.union(set([u for u in cfg[system_][instance]['URLs'][url].split(',') \
+          urlSet = urlSet.union(set([u.strip() for u in cfg[system_][instance]['URLs'][url].split(',') \
                                      if 'Configuration/Server' not in u]))
     return self.__updateServiceConfiguration(urlSet)
 

--- a/ConfigurationSystem/private/ServiceInterface.py
+++ b/ConfigurationSystem/private/ServiceInterface.py
@@ -186,7 +186,7 @@ class ServiceInterface(threading.Thread):
     """
     gLogger.info("Updating services configuration")
     # Get URLs of all the services except for Configuration services
-    cfg = gConfigurationData.remoteCFG['Systems']
+    cfg = gConfigurationData.remoteCFG['Systems'].getAsDict()
     urlSet = set()
     for system_ in cfg:
       for instance in cfg[system_]:

--- a/ConfigurationSystem/private/ServiceInterface.py
+++ b/ConfigurationSystem/private/ServiceInterface.py
@@ -123,19 +123,19 @@ class ServiceInterface(threading.Thread):
     :param bool fromMaster: flag to force updating from the master CS
     :return: S_OK/S_ERROR
     """
+    gLogger.info('Updating service configuration on', url)
     if url.startswith('dip'):
       rpc = RPCClient(url)
-      gLogger.info('Updating service configuration on', url)
       result = rpc.refreshConfiguration(fromMaster)
     elif url.startswith('http'):
       hostCertTuple = getHostCertificateAndKeyLocation()
       resultRequest = requests.get(url,
-                                   headers={'X-RefreshConfiguration:': "True"},
+                                   headers={'X-RefreshConfiguration': "True"},
                                    cert=hostCertTuple,
                                    verify=False)
       result = S_OK()
       if resultRequest.status_code != 200:
-        result = S_ERROR(resultRequest.text)
+        result = S_ERROR("Status code returned %d" % resultRequest.status_code)
     result['URL'] = url
     return result
 
@@ -143,7 +143,7 @@ class ServiceInterface(threading.Thread):
     if result['OK']:
       self.__updateResultDict['Successful'][result['URL']] = True
     else:
-      gLogger.warn("Failed to update configuration on", result['URL'])
+      gLogger.warn("Failed to update configuration on", result['URL'] + ':' + result['Message'])
       self.__updateResultDict['Failed'][result['URL']] = result['Message']
 
   def __updateServiceConfiguration(self, urlSet, fromMaster=False):

--- a/ConfigurationSystem/private/ServiceInterface.py
+++ b/ConfigurationSystem/private/ServiceInterface.py
@@ -202,7 +202,7 @@ class ServiceInterface(threading.Thread):
     :param str sBuffer: newly received configuration data
     :param str committer: the user name of the committer
     :param bool updateVersionOption: flag to update the current configuration version
-    :return:
+    :return: S_OK/S_ERROR of the write-to-disk of the new configuration
     """
     if not gConfigurationData.isMaster():
       return S_ERROR("Configuration modification is not allowed in this server")

--- a/ConfigurationSystem/private/ServiceInterface.py
+++ b/ConfigurationSystem/private/ServiceInterface.py
@@ -9,6 +9,7 @@ import re
 import threading
 import zipfile
 import zlib
+import requests
 
 import DIRAC
 from DIRAC.Core.Utilities.File import mkDir
@@ -17,7 +18,8 @@ from DIRAC.ConfigurationSystem.private.Refresher import gRefresher
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.DISET.RPCClient import RPCClient
-
+from DIRAC.Core.Utilities.ThreadPool import ThreadPool
+from DIRAC.Core.Security.Locations import getHostCertificateAndKeyLocation
 
 class ServiceInterface(threading.Thread):
 
@@ -36,6 +38,8 @@ class ServiceInterface(threading.Thread):
       self.__loadConfigurationData()
       self.dAliveSlaveServers = {}
       self.__launchCheckSlaves()
+
+    self.__updateResultDict = {"Successful":{}, "Failed": {}}
 
   def isMaster(self):
     return gConfigurationData.isMaster()
@@ -109,7 +113,96 @@ class ServiceInterface(threading.Thread):
                                                 ", ".join(self.dAliveSlaveServers.keys())))
       self.__generateNewVersion()
 
-  def updateConfiguration(self, sBuffer, commiter="", updateVersionOption=False):
+  @staticmethod
+  def __forceServiceUpdate(url, fromMaster):
+    """
+    Force updating configuration on a given service
+
+    :param str url: service URL
+    :param bool fromMaster: flag to force updating from the master CS
+    :return: S_OK/S_ERROR
+    """
+    if url.startswith('dip'):
+      rpc = RPCClient(url)
+      gLogger.info('Updating service configuration on', url)
+      result = rpc.refreshConfiguration(fromMaster)
+    elif url.startswith('http'):
+      hostCertTuple = getHostCertificateAndKeyLocation()
+      resultRequest = requests.get(url,
+                                   headers={'X-RefreshConfiguration:': "True"},
+                                   cert=hostCertTuple,
+                                   verify=False)
+      result = S_OK()
+      if resultRequest.status_code != 200:
+        result = S_ERROR(resultRequest.text)
+    result['URL'] = url
+    return result
+
+  def __processResults(self, id_, result):
+    if result['OK']:
+      self.__updateResultDict['Successful'][result['URL']] = True
+    else:
+      gLogger.warn("Failed to update configuration on", result['URL'])
+      self.__updateResultDict['Failed'][result['URL']] = result['Message']
+
+  def __updateServiceConfiguration(self, urlSet, fromMaster=False):
+    """
+    Update configuration in a set of service in parallel
+
+    :param set urlSet: a set of service URLs
+    :param fromMaster: flag to force updating from the master CS
+    :return: S_OK/S_ERROR, Value Successful/Failed dict with service URLs
+    """
+    pool = ThreadPool(len(urlSet))
+    for url in urlSet:
+      pool.generateJobAndQueueIt(self.__forceServiceUpdate,
+                                 args=[url, fromMaster],
+                                 kwargs={},
+                                 oCallback=self.__processResults)
+    pool.processAllResults()
+    return S_OK(self.__updateResultDict)
+
+  def forceSlavesUpdate(self):
+    """
+    Force updating configuration on all the slave configuration servers
+
+    :return: S_OK/S_ERROR, Value Successful/Failed dict with service URLs
+    """
+    gLogger.info("Updating configuration on slave servers")
+    iGraceTime = gConfigurationData.getSlavesGraceTime()
+    self.__updateResultDict = {"Successful":{}, "Failed": {}}
+    urlSet = set()
+    for slaveURL in self.dAliveSlaveServers:
+      if time.time() - self.dAliveSlaveServers[slaveURL] <= iGraceTime:
+        urlSet.add(slaveURL)
+    return self.__updateServiceConfiguration(urlSet, fromMaster=True)
+
+  def forceGlobalUpdate(self):
+    """
+    Force updating configuration of all the registered services
+
+    :return: S_OK/S_ERROR, Value Successful/Failed dict with service URLs
+    """
+    gLogger.info("Updating services configuration")
+    # Get URLs of all the services except for Configuration services
+    cfg = gConfigurationData.remoteCFG['Systems']
+    urlSet = set()
+    for system_ in cfg:
+      for instance in cfg[system_]:
+        for url in cfg[system_][instance]['URLs']:
+          urlSet = urlSet.union(set([u for u in cfg[system_][instance]['URLs'][url].split(',') \
+                                     if 'Configuration/Server' not in u]))
+    return self.__updateServiceConfiguration(urlSet)
+
+  def updateConfiguration(self, sBuffer, committer="", updateVersionOption=False):
+    """
+    Update the master configuration with the newly received changes
+
+    :param str sBuffer: newly received configuration data
+    :param str committer: the user name of the committer
+    :param bool updateVersionOption: flag to update the current configuration version
+    :return:
+    """
     if not gConfigurationData.isMaster():
       return S_ERROR("Configuration modification is not allowed in this server")
     # Load the data in a ConfigurationData object
@@ -149,9 +242,16 @@ class ServiceInterface(threading.Thread):
     gLogger.info("Generating new version")
     gConfigurationData.generateNewVersion()
     # self.__checkSlavesStatus( forceWriteConfiguration = True )
-    gLogger.info("Writing new version to disk!")
-    retVal = gConfigurationData.writeRemoteConfigurationToDisk("%s@%s" % (commiter, gConfigurationData.getVersion()))
-    gLogger.info("New version it is!")
+    gLogger.info("Writing new version to disk")
+    retVal = gConfigurationData.writeRemoteConfigurationToDisk("%s@%s" % (committer, gConfigurationData.getVersion()))
+    gLogger.info("New version", gConfigurationData.getVersion())
+
+    # Attempt to update the configuration on currently registered slave services
+    if gConfigurationData.getAutoSlaveSync():
+      result = self.forceSlavesUpdate()
+      if not result['OK']:
+        gLogger.warn('Failed to update slave servers')
+
     return retVal
 
   def getCompressedConfigurationData(self):
@@ -198,7 +298,7 @@ class ServiceInterface(threading.Thread):
   def __getPreviousCFG(self, oRemoteConfData):
     backupsList = self.__getCfgBackups(gConfigurationData.getBackupDir(), date=oRemoteConfData.getVersion())
     if not backupsList:
-      return S_ERROR("Could not AutoMerge. Could not retrieve original commiter's version")
+      return S_ERROR("Could not AutoMerge. Could not retrieve original committer's version")
     prevRemoteConfData = ConfigurationData()
     backFile = backupsList[0]
     if backFile[0] == "/":
@@ -206,7 +306,7 @@ class ServiceInterface(threading.Thread):
     try:
       prevRemoteConfData.loadConfigurationData(backFile)
     except Exception as e:
-      return S_ERROR("Could not load original commiter's version: %s" % str(e))
+      return S_ERROR("Could not load original committer's version: %s" % str(e))
     gLogger.info("Loaded client original version %s" % prevRemoteConfData.getVersion())
     return S_OK(prevRemoteConfData.getRemoteCFG())
 

--- a/Core/DISET/RequestHandler.py
+++ b/Core/DISET/RequestHandler.py
@@ -496,9 +496,24 @@ class RequestHandler(object):
   @staticmethod
   def export_echo(data):
     """
-    This method used for testing the performance of a service
+    This method is used for testing performance of the service
+
+    :param str data: data to be sent back to the caller
+
+    :return: S_OK, Value is the input data
     """
     return S_OK(data)
+
+  types_refreshConfiguration = [bool]
+
+  @staticmethod
+  def export_refreshConfiguration(fromMaster):
+    """
+    Force refreshing the configuration data
+
+    :param bool fromMaster: flag to refresh from the master configuration service
+    """
+    return gConfig.forceRefresh(fromMaster=fromMaster)
 
 ####
 #
@@ -556,6 +571,9 @@ class RequestHandler(object):
     if 'actionTuple' not in self.serviceInfoDict:
       return ('Unknown yet', )
     return self.serviceInfoDict['actionTuple']
+
+  def srv_getClientVersion(self):
+    return self.serviceInfoDict.get("clientVersion")
 
   @classmethod
   def srv_getURL(cls):

--- a/Core/DISET/RequestHandler.py
+++ b/Core/DISET/RequestHandler.py
@@ -14,6 +14,7 @@ from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR, isReturnStructure
 from DIRAC.Core.Utilities import Time
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
+from DIRAC.Core.Security.Properties import CS_ADMINISTRATOR
 
 
 def getServiceOption(serviceInfo, optionName, defaultValue):
@@ -505,6 +506,7 @@ class RequestHandler(object):
     return S_OK(data)
 
   types_refreshConfiguration = [bool]
+  auth_refreshConfiguration = [CS_ADMINISTRATOR]
 
   @staticmethod
   def export_refreshConfiguration(fromMaster):

--- a/Core/DISET/RequestHandler.py
+++ b/Core/DISET/RequestHandler.py
@@ -572,9 +572,6 @@ class RequestHandler(object):
       return ('Unknown yet', )
     return self.serviceInfoDict['actionTuple']
 
-  def srv_getClientVersion(self):
-    return self.serviceInfoDict.get("clientVersion")
-
   @classmethod
   def srv_getURL(cls):
     return cls.__srvInfoDict['URL']


### PR DESCRIPTION
This PR makes possible to synchronize configuration slave services with the master as part of the CS changes commit operation. It provides also an interface to force all the services to update their configuration. This makes configuration changes immediately available in all the services. This is needed, for example, for newly registered users to be able to use the services right after the registration.

BEGINRELEASENOTES

*Configuration
NEW: Slave configuration servers are automatically updated as part of the new configuration changes commit
NEW: Configuration Server - added forceGlobalConfigurationUpdate() interface to force all registered service to update their configuration

ENDRELEASENOTES
