### PR TITLE
[v6r22] Remove useless calls to gLogger.debug()

### DIFF
--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -538,8 +538,8 @@ class MySQL(object):
         inEscapeValues.append(retDict['Value'])
       elif isinstance(value, (tuple, list)):
         tupleValues = []
-        for v in list(value):
-          retDict = self.__escapeString(v)
+        for val in value:
+          retDict = self.__escapeString(val)
           if not retDict['OK']:
             return retDict
           tupleValues.append(retDict['Value'])
@@ -1032,8 +1032,8 @@ class MySQL(object):
     resultList = []
     for raw in res['Value']:
       attrDict = {}
-      for i in range(len(attrList)):
-        attrDict[attrList[i]] = raw[i]
+      for ind, attr in enumerate(attrList):
+        attrDict[attr] = raw[ind]
       item = (attrDict, raw[len(attrList)])
       resultList.append(item)
     return S_OK(resultList)

--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -395,7 +395,7 @@ class MySQL(object):
 
     # let the derived class decide what to do with if is not 1
     self._threadsafe = MySQLdb.thread_safe()
-    #self.log.debug('thread_safe = %s' % self._threadsafe)
+    # self.log.debug('thread_safe = %s' % self._threadsafe)
 
     self.__hostName = str(hostName)
     self.__userName = str(userName)
@@ -428,11 +428,11 @@ class MySQL(object):
     try:
       raise x
     except MySQLdb.Error as e:
-      #self.log.debug('%s: %s' % (methodName, err),
+      # self.log.debug('%s: %s' % (methodName, err),
                      '%d: %s' % (e.args[0], e.args[1]))
       return S_ERROR(DErrno.EMYSQL, '%s: ( %d: %s )' % (err, e.args[0], e.args[1]))
     except BaseException as e:
-      #self.log.debug('%s: %s' % (methodName, err), repr(e))
+      # self.log.debug('%s: %s' % (methodName, err), repr(e))
       return S_ERROR(DErrno.EMYSQL, '%s: (%s)' % (err, repr(e)))
 
   def __isDateTime(self, dateString):
@@ -480,14 +480,14 @@ class MySQL(object):
             if self.__isDateTime(arg2) or arg2.isalnum():
               if self.__isDateTime(arg3) or arg3.isalnum():
                 return S_OK(myString)
-          #self.log.debug('__escape_string: Could not escape string', '"%s"' % myString)
+          # self.log.debug('__escape_string: Could not escape string', '"%s"' % myString)
           return S_ERROR(DErrno.EMYSQL, '__escape_string: Could not escape string')
 
       escape_string = connection.escape_string(str(myString))
-      #self.log.debug('__escape_string: returns', '"%s"' % escape_string)
+      # self.log.debug('__escape_string: returns', '"%s"' % escape_string)
       return S_OK('"%s"' % escape_string)
     except BaseException as x:
-      #self.log.debug('__escape_string: Could not escape string', '"%s"' % myString)
+      # self.log.debug('__escape_string: Could not escape string', '"%s"' % myString)
       return self._except('__escape_string', x, 'Could not escape string')
 
   def __checkTable(self, tableName, force=False):
@@ -516,7 +516,7 @@ class MySQL(object):
     """
       Wrapper around the internal method __escapeString
     """
-    #self.log.debug('_escapeString:', '"%s"' % str(myString))
+    # self.log.debug('_escapeString:', '"%s"' % str(myString))
 
     return self.__escapeString(myString)
 
@@ -524,7 +524,7 @@ class MySQL(object):
     """
     Escapes all strings in the list of values provided
     """
-    #self.log.debug('_escapeValues:', inValues)
+    # self.log.debug('_escapeValues:', inValues)
 
     inEscapeValues = []
 
@@ -570,15 +570,15 @@ class MySQL(object):
       gLogger.error(error)
       return S_ERROR(DErrno.EMYSQL, error)
 
-    #self.log.debug('_connect:', self._connected)
+    # self.log.debug('_connect:', self._connected)
     if self._connected:
       return S_OK()
 
-    #self.log.debug('_connect: Attempting to access DB',
+    # self.log.debug('_connect: Attempting to access DB',
     #               '[%s@%s] by user %s' %
     #               (self.__dbName, self.__hostName, self.__userName))
     try:
-      #self.log.debug('_connect: Connected.')
+      # self.log.debug('_connect: Connected.')
       self._connected = True
       return S_OK()
     except Exception as x:
@@ -595,7 +595,7 @@ class MySQL(object):
     return S_ERROR upon error
     """
 
-    #self.logger.debug('_query: %s' % self._safeCmd(cmd))
+    # self.logger.debug('_query: %s' % self._safeCmd(cmd))
 
     retDict = self._getConnection()
     if not retDict['OK']:
@@ -618,7 +618,7 @@ class MySQL(object):
 
       retDict = S_OK(res)
     except BaseException as x:
-      #self.log.debug('_query: %s' % self._safeCmd(cmd))
+      # self.log.debug('_query: %s' % self._safeCmd(cmd))
       retDict = self._except('_query', x, 'Execution failed.')
 
     try:
@@ -637,7 +637,7 @@ class MySQL(object):
         return S_ERROR upon error
     """
 
-    #self.logger.debug('_update: %s' % self._safeCmd(cmd))
+    # self.logger.debug('_update: %s' % self._safeCmd(cmd))
 
     retDict = self._getConnection()
     if not retDict['OK']:
