### PR TITLE
[v7r0] Always starting from a clean PYTHONPATH

### DIFF
--- a/Core/Base/Client.py
+++ b/Core/Base/Client.py
@@ -92,7 +92,7 @@ class Client(object):
     if not rpc:
       if not url:
         url = self.serverURL
-      self.__kwargs.setdefault('timeout', timeout)
+      self.__kwargs['timeout'] = timeout
       rpc = RPCClient(url, **self.__kwargs)
     return rpc
 

--- a/Core/Base/Client.py
+++ b/Core/Base/Client.py
@@ -7,9 +7,9 @@ __RCSID__ = "$Id$"
 
 import ast
 import os
-from itertools import izip_longest
 
 from DIRAC.Core.DISET.RPCClient import RPCClient
+from DIRAC.Core.Utilities.Decorators import deprecated
 
 
 class Client(object):
@@ -48,6 +48,7 @@ class Client(object):
     """
     self.serverURL = url
 
+  @deprecated("Please use self._getRPC(timeout)")
   def setTimeout(self, timeout):
     """ Specify the timeout of the call. Forwarded to RPCClient
 

--- a/Core/scripts/dirac-configure.py
+++ b/Core/scripts/dirac-configure.py
@@ -466,34 +466,33 @@ if not os.path.exists(outputFile):
   update = True
   DIRAC.gConfig.dumpLocalCFGToFile(outputFile)
 
-# We need user proxy or server certificate to continue
-if not useServerCert:
-  Script.enableCS()
-  result = getProxyInfo()
-  if not result['OK']:
-    DIRAC.gLogger.notice('Configuration is not completed because no user proxy is available')
-    DIRAC.gLogger.notice('Create one using dirac-proxy-init and execute again with -F option')
-    sys.exit(1)
-else:
-  Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
-  # When using Server Certs CA's will be checked, the flag only disables initial download
-  # this will be replaced by the use of SkipCADownload
-  Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
-  Script.localCfg.addDefaultEntry('/DIRAC/Security/UseServerCertificate', 'yes')
-  Script.enableCS()
-
 if includeAllServers:
+  # We need user proxy or server certificate to continue in order to get all the CS URLs
+  if not useServerCert:
+    Script.enableCS()
+    result = getProxyInfo()
+    if not result['OK']:
+      DIRAC.gLogger.notice('Configuration is not completed because no user proxy is available')
+      DIRAC.gLogger.notice('Create one using dirac-proxy-init and execute again with -F option')
+      sys.exit(1)
+  else:
+    Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
+    # When using Server Certs CA's will be checked, the flag only disables initial download
+    # this will be replaced by the use of SkipCADownload
+    Script.localCfg.addDefaultEntry('/DIRAC/Security/UseServerCertificate', 'yes')
+    Script.enableCS()
+
   DIRAC.gConfig.setOptionValue('/DIRAC/Configuration/Servers', ','.join(DIRAC.gConfig.getServersList()))
   DIRAC.gLogger.verbose('/DIRAC/Configuration/Servers =', ','.join(DIRAC.gConfig.getServersList()))
 
-if useServerCert:
-  # always removing before dumping
-  Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
-  Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
-  Script.localCfg.deleteOption('/DIRAC/Security/SkipVOMSDownload')
+  if useServerCert:
+    # always removing before dumping
+    Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
+    Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
+    Script.localCfg.deleteOption('/DIRAC/Security/SkipVOMSDownload')
 
-if update:
-  DIRAC.gConfig.dumpLocalCFGToFile(outputFile)
+  if update:
+    DIRAC.gConfig.dumpLocalCFGToFile(outputFile)
 
 
 # ## LAST PART: do the vomsdir/vomses magic

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -200,7 +200,6 @@ class Params(object):
     self.tag = ""
     self.modules = {}
     self.externalVersion = ""
-    self.cleanPYTHONPATH = False
     self.createLink = False
     self.scriptSymlink = False
 
@@ -1073,11 +1072,9 @@ class ReleaseConfig(object):
       Web = git://github.com/DIRACGrid/DIRACWeb.git
       VMDIRAC = git://github.com/DIRACGrid/VMDIRAC.git
       DIRAC = git://github.com/DIRACGrid/DIRAC.git
-      MPIDIRAC = git://github.com/DIRACGrid/MPIDIRAC.git
       BoincDIRAC = git://github.com/DIRACGrid/BoincDIRAC.git
       RESTDIRAC = git://github.com/DIRACGrid/RESTDIRAC.git
       COMDIRAC = git://github.com/DIRACGrid/COMDIRAC.git
-      FSDIRAC = git://github.com/DIRACGrid/FSDIRAC.git
       WebAppDIRAC = git://github.com/DIRACGrid/WebAppDIRAC.git
     }
 
