### PR TITLE
[v7r0] Few FTS3 features and bug fixes

### DIFF
--- a/DataManagementSystem/Agent/FTS3Agent.py
+++ b/DataManagementSystem/Agent/FTS3Agent.py
@@ -38,6 +38,7 @@ from DIRAC.DataManagementSystem.private import FTS3Utilities
 from DIRAC.DataManagementSystem.DB.FTS3DB import FTS3DB
 from DIRAC.DataManagementSystem.Client.FTS3Job import FTS3Job
 from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
+from DIRAC.RequestManagementSystem.Client.ReqClient import ReqClient
 
 
 # pylint: disable=attribute-defined-outside-init
@@ -323,50 +324,76 @@ class FTS3Agent(AgentModule):
       else:
         log.debug("FTS3Operation %s is not totally processed yet" % operation.operationID)
 
-        res = operation.prepareNewJobs(
-            maxFilesPerJob=self.maxFilesPerJob, maxAttemptsPerFile=self.maxAttemptsPerFile)
+        # This flag is set to False if we want to stop the ongoing processing
+        # of an operation, typically when the matching RMS Request has been
+        # canceled (see below)
+        continueOperationProcessing = True
 
-        if not res['OK']:
-          log.error("Cannot prepare new Jobs", "FTS3Operation %s : %s" %
-                    (operation.operationID, res))
-          return operation, res
+        # Check the status of the associated RMS Request.
+        # If it is canceled then we will not create new FTS3Jobs, and mark
+        # this as FTS3Operation canceled.
 
-        newJobs = res['Value']
-
-        log.debug("FTS3Operation %s: %s new jobs to be submitted" %
-                  (operation.operationID, len(newJobs)))
-
-        for ftsJob in newJobs:
-          res = self._serverPolicy.chooseFTS3Server()
+        if operation.rmsReqID:
+          res = ReqClient().getRequestStatus(operation.rmsReqID)
           if not res['OK']:
-            log.error(res)
-            continue
+            log.error("Could not get request status", res)
+            return operation, res
+          rmsReqStatus = res['Value']
 
-          ftsServer = res['Value']
-          log.debug("Use %s server" % ftsServer)
+          if rmsReqStatus == 'Canceled':
+            log.info(
+                "The RMS Request is canceled, canceling the FTS3Operation",
+                "rmsReqID: %s, FTS3OperationID: %s" %
+                (operation.rmsReqID,
+                 operation.operationID))
+            operation.status = 'Canceled'
+            continueOperationProcessing = False
 
-          ftsJob.ftsServer = ftsServer
-
-          res = self.getFTS3Context(
-              ftsJob.username, ftsJob.userGroup, ftsServer, threadID=threadID)
-
-          if not res['OK']:
-            log.error("Could not get context", res)
-            continue
-
-          context = res['Value']
-          res = ftsJob.submit(context=context, protocols=self.thirdPartyProtocols)
+        if continueOperationProcessing:
+          res = operation.prepareNewJobs(
+              maxFilesPerJob=self.maxFilesPerJob, maxAttemptsPerFile=self.maxAttemptsPerFile)
 
           if not res['OK']:
-            log.error("Could not submit FTS3Job", "FTS3Operation %s : %s" %
+            log.error("Cannot prepare new Jobs", "FTS3Operation %s : %s" %
                       (operation.operationID, res))
-            continue
+            return operation, res
 
-          operation.ftsJobs.append(ftsJob)
+          newJobs = res['Value']
 
-          submittedFileIds = res['Value']
-          log.info("FTS3Operation %s: Submitted job for %s transfers" %
-                   (operation.operationID, len(submittedFileIds)))
+          log.debug("FTS3Operation %s: %s new jobs to be submitted" %
+                    (operation.operationID, len(newJobs)))
+
+          for ftsJob in newJobs:
+            res = self._serverPolicy.chooseFTS3Server()
+            if not res['OK']:
+              log.error(res)
+              continue
+
+            ftsServer = res['Value']
+            log.debug("Use %s server" % ftsServer)
+
+            ftsJob.ftsServer = ftsServer
+
+            res = self.getFTS3Context(
+                ftsJob.username, ftsJob.userGroup, ftsServer, threadID=threadID)
+
+            if not res['OK']:
+              log.error("Could not get context", res)
+              continue
+
+            context = res['Value']
+            res = ftsJob.submit(context=context, protocols=self.thirdPartyProtocols)
+
+            if not res['OK']:
+              log.error("Could not submit FTS3Job", "FTS3Operation %s : %s" %
+                        (operation.operationID, res))
+              continue
+
+            operation.ftsJobs.append(ftsJob)
+
+            submittedFileIds = res['Value']
+            log.info("FTS3Operation %s: Submitted job for %s transfers" %
+                     (operation.operationID, len(submittedFileIds)))
 
         # new jobs are put in the DB at the same time
       res = self.fts3db.persistOperation(operation)

--- a/DataManagementSystem/Client/FTS3Client.py
+++ b/DataManagementSystem/Client/FTS3Client.py
@@ -44,7 +44,7 @@ class FTS3Client(Client):
     try:
       opObj, _size = decode(opJSON)
       return S_OK(opObj)
-    except BaseException as e:
+    except Exception as e:
       return S_ERROR("Exception when decoding the FTS3Operation object %s" % e)
 
   def getActiveJobs(self, limit=20, lastMonitor=None, jobAssignmentTag='Assigned', ** kwargs):
@@ -62,7 +62,7 @@ class FTS3Client(Client):
     try:
       activeJobs, _size = decode(activeJobsJSON)
       return S_OK(activeJobs)
-    except BaseException as e:
+    except Exception as e:
       return S_ERROR("Exception when decoding the active jobs json %s" % e)
 
   def getNonFinishedOperations(self, limit=20, operationAssignmentTag="Assigned", **kwargs):
@@ -83,7 +83,7 @@ class FTS3Client(Client):
     try:
       operations, _size = decode(operationsJSON)
       return S_OK(operations)
-    except BaseException as e:
+    except Exception as e:
       return S_ERROR(0, "Exception when decoding the non finished operations json %s" % e)
 
   def getOperationsFromRMSOpID(self, rmsOpID, **kwargs):
@@ -100,5 +100,5 @@ class FTS3Client(Client):
     try:
       operations, _size = decode(operationsJSON)
       return S_OK(operations)
-    except BaseException as e:
+    except Exception as e:
       return S_ERROR(0, "Exception when decoding the operations json %s" % e)

--- a/DataManagementSystem/Client/FTS3Client.py
+++ b/DataManagementSystem/Client/FTS3Client.py
@@ -1,8 +1,6 @@
-import json
-
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC import S_OK, S_ERROR
-from DIRAC.DataManagementSystem.private.FTS3Utilities import FTS3JSONDecoder
+from DIRAC.Core.Utilities.JEncode import encode, decode
 
 
 @createClient('DataManagement/FTS3Manager')
@@ -28,7 +26,7 @@ class FTS3Client(Client):
     if isinstance(opObj.sourceSEs, list):
       opObj.sourceSEs = ','.join(opObj.sourceSEs)
 
-    opJSON = opObj.toJSON()
+    opJSON = encode(opObj)
     return self._getRPC(**kwargs).persistOperation(opJSON)
 
   def getOperation(self, operationID, **kwargs):
@@ -44,9 +42,9 @@ class FTS3Client(Client):
     opJSON = res['Value']
 
     try:
-      opObj = json.loads(opJSON, cls=FTS3JSONDecoder)
+      opObj, _size = decode(opJSON)
       return S_OK(opObj)
-    except Exception as e:
+    except BaseException as e:
       return S_ERROR("Exception when decoding the FTS3Operation object %s" % e)
 
   def getActiveJobs(self, limit=20, lastMonitor=None, jobAssignmentTag='Assigned', ** kwargs):
@@ -62,9 +60,9 @@ class FTS3Client(Client):
     activeJobsJSON = res['Value']
 
     try:
-      activeJobs = json.loads(activeJobsJSON, cls=FTS3JSONDecoder)
+      activeJobs, _size = decode(activeJobsJSON)
       return S_OK(activeJobs)
-    except Exception as e:
+    except BaseException as e:
       return S_ERROR("Exception when decoding the active jobs json %s" % e)
 
   def updateFileStatus(self, fileStatusDict, ftsGUID=None, **kwargs):
@@ -100,9 +98,9 @@ class FTS3Client(Client):
     operationsJSON = res['Value']
 
     try:
-      operations = json.loads(operationsJSON, cls=FTS3JSONDecoder)
+      operations, _size = decode(operationsJSON)
       return S_OK(operations)
-    except Exception as e:
+    except BaseException as e:
       return S_ERROR(0, "Exception when decoding the non finished operations json %s" % e)
 
   def getOperationsFromRMSOpID(self, rmsOpID, **kwargs):
@@ -117,7 +115,7 @@ class FTS3Client(Client):
 
     operationsJSON = res['Value']
     try:
-      operations = json.loads(operationsJSON, cls=FTS3JSONDecoder)
+      operations, _size = decode(operationsJSON)
       return S_OK(operations)
-    except Exception as e:
+    except BaseException as e:
       return S_ERROR(0, "Exception when decoding the operations json %s" % e)

--- a/DataManagementSystem/Client/FTS3Client.py
+++ b/DataManagementSystem/Client/FTS3Client.py
@@ -65,23 +65,6 @@ class FTS3Client(Client):
     except BaseException as e:
       return S_ERROR("Exception when decoding the active jobs json %s" % e)
 
-  def updateFileStatus(self, fileStatusDict, ftsGUID=None, **kwargs):
-    """ Update the file ftsStatus and error
-
-       :param fileStatusDict: { fileID : { status , error, ftsGUID } }
-       :param ftsGUID: if specified, only update the files having a matchign ftsGUID
-    """
-
-    return self._getRPC(**kwargs).updateFileStatus(fileStatusDict, ftsGUID)
-
-  def updateJobStatus(self, jobStatusDict, **kwargs):
-    """ Update the job Status and error
-
-       :param jobStatusDict: { jobID : { status , error } }
-    """
-
-    return self._getRPC(**kwargs).updateJobStatus(jobStatusDict)
-
   def getNonFinishedOperations(self, limit=20, operationAssignmentTag="Assigned", **kwargs):
     """ Get all the FTS3Operations that have files in New or Failed state
         (reminder: Failed is NOT terminal for files. Failed is when fts failed, but we

--- a/DataManagementSystem/Client/FTS3File.py
+++ b/DataManagementSystem/Client/FTS3File.py
@@ -1,8 +1,8 @@
 import datetime
-from DIRAC.DataManagementSystem.private.FTS3Utilities import FTS3Serializable
+from DIRAC.Core.Utilities.JEncode import JSerializable
 
 
-class FTS3File(FTS3Serializable):
+class FTS3File(JSerializable):
   """ This class represents an a File on which a given Operation
       (Transfer, Staging) should be executed
    """

--- a/DataManagementSystem/Client/FTS3Job.py
+++ b/DataManagementSystem/Client/FTS3Job.py
@@ -124,7 +124,7 @@ class FTS3Job(JSerializable):
       jobStatusDict = fts3.get_job_status(context, self.ftsGUID, list_files=True)
     # The job is not found
     # Set its status to Failed and return
-    except NotFound as e:
+    except NotFound:
       self.status = 'Failed'
       return S_ERROR(errno.ESRCH, "FTSGUID %s not found on %s" % (self.ftsGUID, self.ftsServer))
     except FTS3ClientException as e:

--- a/DataManagementSystem/Client/FTS3Job.py
+++ b/DataManagementSystem/Client/FTS3Job.py
@@ -18,14 +18,14 @@ from DIRAC.FrameworkSystem.Client.Logger import gLogger
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.Utilities.DErrno import cmpError
 
-from DIRAC.DataManagementSystem.private.FTS3Utilities import FTS3Serializable
+from DIRAC.Core.Utilities.JEncode import JSerializable
 from DIRAC.DataManagementSystem.Client.FTS3File import FTS3File
 
 # 3 days in seconds
 BRING_ONLINE_TIMEOUT = 259200
 
 
-class FTS3Job(FTS3Serializable):
+class FTS3Job(JSerializable):
   """ Abstract class to represent a job to be executed by FTS. It belongs
       to an FTS3Operation
   """

--- a/DataManagementSystem/Client/FTS3Job.py
+++ b/DataManagementSystem/Client/FTS3Job.py
@@ -8,7 +8,7 @@ import errno
 
 # Requires at least version 3.3.3
 import fts3.rest.client.easy as fts3
-from fts3.rest.client.exceptions import FTS3ClientException
+from fts3.rest.client.exceptions import FTS3ClientException, NotFound
 from fts3.rest.client.request import Request as ftsSSLRequest
 
 from DIRAC.Resources.Storage.StorageElement import StorageElement
@@ -83,7 +83,11 @@ class FTS3Job(JSerializable):
     self.accountingDict = None
 
   def monitor(self, context=None, ftsServer=None, ucert=None):
-    """ Queries the fts server to monitor the job
+    """ Queries the fts server to monitor the job.
+        The internal state of the object is updated depending on the
+        monitoring result.
+
+        In case the job is not found on the server, the status is set to 'Failed'
 
         This method assumes that the attribute self.ftsGUID is set
 
@@ -93,7 +97,14 @@ class FTS3Job(JSerializable):
 
         :param ucert: path to the user certificate/proxy. Might be infered by the fts cli (see its doc)
 
-        :returns {FileID: { status, error } }
+        :returns: {FileID: { status, error } }
+
+                  Possible error numbers
+
+                  * errno.ESRCH: If the job does not exist on the server
+                  * errno.EDEADLK: In case the job and file status are inconsistent (see comments inside the code)
+
+
     """
 
     if not self.ftsGUID:
@@ -111,6 +122,11 @@ class FTS3Job(JSerializable):
     jobStatusDict = None
     try:
       jobStatusDict = fts3.get_job_status(context, self.ftsGUID, list_files=True)
+    # The job is not found
+    # Set its status to Failed and return
+    except NotFound as e:
+      self.status = 'Failed'
+      return S_ERROR(errno.ESRCH, "FTSGUID %s not found on %s" % (self.ftsGUID, self.ftsServer))
     except FTS3ClientException as e:
       return S_ERROR("Error getting the job status %s" % e)
 

--- a/DataManagementSystem/Client/FTS3Operation.py
+++ b/DataManagementSystem/Client/FTS3Operation.py
@@ -20,7 +20,7 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
 from DIRAC.DataManagementSystem.Client.FTS3File import FTS3File
-from DIRAC.DataManagementSystem.private.FTS3Utilities import FTS3Serializable
+from DIRAC.Core.Utilities.JEncode import JSerializable
 
 from DIRAC.RequestManagementSystem.Client.ReqClient import ReqClient
 from DIRAC.RequestManagementSystem.Client.Operation import Operation as rmsOperation
@@ -30,7 +30,7 @@ from DIRAC.RequestManagementSystem.Client.Request import Request as rmsRequest
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
 
 
-class FTS3Operation(FTS3Serializable):
+class FTS3Operation(JSerializable):
   """ Abstract class to represent an operation to be executed by FTS. It is a
       container for FTSFiles, as well as for FTSJobs.
 
@@ -360,7 +360,7 @@ class FTS3Operation(FTS3Serializable):
 
       ftsOp.activity = argumentDic['activity']
       ftsOp.priority = argumentDic['priority']
-    except Exception as _e:
+    except BaseException as _e:
       pass
 
     return ftsOp

--- a/DataManagementSystem/Client/FTS3Operation.py
+++ b/DataManagementSystem/Client/FTS3Operation.py
@@ -360,7 +360,7 @@ class FTS3Operation(JSerializable):
 
       ftsOp.activity = argumentDic['activity']
       ftsOp.priority = argumentDic['priority']
-    except BaseException as _e:
+    except Exception:
       pass
 
     return ftsOp

--- a/DataManagementSystem/ConfigTemplate.cfg
+++ b/DataManagementSystem/ConfigTemplate.cfg
@@ -8,6 +8,7 @@ Services
       Default = authenticated
     }
   }
+  ##BEGIN FTS3Manager
   FTS3Manager
   {
     Port = 9193
@@ -16,6 +17,7 @@ Services
       Default = authenticated
     }
   }
+  ##END
   FileCatalogProxy
   {
     Port = 9138

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -148,27 +148,6 @@ class FTS3ManagerHandler(RequestHandler):
 
     return S_OK(activeJobsJSON)
 
-  types_updateFileStatus = [dict]
-  @classmethod
-  def export_updateFileStatus(cls, fileStatusDict, ftsGUID):
-    """ Update the file ftsStatus and error.
-
-       :param fileStatusDict: { fileID : { status , error } }
-       :param ftsGUID: (not mandatory) If specified, only update the rows where the ftsGUID matches this value.
-    """
-
-    return cls.fts3db.updateFileStatus(fileStatusDict, ftsGUID)
-
-  types_updateJobStatus = [dict]
-  @classmethod
-  def export_updateJobStatus(cls, jobStatusDict):
-    """ Update the job Status and error
-
-       :param jobStatusDict: { jobID : { status , error } }
-    """
-
-    return cls.fts3db.updateJobStatus(jobStatusDict)
-
   types_getNonFinishedOperations = [(long, int), basestring]
 
   @classmethod

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -1,5 +1,5 @@
 """
-Service handler for FT3SDB using DISET
+Service handler for FTS3DB using DISET
 
 .. literalinclude:: ../ConfigTemplate.cfg
   :start-after: ##BEGIN FTS3Manager

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -13,7 +13,10 @@ __RCSID__ = "$Id$"
 
 # from DIRAC
 from DIRAC import S_OK, S_ERROR, gLogger
+from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getDNForUsername
 from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
+from DIRAC.Core.Security.Properties import FULL_DELEGATION, LIMITED_DELEGATION, TRUSTED_HOST
+from DIRAC.Core.Utilities import DErrno
 
 
 from DIRAC.DataManagementSystem.DB.FTS3DB import FTS3DB
@@ -43,10 +46,49 @@ class FTS3ManagerHandler(RequestHandler):
     # # create tables for empty db
     return cls.fts3db.createTables()
 
+  @staticmethod
+  def _isAllowed(opObj, remoteCredentials):
+    """
+        Make sure the client is allowed to persist an operation
+        (FULL_DELEGATION or LIMITED_DELEGATION). This is the case of pilots,
+        the RequestExecutingAgent or the FTS3Agent
+
+        :param opObj: the FTS3Operation object
+        :param remoteCredentials: credentials from the clients
+
+        :returns: True if everything is fine, False otherwise
+    """
+
+    credDN = remoteCredentials['DN']
+    credGroup = remoteCredentials['group']
+    credProperties = remoteCredentials['properties']
+
+    # First, get the DN matching the username
+    res = getDNForUsername(opObj.username)
+    # if we have an error, do not allow
+    if not res['OK']:
+      gLogger.error("Error retrieving DN for username", res)
+      return False
+
+    # List of DN matching the username
+    dnList = res['Value']
+
+    # If the credentials in the Request match those from the credentials, it's OK
+    if credDN in dnList and opObj.userGroup == credGroup:
+      return True
+
+    # From here, something/someone is putting a request on behalf of someone else
+
+    # Only allow this if the credentials have Full or Limited delegation properties
+
+    if FULL_DELEGATION in credProperties or LIMITED_DELEGATION in credProperties:
+      return True
+
+    return False
+
   types_persistOperation = [basestring]
 
-  @classmethod
-  def export_persistOperation(cls, opJSON):
+  def export_persistOperation(self, opJSON):
     """ update or insert request into db
 
         :param opJSON: json string representing the operation
@@ -55,7 +97,13 @@ class FTS3ManagerHandler(RequestHandler):
     """
 
     opObj, _size = decode(opJSON)
-    return cls.fts3db.persistOperation(opObj)
+
+    isAuthorized = FTS3ManagerHandler._isAllowed(opObj, self.getRemoteCredentials())
+
+    if not isAuthorized:
+      return S_ERROR(DErrno.ENOAUTH, "Credentials in the requests are not allowed")
+
+    return self.fts3db.persistOperation(opObj)
 
   types_getOperation = [(long, int)]
 
@@ -101,10 +149,9 @@ class FTS3ManagerHandler(RequestHandler):
     return S_OK(activeJobsJSON)
 
   types_updateFileStatus = [dict]
-
   @classmethod
   def export_updateFileStatus(cls, fileStatusDict, ftsGUID):
-    """ Update the file ftsStatus and error
+    """ Update the file ftsStatus and error.
 
        :param fileStatusDict: { fileID : { status , error } }
        :param ftsGUID: (not mandatory) If specified, only update the rows where the ftsGUID matches this value.
@@ -113,7 +160,6 @@ class FTS3ManagerHandler(RequestHandler):
     return cls.fts3db.updateFileStatus(fileStatusDict, ftsGUID)
 
   types_updateJobStatus = [dict]
-
   @classmethod
   def export_updateJobStatus(cls, jobStatusDict):
     """ Update the job Status and error

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -1,15 +1,15 @@
 """
-:mod: FTS3ManagerHandler
-
-.. module: FTS3ManagerHandler
-  :synopsis: handler for FTS3DB using DISET
-
 Service handler for FT3SDB using DISET
+
+.. literalinclude:: ../ConfigTemplate.cfg
+  :start-after: ##BEGIN FTS3Manager
+  :end-before: ##END
+  :dedent: 2
+  :caption: FTS3Manager options
+
 """
 
 __RCSID__ = "$Id$"
-
-import json
 
 # from DIRAC
 from DIRAC import S_OK, S_ERROR, gLogger
@@ -17,7 +17,7 @@ from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
 
 
 from DIRAC.DataManagementSystem.DB.FTS3DB import FTS3DB
-from DIRAC.DataManagementSystem.private.FTS3Utilities import FTS3JSONEncoder, FTS3JSONDecoder
+from DIRAC.Core.Utilities.JEncode import encode, decode
 
 ########################################################################
 
@@ -54,7 +54,7 @@ class FTS3ManagerHandler(RequestHandler):
         :return: OperationID
     """
 
-    opObj = json.loads(opJSON, cls=FTS3JSONDecoder)
+    opObj, _size = decode(opJSON)
     return cls.fts3db.persistOperation(opObj)
 
   types_getOperation = [(long, int)]
@@ -73,7 +73,7 @@ class FTS3ManagerHandler(RequestHandler):
       return getOperation
 
     getOperation = getOperation["Value"]
-    opJSON = getOperation.toJSON()
+    opJSON = encode(getOperation)
     return S_OK(opJSON)
 
   types_getActiveJobs = [(long, int), [None] + [basestring], basestring]
@@ -96,7 +96,7 @@ class FTS3ManagerHandler(RequestHandler):
       return res
 
     activeJobs = res['Value']
-    activeJobsJSON = json.dumps(activeJobs, cls=FTS3JSONEncoder)
+    activeJobsJSON = encode(activeJobs)
 
     return S_OK(activeJobsJSON)
 
@@ -140,7 +140,7 @@ class FTS3ManagerHandler(RequestHandler):
       return res
 
     nonFinishedOperations = res['Value']
-    nonFinishedOperationsJSON = json.dumps(nonFinishedOperations, cls=FTS3JSONEncoder)
+    nonFinishedOperationsJSON = encode(nonFinishedOperations)
 
     return S_OK(nonFinishedOperationsJSON)
 
@@ -160,6 +160,6 @@ class FTS3ManagerHandler(RequestHandler):
       return res
 
     operations = res["Value"]
-    opsJSON = json.dumps(operations, cls=FTS3JSONEncoder)
+    opsJSON = encode(operations)
 
     return S_OK(opsJSON)

--- a/DataManagementSystem/private/FTS3Utilities.py
+++ b/DataManagementSystem/private/FTS3Utilities.py
@@ -36,7 +36,7 @@ def selectUniqueRandomSource(ftsFiles, allowedSources=None):
       :param allowedSources: list of allowed sources
       :param ftsFiles: list of FTS3File object
 
-      :return:  S_OK({ sourceSE: [ FTS3Files] }, {FTS3File: errors})
+      :return:  S_OK(({ sourceSE: [ FTS3Files] }, {FTS3File: errors}))
 
   """
 

--- a/DataManagementSystem/private/FTS3Utilities.py
+++ b/DataManagementSystem/private/FTS3Utilities.py
@@ -74,6 +74,7 @@ def selectUniqueRandomSource(ftsFiles, allowedSources=None):
 
   return S_OK(groupBySource)
 
+
 def groupFilesByTarget(ftsFiles):
   """
         For a list of FTS3files object, group the Files by target
@@ -90,138 +91,6 @@ def groupFilesByTarget(ftsFiles):
     destGroup.setdefault(ftsFile.targetSE, []).append(ftsFile)
 
   return S_OK(destGroup)
-
-
-class FTS3Serializable(object):
-  """ This is the base class for all the FTS3 objects that
-      needs to be serialized, so FTS3Operation, FTS3File
-      and FTS3Job
-
-      The inheriting classes just have to define a class
-      attribute called _attrToSerialize, which is a list of
-      strings, which correspond to the name of the attribute
-      they want to serialize
-  """
-  _datetimeFormat = '%Y-%m-%d %H:%M:%S'
-
-  # MUST BE OVERWRITTEN IN THE CHILD CLASS
-  _attrToSerialize = []
-
-  def toJSON(self, forPrint=False):
-    """ Returns the JSON formated string
-
-        :param forPrint: if set to True, we don't include
-               the 'magic' arguments used for rebuilding the
-               object
-    """
-
-    jsonStr = json.dumps(self, cls=FTS3JSONEncoder, forPrint=forPrint)
-    return jsonStr
-
-  def __str__(self):
-    import pprint
-    js = json.loads(self.toJSON(forPrint=True))
-    return pprint.pformat(js)
-
-  def _getJSONData(self, forPrint=False):
-    """ Returns the data that have to be serialized by JSON
-
-        :param forPrint: if set to True, we don't include
-               the 'magic' arguments used for rebuilding the
-               object
-
-        :return: dictionary to be transformed into json
-    """
-    jsonData = {}
-    datetimeAttributes = []
-    for attrName in self._attrToSerialize:
-      # IDs might not be set since it is managed by SQLAlchemy
-      if not hasattr(self, attrName):
-        continue
-
-      value = getattr(self, attrName)
-      if isinstance(value, datetime.datetime):
-        # We convert date time to a string
-        jsonData[attrName] = value.strftime(self._datetimeFormat)
-        datetimeAttributes.append(attrName)
-      else:
-        jsonData[attrName] = value
-
-    if not forPrint:
-      jsonData['__type__'] = self.__class__.__name__
-      jsonData['__module__'] = self.__module__
-      jsonData['__datetime__'] = datetimeAttributes
-
-    return jsonData
-
-
-class FTS3JSONEncoder(json.JSONEncoder):
-  """ This class is an encoder for the FTS3 objects
-  """
-
-  def __init__(self, *args, **kwargs):
-    if 'forPrint' in kwargs:
-      self._forPrint = kwargs.pop('forPrint')
-    else:
-      self._forPrint = False
-
-    super(FTS3JSONEncoder, self).__init__(*args, **kwargs)
-
-  def default(self, obj):  # pylint: disable=method-hidden
-
-    if hasattr(obj, '_getJSONData'):
-      return obj._getJSONData(forPrint=self._forPrint)
-    else:
-      return json.JSONEncoder.default(self, obj)
-
-
-class FTS3JSONDecoder(json.JSONDecoder):
-  """ This class is an decoder for the FTS3 objects
-  """
-
-  def __init__(self, *args, **kargs):
-    json.JSONDecoder.__init__(self, object_hook=self.dict_to_object,
-                              *args, **kargs)
-
-  def dict_to_object(self, dataDict):
-    """ Convert the dictionary into an object """
-    import importlib
-    # If it is not an FTS3 object, just return the structure as is
-    if not ('__type__' in dataDict and '__module__' in dataDict):
-      return dataDict
-
-    # Get the class and module
-    className = dataDict.pop('__type__')
-    modName = dataDict.pop('__module__')
-    datetimeAttributes = dataDict.pop('__datetime__', [])
-    datetimeSet = set(datetimeAttributes)
-    try:
-      # Load the module
-      mod = importlib.import_module(modName)
-      # import the class
-      cl = getattr(mod, className)
-      # Instantiate the object
-      obj = cl()
-
-      # Set each attribute
-      for attrName, attrValue in dataDict.iteritems():
-        # If the value is None, do not set it
-        # This is needed to play along well with SQLalchemy
-
-        if attrValue is None:
-          continue
-        if attrName in datetimeSet:
-          attrValue = datetime.datetime.strptime(attrValue, FTS3Serializable._datetimeFormat)
-        setattr(obj, attrName, attrValue)
-
-      return obj
-
-    except Exception as e:
-      gLogger.error('exception in FTS3JSONDecoder %s for type %s' % (e, className))
-      dataDict['__type__'] = className
-      dataDict['__module__'] = modName
-      dataDict['__datetime__'] = datetimeAttributes
-      return dataDict
 
 
 threadLocal = threading.local()

--- a/DataManagementSystem/private/test/Test_FTS3Utilities.py
+++ b/DataManagementSystem/private/test/Test_FTS3Utilities.py
@@ -80,7 +80,7 @@ class TestFileGrouping(unittest.TestCase):
 
     self.assertTrue(res['OK'])
 
-    uniqueSources = res['Value']
+    uniqueSources, _failedFiles = res['Value']
 
     # There should be only f1,f2 and f3
     allReturnedFiles = []

--- a/DataManagementSystem/private/test/Test_FTS3Utilities.py
+++ b/DataManagementSystem/private/test/Test_FTS3Utilities.py
@@ -1,73 +1,17 @@
 """ Test the FTS3Utilities"""
+
+__RCSID__ = "$Id$"
+
+import unittest
+
+import mock
+
 from DIRAC.DataManagementSystem.Client.FTS3File import FTS3File
 from DIRAC import S_OK, S_ERROR
 
-__RCSID__ = "$Id $"
-
-import unittest
-import mock
-import datetime
-
-from DIRAC.DataManagementSystem.private.FTS3Utilities import FTS3JSONDecoder, \
-    FTS3Serializable, \
-    groupFilesByTarget, \
+from DIRAC.DataManagementSystem.private.FTS3Utilities import groupFilesByTarget, \
     selectUniqueRandomSource, \
     FTS3ServerPolicy
-
-
-import json
-
-
-class FakeClass(FTS3Serializable):
-  """ Just a fake class"""
-  _attrToSerialize = ['string', 'date', 'dic', 'sub']
-
-  def __init__(self):
-    self.string = ''
-    self.date = None
-    self.dic = {}
-
-
-class TestFTS3Serialization(unittest.TestCase):
-  """ Test the FTS3 JSON serialization mechanizme with FTS3JSONEncoder,
-      FTS3JSONDecoder, FTS3Serializable"""
-
-  def test_01_basic(self):
-    """ Basic json transfer"""
-
-    obj = FakeClass()
-    obj.string = 'tata'
-    obj.date = datetime.datetime.utcnow().replace(microsecond=0)
-    obj.dic = {'a': 1}
-    obj.notSerialized = 'Do not'
-
-    obj2 = json.loads(obj.toJSON(), cls=FTS3JSONDecoder)
-
-    self.assertTrue(obj.string == obj2.string)
-    self.assertTrue(obj.date == obj2.date)
-    self.assertTrue(obj.dic == obj2.dic)
-
-    self.assertTrue(not hasattr(obj2, 'notSerialized'))
-
-  def test_02_subobjects(self):
-    """ Try setting as attribute an object """
-
-    class NonSerializable(object):
-      """ Fake class not inheriting from FTS3Serializable"""
-      pass
-
-    obj = FakeClass()
-    obj.sub = NonSerializable()
-
-    with self.assertRaises(TypeError):
-      obj.toJSON()
-
-    obj.sub = FakeClass()
-    obj.sub.string = 'pipo'
-
-    obj2 = json.loads(obj.toJSON(), cls=FTS3JSONDecoder)
-
-    self.assertTrue(obj.sub.string == obj2.sub.string)
 
 
 def mock__checkSourceReplicas(ftsFiles):
@@ -141,7 +85,7 @@ class TestFileGrouping(unittest.TestCase):
     # There should be only f1,f2 and f3
     allReturnedFiles = []
     existingFiles = [self.f1, self.f2, self.f3]
-    for srcSe, ftsFiles in uniqueSources.iteritems():
+    for _srcSe, ftsFiles in uniqueSources.iteritems():
       allReturnedFiles.extend(ftsFiles)
 
     # No files should be duplicated and all files should be there, except the non existing one
@@ -263,7 +207,6 @@ class TestFTS3ServerPolicy (unittest.TestCase):
 
 
 if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestFTS3Serialization)