@@ -648,12 +648,12 @@ class MySQL(object):
       cursor = connection.cursor()
       res = cursor.execute(cmd)
       # connection.commit()
-      #self.log.debug('_update:', res)
+      # self.log.debug('_update:', res)
       retDict = S_OK(res)
       if cursor.lastrowid:
         retDict['lastRowId'] = cursor.lastrowid
     except Exception as x:
-      #self.log.debug('_update: %s: %s' % (self._safeCmd(cmd), str(x)))
+      # self.log.debug('_update: %s: %s' % (self._safeCmd(cmd), str(x)))
       retDict = self._except('_update', x, 'Execution failed.')
 
     try:
@@ -735,7 +735,7 @@ class MySQL(object):
 
         viewQuery.append(";")
         viewQuery = " ".join(viewQuery)
-        #self.log.debug("`%s` VIEW QUERY IS: %s" % (viewName, viewQuery))
+        # self.log.debug("`%s` VIEW QUERY IS: %s" % (viewName, viewQuery))
         createView = self._query(viewQuery)
         if not createView["OK"]:
           self.log.error('Can not create view', createView["Message"])
@@ -830,7 +830,7 @@ class MySQL(object):
                              % (key, forKey, forTable))
 
         if toBeExtracted:
-          #self.log.debug('Table %s ready to be created' % table)
+          # self.log.debug('Table %s ready to be created' % table)
           extracted = True
           tableList.remove(table)
           tableCreationList[i].append(table)
@@ -894,7 +894,7 @@ class MySQL(object):
         retDict = self._update(cmd)
         if not retDict['OK']:
           return retDict
-        #self.log.debug('Table %s created' % table)
+        # self.log.debug('Table %s created' % table)
 
     return S_OK()
 
@@ -906,10 +906,10 @@ class MySQL(object):
     """
       Wrapper to the new method for backward compatibility
     """
-    #self.log.debug('_getFields:', 'deprecation warning, use getFields methods instead of _getFields.')
+    # self.log.debug('_getFields:', 'deprecation warning, use getFields methods instead of _getFields.')
     retDict = _checkFields(inFields, inValues)
     if not retDict['OK']:
-      #self.log.debug('_getFields:', retDict['Message'])
+      # self.log.debug('_getFields:', retDict['Message'])
       return retDict
 
     condDict = {}
@@ -925,7 +925,7 @@ class MySQL(object):
     """
       Wrapper to the new method for backward compatibility
     """
-    #self.log.debug('_insert:', 'deprecation warning, use insertFields methods instead of _insert.')
+    # self.log.debug('_insert:', 'deprecation warning, use insertFields methods instead of _insert.')
     return self.insertFields(tableName, inFields, inValues, conn)
 
   def _to_value(self, param):
