### PR TITLE
[v7r1] "Safe" Python 3 compatibility fixes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -145,7 +145,7 @@ ignored-classes=SQLObject
 generated-members=REQUEST,acl_users,aq_parent
 
 # List of ignored modules
-ignored-modules = MySQLdb,numpy
+ignored-modules = MySQLdb,numpy,six.moves.urllib
 
 [VARIABLES]
 

--- a/AccountingSystem/Agent/NetworkAgent.py
+++ b/AccountingSystem/Agent/NetworkAgent.py
@@ -171,7 +171,7 @@ class NetworkAgent ( AgentModule ):
 
         # use existing or create a new temporary accounting
         # object to store the data in DB
-        if self.buffer.has_key( networkAccountingObjectKey ):
+        if networkAccountingObjectKey in self.buffer:
           net = self.buffer[networkAccountingObjectKey]['object']
           
           timeDifference = datetime.now() - self.buffer[networkAccountingObjectKey]['addTime']

--- a/AccountingSystem/Client/Types/BaseAccountingType.py
+++ b/AccountingSystem/Client/Types/BaseAccountingType.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities import Time
 from DIRAC.Core.DISET.RPCClient import RPCClient

--- a/AccountingSystem/Client/Types/BaseAccountingType.py
+++ b/AccountingSystem/Client/Types/BaseAccountingType.py
@@ -118,7 +118,7 @@ class BaseAccountingType(object):
       key = self.fieldsList[i]
       if self.valuesList[i] is None:
         errorList.append("no value for %s" % key)
-      if key in self.valueFieldsList and not isinstance(self.valuesList[i], (int, long, float)):
+      if key in self.valueFieldsList and not isinstance(self.valuesList[i], six.integer_types + (float,)):
         errorList.append("value for key %s is not numerical type" % key)
     if errorList:
       return S_ERROR("Invalid values: %s" % ", ".join(errorList))

--- a/AccountingSystem/DB/AccountingDB.py
+++ b/AccountingSystem/DB/AccountingDB.py
@@ -500,7 +500,7 @@ class AccountingDB(DB):
       Adds a key value to a key table if not existant
     """
     # Cast to string just in case
-    if not isinstance(keyValue, basestring):
+    if not isinstance(keyValue, six.string_types):
       keyValue = str(keyValue)
     # No more than 64 chars for keys
     if len(keyValue) > 64:

--- a/AccountingSystem/DB/AccountingDB.py
+++ b/AccountingSystem/DB/AccountingDB.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import datetime
 import time
 import threading

--- a/AccountingSystem/Service/ReportGeneratorHandler.py
+++ b/AccountingSystem/Service/ReportGeneratorHandler.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import types
 import os
 import datetime

--- a/AccountingSystem/private/Policies/FilterExecutor.py
+++ b/AccountingSystem/private/Policies/FilterExecutor.py
@@ -1,6 +1,5 @@
-
-import types
 from DIRAC import S_OK, S_ERROR, gLogger
+
 
 class FilterExecutor:
 
@@ -29,13 +28,13 @@ class FilterExecutor:
   def addFilter( self, iD, myFilter ):
     if iD not in self.__filters:
       self.__filters[ iD ] = []
-    if type( myFilter ) in ( types.ListType, types.TupleType ):
+    if isinstance(myFilter, (list, tuple)):
       self.__filters[ iD ].extend( myFilter )
     else:
       self.__filters[ iD ].append( myFilter )
 
   def addGlobalFilter( self, myFilter ):
-    if type( myFilter ) in ( types.ListType, types.TupleType ):
+    if isinstance(myFilter, (list, tuple)):
       self.__globalFilters.extend( myFilter )
     else:
       self.__globalFilters.append( myFilter )

--- a/ConfigurationSystem/Client/CSAPI.py
+++ b/ConfigurationSystem/Client/CSAPI.py
@@ -3,6 +3,7 @@
     Most of these functions can only be done by administrators
 """
 
+import six
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR
 from DIRAC.Core.DISET.RPCClient import RPCClient
 from DIRAC.Core.Utilities import List, Time

--- a/ConfigurationSystem/Client/CSAPI.py
+++ b/ConfigurationSystem/Client/CSAPI.py
@@ -196,7 +196,7 @@ class CSAPI(object):
     """
     if not self.__initialized['OK']:
       return self.__initialized
-    if isinstance(users, basestring):
+    if isinstance(users, six.string_types):
       users = [users]
     usersData = self.describeUsers(users)['Value']
     for username in users:

--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -195,7 +195,7 @@ class Operations(object):
     if not section:
       return S_ERROR("%s in Operations does not exist" % sectionPath)
     sectionCFG = section['value']
-    if isinstance(sectionCFG, basestring):
+    if isinstance(sectionCFG, six.string_types):
       return S_ERROR("%s in Operations is not a section" % sectionPath)
     return S_OK(sectionCFG)
 

--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -70,6 +70,7 @@
 
 """
 
+import six
 import thread
 import os
 from DIRAC import S_OK, S_ERROR, gConfig

--- a/ConfigurationSystem/Client/Helpers/Path.py
+++ b/ConfigurationSystem/Client/Helpers/Path.py
@@ -10,6 +10,7 @@ __RCSID__ = "$Id$"
 cfgInstallSection = 'LocalInstallation'
 cfgResourceSection = 'Resources'
 import os
+import six
 
 
 def cfgPath(*args):
@@ -31,9 +32,8 @@ def cfgPathToList(arg):
   """
   Basic method to split a cfgPath in to a list of strings
   """
-  from types import StringTypes
   listPath = []
-  if type(arg) not in StringTypes:
+  if not isinstance(arg, six.string_types):
     return listPath
   while arg.find('/') == 0:
     arg = arg[1:]

--- a/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/ConfigurationSystem/Client/Helpers/Registry.py
@@ -1,5 +1,6 @@
 """ Helper for /Registry section
 """
+import six
 import errno
 
 from DIRAC import S_OK, S_ERROR

--- a/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/ConfigurationSystem/Client/Helpers/Registry.py
@@ -205,13 +205,13 @@ def __matchProps(sProps, rProps):
 
 
 def groupHasProperties(groupName, propList):
-  if isinstance(propList, basestring):
+  if isinstance(propList, six.string_types):
     propList = [propList]
   return __matchProps(propList, getPropertiesForGroup(groupName))
 
 
 def hostHasProperties(hostName, propList):
-  if isinstance(propList, basestring):
+  if isinstance(propList, six.string_types):
     propList = [propList]
   return __matchProps(propList, getPropertiesForHost(hostName))
 

--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import re
 import urlparse
 

--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -241,7 +241,7 @@ def getStorageElements(vo=None):
 def getCompatiblePlatforms(originalPlatforms):
   """ Get a list of platforms compatible with the given list
   """
-  if isinstance(originalPlatforms, basestring):
+  if isinstance(originalPlatforms, six.string_types):
     platforms = [originalPlatforms]
   else:
     platforms = list(originalPlatforms)
@@ -282,7 +282,7 @@ def getDIRACPlatform(OSList):
 
   # For backward compatibility allow a single string argument
   osList = OSList
-  if isinstance(OSList, basestring):
+  if isinstance(OSList, six.string_types):
     osList = [OSList]
 
   result = gConfig.getOptionsDict('/Resources/Computing/OSCompatibility')

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -295,7 +295,7 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None):
                 newMaxCPUTime = str(int(0.8 * int(wallTime)))
           newSI00 = ''
           caps = queueInfo.get('GlueCECapability', [])
-          if isinstance(caps, basestring):
+          if isinstance(caps, six.string_types):
             caps = [caps]
           for cap in caps:
             if 'CPUScalingReferenceSI00' in cap:

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -13,6 +13,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import re
 import socket
 from urlparse import urlparse

--- a/Core/Base/API.py
+++ b/Core/Base/API.py
@@ -1,6 +1,7 @@
 """ DIRAC API Base Class """
 
 from __future__ import print_function
+import six
 import pprint
 import sys
 

--- a/Core/Base/API.py
+++ b/Core/Base/API.py
@@ -90,7 +90,7 @@ class API(object):
     self.__dict__.update(state)
     # Build the Logging instance again because it can not be in the dictionary
     # due to the thread locks
-    if isinstance(state['log'], basestring):
+    if isinstance(state['log'], six.string_types):
       self.log = gLogger.getSubLogger(state['log'])
 
   #############################################################################

--- a/Core/Base/CLI.py
+++ b/Core/Base/CLI.py
@@ -10,6 +10,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+import six
 import cmd
 import sys
 import os

--- a/Core/Base/CLI.py
+++ b/Core/Base/CLI.py
@@ -29,7 +29,7 @@ def colorize( text, color ):
 
   startCode = '\033[;3'
   endCode = '\033[0m'
-  if isinstance( color, ( int, long ) ):
+  if isinstance( color, six.integer_types ):
     return "%s%sm%s%s" % ( startCode, color, text, endCode )
   try:
     return "%s%sm%s%s" % ( startCode, gColors[ color ], text, endCode )

--- a/Core/Base/private/ModuleLoader.py
+++ b/Core/Base/private/ModuleLoader.py
@@ -1,6 +1,7 @@
 """ Module invoked for finding and loading DIRAC (and extensions) modules
 """
 
+import six
 import os
 import imp
 from DIRAC.Core.Utilities import List

--- a/Core/Base/private/ModuleLoader.py
+++ b/Core/Base/private/ModuleLoader.py
@@ -200,7 +200,7 @@ class ModuleLoader( object ):
     return S_OK()
 
   def __recurseImport( self, modName, parentModule = None, hideExceptions = False ):
-    if isinstance( modName, basestring):
+    if isinstance(modName, six.string_types):
       modName = List.fromChar( modName, "." )
     try:
       if parentModule:

--- a/Core/DISET/AuthManager.py
+++ b/Core/DISET/AuthManager.py
@@ -79,7 +79,7 @@ class AuthManager(object):
     # Check for invalid forwarding
     if self.KW_EXTRA_CREDENTIALS in credDict:
       # Invalid forwarding?
-      if not isinstance(credDict[self.KW_EXTRA_CREDENTIALS], basestring):
+      if not isinstance(credDict[self.KW_EXTRA_CREDENTIALS], six.string_types):
         self.__authLogger.debug("The credentials seem to be forwarded by a host, but it is not a trusted one")
         return False
     # Is it a host?

--- a/Core/DISET/AuthManager.py
+++ b/Core/DISET/AuthManager.py
@@ -1,6 +1,7 @@
 """ Module that holds DISET Authorization class for services
 """
 
+import six
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.FrameworkSystem.Client.Logger import gLogger

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -4,6 +4,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import time
 import thread
 import DIRAC

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -60,7 +60,7 @@ class BaseClient(object):
       :param keepAliveLapse: Duration for keepAliveLapse (heartbeat like)
     """
 
-    if not isinstance(serviceName, basestring):
+    if not isinstance(serviceName, six.string_types):
       raise TypeError("Service name expected to be a string. Received %s type %s" %
                       (str(serviceName), type(serviceName)))
     self._destinationSrv = serviceName

--- a/Core/DISET/private/FileHelper.py
+++ b/Core/DISET/private/FileHelper.py
@@ -1,5 +1,6 @@
 __RCSID__ = "$Id$"
 
+import six
 import os
 import hashlib
 import threading

--- a/Core/DISET/private/FileHelper.py
+++ b/Core/DISET/private/FileHelper.py
@@ -262,7 +262,7 @@ class FileHelper(object):
 
   def getFileDescriptor( self, uFile, sFileMode ):
     closeAfter = True
-    if isinstance( uFile, basestring ):
+    if isinstance(uFile, six.string_types):
       try:
         self.oFile = open(uFile, sFileMode)
       except IOError:
@@ -281,7 +281,7 @@ class FileHelper(object):
 
   def getDataSink( self, uFile ):
     closeAfter = True
-    if isinstance( uFile, basestring ):
+    if isinstance(uFile, six.string_types):
       try:
         oFile = open(uFile, "wb")
       except IOError:

--- a/Core/DISET/private/SSLSocketFactory.py
+++ b/Core/DISET/private/SSLSocketFactory.py
@@ -6,7 +6,6 @@ It will be removed in v7r1
 # $HeadURL$
 __RCSID__ = "$Id$"
 
-import types
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.Core.DISET.private.Transports.SSL.FakeSocket import FakeSocket
 from DIRAC.Core.DISET.private.Transports.SSL.pygsi.SocketInfoFactory import gSocketInfoFactory
@@ -32,7 +31,7 @@ class SSLSocketFactory:
         kwargs[ arg ] = value
 
   def createClientSocket( self, addressTuple , **kwargs ):
-    if type( addressTuple ) not in ( types.ListType, types.TupleType ):
+    if not isinstance(addressTuple, (list, tuple)):
       return S_ERROR( "hostAdress is not in a tuple form ( 'hostnameorip', port )" )
     res = gConfig.getOptionsDict( "/DIRAC/ConnConf/%s:%s" % addressTuple[0:2] )
     if res[ 'OK' ]:

--- a/Core/DISET/private/Transports/SSLTransport.py
+++ b/Core/DISET/private/Transports/SSLTransport.py
@@ -53,7 +53,7 @@ def checkSanity(urlTuple, kwargs):
     certFile = certTuple[0]
     useCerts = True
   elif "proxyString" in kwargs:
-    if not isinstance(kwargs['proxyString'], basestring):
+    if not isinstance(kwargs['proxyString'], six.string_types):
       gLogger.error("proxyString parameter is not a valid type", str(type(kwargs['proxyString'])))
       return S_ERROR("proxyString parameter is not a valid type")
   else:

--- a/Core/DISET/private/Transports/SSLTransport.py
+++ b/Core/DISET/private/Transports/SSLTransport.py
@@ -1,5 +1,6 @@
 __RCSID__ = "$Id$"
 
+import six
 import os
 
 from DIRAC import gLogger

--- a/Core/LCG/GOCDBClient.py
+++ b/Core/LCG/GOCDBClient.py
@@ -6,6 +6,7 @@
 __RCSID__ = "$Id$"
 
 
+import six
 import time
 import socket
 

--- a/Core/LCG/GOCDBClient.py
+++ b/Core/LCG/GOCDBClient.py
@@ -116,7 +116,7 @@ class GOCDBClient(object):
       startDateMax = startDate + timedelta(hours=startingInHours)
 
     if startDate is not None:
-      if isinstance(startDate, basestring):
+      if isinstance(startDate, six.string_types):
         startDate_STR = startDate
         startDate = datetime(*time.strptime(startDate, "%Y-%m-%d")[0:3])
       elif isinstance(startDate, datetime):
@@ -180,7 +180,7 @@ class GOCDBClient(object):
 
       :attr:`entity` : a string. Actual name of the entity.
     """
-    assert isinstance(granularity, basestring) and isinstance(entity, basestring)
+    assert isinstance(granularity, basestring) and isinstance(entity, six.string_types)
     try:
       serviceXML = self._getServiceEndpointCurlDownload(granularity, entity)
       return S_OK(self._serviceEndpointXMLParsing(serviceXML))
@@ -277,7 +277,7 @@ class GOCDBClient(object):
     # GOCDB-PI to query
     gocdb_ep = gocdbpi_url
     if entity is not None:
-      if isinstance(entity, basestring):
+      if isinstance(entity, six.string_types):
         gocdb_ep = gocdb_ep + "&topentity=" + entity
     gocdb_ep = gocdb_ep + when + gocdbpi_startDate + "&scope="
 
@@ -300,7 +300,7 @@ class GOCDBClient(object):
 
       :attr:`entity` : a string. Actual name of the entity.
     """
-    if not isinstance(granularity, basestring) or not isinstance(entity, basestring):
+    if not isinstance(granularity, basestring) or not isinstance(entity, six.string_types):
       raise ValueError("Arguments must be strings.")
 
     # GOCDB-PI query

--- a/Core/Security/BaseSecurity.py
+++ b/Core/Security/BaseSecurity.py
@@ -66,7 +66,7 @@ class BaseSecurity(object):
     return dict(os.environ)
 
   def _unlinkFiles(self, files):
-    if type(files) in (types.ListType, types.TupleType):
+    if isinstance(files, (list, tuple)):
       for fileName in files:
         self._unlinkFiles(fileName)
     else:

--- a/Core/Security/ProxyFile.py
+++ b/Core/Security/ProxyFile.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import stat
 import tempfile

--- a/Core/Security/ProxyFile.py
+++ b/Core/Security/ProxyFile.py
@@ -119,7 +119,7 @@ def multiProxyArgument(proxy=False):
       proxyLoc = getProxyLocation()
       if not proxyLoc:
         return S_ERROR(DErrno.EPROXYFIND)
-    if isinstance(proxy, basestring):
+    if isinstance(proxy, six.string_types):
       proxyLoc = proxy
     # Load proxy
     proxy = X509Chain()

--- a/Core/Security/ProxyInfo.py
+++ b/Core/Security/ProxyInfo.py
@@ -45,7 +45,7 @@ def getProxyInfo(proxy=False, disableVOMS=False):
   else:
     if not proxy:
       proxyLocation = Locations.getProxyLocation()
-    elif isinstance(proxy, basestring):
+    elif isinstance(proxy, six.string_types):
       proxyLocation = proxy
     if not proxyLocation:
       return S_ERROR(DErrno.EPROXYFIND)
@@ -94,7 +94,7 @@ def formatProxyInfoAsString(infoDict):
   for field in ('subject', 'issuer', 'identity', 'subproxyUser', ('secondsLeft', 'timeleft'),
                 ('group', 'DIRAC group'), 'rfc', 'path', 'username', ('groupProperties', "properties"),
                 ('hasVOMS', 'VOMS'), ('VOMS', 'VOMS fqan'), ('VOMSError', 'VOMS Error')):
-    if isinstance(field, basestring):
+    if isinstance(field, six.string_types):
       dispField = field
     else:
       dispField = field[1]

--- a/Core/Security/ProxyInfo.py
+++ b/Core/Security/ProxyInfo.py
@@ -1,6 +1,7 @@
 """
  Set of utilities to retrieve Information from proxy
 """
+from __future__ import division
 
 import base64
 

--- a/Core/Security/ProxyInfo.py
+++ b/Core/Security/ProxyInfo.py
@@ -3,6 +3,7 @@
 """
 from __future__ import division
 
+import six
 import base64
 
 from DIRAC import S_OK, S_ERROR

--- a/Core/Security/m2crypto/X509Chain.py
+++ b/Core/Security/m2crypto/X509Chain.py
@@ -356,7 +356,7 @@ class X509Chain(object):
     extStack.push(ext)
 
     # Add a dirac group
-    if diracGroup and isinstance(diracGroup, basestring):
+    if diracGroup and isinstance(diracGroup, six.string_types):
       # the str cast is needed because M2Crypto does not play it cool with unicode here it seems
       # Also one needs to specify the ASN1 type. That's what it is...
       dGext = M2Crypto.X509.new_extension(DIRAC_GROUP_OID, str('ASN1:IA5:%s' % diracGroup))

--- a/Core/Security/m2crypto/X509Chain.py
+++ b/Core/Security/m2crypto/X509Chain.py
@@ -9,6 +9,7 @@ here: https://wiki.egi.eu/wiki/Usage_of_the_per_user_sub_proxy_in_EGI
 """
 __RCSID__ = "$Id$"
 
+import six
 import copy
 import os
 import stat

--- a/Core/Utilities/Adler.py
+++ b/Core/Utilities/Adler.py
@@ -36,7 +36,7 @@ def hexAdlerToInt(hexAdler, pos=True):
   :param mixed hexAdler: hex based adler32 checksum integer or a string
   :param boolean pos: flag to determine sign (default True = positive)
   """
-  if isinstance(hexAdler, (int, long)):
+  if isinstance(hexAdler, six.integer_types):
     return hexAdler & 0xffffffff
   # First make sure we can parse the hex properly
   if hexAdler == 'False' or hexAdler == '-False':

--- a/Core/Utilities/Adler.py
+++ b/Core/Utilities/Adler.py
@@ -13,6 +13,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+import six
 from zlib import adler32
 
 

--- a/Core/Utilities/CFG.py
+++ b/Core/Utilities/CFG.py
@@ -27,8 +27,8 @@ except Exception:
 
   class ListDummy:
     def fromChar(self, inputString, sepChar=","):
-      if not (isinstance(inputString, basestring) and
-              isinstance(sepChar, basestring) and
+      if not (isinstance(inputString, six.string_types) and
+              isinstance(sepChar, six.string_types) and
               sepChar):  # to prevent getting an empty String as argument
         return None
 
@@ -106,7 +106,7 @@ class CFG(object):
       if not recDict:
         return S_ERROR("Parent section does not exist %s" % sectionName)
       parentSection = recDict['value']
-      if isinstance(parentSection, basestring):
+      if isinstance(parentSection, six.string_types):
         raise KeyError("Entry %s doesn't seem to be a section" % recDict['key'])
       return parentSection.createNewSection(recDict['levelsBelow'], comment, contents)
     self.__addEntry(sectionName, comment)
@@ -151,7 +151,7 @@ class CFG(object):
       if not recDict:
         return S_ERROR("Parent section does not exist %s" % optionName)
       parentSection = recDict['value']
-      if isinstance(parentSection, basestring):
+      if isinstance(parentSection, six.string_types):
         raise KeyError("Entry %s doesn't seem to be a section" % recDict['key'])
       return parentSection.setOption(recDict['levelsBelow'], value, comment)
     self.__addEntry(optionName, comment)
@@ -265,9 +265,9 @@ class CFG(object):
     :return: List with the option names
     """
     if ordered:
-      return [sKey for sKey in self.__orderedList if isinstance(self.__dataDict[sKey], basestring)]
+      return [sKey for sKey in self.__orderedList if isinstance(self.__dataDict[sKey], six.string_types)]
     else:
-      return [sKey for sKey in self.__dataDict.keys() if isinstance(self.__dataDict[sKey], basestring)]
+      return [sKey for sKey in self.__dataDict.keys() if isinstance(self.__dataDict[sKey], six.string_types)]
 
   @gCFGSynchro
   def listSections(self, ordered=True):
@@ -279,9 +279,9 @@ class CFG(object):
     :return: List with the subsection names
     """
     if ordered:
-      return [sKey for sKey in self.__orderedList if not isinstance(self.__dataDict[sKey], basestring)]
+      return [sKey for sKey in self.__orderedList if not isinstance(self.__dataDict[sKey], six.string_types)]
     else:
-      return [sKey for sKey in self.__dataDict.keys() if not isinstance(self.__dataDict[sKey], basestring)]
+      return [sKey for sKey in self.__dataDict.keys() if not isinstance(self.__dataDict[sKey], six.string_types)]
 
   @gCFGSynchro
   def isSection(self, key):
@@ -297,11 +297,11 @@ class CFG(object):
       if not keyDict:
         return False
       section = keyDict['value']
-      if isinstance(section, basestring):
+      if isinstance(section, six.string_types):
         return False
       secKey = keyDict['levelsBelow']
       return section.isSection(secKey)
-    return key in self.__dataDict and not isinstance(self.__dataDict[key], basestring)
+    return key in self.__dataDict and not isinstance(self.__dataDict[key], six.string_types)
 
   @gCFGSynchro
   def isOption(self, key):
@@ -317,11 +317,11 @@ class CFG(object):
       if not keyDict:
         return False
       section = keyDict['value']
-      if isinstance(section, basestring):
+      if isinstance(section, six.string_types):
         return False
       secKey = keyDict['levelsBelow']
       return section.isOption(secKey)
-    return key in self.__dataDict and isinstance(self.__dataDict[key], basestring)
+    return key in self.__dataDict and isinstance(self.__dataDict[key], six.string_types)
 
   def listAll(self):
     """
@@ -405,7 +405,7 @@ class CFG(object):
         return defaultValue
       dataD = dataV
 
-    if not isinstance(dataV, basestring):
+    if not isinstance(dataV, six.string_types):
       optionValue = defaultValue
     else:
       optionValue = dataV
@@ -471,7 +471,7 @@ class CFG(object):
       if not reqDict:
         return resVal
       keyCfg = reqDict['value']
-      if isinstance(keyCfg, basestring):
+      if isinstance(keyCfg, six.string_types):
         return resVal
       return keyCfg.getAsDict()
     for op in self.listOptions():

--- a/Core/Utilities/CFG.py
+++ b/Core/Utilities/CFG.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
+import six
 import copy
 import os
 import re

--- a/Core/Utilities/ClassAd/ClassAdLight.py
+++ b/Core/Utilities/ClassAd/ClassAdLight.py
@@ -4,6 +4,7 @@
 
 from __future__ import print_function
 __RCSID__ = "$Id$"
+import six
 
 
 class ClassAd(object):

--- a/Core/Utilities/ClassAd/ClassAdLight.py
+++ b/Core/Utilities/ClassAd/ClassAdLight.py
@@ -161,7 +161,7 @@ class ClassAd(object):
     """
 
     if name in self.contents:
-      if isinstance(self.contents[name], (int, long)):
+      if isinstance(self.contents[name], six.integer_types):
         return str(self.contents[name])
       return self.contents[name]
     return ""

--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -15,6 +15,7 @@ Encoding and decoding for dirac, Ids:
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+import six
 import types
 import datetime
 import os

--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -15,6 +15,7 @@ Encoding and decoding for dirac, Ids:
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import six
 import types
 import datetime

--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -343,7 +343,7 @@ def encodeDict(dValue, eList):
 
   if DIRAC_DEBUG_DENCODE_CALLSTACK:
     # If we have numbers as keys
-    if any([isinstance(x, (int, float, long)) for x in dValue]):
+    if any([isinstance(x, six.integer_types + (float,)) for x in dValue]):
       print('=' * 40, "Encoding dict with numeric keys", '=' * 40)
       printDebugCallstack()
 

--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -316,7 +316,7 @@ def cmpError(inErr, candidate):
       If it is a String, we use strerror to check the error string
   """
 
-  if isinstance(inErr, basestring):  # old style
+  if isinstance(inErr, six.string_types):  # old style
     # Compare error message strings
     errMsg = strerror(candidate)
     return errMsg in inErr
@@ -342,7 +342,7 @@ def includeExtensionErrors():
   def __recurseImport(modName, parentModule=None, fullName=False):
     """ Internal function to load modules
     """
-    if isinstance(modName, basestring):
+    if isinstance(modName, six.string_types):
       modName = modName.split(".")
     if not fullName:
       fullName = ".".join(modName)

--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -37,6 +37,7 @@
                              DErrno.ERRX : ['An error message for ERRX that is specific to LHCb']}
 
 """
+import six
 import os
 import imp
 import sys

--- a/Core/Utilities/Distribution.py
+++ b/Core/Utilities/Distribution.py
@@ -63,7 +63,7 @@ def writeVersionToInit(rootPath, version):
 def createTarball(tarballPath, directoryToTar, additionalDirectoriesToTar=None):
   tf = tarfile.open(tarballPath, "w:gz")
   tf.add(directoryToTar, os.path.basename(os.path.abspath(directoryToTar)), recursive=True)
-  if isinstance(additionalDirectoriesToTar, basestring):
+  if isinstance(additionalDirectoriesToTar, six.string_types):
     additionalDirectoriesToTar = [additionalDirectoriesToTar]
   if additionalDirectoriesToTar:
     for dirToTar in additionalDirectoriesToTar:

--- a/Core/Utilities/Distribution.py
+++ b/Core/Utilities/Distribution.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import re
 import tarfile
 import os

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -14,6 +14,7 @@ published information, like a foreign key pointing to non-existant entry.
 
 """
 
+import six
 from pprint import pformat
 
 from DIRAC import gLogger

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -117,7 +117,7 @@ def __getGlue2ShareInfo(host, shareEndpoints, shareInfoDict, cesDict):
 
   exeInfo = []
   executionEnvironments = shareInfoDict['GLUE2ComputingShareExecutionEnvironmentForeignKey']
-  if isinstance(executionEnvironments, basestring):
+  if isinstance(executionEnvironments, six.string_types):
     executionEnvironments = [executionEnvironments]
   for executionEnvironment in executionEnvironments:
     resExeInfo = __getGlue2ExecutionEnvironmentInfo(host, executionEnvironment)
@@ -143,7 +143,7 @@ def __getGlue2ShareInfo(host, shareEndpoints, shareInfoDict, cesDict):
     gLogger.debug("Failed to sort the execution environments: %s" % pformat(exeInfo))
   ceInfo.update(exeInfo[0])
 
-  if isinstance(shareEndpoints, basestring):
+  if isinstance(shareEndpoints, six.string_types):
     shareEndpoints = [shareEndpoints]
   for endpoint in shareEndpoints:
     ceType = endpoint.rsplit('.', 1)[1]

--- a/Core/Utilities/Graphs/GraphData.py
+++ b/Core/Utilities/Graphs/GraphData.py
@@ -41,7 +41,7 @@ def get_key_type(keys):
         num_data = float(key)
       except BaseException:
         num_type = False
-    if not isinstance(key, basestring):
+    if not isinstance(key, six.string_types):
       string_type = False
 
   # Take the most restrictive type
@@ -511,7 +511,7 @@ class PlotData:
     Parse the specific data value; this is the identity.
     """
 
-    if isinstance(data, basestring) and "::" in data:
+    if isinstance(data, six.string_types) and "::" in data:
       datum, error = data.split("::")
     elif isinstance(data, tuple):
       datum, error = data

--- a/Core/Utilities/Graphs/GraphData.py
+++ b/Core/Utilities/Graphs/GraphData.py
@@ -7,6 +7,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+import six
 import time
 import datetime
 import numpy

--- a/Core/Utilities/Graphs/GraphUtilities.py
+++ b/Core/Utilities/Graphs/GraphUtilities.py
@@ -56,7 +56,7 @@ def convert_to_datetime( dstring ):
       results = dstring
     else:
       results = eval( str( dstring ), {'__builtins__':None, 'time':time, 'math':math}, {} )
-    if isinstance(results, (int, float)):
+    if isinstance(results, six.integer_types + (float,)):
       results = datetime.datetime.fromtimestamp( int( results ) )
     elif isinstance( results, datetime.datetime ):
       pass

--- a/Core/Utilities/Graphs/GraphUtilities.py
+++ b/Core/Utilities/Graphs/GraphUtilities.py
@@ -8,6 +8,7 @@
 __RCSID__ = "$Id$"
 
 
+import six
 import os
 import time
 import datetime

--- a/Core/Utilities/Graphs/Legend.py
+++ b/Core/Utilities/Graphs/Legend.py
@@ -19,6 +19,8 @@ from DIRAC.Core.Utilities.Graphs.GraphData import GraphData
 from matplotlib.figure import Figure 
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 import types
+import six
+
 
 class Legend( object ):
 
@@ -27,7 +29,7 @@ class Legend( object ):
     self.text_size = 0
     self.column_width = 0
     self.labels = {}
-    if type(data) == types.DictType:
+    if isinstance(data, dict):
       for label,ddict in data.items():
         #self.labels[label] = pretty_float(max([ float(x) for x in ddict.values() if x ]) )  
         self.labels[label] = "%.1f" % max([ float(x) for x in ddict.values() if x ])   
@@ -118,7 +120,7 @@ class Legend( object ):
       if column_length > max_length:
         max_length = column_length
         if flag:
-          if type(num) == types.IntType or type(num) == types.LongType:
+          if isinstance(num, six.integer_types):
             numString = str(num)
           else:
             numString = "%.1f" % float(num)  

--- a/Core/Utilities/Grid.py
+++ b/Core/Utilities/Grid.py
@@ -46,7 +46,7 @@ def executeGridCommand( proxy, cmd, gridEnvScript = None ):
     if not res['OK']:
       return res
     gridEnv['X509_USER_PROXY' ] = res['Value']['path']
-  elif isinstance( proxy, basestring ):
+  elif isinstance(proxy, six.string_types):
     if os.path.exists( proxy ):
       gridEnv[ 'X509_USER_PROXY' ] = proxy
     else:

--- a/Core/Utilities/Grid.py
+++ b/Core/Utilities/Grid.py
@@ -2,6 +2,7 @@
 The Grid module contains several utilities for grid operations
 """
 
+import six
 import os
 import re
 

--- a/Core/Utilities/List.py
+++ b/Core/Utilities/List.py
@@ -48,7 +48,7 @@ def fromChar(inputString, sepChar=","):
      :return: list of strings or None if sepChar has a wrong type
   """
   # to prevent getting an empty String as argument
-  if not (isinstance(inputString, basestring) and isinstance(sepChar, basestring) and sepChar):
+  if not (isinstance(inputString, basestring) and isinstance(sepChar, six.string_types) and sepChar):
     return None
   return [fieldString.strip() for fieldString in inputString.split(sepChar) if len(fieldString.strip()) > 0]
 

--- a/Core/Utilities/List.py
+++ b/Core/Utilities/List.py
@@ -4,6 +4,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import random
 import sys
 random.seed()

--- a/Core/Utilities/MJF.py
+++ b/Core/Utilities/MJF.py
@@ -10,7 +10,7 @@
 import os
 import ssl
 import time
-import urllib
+from six.moves.urllib.request import urlopen
 
 import DIRAC
 
@@ -136,7 +136,7 @@ class MJF(object):
     # need to check HTTP return code in case we get an HTML error page
     # instead of a true key value.
     try:
-      mjfUrl = urllib.urlopen(url=url, context=self.context)
+      mjfUrl = urlopen(url=url, context=self.context)
       # HTTP return codes other than 2xx mean failure
       if mjfUrl.getcode() / 100 != 2:
         return None

--- a/Core/Utilities/Mail.py
+++ b/Core/Utilities/Mail.py
@@ -74,7 +74,7 @@ class Mail( object ):
 
     if msg is None:
       addresses = self._mailAddress
-      if isinstance( self._mailAddress, basestring ):
+      if isinstance(self._mailAddress, six.string_types):
         addresses = self._mailAddress.split( ", " )
 
       result = self._create(addresses)

--- a/Core/Utilities/Mail.py
+++ b/Core/Utilities/Mail.py
@@ -2,6 +2,7 @@
     Extremely simple utility class to send mails
 """
 
+import six
 import os
 import socket
 

--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -148,6 +148,7 @@
 """
 
 from __future__ import print_function
+import six
 import collections
 import time
 import threading

--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -533,7 +533,7 @@ class MySQL(object):
       return S_OK(inEscapeValues)
 
     for value in inValues:
-      if isinstance(value, basestring):
+      if isinstance(value, six.string_types):
         retDict = self.__escapeString(value)
         if not retDict['OK']:
           return retDict
@@ -853,7 +853,7 @@ class MySQL(object):
           cmdList.append('`%s` %s' % (field, thisTable['Fields'][field]))
 
         if 'PrimaryKey' in thisTable:
-          if isinstance(thisTable['PrimaryKey'], basestring):
+          if isinstance(thisTable['PrimaryKey'], six.string_types):
             cmdList.append('PRIMARY KEY ( `%s` )' % thisTable['PrimaryKey'])
           else:
             cmdList.append('PRIMARY KEY ( %s )' % ", ".join(["`%s`" % str(f) for f in thisTable['PrimaryKey']]))
@@ -1077,7 +1077,7 @@ class MySQL(object):
 
     if condDict is not None:
       for aName, attrValue in condDict.iteritems():
-        if isinstance(aName, basestring):
+        if isinstance(aName, six.string_types):
           attrName = _quotedList([aName])
         elif isinstance(aName, tuple):
           attrName = '(' + _quotedList(list(aName)) + ')'
@@ -1188,7 +1188,7 @@ class MySQL(object):
     for orderAttr in orderAttrList:
       if orderAttr is None:
         continue
-      if not isinstance(orderAttr, basestring):
+      if not isinstance(orderAttr, six.string_types):
         error = 'Invalid orderAttribute argument'
         self.log.debug('buildCondition:', error)
         raise Exception(error)
@@ -1463,7 +1463,7 @@ class MySQL(object):
     try:
       #       execStr = "call %s(%s);" % ( packageName, ",".join( map( str, parameters ) ) )
       execStr = "call %s(%s);" % (packageName, ",".join(
-          ["\"%s\"" % param if isinstance(param, basestring) else str(param) for param in parameters]))
+          ["\"%s\"" % param if isinstance(param, six.string_types) else str(param) for param in parameters]))
       cursor.execute(execStr)
       rows = cursor.fetchall()
       retDict = S_OK(rows)

