### PR TITLE
[v7r1] fix integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,11 @@ coverage.xml
 Local_*
 .hypothesis
 
+integration_test_results/
+tests/CI/CLIENTCONFIG
+tests/CI/SERVERCONFIG
+
+
 # VSCode
 .vscode
 
@@ -76,3 +81,4 @@ docs/source/AdministratorGuide/CommandReference
 docs/source/UserGuide/CommandReference
 docs/_build
 docs/source/_build
+

--- a/environment.yml
+++ b/environment.yml
@@ -39,6 +39,7 @@ dependencies:
   - hypothesis
   - ipython
   - mock
+  - parameterized
   - pylint >=1.6.5
   - pyparsing >=2.0.6
   - pytest >=3.6

--- a/tests/Integration/all_integration_client_tests.sh
+++ b/tests/Integration/all_integration_client_tests.sh
@@ -12,67 +12,67 @@ echo -e '********' "client -> server tests" '********\n'
 set -o pipefail
 ERR=0
 
-echo -e "*** $(date -u)  Getting a non privileged user\n" 2>&1 | tee clientTestOutputs.txt
-dirac-proxy-init $DEBUG 2>&1 | tee clientTestOutputs.txt
+echo -e "*** $(date -u)  Getting a non privileged user\n" 2>&1 | tee -a clientTestOutputs.txt
+dirac-proxy-init -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG 2>&1 | tee -a clientTestOutputs.txt
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Accounting TESTS ****\n"
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/AccountingSystem/Test_DataStoreClient.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/AccountingSystem/Test_ReportsClient.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/AccountingSystem/Test_DataStoreClient.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/AccountingSystem/Test_ReportsClient.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RMS TESTS ****\n"
 
-echo -e "*** $(date -u)  Getting a non privileged user\n" 2>&1 | tee clientTestOutputs.txt
-dirac-proxy-init -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG 2>&1 | tee clientTestOutputs.txt
+echo -e "*** $(date -u)  Getting a non privileged user\n" 2>&1 | tee -a clientTestOutputs.txt
+dirac-proxy-init -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG 2>&1 | tee -a clientTestOutputs.txt
 
-echo -e "*** $(date -u)  Starting RMS Client test as a non privileged user\n" 2>&1 | tee clientTestOutputs.txt
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+echo -e "*** $(date -u)  Starting RMS Client test as a non privileged user\n" 2>&1 | tee -a clientTestOutputs.txt
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
-echo -e "*** $(date -u)  getting the prod role again\n" 2>&1 | tee clientTestOutputs.txt
-dirac-proxy-init -g prod -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG 2>&1 | tee clientTestOutputs.txt
-echo -e "*** $(date -u)  Starting RMS Client test as an admin user\n" 2>&1 | tee clientTestOutputs.txt
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+echo -e "*** $(date -u)  getting the prod role again\n" 2>&1 | tee -a clientTestOutputs.txt
+dirac-proxy-init -g prod -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG 2>&1 | tee -a clientTestOutputs.txt
+echo -e "*** $(date -u)  Starting RMS Client test as an admin user\n" 2>&1 | tee -a clientTestOutputs.txt
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RSS TESTS ****\n"
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_SiteStatus.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_Publisher.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_SiteStatus.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_Publisher.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** WMS TESTS ****\n"
-# python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsLoggingClient.py 2>&1 | tee clientTestOutputs.txt
-python $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_SandboxStoreClient.py $WORKSPACE/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobWrapper.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsClient.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+# python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsLoggingClient.py 2>&1 | tee -a clientTestOutputs.txt
+python $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_SandboxStoreClient.py $WORKSPACE/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobWrapper.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsClient.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 ## no real tests
-python $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/createJobXMLDescriptions.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-$CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_dirac-jobexec.sh 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-$CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_TimeLeft.sh 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+python $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/createJobXMLDescriptions.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+$CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_dirac-jobexec.sh 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+$CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_TimeLeft.sh 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** FTS TESTS ****\n"
-pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Client_FTS3.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Client_FTS3.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** MONITORING TESTS ****\n"
-pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/Monitoring/Test_MonitoringSystem.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/Monitoring/Test_MonitoringSystem.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** TS TESTS ****\n"
-pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/TransformationSystem/Test_Client_Transformation.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-# pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/TransformationSystem/Test_TS_DFC_Catalog.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/TransformationSystem/Test_Client_Transformation.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+# pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/TransformationSystem/Test_TS_DFC_Catalog.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** PS TESTS ****\n"
-pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ProductionSystem/Test_Client_Production.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
-pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ProductionSystem/Test_Client_TS_Prod.py 2>&1 | tee clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ProductionSystem/Test_Client_Production.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ProductionSystem/Test_Client_TS_Prod.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -8,78 +8,80 @@
 echo -e '****************************************'
 echo -e '*******' "integration server tests" '*******\n'
 