@@ -946,7 +946,7 @@ class MySQL(object):
         it will retry MAXCONNECTRETRY to open a new connection and will return
         an error if it fails.
     """
-    #self.log.debug('_getConnection:')
+    # self.log.debug('_getConnection:')
 
     if not self.__initialized:
       error = 'DB not properly initialized'
@@ -984,7 +984,7 @@ class MySQL(object):
     table = _quotedList([table])
     if not table:
       error = 'Invalid table argument'
-      #self.log.debug('countEntries:', error)
+      # self.log.debug('countEntries:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     try:
@@ -1010,13 +1010,13 @@ class MySQL(object):
     table = _quotedList([table])
     if not table:
       error = 'Invalid table argument'
-      #self.log.debug('getCounters:', error)
+      # self.log.debug('getCounters:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     attrNames = _quotedList(attrList)
     if attrNames is None:
       error = 'Invalid updateFields argument'
-      #self.log.debug('getCounters:', error)
+      # self.log.debug('getCounters:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     try:
@@ -1049,13 +1049,13 @@ class MySQL(object):
     table = _quotedList([table])
     if not table:
       error = 'Invalid table argument'
-      #self.log.debug('getDistinctAttributeValues:', error)
+      # self.log.debug('getDistinctAttributeValues:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     attributeName = _quotedList([attribute])
     if not attributeName:
       error = 'Invalid attribute argument'
-      #self.log.debug('getDistinctAttributeValues:', error)
+      # self.log.debug('getDistinctAttributeValues:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     try:
@@ -1095,12 +1095,12 @@ class MySQL(object):
           attrName = '(' + _quotedList(list(aName)) + ')'
         if not attrName:
           error = 'Invalid condDict argument'
-          #self.log.debug('buildCondition:', error)
+          # self.log.debug('buildCondition:', error)
           raise Exception(error)
         if isinstance(attrValue, list):
           retDict = self._escapeValues(attrValue)
           if not retDict['OK']:
-            #self.log.debug('buildCondition:', retDict['Message'])
+            # self.log.debug('buildCondition:', retDict['Message'])
             raise Exception(retDict['Message'])
           else:
             escapeInValues = retDict['Value']
@@ -1113,7 +1113,7 @@ class MySQL(object):
         else:
           retDict = self._escapeValues([attrValue])
           if not retDict['OK']:
-            #self.log.debug('buildCondition:', retDict['Message'])
+            # self.log.debug('buildCondition:', retDict['Message'])
             raise Exception(retDict['Message'])
           else:
             escapeInValue = retDict['Value'][0]
@@ -1127,12 +1127,12 @@ class MySQL(object):
       timeStamp = _quotedList([timeStamp])
       if not timeStamp:
         error = 'Invalid timeStamp argument'
-        #self.log.debug('buildCondition:', error)
+        # self.log.debug('buildCondition:', error)
         raise Exception(error)
       if newer:
         retDict = self._escapeValues([newer])
         if not retDict['OK']:
-          #self.log.debug('buildCondition:', retDict['Message'])
+          # self.log.debug('buildCondition:', retDict['Message'])
           raise Exception(retDict['Message'])
         else:
           escapeInValue = retDict['Value'][0]
@@ -1144,7 +1144,7 @@ class MySQL(object):
       if older:
         retDict = self._escapeValues([older])
         if not retDict['OK']:
-          #self.log.debug('buildCondition:', retDict['Message'])
+          # self.log.debug('buildCondition:', retDict['Message'])
           raise Exception(retDict['Message'])
         else:
           escapeInValue = retDict['Value'][0]
@@ -1158,12 +1158,12 @@ class MySQL(object):
         attrName = _quotedList([attrName])
         if not attrName:
           error = 'Invalid greater argument'
-          #self.log.debug('buildCondition:', error)
+          # self.log.debug('buildCondition:', error)
           raise Exception(error)
 
         retDict = self._escapeValues([attrValue])
         if not retDict['OK']:
-          #self.log.debug('buildCondition:', retDict['Message'])
+          # self.log.debug('buildCondition:', retDict['Message'])
           raise Exception(retDict['Message'])
         else:
           escapeInValue = retDict['Value'][0]
@@ -1178,12 +1178,12 @@ class MySQL(object):
         attrName = _quotedList([attrName])
         if not attrName:
           error = 'Invalid smaller argument'
-          #self.log.debug('buildCondition:', error)
+          # self.log.debug('buildCondition:', error)
           raise Exception(error)
 
         retDict = self._escapeValues([attrValue])
         if not retDict['OK']:
-          #self.log.debug('buildCondition:', retDict['Message'])
+          # self.log.debug('buildCondition:', retDict['Message'])
           raise Exception(retDict['Message'])
         else:
           escapeInValue = retDict['Value'][0]
@@ -1202,13 +1202,13 @@ class MySQL(object):
         continue
       if not isinstance(orderAttr, basestring):
         error = 'Invalid orderAttribute argument'
-        #self.log.debug('buildCondition:', error)
+        # self.log.debug('buildCondition:', error)
         raise Exception(error)
 
       orderField = _quotedList(orderAttr.split(':')[:1])
       if not orderField:
         error = 'Invalid orderAttribute argument'
-        #self.log.debug('buildCondition:', error)
+        # self.log.debug('buildCondition:', error)
         raise Exception(error)
 
       if len(orderAttr.split(':')) == 2:
@@ -1217,7 +1217,7 @@ class MySQL(object):
           orderList.append('%s %s' % (orderField, orderType))
         else:
           error = 'Invalid orderAttribute argument'
-          #self.log.debug('buildCondition:', error)
+          # self.log.debug('buildCondition:', error)
           raise Exception(error)
       else:
         orderList.append(orderAttr)
@@ -1251,7 +1251,7 @@ class MySQL(object):
     table = _quotedList([tableName])
     if not table:
       error = 'Invalid tableName argument'
-      #self.log.debug('getFields:', error)
+      # self.log.debug('getFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     quotedOutFields = '*'
@@ -1259,10 +1259,10 @@ class MySQL(object):
       quotedOutFields = _quotedList(outFields)
       if quotedOutFields is None:
         error = 'Invalid outFields arguments'
-        #self.log.debug('getFields:', error)
+        # self.log.debug('getFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
 
-    #self.log.debug('getFields:', 'selecting fields %s from table %s.' % (quotedOutFields, table))
+    # self.log.debug('getFields:', 'selecting fields %s from table %s.' % (quotedOutFields, table))
 
     if condDict is None:
       condDict = {}
@@ -1299,10 +1299,10 @@ class MySQL(object):
     table = _quotedList([tableName])
     if not table:
       error = 'Invalid tableName argument'
-      #self.log.debug('deleteEntries:', error)
+      # self.log.debug('deleteEntries:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
-    #self.log.debug('deleteEntries:', 'deleting rows from table %s.' % table)
+    # self.log.debug('deleteEntries:', 'deleting rows from table %s.' % table)
 
     try:
       condition = self.buildCondition(condDict=condDict, older=older, newer=newer,
@@ -1336,13 +1336,13 @@ class MySQL(object):
     table = _quotedList([tableName])
     if not table:
       error = 'Invalid tableName argument'
-      #self.log.debug('updateFields:', error)
+      # self.log.debug('updateFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     retDict = _checkFields(updateFields, updateValues)
     if not retDict['OK']:
       error = 'Mismatch between updateFields and updateValues.'
-      #self.log.debug('updateFields:', error)
+      # self.log.debug('updateFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     if updateFields is None:
@@ -1352,23 +1352,23 @@ class MySQL(object):
     if updateDict:
       if not isinstance(updateDict, dict):
         error = 'updateDict must be a of Type DictType'
-        #self.log.debug('updateFields:', error)
+        # self.log.debug('updateFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
       try:
         updateFields += updateDict.keys()
         updateValues += [updateDict[k] for k in updateDict.keys()]
       except TypeError:
         error = 'updateFields and updateValues must be a list'
-        #self.log.debug('updateFields:', error)
+        # self.log.debug('updateFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
 
     updateValues = self._escapeValues(updateValues)
     if not updateValues['OK']:
-      #self.log.debug('updateFields:', updateValues['Message'])
+      # self.log.debug('updateFields:', updateValues['Message'])
       return updateValues
     updateValues = updateValues['Value']
 
-    #self.log.debug('updateFields:', 'updating fields %s from table %s.' % (', '.join(updateFields), table))
+    # self.log.debug('updateFields:', 'updating fields %s from table %s.' % (', '.join(updateFields), table))
 
     try:
       condition = self.buildCondition(condDict=condDict, older=older, newer=newer,
@@ -1393,12 +1393,12 @@ class MySQL(object):
     table = _quotedList([tableName])
     if not table:
       error = 'Invalid tableName argument'
-      #self.log.debug('insertFields:', error)
+      # self.log.debug('insertFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     retDict = _checkFields(inFields, inValues)
     if not retDict['OK']:
-      #self.log.debug('insertFields:', retDict['Message'])
+      # self.log.debug('insertFields:', retDict['Message'])
       return retDict
 
     if inFields is None:
@@ -1408,32 +1408,32 @@ class MySQL(object):
     if inDict:
       if not isinstance(inDict, dict):
         error = 'inDict must be a of Type DictType'
-        #self.log.debug('insertFields:', error)
+        # self.log.debug('insertFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
       try:
         inFields += inDict.keys()
         inValues += [inDict[k] for k in inDict.keys()]
       except TypeError:
         error = 'inFields and inValues must be a list'
-        #self.log.debug('insertFields:', error)
+        # self.log.debug('insertFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
 
     inFieldString = _quotedList(inFields)
     if inFieldString is None:
       error = 'Invalid inFields arguments'
-      #self.log.debug('insertFields:', error)
+      # self.log.debug('insertFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     inFieldString = '(  %s )' % inFieldString
 
     retDict = self._escapeValues(inValues)
     if not retDict['OK']:
-      #self.log.debug('insertFields:', retDict['Message'])
+      # self.log.debug('insertFields:', retDict['Message'])
       return retDict
     inValueString = ', '.join(retDict['Value'])
     inValueString = '(  %s )' % inValueString
 
-    #self.log.debug('insertFields:', 'inserting %s into table %s'
+    # self.log.debug('insertFields:', 'inserting %s into table %s'
                    % (inFieldString, table))
 
     return self._update('INSERT INTO %s %s VALUES %s' %

--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -167,7 +167,6 @@ gInstancesCount = 0
 
 __RCSID__ = "$Id$"
 
-
 MAXCONNECTRETRY = 10
 
 
@@ -429,7 +428,7 @@ class MySQL(object):
       raise x
     except MySQLdb.Error as e:
       # self.log.debug('%s: %s' % (methodName, err),
-                     '%d: %s' % (e.args[0], e.args[1]))
+      #               '%d: %s' % (e.args[0], e.args[1]))
       return S_ERROR(DErrno.EMYSQL, '%s: ( %d: %s )' % (err, e.args[0], e.args[1]))
     except BaseException as e:
       # self.log.debug('%s: %s' % (methodName, err), repr(e))
@@ -500,7 +499,7 @@ class MySQL(object):
     retDict = self._query(cmd)
     if not retDict['OK']:
       return retDict
-    if (tableName, ) in retDict['Value']:
+    if (tableName,) in retDict['Value']:
       if not force:
         # the requested exist and table creation is not force, return with error
         return S_ERROR(DErrno.EMYSQL, 'The requested table already exist')
@@ -610,9 +609,9 @@ class MySQL(object):
         res = ()
 
       # Log the result limiting it to just 10 records
-      #if len(res) <= 10:
+      # if len(res) <= 10:
       #  self.logger.debug('_query: returns', res)
-      #else:
+      # else:
       #  self.logger.debug('_query: Total %d records returned' % len(res))
       #  self.logger.debug('_query: %s ...' % str(res[:10]))
 
@@ -709,7 +708,7 @@ class MySQL(object):
                                         "OrderBy": [ "`b` DESC" ] }
     """
     if force:
