### PR TITLE
[v6r22] Add preamble attribute in SSHBatchComputingElement

### DIFF
--- a/Resources/Computing/SSHBatchComputingElement.py
+++ b/Resources/Computing/SSHBatchComputingElement.py
@@ -78,6 +78,7 @@ class SSHBatchComputingElement(SSHComputingElement):
     if 'RemoveOutput' in self.ceParameters:
       if self.ceParameters['RemoveOutput'].lower() in ['no', 'false', '0']:
         self.removeOutput = False
+    self.preamble = self.ceParameters.get('Preamble', '')
 
   #############################################################################
   def submitJob(self, executableFile, proxy, numberOfJobs=1):


### PR DESCRIPTION

BEGINRELEASENOTES
*Resources
FIX: preamble attribute was missing in SSHBatchComputingElement causing an error in _submitJobHost() 

ENDRELEASENOTES
