### PR TITLE
[v6r22] URGENT SEManager: fix order of calls

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/SEManager.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SEManager.py
@@ -27,11 +27,11 @@ class SEManagerBase:
       self.db.seids = {}
       self.db.seDefinitions = {}
     self.lock = threading.Lock()
-    self._refreshSEs()
     self.seUpdatePeriod = 600
 
     # last time the cache was updated (epoch)
     self.lastUpdate = 0
+    self._refreshSEs()
 
   def setUpdatePeriod(self, period):
     self.seUpdatePeriod = period


### PR DESCRIPTION
Sorry apparently I fucked up the PR yesterday. @atsareg all the releases made yesterday are buggy, sorry about that 


BEGINRELEASENOTES

*DMS
FIX: SEManager correct order of calls at init

ENDRELEASENOTES
