### PR TITLE
[v7r1] Support installing from a local directory in dirac-install.py

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2576,10 +2576,10 @@ if __name__ == "__main__":
         if not retVal['OK']:
           logERROR("Cannot checkout %s" % retVal['Message'])
           sys.exit(1)
-        continue
-      logNOTICE("Installing %s:%s" % (modName, modVersion))
-      if not downloadAndExtractTarball(tarsURL, modName, modVersion):
-        sys.exit(1)
+      else:
+        logNOTICE("Installing %s:%s" % (modName, modVersion))
+        if not downloadAndExtractTarball(tarsURL, modName, modVersion):
+          sys.exit(1)
     logNOTICE("Deploying scripts...")
     ddeLocation = os.path.join(cliParams.targetPath, "DIRAC", "Core",
                                "scripts", "dirac-deploy-scripts.py")

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1688,7 +1688,6 @@ cmdOpts = (('r:', 'release=', 'Release version to install'),
            ('  ', 'tag=', 'release version to install from git, http or local'),
            ('m:', 'module=',
             'Module to be installed. for example: -m DIRAC or -m git://github.com/DIRACGrid/DIRAC.git:DIRAC'),
-           ('s:', 'source=', 'location of the modules to be installed'),
            ('x:', 'external=', 'external version'),
            ('  ', 'cleanPYTHONPATH', 'Only use the DIRAC PYTHONPATH (for pilots installation)'),
            ('  ', 'createLink', 'create version symbolic link from the versions directory. This is equivalent to the \


### PR DESCRIPTION
This is in preparation for being able to run the GitLab CI tests locally. The interesting commit is 21b59b3 and the others are just minor linter/readability improvements.

Unfortunately the diff isn't displayed very well but it just adds these 4 lines before cloning the repository. If `sourceURL` is a directory, copy it instead of cloning. I think this is useful as it will allow the integration tests to be ran locally without any need to commit beforehand.

```python
  if os.path.isdir(sourceURL):
    logNOTICE("Using local copy for source: %s" % sourceURL)
    shutil.copytree(sourceURL, fDirName)
  else:
```

BEGINRELEASENOTES
*Core
NEW: Allow installation from a local directory
ENDRELEASENOTES