--- a/Core/Utilities/ObjectLoader.py
+++ b/Core/Utilities/ObjectLoader.py
@@ -81,7 +81,7 @@ class ObjectLoader(object):
   def __recurseImport(self, modName, parentModule=None, hideExceptions=False, fullName=False):
     """ Internal function to load modules
     """
-    if isinstance(modName, basestring):
+    if isinstance(modName, six.string_types):
       modName = List.fromChar(modName, ".")
     if not fullName:
       fullName = ".".join(modName)
@@ -164,7 +164,7 @@ class ObjectLoader(object):
     else:
       modules = {}
 
-    if isinstance(reFilter, basestring):
+    if isinstance(reFilter, six.string_types):
       reFilter = re.compile(reFilter)
 
     for rootModule in self.__rootModules:

--- a/Core/Utilities/ObjectLoader.py
+++ b/Core/Utilities/ObjectLoader.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import re
 import imp
 import pkgutil

--- a/Core/Utilities/OracleDB.py
+++ b/Core/Utilities/OracleDB.py
@@ -229,7 +229,7 @@ class OracleDB(object):
         if isinstance(type(array[0]), six.string_types):
           result = cursor.arrayvar(cx_Oracle.STRING, array)
           parameters += [result]
-        elif isinstance(array[0], (long, int)):
+        elif isinstance(array[0], six.integer_types):
           result = cursor.arrayvar(cx_Oracle.NUMBER, array)
           parameters += [result]
         else:

--- a/Core/Utilities/OracleDB.py
+++ b/Core/Utilities/OracleDB.py
@@ -226,7 +226,7 @@ class OracleDB(object):
       result = None
       results = None
       if array:
-        if isinstance(type(array[0]), basestring):
+        if isinstance(type(array[0]), six.string_types):
           result = cursor.arrayvar(cx_Oracle.STRING, array)
           parameters += [result]
         elif isinstance(array[0], (long, int)):

--- a/Core/Utilities/OracleDB.py
+++ b/Core/Utilities/OracleDB.py
@@ -50,6 +50,7 @@
 __RCSID__ = "$Id$"
 
 
+import six
 import Queue
 import time
 import threading

--- a/Core/Utilities/Os.py
+++ b/Core/Utilities/Os.py
@@ -4,6 +4,7 @@
 """
 
 from __future__ import print_function
+import six
 import os
 import distutils.spawn  # pylint: disable=no-name-in-module,import-error
 

--- a/Core/Utilities/Os.py
+++ b/Core/Utilities/Os.py
@@ -22,7 +22,7 @@ def uniquePath(path=None):
      Utility to squeeze the string containing a PATH-like value to
      leave only unique elements preserving the original order
   """
-  if not isinstance(path, basestring):
+  if not isinstance(path, six.string_types):
     return None
 
   try:

--- a/Core/Utilities/Os.py
+++ b/Core/Utilities/Os.py
@@ -4,6 +4,7 @@
 """
 
 from __future__ import print_function
+from past.builtins import long
 import six
 import os
 import distutils.spawn  # pylint: disable=no-name-in-module,import-error

--- a/Core/Utilities/Platform.py
+++ b/Core/Utilities/Platform.py
@@ -68,7 +68,7 @@ def libc_ver( executable = sys.executable, lib = '', version = '',
       elif so:
         if lib != 'glibc':
           lib = 'libc'
-          version = max( version, soversion )
+          version = max(version, soversion) if soversion else version
           if threads and version[-len( threads ):] != threads:
             version = version + threads
       pos = m.end()

--- a/Core/Utilities/PrettyPrint.py
+++ b/Core/Utilities/PrettyPrint.py
@@ -84,12 +84,12 @@ def printTable(fields, records, sortField='', numbering=True,
   for record in records:
     strippedRecord = []
     for fieldValue in record:
-      if isinstance(fieldValue, basestring):
+      if isinstance(fieldValue, six.string_types):
         strippedRecord.append(fieldValue.strip())
       elif isinstance(fieldValue, list):
         strippedList = []
         for ll in fieldValue:
-          if isinstance(ll, basestring):
+          if isinstance(ll, six.string_types):
             strippedList.append(ll.strip())
           elif isinstance(ll, dict):
             ll['Value'] = ll['Value'].strip()
@@ -102,7 +102,7 @@ def printTable(fields, records, sortField='', numbering=True,
         strippedRecord.append(strippedList)
       elif isinstance(fieldValue, dict):
         itemValue = fieldValue['Value']
-        if isinstance(itemValue, basestring):
+        if isinstance(itemValue, six.string_types):
           itemValue = itemValue.strip()
           fieldValue.update({'Value': itemValue})
           strippedRecord.append(fieldValue)

--- a/Core/Utilities/PrettyPrint.py
+++ b/Core/Utilities/PrettyPrint.py
@@ -8,6 +8,7 @@
 from __future__ import print_function
 __RCSID__ = '$Id$'
 
+import six
 import StringIO
 
 

--- a/Core/Utilities/ProcessPool.py
+++ b/Core/Utilities/ProcessPool.py
@@ -520,7 +520,7 @@ class ProcessTask(object):
       if isinstance(self.__taskFunction, FunctionType):
         self.__taskResult = self.__taskFunction(*self.__taskArgs, **self.__taskKwArgs)
       # # or a class?
-      elif type(self.__taskFunction) in (TypeType, ClassType):
+      elif isinstance(self.__taskFunction, (type, ClassType)):
         # # create new instance
         taskObj = self.__taskFunction(*self.__taskArgs, **self.__taskKwArgs)
         # ## check if it is callable, raise TypeError if not

--- a/Core/Utilities/ReturnValues.py
+++ b/Core/Utilities/ReturnValues.py
@@ -6,6 +6,7 @@
    keys are converted to string
 """
 
+import six
 import types
 import traceback
 from DIRAC.Core.Utilities.DErrno import strerror

--- a/Core/Utilities/ReturnValues.py
+++ b/Core/Utilities/ReturnValues.py
@@ -23,7 +23,7 @@ def S_ERROR(*args):
 
   message = ''
   if args:
-    if isinstance(args[0], (int, long)):
+    if isinstance(args[0], six.integer_types):
       result['Errno'] = args[0]
       if len(args) > 1:
         message = args[1]

--- a/Core/Utilities/StateMachine.py
+++ b/Core/Utilities/StateMachine.py
@@ -56,7 +56,7 @@ class StateMachine( object ):
     if not issubclass( state.__class__, State ):
       raise TypeError("state should be inherited from State")
     self.__state = state
-    self.transTable = transTable if type(transTable) == dict else {}
+    self.transTable = transTable if isinstance(transTable, dict) else {}
 
   def setState( self, state ):
     """ set state """

--- a/Core/Utilities/Subprocess.py
+++ b/Core/Utilities/Subprocess.py
@@ -26,6 +26,8 @@ set a timeout.
        should be used to wrap third party python functions
 
 """
+from __future__ import division
+
 from multiprocessing import Process, Manager
 import threading
 import time
@@ -469,7 +471,7 @@ class Subprocess:
         exitStatus = exitStatus[1]
 
       if exitStatus >= 256:
-        exitStatus /= 256
+        exitStatus = int(exitStatus / 256)
       return S_OK((exitStatus, self.bufferList[0][0], self.bufferList[1][0]))
     finally:
       try:

--- a/Core/Utilities/ThreadScheduler.py
+++ b/Core/Utilities/ThreadScheduler.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import hashlib
 import threading
 import time

--- a/Core/Utilities/TimeLeft/MJFTimeLeft.py
+++ b/Core/Utilities/TimeLeft/MJFTimeLeft.py
@@ -6,7 +6,7 @@ __RCSID__ = "$Id$"
 
 import os
 import time
-import urllib
+from six.moves.urllib.request import urlopen
 
 from DIRAC import gLogger, S_OK, S_ERROR
 
@@ -51,7 +51,7 @@ class MJFTimeLeft(object):
 
     if jobFeaturesPath:
       try:
-        wallClockLimit = int(urllib.urlopen(jobFeaturesPath + '/wall_limit_secs').read())
+        wallClockLimit = int(urlopen(jobFeaturesPath + '/wall_limit_secs').read())
         self.log.verbose("wallClockLimit from JF = %d" % wallClockLimit)
       except ValueError:
         self.log.warn("/wall_limit_secs is unreadable")
@@ -60,7 +60,7 @@ class MJFTimeLeft(object):
         self.log.warn("Could not determine cpu limit from $JOBFEATURES/wall_limit_secs")
 
       try:
-        jobStartSecs = int(urllib.urlopen(jobFeaturesPath + '/jobstart_secs').read())
+        jobStartSecs = int(urlopen(jobFeaturesPath + '/jobstart_secs').read())
         self.log.verbose("jobStartSecs from JF = %d" % jobStartSecs)
       except ValueError:
         self.log.warn("/jobstart_secs is unreadable, setting a default")
@@ -71,7 +71,7 @@ class MJFTimeLeft(object):
         jobStartSecs = self.startTime
 
       try:
-        cpuLimit = int(urllib.urlopen(jobFeaturesPath + '/cpu_limit_secs').read())
+        cpuLimit = int(urlopen(jobFeaturesPath + '/cpu_limit_secs').read())
         self.log.verbose("cpuLimit from JF = %d" % cpuLimit)
       except ValueError:
         self.log.warn("/cpu_limit_secs is unreadable")
@@ -90,7 +90,7 @@ class MJFTimeLeft(object):
 
     if machineFeaturesPath and jobStartSecs:
       try:
-        shutdownTime = int(urllib.urlopen(machineFeaturesPath + '/shutdowntime').read())
+        shutdownTime = int(urlopen(machineFeaturesPath + '/shutdowntime').read())
         self.log.verbose("shutdownTime from MF = %d" % shutdownTime)
         if int(time.time()) + wallClockLimit > shutdownTime:
           # reduce wallClockLimit if would overrun shutdownTime

--- a/Core/Utilities/TypedList.py
+++ b/Core/Utilities/TypedList.py
@@ -19,6 +19,7 @@ __RCSID__ = "$Id $"
 # @date 2012/07/19 08:21:22
 # @brief Definition of TypedList class.
 
+import six
 from collections import deque
 
 class Unsortable( list ):

--- a/Core/Utilities/TypedList.py
+++ b/Core/Utilities/TypedList.py
@@ -238,7 +238,7 @@ class NumericList( TypedList ):
     :param mixed iterable: initial values
     """
 
-    TypedList.__init__( self, iterable, allowedTypes = ( int, long, float ) )
+    TypedList.__init__( self, iterable, allowedTypes = six.integer_types + (float,) )
 
 class StrList( TypedList ):
   """

--- a/Core/Utilities/TypedList.py
+++ b/Core/Utilities/TypedList.py
@@ -19,6 +19,7 @@ __RCSID__ = "$Id $"
 # @date 2012/07/19 08:21:22
 # @brief Definition of TypedList class.
 
+from past.builtins import long
 import six
 from collections import deque
 

--- a/Core/Utilities/test/Test_TypedList.py
+++ b/Core/Utilities/test/Test_TypedList.py
@@ -36,7 +36,7 @@ class TypedListTestCase(unittest.TestCase):
   """
   def setUp( self ):
     """ test setup """
-    self.numericTypes = ( int, long, float )
+    self.numericTypes = six.integer_types + (float,)
     self.floatType = float 
     self.testClassType = TestClass
 

--- a/Core/Utilities/test/Test_TypedList.py
+++ b/Core/Utilities/test/Test_TypedList.py
@@ -20,6 +20,7 @@ __RCSID__ = "$Id $"
 # @date 2012/07/19 12:16:48
 
 ## imports 
+import six
 import unittest
 ## SUT
 from DIRAC.Core.Utilities.TypedList import TypedList, TDeque

--- a/Core/Workflow/Parameter.py
+++ b/Core/Workflow/Parameter.py
@@ -4,6 +4,7 @@
     class which is the base class for the main Workflow classes.
 """
 from __future__ import print_function
+from past.builtins import long
 from DIRAC.Core.Workflow.Utility import *
 
 __RCSID__ = "$Id$"

--- a/Core/Workflow/Utility.py
+++ b/Core/Workflow/Utility.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+import six
 import re
 
 

--- a/Core/Workflow/Utility.py
+++ b/Core/Workflow/Utility.py
@@ -27,7 +27,7 @@ def substitute(param, variable, value):
   """
 
   tmp_string = str(param).replace('@{' + variable + '}', value)
-  if isinstance(param, basestring):
+  if isinstance(param, six.string_types):
     return tmp_string
   return eval(tmp_string)
 
@@ -42,7 +42,7 @@ def resolveVariables(varDict):
   while ntry < max_tries:
     substFlag = False
     for var, value in varDict.iteritems():
-      if isinstance(value, basestring):
+      if isinstance(value, six.string_types):
         substitute_vars = getSubstitute(value)
         for substitute_var in substitute_vars:
           if substitute_var in variables:

--- a/Core/scripts/dirac-distribution.py
+++ b/Core/scripts/dirac-distribution.py
@@ -15,7 +15,8 @@ __RCSID__ = "$Id$"
 import sys
 import os
 import re
-import urllib2
+from six.moves.urllib.request import urlopen
+from six.moves.urllib.error import URLError
 import tempfile
 import imp
 import hashlib
@@ -223,8 +224,8 @@ class DistributionMaker:
   def getAvailableExternals(self):
     packagesURL = "http://diracproject.web.cern.ch/diracproject/tars/tars.list"
     try:
-      remoteFile = urllib2.urlopen(packagesURL)
-    except urllib2.URLError:
+      remoteFile = urlopen(packagesURL)
+    except URLError:
       gLogger.exception()
       return []
     remoteData = remoteFile.read()

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -134,6 +134,7 @@ You can use install.cfg configuration file::
 
 from __future__ import absolute_import, division, print_function
 
+from past.builtins import long
 import sys
 import os
 import getopt

--- a/DataManagementSystem/Agent/RequestOperations/test/Test_ArchiveFiles.py
+++ b/DataManagementSystem/Agent/RequestOperations/test/Test_ArchiveFiles.py
@@ -65,7 +65,7 @@ def multiRetVal(*args, **kwargs):
              'Successful': {},
              }}
   lfns = args[0]
-  if isinstance(lfns, basestring):
+  if isinstance(lfns, six.string_types):
     lfns = [lfns]
   for _index, lfn in enumerate(lfns):
     if str(kwargs.get('Index', 5)) in lfn:

--- a/DataManagementSystem/Agent/RequestOperations/test/Test_ArchiveFiles.py
+++ b/DataManagementSystem/Agent/RequestOperations/test/Test_ArchiveFiles.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=protected-access, redefined-outer-name
 
+import six
 from functools import partial
 import logging
 import os

--- a/DataManagementSystem/Client/ConsistencyInspector.py
+++ b/DataManagementSystem/Client/ConsistencyInspector.py
@@ -529,7 +529,7 @@ class ConsistencyInspector(object):
 
   def set_lfns(self, value):
     """ Setter """
-    if isinstance(value, basestring):
+    if isinstance(value, six.string_types):
       value = [value]
     value = [v.replace(' ', '').replace('//', '/') for v in value]
     self._lfns = value
@@ -554,7 +554,7 @@ class ConsistencyInspector(object):
     gLogger.info("-" * 40)
     gLogger.info("Performing the FC->SE check")
     gLogger.info("-" * 40)
-    if isinstance(lfnDir, basestring):
+    if isinstance(lfnDir, six.string_types):
       lfnDir = [lfnDir]
     res = self._getCatalogDirectoryContents(lfnDir)
     if not res['OK']:
@@ -573,7 +573,7 @@ class ConsistencyInspector(object):
     gLogger.info("-" * 40)
     gLogger.info("Performing the FC->SE check")
     gLogger.info("-" * 40)
-    if isinstance(lfns, basestring):
+    if isinstance(lfns, six.string_types):
       lfns = [lfns]
     res = self._getCatalogMetadata(lfns)
     if not res['OK']:

--- a/DataManagementSystem/Client/ConsistencyInspector.py
+++ b/DataManagementSystem/Client/ConsistencyInspector.py
@@ -5,6 +5,7 @@
     Should be extended to include the Storage (in DIRAC)
 """
 
+import six
 import os
 import time
 import sys

--- a/DataManagementSystem/Client/DataIntegrityClient.py
+++ b/DataManagementSystem/Client/DataIntegrityClient.py
@@ -35,7 +35,7 @@ class DataIntegrityClient(Client):
     """
     if isinstance( lfn, list ):
       lfns = lfn
-    elif isinstance( lfn, basestring ):
+    elif isinstance(lfn, six.string_types):
       lfns = [lfn]
     else:
       errStr = "DataIntegrityClient.setFileProblematic: Supplied file info must be list or a single LFN."

--- a/DataManagementSystem/Client/DataIntegrityClient.py
+++ b/DataManagementSystem/Client/DataIntegrityClient.py
@@ -4,6 +4,7 @@ problematic file and replicas to the IntegrityDB and their status
 correctly updated in the FileCatalog.
 """
 
+import six
 from DIRAC                                                import S_OK, S_ERROR, gLogger
 from DIRAC.DataManagementSystem.Client.DataManager        import DataManager
 from DIRAC.Resources.Storage.StorageElement               import StorageElement

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -10,6 +10,7 @@ This module consists of DataManager and related classes.
 """
 
 # # imports
+import six
 from datetime import datetime, timedelta
 import fnmatch
 import os

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -119,7 +119,7 @@ class DataManager(object):
   def __hasAccess(self, opType, path):
     """  Check if we have permission to execute given operation on the given file (if exists) or its directory
     """
-    if isinstance(path, basestring):
+    if isinstance(path, six.string_types):
       paths = [path]
     else:
       paths = list(path)
@@ -145,7 +145,7 @@ class DataManager(object):
     """ Clean the logical directory from the catalog and storage
     """
     log = self.log.getSubLogger('cleanLogicalDirectory')
-    if isinstance(lfnDir, basestring):
+    if isinstance(lfnDir, six.string_types):
       lfnDir = [lfnDir]
     retDict = {"Successful": {}, "Failed": {}}
     for folder in lfnDir:
@@ -288,7 +288,7 @@ class DataManager(object):
     :param self: self reference
     :param mixed directory: list of directories or one directory
     """
-    if isinstance(directory, basestring):
+    if isinstance(directory, six.string_types):
       directories = [directory]
     else:
       directories = directory
@@ -307,7 +307,7 @@ class DataManager(object):
     :param int days: ctime days
     :param str wildcard: pattern to match
     """
-    if isinstance(directory, basestring):
+    if isinstance(directory, six.string_types):
       directories = [directory]
     else:
       directories = directory
@@ -360,7 +360,7 @@ class DataManager(object):
     log = self.log.getSubLogger('getFile')
     if isinstance(lfn, list):
       lfns = lfn
-    elif isinstance(lfn, basestring):
+    elif isinstance(lfn, six.string_types):
       lfns = [lfn]
     else:
       errStr = "Supplied lfn must be string or list of strings."
@@ -1156,7 +1156,7 @@ class DataManager(object):
     else:
       lfns = [lfn]
     for lfn in lfns:
-      if not isinstance(lfn, basestring):
+      if not isinstance(lfn, six.string_types):
         errStr = "Supplied lfns must be string or list of strings."
         log.debug(errStr)
         return S_ERROR(errStr)
@@ -1262,7 +1262,7 @@ class DataManager(object):
     else:
       lfns = set([lfn])
     for lfn in lfns:
-      if not isinstance(lfn, basestring):
+      if not isinstance(lfn, six.string_types):
         errStr = "Supplied lfns must be string or list of strings."
         log.debug(errStr)
         return S_ERROR(errStr)
@@ -1388,7 +1388,7 @@ class DataManager(object):
     else:
       lfns = [lfn]
     for lfn in lfns:
-      if not isinstance(lfn, basestring):
+      if not isinstance(lfn, six.string_types):
         errStr = "Supplied lfns must be string or list of strings."
         log.debug(errStr)
         return S_ERROR(errStr)

--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -543,10 +543,10 @@ File Catalog Client $Revision: 1.17 $Date:
         print("Failed to add file to the catalog: ", end=' ')
         print(result['Message'])
       elif result['Value']['Failed']:
-        if result['Value']['Failed'].has_key(lfn):
+        if lfn in result['Value']['Failed']:
           print('Failed to add file:', result['Value']['Failed'][lfn])
       elif result['Value']['Successful']:
-        if result['Value']['Successful'].has_key(lfn):
+        if lfn in result['Value']['Successful']:
           print("File successfully added to the catalog")
     except Exception as x:
       print("add file failed: ", str(x))
@@ -924,10 +924,10 @@ File Catalog Client $Revision: 1.17 $Date:
     result =  self.fc.createDirectory(newdir)    
     if result['OK']:
       if result['Value']['Successful']:
-        if result['Value']['Successful'].has_key(newdir):
+        if newdir in result['Value']['Successful']:
           print("Successfully created directory:", newdir)
       elif result['Value']['Failed']:
-        if result['Value']['Failed'].has_key(newdir):  
+        if newdir in result['Value']['Failed']:  
           print('Failed to create directory:', result['Value']['Failed'][newdir])
     else:
       print('Failed to create directory:', result['Message'])

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
@@ -8,6 +8,7 @@
 
 """
 
+from past.builtins import long
 import six
 import os
 

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
@@ -211,7 +211,7 @@ class DirectoryClosure( DirectoryTreeBase ):
   def getChildren( self, path, connection = False ):
     """ Get child directory IDs for the given directory
     """
-    if isinstance( path, basestring ):
+    if isinstance(path, six.string_types):
       result = self.findDir( path, connection )
       if not result['OK']:
         return result
@@ -454,7 +454,7 @@ class DirectoryClosure( DirectoryTreeBase ):
     # Which procedure to use
     psName = None
     # it is a path ...
-    if isinstance( pathOrDirId, basestring ):
+    if isinstance(pathOrDirId, six.string_types):
       psName = 'ps_get_all_directory_info'
     # it is the dirId
     elif isinstance( pathOrDirId, (list, long) ):

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
@@ -8,6 +8,7 @@
 
 """
 
+import six
 import os
 
 from DIRAC import S_OK, S_ERROR

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryFlatTree.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryFlatTree.py
@@ -219,7 +219,7 @@ class DirectoryFlatTree(DirectoryTreeBase):
 
   def getChildren(self, path):
     """ Get child directory IDs for the given directory  """
-    if isinstance(path, basestring):
+    if isinstance(path, six.string_types):
       result = self.findDir(path)
       if not result['OK']:
         return result

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryFlatTree.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryFlatTree.py
@@ -5,6 +5,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import stat
 

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
@@ -6,6 +6,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 
 from DIRAC import S_OK, S_ERROR

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
@@ -215,7 +215,7 @@ class DirectoryLevelTree(DirectoryTreeBase):
     """
 
     dirID = dirPathOrID
-    if isinstance(dirPathOrID, basestring):
+    if isinstance(dirPathOrID, six.string_types):
       result = self.findDir(dirPathOrID)
       if not result['OK']:
         return result
@@ -344,7 +344,7 @@ class DirectoryLevelTree(DirectoryTreeBase):
   def getChildren(self, path, connection=False):
     """ Get child directory IDs for the given directory
     """
-    if isinstance(path, basestring):
+    if isinstance(path, six.string_types):
       result = self.findDir(path, connection)
       if not result['OK']:
         return result

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
@@ -282,7 +282,7 @@ class DirectoryTreeBase(object):
     """ Get directory ID from the given path or already evaluated ID
     """
 
-    if isinstance(path, basestring):
+    if isinstance(path, six.string_types):
       result = self.findDir(path)
       if not result['OK']:
         return result
@@ -344,7 +344,7 @@ class DirectoryTreeBase(object):
         :param int pvalue: parameter value
     """
     result = getIDSelectString(path)
-    if not result['OK'] and isinstance(path, basestring):
+    if not result['OK'] and isinstance(path, six.string_types):
       result = self.__getDirID(path)
       if not result['OK']:
         return result

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
@@ -2,6 +2,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import time
 import threading
 import os

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -410,7 +410,7 @@ class DirectoryMetadata:
         if operation in ['>', '<', '>=', '<=']:
           if isinstance(operand, list):
             return S_ERROR('Illegal query: list of values for comparison operation')
-          if isinstance(operand, (int, long)):
+          if isinstance(operand, six.integer_types):
             selectList.append("%sValue%s%d" % (table, operation, operand))
           elif isinstance(operand, float):
             selectList.append("%sValue%s%f" % (table, operation, operand))

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -5,6 +5,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Time import queryTime

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -417,7 +417,7 @@ class FileManagerBase(object):
       originalFileID = lfnDict['FileID']
       originalDepth = lfnDict.get('AncestorDepth', 1)
       ancestors = lfnDict.get('Ancestors', [])
-      if isinstance(ancestors, basestring):
+      if isinstance(ancestors, six.string_types):
         ancestors = [ancestors]
       if lfn in ancestors:
         ancestors.remove(lfn)
@@ -712,7 +712,7 @@ class FileManagerBase(object):
     successful = {}
     for lfn in res['Value']['Successful'].keys():
       status = lfns[lfn]
-      if isinstance(status, basestring):
+      if isinstance(status, six.string_types):
         if status not in self.db.validFileStatus:
           failed[lfn] = 'Invalid file status %s' % status
           continue
@@ -876,7 +876,7 @@ class FileManagerBase(object):
       if isinstance(val, dict) and 'GUID' in val:
         # We are in the case {lfn : {PFN:.., GUID:..}}
         guidList = [lfns[lfn]['GUID'] for lfn in lfns]
-      elif isinstance(val, basestring):
+      elif isinstance(val, six.string_types):
         # We hope that it is the GUID which is given
         guidList = lfns.values()
 
@@ -1233,7 +1233,7 @@ class FileManagerBase(object):
     successful = {}
     for lfn in res['Value']['Successful'].keys():
       group = lfns[lfn]
-      if isinstance(group, basestring):
+      if isinstance(group, six.string_types):
         groupRes = self.db.ugManager.findGroup(group)
         if not groupRes['OK']:
           return groupRes
@@ -1263,7 +1263,7 @@ class FileManagerBase(object):
     successful = {}
     for lfn in res['Value']['Successful'].keys():
       owner = lfns[lfn]
-      if isinstance(owner, basestring):
+      if isinstance(owner, six.string_types):
         userRes = self.db.ugManager.findUser(owner)
         if not userRes['OK']:
           return userRes

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -5,6 +5,7 @@ __RCSID__ = "$Id$"
 
 # pylint: disable=protected-access
 
+import six
 import os
 import stat
 

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
@@ -220,7 +220,7 @@ class FileManagerFlat(FileManagerBase):
     # TODO: This is in efficient. Should perform bulk operation
     connection = self._getConnection(connection)
     """ Check if a replica already exists """
-    if isinstance(seID, basestring):
+    if isinstance(seID, six.string_types):
       res = self.db.seManager.findSE(seID)
       if not res['OK']:
         return res
@@ -277,7 +277,7 @@ class FileManagerFlat(FileManagerBase):
     connection = self._getConnection(connection)
     deleteTuples = []
     for fileID, seID in replicaTuples:
-      if isinstance(seID, basestring):
+      if isinstance(seID, six.string_types):
         res = self.db.seManager.findSE(seID)
         if not res['OK']:
           return res
@@ -310,7 +310,7 @@ class FileManagerFlat(FileManagerBase):
 
   def _setReplicaParameter(self, fileID, seID, paramName, paramValue, connection=False):
     connection = self._getConnection(connection)
-    if isinstance(seID, basestring):
+    if isinstance(seID, six.string_types):
       res = self.db.seManager.findSE(seID)
       if not res['OK']:
         return res

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
@@ -1,5 +1,6 @@
 __RCSID__ = "$Id$"
 
+import six
 import os
 
 from DIRAC import S_OK, S_ERROR

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
@@ -515,7 +515,7 @@ class FileManagerPs(FileManagerBase):
       fileID = lfns[lfn]['FileID']
 
       seName = lfns[lfn]['SE']
-      if isinstance(seName, basestring):
+      if isinstance(seName, six.string_types):
         seList = [seName]
       elif isinstance(seName, list):
         seList = seName

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import datetime
 

