### PR TITLE
[v6r22] Log Storage plugin error

### DIFF
--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -1237,7 +1237,7 @@ class StorageElementItem(object):
 
         if not res['OK']:
           errStr = "Completely failed to perform %s." % self.methodName
-          log.debug(errStr, 'with plugin %s: %s' % (pluginName, res['Message']))
+          log.verbose(errStr, 'with plugin %s: %s' % (pluginName, res['Message']))
           for lfn in urlDict.values():
             if lfn not in failed:
               failed[lfn] = ''
@@ -1249,7 +1249,10 @@ class StorageElementItem(object):
               if lfn not in failed:
                 failed[lfn] = ''
               if url in res['Value']['Failed']:
-                self.log.debug(res['Value']['Failed'][url])
+                self.log.verbose(
+                    "Failure in plugin to perform %s" %
+                    self.methodName, "Plugin: %s lfn: %s error %s" %
+                    (pluginName, lfn, res['Value']['Failed'][url]))
                 failed[lfn] = "%s %s" % (failed[lfn], res['Value']['Failed'][url]
                                          ) if failed[lfn] else res['Value']['Failed'][url]
               else:


### PR DESCRIPTION
Currently we are blind when a protocol fails while the next one works. This helps for debugging. 

BEGINRELEASENOTES

*Resources
CHANGE: increase the SE logging level for plugin errors

ENDRELEASENOTES
