### PR TITLE
[v7r0] RSS command fixes

### DIFF
--- a/Core/Utilities/SiteSEMapping.py
+++ b/Core/Utilities/SiteSEMapping.py
@@ -22,7 +22,7 @@ def getSEParameters(seName):
   # This import is here to avoid circular imports
   from DIRAC.Resources.Storage.StorageElement import StorageElement
   se = StorageElement(seName, hideExceptions=True)
-
+  print " SENAME ", seName
   protocolsSet = set(se.localAccessProtocolList) | set(se.localWriteProtocolList)
 
   seParametersList = []
@@ -68,13 +68,16 @@ def getStorageElementsHosts(seNames=None):
 
   for seName in seNames:
 
-    seHost = getSEHosts(seName)
-    if not seHost['OK']:
-      gLogger.warn("Could not get SE Host", "SE: %s" % seName)
-      continue
-    if seHost['Value']:
-      seHosts.extend(seHost['Value'])
-
+    try:
+      seHost = getSEHosts(seName)
+      if not seHost['OK']:
+        gLogger.warn("Could not get SE Host", "SE: %s" % seName)
+        continue
+      if seHost['Value']:
+        seHosts.extend(seHost['Value'])
+    except Exception as excp:  # pylint: disable=broad-except
+          gLogger.error("Failed to get SE %s information (SE skipped) " % seName) 
+          gLogger.exception("Operation finished  with exception: ", lException=excp)
   return S_OK(list(set(seHosts)))
 
 

--- a/Core/Utilities/SiteSEMapping.py
+++ b/Core/Utilities/SiteSEMapping.py
@@ -22,7 +22,7 @@ def getSEParameters(seName):
   # This import is here to avoid circular imports
   from DIRAC.Resources.Storage.StorageElement import StorageElement
   se = StorageElement(seName, hideExceptions=True)
-  print " SENAME ", seName
+
   protocolsSet = set(se.localAccessProtocolList) | set(se.localWriteProtocolList)
 
   seParametersList = []

--- a/Core/Utilities/SiteSEMapping.py
+++ b/Core/Utilities/SiteSEMapping.py
@@ -76,8 +76,8 @@ def getStorageElementsHosts(seNames=None):
       if seHost['Value']:
         seHosts.extend(seHost['Value'])
     except Exception as excp:  # pylint: disable=broad-except
-          gLogger.error("Failed to get SE %s information (SE skipped) " % seName) 
-          gLogger.exception("Operation finished  with exception: ", lException=excp)
+      gLogger.error("Failed to get SE %s information (SE skipped) " % seName)
+      gLogger.exception("Operation finished  with exception: ", lException=excp)
   return S_OK(list(set(seHosts)))
 
 

--- a/ResourceStatusSystem/Agent/CacheFeederAgent.py
+++ b/ResourceStatusSystem/Agent/CacheFeederAgent.py
@@ -45,8 +45,6 @@ class CacheFeederAgent(AgentModule):
     """ Define the commands to be executed, and instantiate the clients that will be used.
     """
 
-    self.am_setOption('shifterProxy', 'DataManager')
-
     res = ObjectLoader().loadObject('DIRAC.ResourceStatusSystem.Client.ResourceStatusClient',
                                     'ResourceStatusClient')
     if not res['OK']:

--- a/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
+++ b/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
@@ -147,11 +147,15 @@ class FreeDiskSpaceCommand(Command):
     """
 
     for name in DMSHelpers().getStorageElements():
-      # keeping TB as default
-      diskSpace = self.doNew((name, 'MB'))
-      if not diskSpace['OK']:
-        gLogger.warn("Unable to calculate free/total disk space", "name: %s" % name)
-        gLogger.warn(diskSpace['Message'])
-        continue
+      try:
+        # keeping TB as default
+        diskSpace = self.doNew((name, 'MB'))
+        if not diskSpace['OK']:
+          gLogger.warn("Unable to calculate free/total disk space", "name: %s" % name)
+          gLogger.warn(diskSpace['Message'])
+          continue
+      except Exception as excp:  # pylint: disable=broad-except                                                                                                                                                                            
+          gLogger.error("Failed to get SE %s FreeDiskSpace information (SE skipped) " % name)
+          gLogger.exception("Operation finished  with exception: ", lException=excp)
 
     return S_OK()

--- a/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
+++ b/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
@@ -155,7 +155,7 @@ class FreeDiskSpaceCommand(Command):
           gLogger.warn(diskSpace['Message'])
           continue
       except Exception as excp:  # pylint: disable=broad-except
-          gLogger.error("Failed to get SE %s FreeDiskSpace information (SE skipped) " % name)
-          gLogger.exception("Operation finished  with exception: ", lException=excp)
+        gLogger.error("Failed to get SE %s FreeDiskSpace information (SE skipped) " % name)
+        gLogger.exception("Operation finished  with exception: ", lException=excp)
 
     return S_OK()

--- a/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
+++ b/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
@@ -154,7 +154,7 @@ class FreeDiskSpaceCommand(Command):
           gLogger.warn("Unable to calculate free/total disk space", "name: %s" % name)
           gLogger.warn(diskSpace['Message'])
           continue
-      except Exception as excp:  # pylint: disable=broad-except                                                                                                                                                                            
+      except Exception as excp:  # pylint: disable=broad-except
           gLogger.error("Failed to get SE %s FreeDiskSpace information (SE skipped) " % name)
           gLogger.exception("Operation finished  with exception: ", lException=excp)
 

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -195,6 +195,7 @@ class StorageElementItem(object):
     res = StorageFactory(useProxy=self.useProxy, vo=self.vo).getStorages(name,
                                                                          pluginList=plugins,
                                                                          hideExceptions=hideExceptions)
+
     if not res['OK']:
       self.valid = False
       self.name = name

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -195,7 +195,6 @@ class StorageElementItem(object):
     res = StorageFactory(useProxy=self.useProxy, vo=self.vo).getStorages(name,
                                                                          pluginList=plugins,
                                                                          hideExceptions=hideExceptions)
-    print " storage VALID :", str(res)
     if not res['OK']:
       self.valid = False
       self.name = name

--- a/Resources/Storage/StorageElement.py
+++ b/Resources/Storage/StorageElement.py
@@ -195,7 +195,7 @@ class StorageElementItem(object):
     res = StorageFactory(useProxy=self.useProxy, vo=self.vo).getStorages(name,
                                                                          pluginList=plugins,
                                                                          hideExceptions=hideExceptions)
-
+    print " storage VALID :", str(res)
     if not res['OK']:
       self.valid = False
       self.name = name


### PR DESCRIPTION
The aim of the change is to:

-    remove a call to shifterProxy configuration which would not work for multi VO Dirac

-    handle a possible exception which might be thrown in a SE loop, so the SE is skipped and the loop continues to process remaining SEs. This might happen, for example where an SE configuration does not define _Protocol_ configuration option.

This PR replaces #4332


BEGINRELEASENOTES

* RSS
CHANGE: remove a call to shifterProxy configuration which would not work for multi VO Dirac

ENDRELEASENOTES