-  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestFileGrouping))
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestFileGrouping)
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestFTS3ServerPolicy))
   unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/Integration/all_integration_client_tests.sh
+++ b/tests/Integration/all_integration_client_tests.sh
@@ -55,12 +55,6 @@ python $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/create
 $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_dirac-jobexec.sh 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_TimeLeft.sh 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
-
-#-------------------------------------------------------------------------------#
-echo -e "*** $(date -u)  **** FTS TESTS ****\n"
-pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Client_FTS3.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
-
-
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** MONITORING TESTS ****\n"
 pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/Monitoring/Test_MonitoringSystem.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -65,6 +65,12 @@ python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Clien
 diracDFCDB 2>&1 | tee -a $SERVER_TEST_OUTPUT
 python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
+
+#-------------------------------------------------------------------------------#
+echo -e "*** $(date -u)  **** FTS TESTS ****\n"
+# I know, it says Client, but it also instaciates a DB, so it needs to be here
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Client_FTS3.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RMS TESTS ****\n"
 python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_ReqDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))


### PR DESCRIPTION
Quite a few pending features and bug fixes
All transparent except the JEncode usage, but that's fine, it's only until both the RMS and the FTS run the latest version. 


BEGINRELEASENOTES
*DMS
CHANGE: FTS3 persistOperation method checks that the caller is allowed to do so
CHANGE: FTS3Manager: do not expose updateJobStatus and updateFileStatus on the service
CHANGE: FTS3 operation is canceled if the matching request is canceled 
CHANGE: when a source file does not exist, defunct the FTS3File associated
CHANGE: use the JEncode serializer instead of the custom FTS3Serializer
CHANGE: cancel an FTS3Job together with its associated FTS3Files if the job is not found on the server
ENDRELEASENOTES
