### PR TITLE
[v7r0] Fix urlopen call in PilotWrapper script

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -164,9 +164,10 @@ for loc in location:
       from urllib.request import urlopen as url_library_urlopen
       from urllib.error import URLError as url_library_URLError
 
-
-    # needs to distinguish versions prior to or after 2.7.9
-    if sys.version_info >= (2, 7, 9):
+    # needs to distinguish wether urlopen method contains the 'context' param
+    # in theory, it should be available from python 2.7.9
+    # in practice, some prior versions may be composed of recent urllib version containing the param
+    if 'context' in url_library_urlopen.__code__.co_varnames:
       import ssl
       context = ssl._create_unverified_context()
       rJson = url_library_urlopen('https://' + loc + '/pilot/pilot.json',


### PR DESCRIPTION
During the previous hackaton we had some issues with the ARC CEs unable to execute the pilot wrapper script and returning: 

```
<dirac server host>:<port>: unreacheable
None of the locations of the pilot files is reachable
```
This was due to the following exception:

```
  File "<stdin>", line 94, in <module>
  File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
  File "/usr/lib64/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 1258, in https_open
    context=self._context, check_hostname=self._check_hostname)
  File "/usr/lib64/python2.7/urllib2.py", line 1214, in do_open
    raise URLError(err)
URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:618)>
```
The reason of this exception is the non-used of the `context` parameter in the `urllib2.urlopen()` method while it is needed.

Indeed, this parameter was added to the method from Python 2.7.9 so the test done should have passed here: 
https://github.com/DIRACGrid/DIRAC/blob/integration/WorkloadManagementSystem/Utilities/PilotWrapper.py#L169

I figured out that the not working CEs were running Python 2.7.5, a prior version of Python, using a more recent `urllib2` version (the Python 2.7.9's one).
This was the case for both of the tested ARC CEs containing the issue.

This fix modifies the previous condition to run the right line according to the version of `urllib` instead of the Python's one. Unfortunately, both versions of `urllib2` in Python 2.7.5 and 2.7.9 are labeled `2.7`, that is why I check the presence of the `context` parameter.


BEGINRELEASENOTES

*WorkloadManagement
FIX: urllib.urlopen() call with and without the 'context' parameter in Utilities/PilotWrapper.py according to the version of urllib instead of the python version 

ENDRELEASENOTES