--- a/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
@@ -4,6 +4,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Time import queryTime
 from DIRAC.Core.Utilities.List import intListToString

--- a/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
@@ -340,7 +340,7 @@ class FileMetadata:
     queryList = []
     if isinstance(value, float):
       queryList.append(('=', '%f' % value))
-    elif isinstance(value, (int, long)):
+    elif isinstance(value, six.integer_types):
       queryList.append(('=', '%d' % value))
     elif isinstance(value, str):
       if value.lower() == 'any':
@@ -378,7 +378,7 @@ class FileMetadata:
           if not result['OK']:
             return result
           escapedOperand = ', '.join(result['Value'])
-        elif isinstance(operand, (int, long)):
+        elif isinstance(operand, six.integer_types):
           escapedOperand = '%d' % operand
         elif isinstance(operand, float):
           escapedOperand = '%f' % operand

--- a/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
@@ -2,6 +2,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import time
 import random
 

--- a/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
@@ -109,7 +109,7 @@ class SEManagerDB(SEManagerBase):
 
   def getSEID(self, seName):
     """ Get ID for a SE specified by its name """
-    if isinstance(seName, (int, long)):
+    if isinstance(seName, six.integer_types):
       return S_OK(seName)
     if seName in self.db.seNames.keys():
       return S_OK(self.db.seNames[seName])

--- a/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerDB.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerDB.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import time
 import threading
 

--- a/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerDB.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerDB.py
@@ -37,7 +37,7 @@ class UserAndGroupManagerDB(UserAndGroupManagerBase):
 
   def getUserID(self, user):
     """ Get ID for a user specified by its name """
-    if isinstance(user, (int, long)):
+    if isinstance(user, six.integer_types):
       return S_OK(user)
     if user in self.db.users.keys():
       return S_OK(self.db.users[user])
@@ -145,7 +145,7 @@ class UserAndGroupManagerDB(UserAndGroupManagerBase):
 
   def getGroupID(self, group):
     """ Get ID for a group specified by its name """
-    if isinstance(group, (int, long)):
+    if isinstance(group, six.integer_types):
       return S_OK(group)
     if group in self.db.groups.keys():
       return S_OK(self.db.groups[group])

--- a/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.List import intListToString
 

--- a/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
@@ -14,7 +14,7 @@ def getIDSelectString(ids):
   """
   if isinstance(ids, six.string_types) and ids.lower().startswith('select'):
     idString = ids
-  elif isinstance(ids, (int, long)):
+  elif isinstance(ids, six.integer_types):
     idString = '%d' % ids
   elif isinstance(ids, (tuple, list)):
     idString = intListToString(ids)

--- a/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
@@ -12,7 +12,7 @@ def getIDSelectString(ids):
   :param ids: input IDs - can be single int, list or tuple or a SELECT string
   :return: Select string
   """
-  if isinstance(ids, basestring) and ids.lower().startswith('select'):
+  if isinstance(ids, six.string_types) and ids.lower().startswith('select'):
     idString = ids
   elif isinstance(ids, (int, long)):
     idString = '%d' % ids

--- a/DataManagementSystem/Service/DataIntegrityHandler.py
+++ b/DataManagementSystem/Service/DataIntegrityHandler.py
@@ -47,7 +47,7 @@ class DataIntegrityHandler( RequestHandler ):
   def export_removeProblematic( fileID ):
     """ Remove the file with the supplied FileID from the database
     """
-    if type( fileID ) == ListType:
+    if isinstance(fileID, list):
       fileIDs = fileID
     else:
       fileIDs = [int( fileID )]

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -9,6 +9,7 @@ Service handler for FT3SDB using DISET
 
 __RCSID__ = "$Id$"
 
+import six
 import json
 
 # from DIRAC

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -57,7 +57,7 @@ class FTS3ManagerHandler(RequestHandler):
     opObj = json.loads(opJSON, cls=FTS3JSONDecoder)
     return cls.fts3db.persistOperation(opObj)
 
-  types_getOperation = [(long, int)]
+  types_getOperation = [six.integer_types]
 
   @classmethod
   def export_getOperation(cls, operationID):
@@ -76,7 +76,7 @@ class FTS3ManagerHandler(RequestHandler):
     opJSON = getOperation.toJSON()
     return S_OK(opJSON)
 
-  types_getActiveJobs = [(long, int), [None] + [basestring], basestring]
+  types_getActiveJobs = [six.integer_types, [None] + [basestring], basestring]
 
   @classmethod
   def export_getActiveJobs(cls, limit, lastMonitor, jobAssignmentTag):
@@ -123,7 +123,7 @@ class FTS3ManagerHandler(RequestHandler):
 
     return cls.fts3db.updateJobStatus(jobStatusDict)
 
-  types_getNonFinishedOperations = [(long, int), basestring]
+  types_getNonFinishedOperations = [six.integer_types, basestring]
 
   @classmethod
   def export_getNonFinishedOperations(cls, limit, operationAssignmentTag):
@@ -144,7 +144,7 @@ class FTS3ManagerHandler(RequestHandler):
 
     return S_OK(nonFinishedOperationsJSON)
 
-  types_getOperationsFromRMSOpID = [(long, int)]
+  types_getOperationsFromRMSOpID = [six.integer_types]
 
   @classmethod
   def export_getOperationsFromRMSOpID(cls, rmsOpID):

--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -158,7 +158,7 @@ class FileCatalogHandler(RequestHandler):
     # The signature of v6r15 is (dict, str)
     # The signature of v6r14 is (str, [dict, str, list])
     # We swap the two params if the first attribute is a string
-    if isinstance(paths, basestring):
+    if isinstance(paths, six.string_types):
       paths, opType = opType, paths
 
     return gFileCatalogDB.hasAccess(opType, paths, self.getRemoteCredentials())

--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -12,6 +12,7 @@
 __RCSID__ = "$Id$"
 
 # imports
+import six
 import cStringIO
 import csv
 import os

--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -81,7 +81,7 @@ def _getConnectionIndex(connectionLevel, default=None):
   """
   if connectionLevel is None:
     connectionLevel = default
-  if isinstance(connectionLevel, (int, long)):
+  if isinstance(connectionLevel, six.integer_types):
     return connectionLevel
   if isinstance(connectionLevel, six.string_types):
     connectionLevel = connectionLevel.upper()
@@ -226,7 +226,7 @@ class DMSHelpers(object):
     if result['OK']:
       for site in self.siteSEMapping[LOCAL] if withStorage else self.siteSet:
         grid, shortSite, _country = site.split('.')
-        if isinstance(tier, (int, long)) and \
+        if isinstance(tier, six.integer_types) and \
             (grid != 'LCG' or
              gConfig.getValue('/Resources/Sites/%s/%s/MoUTierLevel' % (grid, site), 999) != tier):
           continue

--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -30,7 +30,7 @@ def resolveSEGroup(seGroupList, allSEs=None):
       return []
     allSEs = res['Value']
   seList = []
-  if isinstance(seGroupList, basestring):
+  if isinstance(seGroupList, six.string_types):
     seGroupList = [se.strip() for se in seGroupList.split(',') if se.strip()]
   for se in seGroupList:
     seConfig = gConfig.getValue('/Resources/StorageElementGroups/%s' % se, se)
@@ -58,7 +58,7 @@ def resolveSEGroup(seGroupList, allSEs=None):
 
 def siteGridName(site):
   """ Returns the Grid name for a site"""
-  if not isinstance(site, basestring):
+  if not isinstance(site, six.string_types):
     return None
   siteSplit = site.split('.')
   if len(siteSplit) < 3:
@@ -68,7 +68,7 @@ def siteGridName(site):
 
 def siteCountryName(site):
   """ Returns the Grid name for a site"""
-  if not isinstance(site, basestring):
+  if not isinstance(site, six.string_types):
     return None
   siteSplit = site.split('.')
   if len(siteSplit) < 3:
@@ -83,7 +83,7 @@ def _getConnectionIndex(connectionLevel, default=None):
     connectionLevel = default
   if isinstance(connectionLevel, (int, long)):
     return connectionLevel
-  if isinstance(connectionLevel, basestring):
+  if isinstance(connectionLevel, six.string_types):
     connectionLevel = connectionLevel.upper()
   return {'LOCAL': LOCAL, 'PROTOCOL': PROTOCOL, 'DOWNLOAD': DOWNLOAD}.get(connectionLevel)
 
@@ -252,7 +252,7 @@ class DMSHelpers(object):
           'DataManagement/SEsUsedForFailover', []))
       self.failoverSEs = resolveSEGroup(seList)
     # FIXME: remove string test at some point
-    return storageElement in self.failoverSEs or (not self.failoverSEs and isinstance(storageElement, basestring) and
+    return storageElement in self.failoverSEs or (not self.failoverSEs and isinstance(storageElement, six.string_types) and
                                                   'FAILOVER' in storageElement.upper())
 
   def isSEForJobs(self, storageElement, checkSE=True):
@@ -274,7 +274,7 @@ class DMSHelpers(object):
           'DataManagement/SEsUsedForArchive', []))
       self.archiveSEs = resolveSEGroup(seList)
     # FIXME: remove string test at some point
-    return storageElement in self.archiveSEs or (not self.archiveSEs and isinstance(storageElement, basestring) and
+    return storageElement in self.archiveSEs or (not self.archiveSEs and isinstance(storageElement, six.string_types) and
                                                  'ARCHIVE' in storageElement.upper())
 
   def getSitesForSE(self, storageElement, connectionLevel=None):

--- a/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/DataManagementSystem/Utilities/DMSHelpers.py
@@ -3,6 +3,7 @@
 
 """
 
+import six
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations

--- a/DataManagementSystem/scripts/dirac-dms-catalog-metadata.py
+++ b/DataManagementSystem/scripts/dirac-dms-catalog-metadata.py
@@ -54,16 +54,16 @@ print(
 for lfn in sorted( res['Value']['Successful'].keys() ):
   metadata = res['Value']['Successful'][lfn]
   checksum = ''
-  if metadata.has_key('Checksum'):
+  if 'Checksum' in metadata:
     checksum = str(metadata['Checksum'])
   size = ''
-  if metadata.has_key('Size'):
+  if 'Size' in metadata:
     size = str(metadata['Size'])
   guid = ''
-  if metadata.has_key('GUID'):
+  if 'GUID' in metadata:
     guid = str(metadata['GUID'])
   status = ''
-  if metadata.has_key('Status'):
+  if 'Status' in metadata:
     status = str(metadata['Status'])
   print('%s %s %s %s %s' % (lfn.ljust(100), size.ljust(10), guid.ljust(40), status.ljust(8), checksum.ljust(10)))
 

--- a/DataManagementSystem/scripts/dirac-dms-directory-sync.py
+++ b/DataManagementSystem/scripts/dirac-dms-directory-sync.py
@@ -12,6 +12,7 @@ If option --sync is used contend that is not in the source directory but is
 only in the target directory will be deleted.
 """
 
+from past.builtins import long
 import os
 import DIRAC
 from DIRAC.Core.Base import Script

--- a/DataManagementSystem/scripts/dirac-dms-directory-sync.py
+++ b/DataManagementSystem/scripts/dirac-dms-directory-sync.py
@@ -291,9 +291,9 @@ def createRemoteDirectory(fc,newdir):
   """
   result = fc.createDirectory(newdir)
   if result['OK']:
-    if result['Value']['Successful'] and result['Value']['Successful'].has_key(newdir):
+    if result['Value']['Successful'] and newdir in result['Value']['Successful']:
       return S_OK("Successfully created directory:" + newdir)
-    elif result['Value']['Failed'] and result['Value']['Failed'].has_key(newdir):
+    elif result['Value']['Failed'] and newdir in result['Value']['Failed']:
       return S_ERROR('Failed to create directory: ' + result['Value']['Failed'][newdir])
   else:
     return S_ERROR('Failed to create directory:' + result['Message'])

--- a/FrameworkSystem/Client/ComponentInstaller.py
+++ b/FrameworkSystem/Client/ComponentInstaller.py
@@ -1202,7 +1202,7 @@ class ComponentInstaller(object):
         if result['OK'] and result['Value']:
           stats = result['Value'][1]
           values = re.findall(r"\d*\.\d+|\d+", stats)
-          if values > 0:
+          if values:
             runDict['CPU'] = values[1]
             runDict['MEM'] = values[2]
             runDict['VSZ'] = values[3]

--- a/FrameworkSystem/Client/MonitoringClient.py
+++ b/FrameworkSystem/Client/MonitoringClient.py
@@ -6,7 +6,8 @@
 __RCSID__ = "$Id"
 
 import time
-import types
+
+import six
 
 import DIRAC
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
@@ -79,7 +80,7 @@ class MonitoringClient(object):
   COMPONENT_WEB = "web"
   COMPONENT_SCRIPT = "script"
 
-  __validMonitoringValues = (types.IntType, types.LongType, types.FloatType)
+  __validMonitoringValues = six.integer_types + (float,)
 
   def __init__(self):
     self.sourceId = 0
@@ -236,7 +237,7 @@ class MonitoringClient(object):
     if name not in self.activitiesDefinitions:
       raise MonitoringClientActivityNotDefined("You must register activity %s before adding marks to it" % name)
       # raise Exception( "You must register activity %s before adding marks to it" % name )
-    if type(value) not in self.__validMonitoringValues:
+    if not isinstance(value, self.__validMonitoringValues):
       raise MonitoringClientActivityValueTypeError("Activity '%s' value's type (%s) is not valid" % (name, type(value)))
       # raise Exception( "Value's type %s is not valid" % value )
     self.activitiesLock.acquire()
@@ -397,7 +398,7 @@ class MonitoringClient(object):
         return False
       condVal = condDict[key]
       componentVal = component[key]
-      if type(condVal) in (types.ListType, types.TupleType):
+      if type(condVal) in (list, tuple):
         if componentVal not in condVal:
           return False
       else:

--- a/FrameworkSystem/Client/NotificationClient.py
+++ b/FrameworkSystem/Client/NotificationClient.py
@@ -4,6 +4,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import gLogger, S_ERROR
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.Core.Utilities.Mail import Mail

--- a/FrameworkSystem/Client/NotificationClient.py
+++ b/FrameworkSystem/Client/NotificationClient.py
@@ -30,7 +30,7 @@ class NotificationClient(Client):
                                                                                               body))
     result = S_ERROR()
 
-    addresses = [addresses] if isinstance(addresses, basestring) else list(addresses)
+    addresses = [addresses] if isinstance(addresses, six.string_types) else list(addresses)
     for address in addresses:
 
       if localAttempt:

--- a/FrameworkSystem/Client/ProxyGeneration.py
+++ b/FrameworkSystem/Client/ProxyGeneration.py
@@ -2,6 +2,7 @@
 # File :   ProxyGeneration.py
 # Author : Adrian Casajus
 ########################################################################
+from __future__ import division
 
 import sys
 import getpass
@@ -52,8 +53,8 @@ class CLIParams(object):
     return S_OK()
 
   def getProxyLifeTime(self):
-    hours = self.proxyLifeTime / 3600
-    mins = self.proxyLifeTime / 60 - hours * 60
+    hours = int(self.proxyLifeTime / 3600)
+    mins = int(self.proxyLifeTime / 60 - hours * 60)
     return "%s:%s" % (hours, mins)
 
   def getProxyRemainingSecs(self):
@@ -174,7 +175,7 @@ def generateProxy(params):
   retVal = testChain.loadChainFromFile(params.certLoc)
   if not retVal['OK']:
     return S_ERROR("Cannot load certificate %s: %s" % (params.certLoc, retVal['Message']))
-  timeLeft = testChain.getRemainingSecs()['Value'] / 86400
+  timeLeft = int(testChain.getRemainingSecs()['Value'] / 86400)
   if timeLeft < 30:
     gLogger.notice("\nYour certificate will expire in %d days. Please renew it!\n" % timeLeft)
 

--- a/FrameworkSystem/Client/ProxyManagerClient.py
+++ b/FrameworkSystem/Client/ProxyManagerClient.py
@@ -1,5 +1,6 @@
 """ ProxyManagementAPI has the functions to "talk" to the ProxyManagement service
 """
+from past.builtins import long
 import six
 import os
 import datetime

--- a/FrameworkSystem/Client/ProxyManagerClient.py
+++ b/FrameworkSystem/Client/ProxyManagerClient.py
@@ -175,7 +175,7 @@ class ProxyManagerClient(object):
         proxyLocation = Locations.getProxyLocation()
         if not proxyLocation:
           return S_ERROR("Can't find a valid proxy")
-      elif isinstance(proxy, basestring):
+      elif isinstance(proxy, six.string_types):
         proxyLocation = proxy
       else:
         return S_ERROR("Can't find a valid proxy")

--- a/FrameworkSystem/Client/ProxyManagerClient.py
+++ b/FrameworkSystem/Client/ProxyManagerClient.py
@@ -1,5 +1,6 @@
 """ ProxyManagementAPI has the functions to "talk" to the ProxyManagement service
 """
+import six
 import os
 import datetime
 

--- a/FrameworkSystem/Client/UserProfileClient.py
+++ b/FrameworkSystem/Client/UserProfileClient.py
@@ -24,7 +24,7 @@ class UserProfileClient(object):
       return "o"
     if isinstance(dataObj, (int, long, float)):
       return "n"
-    if isinstance(dataObj, basestring):
+    if isinstance(dataObj, six.string_types):
       return "s"
     # Not even trying here...
     if type(dataObj) in Time._allTypes:

--- a/FrameworkSystem/Client/UserProfileClient.py
+++ b/FrameworkSystem/Client/UserProfileClient.py
@@ -22,7 +22,7 @@ class UserProfileClient(object):
       return "b"
     if dataObj is None:
       return "o"
-    if isinstance(dataObj, (int, long, float)):
+    if isinstance(dataObj, six.integer_types + (float,)):
       return "n"
     if isinstance(dataObj, six.string_types):
       return "s"

--- a/FrameworkSystem/Client/UserProfileClient.py
+++ b/FrameworkSystem/Client/UserProfileClient.py
@@ -1,4 +1,5 @@
 
+import six
 import re
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.DISET.RPCClient import RPCClient

--- a/FrameworkSystem/DB/ComponentMonitoringDB.py
+++ b/FrameworkSystem/DB/ComponentMonitoringDB.py
@@ -228,7 +228,7 @@ class ComponentMonitoringDB(DB):
       val = condDict[field]
       if isinstance(val, six.string_types):
         sqlWhere.append("%s='%s'" % (field, val))
-      elif isinstance(val, (int, long, float)):
+      elif isinstance(val, six.integer_types + (float,)):
         sqlWhere.append("%s='%s'" % (field, val))
       else:
         sqlWhere.append("( %s )" % " OR ".join(["%s='%s'" % (field, v) for v in val]))

--- a/FrameworkSystem/DB/ComponentMonitoringDB.py
+++ b/FrameworkSystem/DB/ComponentMonitoringDB.py
@@ -80,7 +80,7 @@ class ComponentMonitoringDB(DB):
     return self._createTables(tablesD)
 
   def __datetime2str(self, dt):
-    if isinstance(dt, basestring):
+    if isinstance(dt, six.string_types):
       return dt
     return "%s-%s-%s %s:%s:%s" % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
 
@@ -226,7 +226,7 @@ class ComponentMonitoringDB(DB):
     sqlWhere = []
     for field in condDict:
       val = condDict[field]
-      if isinstance(val, basestring):
+      if isinstance(val, six.string_types):
         sqlWhere.append("%s='%s'" % (field, val))
       elif isinstance(val, (int, long, float)):
         sqlWhere.append("%s='%s'" % (field, val))

--- a/FrameworkSystem/DB/ComponentMonitoringDB.py
+++ b/FrameworkSystem/DB/ComponentMonitoringDB.py
@@ -1,6 +1,7 @@
 """ ComponentMonitoring class is a front-end to the Component monitoring Database
 """
 
+import six
 import random
 
 from DIRAC import gConfig, S_OK, S_ERROR

--- a/FrameworkSystem/DB/InstalledComponentsDB.py
+++ b/FrameworkSystem/DB/InstalledComponentsDB.py
@@ -2,6 +2,7 @@
 Classes and functions for easier management of the InstalledComponents database
 """
 
+import six
 import re
 import datetime
 from sqlalchemy import MetaData, Column, Integer, String, DateTime, create_engine, text

--- a/FrameworkSystem/DB/InstalledComponentsDB.py
+++ b/FrameworkSystem/DB/InstalledComponentsDB.py
@@ -437,7 +437,7 @@ class InstalledComponentsDB(object):
             toAppend = element
             if isinstance(toAppend, datetime.datetime):
               toAppend = toAppend.strftime("%Y-%m-%d %H:%M:%S")
-            if isinstance(toAppend, basestring):
+            if isinstance(toAppend, six.string_types):
               toAppend = '\'%s\'' % (toAppend)
             if i == 0:
               sql = '%s%s' % (sql, toAppend)
@@ -446,7 +446,7 @@ class InstalledComponentsDB(object):
           sql = '%s )' % (sql)
         else:
           continue
-      elif isinstance(matchFields[key], basestring):
+      elif isinstance(matchFields[key], six.string_types):
         sql = '`%s` %s \'%s\'' % (actualKey, comparison, matchFields[key])
       elif isinstance(matchFields[key], datetime.datetime):
         sql = '%s %s \'%s\'' % \

--- a/FrameworkSystem/DB/ProxyDB.py
+++ b/FrameworkSystem/DB/ProxyDB.py
@@ -6,7 +6,7 @@ __RCSID__ = "$Id$"
 import os
 import glob
 import time
-import urllib
+from six.moves.urllib.request import urlopen
 import random
 import hashlib
 import commands
@@ -678,8 +678,8 @@ class ProxyDB(DB):
               "&rfc-proxy=true&cn-label=user:%s" % (puspServiceURL, vomsVO, vomsAttribute, user)
 
     try:
-      proxy = urllib.urlopen(puspURL).read()
-    except Exception as e:
+      proxy = urlopen(puspURL).read()
+    except Exception:
       return S_ERROR('Failed to get proxy from the PUSP server')
 
     chain = X509Chain()

--- a/FrameworkSystem/DB/SystemLoggingDB.py
+++ b/FrameworkSystem/DB/SystemLoggingDB.py
@@ -7,6 +7,7 @@
     getMessages()
 """
 
+import six
 import re
 
 from DIRAC                                     import gLogger, S_OK, S_ERROR

--- a/FrameworkSystem/DB/SystemLoggingDB.py
+++ b/FrameworkSystem/DB/SystemLoggingDB.py
@@ -275,7 +275,7 @@ class SystemLoggingDB( DB ):
                        'VariableText', 'SystemName',
                        'SubSystemName', 'OwnerDN', 'OwnerGroup',
                        'ClientIPNumberString', 'SiteName']
-    elif isinstance( showFieldList, basestring ):
+    elif isinstance(showFieldList, six.string_types):
       showFieldList = [ showFieldList ]
     elif not isinstance( showFieldList, list ):
       errorString = 'The showFieldList variable should be a string or a list of strings'

--- a/FrameworkSystem/DB/UserProfileDB.py
+++ b/FrameworkSystem/DB/UserProfileDB.py
@@ -483,7 +483,7 @@ class UserProfileDB(DB):
       pass
 
   def __profilesCondGenerator(self, value, varType, initialValue=False):
-    if isinstance(value, basestring):
+    if isinstance(value, six.string_types):
       value = [value]
     ids = []
     if initialValue:

--- a/FrameworkSystem/DB/UserProfileDB.py
+++ b/FrameworkSystem/DB/UserProfileDB.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+import six
 import os
 import sys
 import hashlib

--- a/FrameworkSystem/Service/BundleDeliveryHandler.py
+++ b/FrameworkSystem/Service/BundleDeliveryHandler.py
@@ -110,7 +110,7 @@ class BundleDeliveryHandler(RequestHandler):
   def transfer_toClient(self, fileId, token, fileHelper):
     global gBundleManager
     version = ""
-    if isinstance(fileId, basestring):
+    if isinstance(fileId, six.string_types):
       if fileId in ['CAs', 'CRLs']:
         return self.__transferFile(fileId, fileHelper)
       else:

--- a/FrameworkSystem/Service/BundleDeliveryHandler.py
+++ b/FrameworkSystem/Service/BundleDeliveryHandler.py
@@ -4,6 +4,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import cStringIO
 import tarfile
 import os

--- a/FrameworkSystem/Service/MonitoringHandler.py
+++ b/FrameworkSystem/Service/MonitoringHandler.py
@@ -166,7 +166,7 @@ class MonitoringHandler(RequestHandler):
     return S_OK(gServiceInterface.getActivities(dbCondition))
 
   types_getActivitiesContents = [dict, (list, tuple),
-                                 (int, long), (int, long)]
+                                 six.integer_types, six.integer_types]
 
   def export_getActivitiesContents(self, selDict, sortList, start, limit):
     """

--- a/FrameworkSystem/Service/MonitoringHandler.py
+++ b/FrameworkSystem/Service/MonitoringHandler.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 
 from DIRAC import gLogger, gConfig, rootPath, S_OK, S_ERROR

--- a/FrameworkSystem/Service/NotificationHandler.py
+++ b/FrameworkSystem/Service/NotificationHandler.py
@@ -13,6 +13,7 @@
     subscribing to them.
 """
 
+import six
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
 
 from DIRAC.Core.DISET.RequestHandler import RequestHandler

--- a/FrameworkSystem/Service/NotificationHandler.py
+++ b/FrameworkSystem/Service/NotificationHandler.py
@@ -174,7 +174,7 @@ class NotificationHandler(RequestHandler):
     updateDefinition['author'] = credDict['username']
     return gNotDB.updateAlarm(updateDefinition)
 
-  types_getAlarmInfo = [(int, long)]
+  types_getAlarmInfo = [six.integer_types]
 
   def export_getAlarmInfo(self, alarmId):
     """ Get the extended info of an alarm

--- a/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -4,6 +4,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.Security import Properties

--- a/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -118,7 +118,7 @@ class ProxyManagerHandler(RequestHandler):
       gLogger.error("Upload request failed", "by %s:%s : %s" % (userName, userGroup, result['Message']))
     return result
 
-  types_completeDelegationUpload = [(int, long), basestring]
+  types_completeDelegationUpload = [six.integer_types, basestring]
 
   def export_completeDelegationUpload(self, requestId, pemChain):
     """ Upload result of delegation
@@ -174,7 +174,7 @@ class ProxyManagerHandler(RequestHandler):
     # Not authorized!
     return S_ERROR("You can't get proxies!")
 
-  types_getProxy = [basestring, basestring, basestring, (int, long)]
+  types_getProxy = [basestring, basestring, basestring, six.integer_types]
 
   def export_getProxy(self, userDN, userGroup, requestPem, requiredLifetime):
     """ Get a proxy for a userDN/userGroup
@@ -221,7 +221,7 @@ class ProxyManagerHandler(RequestHandler):
       return retVal
     return S_OK(retVal['Value'])
 
-  types_getVOMSProxy = [basestring, basestring, basestring, (int, long), basestring]
+  types_getVOMSProxy = [basestring, basestring, basestring, six.integer_types, basestring]
 
   def export_getVOMSProxy(self, userDN, userGroup, requestPem, requiredLifetime, vomsAttribute=None):
     """ Get a proxy for a userDN/userGroup
@@ -324,7 +324,7 @@ class ProxyManagerHandler(RequestHandler):
     self.__proxyDB.logAction("delete proxy", credDict['DN'], credDict['group'], userDN, userGroup)
     return S_OK()
 
-  types_getContents = [dict, (list, tuple), (int, long), (int, long)]
+  types_getContents = [dict, (list, tuple), six.integer_types, six.integer_types]
 
   def export_getContents(self, selDict, sortDict, start, limit):
     """ Retrieve the contents of the DB
@@ -341,7 +341,7 @@ class ProxyManagerHandler(RequestHandler):
       selDict['UserName'] = credDict['username']
     return self.__proxyDB.getProxiesContent(selDict, sortDict, start, limit)
 
-  types_getLogContents = [dict, (list, tuple), (int, long), (int, long)]
+  types_getLogContents = [dict, (list, tuple), six.integer_types, six.integer_types]
 
   def export_getLogContents(self, selDict, sortDict, start, limit):
     """ Retrieve the contents of the DB
@@ -355,7 +355,7 @@ class ProxyManagerHandler(RequestHandler):
     """
     return self.__proxyDB.getLogsContent(selDict, sortDict, start, limit)
 
-  types_generateToken = [basestring, basestring, (int, long)]
+  types_generateToken = [basestring, basestring, six.integer_types]
 
   def export_generateToken(self, requesterDN, requesterGroup, tokenUses):
     """ Generate tokens for proxy retrieval
@@ -370,7 +370,7 @@ class ProxyManagerHandler(RequestHandler):
     self.__proxyDB.logAction("generate tokens", credDict['DN'], credDict['group'], requesterDN, requesterGroup)
     return self.__proxyDB.generateToken(requesterDN, requesterGroup, numUses=tokenUses)
 
-  types_getProxyWithToken = [basestring, basestring, basestring, (int, long), basestring]
+  types_getProxyWithToken = [basestring, basestring, basestring, six.integer_types, basestring]
 
   def export_getProxyWithToken(self, userDN, userGroup, requestPem, requiredLifetime, token):
     """ Get a proxy for a userDN/userGroup
@@ -399,7 +399,7 @@ class ProxyManagerHandler(RequestHandler):
     self.__proxyDB.logAction("download proxy with token", credDict['DN'], credDict['group'], userDN, userGroup)
     return self.__getProxy(userDN, userGroup, requestPem, requiredLifetime, True)
 
-  types_getVOMSProxyWithToken = [basestring, basestring, basestring, (int, long), basestring]
+  types_getVOMSProxyWithToken = [basestring, basestring, basestring, six.integer_types, basestring]
 
   def export_getVOMSProxyWithToken(self, userDN, userGroup, requestPem, requiredLifetime, token, vomsAttribute=None):
     """ Get a proxy for a userDN/userGroup

--- a/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -4,6 +4,7 @@
 
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import six
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -452,7 +452,7 @@ class SystemAdministratorHandler(RequestHandler):
               for sname in result['Value'][ctype]:
                 for cname in result['Value'][ctype][sname]:
                   componentList.append('/'.join([sname, cname]))
-    elif isinstance(component, basestring):
+    elif isinstance(component, six.string_types):
       componentList = [component]
     else:
       componentList = component

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import socket
 import os
 import re

--- a/FrameworkSystem/private/monitoring/Activity.py
+++ b/FrameworkSystem/private/monitoring/Activity.py
@@ -1,8 +1,9 @@
 # $HeadURL$
 __RCSID__ = "$Id$"
 
-import types
 from string import Template
+import six
+
 
 class Activity:
 
@@ -114,7 +115,7 @@ class Activity:
     return self.groupLabel
 
   def getLabel(self):
-    if type( self.labelTemplate ) == types.UnicodeType:
+    if isinstance(self.labelTemplate, six.text_type):
       self.labelTemplate = self.labelTemplate.encode( "utf-8" )
     return Template( self.labelTemplate ).safe_substitute( self.templateMap )
 

--- a/FrameworkSystem/private/monitoring/MonitoringCatalog.py
+++ b/FrameworkSystem/private/monitoring/MonitoringCatalog.py
@@ -1,6 +1,7 @@
 """ interacts with sqlite3 db
 """
 
+import six
 import sqlite3
 import os
 import hashlib

--- a/FrameworkSystem/private/monitoring/MonitoringCatalog.py
+++ b/FrameworkSystem/private/monitoring/MonitoringCatalog.py
@@ -123,7 +123,7 @@ class MonitoringCatalog( object ):
       else:
         valuesList.append( dataDict[ key ] )
         keysList.append( "%s = ?" % key )
-    if isinstance( fields, basestring ):
+    if isinstance(fields, six.string_types):
       fields = [ fields ]
     if len( keysList ) > 0:
       whereCond = "WHERE %s" % ( " AND ".join( keysList ) )
@@ -336,7 +336,7 @@ class MonitoringCatalog( object ):
     """
     Get a view for a given id
     """
-    if isinstance( viewId, basestring ):
+    if isinstance(viewId, six.string_types):
       return self.__select( "definition, variableFields", "views", { "name" : viewId } )
     else:
       return self.__select( "definition, variableFields", "views", { "id" : viewId } )

