### PR TITLE
[v6r22] GFAL_STORAGEBASE: enable or disable session_reuse ...

### DIFF
--- a/Resources/Storage/GFAL2_StorageBase.py
+++ b/Resources/Storage/GFAL2_StorageBase.py
@@ -5,6 +5,12 @@
     .. module: python
 
     :synopsis: GFAL2 class from StorageElement using gfal2. Other modules can inherit from this use the gfal2 methods.
+
+Environment Variables
+---------------------
+
+DIRAC_GFAL_GRIDFTP_SESSION_REUSE: This should be exported and set to true in server bashrc files for efficiency reasons.
+
 """
 
 # pylint: disable=arguments-differ
@@ -74,6 +80,10 @@ class GFAL2_StorageBase(StorageBase):
 
     # by default turn off BDII checks
     self.ctx.set_opt_boolean("BDII", "ENABLE", False)
+
+    # session reuse should only be done on servers
+    self.ctx.set_opt_boolean("GRIDFTP PLUGIN", "SESSION_REUSE",
+                             os.environ.get("DIRAC_GFAL_GRIDFTP_SESSION_REUSE", "no").lower() in ["true", "yes"])
 
     # Enable IPV6 for gsiftp
     self.ctx.set_opt_boolean("GRIDFTP PLUGIN", "IPV6", True)


### PR DESCRIPTION
...based on environment variable DIRAC_GFAL_GRIDFTP_SESSION_REUSE

We caused some issues on a StorageElement recently because there were too many sessions connecting to it, which in the end just stayed open for too long, see here https://ggus.eu/index.php?mode=ticket_info&ticket_id=143835

This was inadvertently caused by this change when we moved to v6r22 https://github.com/DIRACGrid/DIRAC/pull/4200 Which enabled the SESSION_REUSE for gfal .
In our jobs we download files from different SEs in a workflow module (getting "overlay" files, not the "inputdata"), the SEs end up in the StorageElementCache and are only purged after 30 minutes, 

The session reuse should only be done on dirac servers, where there is a real benefit from this.

Many thanks for @chaen helping me with this problem

- [ ]  add commented entry in bashrc?
- [x]  different place for documentation: #4335

BEGINRELEASENOTES

*Resources
NEW: GFAL2_StorageBase: Disable GRIDFTP SESSION_REUSE by default. It can be enabled via an environment variable ``export DIRAC_GFAL_GRIDFTP_SESSION_REUSE=True``. This export should be added in server bashrc files.

ENDRELEASENOTES
