### PR TITLE
[v7r0] TransformationClient: Rename Operations option Productions/Production…

### DIFF
--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -17,7 +17,7 @@ class TransformationClient(Client):
 
     Client.__init__(self, **kwargs)
     opsH = Operations()
-    self.maxResetCounter = opsH.getValue('Productions/ProductionFilesMaxResetCounter', 10)
+    self.maxResetCounter = opsH.getValue('Transformations/FilesMaxResetCounter', 10)
 
     self.setServer('Transformation/TransformationManager')
 


### PR DESCRIPTION
…FilesMaxResetCounter to Transformations/FilesMaxResetCounter

Fixes #4305 

BEGINRELEASENOTES

*TS
CHANGE: Rename Operations option ``Productions/ProductionFilesMaxResetCounter`` to ``Transformations/FilesMaxResetCounter``

ENDRELEASENOTES