+SERVER_TEST_OUTPUT=serverTestOutputs.txt
+
 set -o pipefail
 ERR=0
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Core TESTS ****\n"
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Core/Test_ElasticsearchDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Core/Test_ElasticsearchDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** FRAMEWORK TESTS (partially skipped) ****\n"
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_InstalledComponentsDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-python $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_ProxyDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-#pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_LoggingDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_InstalledComponentsDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+python $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_ProxyDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+#pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_LoggingDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RSS TESTS ****\n"
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_FullChain.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_FullChain.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** WMS TESTS ****\n"
-python $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py $WORKSPACE/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobLoggingDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_TaskQueueDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_ElasticJobDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+python $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py $WORKSPACE/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobLoggingDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_TaskQueueDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_ElasticJobDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** DMS TESTS ****\n"
 ## DFC
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_DataIntegrityDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_DataIntegrityDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
-echo "Test DFC DB" 2>&1 | tee serverTestOutputs.txt
-python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+echo "Test DFC DB" 2>&1 | tee -a $SERVER_TEST_OUTPUT
+python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
-echo -e "*** $(date -u)  Reinitialize the DFC DB\n" 2>&1 | tee serverTestOutputs.txt
-diracDFCDB 2>&1 | tee serverTestOutputs.txt
+echo -e "*** $(date -u)  Reinitialize the DFC DB\n" 2>&1 | tee -a $SERVER_TEST_OUTPUT
+diracDFCDB 2>&1 | tee -a $SERVER_TEST_OUTPUT
 
-echo -e "*** $(date -u)  Run the DFC client tests as user without admin privileges" 2>&1 | tee serverTestOutputs.txt
-echo -e "*** $(date -u)  Getting a non privileged user\n" 2>&1 | tee serverTestOutputs.txt
+echo -e "*** $(date -u)  Run the DFC client tests as user without admin privileges" 2>&1 | tee -a $SERVER_TEST_OUTPUT
+echo -e "*** $(date -u)  Getting a non privileged user\n" 2>&1 | tee -a $SERVER_TEST_OUTPUT
 dirac-proxy-init -C $WORKSPACE/ServerInstallDIR/user/client.pem -K $WORKSPACE/ServerInstallDIR/user/client.key $DEBUG
-python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Client_DFC.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-diracDFCDB 2>&1 | tee serverTestOutputs.txt
-python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Client_DFC.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+diracDFCDB 2>&1 | tee -a $SERVER_TEST_OUTPUT
+python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
-echo "Reinitialize the DFC DB" 2>&1 | tee serverTestOutputs.txt
-diracDFCDB 2>&1 | tee serverTestOutputs.txt
+echo "Reinitialize the DFC DB" 2>&1 | tee -a $SERVER_TEST_OUTPUT
+diracDFCDB 2>&1 | tee -a $SERVER_TEST_OUTPUT
 
-echo -e "*** $(date -u)  Restart the DFC service\n" &>> serverTestOutputs.txt
-dirac-restart-component DataManagement FileCatalog $DEBUG &>> serverTestOutputs.txt
+echo -e "*** $(date -u)  Restart the DFC service\n" 2>&1 | tee -a $SERVER_TEST_OUTPUT
+dirac-restart-component DataManagement FileCatalog $DEBUG 2>&1 | tee -a $SERVER_TEST_OUTPUT
 