--- a/FrameworkSystem/private/monitoring/ServiceInterface.py
+++ b/FrameworkSystem/private/monitoring/ServiceInterface.py
@@ -7,6 +7,7 @@
 
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 from DIRAC import S_OK, S_ERROR
 
 from DIRAC import gLogger, rootPath, gConfig

--- a/FrameworkSystem/scripts/dirac-proxy-init.py
+++ b/FrameworkSystem/scripts/dirac-proxy-init.py
@@ -3,6 +3,7 @@
 # File :    dirac-proxy-init.py
 # Author :  Adrian Casajus
 ########################################################################
+from __future__ import division
 
 import os
 import sys

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -96,7 +96,7 @@ class Dirac(API):
   def _checkFileArgument(self, fnList, prefix=None, single=False):
     if prefix is None:
       prefix = 'LFN'
-    if isinstance(fnList, basestring):
+    if isinstance(fnList, six.string_types):
       otherPrefix = 'LFN:' if prefix == 'PFN' else 'PFN:'
       if otherPrefix in fnList:
         return self._errorReport('Expected %s string, not %s') % (prefix, otherPrefix)
@@ -314,7 +314,7 @@ class Dirac(API):
     """
     self.__printInfo()
 
-    if isinstance(job, basestring):
+    if isinstance(job, six.string_types):
       if os.path.exists(job):
         self.log.verbose('Found job JDL file %s' % (job))
         with open(job, 'r') as fd:
@@ -819,7 +819,7 @@ class Dirac(API):
     sandbox = parameters.get('InputSandbox')
     if sandbox:
       self.log.verbose("Input Sandbox is %s" % sandbox)
-      if isinstance(sandbox, basestring):
+      if isinstance(sandbox, six.string_types):
         sandbox = [isFile.strip() for isFile in sandbox.split(',')]
       for isFile in sandbox:
         self.log.debug("Resolving Input Sandbox %s" % isFile)
@@ -881,7 +881,7 @@ class Dirac(API):
     variableList = parameters.get('ExecutionEnvironment')
     if variableList:
       self.log.verbose('Adding variables to execution environment')
-      if isinstance(variableList, basestring):
+      if isinstance(variableList, six.string_types):
         variableList = [variableList]
       for var in variableList:
         nameEnv = var.split('=')[0]
@@ -925,7 +925,7 @@ class Dirac(API):
       sandbox = parameters.get('OutputSandbox')
 
     if sandbox:
-      if isinstance(sandbox, basestring):
+      if isinstance(sandbox, six.string_types):
         sandbox = [osFile.strip() for osFile in sandbox.split(',')]
       for i in sandbox:
         globList = glob.glob(i)
@@ -965,7 +965,7 @@ class Dirac(API):
     """
     inputData = parameters.get('InputData')
     if inputData:
-      if isinstance(inputData, basestring):
+      if isinstance(inputData, six.string_types):
         inputData = [inputData]
     return S_OK(inputData)
 
@@ -1388,9 +1388,9 @@ class Dirac(API):
       sourceSE = ''
     if not localCache:
       localCache = ''
-    if not isinstance(sourceSE, basestring):
+    if not isinstance(sourceSE, six.string_types):
       return self._errorReport('Expected string for source SE name')
-    if not isinstance(localCache, basestring):
+    if not isinstance(localCache, six.string_types):
       return self._errorReport('Expected string for path to local cache')
 
     localFile = os.path.join(localCache, os.path.basename(lfn))
@@ -1440,7 +1440,7 @@ class Dirac(API):
     if not sourceSE:
       sourceSE = ''
 
-    if not isinstance(sourceSE, basestring):
+    if not isinstance(sourceSE, six.string_types):
       return self._errorReport('Expected string for source SE name')
 
     dm = DataManager()
@@ -1996,7 +1996,7 @@ class Dirac(API):
       return S_ERROR('No output data files found to download')
 
     if outputFiles:
-      if isinstance(outputFiles, basestring):
+      if isinstance(outputFiles, six.string_types):
         outputFiles = [os.path.basename(outputFiles)]
       elif isinstance(outputFiles, list):
         try:
@@ -2284,7 +2284,7 @@ class Dirac(API):
     """Internal function.  Writes a python object to a specified file path.
     """
     with open(fileName, 'w') as fopen:
-      if not isinstance(pObject, basestring):
+      if not isinstance(pObject, six.string_types):
         fopen.write('%s\n' % self.pPrint.pformat(pObject))
       else:
         fopen.write(pObject)
@@ -2511,7 +2511,7 @@ class Dirac(API):
        :returns: S_OK,S_ERROR
     """
 
-    if not isinstance(system, basestring) and isinstance(service, basestring) and not isinstance(url, basestring):
+    if not isinstance(system, basestring) and isinstance(service, basestring) and not isinstance(url, six.string_types):
       return self._errorReport('Expected string for system and service or a url to ping()')
     result = S_ERROR()
     try:
@@ -2582,7 +2582,7 @@ class Dirac(API):
       with open(jdl, 'r') as jdlFile:
         jdl = jdlFile.read()
 
-    if not isinstance(jdl, basestring):
+    if not isinstance(jdl, six.string_types):
       return S_ERROR("Can't read JDL")
 
     try:

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -975,7 +975,7 @@ class Dirac(API):
     """Internal callback function to return standard output when running locally.
     """
     if fd:
-      if isinstance(fd, (int, long)):
+      if isinstance(fd, six.integer_types):
         if fd == 0:
           print(message, file=sys.stdout)
         elif fd == 1:
@@ -1191,7 +1191,7 @@ class Dirac(API):
       return ret
     lfns = ret['Value']
 
-    if not isinstance(maxFilesPerJob, (int, long)):
+    if not isinstance(maxFilesPerJob, six.integer_types):
       try:
         maxFilesPerJob = int(maxFilesPerJob)
       except Exception as x:

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import six
 import re
 import os

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+import six
 import re
 import os
 import sys

--- a/Interfaces/API/DiracAdmin.py
+++ b/Interfaces/API/DiracAdmin.py
@@ -8,6 +8,7 @@ site banning and unbanning, WMS proxy uploading etc.
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+import six
 import os
 
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR

--- a/Interfaces/API/DiracAdmin.py
+++ b/Interfaces/API/DiracAdmin.py
@@ -437,7 +437,7 @@ class DiracAdmin(API):
        :return: S_OK,S_ERROR
 
     """
-    if isinstance(jobID, basestring):
+    if isinstance(jobID, six.string_types):
       try:
         jobID = int(jobID)
       except Exception as x:
@@ -514,7 +514,7 @@ class DiracAdmin(API):
        :type job: integer or string
        :return: S_OK,S_ERROR
     """
-    if not isinstance(gridReference, basestring):
+    if not isinstance(gridReference, six.string_types):
       return self._errorReport('Expected string for pilot reference')
 
     if not directory:
@@ -571,7 +571,7 @@ class DiracAdmin(API):
        :type gridReference: string
        :return: S_OK,S_ERROR
     """
-    if not isinstance(gridReference, basestring):
+    if not isinstance(gridReference, six.string_types):
       return self._errorReport('Expected string for pilot reference')
 
     result = PilotManagerClient().getPilotInfo(gridReference)
@@ -587,7 +587,7 @@ class DiracAdmin(API):
        :param gridReference: Pilot Job Reference
        :return: S_OK,S_ERROR
     """
-    if not isinstance(gridReference, basestring):
+    if not isinstance(gridReference, six.string_types):
       return self._errorReport('Expected string for pilot reference')
 
     result = PilotManagerClient().killPilot(gridReference)
@@ -604,7 +604,7 @@ class DiracAdmin(API):
        :type gridReference: string
        :return: S_OK,S_ERROR
     """
-    if not isinstance(gridReference, basestring):
+    if not isinstance(gridReference, six.string_types):
       return self._errorReport('Expected string for pilot reference')
 
     return PilotManagerClient().getPilotLoggingInfo(gridReference)
@@ -622,7 +622,7 @@ class DiracAdmin(API):
        :return: S_OK,S_ERROR
 
     """
-    if isinstance(jobID, basestring):
+    if isinstance(jobID, six.string_types):
       try:
         jobID = int(jobID)
       except Exception as x:

--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -1159,7 +1159,7 @@ class Job(API):
             classadJob.insertAttributeVectorInt(name, value)
         elif isinstance(value, six.string_types) and value:
           classadJob.insertAttributeInt(name, value)
-        elif isinstance(value, (int, long, float)):
+        elif isinstance(value, six.integer_types + (float,)):
           classadJob.insertAttributeInt(name, value)
 
     if self.numberOfParameters > 0:

--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -137,8 +137,8 @@ class Job(API):
        :type parameters: python:list of tuples
     """
     kwargs = {'executable': executable, 'arguments': arguments, 'logFile': logFile}
-    if not isinstance(executable, basestring) or not isinstance(arguments, basestring) or \
-       not isinstance(logFile, basestring):
+    if not isinstance(executable, basestring) or not isinstance(arguments, six.string_types) or \
+       not isinstance(logFile, six.string_types):
       return self._reportError('Expected strings for executable and arguments', **kwargs)
 
     if os.path.exists(executable):
@@ -153,7 +153,7 @@ class Job(API):
     stepName = 'RunScriptStep%s' % (self.stepCount)
 
     if logFile:
-      if isinstance(logFile, basestring):
+      if isinstance(logFile, six.string_types):
         logName = str(logFile)
     else:
       logName = "Script%s_%s" % (self.stepCount, logName)
@@ -202,7 +202,7 @@ class Job(API):
        :type jobName: string
     """
     kwargs = {'jobname': jobName}
-    if not isinstance(jobName, basestring):
+    if not isinstance(jobName, six.string_types):
       return self._reportError('Expected strings for job name', **kwargs)
     else:
       self.workflow.setName(jobName)
@@ -239,7 +239,7 @@ class Job(API):
       description = 'Input sandbox file list'
       self._addParameter(self.workflow, 'InputSandbox', 'JDL', fileList, description)
       # self.sandboxFiles=resolvedFiles
-    elif isinstance(files, basestring):
+    elif isinstance(files, six.string_types):
       resolvedFiles = self._resolveInputSandbox([files])
       fileList = ';'.join(resolvedFiles)
       description = 'Input sandbox file'
@@ -273,7 +273,7 @@ class Job(API):
       fileList = ';'.join(files)
       description = 'Output sandbox file list'
       self._addParameter(self.workflow, 'OutputSandbox', 'JDL', fileList, description)
-    elif isinstance(files, basestring):
+    elif isinstance(files, six.string_types):
       description = 'Output sandbox file'
       self._addParameter(self.workflow, 'OutputSandbox', 'JDL', files, description)
     else:
@@ -304,7 +304,7 @@ class Job(API):
       inputDataStr = ';'.join(inputData)
       description = 'List of input data specified by LFNs'
       self._addParameter(self.workflow, 'InputData', 'JDL', inputDataStr, description)
-    elif isinstance(lfns, basestring):  # single LFN
+    elif isinstance(lfns, six.string_types):  # single LFN
       description = 'Input data specified by LFN'
       self._addParameter(self.workflow, 'InputData', 'JDL', lfns, description)
     else:
@@ -334,7 +334,7 @@ class Job(API):
 
     self.parameterSeqs[name] = parameterList
     if addToWorkflow:
-      if isinstance(addToWorkflow, basestring):
+      if isinstance(addToWorkflow, six.string_types):
         self.wfArguments[name] = addToWorkflow
       else:
         self.wfArguments[name] = name
@@ -425,7 +425,7 @@ class Job(API):
       description = 'List of output data files'
       self._addParameter(self.workflow, 'OutputData',
                          'JDL', outputDataStr, description)
-    elif isinstance(lfns, basestring):
+    elif isinstance(lfns, six.string_types):
       description = 'Output data file'
       self._addParameter(self.workflow, 'OutputData', 'JDL', lfns, description)
     else:
@@ -433,7 +433,7 @@ class Job(API):
 
     if outputSE:
       description = 'User specified Output SE'
-      if isinstance(outputSE, basestring):
+      if isinstance(outputSE, six.string_types):
         outputSE = [outputSE]
       elif not isinstance(outputSE, list):
         return self._reportError('Expected string or list for OutputSE', **kwargs)
@@ -443,7 +443,7 @@ class Job(API):
 
     if outputPath:
       description = 'User specified Output Path'
-      if not isinstance(outputPath, basestring):
+      if not isinstance(outputPath, six.string_types):
         return self._reportError('Expected string for OutputPath', **kwargs)
       # Remove leading "/" that might cause problems with os.path.join
       # This will prevent to set OutputPath outside the Home of the User
@@ -462,7 +462,7 @@ class Job(API):
     """
     kwargs = {'platform': platform}
 
-    if not isinstance(platform, basestring):
+    if not isinstance(platform, six.string_types):
       return self._reportError("Expected string for platform", **kwargs)
 
     if not platform.lower() == 'any':
@@ -486,7 +486,7 @@ class Job(API):
     """
     # should add protection here for list of supported platforms
     kwargs = {'backend': backend}
-    if not isinstance(backend, basestring):
+    if not isinstance(backend, six.string_types):
       return self._reportError('Expected string for SubmitPool', **kwargs)
 
     if not backend.lower() == 'any':
@@ -536,7 +536,7 @@ class Job(API):
        :type destination: str or python:list
     """
     kwargs = {'destination': destination}
-    if isinstance(destination, basestring):
+    if isinstance(destination, six.string_types):
       destination = destination.replace(' ', '').split(',')
       description = 'User specified destination site'
     else:
@@ -630,7 +630,7 @@ class Job(API):
       bannedSites = ';'.join(sites)
       description = 'List of sites excluded by user'
       self._addParameter(self.workflow, 'BannedSites', 'JDL', bannedSites, description)
-    elif isinstance(sites, basestring):
+    elif isinstance(sites, six.string_types):
       description = 'Site excluded by user'
       self._addParameter(self.workflow, 'BannedSites', 'JDL', sites, description)
     else:
@@ -644,7 +644,7 @@ class Job(API):
 
        Normally users should always specify their immutable DIRAC nickname.
     """
-    if not isinstance(ownerProvided, basestring):
+    if not isinstance(ownerProvided, six.string_types):
       return self._reportError('Expected string for owner', **{'ownerProvided': ownerProvided})
 
     self._addParameter(self.workflow, 'Owner', 'JDL', ownerProvided, 'User specified ID')
@@ -656,7 +656,7 @@ class Job(API):
 
        Allows to force expected owner group of proxy.
     """
-    if not isinstance(ownerGroup, basestring):
+    if not isinstance(ownerGroup, six.string_types):
       return self._reportError('Expected string for job owner group', **{'ownerGroup': ownerGroup})
 
     self._addParameter(self.workflow, 'OwnerGroup', 'JDL', ownerGroup, 'User specified owner group.')
@@ -668,7 +668,7 @@ class Job(API):
 
        Allows to force expected owner DN of proxy.
     """
-    if not isinstance(ownerDN, basestring):
+    if not isinstance(ownerDN, six.string_types):
       return self._reportError('Expected string for job owner DN', **{'ownerGroup': ownerDN})
 
     self._addParameter(self.workflow, 'OwnerDN', 'JDL', ownerDN, 'User specified owner DN.')
@@ -680,7 +680,7 @@ class Job(API):
 
        Specify job type for testing purposes.
     """
-    if not isinstance(jobType, basestring):
+    if not isinstance(jobType, six.string_types):
       return self._reportError('Expected string for job type', **{'jobType': jobType})
 
     self._addParameter(self.workflow, 'JobType', 'JDL', jobType, 'User specified type')
@@ -700,7 +700,7 @@ class Job(API):
         :type tags: str or python:list
     """
 
-    if isinstance(tags, basestring):
+    if isinstance(tags, six.string_types):
       tagValue = tags
     elif isinstance(tags, list):
       tagValue = ";".join(tags)
@@ -724,7 +724,7 @@ class Job(API):
        :param jobGroup: JobGroup name
        :type jobGroup: string
     """
-    if not isinstance(jobGroup, basestring):
+    if not isinstance(jobGroup, six.string_types):
       return self._reportError('Expected string for job group name', **{'jobGroup': jobGroup})
 
     description = 'User specified job group'
@@ -748,7 +748,7 @@ class Job(API):
        :type logLevel: string
     """
     kwargs = {'logLevel': logLevel}
-    if isinstance(logLevel, basestring):
+    if isinstance(logLevel, six.string_types):
       if logLevel.upper() in gLogger.getAllPossibleLevels():
         description = 'User specified logging level'
         self.logLevel = logLevel
@@ -764,7 +764,7 @@ class Job(API):
     """Developer function. Allow to pass arbitrary settings to the payload
        configuration service environment.
     """
-    if not isinstance(cfgString, basestring):
+    if not isinstance(cfgString, six.string_types):
       return self._reportError('Expected string for DIRAC Job Config Args', **{'cfgString': cfgString})
 
     description = 'User specified cfg settings'
@@ -968,7 +968,7 @@ class Job(API):
         if pName == "InputSandbox":
           if isinstance(paramsDict[pName]['value'], list):
             paramsDict[pName]['value'].append('%%(%s)s' % pName)
-          elif isinstance(paramsDict[pName]['value'], basestring):
+          elif isinstance(paramsDict[pName]['value'], six.string_types):
             if paramsDict[pName]['value']:
               paramsDict[pName]['value'] += ';%%(%s)s' % pName
             else:
@@ -1146,7 +1146,7 @@ class Job(API):
     for name, props in paramsDict.iteritems():
       ptype = props['type']
       value = props['value']
-      if isinstance(value, basestring) and re.search(';', value):
+      if isinstance(value, six.string_types) and re.search(';', value):
         value = value.split(';')
       if name.lower() == 'requirements' and ptype == 'JDL':
         self.log.verbose('Found existing requirements: %s' % (value))
@@ -1157,7 +1157,7 @@ class Job(API):
             classadJob.insertAttributeVectorStringList(name, value)
           else:
             classadJob.insertAttributeVectorInt(name, value)
-        elif isinstance(value, basestring) and value:
+        elif isinstance(value, six.string_types) and value:
           classadJob.insertAttributeInt(name, value)
         elif isinstance(value, (int, long, float)):
           classadJob.insertAttributeInt(name, value)

--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -25,6 +25,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import re
 import os
 import urllib

--- a/MonitoringSystem/Service/MonitoringHandler.py
+++ b/MonitoringSystem/Service/MonitoringHandler.py
@@ -3,6 +3,7 @@
 It is used to create plots using Elasticsearch
 
 """
+from past.builtins import long
 import datetime
 import os
 

--- a/ProductionSystem/DB/ProductionDB.py
+++ b/ProductionSystem/DB/ProductionDB.py
@@ -5,6 +5,7 @@
 """
 
 # # imports
+from past.builtins import long
 import six
 import json
 import threading

--- a/ProductionSystem/DB/ProductionDB.py
+++ b/ProductionSystem/DB/ProductionDB.py
@@ -173,7 +173,7 @@ class ProductionDB(DB):
     :param str prodName: the Production name or ID
     :param str parameters: any valid production parameter in self.PRODPARAMS
     """
-    if isinstance(parameters, basestring):
+    if isinstance(parameters, six.string_types):
       parameters = [parameters]
     res = self.getProduction(prodName, connection=connection)
     if not res['OK']:
@@ -568,7 +568,7 @@ class ProductionDB(DB):
       prodName = long(prodName)
       cmd = "SELECT ProductionID from Productions WHERE ProductionID=%d;" % prodName
     except BaseException:
-      if not isinstance(prodName, basestring):
+      if not isinstance(prodName, six.string_types):
         return S_ERROR("Production should be ID or name")
       cmd = "SELECT ProductionID from Productions WHERE ProductionName='%s';" % prodName
     res = self._query(cmd, connection)

--- a/ProductionSystem/DB/ProductionDB.py
+++ b/ProductionSystem/DB/ProductionDB.py
@@ -140,7 +140,7 @@ class ProductionDB(DB):
     resultList = []
     for row in res['Value']:
       # Prepare the structure for the web
-      rList = [str(item) if not isinstance(item, (long, int)) else item for item in row]
+      rList = [str(item) if not isinstance(item, six.integer_types) else item for item in row]
       prodDict = dict(zip(self.PRODPARAMS, row))
       webList.append(rList)
       resultList.append(prodDict)
@@ -273,7 +273,7 @@ class ProductionDB(DB):
     resultList = []
     for row in res['Value']:
       # Prepare the structure for the web
-      rList = [str(item) if not isinstance(item, (long, int)) else item for item in row]
+      rList = [str(item) if not isinstance(item, six.integer_types) else item for item in row]
       transDict = dict(zip(self.TRANSPARAMS, row))
       webList.append(rList)
       resultList.append(transDict)

--- a/ProductionSystem/DB/ProductionDB.py
+++ b/ProductionSystem/DB/ProductionDB.py
@@ -5,6 +5,7 @@
 """
 
 # # imports
+import six
 import json
 import threading
 

--- a/RequestManagementSystem/Client/File.py
+++ b/RequestManagementSystem/Client/File.py
@@ -19,7 +19,7 @@ __RCSID__ = "$Id$"
 import datetime
 import os
 import json
-from types import StringTypes
+import six
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.File import checkGuid
@@ -73,14 +73,14 @@ class File(object):
     self.initialLoading = True
 
     fromDict = fromDict if isinstance(fromDict, dict)\
-        else json.loads(fromDict) if isinstance(fromDict, StringTypes)\
+        else json.loads(fromDict) if isinstance(fromDict, six.string_types)\
         else {}
 
     for attrName, attrValue in fromDict.iteritems():
       # The JSON module forces the use of UTF-8, which is not properly
       # taken into account in DIRAC.
-      # One would need to replace all the '== str' with 'in StringTypes'
-      if type(attrValue) in StringTypes:
+      # One would need to replace all the '== str' with 'in six.string_types'
+      if isinstance(attrValue, six.string_types):
         attrValue = attrValue.encode()
       if attrValue:
         setattr(self, attrName, attrValue)
@@ -95,7 +95,7 @@ class File(object):
   @LFN.setter
   def LFN(self, value):
     """ lfn setter """
-    if type(value) not in StringTypes:
+    if not isinstance(value, six.string_types):
       raise TypeError("LFN has to be a string!")
     if not os.path.isabs(value):
       raise ValueError("LFN should be an absolute path!")
@@ -110,7 +110,7 @@ class File(object):
   def GUID(self, value):
     """ GUID setter """
     if value:
-      if type(value) not in StringTypes:
+      if not isinstance(value, six.string_types):
         raise TypeError("GUID should be a string!")
       if not checkGuid(value):
         raise ValueError("'%s' is not a valid GUID!" % str(value))

--- a/RequestManagementSystem/Client/Operation.py
+++ b/RequestManagementSystem/Client/Operation.py
@@ -16,8 +16,8 @@ Operation implementation
 __RCSID__ = "$Id$"
 
 import datetime
-from types import StringTypes
 import json
+import six
 # # from DIRAC
 from DIRAC import S_OK, S_ERROR
 from DIRAC.RequestManagementSystem.Client.File import File
@@ -89,7 +89,7 @@ class Operation( object ):
 
 
     fromDict = fromDict if isinstance( fromDict, dict )\
-               else json.loads( fromDict ) if isinstance( fromDict, StringTypes )\
+               else json.loads(fromDict) if isinstance(fromDict, six.string_types)\
                else {}
 
 
@@ -102,8 +102,8 @@ class Operation( object ):
     for key, value in fromDict.items():
       # The JSON module forces the use of UTF-8, which is not properly
       # taken into account in DIRAC.
-      # One would need to replace all the '== str' with 'in StringTypes'
-      if type( value ) in StringTypes:
+      # One would need to replace all the '== str' with 'in six.string_types'
+      if isinstance(value, six.string_types):
         value = value.encode()
       if value:
         setattr( self, key, value )
@@ -284,9 +284,9 @@ class Operation( object ):
   @CreationTime.setter
   def CreationTime( self, value = None ):
     """ creation time setter """
-    if type( value ) not in ( [datetime.datetime] + list( StringTypes ) ):
+    if not isinstance(value, (datetime.datetime,) + six.string_types):
       raise TypeError( "CreationTime should be a datetime.datetime!" )
-    if type( value ) in StringTypes:
+    if isinstance(value, six.string_types):
       value = datetime.datetime.strptime( value.split( "." )[0], self._datetimeFormat )
     self._CreationTime = value
 
@@ -298,9 +298,9 @@ class Operation( object ):
   @SubmitTime.setter
   def SubmitTime( self, value = None ):
     """ submit time setter """
-    if type( value ) not in ( [datetime.datetime] + list( StringTypes ) ):
+    if not isinstance(value, (datetime.datetime,) + six.string_types):
       raise TypeError( "SubmitTime should be a datetime.datetime!" )
-    if type( value ) in StringTypes:
+    if isinstance(value, six.string_types):
       value = datetime.datetime.strptime( value.split( "." )[0], self._datetimeFormat )
     self._SubmitTime = value
 
@@ -312,9 +312,9 @@ class Operation( object ):
   @LastUpdate.setter
   def LastUpdate( self, value = None ):
     """ last update setter """
-    if type( value ) not in ( [datetime.datetime] + list( StringTypes ) ):
+    if not isinstance(value, (datetime.datetime,) + six.string_types):
       raise TypeError( "LastUpdate should be a datetime.datetime!" )
-    if type( value ) in StringTypes:
+    if isinstance(value, six.string_types):
       value = datetime.datetime.strptime( value.split( "." )[0], self._datetimeFormat )
     self._LastUpdate = value
     if self._parent:

--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -6,6 +6,7 @@
 
 """
 
+import six
 import os
 import time
 import random

--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -234,7 +234,7 @@ class ReqClient(Client):
     :param self: self reference
     :param int requestID: id of the request
     """
-    if isinstance(requestID, basestring):
+    if isinstance(requestID, six.string_types):
       requestID = int(requestID)
     self.log.debug("getRequestStatus: attempting to get status for '%d' request." % requestID)
     requestStatus = self._getRPC().getRequestStatus(requestID)
@@ -435,7 +435,7 @@ def prettyPrint(mainItem, key='', offset=0):
     for item in mainItem:
       prettyPrint(item, offset=offset + 2)
     output += "%s%s\n" % (blanks, ']' if isinstance(mainItem, list) else ')')
-  elif isinstance(mainItem, basestring):
+  elif isinstance(mainItem, six.string_types):
     if '\n' in mainItem:
       prettyPrint(mainItem.strip('\n').split('\n'), offset=offset)
     else:

--- a/RequestManagementSystem/Client/Request.py
+++ b/RequestManagementSystem/Client/Request.py
@@ -17,17 +17,14 @@ __RCSID__ = "$Id$"
 
 # # imports
 import datetime
-from types import StringTypes
 import json
+import six
 # # from DIRAC
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.RequestManagementSystem.Client.Operation import Operation
 from DIRAC.RequestManagementSystem.private.JSONUtils import RMSEncoder
 from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
-
-from types import NoneType
-
 
 
 ########################################################################
@@ -95,7 +92,7 @@ class Request( object ):
     self.__operations__ = []
 
     fromDict = fromDict if isinstance( fromDict, dict )\
-               else json.loads( fromDict ) if isinstance( fromDict, StringTypes )\
+               else json.loads(fromDict) if isinstance(fromDict, six.string_types)\
                 else {}
 
 
@@ -108,8 +105,8 @@ class Request( object ):
     for key, value in fromDict.items():
       # The JSON module forces the use of UTF-8, which is not properly
       # taken into account in DIRAC.
-      # One would need to replace all the '== str' with 'in StringTypes'
-      if type( value ) in StringTypes:
+      # One would need to replace all the '== str' with 'in six.string_types'
+      if isinstance(value, six.string_types):
         value = value.encode()
 
       if value:
@@ -288,9 +285,9 @@ class Request( object ):
   @CreationTime.setter
   def CreationTime( self, value = None ):
     """ creation time setter """
-    if type( value ) not in ( [datetime.datetime] + list( StringTypes ) ) :
+    if not isinstance(value, (datetime.datetime,) + six.string_types):
       raise TypeError( "CreationTime should be a datetime.datetime!" )
-    if type( value ) in StringTypes:
+    if isinstance(value, six.string_types):
       value = datetime.datetime.strptime( value.split( "." )[0], self._datetimeFormat )
     self._CreationTime = value
 
@@ -302,9 +299,9 @@ class Request( object ):
   @SubmitTime.setter
   def SubmitTime( self, value = None ):
     """ submission time setter """
-    if type( value ) not in ( [datetime.datetime] + list( StringTypes ) ):
+    if not isinstance(value, (datetime.datetime,) + six.string_types):
       raise TypeError( "SubmitTime should be a datetime.datetime!" )
-    if type( value ) in StringTypes:
+    if isinstance(value, six.string_types):
       value = datetime.datetime.strptime( value.split( "." )[0], self._datetimeFormat )
     self._SubmitTime = value
 
@@ -318,9 +315,9 @@ class Request( object ):
   @NotBefore.setter
   def NotBefore( self, value = None ):
     """ Setter for the NotBefore time """
-    if type( value ) not in ( [NoneType] + [datetime.datetime] + list( StringTypes ) ):
+    if not isinstance(value, (type(None), datetime.datetime) + six.string_types):
       raise TypeError( "NotBefore should be a datetime.datetime!" )
-    if type( value ) in StringTypes:
+    if isinstance(value, six.string_types):
       value = datetime.datetime.strptime( value.split( "." )[0], self._datetimeFormat )
     self._NotBefore = value
 
@@ -346,9 +343,9 @@ class Request( object ):
   @LastUpdate.setter
   def LastUpdate( self, value = None ):
     """ last update setter """
-    if type( value ) not in ( [datetime.datetime] + list( StringTypes ) ):
+    if not isinstance(value, (datetime.datetime,) + six.string_types):
       raise TypeError( "LastUpdate should be a datetime.datetime!" )
-    if type( value ) in StringTypes:
+    if isinstance(value, six.string_types):
       value = datetime.datetime.strptime( value.split( "." )[0], self._datetimeFormat )
     self._LastUpdate = value
 

--- a/RequestManagementSystem/Client/test/Test_Request.py
+++ b/RequestManagementSystem/Client/test/Test_Request.py
@@ -25,6 +25,7 @@ __RCSID__ = "$Id$"
 # @brief Definition of RequestTests class.
 
 # # imports
+import six
 import unittest
 import datetime
 # # from DIRAC

--- a/RequestManagementSystem/Client/test/Test_Request.py
+++ b/RequestManagementSystem/Client/test/Test_Request.py
@@ -38,7 +38,7 @@ from DIRAC.RequestManagementSystem.Client.ReqClient import printRequest
 def optimizeRequest(req, printOutput=None):
   from DIRAC import gLogger
   if printOutput:
-    if isinstance(printOutput, basestring):
+    if isinstance(printOutput, six.string_types):
       gLogger.always('Request %s:' % printOutput)
     printRequest(req)
     gLogger.always('=========== Optimized ===============')

--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -16,6 +16,7 @@
 
     db holding Request, Operation and File
 """
+import six
 import random
 
 import datetime

--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -741,7 +741,7 @@ class RequestDB( object ):
     self.log.debug( "getRequestIDsForJobs: got %s jobIDs to check" % str( jobIDs ) )
     if not jobIDs:
       return S_ERROR( "Must provide jobID list as argument." )
-    if isinstance( jobIDs, ( long, int ) ):
+    if isinstance( jobIDs, six.integer_types ):
       jobIDs = [ jobIDs ]
     jobIDs = set( jobIDs )
 
@@ -776,7 +776,7 @@ class RequestDB( object ):
     self.log.debug( "readRequestForJobs: got %s jobIDs to check" % str( jobIDs ) )
     if not jobIDs:
       return S_ERROR( "Must provide jobID list as argument." )
-    if isinstance( jobIDs, ( long, int ) ):
+    if isinstance( jobIDs, six.integer_types ):
       jobIDs = [ jobIDs ]
     jobIDs = set( jobIDs )
 

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -63,7 +63,7 @@ class ReqManagerHandler(RequestHandler):
   @classmethod
   def export_getRequestIDForName(cls, requestName):
     """ get requestID for given :requestName: """
