### PR TITLE
[v7r0] HTCondorCE: modify the PilotJobReferences to determine the paths of the job outputs

### DIFF
--- a/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -94,7 +94,7 @@ class HTCondorCETests( unittest.TestCase ):
          patch( MODNAME+".tempfile.mkstemp", new=Mock( return_value=("os", "pilotName"))), \
          patch( MODNAME+".mkDir", new=Mock()):
 
-      htce._HTCondorCEComputingElement__writeSub( "dirac-install", 42 ) #pylint: disable=E1101
+      htce._HTCondorCEComputingElement__writeSub( "dirac-install", 42, '' ) #pylint: disable=E1101
       for option in [ "ShouldTransferFiles = YES", "WhenToTransferOutput = ON_EXIT_OR_EVICT", "universe = grid"]:
         # the three [0] are: call_args_list[firstCall][ArgsArgumentsTuple][FirstArgsArgument]
         self.assertIn( option, subFileMock.write.call_args_list[0][0][0] )
@@ -108,7 +108,7 @@ class HTCondorCETests( unittest.TestCase ):
          patch( MODNAME+".tempfile.mkstemp", new=Mock( return_value=("os", "pilotName"))), \
          patch( MODNAME+".mkDir", new=Mock()):
 
-      htce._HTCondorCEComputingElement__writeSub( "dirac-install", 42 ) #pylint: disable=E1101
+      htce._HTCondorCEComputingElement__writeSub( "dirac-install", 42, '' ) #pylint: disable=E1101
       for option in [ "ShouldTransferFiles = YES", "WhenToTransferOutput = ON_EXIT_OR_EVICT" ]:
         self.assertNotIn( option, subFileMock.write.call_args_list[0][0][0] )
       for option in [ "universe = vanilla"]:

--- a/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -17,24 +17,22 @@ STATUS_LINES = """
 123.1 3
 """.strip().split('\n')
 
-HISTORY_LINES ="""
+HISTORY_LINES = """
 123 0 4
 """.strip().split('\n')
 
-class HTCondorCETests( unittest.TestCase ):
+
+class HTCondorCETests(unittest.TestCase):
   """ tests for the HTCondorCE Module """
 
-  def setUp( self ):
-    self.ceParameters = { 'Queue': "espresso",
-                          'GridEnv': "/dev/null",
-                        }
+  def setUp(self):
+    self.ceParameters = {'Queue': "espresso",
+                         'GridEnv': "/dev/null"}
 
-
-  def tearDown( self ):
+  def tearDown(self):
     pass
 
-
-  def test_parseCondorStatus( self ):
+  def test_parseCondorStatus(self):
     statusLines = """
     104097.9 2
     104098.0 1