-      #gLogger.debug(viewsDict)
+      # gLogger.debug(viewsDict)
 
       for viewName, viewDict in viewsDict.iteritems():
 
@@ -1434,7 +1433,7 @@ class MySQL(object):
     inValueString = '(  %s )' % inValueString
 
     # self.log.debug('insertFields:', 'inserting %s into table %s'
-                   % (inFieldString, table))
+    #               % (inFieldString, table))
 
     return self._update('INSERT INTO %s %s VALUES %s' %
                         (table, inFieldString, inValueString), conn)

--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -395,7 +395,7 @@ class MySQL(object):
 
     # let the derived class decide what to do with if is not 1
     self._threadsafe = MySQLdb.thread_safe()
-    self.log.debug('thread_safe = %s' % self._threadsafe)
+    #self.log.debug('thread_safe = %s' % self._threadsafe)
 
     self.__hostName = str(hostName)
     self.__userName = str(userName)
@@ -428,11 +428,11 @@ class MySQL(object):
     try:
       raise x
     except MySQLdb.Error as e:
-      self.log.debug('%s: %s' % (methodName, err),
+      #self.log.debug('%s: %s' % (methodName, err),
                      '%d: %s' % (e.args[0], e.args[1]))
       return S_ERROR(DErrno.EMYSQL, '%s: ( %d: %s )' % (err, e.args[0], e.args[1]))
     except BaseException as e:
