### PR TITLE
[v6r22] Ensure lcgBundle is installed in singularity container

### DIFF
--- a/Resources/Computing/SingularityComputingElement.py
+++ b/Resources/Computing/SingularityComputingElement.py
@@ -120,6 +120,9 @@ class SingularityComputingElement(ComputingElement):
       extensionsList = CSGlobals.getCSExtensions()
     if extensionsList:
       instOpts.append("-e '%s'" % ','.join([ext for ext in extensionsList if 'Web' not in ext]))
+    lcgVer = opsHelper.getValue("Pilot/LCGBundleVersion", None)
+    if lcgVer:
+      instOpts.append("-g %s" % lcgVer)
     if 'ContainerExtraOpts' in self.ceParameters:
       instOpts.append(self.ceParameters['ContainerExtraOpts'])
     return ' '.join(instOpts)


### PR DESCRIPTION
This adds the lcgBundle version to the dirac-install flags within the SingularityCE container to make the behaviour like the normal grid pilot.

BEGINRELEASENOTES
*Resources
FIX: Ensure lcgBundle is installed in container if LCGBundleVersion is set.
ENDRELEASENOTES
