### PR TITLE
[v7r1] Fix proxy generation

### DIFF
--- a/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -84,7 +84,7 @@ class ProxyManagerHandler(RequestHandler):
 
   # WARN: Since v7r1 requestDelegationUpload method use only first argument!
   # WARN:   Second argument for compatibility with older versions
-  types_requestDelegationUpload = [[int, long], [basestring, bool]]
+  types_requestDelegationUpload = [[int, long], [basestring, bool, type(None)]]
 
   def export_requestDelegationUpload(self, requestedUploadTime, diracGroup=None):
     """ Request a delegation. Send a delegation request to client


### PR DESCRIPTION
The integration tests are failing as `diracGroup` is set to `None` but the type checking doesn't allow this:

https://github.com/DIRACGrid/DIRAC/blob/fe33283186cd5b1ba15755ecd50307877af64488/FrameworkSystem/Client/ProxyManagerClient.py#L197

Alternatively this could be fixed by relying on the default value.

@atsareg There are a lot failures in the integration tests. Can you make sure they're fixed before the certification hackathon next week?