@@ -1680,7 +1677,6 @@ cmdOpts = (('r:', 'release=', 'Release version to install'),
             'Module to be installed. for example: -m DIRAC or -m git://github.com/DIRACGrid/DIRAC.git:DIRAC'),
            ('s:', 'source=', 'location of the modules to be installed'),
            ('x:', 'external=', 'external version'),
-           ('  ', 'cleanPYTHONPATH', 'Only use the DIRAC PYTHONPATH (for pilots installation)'),
            ('  ', 'createLink', 'create version symbolic link from the versions directory. This is equivalent to the \
            following command: ln -s /opt/dirac/versions/vArBpC vArBpC'),
            ('  ', 'scriptSymlink', 'Symlink the scripts instead of creating wrapper')
@@ -1825,8 +1821,6 @@ def loadConfiguration():
       cliParams.modules = discoverModules(v)
     elif o in ('-x', '--external'):
       cliParams.externalVersion = v
-    elif o == '--cleanPYTHONPATH':
-      cliParams.cleanPYTHONPATH = True
     elif o == '--createLink':
       cliParams.createLink = True
     elif o == '--scriptSymlink':
@@ -2131,10 +2125,7 @@ def createBashrc():
                     '( echo $DYLD_LIBRARY_PATH | grep -q $DIRACLIB/mysql ) || \
                     export DYLD_LIBRARY_PATH=$DIRACLIB/mysql:$DYLD_LIBRARY_PATH'])
 
-      if cliParams.cleanPYTHONPATH:
-        lines.extend(['export PYTHONPATH=$DIRAC'])
-      else:
-        lines.extend(['( echo $PYTHONPATH | grep -q $DIRAC ) || export PYTHONPATH=$DIRAC:$PYTHONPATH'])
+      lines.extend(['export PYTHONPATH=$DIRAC'])
 
       lines.extend(['# new OpenSSL version require OPENSSL_CONF to point to some accessible location',
                     'export OPENSSL_CONF=/tmp'])
@@ -2233,10 +2224,7 @@ def createCshrc():
                     '( echo $DYLD_LIBRARY_PATH | grep -q $DIRACLIB/mysql ) || \
                     setenv DYLD_LIBRARY_PATH ${DIRACLIB}/mysql:$DYLD_LIBRARY_PATH'])
 
-      if cliParams.cleanPYTHONPATH:
-        lines.extend(['setenv PYTHONPATH ${DIRAC}'])
-      else:
-        lines.extend(['( echo $PYTHONPATH | grep -q $DIRAC ) || setenv PYTHONPATH ${DIRAC}:$PYTHONPATH'])
+      lines.extend(['setenv PYTHONPATH ${DIRAC}'])
 
       lines.extend(['# new OpenSSL version require OPENSSL_CONF to point to some accessible location',
                     'setenv OPENSSL_CONF /tmp'])
@@ -2417,10 +2405,7 @@ def createBashrcForDiracOS():
 
       lines.extend(['( echo $PATH | grep -q $DIRACSCRIPTS ) || export PATH=$DIRACSCRIPTS:$PATH'])
 
-      if cliParams.cleanPYTHONPATH:
-        lines.extend(['export PYTHONPATH=$DIRAC'])
-      else:
-        lines.extend(['( echo $PYTHONPATH | grep -q $DIRAC ) || export PYTHONPATH=$DIRAC:$PYTHONPATH'])
+      lines.extend(['export PYTHONPATH=$DIRAC'])
 
       lines.extend(['# new OpenSSL version require OPENSSL_CONF to point to some accessible location',
                     'export OPENSSL_CONF=/tmp'])

--- a/WorkloadManagementSystem/PilotAgent/pilotCommands.py
+++ b/WorkloadManagementSystem/PilotAgent/pilotCommands.py
@@ -200,9 +200,6 @@ class InstallDIRAC(CommandBase):
     # The release version to install is a requirement
     self.installOpts.append('-r "%s"' % self.pp.releaseVersion)
 
-    # We clean the PYTHONPATH from the created bashrc
-    self.installOpts.append('--cleanPYTHONPATH')
-
     self.log.debug('INSTALL OPTIONS [%s]' % ', '.join(map(str, self.installOpts)))
 
   def _locateInstallationScript(self):


### PR DESCRIPTION
This is a draft PR, that needs agreement from @atsareg @marianne013 @andresailer @sfayer @iueda 

This is a continuation from https://github.com/DIRACGrid/DIRAC/pull/3923 and it has the same reasons: python packages shipped with diracos shouldn't be overridden by those same python packages found on the PYTHONPATH.

BEGINRELEASENOTES

*Core
CHANGE: {bash,tchs,diracos}rc set the PYTHONPATH to only dirac (ignore existing PYTHONPATH)
CHANGE: dirac-configure might work without the need of a proxy
CHANGE: the timeout of an RPC call is always updated

ENDRELEASENOTES
