### PR TITLE
[v7r1] DMS client tests to use DIRAC user name, rather than the local user name

### DIFF
--- a/tests/System/client_dms.sh
+++ b/tests/System/client_dms.sh
@@ -9,7 +9,9 @@ echo " "
 echo "====== dirac-proxy-init -g dteam_user" #this is necesary to upload user files
 dirac-proxy-init -g dteam_user
 
-userdir="/dteam/user/$( echo "$USER" |cut -c 1)/$USER"
+dirac_user=$( dirac-proxy-info | awk '/^username / {print $3}' )
+#userdir="/dteam/user/$( echo "$USER" |cut -c 1)/$USER"
+userdir="/dteam/user/$( echo "$dirac_user" |cut -c 1)/$dirac_user"
 echo "this is a test file" >> DMS_Scripts_Test_File.txt
 
 echo " "


### PR DESCRIPTION
In this "Basic DMS client tests" script, the executor's local user name '$USER' is used in composing the test LFN, which would be ok only when the dirac user name and the local system user name are the same.
When they are different, the check with 'dirac-dms-user-lfns' will fail.
The script should take the DIRAC user name.

BEGINRELEASENOTES

*tests
FIX: DMS client tests to use DIRAC user name, rather than the local system user name

ENDRELEASENOTES
