### PR TITLE
[v7r0] JobState - restored logic of having global database clients

### DIFF
--- a/WorkloadManagementSystem/Client/JobState/JobState.py
+++ b/WorkloadManagementSystem/Client/JobState/JobState.py
@@ -18,12 +18,32 @@ from DIRAC.WorkloadManagementSystem.Service.JobPolicy import RIGHT_RESET, RIGHT_
 
 class JobState(object):
 
+  class DBHold:
+
+    def __init__(self):
+      self.checked = False
+      self.reset()
+
+    def reset(self):
+      self.jobDB = None
+      self.logDB = None
+      self.tqDB = None
+
+  __db = DBHold()
+
+  @classmethod
+  def checkDBAccess(cls):
+    # Init DB if there
+    if not JobState.__db.checked:
+      JobState.__db.checked = True
+      JobState.__db.jobDB = JobDB()
+      JobState.__db.logDB = JobLoggingDB()
+      JobState.__db.tqDB = TaskQueueDB()
+
   def __init__(self, jid, source="Unknown"):
     self.__jid = jid
     self.__source = str(source)
-    self.jobDB = JobDB()
-    self.logDB = JobLoggingDB()
-    self.tqDB = TaskQueueDB()
+    self.checkDBAccess()
 
   @property
   def jid(self):
@@ -32,11 +52,8 @@ class JobState(object):
   def setSource(self, source):
     self.__source = source
 
-  def __getDB(self):
-    return self.jobDB
-
   def getManifest(self, rawData=False):
-    result = self.__getDB().getJobJDL(self.__jid)
+    result = JobState.__db.jobDB.getJobJDL(self.__jid)
     if not result['OK'] or rawData:
       return result
     if not result['Value']:
@@ -55,7 +72,7 @@ class JobState(object):
       if not result['OK']:
         return result
     manifestJDL = manifest.dumpAsJDL()
-    return self.__retryFunction(5, self.__getDB().setJobJDL, (self.__jid, manifestJDL))
+    return self.__retryFunction(5, JobState.__db.jobDB.setJobJDL, (self.__jid, manifestJDL))
 
 # Execute traces
 
@@ -99,23 +116,23 @@ class JobState(object):
     if data['att']:
       attN = [t[0] for t in data['att']]
       attV = [t[1] for t in data['att']]