@@ -45,156 +43,142 @@ class HTCondorCETests( unittest.TestCase ):
     104098.3 5
     104098.4 7
     """.strip().split('\n')
-    ## force there to be an empty line
+    # force there to be an empty line
 
-    expectedResults = {
-      "104097.9": "Running",
-      "104098.0": "Waiting",
-      "104098.1": "Done",
-      "104098.2": "Aborted",
-      "104098.3": "HELD",
-      "104098.4": "Unknown",
-    }
+    expectedResults = {"104097.9": "Running",
+                       "104098.0": "Waiting",
+                       "104098.1": "Done",
+                       "104098.2": "Aborted",
+                       "104098.3": "HELD",
+                       "104098.4": "Unknown"}
+
     for jobID, expected in expectedResults.iteritems():
-      self.assertEqual( HTCE.parseCondorStatus( statusLines, jobID ), expected )
+      self.assertEqual(HTCE.parseCondorStatus(statusLines, jobID), expected)
 
-  def test_getJobStatus( self ):
+  @patch(MODNAME + ".commands.getstatusoutput", new=Mock(side_effect=([(0, "\n".join(STATUS_LINES)),
+                                                                       (0, "\n".join(HISTORY_LINES)),
+                                                                       (0, 0)])))
+  @patch(MODNAME + ".HTCondorCEComputingElement._HTCondorCEComputingElement__cleanup", new=Mock())
+  def test_getJobStatus(self):
 
-    htce = HTCE.HTCondorCEComputingElement( 12345 )
+    htce = HTCE.HTCondorCEComputingElement(12345)
 
-    with patch( MODNAME+".commands.getstatusoutput", new=Mock(
-      side_effect=( [ (0, "\n".join(STATUS_LINES) ), # condor_q
-                      (0, "\n".join(HISTORY_LINES)), # condor_history
-                      (0, 0), # condor_rm, ignored in any case
-                    ] ))), \
-      patch( MODNAME+".HTCondorCEComputingElement._HTCondorCEComputingElement__cleanup", new=Mock() ) \
-      :
-      ret = htce.getJobStatus( ["htcondorce://condorce.foo.arg/123.0:::abc321",
-                                "htcondorce://condorce.foo.arg/123.1:::c3b2a1",
-                                "htcondorce://condorce.foo.arg/123.2:::c3b2a2",
-                                "htcondorce://condorce.foo.arg/333.3:::c3b2a3",
-                               ]
-                             )
+    ret = htce.getJobStatus(["htcondorce://condorce.foo.arg/123.0:::abc321",
+                             "htcondorce://condorce.foo.arg/123.1:::c3b2a1",
+                             "htcondorce://condorce.foo.arg/123.2:::c3b2a2",
+                             "htcondorce://condorce.foo.arg/333.3:::c3b2a3"])
 
-    expectedResults = { "htcondorce://condorce.foo.arg/123.0":"Done",
-                        "htcondorce://condorce.foo.arg/123.1":"Aborted",
-                        "htcondorce://condorce.foo.arg/123.2":"Aborted",
-                        "htcondorce://condorce.foo.arg/333.3":"Unknown",
-                      }
+    expectedResults = {"htcondorce://condorce.foo.arg/123.0": "Done",
+                       "htcondorce://condorce.foo.arg/123.1": "Aborted",
+                       "htcondorce://condorce.foo.arg/123.2": "Aborted",
+                       "htcondorce://condorce.foo.arg/333.3": "Unknown"}
 
-    self.assertTrue( ret['OK'] , ret.get('Message', '') )
-    self.assertEqual( expectedResults, ret['Value'] )
+    self.assertTrue(ret['OK'], ret.get('Message', ''))
+    self.assertEqual(expectedResults, ret['Value'])
 
-
-  def test__writeSub_local( self ):
-    htce = HTCE.HTCondorCEComputingElement( 12345 )
+  def test__writeSub_local(self):
+    htce = HTCE.HTCondorCEComputingElement(12345)
     htce.useLocalSchedd = True
     subFileMock = Mock()
-    with patch( MODNAME+".os.fdopen", new=Mock( return_value=subFileMock ) ), \
-         patch( MODNAME+".tempfile.mkstemp", new=Mock( return_value=("os", "pilotName"))), \
-         patch( MODNAME+".mkDir", new=Mock()):
 
-      htce._HTCondorCEComputingElement__writeSub( "dirac-install", 42, '' ) #pylint: disable=E1101
-      for option in [ "ShouldTransferFiles = YES", "WhenToTransferOutput = ON_EXIT_OR_EVICT", "universe = grid"]:
+    patchFdopen = patch(MODNAME + ".os.fdopen", new=Mock(return_value=subFileMock))
+    patchMkstemp = patch(MODNAME + ".tempfile.mkstemp", new=Mock(return_value=("os", "pilotName")))
+    patchMkdir = patch(MODNAME + ".mkDir", new=Mock())
+
+    with patchFdopen, patchMkstemp, patchMkdir:
+      htce._HTCondorCEComputingElement__writeSub("dirac-install", 42, '')  # pylint: disable=E1101
+      for option in ["ShouldTransferFiles = YES", "WhenToTransferOutput = ON_EXIT_OR_EVICT", "universe = grid"]:
         # the three [0] are: call_args_list[firstCall][ArgsArgumentsTuple][FirstArgsArgument]
-        self.assertIn( option, subFileMock.write.call_args_list[0][0][0] )
+        self.assertIn(option, subFileMock.write.call_args_list[0][0][0])
 
-
-  def test__writeSub_remote( self ):
-    htce = HTCE.HTCondorCEComputingElement( 12345 )
+  def test__writeSub_remote(self):
+    htce = HTCE.HTCondorCEComputingElement(12345)
     htce.useLocalSchedd = False
     subFileMock = Mock()
-    with patch( MODNAME+".os.fdopen", new=Mock( return_value=subFileMock ) ), \
-         patch( MODNAME+".tempfile.mkstemp", new=Mock( return_value=("os", "pilotName"))), \
-         patch( MODNAME+".mkDir", new=Mock()):
 
-      htce._HTCondorCEComputingElement__writeSub( "dirac-install", 42, '' ) #pylint: disable=E1101
-      for option in [ "ShouldTransferFiles = YES", "WhenToTransferOutput = ON_EXIT_OR_EVICT" ]:
-        self.assertNotIn( option, subFileMock.write.call_args_list[0][0][0] )
-      for option in [ "universe = vanilla"]:
-        self.assertIn( option, subFileMock.write.call_args_list[0][0][0] )
+    patchFdopen = patch(MODNAME + ".os.fdopen", new=Mock(return_value=subFileMock))
+    patchMkstemp = patch(MODNAME + ".tempfile.mkstemp", new=Mock(return_value=("os", "pilotName")))
+    patchMkdir = patch(MODNAME + ".mkDir", new=Mock())
 
+    with patchFdopen, patchMkstemp, patchMkdir:
+      htce._HTCondorCEComputingElement__writeSub("dirac-install", 42, '')  # pylint: disable=E1101
+      for option in ["ShouldTransferFiles = YES", "WhenToTransferOutput = ON_EXIT_OR_EVICT"]:
+        self.assertNotIn(option, subFileMock.write.call_args_list[0][0][0])
+      for option in ["universe = vanilla"]:
+        self.assertIn(option, subFileMock.write.call_args_list[0][0][0])
 
-  def test_reset_local( self ):
-    htce = HTCE.HTCondorCEComputingElement( 12345 )
+  def test_reset_local(self):
+    htce = HTCE.HTCondorCEComputingElement(12345)
     htce.ceParameters = self.ceParameters
     htce.useLocalSchedd = True
     ceName = "condorce.cern.ch"
     htce.ceName = ceName
     htce._reset()
-    self.assertEqual( htce.remoteScheddOptions, "" )
+    self.assertEqual(htce.remoteScheddOptions, "")
 
-
-  def test_reset_remote( self ):
-    htce = HTCE.HTCondorCEComputingElement( 12345 )
+  def test_reset_remote(self):
+    htce = HTCE.HTCondorCEComputingElement(12345)
     htce.ceParameters = self.ceParameters
     htce.useLocalSchedd = False
     ceName = "condorce.cern.ch"
     htce.ceName = ceName
     htce._reset()
-    self.assertEqual( htce.remoteScheddOptions, "-pool %s:9619 -name %s " %(ceName, ceName ) )
+    self.assertEqual(htce.remoteScheddOptions, "-pool %s:9619 -name %s " % (ceName, ceName))
 
-
-  def test_submitJob_local( self ):
-    htce = HTCE.HTCondorCEComputingElement( 12345 )
+  def test_submitJob_local(self):
+    htce = HTCE.HTCondorCEComputingElement(12345)
     htce.ceParameters = self.ceParameters
     htce.useLocalSchedd = True
     ceName = "condorce.cern.ch"
     htce.ceName = ceName
-    execMock = Mock( return_value=S_OK( (0, "123.0 - 123.0")))
-    htce._HTCondorCEComputingElement__writeSub = Mock( return_value= "dirac-pilot" )
-    with patch( MODNAME+".executeGridCommand", new=execMock), \
-         patch( MODNAME+".os", new=Mock() ):
-      result = htce.submitJob( "pilot", "proxy", 1 )
+    execMock = Mock(return_value=S_OK((0, "123.0 - 123.0")))
+    htce._HTCondorCEComputingElement__writeSub = Mock(return_value="dirac-pilot")
+    with patch(MODNAME + ".executeGridCommand", new=execMock), patch(MODNAME + ".os", new=Mock()):
+      result = htce.submitJob("pilot", "proxy", 1)
 
-    self.assertTrue( result['OK'], result.get('Message') )
-    remotePoolList = " ".join([ '-pool', '%s:9619'%ceName, '-remote', ceName ])
-    self.assertNotIn( remotePoolList, " ".join(execMock.call_args_list[0][0][1]) )
+    self.assertTrue(result['OK'], result.get('Message'))
+    remotePoolList = " ".join(['-pool', '%s:9619' % ceName, '-remote', ceName])
+    self.assertNotIn(remotePoolList, " ".join(execMock.call_args_list[0][0][1]))
 
-
-  def test_submitJob_remote( self ):
-    htce = HTCE.HTCondorCEComputingElement( 12345 )
+  def test_submitJob_remote(self):
+    htce = HTCE.HTCondorCEComputingElement(12345)
     htce.ceParameters = self.ceParameters
     htce.useLocalSchedd = False
     ceName = "condorce.cern.ch"
     htce.ceName = ceName
-    execMock = Mock( return_value=S_OK( (0, "123.0 - 123.0")))
-    htce._HTCondorCEComputingElement__writeSub = Mock( return_value= "dirac-pilot" )
-    with patch( MODNAME+".executeGridCommand", new=execMock), \
-         patch( MODNAME+".os", new=Mock() ):
-      result = htce.submitJob( "pilot", "proxy", 1 )
+    execMock = Mock(return_value=S_OK((0, "123.0 - 123.0")))
+    htce._HTCondorCEComputingElement__writeSub = Mock(return_value="dirac-pilot")
+    with patch(MODNAME + ".executeGridCommand", new=execMock), patch(MODNAME + ".os", new=Mock()):
+      result = htce.submitJob("pilot", "proxy", 1)
 
-    self.assertTrue( result['OK'], result.get('Message') )
-    remotePoolList = " ".join([ '-pool', '%s:9619'%ceName, '-remote', ceName ])
-    self.assertIn( remotePoolList, " ".join(execMock.call_args_list[0][0][1]) )
+    self.assertTrue(result['OK'], result.get('Message'))
+    remotePoolList = " ".join(['-pool', '%s:9619' % ceName, '-remote', ceName])
+    self.assertIn(remotePoolList, " ".join(execMock.call_args_list[0][0][1]))
 
 
-class BatchCondorTest( unittest.TestCase ):
+class BatchCondorTest(unittest.TestCase):
   """ tests for the plain batchSystem Condor Module """
 
-  def test_getJobStatus( self ):
+  def test_getJobStatus(self):
+    mock = Mock(side_effect=([(0, "\n".join(STATUS_LINES)),  # condor_q
+                              (0, "\n".join(HISTORY_LINES))]))  # condor_history
 
-    with patch( MODNAME+".commands.getstatusoutput", new=Mock(
-      side_effect=( [ (0, "\n".join(STATUS_LINES) ), # condor_q
-                      (0, "\n".join(HISTORY_LINES)), # condor_history
-                    ] ))):
-      ret = Condor.Condor().getJobStatus( JobIDList = [ "123.0",
-                                                        "123.1",
-                                                        "123.2",
-                                                        "333.3",
-                                                      ]
-                                        )
+    with patch(MODNAME + ".commands.getstatusoutput", new=mock):
+      ret = Condor.Condor().getJobStatus(JobIDList=["123.0",
+                                                    "123.1",
+                                                    "123.2",
+                                                    "333.3"])
 
-    expectedResults = { "123.0":"Done",
-                        "123.1":"Aborted",
-                        "123.2":"Unknown", ##HELD is treated as Unknown
-                        "333.3":"Unknown",
-                      }
+    expectedResults = {"123.0": "Done",
+                       "123.1": "Aborted",
+                       "123.2": "Unknown",  # HELD is treated as Unknown
+                       "333.3": "Unknown"}
 
-    self.assertEqual( ret['Status'] , 0 )
-    self.assertEqual( expectedResults, ret['Jobs'] )
+    self.assertEqual(ret['Status'], 0)
+    self.assertEqual(expectedResults, ret['Jobs'])
+
 
 if __name__ == '__main__':
-  SUITE = unittest.defaultTestLoader.loadTestsFromTestCase( HTCondorCETests )
-  SUITE.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( BatchCondorTest ) )
-  unittest.TextTestRunner( verbosity = 2 ).run( SUITE )
+  SUITE = unittest.defaultTestLoader.loadTestsFromTestCase(HTCondorCETests)
+  SUITE.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(BatchCondorTest))
+  unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -144,7 +144,10 @@ class PilotManagerHandler(RequestHandler):
     owner = pilotDict['OwnerDN']
     group = pilotDict['OwnerGroup']
     gridType = pilotDict['GridType']
+    pilotStamp = pilotDict['PilotStamp']
 
+    # Add the pilotStamp to the pilot Reference, some CEs may need it to retrieve the logging info
+    pilotReference = pilotReference + ':::' + pilotStamp
     return getPilotLoggingInfo(gridType, pilotReference,  # pylint: disable=unexpected-keyword-arg
                                proxyUserDN=owner, proxyUserGroup=group)
 

--- a/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -43,6 +43,9 @@ def getPilotLoggingInfo(grid, pilotRef):
    Get LoggingInfo of a GRID job
   """
   if grid == 'CREAM':
