### PR TITLE
[integration] dirac-install: add possible env vars to bashrc

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2171,7 +2171,7 @@ def createBashrc():
       lines.append('# export DIRAC_GFAL_GRIDFTP_SESSION_REUSE=true')
       lines.append('# export DIRAC_USE_M2CRYPTO=true')
       lines.append('# export DIRAC_USE_NEWTHREADPOOL=yes')
-      lines.append('# export DIRAC_VOMSES=/etc/grid-security/vomsdir')
+      lines.append('# export DIRAC_VOMSES=$DIRAC/etc/grid-security/vomses')
 
       lines.append('')
       f = open(bashrcFile, 'w')

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2160,6 +2160,19 @@ def createBashrc():
         for envName, envValue in cliParams.userEnvVariables.items():
           lines.extend(['export %s=%s' % (envName, envValue)])
 
+      # Add possible DIRAC environment variables
+      lines.append('')
+      lines.append('# before enabling any of these variables, please see the documentation ')
+      lines.append('# https://dirac.readthedocs.io/en/latest/AdministratorGuide/' +
+                   'ServerInstallations/environment_variable_configuration.html')
+      lines.append('# export DIRAC_DEBUG_DENCODE_CALLSTACK=1')
+      lines.append('# export DIRAC_DEBUG_STOMP=1')
+      lines.append('# export DIRAC_DEPRECATED_FAIL=1')
+      lines.append('# export DIRAC_GFAL_GRIDFTP_SESSION_REUSE=true')
+      lines.append('# export DIRAC_USE_M2CRYPTO=true')
+      lines.append('# export DIRAC_USE_NEWTHREADPOOL=yes')
+      lines.append('# export DIRAC_VOMSES=/etc/grid-security/vomsdir')
+
       lines.append('')
       f = open(bashrcFile, 'w')
       f.write('\n'.join(lines))


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
NEW: When `dirac-install` creates the bashrc file all currently existing "DIRAC_" environment variables are added as comments to the file, fixes #4351 

ENDRELEASENOTES