-      self.log.debug('%s: %s' % (methodName, err), repr(e))
+      #self.log.debug('%s: %s' % (methodName, err), repr(e))
       return S_ERROR(DErrno.EMYSQL, '%s: (%s)' % (err, repr(e)))
 
   def __isDateTime(self, dateString):
@@ -480,14 +480,14 @@ class MySQL(object):
             if self.__isDateTime(arg2) or arg2.isalnum():
               if self.__isDateTime(arg3) or arg3.isalnum():
                 return S_OK(myString)
-          self.log.debug('__escape_string: Could not escape string', '"%s"' % myString)
+          #self.log.debug('__escape_string: Could not escape string', '"%s"' % myString)
           return S_ERROR(DErrno.EMYSQL, '__escape_string: Could not escape string')
 
       escape_string = connection.escape_string(str(myString))
-      self.log.debug('__escape_string: returns', '"%s"' % escape_string)
+      #self.log.debug('__escape_string: returns', '"%s"' % escape_string)
       return S_OK('"%s"' % escape_string)
     except BaseException as x:
-      self.log.debug('__escape_string: Could not escape string', '"%s"' % myString)
+      #self.log.debug('__escape_string: Could not escape string', '"%s"' % myString)
       return self._except('__escape_string', x, 'Could not escape string')
 
   def __checkTable(self, tableName, force=False):
@@ -516,7 +516,7 @@ class MySQL(object):
     """
       Wrapper around the internal method __escapeString
     """
-    self.log.debug('_escapeString:', '"%s"' % str(myString))
+    #self.log.debug('_escapeString:', '"%s"' % str(myString))
 
     return self.__escapeString(myString)
 
@@ -524,7 +524,7 @@ class MySQL(object):
     """
     Escapes all strings in the list of values provided
     """
-    self.log.debug('_escapeValues:', inValues)
+    #self.log.debug('_escapeValues:', inValues)
 
     inEscapeValues = []
 
@@ -570,19 +570,18 @@ class MySQL(object):
       gLogger.error(error)
       return S_ERROR(DErrno.EMYSQL, error)
 
-    self.log.debug('_connect:', self._connected)
+    #self.log.debug('_connect:', self._connected)
     if self._connected:
       return S_OK()
 
-    self.log.debug('_connect: Attempting to access DB',
-                   '[%s@%s] by user %s' %
-                   (self.__dbName, self.__hostName, self.__userName))
+    #self.log.debug('_connect: Attempting to access DB',
+    #               '[%s@%s] by user %s' %
+    #               (self.__dbName, self.__hostName, self.__userName))
     try:
-      self.log.debug('_connect: Connected.')
+      #self.log.debug('_connect: Connected.')
       self._connected = True
       return S_OK()
     except Exception as x:
-      print x
       return self._except('_connect', x, 'Could not connect to DB.')
 
   def _query(self, cmd, conn=None, debug=False):
@@ -596,7 +595,7 @@ class MySQL(object):
     return S_ERROR upon error
     """
 
-    self.logger.debug('_query: %s' % self._safeCmd(cmd))
+    #self.logger.debug('_query: %s' % self._safeCmd(cmd))
 
     retDict = self._getConnection()
     if not retDict['OK']:
@@ -611,15 +610,15 @@ class MySQL(object):
         res = ()
 
       # Log the result limiting it to just 10 records
-      if len(res) <= 10:
-        self.logger.debug('_query: returns', res)
-      else:
-        self.logger.debug('_query: Total %d records returned' % len(res))
-        self.logger.debug('_query: %s ...' % str(res[:10]))
+      #if len(res) <= 10:
+      #  self.logger.debug('_query: returns', res)
+      #else:
+      #  self.logger.debug('_query: Total %d records returned' % len(res))
+      #  self.logger.debug('_query: %s ...' % str(res[:10]))
 
       retDict = S_OK(res)
     except BaseException as x:
-      self.log.debug('_query: %s' % self._safeCmd(cmd))
+      #self.log.debug('_query: %s' % self._safeCmd(cmd))
       retDict = self._except('_query', x, 'Execution failed.')
 
     try:
@@ -638,7 +637,7 @@ class MySQL(object):
         return S_ERROR upon error
     """
 
-    self.logger.debug('_update: %s' % self._safeCmd(cmd))
+    #self.logger.debug('_update: %s' % self._safeCmd(cmd))
 
     retDict = self._getConnection()
     if not retDict['OK']:
@@ -649,12 +648,12 @@ class MySQL(object):
       cursor = connection.cursor()
       res = cursor.execute(cmd)
       # connection.commit()
-      self.log.debug('_update:', res)
+      #self.log.debug('_update:', res)
       retDict = S_OK(res)
       if cursor.lastrowid:
         retDict['lastRowId'] = cursor.lastrowid
     except Exception as x:
