### PR TITLE
[v6r22] Define queue name as seen by CE

### DIFF
--- a/Resources/Computing/CREAMComputingElement.py
+++ b/Resources/Computing/CREAMComputingElement.py
@@ -96,7 +96,7 @@ class CREAMComputingElement(ComputingElement):
     return name, diracStamp
 
   def _reset(self):
-    self.queue = self.ceParameters['Queue']
+    self.queue = self.ceParameters.get("CEQueueName", self.ceParameters['Queue'])
     self.outputURL = self.ceParameters.get('OutputURL', 'gsiftp://localhost')
     if 'GridEnv' in self.ceParameters:
       self.gridEnv = self.ceParameters['GridEnv']


### PR DESCRIPTION
  This fix was made in #3739 but was somehow lost afterwards. 

BEGINRELEASENOTES

*Resources
FIX: CREAMComputingElement - possibility to defined CEQueueName to be used in the pilot submission command

ENDRELEASENOTES