-    if isinstance(requestName, basestring):
+    if isinstance(requestName, six.string_types):
       result = cls.__requestDB.getRequestIDForName(requestName)
       if not result["OK"]:
         return result
@@ -343,7 +343,7 @@ class ReqManagerHandler(RequestHandler):
   @classmethod
   def export_getRequestFileStatus(cls, requestID, lfnList):
     """ get request file status for a given LFNs list and requestID """
-    if isinstance(lfnList, basestring):
+    if isinstance(lfnList, six.string_types):
       lfnList = [lfnList]
     res = cls.__requestDB.getRequestFileStatus(requestID, lfnList)
     if not res["OK"]:

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -10,6 +10,7 @@
 """
 __RCSID__ = "$Id$"
 # # imports
+from past.builtins import long
 import six
 import json
 import datetime

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -10,6 +10,7 @@
 """
 __RCSID__ = "$Id$"
 # # imports
+import six
 import json
 import datetime
 import math

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -70,7 +70,7 @@ class ReqManagerHandler(RequestHandler):
       requestID = result["Value"]
     return S_OK(requestID)
 
-  types_cancelRequest = [(int, long)]
+  types_cancelRequest = [six.integer_types]
 
   @classmethod
   def export_cancelRequest(cls, requestID):
@@ -143,7 +143,7 @@ class ReqManagerHandler(RequestHandler):
     gLogger.info("putRequest: Attempting to set request '%s'" % requestName)
     return self.__requestDB.putRequest(request)
 
-  types_getScheduledRequest = [(int, long)]
+  types_getScheduledRequest = [six.integer_types]
 
   @classmethod
   def export_getScheduledRequest(cls, operationID):
@@ -166,7 +166,7 @@ class ReqManagerHandler(RequestHandler):
     """ Get the summary of requests in the Request DB """
     return cls.__requestDB.getDBSummary()
 
-  types_getRequest = [(long, int)]
+  types_getRequest = [six.integer_types]
 
   @classmethod
   def export_getRequest(cls, requestID=0):
@@ -211,7 +211,7 @@ class ReqManagerHandler(RequestHandler):
       return S_OK(toJSONDict)
     return S_OK()
 
-  types_peekRequest = [(long, int)]
+  types_peekRequest = [six.integer_types]
 
   @classmethod
   def export_peekRequest(cls, requestID=0):
@@ -269,7 +269,7 @@ class ReqManagerHandler(RequestHandler):
 
     return cls.__requestDB.getRequestCountersWeb(groupingAttribute, selectDict)
 
-  types_deleteRequest = [(int, long)]
+  types_deleteRequest = [six.integer_types]
 
   @classmethod
   def export_deleteRequest(cls, requestID):
@@ -317,7 +317,7 @@ class ReqManagerHandler(RequestHandler):
       requests["Value"]["Successful"][jobID] = request.toJSON()["Value"]
     return requests
 
-  types_getDigest = [(int, long)]
+  types_getDigest = [six.integer_types]
 
   @classmethod
   def export_getDigest(cls, requestID):
@@ -328,7 +328,7 @@ class ReqManagerHandler(RequestHandler):
     """
     return cls.__requestDB.getDigest(requestID)
 
-  types_getRequestStatus = [(int, long)]
+  types_getRequestStatus = [six.integer_types]
 
   @classmethod
   def export_getRequestStatus(cls, requestID):

--- a/ResourceStatusSystem/Client/SiteStatus.py
+++ b/ResourceStatusSystem/Client/SiteStatus.py
@@ -110,7 +110,7 @@ class SiteStatus(object):
       siteStatusDict = {}
       wmsAdmin = WMSAdministratorClient()
       if siteNames:
-        if isinstance(siteNames, basestring):
+        if isinstance(siteNames, six.string_types):
           siteNames = [siteNames]
         for siteName in siteNames:
           result = wmsAdmin.getSiteMaskStatus(siteName)

--- a/ResourceStatusSystem/Client/SiteStatus.py
+++ b/ResourceStatusSystem/Client/SiteStatus.py
@@ -6,6 +6,7 @@
 
 __RCSID__ = '$Id$'
 
+import six
 import errno
 import math
 from time import sleep

--- a/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -558,7 +558,7 @@ class ResourceManagementDB(object):
         column_a = getattr(table_c, newer[0].lower())
         select = select.filter(column_a > newer[1])
       if order:
-        order = [order] if isinstance(order, basestring) else list(order)
+        order = [order] if isinstance(order, six.string_types) else list(order)
         column_a = getattr(table_c, order[0].lower())
         if len(order) == 2 and order[1].lower() == 'desc':
           select = select.order_by(desc(column_a))
@@ -637,7 +637,7 @@ class ResourceManagementDB(object):
         column_a = getattr(table_c, newer[0].lower())
         deleteQuery = deleteQuery.filter(column_a > newer[1])
       if order:
-        order = [order] if isinstance(order, basestring) else list(order)
+        order = [order] if isinstance(order, six.string_types) else list(order)
         column_a = getattr(table_c, order[0].lower())
         if len(order) == 2 and order[1].lower() == 'desc':
           deleteQuery = deleteQuery.order_by(desc(column_a))
@@ -697,7 +697,7 @@ class ResourceManagementDB(object):
         column_a = getattr(table_c, columnName.lower())
         if isinstance(columnValue, (list, tuple)):
           select = select.filter(column_a.in_(list(columnValue)))
-        elif isinstance(columnValue, basestring):
+        elif isinstance(columnValue, six.string_types):
           select = select.filter(column_a == columnValue)
         else:
           self.log.error("type(columnValue) == %s" % type(columnValue))

--- a/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -18,6 +18,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import datetime
 from sqlalchemy import desc
 from sqlalchemy.orm import sessionmaker, class_mapper

--- a/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -438,7 +438,7 @@ class ResourceStatusDB(object):
         column_a = getattr(table_c, newer[0].lower())
         select = select.filter(column_a > newer[1])
       if order:
-        order = [order] if isinstance(order, basestring) else list(order)
+        order = [order] if isinstance(order, six.string_types) else list(order)
         column_a = getattr(table_c, order[0].lower())
         if len(order) == 2 and order[1].lower() == 'desc':
           select = select.order_by(desc(column_a))
@@ -516,7 +516,7 @@ class ResourceStatusDB(object):
         column_a = getattr(table_c, newer[0].lower())
         deleteQuery = deleteQuery.filter(column_a > newer[1])
       if order:
-        order = [order] if isinstance(order, basestring) else list(order)
+        order = [order] if isinstance(order, six.string_types) else list(order)
         column_a = getattr(table_c, order[0].lower())
         if len(order) == 2 and order[1].lower() == 'desc':
           deleteQuery = deleteQuery.order_by(desc(column_a))
@@ -573,7 +573,7 @@ class ResourceStatusDB(object):
         column_a = getattr(table_c, columnName.lower())
         if isinstance(columnValue, (list, tuple)):
           select = select.filter(column_a.in_(list(columnValue)))
-        elif isinstance(columnValue, basestring):
+        elif isinstance(columnValue, six.string_types):
           select = select.filter(column_a == columnValue)
         else:
           self.log.error("type(columnValue) == %s" % type(columnValue))
@@ -643,7 +643,7 @@ class ResourceStatusDB(object):
         column_a = getattr(table_c, columnName.lower())
         if isinstance(columnValue, (list, tuple)):
           select = select.filter(column_a.in_(list(columnValue)))
-        elif isinstance(columnValue, basestring):
+        elif isinstance(columnValue, six.string_types):
           select = select.filter(column_a == columnValue)
         else:
           self.log.error("type(columnValue) == %s" % type(columnValue))

--- a/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -19,6 +19,7 @@
 __RCSID__ = "$Id$"
 
 
+import six
 import datetime
 
 from sqlalchemy import desc

--- a/ResourceStatusSystem/PolicySystem/Actions/EmailAction.py
+++ b/ResourceStatusSystem/PolicySystem/Actions/EmailAction.py
@@ -76,7 +76,7 @@ class EmailAction(BaseAction):
       elif not siteName['Value']:
         siteName = "Unassigned Resources"
       else:
-        siteName = siteName['Value'] if isinstance(siteName['Value'], basestring) else siteName['Value'][0]
+        siteName = siteName['Value'] if isinstance(siteName['Value'], six.string_types) else siteName['Value'][0]
 
     with sqlite3.connect(self.cacheFile) as conn:
 

--- a/ResourceStatusSystem/PolicySystem/Actions/EmailAction.py
+++ b/ResourceStatusSystem/PolicySystem/Actions/EmailAction.py
@@ -7,6 +7,7 @@
 
 __RCSID__ = '$Id$'
 
+import six
 import os
 import sqlite3
 from DIRAC import S_ERROR, S_OK

--- a/ResourceStatusSystem/Service/PublisherHandler.py
+++ b/ResourceStatusSystem/Service/PublisherHandler.py
@@ -88,7 +88,7 @@ class PublisherHandler(RequestHandler):
         return siteNames
       siteNames = siteNames['Value']
 
-    if isinstance(siteNames, basestring):
+    if isinstance(siteNames, six.string_types):
       siteNames = [siteNames]
 
     sitesRes = {}

--- a/ResourceStatusSystem/Service/PublisherHandler.py
+++ b/ResourceStatusSystem/Service/PublisherHandler.py
@@ -9,6 +9,7 @@ __RCSID__ = '$Id$'
 
 #  pylint: disable=no-self-use
 
+import six
 import types
 from datetime import datetime, timedelta
 

--- a/ResourceStatusSystem/Utilities/RSSCacheNoThread.py
+++ b/ResourceStatusSystem/Utilities/RSSCacheNoThread.py
@@ -320,7 +320,7 @@ class RSSCache(Cache):
 
     cacheKeys = validCache.keys()
 
-    if isinstance(elementNames, basestring):
+    if isinstance(elementNames, six.string_types):
       elementNames = [elementNames]
     elif elementNames is None:
       if isinstance(cacheKeys[0], (tuple, list)):
@@ -330,7 +330,7 @@ class RSSCache(Cache):
     # Remove duplicates, makes Cartesian product faster
     elementNamesSet = set(elementNames)
 
-    if isinstance(elementType, basestring):
+    if isinstance(elementType, six.string_types):
       if not elementType or elementType == 'Site':
         elementType = []
       else:
@@ -340,7 +340,7 @@ class RSSCache(Cache):
     # Remove duplicates, makes Cartesian product faster
     elementTypeSet = set(elementType)
 
-    if isinstance(statusTypes, basestring):
+    if isinstance(statusTypes, six.string_types):
       if not statusTypes:
         statusTypes = []
       else:

--- a/ResourceStatusSystem/Utilities/RSSCacheNoThread.py
+++ b/ResourceStatusSystem/Utilities/RSSCacheNoThread.py
@@ -10,6 +10,7 @@ After that, the cache is empty.
 
 __RCSID__ = '$Id$'
 
+import six
 import itertools
 import random
 

--- a/Resources/Catalog/FileCatalog.py
+++ b/Resources/Catalog/FileCatalog.py
@@ -77,7 +77,7 @@ class FileCatalog( object ):
     self.opHelper = Operations( vo = self.vo )
 
     catalogList = []
-    if isinstance( catalogs, basestring ):
+    if isinstance(catalogs, six.string_types):
       catalogList = [catalogs]
     elif isinstance( catalogs, ( list, tuple ) ):
       catalogList = list( catalogs )

--- a/Resources/Catalog/FileCatalog.py
+++ b/Resources/Catalog/FileCatalog.py
@@ -44,6 +44,7 @@
 
 """
 
+import six
 import re
 
 from DIRAC                                               import gLogger, gConfig, S_OK, S_ERROR

--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -304,7 +304,7 @@ class LcgFileCatalogClient( FileCatalogClientBase ):
         failed[lfn] = res['Message']
       elif res['Value']:
         successful[lfn] = lfn
-      elif not isinstance( guid, basestring ):
+      elif not isinstance(guid, six.string_types):
         successful[lfn] = False
       else:
         res = existsGuid( guid )

--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id"
 
+from past.builtins import long
 import six
 from stat import *
 import os

--- a/Resources/Catalog/LcgFileCatalogClient.py
+++ b/Resources/Catalog/LcgFileCatalogClient.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id"
 
+import six
 from stat import *
 import os
 import re

--- a/Resources/Catalog/PoolXMLCatalog.py
+++ b/Resources/Catalog/PoolXMLCatalog.py
@@ -6,7 +6,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
-import os, xml.dom.minidom, types
+import os, xml.dom.minidom
 from DIRAC import S_OK, S_ERROR
 
 class PoolFile( object ):
@@ -154,7 +154,7 @@ class PoolXMLCatalog( object ):
 
     # Get the dom representation of the catalog
     if xmlfile:
-      if type( xmlfile ) == list:
+      if isinstance(xmlfile, list):
         for xmlf in xmlfile:
           try:
             _sfile = file( xmlf, 'r' )
@@ -343,9 +343,9 @@ class PoolXMLCatalog( object ):
     """ Add one or more files to the catalog
     """
 
-    if type( fileTuple ) == types.TupleType:
+    if isinstance(fileTuple, tuple):
       files = [fileTuple]
-    elif type( fileTuple ) == types.ListType:
+    elif isinstance(fileTuple, list):
       files = fileTuple
     else:
       return S_ERROR( 'PoolXMLCatalog.addFile: Must supply a file tuple of list of tuples' )
@@ -376,9 +376,9 @@ class PoolXMLCatalog( object ):
 
         where master = True or False
     """
-    if type( replicaTuple ) == types.TupleType:
+    if isinstance(replicaTuple, tuple):
       replicas = [replicaTuple]
-    elif type( replicaTuple ) == types.ListType:
+    elif isinstance(replicaTuple, list):
       replicas = replicaTuple
     else:
       return S_ERROR( 'PoolXMLCatalog.addReplica: Must supply a replica tuple of list of tuples' )

--- a/Resources/Catalog/PoolXMLCatalog.py
+++ b/Resources/Catalog/PoolXMLCatalog.py
@@ -336,7 +336,7 @@ class PoolXMLCatalog( object ):
     for guid, pfile in self.files.items():
       for l in pfile.lfns:
         if lfn == l:
-          if self.files.has_key( guid ):
+          if guid in self.files:
             del self.files[guid]
 
   def addFile( self, fileTuple ):

--- a/Resources/Catalog/Utilities.py
+++ b/Resources/Catalog/Utilities.py
@@ -7,6 +7,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import errno
 import functools

--- a/Resources/Catalog/Utilities.py
+++ b/Resources/Catalog/Utilities.py
@@ -20,7 +20,7 @@ def checkArgumentFormat( path, generateMap = False ):
 
   def checkArgumentDict( path ):
     """ Check and process format of the arguments to FileCatalog methods """
-    if isinstance( path, basestring ):
+    if isinstance(path, six.string_types):
       urls = {path:True}
     elif isinstance( path, list ):
       urls = {}

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -10,6 +10,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import stat
 

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -286,7 +286,7 @@ class ARCComputingElement(ComputingElement):
     self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
 
     jobList = list(jobIDList)
-    if isinstance(jobIDList, basestring):
+    if isinstance(jobIDList, six.string_types):
       jobList = [jobIDList]
 
     gLogger.debug("Killing jobs %s" % jobIDList)
@@ -363,7 +363,7 @@ class ARCComputingElement(ComputingElement):
     self.usercfg.ProxyPath(os.environ['X509_USER_PROXY'])
 
     jobTmpList = list(jobIDList)
-    if isinstance(jobIDList, basestring):
+    if isinstance(jobIDList, six.string_types):
       jobTmpList = [jobIDList]
 
     # Pilots are stored with a DIRAC stamp (":::XXXXX") appended

--- a/Resources/Computing/CREAMComputingElement.py
+++ b/Resources/Computing/CREAMComputingElement.py
@@ -169,7 +169,7 @@ class CREAMComputingElement(ComputingElement):
     """ Kill the specified jobs
     """
     jobList = list(jobIDList)
-    if isinstance(jobIDList, basestring):
+    if isinstance(jobIDList, six.string_types):
       jobList = [jobIDList]
 
     cmd = ['glite-ce-job-cancel', '-n', '-N'] + jobList

--- a/Resources/Computing/CREAMComputingElement.py
+++ b/Resources/Computing/CREAMComputingElement.py
@@ -8,6 +8,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import re
 import tempfile

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -435,7 +435,7 @@ class ComputingElement(object):
           ceDict[option] = int(value)
         except ValueError:
           ceDict[option] = value
-      elif isinstance(value, (int, long, float)):
+      elif isinstance(value, six.integer_types + (float,)):
         ceDict[option] = value
       else:
         self.log.warn('Type of option %s = %s not determined' % (option, value))

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -27,6 +27,7 @@
 """
 
 from __future__ import print_function
+import six
 import os
 import multiprocessing
 

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -430,7 +430,7 @@ class ComputingElement(object):
     for option, value in self.ceParameters.iteritems():
       if isinstance(value, list):
         ceDict[option] = value
-      elif isinstance(value, basestring):
+      elif isinstance(value, six.string_types):
         try:
           ceDict[option] = int(value)
         except ValueError:

--- a/Resources/Computing/GlobusComputingElement.py
+++ b/Resources/Computing/GlobusComputingElement.py
@@ -95,7 +95,7 @@ class GlobusComputingElement(ComputingElement):
     """ Kill the specified jobs
     """
     jobList = list(jobIDList)
-    if isinstance(jobIDList, basestring):
+    if isinstance(jobIDList, six.string_types):
       jobList = [jobIDList]
     for jobID in jobList:
       cmd = ['globus-job-clean', '-f', jobID]

--- a/Resources/Computing/GlobusComputingElement.py
+++ b/Resources/Computing/GlobusComputingElement.py
@@ -14,6 +14,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 
 from DIRAC import S_OK, S_ERROR

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -175,7 +175,7 @@ Queue %(nJobs)s
     self.daysToKeepLogs = self.ceParameters.get('DaysToKeepLogs', DEFAULT_DAYSTOKEEPLOGS)
     self.extraSubmitString = self.ceParameters.get('ExtraSubmitString', '').decode('string_escape')
     self.useLocalSchedd = self.ceParameters.get('UseLocalSchedd', self.useLocalSchedd)
-    if isinstance(self.useLocalSchedd, basestring):
+    if isinstance(self.useLocalSchedd, six.string_types):
       if self.useLocalSchedd == "False":
         self.useLocalSchedd = False
 
@@ -233,7 +233,7 @@ Queue %(nJobs)s
   def killJob(self, jobIDList):
     """ Kill the specified jobs
     """
-    if isinstance(jobIDList, basestring):
+    if isinstance(jobIDList, six.string_types):
       jobIDList = [jobIDList]
 
     self.log.verbose("KillJob jobIDList: %s" % jobIDList)
@@ -282,7 +282,7 @@ Queue %(nJobs)s
     self.__cleanup()
 
     self.log.verbose("Job ID List for status: %s " % jobIDList)
-    if isinstance(jobIDList, basestring):
+    if isinstance(jobIDList, six.string_types):
       jobIDList = [jobIDList]
 
     resultDict = {}

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -23,6 +23,7 @@
 # created documentation, there should only be one slash when setting the option,
 # but "\n" gets rendered as a linebreak in sphinx
 
+import six
 import os
 import tempfile
 import commands

--- a/Resources/Computing/SSHBatchComputingElement.py
+++ b/Resources/Computing/SSHBatchComputingElement.py
@@ -10,6 +10,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import socket
 import stat

--- a/Resources/Computing/SSHBatchComputingElement.py
+++ b/Resources/Computing/SSHBatchComputingElement.py
@@ -151,7 +151,7 @@ class SSHBatchComputingElement(SSHComputingElement):
     """ Kill specified jobs
     """
     jobIDList = list(jobIDs)
-    if isinstance(jobIDs, basestring):
+    if isinstance(jobIDs, six.string_types):
       jobIDList = [jobIDs]
 
     hostDict = {}

--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -460,7 +460,7 @@ class SSHComputingElement(ComputingElement):
       try:
         output = urllib.unquote(output)
         result = json.loads(output)
-        if isinstance(result, basestring) and result.startswith('Exception:'):
+        if isinstance(result, six.string_types) and result.startswith('Exception:'):
           return S_ERROR(result)
         return S_OK(result)
       except BaseException:
@@ -543,7 +543,7 @@ class SSHComputingElement(ComputingElement):
   def killJob(self, jobIDList):
     """ Kill a bunch of jobs
     """
-    if isinstance(jobIDList, basestring):
+    if isinstance(jobIDList, six.string_types):
       jobIDList = [jobIDList]
     return self._killJobOnHost(jobIDList)
 

--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -8,6 +8,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import urllib
 import json

--- a/Resources/ProxyProvider/DIRACCAProxyProvider.py
+++ b/Resources/ProxyProvider/DIRACCAProxyProvider.py
@@ -2,6 +2,7 @@
     CA credentials
 """
 
+from past.builtins import long
 import os
 import re
 import time

--- a/Resources/ProxyProvider/PUSPProxyProvider.py
+++ b/Resources/ProxyProvider/PUSPProxyProvider.py
@@ -2,7 +2,7 @@
     proxy server
 """
 
-import urllib
+from six.moves.urllib.request import urlopen
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-error
@@ -63,8 +63,8 @@ class PUSPProxyProvider(ProxyProvider):
               "&rfc-proxy=true&cn-label=user:%s" % (puspServiceURL, vomsVO, vomsAttribute, user)
 
     try:
-      proxy = urllib.urlopen(puspURL).read()
-    except Exception as e:
+      proxy = urlopen(puspURL).read()
+    except Exception:
       return S_ERROR('Failed to get proxy from the PUSP server')
 
     chain = X509Chain()

--- a/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/Resources/Storage/GFAL2_SRM2Storage.py
@@ -9,6 +9,7 @@
 
 # pylint: disable=invalid-name
 
+import six
 import errno
 import json
 

--- a/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/Resources/Storage/GFAL2_SRM2Storage.py
@@ -113,7 +113,7 @@ class GFAL2_SRM2Storage(GFAL2_StorageBase):
       if not listProtocols:
         return S_ERROR(
             "GFAL2_SRM2Storage.getTransportURL: No local protocols defined and no defaults found.")
-    elif isinstance(protocols, basestring):
+    elif isinstance(protocols, six.string_types):
       listProtocols = [protocols]
     elif isinstance(protocols, list):
       listProtocols = protocols

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -10,6 +10,7 @@
 # pylint: disable=arguments-differ
 
 # # imports
+import six
 import os
 import datetime
 import errno

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -806,7 +806,7 @@ class GFAL2_StorageBase(StorageBase):
     log = self.log.getSubLogger("GFAL2_StorageBase.__prestageSingleFileStatus")
     log.debug("Checking prestage file status for %s" % path)
     # also allow int as token - converting them to strings
-    if not isinstance(token, basestring):
+    if not isinstance(token, six.string_types):
       token = str(token)
 
     try:
@@ -934,7 +934,7 @@ class GFAL2_StorageBase(StorageBase):
     """
     log = self.log.getSubLogger("GFAL2_StorageBase.__releaseSingleFile")
     log.debug("Attempting to release single file: %s" % path)
-    if not isinstance(token, basestring):
+    if not isinstance(token, six.string_types):
       token = str(token)
     try:
       self.ctx.set_opt_boolean("BDII", "ENABLE", True)

--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -10,6 +10,7 @@
 # pylint: disable=arguments-differ
 
 # # imports
+from past.builtins import long
 import six
 import os
 import datetime

--- a/Resources/Storage/RFIOStorage.py
+++ b/Resources/Storage/RFIOStorage.py
@@ -3,10 +3,11 @@
 
 __RCSID__ = "$Id$"
 
-import types
 import re
 import os
 import time
+
+import six
 
 from DIRAC                                      import gLogger, S_OK, S_ERROR
 from DIRAC.Resources.Storage.Utilities          import checkArgumentFormat
@@ -994,11 +995,11 @@ class RFIOStorage( StorageBase ):
   def __checkArgumentFormat( self, path ):
     """  FIXME: Can be replaced by a generic checkArgumentFormat Utility 
     """
-    if type( path ) in types.StringTypes:
+    if isinstance(path, six.string_types):
       urls = [path]
-    elif type( path ) == types.ListType:
+    elif isinstance(path, list):
       urls = path
-    elif type( path ) == types.DictType:
+    elif isinstance(path, dict):
       urls = path.keys()
     else:
       return S_ERROR( "RFIOStorage.__checkArgumentFormat: Supplied path is not of the correct format." )

--- a/Resources/Storage/RFIOStorage.py
+++ b/Resources/Storage/RFIOStorage.py
@@ -183,7 +183,7 @@ class RFIOStorage( StorageBase ):
         if status in ['STAGED', 'CANBEMIGR']:
           successful[pfn]['Cached'] = True
     for pfn in urls:
-      if not successful[pfn].has_key( 'Cached' ):
+      if 'Cached' not in successful[pfn]:
         successful[pfn]['Cached'] = False
 
     # Now for the files that exist get the tape segment (i.e. whether they have been migrated) and related checksum
@@ -203,7 +203,7 @@ class RFIOStorage( StorageBase ):
         successful[pfn]['Migrated'] = True
         successful[pfn]['Checksum'] = checksum
     for pfn in urls:
-      if not successful[pfn].has_key( 'Migrated' ):
+      if 'Migrated' not in successful[pfn]:
         successful[pfn]['Migrated'] = False
         
         
@@ -517,7 +517,7 @@ class RFIOStorage( StorageBase ):
     failed = {}
     requestFiles = {}
     for url, requestID in urls.items():
-      if not requestFiles.has_key( requestID ):
+      if requestID not in requestFiles:
         requestFiles[requestID] = []
       requestFiles[requestID].append( url )
     for requestID, urls in requestFiles.items():
@@ -658,7 +658,7 @@ class RFIOStorage( StorageBase ):
       errStr = "RFIOStorage.__getDir: Failed to find the supplied source directory."
       gLogger.error( errStr, srcDirectory )
       return S_ERROR( errStr )
-    if not res['Value']['Successful'].has_key( srcDirectory ):
+    if srcDirectory not in res['Value']['Successful']:
       errStr = "RFIOStorage.__getDir: Failed to find the supplied source directory."
       gLogger.error( errStr, srcDirectory )
       return S_ERROR( errStr )
@@ -676,7 +676,7 @@ class RFIOStorage( StorageBase ):
     if not res['OK']:
       errStr = "RFIOStorage.__getDir: Failed to list the source directory."
       gLogger.error( errStr, srcDirectory )
-    if not res['Value']['Successful'].has_key( srcDirectory ):
+    if srcDirectory not in res['Value']['Successful']:
       errStr = "RFIOStorage.__getDir: Failed to list the source directory."
       gLogger.error( errStr, srcDirectory )
 
@@ -693,7 +693,7 @@ class RFIOStorage( StorageBase ):
       fileDict = {surl:localPath}
       res = self.getFile( fileDict )
       if res['OK']:
-        if res['Value']['Successful'].has_key( surl ):
+        if surl in res['Value']['Successful']:
           filesGot += 1
           sizeGot += fileSize
           surlGot = True
@@ -788,7 +788,7 @@ class RFIOStorage( StorageBase ):
         fileDict = {remotePath:localPath}
         res = self.putFile( fileDict )
         if res['OK']:
-          if res['Value']['Successful'].has_key( remotePath ):
+          if remotePath in res['Value']['Successful']:
             filesPut += 1
             sizePut += res['Value']['Successful'][remotePath]
             pathSuccessful = True
@@ -836,13 +836,13 @@ class RFIOStorage( StorageBase ):
     if not res['OK']:
       return res
     if res['OK']:
-      if res['Value']['Successful'].has_key( path ):
+      if path in res['Value']['Successful']:
         if res['Value']['Successful'][path]:
           return S_OK()
         else:
           res = self.exists( pDir )
           if res['OK']:
-            if res['Value']['Successful'].has_key( pDir ):
+            if pDir in res['Value']['Successful']:
               if res['Value']['Successful'][pDir]:
                 res = self.__makeDir( path )
               else:

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -3,6 +3,7 @@
 
 # # custom duty
 
+import six
 import copy
 import datetime
 import errno

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -935,7 +935,7 @@ class StorageElementItem(object):
       protocols = self.turlProtocols
     elif isinstance(protocol, list):
       protocols = protocol
-    elif isinstance(protocol, basestring):
+    elif isinstance(protocol, six.string_types):
       protocols = [protocol]
 
     self.methodName = "getTransportURL"
@@ -1032,7 +1032,7 @@ class StorageElementItem(object):
         "Filtering plugins for %s (protocol = %s ; inputProtocol = %s)" %
         (methodName, protocols, inputProtocol))
 
-    if isinstance(protocols, basestring):
+    if isinstance(protocols, six.string_types):
       protocols = [protocols]
 
     pluginsToUse = []

--- a/Resources/Storage/StorageFactory.py
+++ b/Resources/Storage/StorageFactory.py
@@ -90,7 +90,7 @@ class StorageFactory(object):
     self.storages = []
     if pluginList is None:
       pluginList = []
-    elif isinstance(pluginList, basestring):
+    elif isinstance(pluginList, six.string_types):
       pluginList = [pluginList]
     if not self.vo:
       gLogger.warn('No VO information available')

--- a/Resources/Storage/StorageFactory.py
+++ b/Resources/Storage/StorageFactory.py
@@ -14,6 +14,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR
 from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath

--- a/Resources/Storage/Utilities.py
+++ b/Resources/Storage/Utilities.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import errno
 
 from DIRAC import S_OK, S_ERROR

--- a/Resources/Storage/Utilities.py
+++ b/Resources/Storage/Utilities.py
@@ -11,10 +11,10 @@ def checkArgumentFormat( path ):
   """ returns {'/this/is/an/lfn.1':False, '/this/is/an/lfn.2':False ...}
   """
 
-  if isinstance( path, basestring ):
+  if isinstance(path, six.string_types):
     return S_OK( {path:False} )
   elif isinstance( path, list ):
-    return S_OK( dict( [( url, False ) for url in path if isinstance( url, basestring )] ) )
+    return S_OK( dict( [( url, False ) for url in path if isinstance(url, six.string_types)] ) )
   elif isinstance( path, dict ):
     returnDict = path.copy()
     return S_OK( returnDict )

--- a/Resources/Storage/test/FIXME_Test_RFIOPlugIn.py
+++ b/Resources/Storage/test/FIXME_Test_RFIOPlugIn.py
@@ -73,7 +73,7 @@ class StoragePlugInTestCase( unittest.TestCase ):
     res = self.storage.createDirectory( destDir )
     print(res)
     self.assertTrue(res['OK'])
-    self.assertTrue( res['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( destDir in res['Value']['Successful'] )
     self.assertTrue( res['Value']['Successful'][destDir] )
 
 class DirectoryTestCase( StoragePlugInTestCase ):
@@ -90,11 +90,11 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Check the is directory operation
     self.assertTrue( isDirRes['OK'] )
-    self.assertTrue( isDirRes['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( destDir in isDirRes['Value']['Successful'] )
     self.assertTrue( isDirRes['Value']['Successful'][destDir] )
     # Check the non existant directory operation
     self.assertTrue( nonExistantDirRes['OK'] )
-    self.assertTrue( nonExistantDirRes['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( destDir in nonExistantDirRes['Value']['Successful'] )
     self.assertFalse( nonExistantDirRes['Value']['Successful'][destDir] )
 
   def test_putRemoveDirectory( self ):
@@ -130,13 +130,13 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the remove dir operation
     self.assertTrue( removeDirRes['OK'] )
-    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in removeDirRes['Value']['Successful'] )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -177,19 +177,19 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the get metadata operation
     self.assertTrue( getMetadataRes['OK'] )
-    self.assertTrue( getMetadataRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in getMetadataRes['Value']['Successful'] )
     resDict = getMetadataRes['Value']['Successful'][remoteDir]
-    self.assertTrue( resDict.has_key( 'Mode' ) )
+    self.assertTrue( 'Mode' in resDict )
     self.assertEqual( resDict['Mode'], 493 )
     # Perform the checks for the remove directory operation
     self.assertTrue( removeDirRes['OK'] )
-    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in removeDirRes['Value']['Successful'] )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -230,19 +230,19 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     #Now perform the checks for the get directory size operation
     self.assertTrue( getDirSizeRes['OK'] )
-    self.assertTrue( getDirSizeRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in getDirSizeRes['Value']['Successful'] )
     resDict = getDirSizeRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     self.assertEqual( resDict['Files'], numberOfFiles )
     # Perform the checks for the remove directory operation
     self.assertTrue( removeDirRes['OK'] )
-    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in removeDirRes['Value']['Successful'] )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -283,20 +283,20 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the list dir operation
     self.assertTrue( listDirRes['OK'] )
-    self.assertTrue( listDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in listDirRes['Value']['Successful'] )
     resDict = listDirRes['Value']['Successful'][remoteDir]
-    self.assertTrue( resDict.has_key( 'SubDirs' ) )
-    self.assertTrue( resDict.has_key( 'Files' ) )
+    self.assertTrue( 'SubDirs' in resDict )
+    self.assertTrue( 'Files' in resDict )
     self.assertEqual( len( resDict['Files'].keys() ), numberOfFiles )
     # Perform the checks for the remove directory operation
     self.assertTrue( removeDirRes['OK'] )
-    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in removeDirRes['Value']['Successful'] )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -344,19 +344,19 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     resDict = putDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the get dir operation
     self.assertTrue( getDirRes['OK'] )
-    self.assertTrue( getDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in getDirRes['Value']['Successful'] )
     resDict = getDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
     # Perform the checks for the remove directory operation
     self.assertTrue( removeDirRes['OK'] )
-    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in removeDirRes['Value']['Successful'] )
     resDict = removeDirRes['Value']['Successful'][remoteDir]
     self.assertEqual( resDict['Files'], numberOfFiles )
     self.assertEqual( resDict['Size'], numberOfFiles * sizeOfLocalFile )
@@ -382,15 +382,15 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the failed put file operation
     self.assertTrue( failedPutFileRes['OK'] )
-    self.assertTrue( failedPutFileRes['Value']['Failed'].has_key( destFile ) )
+    self.assertTrue( destFile in failedPutFileRes['Value']['Failed'] )
     expectedError = 'RFIOStorage.putFile: Source and destination file sizes do not match.'
     self.assertEqual( failedPutFileRes['Value']['Failed'][destFile], expectedError )
     # Check the successful put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in putFileRes['Value']['Successful'] )
     # Check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in removeFileRes['Value']['Successful'] )
 
   """
   def test_putGetFile(self):
