### PR TITLE
[v7r0] Core: remove unexisting import from dirac-info

### DIFF
--- a/Core/scripts/dirac-info.py
+++ b/Core/scripts/dirac-info.py
@@ -61,18 +61,6 @@ if gConfig.getValue('/DIRAC/Security/SkipCAChecks', False):
 else:
   records.append(('Skip CA Checks', 'No'))
 
-try:
-  import gfalthr  # pylint: disable=import-error
-  records.append(('gfal version', gfalthr.gfal_version()))
-except BaseException:
-  pass
-
-try:
-  import lcg_util  # pylint: disable=import-error
-  records.append(('lcg_util version', lcg_util.lcg_util_version()))
-except BaseException:
-  pass
-
 records.append(('DIRAC version', DIRAC.version))
 
 fields = ['Option', 'Value']


### PR DESCRIPTION
Found thanks to the new automated tests of DIRACOS

BEGINRELEASENOTES
*Core
FIX:  remove unexisting import from dirac-info

ENDRELEASENOTES