-      self.log.debug('_update: %s: %s' % (self._safeCmd(cmd), str(x)))
+      #self.log.debug('_update: %s: %s' % (self._safeCmd(cmd), str(x)))
       retDict = self._except('_update', x, 'Execution failed.')
 
     try:
@@ -710,7 +709,7 @@ class MySQL(object):
                                         "OrderBy": [ "`b` DESC" ] }
     """
     if force:
-      gLogger.debug(viewsDict)
+      #gLogger.debug(viewsDict)
 
       for viewName, viewDict in viewsDict.iteritems():
 
@@ -736,10 +735,10 @@ class MySQL(object):
 
         viewQuery.append(";")
         viewQuery = " ".join(viewQuery)
-        self.log.debug("`%s` VIEW QUERY IS: %s" % (viewName, viewQuery))
+        #self.log.debug("`%s` VIEW QUERY IS: %s" % (viewName, viewQuery))
         createView = self._query(viewQuery)
         if not createView["OK"]:
-          gLogger.error('Can not create view', createView["Message"])
+          self.log.error('Can not create view', createView["Message"])
           return createView
     return S_OK()
 
@@ -831,7 +830,7 @@ class MySQL(object):
                              % (key, forKey, forTable))
 
         if toBeExtracted:
-          self.log.debug('Table %s ready to be created' % table)
+          #self.log.debug('Table %s ready to be created' % table)
           extracted = True
           tableList.remove(table)
           tableCreationList[i].append(table)
@@ -895,7 +894,7 @@ class MySQL(object):
         retDict = self._update(cmd)
         if not retDict['OK']:
           return retDict
-        self.log.debug('Table %s created' % table)
+        #self.log.debug('Table %s created' % table)
 
     return S_OK()
 
@@ -907,10 +906,10 @@ class MySQL(object):
     """
       Wrapper to the new method for backward compatibility
     """
-    self.log.debug('_getFields:', 'deprecation warning, use getFields methods instead of _getFields.')
+    #self.log.debug('_getFields:', 'deprecation warning, use getFields methods instead of _getFields.')
     retDict = _checkFields(inFields, inValues)
     if not retDict['OK']:
-      self.log.debug('_getFields:', retDict['Message'])
+      #self.log.debug('_getFields:', retDict['Message'])
       return retDict
 
     condDict = {}
@@ -926,7 +925,7 @@ class MySQL(object):
     """
       Wrapper to the new method for backward compatibility
     """
-    self.log.debug('_insert:', 'deprecation warning, use insertFields methods instead of _insert.')
+    #self.log.debug('_insert:', 'deprecation warning, use insertFields methods instead of _insert.')
     return self.insertFields(tableName, inFields, inValues, conn)
 
   def _to_value(self, param):
@@ -947,7 +946,7 @@ class MySQL(object):
         it will retry MAXCONNECTRETRY to open a new connection and will return
         an error if it fails.
     """
-    self.log.debug('_getConnection:')
+    #self.log.debug('_getConnection:')
 
     if not self.__initialized:
       error = 'DB not properly initialized'
@@ -985,7 +984,7 @@ class MySQL(object):
     table = _quotedList([table])
     if not table:
       error = 'Invalid table argument'
-      self.log.debug('countEntries:', error)
+      #self.log.debug('countEntries:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     try:
@@ -1011,13 +1010,13 @@ class MySQL(object):
     table = _quotedList([table])
     if not table:
       error = 'Invalid table argument'
-      self.log.debug('getCounters:', error)
+      #self.log.debug('getCounters:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     attrNames = _quotedList(attrList)
     if attrNames is None:
       error = 'Invalid updateFields argument'
-      self.log.debug('getCounters:', error)
+      #self.log.debug('getCounters:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     try:
@@ -1050,13 +1049,13 @@ class MySQL(object):
     table = _quotedList([table])
     if not table:
       error = 'Invalid table argument'
-      self.log.debug('getDistinctAttributeValues:', error)
+      #self.log.debug('getDistinctAttributeValues:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     attributeName = _quotedList([attribute])
     if not attributeName:
       error = 'Invalid attribute argument'
-      self.log.debug('getDistinctAttributeValues:', error)
+      #self.log.debug('getDistinctAttributeValues:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     try:
@@ -1096,12 +1095,12 @@ class MySQL(object):
           attrName = '(' + _quotedList(list(aName)) + ')'
         if not attrName:
           error = 'Invalid condDict argument'
-          self.log.debug('buildCondition:', error)
+          #self.log.debug('buildCondition:', error)
           raise Exception(error)
         if isinstance(attrValue, list):
           retDict = self._escapeValues(attrValue)
           if not retDict['OK']:
-            self.log.debug('buildCondition:', retDict['Message'])
+            #self.log.debug('buildCondition:', retDict['Message'])
             raise Exception(retDict['Message'])
           else:
             escapeInValues = retDict['Value']
@@ -1114,7 +1113,7 @@ class MySQL(object):
         else:
           retDict = self._escapeValues([attrValue])
           if not retDict['OK']:
-            self.log.debug('buildCondition:', retDict['Message'])
+            #self.log.debug('buildCondition:', retDict['Message'])
             raise Exception(retDict['Message'])
           else:
             escapeInValue = retDict['Value'][0]
@@ -1128,12 +1127,12 @@ class MySQL(object):
       timeStamp = _quotedList([timeStamp])
       if not timeStamp:
         error = 'Invalid timeStamp argument'
