### PR TITLE
[v7r0] dirac wrapper script cleanup, convert to bash

### DIFF
--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -30,60 +30,10 @@ simpleCopyMask = [os.path.basename(__file__),
                   'dirac_install.py',
                   'dirac_platform.py']
 
-wrapperTemplate = """#!$PYTHONLOCATION$
-#
-import os,sys,imp
-#
-DiracRoot = os.path.dirname(os.path.dirname( os.path.realpath( sys.argv[0] ) ))
-if 'DIRACPLAT' in os.environ:
-  DiracPlatform = os.environ['DIRACPLAT']
-else:
-  platformPath = os.path.join( DiracRoot, "DIRAC", "Core", "Utilities", "Platform.py" )
-  with open( platformPath, "r" ) as platFD:
-    Platform = imp.load_module( "Platform", platFD, platformPath, ( "", "r", imp.PY_SOURCE ) )
-  DiracPlatform = Platform.getPlatformString()
-  if not DiracPlatform or DiracPlatform == "ERROR":
-    print >> sys.stderr, "Can not determine local platform"
-    sys.exit(-1)
-DiracPath        = '%s' % ( os.path.join(DiracRoot,DiracPlatform,'bin'), )
-DiracPythonPath  = '%s' % ( DiracRoot, )
-DiracLibraryPath      = '%s' % ( os.path.join(DiracRoot,DiracPlatform,'lib'), )
+wrapperTemplate = """#!/bin/bash
 
-baseLibPath = DiracLibraryPath
-if os.path.exists( baseLibPath ):
-  for entry in os.listdir( baseLibPath ):
-    if os.path.isdir( entry ):
-      DiracLibraryPath = '%s:%s' % ( DiracLibraryPath, os.path.join( baseLibPath, entry ) )
-
-
-os.environ['PATH'] = '%s:%s' % ( DiracPath, os.environ['PATH'] )
-
-for varName in ( 'LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH'):
-  if varName not in os.environ:
-    os.environ[varName] = DiracLibraryPath
-  else:
-    os.environ[varName] = '%s:%s' % ( DiracLibraryPath, os.environ[varName] )
-
-if 'PYTHONPATH' not in os.environ:
-  os.environ['PYTHONPATH'] = DiracPythonPath
-else:
-  os.environ['PYTHONPATH'] = '%s:%s' % ( DiracPythonPath, os.environ['PYTHONPATH'] )
-
-DiracScript = os.path.join( DiracRoot, '$SCRIPTLOCATION$' )
-
-certDir = os.path.join( "etc", "grid-security", "certificates" )
-if 'X509_CERT_DIR' not in os.environ and \
-  not os.path.isdir( os.path.join( "/", certDir ) ) and \
-  os.path.isdir( os.path.join( DiracRoot, certDir ) ):
-  os.environ[ 'X509_CERT_DIR' ] = os.path.join( DiracRoot, certDir )
-
-# DCommands special
-os.environ['DCOMMANDS_PPID'] = str( os.getppid( ) )
-
-if sys.argv[1:]:
-  args = ' "%s"' % '" "'.join( sys.argv[1:] )
-else:
-  args = ''
+export DCOMMANDS_PPID=$PPID
+$PYTHONLOCATION$ $DIRAC/$SCRIPTLOCATION$ "$@"
 """
 
 # Python interpreter location can be specified as an argument
@@ -109,17 +59,6 @@ if args:
   pythonLocation = os.path.join(args[0], 'bin', 'python')
 
 wrapperTemplate = wrapperTemplate.replace('$PYTHONLOCATION$', pythonLocation)
-
-# On the newest MacOS the DYLD_LIBRARY_PATH variable is not passed to the shell of
-# the os.system() due to System Integrity Protection feature
-if platform.system() == "Darwin":
-  wrapperTemplate += """
-sys.exit( os.system( 'DYLD_LIBRARY_PATH=%s python "%s"%s' % ( DiracLibraryPath, DiracScript, args )  ) / 256 )
-"""
-else:
-  wrapperTemplate += """
-sys.exit( os.system('python "%s"%s' % ( DiracScript, args )  ) / 256 )
-"""
 
 
 def lookForScriptsInPath(basePath, rootModule):
@@ -203,11 +142,6 @@ for rootModule in listDir:
         print((" Copying %s" % scriptName))
       shutil.copy(os.path.join(rootPath, scriptPath), targetScriptsPath)
       copyPath = os.path.join(targetScriptsPath, scriptName)
-      if platform.system() == 'Darwin':
-        with open(copyPath, 'r+') as script:
-          scriptStr = script.read()
-          script.seek(0)
-          script.write(scriptStr.replace('/usr/bin/env python', pythonLocation))
       os.chmod(copyPath, gDefaultPerms)
       cLen = len(copyPath)
       reFound = pythonScriptRE.match(copyPath)

--- a/Core/scripts/dirac-deploy-scripts.py
+++ b/Core/scripts/dirac-deploy-scripts.py
@@ -33,7 +33,7 @@ simpleCopyMask = [os.path.basename(__file__),
 wrapperTemplate = """#!/bin/bash
 
 export DCOMMANDS_PPID=$PPID
-$PYTHONLOCATION$ $DIRAC/$SCRIPTLOCATION$ "$@"
+exec $PYTHONLOCATION$ $DIRAC/$SCRIPTLOCATION$ "$@"
 """
 
 # Python interpreter location can be specified as an argument

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1615,8 +1615,7 @@ def installExternalRequirements(extType):
   if os.path.isfile(reqScript):
     os.chmod(reqScript, executablePerms)
     logNOTICE("Executing %s..." % reqScript)
-    command = "python '%s' -t '%s' > '%s.out' 2> '%s.err'" % (reqScript, extType,
-                                                              reqScript, reqScript)
+    command = "%s -t '%s' > '%s.out' 2> '%s.err'" % (reqScript, extType, reqScript, reqScript)
     if os.system('bash -c "source %s; %s"' % (bashrcFile, command)):
       logERROR("Requirements installation script %s failed. Check %s.err" % (reqScript,
                                                                              reqScript))


### PR DESCRIPTION
This is a prerequisite for the environment changes we discussed at the meeting. We believe it's fully backwards compatible and should not interfere with LHCb.
BEGINRELEASENOTES
*Core
CHANGE: Simplify and convert command wrapper scripts to bash. Also removed some obsolete MacOS code.
ENDRELEASENOTES