@@ -451,17 +451,17 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in putFileRes['Value']['Successful'] )
     # Check the exists operation
     self.assertTrue( existsFileRes['OK'] )
-    self.assertTrue( existsFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in existsFileRes['Value']['Successful'] )
     self.assertTrue( existsFileRes['Value']['Successful'][destFile] )
     # Check the removal operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in removeFileRes['Value']['Successful'] )
     # Check the failed exists operation
     self.assertTrue( failedExistRes['OK'] )
-    self.assertTrue( failedExistRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in failedExistRes['Value']['Successful'] )
     self.assertFalse( failedExistRes['Value']['Successful'][destFile] )
 
   def test_putIsFile( self ):
@@ -484,17 +484,17 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in putFileRes['Value']['Successful'] )
     # Check the is file operation
     self.assertTrue( isFileRes['OK'] )
-    self.assertTrue( isFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in isFileRes['Value']['Successful'] )
     self.assertTrue( isFileRes['Value']['Successful'][destFile] )
     # check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in removeFileRes['Value']['Successful'] )
     # Check that the directory is not a file
     self.assertTrue( failedIsFileRes['OK'] )
-    self.assertTrue( failedIsFileRes['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( destDir in failedIsFileRes['Value']['Successful'] )
     self.assertFalse( failedIsFileRes['Value']['Successful'][destDir] )
 
   def test_putGetFileMetaData( self ):
@@ -519,25 +519,25 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in putFileRes['Value']['Successful'] )
     # Check the get metadata operation
     self.assertTrue( getMetadataRes['OK'] )
-    self.assertTrue( getMetadataRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in getMetadataRes['Value']['Successful'] )
     fileMetaData = getMetadataRes['Value']['Successful'][destFile]
     #self.assertTrue(fileMetaData['Cached'])
     #self.assertFalse(fileMetaData['Migrated'])
     self.assertEqual( fileMetaData['Size'], fileSize )
     # check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in removeFileRes['Value']['Successful'] )
     # Check the get metadata for non existant file
     self.assertTrue( failedMetadataRes['OK'] )
-    self.assertTrue( failedMetadataRes['Value']['Failed'].has_key( destFile ) )
+    self.assertTrue( destFile in failedMetadataRes['Value']['Failed'] )
     expectedError = "No such file or directory"
     self.assertEqual( failedMetadataRes['Value']['Failed'][destFile], expectedError )
     # Check that metadata operation with a directory
     self.assertTrue( directoryMetadataRes['OK'] )
-    self.assertTrue( directoryMetadataRes['Value']['Failed'].has_key( destDir ) )
+    self.assertTrue( destDir in directoryMetadataRes['Value']['Failed'] )
     expectedError = "RFIOStorage.getFileMetadata: Supplied path is not a file."
     self.assertEqual( directoryMetadataRes['Value']['Failed'][destDir], expectedError )
 
@@ -563,22 +563,22 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in putFileRes['Value']['Successful'] )
     # Check that we got the file size correctly
     self.assertTrue( getSizeRes['OK'] )
-    self.assertTrue( getSizeRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in getSizeRes['Value']['Successful'] )
     self.assertEqual( getSizeRes['Value']['Successful'][destFile], fileSize )
     # check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in removeFileRes['Value']['Successful'] )
     # Check the get size with non existant file works properly
     self.assertTrue( failedSizeRes['OK'] )
-    self.assertTrue( failedSizeRes['Value']['Failed'].has_key( destFile ) )
+    self.assertTrue( destFile in failedSizeRes['Value']['Failed'] )
     expectedError = "No such file or directory"
     self.assertEqual( failedSizeRes['Value']['Failed'][destFile], expectedError )
     # Check that the passing a directory is handled correctly
     self.assertTrue( directorySizeRes['OK'] )
-    self.assertTrue( directorySizeRes['Value']['Failed'].has_key( destDir ) )
+    self.assertTrue( destDir in directorySizeRes['Value']['Failed'] )
     expectedError = "RFIOStorage.getFileSize: Supplied path is not a file."
     self.assertEqual( directorySizeRes['Value']['Failed'][destDir], expectedError )
 
@@ -600,14 +600,14 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in putFileRes['Value']['Successful'] )
     # Check the prestage file operation
     self.assertTrue( prestageRes['OK'] )
-    self.assertTrue( prestageRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in prestageRes['Value']['Successful'] )
     self.assertTrue( prestageRes['Value']['Successful'][destFile] )
     # Check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in removeFileRes['Value']['Successful'] )
 
     # These checks are currently disabled until a bug is fixed
     # Check what happens with deleted files
@@ -641,17 +641,17 @@ class FileTestCase( StoragePlugInTestCase ):
     # Check the put file operation
     print(putFileRes)
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in putFileRes['Value']['Successful'] )
     # check the get turl operation
     print(getTurlRes, destFile)
     self.assertTrue( getTurlRes['OK'] )
-    self.assertTrue( getTurlRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in getTurlRes['Value']['Successful'] )
     # check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in removeFileRes['Value']['Successful'] )
     #Check the get turl with non existant file operation
     self.assertTrue( failedGetTurlRes['OK'] )
-    self.assertTrue( failedGetTurlRes['Value']['Failed'].has_key( destFile ) )
+    self.assertTrue( destFile in failedGetTurlRes['Value']['Failed'] )
     expectedError = "RFIOStorage.getTransportURL: File does not exist."
     self.assertEqual( failedGetTurlRes['Value']['Failed'][destFile], expectedError )
 

--- a/Resources/Storage/test/FIXME_Test_StorageElement.py
+++ b/Resources/Storage/test/FIXME_Test_StorageElement.py
@@ -511,8 +511,8 @@ class DirectoryTestCases( StorageElementTestCase ):
     # Perform the checks for the list dir operation
     self.assertTrue( listDirRes['OK'] )
     self.assertTrue( listDirRes['Value'] )
-    self.assertTrue( listDirRes['Value']['Successful'][destDirectory].has_key( 'SubDirs' ) )
-    self.assertTrue( listDirRes['Value']['Successful'][destDirectory].has_key( 'Files' ) )
+    self.assertTrue( 'SubDirs' in listDirRes['Value']['Successful'][destDirectory] )
+    self.assertTrue( 'Files' in listDirRes['Value']['Successful'][destDirectory] )
     self.assertEqual( len( listDirRes['Value']['Successful'][destDirectory]['Files'].keys() ), self.numberOfFiles )
     # Perform the checks for the remove directory operation
     self.assertTrue( removeDirRes['OK'] )

--- a/Resources/Storage/test/FIXME_Test_StoragePlugIn.py
+++ b/Resources/Storage/test/FIXME_Test_StoragePlugIn.py
@@ -40,7 +40,7 @@ class StoragePlugInTestCase( unittest.TestCase ):
     destDir = self.storage.getCurrentURL( '' )['Value']
     res = self.storage.createDirectory( destDir )
     self.assertTrue(res['OK'])
-    self.assertTrue( res['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( destDir in res['Value']['Successful'] )
     self.assertTrue( res['Value']['Successful'][destDir] )
     self.numberOfFiles = 1
 
@@ -77,7 +77,7 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
@@ -85,7 +85,7 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     # Perform the checks for the remove dir operation
     self.assertTrue( removeDirRes['OK'] )
-    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in removeDirRes['Value']['Successful'] )
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
@@ -104,11 +104,11 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Check the is directory operation
     self.assertTrue( isDirRes['OK'] )
-    self.assertTrue( isDirRes['Value']['Successful'].has_key( destDir ) )
+    self.assertTrue( destDir in isDirRes['Value']['Successful'] )
     self.assertTrue( isDirRes['Value']['Successful'][destDir] )
     # Check the non existant directory operation
     self.assertTrue( nonExistantDirRes['OK'] )
-    self.assertTrue( nonExistantDirRes['Value']['Failed'].has_key( dummyDir ) )
+    self.assertTrue( dummyDir in nonExistantDirRes['Value']['Failed'] )
     expectedError = 'Path does not exist'
     self.assertTrue( expectedError in nonExistantDirRes['Value']['Failed'][dummyDir] )
 
@@ -142,7 +142,7 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
@@ -150,9 +150,9 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     # Perform the checks for the get metadata operation
     self.assertTrue( getMetadataRes['OK'] )
-    self.assertTrue( getMetadataRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in getMetadataRes['Value']['Successful'] )
     resDict = getMetadataRes['Value']['Successful'][remoteDir]
-    self.assertTrue( resDict.has_key( 'Mode' ) )
+    self.assertTrue( 'Mode' in resDict )
     self.assertTrue( type( resDict['Mode'] ) == IntType )
     # Perform the checks for the remove directory operation
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
@@ -189,7 +189,7 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
@@ -197,13 +197,13 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     #Now perform the checks for the get directory size operation
     self.assertTrue( getDirSizeRes['OK'] )
-    self.assertTrue( getDirSizeRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in getDirSizeRes['Value']['Successful'] )
     resDict = getDirSizeRes['Value']['Successful'][remoteDir]
     self.assertTrue( type( resDict['Size'] ) in [LongType, IntType] )
     self.assertTrue( type( resDict['Files'] ) == IntType )
     # Perform the checks for the remove directory operation
     self.assertTrue( removeDirRes['OK'] )
-    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in removeDirRes['Value']['Successful'] )
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
@@ -238,7 +238,7 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
@@ -246,14 +246,14 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     # Perform the checks for the list dir operation
     self.assertTrue( listDirRes['OK'] )
-    self.assertTrue( listDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in listDirRes['Value']['Successful'] )
     resDict = listDirRes['Value']['Successful'][remoteDir]
-    self.assertTrue( resDict.has_key( 'SubDirs' ) )
-    self.assertTrue( resDict.has_key( 'Files' ) )
+    self.assertTrue( 'SubDirs' in resDict )
+    self.assertTrue( 'Files' in resDict )
     self.assertEqual( len( resDict['Files'].keys() ), self.numberOfFiles )
     # Perform the checks for the remove directory operation
     self.assertTrue( removeDirRes['OK'] )
-    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in removeDirRes['Value']['Successful'] )
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
@@ -290,7 +290,7 @@ class DirectoryTestCase( StoragePlugInTestCase ):
 
     # Perform the checks for the put dir operation
     self.assertTrue( putDirRes['OK'] )
-    self.assertTrue( putDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in putDirRes['Value']['Successful'] )
     if putDirRes['Value']['Successful'][remoteDir]['Files']:
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Files'], self.numberOfFiles )
       self.assertEqual( putDirRes['Value']['Successful'][remoteDir]['Size'], self.numberOfFiles * sizeOfLocalFile )
@@ -298,7 +298,7 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     self.assertTrue( type( putDirRes['Value']['Successful'][remoteDir]['Size'] ) in [LongType, IntType] )
     # Perform the checks for the get dir operation
     self.assertTrue( getDirRes['OK'] )
-    self.assertTrue( getDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in getDirRes['Value']['Successful'] )
     resDict = getDirRes['Value']['Successful'][remoteDir]
     if resDict['Files']:
       self.assertEqual( resDict['Files'], self.numberOfFiles )
@@ -307,7 +307,7 @@ class DirectoryTestCase( StoragePlugInTestCase ):
     self.assertTrue( type( resDict['Size'] ) in [LongType, IntType] )
     # Perform the checks for the remove directory operation
     self.assertTrue( removeDirRes['OK'] )
-    self.assertTrue( removeDirRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in removeDirRes['Value']['Successful'] )
     if removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved']:
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['FilesRemoved'], self.numberOfFiles )
       self.assertEqual( removeDirRes['Value']['Successful'][remoteDir]['SizeRemoved'], self.numberOfFiles * sizeOfLocalFile )
@@ -332,11 +332,11 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the successful put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in putFileRes['Value']['Successful'] )
     self.assertEqual( putFileRes['Value']['Successful'][destFile], srcFileSize )
     # Check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( destFile ) )
+    self.assertTrue( destFile in removeFileRes['Value']['Successful'] )
     self.assertTrue( removeFileRes['Value']['Successful'][destFile] )
 
   def test_putGetFile( self ):
@@ -360,15 +360,15 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in putFileRes['Value']['Successful'] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the get operation
     self.assertTrue( getFileRes['OK'] )
-    self.assertTrue( getFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in getFileRes['Value']['Successful'] )
     self.assertEqual( getFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the remove operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in removeFileRes['Value']['Successful'] )
     self.assertTrue( removeFileRes['Value']['Successful'][remoteFile] )
 
   def test_putExistsFile( self ):
@@ -390,18 +390,18 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in putFileRes['Value']['Successful'] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the exists operation
     self.assertTrue( existsFileRes['OK'] )
-    self.assertTrue( existsFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in existsFileRes['Value']['Successful'] )
     self.assertTrue( existsFileRes['Value']['Successful'][remoteFile] )
     # Check the removal operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in removeFileRes['Value']['Successful'] )
     # Check the failed exists operation
     self.assertTrue( failedExistRes['OK'] )
-    self.assertTrue( failedExistRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in failedExistRes['Value']['Successful'] )
     self.assertFalse( failedExistRes['Value']['Successful'][remoteFile] )
 
   def test_putIsFile( self ):
@@ -424,19 +424,19 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in putFileRes['Value']['Successful'] )
     self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the is file operation
     self.assertTrue( isFileRes['OK'] )
-    self.assertTrue( isFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in isFileRes['Value']['Successful'] )
     self.assertTrue( isFileRes['Value']['Successful'][remoteFile] )
     # check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in removeFileRes['Value']['Successful'] )
     # Check that the directory is not a file
     self.assertTrue( failedIsFileRes['OK'] )
-    self.assertTrue( failedIsFileRes['Value']['Successful'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in failedIsFileRes['Value']['Successful'] )
     self.assertFalse( failedIsFileRes['Value']['Successful'][remoteDir] )
 
   def test_putGetFileMetaData( self ):
@@ -461,27 +461,27 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in putFileRes['Value']['Successful'] )
     self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the get metadata operation
     self.assertTrue( getMetadataRes['OK'] )
-    self.assertTrue( getMetadataRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in getMetadataRes['Value']['Successful'] )
     fileMetaData = getMetadataRes['Value']['Successful'][remoteFile]
     self.assertTrue( fileMetaData['Cached'] )
     self.assertFalse( fileMetaData['Migrated'] )
     self.assertEqual( fileMetaData['Size'], srcFileSize )
     # check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in removeFileRes['Value']['Successful'] )
     # Check the get metadata for non existant file
     self.assertTrue( failedMetadataRes['OK'] )
