### PR TITLE
[v7r0] increased length of User and Site fields in AccountingDB

### DIFF
--- a/AccountingSystem/Client/Types/DataOperation.py
+++ b/AccountingSystem/Client/Types/DataOperation.py
@@ -9,7 +9,7 @@ class DataOperation(BaseAccountingType):
   def __init__(self):
     BaseAccountingType.__init__(self)
     self.definitionKeyFields = [('OperationType', "VARCHAR(32)"),
-                                ('User', "VARCHAR(32)"),
+                                ('User', "VARCHAR(64)"),
                                 ('ExecutionSite', 'VARCHAR(256)'),
                                 ('Source', 'VARCHAR(32)'),
                                 ('Destination', 'VARCHAR(32)'),

--- a/AccountingSystem/Client/Types/Job.py
+++ b/AccountingSystem/Client/Types/Job.py
@@ -8,13 +8,13 @@ class Job(BaseAccountingType):
 
   def __init__(self):
     BaseAccountingType.__init__(self)
-    self.definitionKeyFields = [('User', 'VARCHAR(32)'),
+    self.definitionKeyFields = [('User', 'VARCHAR(64)'),
                                 ('UserGroup', 'VARCHAR(32)'),
                                 ('JobGroup', "VARCHAR(64)"),
                                 ('JobType', 'VARCHAR(32)'),
                                 ('JobClass', 'VARCHAR(32)'),
                                 ('ProcessingType', 'VARCHAR(256)'),
-                                ('Site', 'VARCHAR(32)'),
+                                ('Site', 'VARCHAR(64)'),
                                 ('FinalMajorStatus', 'VARCHAR(32)'),
                                 ('FinalMinorStatus', 'VARCHAR(256)')
                                 ]

--- a/AccountingSystem/Client/Types/Pilot.py
+++ b/AccountingSystem/Client/Types/Pilot.py
@@ -7,9 +7,9 @@ class Pilot(BaseAccountingType):
 
   def __init__(self):
     BaseAccountingType.__init__(self)
-    self.definitionKeyFields = [('User', 'VARCHAR(32)'),
+    self.definitionKeyFields = [('User', 'VARCHAR(64)'),
                                 ('UserGroup', 'VARCHAR(32)'),
-                                ('Site', 'VARCHAR(32)'),
+                                ('Site', 'VARCHAR(64)'),
                                 ('GridCE', "VARCHAR(128)"),
                                 ('GridMiddleware', 'VARCHAR(32)'),
                                 ('GridResourceBroker', 'VARCHAR(128)'),


### PR DESCRIPTION
This is a change to the dababase schema, so it needs a warning in the release notes. We need this as both our user and sitenames follow conventions which occasionally result in a site or user name > 32 characters.

BEGINRELEASENOTES
*Accounting
FIX: Allow longer user and site names.
ENDRELEASENOTES
