### PR TITLE
[v6r22] WMSUtilities: fix typo itertems -> iteritems

### DIFF
--- a/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -152,7 +152,7 @@ def killPilotsInQueues(pilotRefDict):
 
   ceFactory = ComputingElementFactory()
   failed = []
-  for key, pilotDict in pilotRefDict.itertems():
+  for key, pilotDict in pilotRefDict.iteritems():
 
     owner, group, site, ce, queue = key.split('@@@')
     result = getQueue(site, ce, queue)


### PR DESCRIPTION
"Backporting" this bugfix: https://github.com/DIRACGrid/DIRAC/pull/4317/files#diff-69fd7edbaf3eaf4d1596939a4e3771c2L155

BEGINRELEASENOTES

*WMS
FIX: Fix exception for PilotManager or PilotStatusAgent: itertems -> iteritems

ENDRELEASENOTES
