### PR TITLE
[v7] DiracDocTools improvements

### DIFF
--- a/docs/diracdoctools/Config.py
+++ b/docs/diracdoctools/Config.py
@@ -60,8 +60,8 @@ class Configuration(object):
           LOG.info('Parsing config section: %r', section)
           pattern = listify(config.get(section, 'pattern'))
           title = config.get(section, 'title')
-          scripts = listify(config.get(section, 'scripts'))
-          ignore = listify(config.get(section, 'ignore'))
+          manual = listify(config.get(section, 'manual'))
+          exclude = listify(config.get(section, 'exclude'))
           sectionPath = config.get(section, 'sectionpath').replace(' ', '')
           indexFile = self._fullPath(config.get(section, 'indexfile')) if \
               config.has_option(section, 'indexfile') else None
@@ -70,8 +70,9 @@ class Configuration(object):
 
           self.com_MSS.append(dict(pattern=pattern,
                                    title=title,
-                                   scripts=scripts,
-                                   ignore=ignore,
+                                   scripts=[],
+                                   exclude=exclude,
+                                   manual=manual,
                                    indexFile=indexFile,
                                    prefix=prefix,
                                    sectionPath=sectionPath))

--- a/docs/diracdoctools/Config.py
+++ b/docs/diracdoctools/Config.py
@@ -61,6 +61,7 @@ class Configuration(object):
           pattern = listify(config.get(section, 'pattern'))
           title = config.get(section, 'title')
           manual = listify(config.get(section, 'manual'))
+          self.com_ignore_commands.extend(manual)
           exclude = listify(config.get(section, 'exclude'))
           sectionPath = config.get(section, 'sectionpath').replace(' ', '')
           indexFile = self._fullPath(config.get(section, 'indexfile')) if \

--- a/docs/diracdoctools/cmd/commandReference.py
+++ b/docs/diracdoctools/cmd/commandReference.py
@@ -17,7 +17,8 @@ LOG = makeLogger('CommandReference')
 TITLE = 'title'
 PATTERN = 'pattern'
 SCRIPTS = 'scripts'
-IGNORE = 'ignore'
+MANUAL = 'manual'
+EXCLUDE = 'exclude'
 SECTION_PATH = 'sectionPath'
 INDEX_FILE = 'indexFile'
 PREFIX = 'prefix'
@@ -53,7 +54,7 @@ class CommandReference(object):
 
       for mT in self.sectionDicts:
         if any(pattern in scriptPath for pattern in mT[PATTERN]) and \
-           not any(pattern in scriptPath for pattern in mT[IGNORE]):
+           not any(pattern in scriptPath for pattern in mT[EXCLUDE]):
           mT[SCRIPTS].append(scriptPath)
 
     return
@@ -83,7 +84,7 @@ class CommandReference(object):
 
     listOfScripts = []
     # these scripts use pre-existing rst files, cannot re-create them automatically
-    listOfScripts.extend(sectionDict[IGNORE])
+    listOfScripts.extend(sectionDict[MANUAL])
     sectionPath = os.path.join(self.config.docsPath, sectionDict[SECTION_PATH])
     for script in sectionDict[SCRIPTS]:
       scriptName = os.path.basename(script)
@@ -112,7 +113,7 @@ class CommandReference(object):
       commandList = indexFile.read().replace('\n', '')
 
     missingCommands = []
-    for script in sectionDict[SCRIPTS]:
+    for script in sectionDict[SCRIPTS] + sectionDict[MANUAL]:
       scriptName = os.path.basename(script)
       if scriptName.endswith('.py'):
         scriptName = scriptName[:-3]
