### PR TITLE
[v6r22] NotificationHandler: correct name of initializeHandler function

### DIFF
--- a/FrameworkSystem/Service/NotificationHandler.py
+++ b/FrameworkSystem/Service/NotificationHandler.py
@@ -43,7 +43,7 @@ def purgeDelayedEMails():
 class NotificationHandler( RequestHandler ):
 
   @classmethod
-  def initializeNotificationHandler( cls, serviceInfo ):
+  def initializeHandler(cls, serviceInfo):
     """ Handler initialization
     """
     global gNotDB


### PR DESCRIPTION
Since some update last week we no longer receive emails from the Bdii2CSAgent. (I don't know why it was still working last week, maybe the agent or NotificationHandler was not restarted for a long time)
I think is is ultimately caused by the fact that the `initializeNotificationHandler` function is a classMethod of the NotificationHandler and not a module level function (as is the case for the FileCatalogHandler for example). As a `@classMethod` this should be called `initializeHandler`

https://github.com/DIRACGrid/DIRAC/blob/045612125204e96f155fdbd4fd6cf72d0c4fc600/FrameworkSystem/Service/NotificationHandler.py#L46

cf.

https://github.com/DIRACGrid/DIRAC/blob/f07d67a1e96c3fca6983af3cd5b1c2d9d246887c/DataManagementSystem/Service/FileCatalogHandler.py#L31

This function is not called, which means there is no periodic task to send emails with "avoidSpam", which is something added in the Bdii2CSAgent some time ago.

BEGINRELEASENOTES
*Framework
FIX: NotificationHandler: fix name of initializeHandler function so the handler is properly initialized and the periodicTasks are created

ENDRELEASENOTES


This code is looking for initializeHandler or initializeHANLDERNAME
https://github.com/DIRACGrid/DIRAC/blob/f07d67a1e96c3fca6983af3cd5b1c2d9d246887c/Core/DISET/private/Service.py#L185-L189