-        self.log.debug('buildCondition:', error)
+        #self.log.debug('buildCondition:', error)
         raise Exception(error)
       if newer:
         retDict = self._escapeValues([newer])
         if not retDict['OK']:
-          self.log.debug('buildCondition:', retDict['Message'])
+          #self.log.debug('buildCondition:', retDict['Message'])
           raise Exception(retDict['Message'])
         else:
           escapeInValue = retDict['Value'][0]
@@ -1145,7 +1144,7 @@ class MySQL(object):
       if older:
         retDict = self._escapeValues([older])
         if not retDict['OK']:
-          self.log.debug('buildCondition:', retDict['Message'])
+          #self.log.debug('buildCondition:', retDict['Message'])
           raise Exception(retDict['Message'])
         else:
           escapeInValue = retDict['Value'][0]
@@ -1159,12 +1158,12 @@ class MySQL(object):
         attrName = _quotedList([attrName])
         if not attrName:
           error = 'Invalid greater argument'
-          self.log.debug('buildCondition:', error)
+          #self.log.debug('buildCondition:', error)
           raise Exception(error)
 
         retDict = self._escapeValues([attrValue])
         if not retDict['OK']:
-          self.log.debug('buildCondition:', retDict['Message'])
+          #self.log.debug('buildCondition:', retDict['Message'])
           raise Exception(retDict['Message'])
         else:
           escapeInValue = retDict['Value'][0]
@@ -1179,12 +1178,12 @@ class MySQL(object):
         attrName = _quotedList([attrName])
         if not attrName:
           error = 'Invalid smaller argument'
-          self.log.debug('buildCondition:', error)
+          #self.log.debug('buildCondition:', error)
           raise Exception(error)
 
         retDict = self._escapeValues([attrValue])
         if not retDict['OK']:
-          self.log.debug('buildCondition:', retDict['Message'])
+          #self.log.debug('buildCondition:', retDict['Message'])
           raise Exception(retDict['Message'])
         else:
           escapeInValue = retDict['Value'][0]
@@ -1203,13 +1202,13 @@ class MySQL(object):
         continue
       if not isinstance(orderAttr, basestring):
         error = 'Invalid orderAttribute argument'
-        self.log.debug('buildCondition:', error)
+        #self.log.debug('buildCondition:', error)
         raise Exception(error)
 
       orderField = _quotedList(orderAttr.split(':')[:1])
       if not orderField:
         error = 'Invalid orderAttribute argument'
-        self.log.debug('buildCondition:', error)
+        #self.log.debug('buildCondition:', error)
         raise Exception(error)
 
       if len(orderAttr.split(':')) == 2:
@@ -1218,7 +1217,7 @@ class MySQL(object):
           orderList.append('%s %s' % (orderField, orderType))
         else:
           error = 'Invalid orderAttribute argument'
-          self.log.debug('buildCondition:', error)
+          #self.log.debug('buildCondition:', error)
           raise Exception(error)
       else:
         orderList.append(orderAttr)
@@ -1252,7 +1251,7 @@ class MySQL(object):
     table = _quotedList([tableName])
     if not table:
       error = 'Invalid tableName argument'
-      self.log.debug('getFields:', error)
+      #self.log.debug('getFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     quotedOutFields = '*'
@@ -1260,10 +1259,10 @@ class MySQL(object):
       quotedOutFields = _quotedList(outFields)
       if quotedOutFields is None:
         error = 'Invalid outFields arguments'
-        self.log.debug('getFields:', error)
+        #self.log.debug('getFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
 
-    self.log.debug('getFields:', 'selecting fields %s from table %s.' % (quotedOutFields, table))
+    #self.log.debug('getFields:', 'selecting fields %s from table %s.' % (quotedOutFields, table))
 
     if condDict is None:
       condDict = {}
@@ -1300,10 +1299,10 @@ class MySQL(object):
     table = _quotedList([tableName])
     if not table:
       error = 'Invalid tableName argument'