+    # pilotRef may integrate the pilot stamp
+    # it has to be removed before being passed in parameter
+    pilotRef = pilotRef.split(':::')[0]
     cmd = ['glite-ce-job-status', '-L', '2', '%s' % pilotRef]
   elif grid == 'HTCondorCE':
     # need to import here, otherwise import errors happen


### PR DESCRIPTION
To avoid to have too many of them in a single directory, job outputs are randomly sorted into multiple directories on two levels on the server: `workingDirectory/<random_dir1>/<random_dir2>/<job_output>`

The information about their locations is not kept in the pilot job reference which is only composed of the job id. Therefore, the only way to retrieve an output is to perform a `find` command in the `workingDirectory` with the job id.

This PR aims at adding the name of the directories in the pilot job reference to quickly retrieve the associated job output.

Here is the current structure of the pilot job reference:
`htcondorce://<ce name>/<clusterid>.<jobid>`
Here is the proposed one:
`htcondorce://<ce name>/<random dir1><random dir2>-<clusterid>.<jobid>`

The previous pilot job references are still supported in this PR, so that the change is progressive. 

BEGINRELEASENOTES

*Resources
CHANGE: in HTCondor CEs, the pilot stamps are now used to retrieve outputs and logging info.  

ENDRELEASENOTES
