### PR TITLE
[v6r22] Accept both unicode and str filenames to workflow XML

### DIFF
--- a/Core/Workflow/Workflow.py
+++ b/Core/Workflow/Workflow.py
@@ -4,6 +4,7 @@
 
 import os, re, types
 import xml.sax
+import six
 from DIRAC.Core.Workflow.Parameter import *
 from DIRAC.Core.Workflow.Module import *
 from DIRAC.Core.Workflow.Step import *
@@ -34,7 +35,7 @@ class Workflow( AttributeCollection ):
 
     elif isinstance( obj, Workflow ):
       self.fromWorkflow( obj )
-    elif isinstance( obj, str ):
+    elif isinstance( obj, six.string_types ):
       self.parameters = ParameterCollection( None )
       self.step_instances = InstancesPool( self )
       self.step_definitions = DefinitionsPool( self )


### PR DESCRIPTION
Something I've been working on results in obj being a `unicode` filename rather than `str` (still only using ASCII characters). Patching it to accept any string type works as expected.

BEGINRELEASENOTES
*Core
FIX: Accept unicode file path to workflow XML
ENDRELEASENOTES
