### PR TITLE
[vr7r0] Docs.Admin.Commands: fix entries for dirac-transformation commands

### DIFF
--- a/docs/source/AdministratorGuide/CommandReference/index.rst
+++ b/docs/source/AdministratorGuide/CommandReference/index.rst
@@ -85,10 +85,8 @@ Transformation management commands:
     dirac-transformation-clean
     dirac-transformation-cli
     dirac-transformation-get-files
-    dirac-transformation-remove-output
     dirac-transformation-recover-data
-    dirac-transformation-resolve-problematics
-    dirac-transformation-verify-outputdata
+    dirac-transformation-remove-output
     dirac-transformation-replication
     dirac-transformation-verify-outputdata
 


### PR DESCRIPTION
Just a small fix for doc entries.