-echo -e "*** $(date -u)  Run it with the admin privileges" 2>&1 | tee serverTestOutputs.txt
-echo -e "*** $(date -u)  getting the prod role again\n" 2>&1 | tee serverTestOutputs.txt
-dirac-proxy-init -g prod -C $WORKSPACE/ServerInstallDIR/user/client.pem -K $WORKSPACE/ServerInstallDIR/user/client.key $DEBUG 2>&1 | tee serverTestOutputs.txt
-python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Client_DFC.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-diracDFCDB 2>&1 | tee serverTestOutputs.txt
-python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+echo -e "*** $(date -u)  Run it with the admin privileges" 2>&1 | tee -a $SERVER_TEST_OUTPUT
+echo -e "*** $(date -u)  getting the prod role again\n" 2>&1 | tee -a $SERVER_TEST_OUTPUT
+dirac-proxy-init -g prod -C $WORKSPACE/ServerInstallDIR/user/client.pem -K $WORKSPACE/ServerInstallDIR/user/client.key $DEBUG 2>&1 | tee -a $SERVER_TEST_OUTPUT
+python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Client_DFC.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+diracDFCDB 2>&1 | tee -a $SERVER_TEST_OUTPUT
+python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RMS TESTS ****\n"
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_ReqDB.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_ReqDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** MONITORING TESTS ****\n"
-pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Monitoring/Test_MonitoringReporter.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Monitoring/Test_MonitoringReporter.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** Resources TESTS ****\n"
 
-python $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/Storage/Test_Resources_GFAL2StorageBase.py ProductionSandboxSE 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
-python $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/ProxyProvider/Test_DIRACCAProxyProvider.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+python $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/Storage/Test_Resources_GFAL2StorageBase.py ProductionSandboxSE 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+python $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/ProxyProvider/Test_DIRACCAProxyProvider.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 # Can only run if there's a Stomp MQ local...
-# python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/MessageQueue/Test_ActiveClose.py 2>&1 | tee serverTestOutputs.txt; (( ERR |= $? ))
+# python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/MessageQueue/Test_ActiveClose.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -824,7 +824,7 @@ dropDBs(){
   echo '==> [dropDBs]'
 
   dbs=$(cut -d ' ' -f 2 < databases | cut -d '.' -f 1 | grep -v ^RequestDB | grep -v ^FileCatalogDB)
-  python "$TESTCODE/DIRAC/tests/Jenkins/dirac-drop-db.py" "$dbs" "$DEBUG"
+  python "$TESTCODE/DIRAC/tests/Jenkins/dirac-drop-db.py" $dbs $DEBUG
 }
 
 #-------------------------------------------------------------------------------

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -313,9 +313,13 @@ function installDIRAC(){
   cp "$TESTCODE/DIRAC/Core/scripts/dirac-install.py" "$CLIENTINSTALLDIR/dirac-install"
   chmod +x "$CLIENTINSTALLDIR/dirac-install"
 
-  if [ $modules ]
-  then
-    INSTALLOPTIONS+=" --module="$modules
+  if [ "$CLIENT_ALTERNATIVE_MODULES" ]; then
+    echo "Installing from non-release code"
+    if [[ -d "$CLIENT_ALTERNATIVE_MODULES" ]]; then
+      INSTALLOPTIONS+="--module=$CLIENT_ALTERNATIVE_MODULES:::DIRAC:::local"
+    else
+      INSTALLOPTIONS+="--module=$CLIENT_ALTERNATIVE_MODULES"
+    fi
   fi
 
   ./dirac-install -r $DIRAC_RELEASE -t client $INSTALLOPTIONS $DEBUG


### PR DESCRIPTION
Fixes quite a few mistakes from the tests:

* https://github.com/DIRACGrid/DIRAC/commit/a9a654e37db44704b2660d3a06f7258a7ecae1eb : the `dbs` argument is a list. Since they are between quote, the parse would interpret it as a single argument, and of course that breaks the call "DROP DATABASE"
* Use `tee` in append mode
*  Use CLIENT_ALTERNATIVE_MODULES instead of just `modules` env variable for client test
* Specify proxy locations in the client tests
* add `parameterized` to the dependencies in `environment.yml`
* ignore test generated files in git

@chrisburr can you please check it ? 
@fstagni @atsareg this one is needed to have any PR against v7r1 show green in githubAction. Please merge it as soon as @chrisburr will have reviewed it. Thanks