### PR TITLE
[v6r22] SandboxStore: use host credentials to query the DB for async removal

### DIFF
--- a/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -12,7 +12,7 @@ import tempfile
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
-from DIRAC.Core.Security import Properties
+from DIRAC.Core.Security import Locations, Properties, X509Certificate
 from DIRAC.WorkloadManagementSystem.DB.SandboxMetadataDB import SandboxMetadataDB
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.DataManagementSystem.Service.StorageElementHandler import getDiskSpace
@@ -54,6 +54,14 @@ class SandboxStoreHandler(RequestHandler):
       SandboxStoreHandler.__purgeCount = 0
     if SandboxStoreHandler.__purgeCount == 0:
       threading.Thread(target=self.purgeUnusedSandboxes).start()
+
+    # We need the hostDN used in order to pass these credentials to the
+    # SandboxStoreDB..
+    hostCertLocation, _ = Locations.getHostCertificateAndKeyLocation()
+    hostCert = X509Certificate.X509Certificate()
+    hostCert.loadFromFile(hostCertLocation)
+    self.hostDN = hostCert.getSubjectDN().get('Value')
+
 
   def __getSandboxPath(self, md5):
     """ Generate the sandbox path
@@ -479,8 +487,8 @@ class SandboxStoreHandler(RequestHandler):
     if self.getCSOption("DelayedExternalDeletion", True):
       gLogger.info("Setting deletion request")
       try:
-        credDict = self.getRemoteCredentials()
-        result = sandboxDB.getSandboxOwner(SEName, SEPFN, credDict['username'], credDict['group'])
+        # use the host authentication to fetch the data
+        result = sandboxDB.getSandboxOwner(SEName, SEPFN, self.hostDN, 'hosts')
         if not result['OK']:
           return result
         _owner, ownerDN, ownerGroup = result['Value']


### PR DESCRIPTION
Fixes bug introduced in https://github.com/DIRACGrid/DIRAC/pull/4217
```
2019-08-22 08:09:50 UTC WorkloadManagement/SandboxStore ERROR: Exception while setting deletion request Traceback (most recent call last): 
File "/opt/dirac/pro/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py", line 482, in __deleteSandboxFromExternalBackend credDict = self.getRemoteCredentials() 
File "/opt/dirac/pro/DIRAC/Core/DISET/RequestHandler.py", line 97, in getRemoteCredentials return self.__trPool.get(self.__trid).getConnectingCredentials()
AttributeError: 'NoneType' object has no attribute 'getConnectingCredentials' 

2019-08-22 08:09:50 UTC WorkloadManagement/SandboxStore ERROR: Cannot delete sandbox from backend Cannot set deletion request: 'NoneType' object has no attribute 'getConnectingCredentials'
```

Hot fixed in lhcb prod


BEGINRELEASENOTES

*WMS
FIX: use host credentials to query the SandboxMetadataDB for async removal

ENDRELEASENOTES