-      self.log.debug('deleteEntries:', error)
+      #self.log.debug('deleteEntries:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
-    self.log.debug('deleteEntries:', 'deleting rows from table %s.' % table)
+    #self.log.debug('deleteEntries:', 'deleting rows from table %s.' % table)
 
     try:
       condition = self.buildCondition(condDict=condDict, older=older, newer=newer,
@@ -1337,13 +1336,13 @@ class MySQL(object):
     table = _quotedList([tableName])
     if not table:
       error = 'Invalid tableName argument'
-      self.log.debug('updateFields:', error)
+      #self.log.debug('updateFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     retDict = _checkFields(updateFields, updateValues)
     if not retDict['OK']:
       error = 'Mismatch between updateFields and updateValues.'
-      self.log.debug('updateFields:', error)
+      #self.log.debug('updateFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     if updateFields is None:
@@ -1353,23 +1352,23 @@ class MySQL(object):
     if updateDict:
       if not isinstance(updateDict, dict):
         error = 'updateDict must be a of Type DictType'
-        self.log.debug('updateFields:', error)
+        #self.log.debug('updateFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
       try:
         updateFields += updateDict.keys()
         updateValues += [updateDict[k] for k in updateDict.keys()]
       except TypeError:
         error = 'updateFields and updateValues must be a list'
-        self.log.debug('updateFields:', error)
+        #self.log.debug('updateFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
 
     updateValues = self._escapeValues(updateValues)
     if not updateValues['OK']:
-      self.log.debug('updateFields:', updateValues['Message'])
+      #self.log.debug('updateFields:', updateValues['Message'])
       return updateValues
     updateValues = updateValues['Value']
 
-    self.log.debug('updateFields:', 'updating fields %s from table %s.' % (', '.join(updateFields), table))
+    #self.log.debug('updateFields:', 'updating fields %s from table %s.' % (', '.join(updateFields), table))
 
     try:
       condition = self.buildCondition(condDict=condDict, older=older, newer=newer,
@@ -1394,12 +1393,12 @@ class MySQL(object):
     table = _quotedList([tableName])
     if not table:
       error = 'Invalid tableName argument'
-      self.log.debug('insertFields:', error)
+      #self.log.debug('insertFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     retDict = _checkFields(inFields, inValues)
     if not retDict['OK']:
-      self.log.debug('insertFields:', retDict['Message'])
+      #self.log.debug('insertFields:', retDict['Message'])
       return retDict
 
     if inFields is None:
@@ -1409,32 +1408,32 @@ class MySQL(object):
     if inDict:
       if not isinstance(inDict, dict):
         error = 'inDict must be a of Type DictType'
-        self.log.debug('insertFields:', error)
+        #self.log.debug('insertFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
       try:
         inFields += inDict.keys()
         inValues += [inDict[k] for k in inDict.keys()]
       except TypeError:
         error = 'inFields and inValues must be a list'
-        self.log.debug('insertFields:', error)
+        #self.log.debug('insertFields:', error)
         return S_ERROR(DErrno.EMYSQL, error)
 
     inFieldString = _quotedList(inFields)
     if inFieldString is None:
       error = 'Invalid inFields arguments'
-      self.log.debug('insertFields:', error)
+      #self.log.debug('insertFields:', error)
       return S_ERROR(DErrno.EMYSQL, error)
 
     inFieldString = '(  %s )' % inFieldString
 
     retDict = self._escapeValues(inValues)
     if not retDict['OK']:
-      self.log.debug('insertFields:', retDict['Message'])
+      #self.log.debug('insertFields:', retDict['Message'])
       return retDict
     inValueString = ', '.join(retDict['Value'])
     inValueString = '(  %s )' % inValueString
 
-    self.log.debug('insertFields:', 'inserting %s into table %s'
+    #self.log.debug('insertFields:', 'inserting %s into table %s'
                    % (inFieldString, table))
 
     return self._update('INSERT INTO %s %s VALUES %s' %

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -287,7 +287,7 @@ class JobDB(DB):
         return ret
       jobIDList.append(ret['Value'])
 
-    self.log.debug('JobDB.getParameters: Getting Parameters for jobs %s' % ','.join(jobIDList))
+    # self.log.debug('JobDB.getParameters: Getting Parameters for jobs %s' % ','.join(jobIDList))
 
     resultDict = {}
     if paramList:
@@ -342,7 +342,7 @@ class JobDB(DB):
       return ret
     jobID = ret['Value']
 
-    self.log.debug('JobDB.getAtticJobParameters: Getting Attic Parameters for job %s' % jobID)
+    # self.log.debug('JobDB.getAtticJobParameters: Getting Attic Parameters for job %s' % jobID)
 
     resultDict = {}
     paramCondition = ''
@@ -394,7 +394,7 @@ class JobDB(DB):
       x = "`" + ret['Value'][1:-1] + "`"
       attrNameList.append(x)
     attrNames = ','.join(attrNameList)
-    self.log.debug('JobDB.getAllJobAttributes: Getting Attributes for job = %s.' % jobID)
+    # self.log.debug('JobDB.getAllJobAttributes: Getting Attributes for job = %s.' % jobID)
 
     cmd = 'SELECT %s FROM Jobs WHERE JobID=%s' % (attrNames, jobID)
     res = self._query(cmd)
@@ -587,7 +587,7 @@ class JobDB(DB):
         number of jobs if requested.
     """
 
-    self.log.debug('JobDB.selectJobs: retrieving jobs.')
+    # self.log.debug('JobDB.selectJobs: retrieving jobs.')
 
     res = self.getFields('Jobs', ['JobID'], condDict=condDict, limit=limit,
                          older=older, newer=newer, timeStamp=timeStamp, orderAttribute=orderAttribute)

--- a/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -137,7 +137,7 @@ class JobLoggingDB(DB):
     """ Get TimeStamps for job MajorState transitions
         return a {State:timestamp} dictionary
     """
-    self.log.debug('getWMSTimeStamps: Retrieving Timestamps for Job %d' % int(jobID))
+    # self.log.debug('getWMSTimeStamps: Retrieving Timestamps for Job %d' % int(jobID))
 
     result = {}
     cmd = 'SELECT Status,StatusTimeOrder FROM LoggingInfo WHERE JobID=%d' % int(jobID)


### PR DESCRIPTION

BEGINRELEASENOTES
CHANGE: remove many calls too gLogger.debug() is low level DB modules (in particular MySQL.py) that may slowdown services

For the moment only commented out the calls but if everybody agrees they should IMHO be removed...

Of course this should be done systematically in all services. This is just because I was looking at possible slowdown in JobDB handling which is very heavily called...
ENDRELEASENOTES