-    self.assertTrue( failedMetadataRes['Value']['Failed'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in failedMetadataRes['Value']['Failed'] )
     expectedError = "File does not exist"
     self.assertTrue( expectedError in failedMetadataRes['Value']['Failed'][remoteFile] )
     # Check that metadata operation with a directory
     self.assertTrue( directoryMetadataRes['OK'] )
-    self.assertTrue( directoryMetadataRes['Value']['Failed'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in directoryMetadataRes['Value']['Failed'] )
     expectedError = "Supplied path is not a file"
     self.assertTrue( expectedError in directoryMetadataRes['Value']['Failed'][remoteDir] )
 
@@ -507,24 +507,24 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in putFileRes['Value']['Successful'] )
     self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check that we got the file size correctly
     self.assertTrue( getSizeRes['OK'] )
-    self.assertTrue( getSizeRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in getSizeRes['Value']['Successful'] )
     self.assertEqual( getSizeRes['Value']['Successful'][remoteFile], srcFileSize )
     # check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in removeFileRes['Value']['Successful'] )
     # Check the get size with non existant file works properly
     self.assertTrue( failedSizeRes['OK'] )
-    self.assertTrue( failedSizeRes['Value']['Failed'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in failedSizeRes['Value']['Failed'] )
     expectedError = "File does not exist"
     self.assertTrue( expectedError in failedSizeRes['Value']['Failed'][remoteFile] )
     # Check that the passing a directory is handled correctly
     self.assertTrue( directorySizeRes['OK'] )
-    self.assertTrue( directorySizeRes['Value']['Failed'].has_key( remoteDir ) )
+    self.assertTrue( remoteDir in directorySizeRes['Value']['Failed'] )
     expectedError = "Supplied path is not a file"
     self.assertTrue( expectedError in directorySizeRes['Value']['Failed'][remoteDir] )
 
@@ -547,19 +547,19 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in putFileRes['Value']['Successful'] )
     self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the prestage file operation
     self.assertTrue( prestageRes['OK'] )
-    self.assertTrue( prestageRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in prestageRes['Value']['Successful'] )
     self.assertTrue( prestageRes['Value']['Successful'][remoteFile] )
     # Check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in removeFileRes['Value']['Successful'] )
     # Check that pre-staging non-existant file fails
     self.assertTrue( deletedPrestageRes['OK'] )
-    self.assertTrue( deletedPrestageRes['Value']['Failed'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in deletedPrestageRes['Value']['Failed'] )
     expectedError = "No such file or directory"
     self.assertTrue( expectedError in deletedPrestageRes['Value']['Failed'][remoteFile] )
 
@@ -582,18 +582,18 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in putFileRes['Value']['Successful'] )
     self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # check the get turl operation
     self.assertTrue( getTurlRes['OK'] )
-    self.assertTrue( getTurlRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in getTurlRes['Value']['Successful'] )
     # check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in removeFileRes['Value']['Successful'] )
     #Check the get turl with non existant file operation
     self.assertTrue( failedGetTurlRes['OK'] )
-    self.assertTrue( failedGetTurlRes['Value']['Failed'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in failedGetTurlRes['Value']['Failed'] )
     expectedError = "File does not exist"
     self.assertTrue( expectedError in failedGetTurlRes['Value']['Failed'][remoteFile] )
 
@@ -611,7 +611,7 @@ class FileTestCase( StoragePlugInTestCase ):
     pinFileRes = self.storage.pinFile( remoteFile )
     srmID = ''
     if pinFileRes['OK']:
-      if pinFileRes['Value']['Successful'].has_key( remoteFile ):
+      if remoteFile in pinFileRes['Value']['Successful']:
         srmID = pinFileRes['Value']['Successful'][remoteFile]
     # Check that we can release the file
     releaseFileRes = self.storage.releaseFile( {remoteFile:srmID} )
@@ -620,19 +620,19 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in putFileRes['Value']['Successful'] )
     self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the pin file operation
     self.assertTrue( pinFileRes['OK'] )
-    self.assertTrue( pinFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in pinFileRes['Value']['Successful'] )
     self.assertTrue( type( pinFileRes['Value']['Successful'][remoteFile] ) in StringTypes )
     # Check the release file operation
     self.assertTrue( releaseFileRes['OK'] )
-    self.assertTrue( releaseFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in releaseFileRes['Value']['Successful'] )
     # check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in removeFileRes['Value']['Successful'] )
 
   def test_putPrestageStatus( self ):
     print('\n\n#########################################################'
@@ -648,7 +648,7 @@ class FileTestCase( StoragePlugInTestCase ):
     prestageRes = self.storage.prestageFile( remoteFile )
     srmID = ''
     if prestageRes['OK']:
-      if prestageRes['Value']['Successful'].has_key( remoteFile ):
+      if remoteFile in prestageRes['Value']['Successful']:
         srmID = prestageRes['Value']['Successful'][remoteFile]
     # Take a quick break to allow the SRM to realise the file is available
     sleepTime = 10
@@ -661,21 +661,21 @@ class FileTestCase( StoragePlugInTestCase ):
 
     # Check the put file operation
     self.assertTrue( putFileRes['OK'] )
-    self.assertTrue( putFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in putFileRes['Value']['Successful'] )
     self.assertTrue( putFileRes['Value']['Successful'][remoteFile] )
     self.assertEqual( putFileRes['Value']['Successful'][remoteFile], srcFileSize )
     # Check the prestage file operation
     self.assertTrue( prestageRes['OK'] )
-    self.assertTrue( prestageRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in prestageRes['Value']['Successful'] )
     self.assertTrue( prestageRes['Value']['Successful'][remoteFile] )
     self.assertTrue( type( prestageRes['Value']['Successful'][remoteFile] ) in StringTypes )
     # Check the prestage status operation
     self.assertTrue( prestageStatusRes['OK'] )
-    self.assertTrue( prestageStatusRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in prestageStatusRes['Value']['Successful'] )
     self.assertTrue( prestageStatusRes['Value']['Successful'][remoteFile] )
     # Check the remove file operation
     self.assertTrue( removeFileRes['OK'] )
-    self.assertTrue( removeFileRes['Value']['Successful'].has_key( remoteFile ) )
+    self.assertTrue( remoteFile in removeFileRes['Value']['Successful'] )
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase( FileTestCase )

--- a/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/StorageManagementSystem/Client/StorageManagerClient.py
@@ -2,6 +2,7 @@
 """
 __RCSID__ = "$Id$"
 
+import six
 import random
 import errno
 

--- a/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/StorageManagementSystem/Client/StorageManagerClient.py
@@ -22,7 +22,7 @@ def getFilesToStage( lfnList, jobState = None, checkOnlyTapeSEs = None, jobLog =
     return S_OK( {'onlineLFNs':[], 'offlineLFNs': {}, 'failedLFNs':[], 'absentLFNs':{}} )
 
   dm = DataManager()
-  if isinstance( lfnList, basestring ):
+  if isinstance(lfnList, six.string_types):
     lfnList = [lfnList]
 
   lfnListReplicas = dm.getReplicasForJobs( lfnList, getUrl = False )

--- a/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/StorageManagementSystem/DB/StorageManagementDB.py
@@ -12,6 +12,7 @@
 
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import six
 import inspect
 import threading

--- a/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/StorageManagementSystem/DB/StorageManagementDB.py
@@ -12,6 +12,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import inspect
 import threading
 

--- a/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/StorageManagementSystem/DB/StorageManagementDB.py
@@ -656,7 +656,7 @@ class StorageManagementDB(DB):
     allReplicaIDs = []
     taskStates = []
     for se, lfns in lfnDict.iteritems():
-      if isinstance(lfns, basestring):
+      if isinstance(lfns, six.string_types):
         lfns = [lfns]
       res = self._getExistingReplicas(se, lfns, connection=connection)
       if not res['OK']:

--- a/TransformationSystem/Agent/InputDataAgent.py
+++ b/TransformationSystem/Agent/InputDataAgent.py
@@ -15,6 +15,7 @@ The following options can be set for the InputDataAgent.
   :caption: InputDataAgent options
 '''
 
+from past.builtins import long
 import time
 import datetime
 

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -9,6 +9,7 @@ The following options can be set for the TransformationAgent.
   :caption: TransformationAgent options
 """
 
+from past.builtins import long
 import time
 import Queue
 import os

--- a/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -11,6 +11,7 @@
 __RCSID__ = "$Id$"
 
 # # imports
+from past.builtins import long
 import re
 import ast
 import os

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -6,6 +6,7 @@ __RCSID__ = "$Id$"
 # pylint: disable=protected-access
 
 
+import six
 import time
 import StringIO
 import json

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -198,7 +198,7 @@ class RequestTasks(TaskBase):
       oRequest = Request()
       if isinstance(task['InputData'], list):
         files = task['InputData']
-      elif isinstance(task['InputData'], basestring):
+      elif isinstance(task['InputData'], six.string_types):
         files = task['InputData'].split(';')
 
       # create the operations from the json structure
@@ -254,7 +254,7 @@ class RequestTasks(TaskBase):
       if task.get('InputData'):
         if isinstance(task['InputData'], list):
           files = task['InputData']
-        elif isinstance(task['InputData'], basestring):
+        elif isinstance(task['InputData'], six.string_types):
           files = task['InputData'].split(';')
         for lfn in files:
           trFile = File()
@@ -592,7 +592,7 @@ class WorkflowTasks(TaskBase):
       # Handle Input Data
       inputData = paramsDict.get('InputData')
       if inputData:
-        if isinstance(inputData, basestring):
+        if isinstance(inputData, six.string_types):
           inputData = inputData.replace(' ', '').split(';')
         self._logVerbose('Setting input data to %s' % inputData,
                          transID=transID, method=method)
@@ -943,7 +943,7 @@ class WorkflowTasks(TaskBase):
   def submitTaskToExternal(self, job):
     """ Submits a single job (which can be a bulk one) to the WMS.
     """
-    if isinstance(job, basestring):
+    if isinstance(job, six.string_types):
       try:
         oJob = self.jobClass(job)
       except Exception as x:  # pylint: disable=broad-except

--- a/TransformationSystem/Client/TaskManagerPlugin.py
+++ b/TransformationSystem/Client/TaskManagerPlugin.py
@@ -30,7 +30,7 @@ class TaskManagerPlugin(PluginBase):
     try:
       seList = ['Unknown']
       if self.params['TargetSE']:
-        if isinstance(self.params['TargetSE'], basestring):
+        if isinstance(self.params['TargetSE'], six.string_types):
           seList = fromChar(self.params['TargetSE'])
         elif isinstance(self.params['TargetSE'], list):
           seList = self.params['TargetSE']

--- a/TransformationSystem/Client/TaskManagerPlugin.py
+++ b/TransformationSystem/Client/TaskManagerPlugin.py
@@ -1,6 +1,7 @@
 """ Container for TaskManager plug-ins, to handle the destination of the tasks
 """
 
+import six
 from DIRAC import gLogger
 
 from DIRAC.Core.Utilities.List import fromChar

--- a/TransformationSystem/Client/Transformation.py
+++ b/TransformationSystem/Client/Transformation.py
@@ -117,7 +117,7 @@ class Transformation(API):
     :returns: S_OK, S_ERROR
     """
     self.item_called = "Body"
-    if isinstance(body, basestring):
+    if isinstance(body, six.string_types):
       return self.__setParam(body)
     if not isinstance(body, (list, tuple)):
       raise TypeError("Expected list or string, but %r is %s" % (body, type(body)))
@@ -127,12 +127,12 @@ class Transformation(API):
         raise TypeError("Expected tuple or list, but %r is %s" % (tup, type(tup)))
       if len(tup) != 2:
         raise TypeError("Expected 2-tuple, but %r is length %d" % (tup, len(tup)))
-      if not isinstance(tup[0], basestring):
+      if not isinstance(tup[0], six.string_types):
         raise TypeError("Expected string, but first entry in tuple %r is %s" % (tup, type(tup[0])))
       if not isinstance(tup[1], dict):
         raise TypeError("Expected dictionary, but second entry in tuple %r is %s" % (tup, type(tup[0])))
       for par, val in tup[1].iteritems():
-        if not isinstance(par, basestring):
+        if not isinstance(par, six.string_types):
           raise TypeError("Expected string, but key in dictionary %r is %s" % (par, type(par)))
         if par not in Operation.ATTRIBUTE_NAMES:
           raise ValueError("Unknown attribute for Operation: %s" % par)
@@ -157,7 +157,7 @@ class Transformation(API):
     return S_OK()
 
   def __setSE(self, seParam, seList):
-    if isinstance(seList, basestring):
+    if isinstance(seList, six.string_types):
       try:
         seList = eval(seList)
       except BaseException:

--- a/TransformationSystem/Client/Transformation.py
+++ b/TransformationSystem/Client/Transformation.py
@@ -4,6 +4,7 @@ See the information about transformation parameters below.
 """
 
 from __future__ import print_function
+import six
 import types
 import json
 

--- a/TransformationSystem/Client/Transformation.py
+++ b/TransformationSystem/Client/Transformation.py
@@ -4,6 +4,7 @@ See the information about transformation parameters below.
 """
 
 from __future__ import print_function
+from past.builtins import long
 import six
 import types
 import json

--- a/TransformationSystem/Client/TransformationCLI.py
+++ b/TransformationSystem/Client/TransformationCLI.py
@@ -3,6 +3,7 @@
 
 #! /usr/bin/env python
 from __future__ import print_function
+from past.builtins import long
 from DIRAC.Core.Base.Script import parseCommandLine
 parseCommandLine()
 

--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -343,10 +343,10 @@ class TransformationClient(Client):
 
     """
     # create dictionary in case newLFNsStatus is a string
-    if isinstance(newLFNsStatus, basestring):
+    if isinstance(newLFNsStatus, six.string_types):
       if not lfns:
         return S_OK({})
-      if isinstance(lfns, basestring):
+      if isinstance(lfns, six.string_types):
         lfns = [lfns]
       newLFNsStatus = dict.fromkeys(lfns, newLFNsStatus)
     if not newLFNsStatus:

--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -2,6 +2,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC                                                         import S_OK, gLogger
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.Core.Utilities.List                                     import breakListIntoChunks

--- a/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -3,6 +3,7 @@
 
 # pylint: disable=protected-access,missing-docstring,invalid-name
 
+import six
 import unittest
 import json
 import mock

--- a/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -251,7 +251,7 @@ class TransformationSuccess(ClientsTestCase):
     self.assertTrue(res['OK'])
     defaultParams = res['Value'].copy()
     for parameterName, defaultValue in res['Value'].items():
-      if isinstance(defaultValue, basestring):
+      if isinstance(defaultValue, six.string_types):
         testValue = 'TestValue'
       else:
         testValue = 99999

--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -301,7 +301,7 @@ class TransformationDB(DB):
 
   def getTransformationParameters(self, transName, parameters, connection=False):
     """ Get the requested parameters for a supplied transformation """
-    if isinstance(parameters, basestring):
+    if isinstance(parameters, six.string_types):
       parameters = [parameters]
     extraParams = bool(set(parameters) - set(self.TRANSPARAMS))
     res = self.getTransformation(transName, extraParams=extraParams, connection=connection)
@@ -372,7 +372,7 @@ class TransformationDB(DB):
       transName = long(transName)
       cmd = "SELECT TransformationID from Transformations WHERE TransformationID=%d;" % transName
     except ValueError:
-      if not isinstance(transName, basestring):
+      if not isinstance(transName, six.string_types):
         return S_ERROR("Transformation should be ID or name")
       cmd = "SELECT TransformationID from Transformations WHERE TransformationName='%s';" % transName
     res = self._query(cmd, connection)
@@ -542,7 +542,7 @@ class TransformationDB(DB):
     if condDict or older or newer:
       lfns = condDict.pop('LFN', None)
       if lfns:
-        if isinstance(lfns, basestring):
+        if isinstance(lfns, six.string_types):
           lfns = [lfns]
         res = self.__getFileIDsForLfns(lfns, connection=connection)
         if not res['OK']:

--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -6,6 +6,7 @@
     databases
 """
 
+import six
 import re
 import time
 import threading

--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -6,6 +6,7 @@
     databases
 """
 
+from past.builtins import long
 import six
 import re
 import time

--- a/TransformationSystem/DB/TransformationDB.py
+++ b/TransformationSystem/DB/TransformationDB.py
@@ -269,7 +269,7 @@ class TransformationDB(DB):
     resultList = []
     for row in res['Value']:
       # Prepare the structure for the web
-      rList = [str(item) if not isinstance(item, (long, int)) else item for item in row]
+      rList = [str(item) if not isinstance(item, six.integer_types) else item for item in row]
       transDict = dict(zip(self.TRANSPARAMS, row))
       webList.append(rList)
       if extraParams:
@@ -469,7 +469,7 @@ class TransformationDB(DB):
       return S_ERROR("Failed to parse parameter value")
     paramValue = res['Value']
     paramType = 'StringType'
-    if isinstance(paramValue, (long, int)):
+    if isinstance(paramValue, six.integer_types):
       paramType = 'IntType'
     req = "INSERT INTO AdditionalParameters (%s) VALUES (%s,'%s',%s,'%s');" % (', '.join(self.ADDITIONALPARAMETERS),
                                                                                transID, paramName,
@@ -578,7 +578,7 @@ class TransformationDB(DB):
         fDict = {'LFN': lfn}
         fDict.update(dict(zip(self.TRANSFILEPARAMS, row)))
         # Note: the line below is returning "None" if the item is None... This seems to work but is ugly...
-        rList = [lfn] + [str(item) if not isinstance(item, (long, int)) else item for item in row]
+        rList = [lfn] + [str(item) if not isinstance(item, six.integer_types) else item for item in row]
         webList.append(rList)
         resultList.append(fDict)
     result = S_OK(resultList)
@@ -805,7 +805,7 @@ class TransformationDB(DB):
     resultList = []
     for row in res['Value']:
       # Prepare the structure for the web
-      rList = [str(item) if not isinstance(item, (long, int)) else item for item in row]
+      rList = [str(item) if not isinstance(item, six.integer_types) else item for item in row]
       taskDict = dict(zip(self.TASKSPARAMS, row))
       webList.append(rList)
       if inputVector:
@@ -1007,12 +1007,12 @@ class TransformationDB(DB):
         continue
       parameterType = 'String'
       if isinstance(parameterValue, (list, tuple)):
-        if isinstance(parameterValue[0], (long, int)):
+        if isinstance(parameterValue[0], six.integer_types):
           parameterType = 'Integer'
           parameterValue = [str(x) for x in parameterValue]
         parameterValue = ';;;'.join(parameterValue)
       else:
-        if isinstance(parameterValue, (long, int)):
+        if isinstance(parameterValue, six.integer_types):
           parameterType = 'Integer'
           parameterValue = str(parameterValue)
         if isinstance(parameterValue, dict):

--- a/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/TransformationSystem/Service/TransformationManagerHandler.py
@@ -1,6 +1,7 @@
 """ DISET request handler base class for the TransformationDB.
 """
 
+from past.builtins import long
 import six
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler

--- a/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/TransformationSystem/Service/TransformationManagerHandler.py
@@ -194,7 +194,7 @@ class TransformationManagerHandler(RequestHandler):
       return S_OK({})
 
     statusSample = dictOfNewFilesStatus.values()[0]
-    if isinstance(statusSample, basestring):
+    if isinstance(statusSample, six.string_types):
       # FIXME: kept for backward compatibility with old clients... Remove when no longer needed
       # This comes from an old client, set the error flag but we must get the current status first
       newStatusForFileIDs = {}

--- a/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/TransformationSystem/Service/TransformationManagerHandler.py
@@ -1,6 +1,7 @@
 """ DISET request handler base class for the TransformationDB.
 """
 
+import six
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.TransformationSystem.DB.TransformationDB import TransformationDB

--- a/TransformationSystem/Utilities/ReplicationTransformation.py
+++ b/TransformationSystem/Utilities/ReplicationTransformation.py
@@ -2,6 +2,7 @@
 Utilities to create replication transformations
 """
 
+import six
 from DIRAC.TransformationSystem.Client.Transformation import Transformation
 from DIRAC import gLogger, S_OK, S_ERROR
 

--- a/TransformationSystem/Utilities/ReplicationTransformation.py
+++ b/TransformationSystem/Utilities/ReplicationTransformation.py
@@ -38,7 +38,7 @@ def createDataTransformation(flavour, targetSE, sourceSE,
 
   gLogger.debug("Using %r for metadata search" % metadata)
 
-  if isinstance(targetSE, basestring):
+  if isinstance(targetSE, six.string_types):
     targetSE = [targetSE]
 
   gLogger.debug('Using plugin: %r' % plugin)

--- a/Workflow/Modules/ModuleBase.py
+++ b/Workflow/Modules/ModuleBase.py
@@ -10,6 +10,7 @@
     The DIRAC APIs are used to create Jobs that make use of these modules.
 """
 
+import six
 import os
 import copy
 

--- a/Workflow/Modules/ModuleBase.py
+++ b/Workflow/Modules/ModuleBase.py
@@ -292,7 +292,7 @@ class ModuleBase(object):
 
     if 'outputDataFileMask' in self.workflow_commons:
       self.outputDataFileMask = self.workflow_commons['outputDataFileMask']
-      if isinstance(self.outputDataFileMask, basestring):
+      if isinstance(self.outputDataFileMask, six.string_types):
         self.outputDataFileMask = [i.lower().strip()
                                    for i in self.outputDataFileMask.split(';')]  # pylint: disable=no-member
 
@@ -355,7 +355,7 @@ class ModuleBase(object):
 
     if self._checkWFAndStepStatus(noPrint=True):
       # The application status won't be updated in case the workflow or the step is failed already
-      if not isinstance(status, basestring):
+      if not isinstance(status, six.string_types):
         status = str(status)
       self.log.verbose('setJobApplicationStatus(%s, %s)' % (self.jobID, status))
       jobStatus = self.jobReport.setApplicationStatus(status, sendFlag)

--- a/Workflow/Modules/ModuleBase.py
+++ b/Workflow/Modules/ModuleBase.py
@@ -137,11 +137,11 @@ class ModuleBase(object):
 
     # This catches everything that is voluntarily thrown within the modules, so an error
     except RuntimeError as rte:
-      if len(rte.args) > 1:  # In this case the RuntimeError is supposed to return in rte[1] an error code
-                             # (possibly from DErrno)
-        self.log.error(rte[0])
-        self.setApplicationStatus(rte[0])
-        return S_ERROR(rte[1], rte[0])  # rte[1] should be an error code
+      if len(rte.args) > 1:
+        # In this case the RuntimeError is supposed to return in rte[1] an error code (possibly from DErrno)
+        self.log.error(rte.args[0])
+        self.setApplicationStatus(rte.args[0])
+        return S_ERROR(rte.args[1], rte.args[0])  # rte[1] should be an error code
 
       # If we are here it is just a string
       self.log.error(rte)

--- a/Workflow/Modules/UploadOutputs.py
+++ b/Workflow/Modules/UploadOutputs.py
@@ -37,7 +37,7 @@ class UploadOutputs(ModuleBase):
     # this comes from Job().setOutputData(). Typical for user jobs
     if 'OutputData' in self.workflow_commons:
       self.outputData = self.workflow_commons['OutputData']
-      if isinstance(self.outputData, basestring):
+      if isinstance(self.outputData, six.string_types):
         self.outputData = [i.strip() for i in self.outputData.split(';')]
     # if not present, we use the outputList, which is instead incrementally created based on the single step outputs
     # This is more typical for production jobs, that can have many steps linked one after the other

--- a/Workflow/Modules/UploadOutputs.py
+++ b/Workflow/Modules/UploadOutputs.py
@@ -6,6 +6,7 @@
     defined in the production workflow.
 """
 
+import six
 from DIRAC import gLogger
 from DIRAC.Workflow.Modules.ModuleBase import ModuleBase, GracefulTermination
 

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -15,6 +15,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import sys
 import random

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -333,10 +333,10 @@ class SiteDirector(AgentModule):
           # This also converts them from a string to a list if required.
           for tagFieldName in ('Tag', 'RequiredTag'):
             ceTags = ceDict.get(tagFieldName, [])
-            if isinstance(ceTags, basestring):
+            if isinstance(ceTags, six.string_types):
               ceTags = fromChar(ceTags)
             queueTags = self.queueDict[queueName]['ParametersDict'].get(tagFieldName)
-            if queueTags and isinstance(queueTags, basestring):
+            if queueTags and isinstance(queueTags, six.string_types):
               queueTags = fromChar(queueTags)
               self.queueDict[queueName]['ParametersDict'][tagFieldName] = queueTags
             if ceTags:

--- a/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -461,7 +461,7 @@ the stalledTime limit.
       if not startTime or startTime == 'None':
         startTime = jobDict['SubmissionTime']
 
-    if isinstance(startTime, basestring):
+    if isinstance(startTime, six.string_types):
       startTime = fromString(startTime)
       if startTime is None:
         self.log.error('Wrong timestamp in DB', items[3])

--- a/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -7,6 +7,7 @@ from __future__ import print_function, absolute_import
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 from DIRAC.WorkloadManagementSystem.DB.JobLoggingDB import JobLoggingDB
 from DIRAC.Core.Base.AgentModule import AgentModule

--- a/WorkloadManagementSystem/Client/CPUNormalization.py
+++ b/WorkloadManagementSystem/Client/CPUNormalization.py
@@ -8,7 +8,7 @@
 """
 
 import os
-import urllib
+from six.moves.urllib.request import urlopen
 
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.SiteCEMapping import getQueueInfo
@@ -36,7 +36,7 @@ def __getFeatures(envVariable, items):
     fname = os.path.join(featuresDir, item)
     try:
       # Only keep features that do exist
-      features[item] = urllib.urlopen(fname).read()
+      features[item] = urlopen(fname).read()
     except IOError:
       pass
   return features

--- a/WorkloadManagementSystem/Client/DIRACbenchmark.py
+++ b/WorkloadManagementSystem/Client/DIRACbenchmark.py
@@ -22,6 +22,7 @@
 """
 
 from __future__ import print_function
+from past.builtins import long
 import os
 import sys
 import random

--- a/WorkloadManagementSystem/Client/DIRACbenchmark.py
+++ b/WorkloadManagementSystem/Client/DIRACbenchmark.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 import os
 import sys
 import random
-import urllib
+from six.moves.urllib.request import urlopen
 import multiprocessing
 
 version = '00.04 DB12'
@@ -148,7 +148,7 @@ def wholenodeDiracBenchmark(copies=None, iterations=1, extraIteration=False):
   # Try $MACHINEFEATURES first if not given by caller
   if copies is None and 'MACHINEFEATURES' in os.environ:
     try:
-      copies = int(urllib.urlopen(os.environ['MACHINEFEATURES'] + '/total_cpu').read())
+      copies = int(urlopen(os.environ['MACHINEFEATURES'] + '/total_cpu').read())
     except BaseException:
       pass
 
@@ -169,7 +169,7 @@ def jobslotDiracBenchmark(copies=None, iterations=1, extraIteration=False):
   # Try $JOBFEATURES first if not given by caller
   if copies is None and 'JOBFEATURES' in os.environ:
     try:
-      copies = int(urllib.urlopen(os.environ['JOBFEATURES'] + '/allocated_cpu').read())
+      copies = int(urlopen(os.environ['JOBFEATURES'] + '/allocated_cpu').read())
     except BaseException:
       pass
 

--- a/WorkloadManagementSystem/Client/InputDataByProtocol.py
+++ b/WorkloadManagementSystem/Client/InputDataByProtocol.py
@@ -53,7 +53,7 @@ class InputDataByProtocol(object):
       self.log.verbose('Data to resolve passed directly to InputDataByProtocol module')
       self.inputData = dataToResolve  # e.g. list supplied by another module
 
-    if isinstance(self.inputData, basestring):
+    if isinstance(self.inputData, six.string_types):
       self.inputData = self.inputData.replace(' ', '').split(',')
 
     self.inputData = [x.replace('LFN:', '') for x in self.inputData]

--- a/WorkloadManagementSystem/Client/InputDataByProtocol.py
+++ b/WorkloadManagementSystem/Client/InputDataByProtocol.py
@@ -10,6 +10,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.WorkloadManagementSystem.Client.JobStateUpdateClient import JobStateUpdateClient

--- a/WorkloadManagementSystem/Client/InputDataResolution.py
+++ b/WorkloadManagementSystem/Client/InputDataResolution.py
@@ -101,7 +101,7 @@ class InputDataResolution(object):
     policy = self.arguments['Job'].get('InputDataPolicy', [])
     if policy:
       # In principle this can be a list of modules with the first taking precedence
-      if isinstance(policy, basestring):
+      if isinstance(policy, six.string_types):
         policy = [policy]
       self.log.info('Job has a specific policy setting: %s' % (', '.join(policy)))
     else:

--- a/WorkloadManagementSystem/Client/InputDataResolution.py
+++ b/WorkloadManagementSystem/Client/InputDataResolution.py
@@ -7,6 +7,7 @@
     for applications.
 """
 
+import six
 import DIRAC
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities.ModuleFactory import ModuleFactory

--- a/WorkloadManagementSystem/Client/JobDescription.py
+++ b/WorkloadManagementSystem/Client/JobDescription.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.CFG import CFG
 from DIRAC.Core.Utilities import List

--- a/WorkloadManagementSystem/Client/JobState/CachedJobState.py
+++ b/WorkloadManagementSystem/Client/JobState/CachedJobState.py
@@ -121,7 +121,7 @@ class CachedJobState(object):
     if len(dataTuple) != 7:
       return S_ERROR("Invalid stub")
     # jid
-    if not isinstance(dataTuple[0], (int, long)):
+    if not isinstance(dataTuple[0], six.integer_types):
       return S_ERROR("Invalid stub 0")
     # cache
     if not isinstance(dataTuple[1], dict):

--- a/WorkloadManagementSystem/Client/JobState/CachedJobState.py
+++ b/WorkloadManagementSystem/Client/JobState/CachedJobState.py
@@ -4,6 +4,7 @@
     everything locally instead of going to the DB.
 """
 
+import six
 import copy
 import time
 

--- a/WorkloadManagementSystem/Client/JobState/CachedJobState.py
+++ b/WorkloadManagementSystem/Client/JobState/CachedJobState.py
@@ -165,7 +165,7 @@ class CachedJobState(object):
     self.__dirtyKeys.add(key)
 
   def __cacheExists(self, keyList):
-    if isinstance(keyList, basestring):
+    if isinstance(keyList, six.string_types):
       keyList = [keyList]
     for key in keyList:
       if key not in self.__cache:
@@ -174,7 +174,7 @@ class CachedJobState(object):
 
   def __cacheResult(self, cKey, functor, fArgs=None):
     # If it's a string
-    if isinstance(cKey, basestring):
+    if isinstance(cKey, six.string_types):
       if cKey not in self.__cache:
         if self.dOnlyCache:
           return S_ERROR("%s is not cached")
@@ -311,7 +311,7 @@ class CachedJobState(object):
 #
 
   def setAttribute(self, name, value):
-    if not isinstance(name, basestring):
+    if not isinstance(name, six.string_types):
       return S_ERROR("Attribute name has to be a string")
     self.__cacheAdd("att.%s" % name, value)
     return S_OK()
@@ -334,7 +334,7 @@ class CachedJobState(object):
 # Optimizer params
 
   def setOptParameter(self, name, value):
-    if not isinstance(name, basestring):
+    if not isinstance(name, six.string_types):
       return S_ERROR("Optimizer parameter name has to be a string")
     self.__cacheAdd('optp.%s' % name, value)
     return S_OK()

--- a/WorkloadManagementSystem/Client/JobState/JobManifest.py
+++ b/WorkloadManagementSystem/Client/JobState/JobManifest.py
@@ -1,6 +1,7 @@
 """
 """
 
+from past.builtins import long
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.CFG import CFG
 from DIRAC.Core.Utilities import List

--- a/WorkloadManagementSystem/Client/JobState/JobState.py
+++ b/WorkloadManagementSystem/Client/JobState/JobState.py
@@ -289,7 +289,7 @@ class JobState(object):
   right_removeOptParameters = RIGHT_GET_INFO
 
   def removeOptParameters(self, nameList):
-    if isinstance(nameList, basestring):
+    if isinstance(nameList, six.string_types):
       nameList = [nameList]
     try:
       self.__checkType(nameList, (list, tuple))

--- a/WorkloadManagementSystem/Client/JobState/JobState.py
+++ b/WorkloadManagementSystem/Client/JobState/JobState.py
@@ -5,6 +5,7 @@ from __future__ import print_function, absolute_import
 
 __RCSID__ = "$Id"
 
+import six
 import datetime
 
 from DIRAC import gLogger, S_OK, S_ERROR

--- a/WorkloadManagementSystem/Client/PoolXMLSlice.py
+++ b/WorkloadManagementSystem/Client/PoolXMLSlice.py
@@ -7,7 +7,7 @@
 from DIRAC.Resources.Catalog.PoolXMLCatalog                         import PoolXMLCatalog
 from DIRAC                                                          import S_OK, S_ERROR, gLogger
 
-import os, types
+import os
 
 __RCSID__ = "$Id$"
 
@@ -34,7 +34,7 @@ class PoolXMLSlice( object ):
 
       for lfn, mdataList in dataDict.items():
         # lfn,pfn,se,guid tuple taken by POOL XML Catalogue
-        if type( mdataList ) != types.ListType:
+        if not isinstance(mdataList, list):
           mdataList = [mdataList]
         # As a file may have several replicas, set first the file, then the replicas
         poolXMLCat.addFile( ( lfn, None, None, mdataList[0]['guid'], None ) )

--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -250,7 +250,7 @@ class SandboxStoreClient(object):
 
   def unassignJobs(self, jobIdList):
     """ Unassign SB to a job """
-    if isinstance(jobIdList, (int, long)):
+    if isinstance(jobIdList, six.integer_types):
       jobIdList = [jobIdList]
     entitiesList = []
     for jobId in jobIdList:
@@ -296,7 +296,7 @@ class SandboxStoreClient(object):
 
   def unassignPilots(self, pilotIdIdList):
     """ Unassign SB to a pilot """
-    if isinstance(pilotIdIdList, (int, long)):
+    if isinstance(pilotIdIdList, six.integer_types):
       pilotIdIdList = [pilotIdIdList]
     entitiesList = []
     for pilotId in pilotIdIdList:

--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -104,7 +104,7 @@ class SandboxStoreClient(object):
       return S_ERROR("fileList must be a list or tuple!")
 
     for sFile in fileList:
-      if isinstance(sFile, basestring):
+      if isinstance(sFile, six.string_types):
         if re.search('^lfn:', sFile, flags=re.IGNORECASE):
           pass
         else:
@@ -129,7 +129,7 @@ class SandboxStoreClient(object):
 
     with tarfile.open(name=tmpFilePath, mode="w|bz2") as tf:
       for sFile in files2Upload:
-        if isinstance(sFile, basestring):
+        if isinstance(sFile, six.string_types):
           tf.add(os.path.realpath(sFile), os.path.basename(sFile), recursive=True)
         elif isinstance(sFile, StringIO.StringIO):
           tarInfo = tarfile.TarInfo(name='jobDescription.xml')

--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -4,6 +4,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import os
 import tarfile
 import hashlib

--- a/WorkloadManagementSystem/Client/WMSClient.py
+++ b/WorkloadManagementSystem/Client/WMSClient.py
@@ -174,10 +174,9 @@ class WMSClient(object):
     if not result['OK']:
       return result
     nJobs = result['Value']
-    parametricJob = nJobs > 0
     result = self.jobManager.submitJob(classAdJob.asJDL())
 
-    if parametricJob:
+    if nJobs:
       gLogger.debug('Applying transactional job submission')
       # The server applies transactional bulk submission, we should confirm the jobs
       if result['OK']:

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -294,7 +294,7 @@ class JobDB(DB):
 
     resultDict = {}
     if paramList:
-      if isinstance(paramList, basestring):
+      if isinstance(paramList, six.string_types):
         paramList = paramList.split(',')
       paramNameList = []
       for pn in paramList:

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -41,6 +41,7 @@
 """
 
 from __future__ import print_function, absolute_import, division
+from past.builtins import long
 import six
 from six.moves import range
 

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -41,6 +41,7 @@
 """
 
 from __future__ import print_function, absolute_import, division
+import six
 from six.moves import range
 
 __RCSID__ = "$Id$"

--- a/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -56,7 +56,7 @@ class JobLoggingDB(DB):
       time_order = round(epoc, 3)
     else:
       try:
-        if isinstance(date, basestring):
+        if isinstance(date, six.string_types):
           # The date is provided as a string in UTC
           _date = Time.fromString(date)
           epoc = time.mktime(_date.timetuple()) + _date.microsecond / 1000000. - MAGIC_EPOC_NUMBER
@@ -122,7 +122,7 @@ class JobLoggingDB(DB):
     # Make sure that we have a list of jobs
     if isinstance(jobID, (int, long)):
       jobList = [str(jobID)]
-    elif isinstance(jobID, basestring):
+    elif isinstance(jobID, six.string_types):
       jobList = [jobID]
     else:
       jobList = list(jobID)

--- a/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -120,7 +120,7 @@ class JobLoggingDB(DB):
     """
 
     # Make sure that we have a list of jobs
-    if isinstance(jobID, (int, long)):
+    if isinstance(jobID, six.integer_types):
       jobList = [str(jobID)]
     elif isinstance(jobID, six.string_types):
       jobList = [jobID]

--- a/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -9,6 +9,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import time
 
 from DIRAC import S_OK, S_ERROR

--- a/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -649,14 +649,14 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
     site_select = []
     if 'GridSite' in selectDict:
       site_select = selectDict['GridSite']
-      if not isinstance(site_select, type([])):
+      if not isinstance(site_select, list):
         site_select = [site_select]
       del selectDict['GridSite']
 
     status_select = []
     if 'Status' in selectDict:
       status_select = selectDict['Status']
-      if not isinstance(status_select, type([])):
+      if not isinstance(status_select, list):
         status_select = [status_select]
       del selectDict['Status']
 
@@ -970,7 +970,7 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
       del selectDict['LastUpdateTime']
     if 'Owner' in selectDict:
       userList = selectDict['Owner']
-      if not isinstance(userList, type([])):
+      if not isinstance(userList, list):
         userList = [userList]
       dnList = []
       for uName in userList:

--- a/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -224,7 +224,7 @@ class PilotAgentsDB(DB):
   def deletePilot(self, pilotRef, conn=False):
     """ Delete Pilot with the given reference from the PilotAgentsDB """
 
-    if isinstance(pilotRef, basestring):
+    if isinstance(pilotRef, six.string_types):
       pilotID = self.__getPilotID(pilotRef)
     else:
       pilotID = pilotRef
@@ -410,7 +410,7 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
     """ Get Pilot ID for the given pilot reference or a list of references
     """
 
-    if isinstance(pilotRef, basestring):
+    if isinstance(pilotRef, six.string_types):
       req = "SELECT PilotID from PilotAgents WHERE PilotJobReference='%s'" % pilotRef
       result = self._query(req)
       if not result['OK']:

--- a/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -19,6 +19,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import threading
 
 from DIRAC import S_OK, S_ERROR

--- a/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -1033,7 +1033,7 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
     for pilot in pilotList:
       parList = []
       for parameter in paramNames:
-        if not isinstance(pilotDict[pilot][parameter], (int, long)):
+        if not isinstance(pilotDict[pilot][parameter], six.integer_types):
           parList.append(str(pilotDict[pilot][parameter]))
         else:
           parList.append(pilotDict[pilot][parameter])

--- a/WorkloadManagementSystem/DB/PilotsLoggingDB.py
+++ b/WorkloadManagementSystem/DB/PilotsLoggingDB.py
@@ -165,7 +165,7 @@ class PilotsLoggingDB(object):
   def deletePilotsLogging(self, pilotUUID):
     """Delete all logging entries for pilot"""
 
-    if isinstance(pilotUUID, basestring):
+    if isinstance(pilotUUID, six.string_types):
       pilotUUID = [pilotUUID, ]
 
     session = self.sqlalchemySession()

--- a/WorkloadManagementSystem/DB/PilotsLoggingDB.py
+++ b/WorkloadManagementSystem/DB/PilotsLoggingDB.py
@@ -14,6 +14,7 @@
 __RCSID__ = "$Id$"
 
 
+import six
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.ConfigurationSystem.Client.Utilities import getDBParameters

--- a/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -179,7 +179,7 @@ class TaskQueueDB(DB):
         if not isinstance(tqDefDict[field], (int, long)):
           return S_ERROR("Mandatory field %s value type is not valid: %s" % (field, type(tqDefDict[field])))
       else:
-        if not isinstance(tqDefDict[field], basestring):
+        if not isinstance(tqDefDict[field], six.string_types):
           return S_ERROR("Mandatory field %s value type is not valid: %s" % (field, type(tqDefDict[field])))
         result = self._escapeString(tqDefDict[field])
         if not result['OK']:

--- a/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -176,7 +176,7 @@ class TaskQueueDB(DB):
       if field not in tqDefDict:
         return S_ERROR("Missing mandatory field '%s' in task queue definition" % field)
       if field in ["CPUTime"]:
-        if not isinstance(tqDefDict[field], (int, long)):
+        if not isinstance(tqDefDict[field], six.integer_types):
           return S_ERROR("Mandatory field %s value type is not valid: %s" % (field, type(tqDefDict[field])))
       else:
         if not isinstance(tqDefDict[field], six.string_types):
@@ -223,7 +223,7 @@ class TaskQueueDB(DB):
         continue
       fieldValue = tqMatchDict[field]
       if field in ["CPUTime"]:
-        result = travelAndCheckType(fieldValue, (int, long), escapeValues=False)
+        result = travelAndCheckType(fieldValue, six.integer_types, escapeValues=False)
       else:
         result = travelAndCheckType(fieldValue, basestring)
       if not result['OK']:

--- a/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id"
 
+import six
 import random
 import string
 

--- a/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -3,6 +3,7 @@
 
 __RCSID__ = "$Id"
 
+from past.builtins import long
 import six
 import random
 import string

--- a/WorkloadManagementSystem/Executor/JobPath.py
+++ b/WorkloadManagementSystem/Executor/JobPath.py
@@ -9,6 +9,7 @@
 """
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities import List
 from DIRAC.WorkloadManagementSystem.Executor.Base.OptimizerExecutor import OptimizerExecutor

--- a/WorkloadManagementSystem/Executor/JobPath.py
+++ b/WorkloadManagementSystem/Executor/JobPath.py
@@ -28,7 +28,7 @@ class JobPath(OptimizerExecutor):
     return S_OK()
 
   def __setOptimizerChain(self, jobState, opChain):
-    if not isinstance(opChain, basestring):
+    if not isinstance(opChain, six.string_types):
       opChain = ",".join(opChain)
     return jobState.setOptParameter("OptimizerChain", opChain)
 
@@ -59,7 +59,7 @@ class JobPath(OptimizerExecutor):
     if not result['OK']:
       return result
     extraPath = result['Value']
-    if isinstance(extraPath, basestring):
+    if isinstance(extraPath, six.string_types):
       extraPath = List.fromChar(result['Value'])
     return S_OK(extraPath)
 

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -10,6 +10,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import six
 import os
 import stat

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -10,6 +10,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+import six
 import os
 import stat
 import re

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -337,7 +337,7 @@ class JobWrapper(object):
     if 'ExecutionEnvironment' in self.jobArgs:
       self.log.verbose('Adding variables to execution environment')
       variableList = self.jobArgs['ExecutionEnvironment']
-      if isinstance(variableList, basestring):
+      if isinstance(variableList, six.string_types):
         variableList = [variableList]
       for var in variableList:
         nameEnv = var.split('=')[0]
@@ -542,7 +542,7 @@ class JobWrapper(object):
       self.log.error(msg)
       return S_ERROR(msg)
     else:
-      if isinstance(inputData, basestring):
+      if isinstance(inputData, six.string_types):
         inputData = [inputData]
       lfns = [fname.replace('LFN:', '') for fname in inputData]
       self.log.verbose('Job input data requirement is \n%s' % ',\n'.join(lfns))
@@ -556,7 +556,7 @@ class JobWrapper(object):
     if not localSEList:
       self.log.warn("Job has input data requirement but no site LocalSE defined")
     else:
-      if isinstance(localSEList, basestring):
+      if isinstance(localSEList, six.string_types):
         localSEList = List.fromChar(localSEList)
       self.log.info("Site has the following local SEs: %s" % ', '.join(localSEList))
 
@@ -719,12 +719,12 @@ class JobWrapper(object):
 
     # first iteration of this, no checking of wildcards or oversize sandbox files etc.
     outputSandbox = self.jobArgs.get('OutputSandbox', [])
-    if isinstance(outputSandbox, basestring):
+    if isinstance(outputSandbox, six.string_types):
       outputSandbox = [outputSandbox]
     if outputSandbox:
       self.log.verbose('OutputSandbox files are: %s' % ', '.join(outputSandbox))
     outputData = self.jobArgs.get('OutputData', [])
-    if outputData and isinstance(outputData, basestring):
+    if outputData and isinstance(outputData, six.string_types):
       outputData = outputData.split(';')
     if outputData:
       self.log.verbose('OutputData files are: %s' % ', '.join(outputData))
@@ -785,11 +785,11 @@ class JobWrapper(object):
       # Do not upload outputdata if the job has failed.
       # The exception is when the outputData is what was the OutputSandbox, which should be uploaded in any case
       outputSE = self.jobArgs.get('OutputSE', self.defaultOutputSE)
-      if isinstance(outputSE, basestring):
+      if isinstance(outputSE, six.string_types):
         outputSE = [outputSE]
 
       outputPath = self.jobArgs.get('OutputPath', self.defaultOutputPath)
-      if not isinstance(outputPath, basestring):
+      if not isinstance(outputPath, six.string_types):
         outputPath = self.defaultOutputPath
 
       if not outputSE and not self.defaultFailoverSE:
@@ -1194,7 +1194,7 @@ class JobWrapper(object):
     if 'JobName' in self.jobArgs:
       # To make the request names more appealing for users
       jobName = self.jobArgs['JobName']
-      if isinstance(jobName, basestring) and jobName:
+      if isinstance(jobName, six.string_types) and jobName:
         jobName = jobName.replace(' ', '').replace('(', '').replace(')', '').replace('"', '')
         jobName = jobName.replace('.', '').replace('{', '').replace('}', '').replace(':', '')
         requestName = '%s_%s' % (jobName, requestName)

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -287,7 +287,7 @@ class ReplaceDIRACCode(CommandBase):
     """ Download/unzip an archive file
     """
     from io import BytesIO
-    from urllib2 import urlopen
+    from six.moves.urllib.request import urlopen
     from zipfile import ZipFile
 
     zipresp = urlopen(self.pp.genericOption)

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -287,7 +287,7 @@ class ReplaceDIRACCode(CommandBase):
     """ Download/unzip an archive file
     """
     from io import BytesIO
-    from six.moves.urllib.request import urlopen
+    from urllib2 import urlopen
     from zipfile import ZipFile
 
     zipresp = urlopen(self.pp.genericOption)

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -143,7 +143,7 @@ class ObjectLoader(object):
   def __recurseImport(self, modName, parentModule=None, hideExceptions=False):
     """ Internal function to load modules
     """
-    if isinstance(modName, basestring):
+    if isinstance(modName, six.string_types):
       modName = modName.split('.')
     try:
       if parentModule:

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -11,7 +11,8 @@ import os
 import pickle
 import getopt
 import imp
-import urllib2
+from six.moves.urllib.request import urlopen
+from six.moves.urllib.error import URLError, HTTPError
 import signal
 
 
@@ -66,7 +67,7 @@ def retrieveUrlTimeout(url, fileName, log, timeout=0):
     # set timeout alarm
     signal.alarm(timeout + 5)
   try:
-    remoteFD = urllib2.urlopen(url)
+    remoteFD = urlopen(url)
     expectedBytes = 0
     # Sometimes repositories do not return Content-Length parameter
     try:
@@ -91,13 +92,13 @@ def retrieveUrlTimeout(url, fileName, log, timeout=0):
     else:
       return urlData
 
-  except urllib2.HTTPError as x:
+  except HTTPError as x:
     if x.code == 404:
       log.error("URL retrieve: %s does not exist" % url)
       if timeout:
         signal.alarm(0)
       return False
-  except urllib2.URLError:
+  except URLError:
     log.error('Timeout after %s seconds on transfer request for "%s"' % (str(timeout), url))
     return False
   except Exception as x:

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 __RCSID__ = '$Id$'
 
+import six
 import sys
 import time
 import os

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 __RCSID__ = '$Id$'
 
+from past.builtins import long
 import six
 import sys
 import time

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -1,19 +1,15 @@
 """ A set of common tools to be used in pilot commands
 """
-from __future__ import print_function
 
 __RCSID__ = '$Id$'
 
-from past.builtins import long
-import six
 import sys
 import time
 import os
 import pickle
 import getopt
 import imp
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import URLError, HTTPError
+import urllib2
 import signal
 
 
@@ -33,7 +29,7 @@ def pythonPathCheck():
   try:
     os.umask(18)  # 022
     pythonpath = os.getenv('PYTHONPATH', '').split(':')
-    print('Directories in PYTHONPATH:', pythonpath)
+    print 'Directories in PYTHONPATH:', pythonpath
     for p in pythonpath:
       if p == '':
         continue
@@ -42,15 +38,15 @@ def pythonPathCheck():
           # In case a given directory is twice in PYTHONPATH it has to removed only once
           sys.path.remove(os.path.normpath(p))
       except Exception as x:
-        print(x)
-        print("[EXCEPTION-info] Failing path:", p, os.path.normpath(p))
-        print("[EXCEPTION-info] sys.path:", sys.path)
+        print x
+        print "[EXCEPTION-info] Failing path:", p, os.path.normpath(p)
+        print "[EXCEPTION-info] sys.path:", sys.path
         raise x
   except Exception as x:
-    print(x)
-    print("[EXCEPTION-info] sys.executable:", sys.executable)
-    print("[EXCEPTION-info] sys.version:", sys.version)
-    print("[EXCEPTION-info] os.uname():", os.uname())
+    print x
+    print "[EXCEPTION-info] sys.executable:", sys.executable
+    print "[EXCEPTION-info] sys.version:", sys.version
+    print "[EXCEPTION-info] os.uname():", os.uname()
     raise x
 
 
@@ -68,7 +64,7 @@ def retrieveUrlTimeout(url, fileName, log, timeout=0):
     # set timeout alarm
     signal.alarm(timeout + 5)
   try:
-    remoteFD = urlopen(url)
+    remoteFD = urllib2.urlopen(url)
     expectedBytes = 0
     # Sometimes repositories do not return Content-Length parameter
     try:
@@ -93,13 +89,13 @@ def retrieveUrlTimeout(url, fileName, log, timeout=0):
     else:
       return urlData
 
-  except HTTPError as x:
+  except urllib2.HTTPError as x:
     if x.code == 404:
       log.error("URL retrieve: %s does not exist" % url)
       if timeout:
         signal.alarm(0)
       return False
-  except URLError:
+  except urllib2.URLError:
     log.error('Timeout after %s seconds on transfer request for "%s"' % (str(timeout), url))
     return False
   except Exception as x:
@@ -147,7 +143,7 @@ class ObjectLoader(object):
   def __recurseImport(self, modName, parentModule=None, hideExceptions=False):
     """ Internal function to load modules
     """
-    if isinstance(modName, six.string_types):
+    if isinstance(modName, basestring):
       modName = modName.split('.')
     try:
       if parentModule:
@@ -253,11 +249,11 @@ class Logger(object):
                                              level,
                                              self.name,
                                              _line)
-            print(outLine)
+            print outLine
             if self.out:
               outputFile.write(outLine + '\n')
           else:
-            print(_line)
+            print _line
             outputFile.write(_line + '\n')
     sys.stdout.flush()
 

--- a/WorkloadManagementSystem/PilotAgent/pilotTools.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotTools.py
@@ -1,5 +1,6 @@
 """ A set of common tools to be used in pilot commands
 """
+from __future__ import print_function
 
 __RCSID__ = '$Id$'
 
@@ -29,7 +30,7 @@ def pythonPathCheck():
   try:
     os.umask(18)  # 022
     pythonpath = os.getenv('PYTHONPATH', '').split(':')
-    print 'Directories in PYTHONPATH:', pythonpath
+    print('Directories in PYTHONPATH:', pythonpath)
     for p in pythonpath:
       if p == '':
         continue
@@ -38,15 +39,15 @@ def pythonPathCheck():
           # In case a given directory is twice in PYTHONPATH it has to removed only once
           sys.path.remove(os.path.normpath(p))
       except Exception as x:
-        print x
-        print "[EXCEPTION-info] Failing path:", p, os.path.normpath(p)
-        print "[EXCEPTION-info] sys.path:", sys.path
+        print(x)
+        print("[EXCEPTION-info] Failing path:", p, os.path.normpath(p))
+        print("[EXCEPTION-info] sys.path:", sys.path)
         raise x
   except Exception as x:
-    print x
-    print "[EXCEPTION-info] sys.executable:", sys.executable
-    print "[EXCEPTION-info] sys.version:", sys.version
-    print "[EXCEPTION-info] os.uname():", os.uname()
+    print(x)
+    print("[EXCEPTION-info] sys.executable:", sys.executable)
+    print("[EXCEPTION-info] sys.version:", sys.version)
+    print("[EXCEPTION-info] os.uname():", os.uname())
     raise x
 
 
@@ -249,11 +250,11 @@ class Logger(object):
                                              level,
                                              self.name,
                                              _line)
-            print outLine
+            print(outLine)
             if self.out:
               outputFile.write(outLine + '\n')
           else:
-            print _line
+            print(_line)
             outputFile.write(_line + '\n')
     sys.stdout.flush()
 

--- a/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -287,7 +287,7 @@ class JobManagerHandler(RequestHandler):
 
     if isinstance(jobInput, int):
       return [jobInput]
-    if isinstance(jobInput, basestring):
+    if isinstance(jobInput, six.string_types):
       try:
         ijob = int(jobInput)
         return [ijob]

--- a/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -12,6 +12,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import gConfig, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.DISET.MessageClient import MessageClient

--- a/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -7,6 +7,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 from datetime import timedelta
 
 from DIRAC import S_OK, S_ERROR

--- a/WorkloadManagementSystem/Service/MatcherHandler.py
+++ b/WorkloadManagementSystem/Service/MatcherHandler.py
@@ -6,6 +6,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import gLogger, S_OK, S_ERROR
 
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler

--- a/WorkloadManagementSystem/Service/MatcherHandler.py
+++ b/WorkloadManagementSystem/Service/MatcherHandler.py
@@ -118,7 +118,7 @@ class MatcherHandler(RequestHandler):
   def export_getMatchingTaskQueues(self, resourceDict):
     """ Return all task queues that match the resourceDict
     """
-    if 'Site' in resourceDict and isinstance(resourceDict['Site'], basestring):
+    if 'Site' in resourceDict and isinstance(resourceDict['Site'], six.string_types):
       negativeCond = self.limiter.getNegativeCondForSite(resourceDict['Site'])
     else:
       negativeCond = self.limiter.getNegativeCond()

--- a/WorkloadManagementSystem/Service/OptimizationMindHandler.py
+++ b/WorkloadManagementSystem/Service/OptimizationMindHandler.py
@@ -1,6 +1,7 @@
 __RCSID__ = "$Id$"
 
 
+from past.builtins import long
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities import ThreadScheduler
 from DIRAC.Core.Base.ExecutorMindHandler import ExecutorMindHandler

--- a/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -4,6 +4,7 @@ This is the interface to DIRAC PilotAgentsDB.
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import gConfig, S_OK, S_ERROR
 import DIRAC.Core.Utilities.Time as Time
 

--- a/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -4,6 +4,7 @@ This is the interface to DIRAC PilotAgentsDB.
 
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import six
 from DIRAC import gConfig, S_OK, S_ERROR
 import DIRAC.Core.Utilities.Time as Time

--- a/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -81,7 +81,7 @@ class PilotManagerHandler(RequestHandler):
     return S_OK(resultDict)
 
   ##########################################################################################
-  types_addPilotTQReference = [list, (int, long), basestring, basestring]
+  types_addPilotTQReference = [list, six.integer_types, basestring, basestring]
 
   @classmethod
   def export_addPilotTQReference(cls, pilotRef, taskQueueID, ownerDN, ownerGroup, broker='Unknown',
@@ -160,7 +160,7 @@ class PilotManagerHandler(RequestHandler):
     return result
 
   ##############################################################################
-  types_getPilotMonitorWeb = [dict, list, (int, long), [int, long]]
+  types_getPilotMonitorWeb = [dict, list, six.integer_types, [int, long]]
 
   @classmethod
   def export_getPilotMonitorWeb(cls, selectDict, sortList, startItem, maxItems):
@@ -183,7 +183,7 @@ class PilotManagerHandler(RequestHandler):
     return result
 
   ##############################################################################
-  types_getPilotSummaryWeb = [dict, list, (int, long), [int, long]]
+  types_getPilotSummaryWeb = [dict, list, six.integer_types, [int, long]]
 
   @classmethod
   def export_getPilotSummaryWeb(cls, selectDict, sortList, startItem, maxItems):
@@ -376,7 +376,7 @@ class PilotManagerHandler(RequestHandler):
     if isinstance(pilotIDs, six.string_types):
       return pilotDB.deletePilot(pilotIDs)
 
-    if isinstance(pilotIDs, (int, long)):
+    if isinstance(pilotIDs, six.integer_types):
       pilotIDs = [pilotIDs, ]
 
     result = pilotDB.deletePilots(pilotIDs)
@@ -397,7 +397,7 @@ class PilotManagerHandler(RequestHandler):
     return S_OK()
 
 ##############################################################################
-  types_clearPilots = [(int, long), (int, long)]
+  types_clearPilots = [six.integer_types, six.integer_types]
 
   def export_clearPilots(self, interval=30, aborted_interval=7):
 

--- a/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -237,7 +237,7 @@ class PilotManagerHandler(RequestHandler):
     """
     # Make a list if it is not yet
     pilotRefs = list(pilotRefList)
-    if isinstance(pilotRefList, basestring):
+    if isinstance(pilotRefList, six.string_types):
       pilotRefs = [pilotRefList]
 
     # Regroup pilots per site and per owner
@@ -373,7 +373,7 @@ class PilotManagerHandler(RequestHandler):
 
   def export_deletePilots(self, pilotIDs):
 
-    if isinstance(pilotIDs, basestring):
+    if isinstance(pilotIDs, six.string_types):
       return pilotDB.deletePilot(pilotIDs)
 
     if isinstance(pilotIDs, (int, long)):

--- a/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -155,7 +155,7 @@ class WMSAdministratorHandler(RequestHandler):
     """ Get the site mask logging history
     """
 
-    if isinstance(sites, basestring):
+    if isinstance(sites, six.string_types):
       sites = [sites]
 
     return jobDB.getSiteMaskLogging(sites)
@@ -473,7 +473,7 @@ class WMSAdministratorHandler(RequestHandler):
     """
     # Make a list if it is not yet
     pilotRefs = list(pilotRefList)
-    if isinstance(pilotRefList, basestring):
+    if isinstance(pilotRefList, six.string_types):
       pilotRefs = [pilotRefList]
 
     # Regroup pilots per site and per owner
@@ -618,7 +618,7 @@ class WMSAdministratorHandler(RequestHandler):
   @deprecated("Moved to PilotManagerHandler")
   def export_deletePilots(cls, pilotIDs):
 
-    if isinstance(pilotIDs, basestring):
+    if isinstance(pilotIDs, six.string_types):
       return PilotAgentsDB().deletePilot(pilotIDs)
 
     if isinstance(pilotIDs, (int, long)):

--- a/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -4,6 +4,7 @@ This is a DIRAC WMS administrator interface.
 
 __RCSID__ = "$Id$"
 
+import six
 from DIRAC import gConfig, S_OK, S_ERROR
 
 from DIRAC.Core.DISET.RequestHandler import RequestHandler

--- a/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -4,6 +4,7 @@ This is a DIRAC WMS administrator interface.
 
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import six
 from DIRAC import gConfig, S_OK, S_ERROR
 

--- a/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -219,7 +219,7 @@ class WMSAdministratorHandler(RequestHandler):
     return S_ERROR('No pilot job reference found')
 
   ##############################################################################
-  types_getSiteSummaryWeb = [dict, list, (int, long), (int, long)]
+  types_getSiteSummaryWeb = [dict, list, six.integer_types, six.integer_types]
 
   @classmethod
   def export_getSiteSummaryWeb(cls, selectDict, sortList, startItem, maxItems):
@@ -304,7 +304,7 @@ class WMSAdministratorHandler(RequestHandler):
     return S_OK(resultDict)
 
   ##########################################################################################
-  types_addPilotTQReference = [list, (int, long), basestring, basestring]
+  types_addPilotTQReference = [list, six.integer_types, basestring, basestring]
 
   @classmethod
   @deprecated("Moved to PilotManagerHandler")
@@ -391,7 +391,7 @@ class WMSAdministratorHandler(RequestHandler):
     return result
 
   ##############################################################################
-  types_getPilotMonitorWeb = [dict, list, (int, long), [int, long]]
+  types_getPilotMonitorWeb = [dict, list, six.integer_types, [int, long]]
 
   @classmethod
   @deprecated("Moved to PilotManagerHandler")
@@ -416,7 +416,7 @@ class WMSAdministratorHandler(RequestHandler):
     return result
 
   ##############################################################################
-  types_getPilotSummaryWeb = [dict, list, (int, long), [int, long]]
+  types_getPilotSummaryWeb = [dict, list, six.integer_types, [int, long]]
 
   @classmethod
   @deprecated("Moved to PilotManagerHandler")
@@ -621,7 +621,7 @@ class WMSAdministratorHandler(RequestHandler):
     if isinstance(pilotIDs, six.string_types):
       return PilotAgentsDB().deletePilot(pilotIDs)
 
-    if isinstance(pilotIDs, (int, long)):
+    if isinstance(pilotIDs, six.integer_types):
       pilotIDs = [pilotIDs, ]
 
     result = PilotAgentsDB().deletePilots(pilotIDs)
@@ -642,7 +642,7 @@ class WMSAdministratorHandler(RequestHandler):
     return S_OK()
 
 ##############################################################################
-  types_clearPilots = [(int, long), (int, long)]
+  types_clearPilots = [six.integer_types, six.integer_types]
 
   @classmethod
   @deprecated("Moved to PilotManagerHandler")

--- a/WorkloadManagementSystem/Utilities/JobParameters.py
+++ b/WorkloadManagementSystem/Utilities/JobParameters.py
@@ -6,7 +6,7 @@ __RCSID__ = "$Id$"
 import os
 import re
 import multiprocessing
-import urllib2
+from six.moves.urllib.request import urlopen
 
 from DIRAC import gLogger, gConfig
 from DIRAC.Core.Utilities.List import fromChar
@@ -21,7 +21,7 @@ def getJobFeatures():
                'cpu_limit_secs', 'max_rss_bytes', 'max_swap_bytes', 'scratch_limit_bytes'):
     fname = os.path.join(os.environ['JOBFEATURES'], item)
     try:
-      val = urllib2.urlopen(fname).read()
+      val = urlopen(fname).read()
     except BaseException:
       val = 0
     features[item] = val

--- a/WorkloadManagementSystem/Utilities/ParametricJob.py
+++ b/WorkloadManagementSystem/Utilities/ParametricJob.py
@@ -170,7 +170,7 @@ def generateParametricJobs(jobClassAd):
         attribute = 'Parameter'
       else:
         attribute = 'Parameter.%s' % seqID
-      if isinstance(parameter, basestring) and parameter.startswith('{'):
+      if isinstance(parameter, six.string_types) and parameter.startswith('{'):
         newClassAd.insertAttributeInt(attribute, str(parameter))
       else:
         newClassAd.insertAttributeString(attribute, str(parameter))

--- a/WorkloadManagementSystem/Utilities/ParametricJob.py
+++ b/WorkloadManagementSystem/Utilities/ParametricJob.py
@@ -7,6 +7,7 @@
 
 __RCSID__ = "$Id$"
 
+import six
 import re
 
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd

--- a/WorkloadManagementSystem/scripts/dirac-admin-show-task-queues.py
+++ b/WorkloadManagementSystem/scripts/dirac-admin-show-task-queues.py
@@ -9,6 +9,7 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
+from past.builtins import long
 import sys
 
 from DIRAC import S_OK, gLogger

--- a/docs/source/DeveloperGuide/AddingNewComponents/DevelopingExecutors/PingPongMindHandler.py
+++ b/docs/source/DeveloperGuide/AddingNewComponents/DevelopingExecutors/PingPongMindHandler.py
@@ -13,7 +13,7 @@ random.seed()
 
 class PingPongMindHandler(ExecutorMindHandler):
 
-  MSG_DEFINITIONS = {'StartReaction': {'numBounces': (int, long)}}
+  MSG_DEFINITIONS = {'StartReaction': {'numBounces': six.integer_types}}
 
   auth_msg_StartReaction = ['all']
 

--- a/docs/source/DeveloperGuide/AddingNewComponents/DevelopingExecutors/PingPongMindHandler.py
+++ b/docs/source/DeveloperGuide/AddingNewComponents/DevelopingExecutors/PingPongMindHandler.py
@@ -2,6 +2,7 @@
 """
 
 from __future__ import print_function
+import six
 import time
 import random
 from DIRAC import S_OK, gLogger

--- a/docs/source/DeveloperGuide/Systems/Framework/stableconns/service.py
+++ b/docs/source/DeveloperGuide/Systems/Framework/stableconns/service.py
@@ -13,6 +13,7 @@
     }
 """
 
+import six
 from DIRAC import S_OK
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 

--- a/docs/source/DeveloperGuide/Systems/Framework/stableconns/service.py
+++ b/docs/source/DeveloperGuide/Systems/Framework/stableconns/service.py
@@ -19,8 +19,8 @@ from DIRAC.Core.DISET.RequestHandler import RequestHandler
 
 class PingPongHandler(RequestHandler):
 
-  MSG_DEFINITIONS = {'Ping': {'id': (int, long)},
-                     'Pong': {'id': (int, long)}}
+  MSG_DEFINITIONS = {'Ping': {'id': six.integer_types},
+                     'Pong': {'id': six.integer_types}}
 
   auth_conn_connected = ['all']
 

--- a/tests/Integration/DataManagementSystem/FIXME_Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/FIXME_Test_DataManager.py
@@ -25,13 +25,13 @@ class ReplicaManagerTestCase(unittest.TestCase):
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in putRes['Value'])
+    self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterReplicate(self):
@@ -45,18 +45,18 @@ class ReplicaManagerTestCase(unittest.TestCase):
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in putRes['Value'])
+    self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replicate was successful
     self.assertTrue(replicateRes['OK'])
-    self.assertTrue(replicateRes['Value'].has_key('Successful'))
-    self.assertTrue(replicateRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in replicateRes['Value'])
+    self.assertTrue(lfn in replicateRes['Value']['Successful'])
     self.assertTrue(replicateRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterGetReplicaMetadata(self):
@@ -70,22 +70,22 @@ class ReplicaManagerTestCase(unittest.TestCase):
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in putRes['Value'])
+    self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the metadata query was successful
     self.assertTrue(metadataRes['OK'])
-    self.assertTrue(metadataRes['Value'].has_key('Successful'))
-    self.assertTrue(metadataRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in metadataRes['Value'])
+    self.assertTrue(lfn in metadataRes['Value']['Successful'])
     self.assertTrue(metadataRes['Value']['Successful'][lfn])
     metadataDict = metadataRes['Value']['Successful'][lfn]
-    self.assertTrue(metadataDict.has_key('Cached'))
-    self.assertTrue(metadataDict.has_key('Migrated'))
-    self.assertTrue(metadataDict.has_key('Size'))
+    self.assertTrue('Cached' in metadataDict)
+    self.assertTrue('Migrated' in metadataDict)
+    self.assertTrue('Size' in metadataDict)
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
 
@@ -101,18 +101,18 @@ class ReplicaManagerTestCase(unittest.TestCase):
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in putRes['Value'])
+    self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the access url was successful
     self.assertTrue(getAccessUrlRes['OK'])
-    self.assertTrue(getAccessUrlRes['Value'].has_key('Successful'))
-    self.assertTrue(getAccessUrlRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in getAccessUrlRes['Value'])
+    self.assertTrue(lfn in getAccessUrlRes['Value']['Successful'])
     self.assertTrue(getAccessUrlRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterRemoveReplica(self):
@@ -126,18 +126,18 @@ class ReplicaManagerTestCase(unittest.TestCase):
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in putRes['Value'])
+    self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
     self.assertTrue(removeReplicaRes['OK'])
-    self.assertTrue(removeReplicaRes['Value'].has_key('Successful'))
-    self.assertTrue(removeReplicaRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeReplicaRes['Value'])
+    self.assertTrue(lfn in removeReplicaRes['Value']['Successful'])
     self.assertTrue(removeReplicaRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_registerFile(self):
@@ -153,8 +153,8 @@ class ReplicaManagerTestCase(unittest.TestCase):
 
     # Check that the file registration was done correctly
     self.assertTrue(registerRes['OK'])
-    self.assertTrue(registerRes['Value'].has_key('Successful'))
-    self.assertTrue(registerRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in registerRes['Value'])
+    self.assertTrue(lfn in registerRes['Value']['Successful'])
     self.assertTrue(registerRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
     # self.assertTrue(removeCatalogReplicaRes['OK'])
@@ -163,8 +163,8 @@ class ReplicaManagerTestCase(unittest.TestCase):
     # self.assertTrue(removeCatalogReplicaRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeFileRes['OK'])
-    self.assertTrue(removeFileRes['Value'].has_key('Successful'))
-    self.assertTrue(removeFileRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeFileRes['Value'])
+    self.assertTrue(lfn in removeFileRes['Value']['Successful'])
     self.assertTrue(removeFileRes['Value']['Successful'][lfn])
 
   def test_registerReplica(self):
@@ -186,13 +186,13 @@ class ReplicaManagerTestCase(unittest.TestCase):
 
     # Check that the file registration was done correctly
     self.assertTrue(registerRes['OK'])
-    self.assertTrue(registerRes['Value'].has_key('Successful'))
-    self.assertTrue(registerRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in registerRes['Value'])
+    self.assertTrue(lfn in registerRes['Value']['Successful'])
     self.assertTrue(registerRes['Value']['Successful'][lfn])
     # Check that the replica registration was successful
     self.assertTrue(registerReplicaRes['OK'])
-    self.assertTrue(registerReplicaRes['Value'].has_key('Successful'))
-    self.assertTrue(registerReplicaRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in registerReplicaRes['Value'])
+    self.assertTrue(lfn in registerReplicaRes['Value']['Successful'])
     self.assertTrue(registerReplicaRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
     # self.assertTrue(removeCatalogReplicaRes1['OK'])
@@ -206,8 +206,8 @@ class ReplicaManagerTestCase(unittest.TestCase):
     # self.assertTrue(removeCatalogReplicaRes2['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeFileRes['OK'])
-    self.assertTrue(removeFileRes['Value'].has_key('Successful'))
-    self.assertTrue(removeFileRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeFileRes['Value'])
+    self.assertTrue(lfn in removeFileRes['Value']['Successful'])
     self.assertTrue(removeFileRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterGet(self):
@@ -224,18 +224,18 @@ class ReplicaManagerTestCase(unittest.TestCase):
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in putRes['Value'])
+    self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
     self.assertTrue(getRes['OK'])
-    self.assertTrue(getRes['Value'].has_key('Successful'))
-    self.assertTrue(getRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in getRes['Value'])
+    self.assertTrue(lfn in getRes['Value']['Successful'])
     self.assertEqual(getRes['Value']['Successful'][lfn],localFilePath)
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
 if __name__ == '__main__':

--- a/tests/Integration/RequestManagementSystem/Test_Client_Req.py
+++ b/tests/Integration/RequestManagementSystem/Test_Client_Req.py
@@ -8,6 +8,7 @@
 
 from __future__ import print_function
 
+from past.builtins import long
 import unittest
 import sys
 

--- a/tests/Integration/Resources/Catalog/FIXME_Test_CatalogPlugin.py
+++ b/tests/Integration/Resources/Catalog/FIXME_Test_CatalogPlugin.py
@@ -61,14 +61,14 @@ class CatalogPlugInTestCase(unittest.TestCase):
     self.assertTrue(res['OK'])
     self.assertTrue(res['Value'])
     self.assertTrue(res['Value']['Successful'])
-    self.assertTrue(res['Value']['Successful'].has_key(path))
+    self.assertTrue(path in res['Value']['Successful'])
     return res['Value']['Successful'][path]
 
   def parseError(self,res,path):
     self.assertTrue(res['OK'])
     self.assertTrue(res['Value'])
     self.assertTrue(res['Value']['Failed'])
-    self.assertTrue(res['Value']['Failed'].has_key(path))
+    self.assertTrue(path in res['Value']['Failed'])
     return res['Value']['Failed'][path]
 
   def cleanDirectory(self):
@@ -124,7 +124,7 @@ class FileTestCase(CatalogPlugInTestCase):
     self.assertEqual(returnValue['Size'],10000000)
     self.metadata = ['Status', 'ChecksumType', 'NumberOfLinks', 'CreationDate', 'Checksum', 'ModificationDate', 'Mode', 'GUID', 'Size']
     for key in self.metadata:
-      self.assertTrue(returnValue.has_key(key))
+      self.assertTrue(key in returnValue)
     # Test getFileMetadata for missing path
     res = self.catalog.getFileMetadata(self.files[0][:-1])
     error = self.parseError(res,self.files[0][:-1])
@@ -136,7 +136,7 @@ class FileTestCase(CatalogPlugInTestCase):
     self.assertEqual(returnValue['Size'],0)
     self.metadata = ['Status', 'ChecksumType', 'NumberOfLinks', 'CreationDate', 'Checksum', 'ModificationDate', 'Mode', 'GUID', 'Size']
     for key in self.metadata:
-      self.assertTrue(returnValue.has_key(key))
+      self.assertTrue(key in returnValue)
 
   def test_getFileSize(self):
     # Test getFileSize with a file
@@ -305,14 +305,14 @@ class DirectoryTestCase(CatalogPlugInTestCase):
     self.assertEqual(returnValue['Size'],0)
     self.assertEqual(returnValue['NumberOfSubPaths'],self.numberOfFiles)
     for key in self.dirMetadata:
-      self.assertTrue(returnValue.has_key(key))
+      self.assertTrue(key in returnValue)
     # Test getDirectoryMetadata with a file
     res = self.catalog.getDirectoryMetadata(self.files[0])
     returnValue = self.parseResult(res,self.files[0])
     self.assertEqual(returnValue['Status'],'-')
     self.assertEqual(returnValue['Size'],10000000)
     for key in self.dirMetadata:
-      self.assertTrue(returnValue.has_key(key))
+      self.assertTrue(key in returnValue)
     # Test getDirectoryMetadata for missing path
     res = self.catalog.getDirectoryMetadata(self.files[0][:-1])
     error = self.parseError(res,self.files[0][:-1])
@@ -328,11 +328,11 @@ class DirectoryTestCase(CatalogPlugInTestCase):
     self.assertEqual(sorted(returnValue['Files'].keys()),sorted(self.files))
     directoryFiles = returnValue['Files']
     for lfn,fileDict in directoryFiles.items():
-      self.assertTrue(fileDict.has_key('Replicas'))
+      self.assertTrue('Replicas' in fileDict)
       self.assertEqual(len(fileDict['Replicas']),1)
-      self.assertTrue(fileDict.has_key('MetaData'))
+      self.assertTrue('MetaData' in fileDict)
       for key in self.fileMetadata:
-        self.assertTrue(fileDict['MetaData'].has_key(key))
+        self.assertTrue(key in fileDict['MetaData'])
     # Test listDirectory for a file
     res = self.catalog.listDirectory(self.files[0],True)
     error = self.parseError(res,self.files[0])
@@ -346,7 +346,7 @@ class DirectoryTestCase(CatalogPlugInTestCase):
     # Test getDirectoryReplicas for directory
     res = self.catalog.getDirectoryReplicas(self.destDir,True)
     returnValue = self.parseResult(res,self.destDir)
-    self.assertTrue(returnValue.has_key(self.files[0]))
+    self.assertTrue(self.files[0] in returnValue)
     fileReplicas = returnValue[self.files[0]]
     self.assertEqual(fileReplicas.keys(),['DIRAC-storage'])
     self.assertEqual(fileReplicas.values(),['protocol://host:port/storage/path%s' % self.files[0]])
@@ -364,7 +364,7 @@ class DirectoryTestCase(CatalogPlugInTestCase):
     res = self.catalog.getDirectorySize(self.destDir)
     returnValue = self.parseResult(res,self.destDir)
     for key in ['Files','TotalSize','SubDirs','ClosedDirs','SiteUsage']:
-      self.assertTrue(returnValue.has_key(key))
+      self.assertTrue(key in returnValue)
     self.assertEqual(returnValue['Files'],self.numberOfFiles)
     self.assertEqual(returnValue['TotalSize'],(self.numberOfFiles*10000000))
     #TODO create a sub dir, check, close it, check

--- a/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
@@ -26,6 +26,7 @@
 # pylint: disable=protected-access,wrong-import-position,invalid-name
 
 from __future__ import print_function
+from past.builtins import long
 import unittest
 import sys
 import datetime

--- a/tests/Utilities/assertingUtils.py
+++ b/tests/Utilities/assertingUtils.py
@@ -28,15 +28,15 @@ def _parseOption(outDict, inDict, optionPrefix=''):
   for option, value in inDict.iteritems():
     optionName = "/".join([optionPrefix, option]).strip('/')
     LOG.info("Parsing %r with %r", optionName, value)
-    if isinstance(value, basestring) and value.lower() in ('no', 'false'):
+    if isinstance(value, six.string_types) and value.lower() in ('no', 'false'):
       outDict[optionName] = False
-    elif isinstance(value, basestring) and value.lower() in ('yes', 'true'):
+    elif isinstance(value, six.string_types) and value.lower() in ('yes', 'true'):
       outDict[optionName] = True
-    elif isinstance(value, basestring) and ',' in value:
+    elif isinstance(value, six.string_types) and ',' in value:
       outDict[optionName] = [val.strip() for val in value.split(',')]
     elif isinstance(value, dict):
       _parseOption(outDict, value, optionPrefix=optionName)
-    elif isinstance(value, basestring):
+    elif isinstance(value, six.string_types):
       outDict[optionName] = value
       if value.isdigit():
         try:

--- a/tests/Utilities/assertingUtils.py
+++ b/tests/Utilities/assertingUtils.py
@@ -4,6 +4,7 @@ The AgentOptionsTest can be used to check consistency of options for Agents.
 
 """
 
+import six
 import inspect
 import importlib
 import logging


### PR DESCRIPTION
Each commit corresponds to a single change made using a one liner to fix the source and, assuming there are no typos, it should be completely safe to merge and have no effect in Python 2.

The formatting CI will likely fail but I'd rather not make this PR any bigger than it already is.

There is a chance I've accidentally made the install scripts dependent on `six`. The list of modified files should be checked before merging.

Non trivial changes are in these commits:
* 45f08de: Looks like a minor bug
* fb88716: Avoid comparing unequal types, e.g `None > 0`
* 8d9747c6f: [Warning from sqlalchemy](https://docs.sqlalchemy.org/en/13/changelog/migration_09.html#new-query-options-api-load-only-option)
* 3fb2571c5: `urllib` moves. This was done by hand so I could easily have made a mistake.
* 2d0e8aa30: This might be slightly more permissive as it will accept subclasses in many cases.

BEGINRELEASENOTES
Safe Python 3 compatibility fixes
ENDRELEASENOTES
