### PR TITLE
[v6r22] Fix error handling in Dirac().getJobParameters

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -2428,7 +2428,10 @@ class Dirac(API):
     if printOutput:
       print self.pPrint.pformat(result['Value'])
 
-    return S_OK(result['Value'][jobID])
+    if jobID in result['Value']:
+      return S_OK(result['Value'][jobID])
+    else:
+      return S_ERROR('Failed to get job parameters for %s' % jobID)
 
   #############################################################################
   @deprecated("Use getJobLoggingInfo instead")


### PR DESCRIPTION
```bash
$ dirac-wms-job-get-output.py -g $JOB_NAME
Traceback (most recent call last):
  File "bin/dirac-wms-job-get-output.py", line 97, in <module>
    result = dirac.getOutputSandbox( job, outputDir = outputDir )
  File "DIRAC/Interfaces/API/Dirac.py", line 1717, in getOutputSandbox
    params = self.getJobParameters(int(jobID))
  File "DIRAC/Interfaces/API/Dirac.py", line 2431, in getJobParameters
    return S_OK(result['Value'][jobID])
KeyError: 306217237
```

BEGINRELEASENOTES
*Interfaces
FIX: Error handling in Dirac().getJobParameters
ENDRELEASENOTES
