### PR TITLE
[v6r22] StalledJobAgent: correct treatment of empty result of getJobParameter

### DIFF
--- a/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -350,7 +350,11 @@ used to fail jobs due to the optimizer chain.
 
       result = JobMonitoringClient().getJobParameter(jobID, 'CPUNormalizationFactor')
       if not result['OK'] or not result['Value']:
-        self.log.error('Error getting Job Parameter CPUNormalizationFactor, setting 0', result['Message'])
+        self.log.error(
+            'Error getting Job Parameter CPUNormalizationFactor, setting 0',
+            result.get(
+                'Message',
+                'No such value'))
         cpuNormalization = 0.0
       else:
         cpuNormalization = float(result['Value'].get('CPUNormalizationFactor'))


### PR DESCRIPTION
fixes https://github.com/DIRACGrid/DIRAC/issues/4254
BEGINRELEASENOTES

*WMS
FIX: handle empty results of getJobParameter in StalledJobAgent

ENDRELEASENOTES