@@ -133,7 +134,7 @@ class CommandReference(object):
     If an rst file exists for a command, we move it.
     An existing entry for a non existing rst file will create a warning when running sphinx.
     """
-    existingCommands = {os.path.basename(com).replace('.py', '') for com in sectionDict[SCRIPTS] + sectionDict[IGNORE]}
+    existingCommands = {os.path.basename(com).replace('.py', '') for com in sectionDict[SCRIPTS] + sectionDict[MANUAL]}
     sectionPath = os.path.join(self.config.docsPath, sectionDict[SECTION_PATH])
     LOG.info('Checking %r for non-existent commands', sectionPath)
     # read the script index

--- a/docs/docs.conf
+++ b/docs/docs.conf
@@ -57,7 +57,9 @@ ignore_commands=
 # no doc, purely internal use
   dirac-executor,
 # no doc, purely internal use
-  dirac-service
+  dirac-service,
+# shell script
+  dirac-cert-convert.sh,
 
 # scripts where the module docstring should be added to the documentation
 add_module_docstring = dirac-install
@@ -72,10 +74,10 @@ pattern = admin, accounting, FrameworkSystem, framework, install, utils,
         transformation, stager
 # title of the section
 title = Admin
-# scripts to add by hand, instead of pattern matching
-scripts =
-# more files to ignore, rst files have to be created by hand
-ignore = dirac-cert-convert.sh, dirac-platform, dirac-version
+# this list of patterns will reject scripts that are matched by the patterns above
+exclude =
+# the scripts in this list are added to the indexFile, but the rst file has to be provided manually
+manual = dirac-cert-convert.sh, dirac-platform, dirac-version
 # where to place the rst files
 sectionPath = source/AdministratorGuide/CommandReference
 # optional: only if a hand curated rst file exists
@@ -86,20 +88,20 @@ prefix = admin
 [commands.dms]
 pattern = dms
 title = Data Management
-scripts =
-ignore =
+manual =
+exclude =
 sectionPath = source/UserGuide/CommandReference/%(title)s
 
 [commands.wms]
 pattern = wms
 title = Workload Management
-scripts =
-ignore =
+manual =
+exclude =
 sectionPath = source/UserGuide/CommandReference/%(title)s
 
 [commands.z_section3]
 pattern = dirac-proxy, dirac-info, myproxy, -resource-
 title = Others
-scripts =
-ignore = dirac-cert-convert.sh, dirac-platform, dirac-version
+exclude =
+manual = dirac-cert-convert.sh, dirac-platform, dirac-version
 sectionPath = source/UserGuide/CommandReference/%(title)s

--- a/docs/docs.conf
+++ b/docs/docs.conf
@@ -66,7 +66,7 @@ add_module_docstring = dirac-install
 # rst files for each command matching the pattern. all options are mandatory,
 # except indexFile and prefix
 [commands.admin]
-# pattern to match in the command names
+# pattern to match in the full path of the command names
 pattern = admin, accounting, FrameworkSystem, framework, install, utils,
         dirac-repo-monitor, dirac-jobexec, dirac-info, ConfigurationSystem, Core, rss,
         transformation, stager

--- a/docs/docs.conf
+++ b/docs/docs.conf
@@ -8,7 +8,7 @@ source_folder = ../
 
 [Code]
 # building code reference
-# where to please the code reference
+# where to place the code reference
 docs_target_path = ./source/CodeDocumentation
 # where Custom docstrings can be found, see
 # DIRAC/docs/diracdoctools/CustomizedDocs for an example
@@ -76,7 +76,7 @@ title = Admin
 scripts =
 # more files to ignore, rst files have to be created by hand
 ignore = dirac-cert-convert.sh, dirac-platform, dirac-version
-# where to please the rst files
+# where to place the rst files
 sectionPath = source/AdministratorGuide/CommandReference
 # optional: only if a hand curated rst file exists
 indexFile = source/AdministratorGuide/CommandReference/index.rst

--- a/docs/docs.conf
+++ b/docs/docs.conf
@@ -58,8 +58,6 @@ ignore_commands=
   dirac-executor,
 # no doc, purely internal use
   dirac-service,
-# shell script
-  dirac-cert-convert.sh,
 
 # scripts where the module docstring should be added to the documentation
 add_module_docstring = dirac-install

--- a/docs/docs.conf
+++ b/docs/docs.conf
@@ -3,7 +3,7 @@
 # name of the module to documented, DIRAC, voDIRAC, ExtensionDIRAC
 module_name = DIRAC
 
-# path to the source folder relative to docs.conf, all paths are relative to this file
+# path to the source folder relative to docs.conf
 source_folder = ../
 
 [Code]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,16 +1,17 @@
 # cannot use DIRAC requirements because of inability to install pycurl (from FTS dependency) on RTD
 #-r https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/requirements.txt
 -e git+https://github.com/DIRACGrid/DIRAC/@integration#egg=diracdoctools&subdirectory=docs
-Sphinx>=1.8.0
-mock
-elasticsearch_dsl
-matplotlib
-mysql-python
-sqlalchemy
-suds
-pytz
-psutil
-pyparsing
 M2Crypto==0.32
+Sphinx>=1.8.0
+elasticsearch_dsl
+future
+matplotlib
+mock
+mysql-python
+psutil
 pyasn1>0.4.1
 pyasn1_modules
+pyparsing
+pytz
+sqlalchemy
+suds


### PR DESCRIPTION

BEGINRELEASENOTES

*Docs
CHANGE: The options in the command reference sections: 'ignore' and 'scripts', are replaced by 'exclude' and 'manual' respectively. The entries in 'exclude' will now reject scripts that are otherwise picked up by the 'patterns'. Entries in 'manual' will be added to the indexFile, but their rst file has to be provided by hand. Fixes #4345 

ENDRELEASENOTES