-      result = self.__retryFunction(5, self.jobDB.setJobAttributes,
+      result = self.__retryFunction(5, JobState.__db.jobDB.setJobAttributes,
                                     (self.__jid, attN, attV), {'update': True})
       if not result['OK']:
         return result
 
     if data['jobp']:
-      result = self.__retryFunction(5, self.jobDB.setJobParameters, (self.__jid, data['jobp']))
+      result = self.__retryFunction(5, JobState.__db.jobDB.setJobParameters, (self.__jid, data['jobp']))
       if not result['OK']:
         return result
 
     for k, v in data['optp']:
-      result = self.__retryFunction(5, self.jobDB.setJobOptParameter, (self.__jid, k, v))
+      result = self.__retryFunction(5, JobState.__db.jobDB.setJobOptParameter, (self.__jid, k, v))
       if not result['OK']:
         return result
 
     if 'inputData' in cache:
-      result = self.__retryFunction(5, self.jobDB.setInputData, (self.__jid, cache['inputData']))
+      result = self.__retryFunction(5, JobState.__db.jobDB.setInputData, (self.__jid, cache['inputData']))
       if not result['OK']:
         return result
 
@@ -124,7 +141,7 @@ class JobState(object):
       gLogger.verbose("Logging records for %s: %s %s %s" % (self.__jid, record, updateTime, source))
       record['date'] = updateTime
       record['source'] = source
-      result = self.__retryFunction(5, self.logDB.addLoggingRecord, (self.__jid, ), record)
+      result = self.__retryFunction(5, JobState.__db.logDB.addLoggingRecord, (self.__jid, ), record)
       if not result['OK']:
         return result
 
@@ -160,7 +177,7 @@ class JobState(object):
       self.__checkType(updateTime, datetime.datetime, canBeNone=True)
     except TypeError as excp:
       return S_ERROR(str(excp))
-    result = self.jobDB.setJobStatus(self.__jid, majorStatus, minorStatus, appStatus)
+    result = JobState.__db.jobDB.setJobStatus(self.__jid, majorStatus, minorStatus, appStatus)
     if not result['OK']:
       return result
     # HACK: Cause joblogging is crappy
@@ -168,7 +185,7 @@ class JobState(object):
       minorStatus = 'idem'
     if not source:
       source = self.__source
-    return self.logDB.addLoggingRecord(self.__jid, majorStatus, minorStatus, appStatus,
+    return JobState.__db.logDB.addLoggingRecord(self.__jid, majorStatus, minorStatus, appStatus,
                                        date=updateTime, source=source)
 
   right_getMinorStatus = RIGHT_GET_INFO
@@ -179,16 +196,16 @@ class JobState(object):
       self.__checkType(source, basestring, canBeNone=True)
     except TypeError as excp:
       return S_ERROR(str(excp))
-    result = self.jobDB.setJobStatus(self.__jid, minor=minorStatus)
+    result = JobState.__db.jobDB.setJobStatus(self.__jid, minor=minorStatus)
     if not result['OK']:
       return result
     if not source:
       source = self.__source
-    return self.logDB.addLoggingRecord(self.__jid, minor=minorStatus,
+    return JobState.__db.logDB.addLoggingRecord(self.__jid, minor=minorStatus,
                                        date=updateTime, source=source)
 
   def getStatus(self):
-    result = self.jobDB.getJobAttributes(self.__jid, ['Status', 'MinorStatus'])
+    result = JobState.__db.jobDB.getJobAttributes(self.__jid, ['Status', 'MinorStatus'])
     if not result['OK']:
       return result
     data = result['Value']
@@ -204,18 +221,18 @@ class JobState(object):
       self.__checkType(source, basestring, canBeNone=True)
     except TypeError as excp:
       return S_ERROR(str(excp))
-    result = self.jobDB.setJobStatus(self.__jid, application=appStatus)
+    result = JobState.__db.jobDB.setJobStatus(self.__jid, application=appStatus)
     if not result['OK']:
       return result
     if not source:
       source = self.__source
-    return self.logDB.addLoggingRecord(self.__jid, application=appStatus,
+    return JobState.__db.logDB.addLoggingRecord(self.__jid, application=appStatus,
                                        date=updateTime, source=source)
 
   right_getAppStatus = RIGHT_GET_INFO
 
   def getAppStatus(self):
-    result = self.jobDB.getJobAttributes(self.__jid, ['ApplicationStatus'])
+    result = JobState.__db.jobDB.getJobAttributes(self.__jid, ['ApplicationStatus'])
     if result['OK']:
       result['Value'] = result['Value']['ApplicationStatus']
     return result
@@ -230,7 +247,7 @@ class JobState(object):
       self.__checkType(value, basestring)
     except TypeError as excp:
       return S_ERROR(str(excp))
-    return self.jobDB.setJobAttribute(self.__jid, name, value)
+    return JobState.__db.jobDB.setJobAttribute(self.__jid, name, value)
 
   right_setAttributes = RIGHT_GET_INFO
 
@@ -241,7 +258,7 @@ class JobState(object):
       return S_ERROR(str(excp))
     keys = [key for key in attDict]
     values = [attDict[key] for key in keys]
-    return self.jobDB.setJobAttributes(self.__jid, keys, values)
+    return JobState.__db.jobDB.setJobAttributes(self.__jid, keys, values)
 
   right_getAttribute = RIGHT_GET_INFO
 
@@ -250,7 +267,7 @@ class JobState(object):
       self.__checkType(name, basestring)
     except TypeError as excp:
       return S_ERROR(str(excp))
-    return self.jobDB.getJobAttribute(self.__jid, name)
+    return JobState.__db.jobDB.getJobAttribute(self.__jid, name)
 
   right_getAttributes = RIGHT_GET_INFO
 
@@ -259,7 +276,7 @@ class JobState(object):
       self.__checkType(nameList, (list, tuple), canBeNone=True)
     except TypeError as excp:
       return S_ERROR(str(excp))
-    return self.jobDB.getJobAttributes(self.__jid, nameList)
+    return JobState.__db.jobDB.getJobAttributes(self.__jid, nameList)
 
 # OptimizerParameters
 
@@ -271,7 +288,7 @@ class JobState(object):
       self.__checkType(value, basestring)
     except TypeError as excp:
       return S_ERROR(str(excp))
-    return self.jobDB.setJobOptParameter(self.__jid, name, value)
+    return JobState.__db.jobDB.setJobOptParameter(self.__jid, name, value)
 
   right_setOptParameters = RIGHT_GET_INFO
 
@@ -281,7 +298,7 @@ class JobState(object):
     except TypeError as excp:
       return S_ERROR(str(excp))
     for name in pDict:
-      result = self.jobDB.setJobOptParameter(self.__jid, name, pDict[name])
+      result = JobState.__db.jobDB.setJobOptParameter(self.__jid, name, pDict[name])
       if not result['OK']:
         return result
     return S_OK()
@@ -296,7 +313,7 @@ class JobState(object):
     except TypeError as excp:
       return S_ERROR(str(excp))
     for name in nameList:
-      result = self.jobDB.removeJobOptParameter(self.__jid, name)
+      result = JobState.__db.jobDB.removeJobOptParameter(self.__jid, name)
       if not result['OK']:
         return result
     return S_OK()
@@ -308,7 +325,7 @@ class JobState(object):
       self.__checkType(name, basestring)
     except TypeError as excp:
       return S_ERROR(str(excp))
-    return self.jobDB.getJobOptParameter(self.__jid, name)
+    return JobState.__db.jobDB.getJobOptParameter(self.__jid, name)
 
   right_getOptParameters = RIGHT_GET_INFO
 
@@ -317,41 +334,41 @@ class JobState(object):
       self.__checkType(nameList, (list, tuple), canBeNone=True)
     except TypeError as excp:
       return S_ERROR(str(excp))
-    return self.jobDB.getJobOptParameters(self.__jid, nameList)
+    return JobState.__db.jobDB.getJobOptParameters(self.__jid, nameList)
 
 # Other
 
   right_resetJob = RIGHT_RESCHEDULE
 
   def rescheduleJob(self, source=""):
-    result = self.tqDB.deleteJob(self.__jid)
+    result = JobState.__db.tqDB.deleteJob(self.__jid)
     if not result['OK']:
       return S_ERROR("Cannot delete from TQ job %s: %s" % (self.__jid, result['Message']))
-    result = self.jobDB.rescheduleJob(self.__jid)
+    result = JobState.__db.jobDB.rescheduleJob(self.__jid)
     if not result['OK']:
       return S_ERROR("Cannot reschedule in JobDB job %s: %s" % (self.__jid, result['Message']))
-    self.logDB.addLoggingRecord(self.__jid, "Received", "", "", source=source)
+    JobState.__db.logDB.addLoggingRecord(self.__jid, "Received", "", "", source=source)
     return S_OK()
 
   right_resetJob = RIGHT_RESET
 
   def resetJob(self, source=""):
-    result = self.jobDB.setJobAttribute(self.__jid, "RescheduleCounter", -1)
+    result = JobState.__db.jobDB.setJobAttribute(self.__jid, "RescheduleCounter", -1)
     if not result['OK']:
       return S_ERROR("Cannot set the RescheduleCounter for job %s: %s" % (self.__jid, result['Message']))
-    result = self.tqDB.deleteJob(self.__jid)
+    result = JobState.__db.tqDB.deleteJob(self.__jid)
     if not result['OK']:
       return S_ERROR("Cannot delete from TQ job %s: %s" % (self.__jid, result['Message']))
-    result = self.jobDB.rescheduleJob(self.__jid)
+    result = JobState.__db.jobDB.rescheduleJob(self.__jid)
     if not result['OK']:
       return S_ERROR("Cannot reschedule in JobDB job %s: %s" % (self.__jid, result['Message']))
-    self.logDB.addLoggingRecord(self.__jid, "Received", "", "", source=source)
+    JobState.__db.logDB.addLoggingRecord(self.__jid, "Received", "", "", source=source)
     return S_OK()
 
   right_getInputData = RIGHT_GET_INFO
 
   def getInputData(self):
-    return self.jobDB.getInputData(self.__jid)
+    return JobState.__db.jobDB.getInputData(self.__jid)
 
   @classmethod
   def checkInputDataStructure(cls, pDict):
@@ -372,7 +389,7 @@ class JobState(object):
     result = self.checkInputDataStructure(lfnData)
     if not result['OK']:
       return result
-    return self.jobDB.setInputData(self.__jid, lfnData)
+    return JobState.__db.jobDB.setInputData(self.__jid, lfnData)
 
   right_insertIntoTQ = RIGHT_CHANGE_STATUS
 
@@ -404,11 +421,11 @@ class JobState(object):
 
     jobPriority = reqCfg.getOption('UserPriority', 1)
 
-    result = self.__retryFunction(2, self.tqDB.insertJob, (self.__jid, jobReqDict, jobPriority))
+    result = self.__retryFunction(2, JobState.__db.tqDB.insertJob, (self.__jid, jobReqDict, jobPriority))
     if not result['OK']:
       errMsg = result['Message']
       # Force removing the job from the TQ if it was actually inserted
-      result = self.tqDB.deleteJob(self.__jid)
+      result = JobState.__db.tqDB.deleteJob(self.__jid)
       if result['OK']:
         if result['Value']:
           gLogger.info("Job %s removed from the TQ" % self.__jid)

--- a/WorkloadManagementSystem/Client/JobState/JobState.py
+++ b/WorkloadManagementSystem/Client/JobState/JobState.py
@@ -18,7 +18,7 @@ from DIRAC.WorkloadManagementSystem.Service.JobPolicy import RIGHT_RESET, RIGHT_
 
 class JobState(object):
 
-  class DBHold:
+  class DBHold(object):
 
     def __init__(self):
       self.checked = False


### PR DESCRIPTION
JobState object is instrumented to have database clients on the class level in order not to recreate them at each JobState object instantiation 

BEGINRELEASENOTES

*WMS
FIX: JobState - restored logic of having database clients at the class level

ENDRELEASENOTES
