### PR TITLE
[v6r22] fixed typo

### DIFF
--- a/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -152,7 +152,7 @@ def killPilotsInQueues(pilotRefDict):
 
   ceFactory = ComputingElementFactory()
   failed = []
-  for key, pilotDict in pilotRefDict.itertems():
+  for key, pilotDict in pilotRefDict.iteritems():
 
     owner, group, site, ce, queue = key.split('@@@')
     result = getQueue(site, ce, queue)


### PR DESCRIPTION

BEGINRELEASENOTES
*WorkloadManagement
FIX: removed itertem typo in killPilotsInQueues
ENDRELEASENOTES
