### PR TITLE
[v7r1] DFC: remove SEPrefix, VOPath, VOPrefix, ResolvePFN and SEDefinition from the DFC

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
@@ -718,16 +718,7 @@ class DirectoryTreeBase(object):
       for fileName in fileDict:
         successful[path][fileName] = fileDict[fileName]
 
-    result = S_OK({'Successful': successful, 'Failed': failed})
-
-    if self.db.lfnPfnConvention:
-      sePrefixDict = {}
-      resSE = self.db.seManager.getSEPrefixes()
-      if resSE['OK']:
-        sePrefixDict = resSE['Value']
-      result['Value']['SEPrefixes'] = sePrefixDict
-
-    return result
+    return S_OK({'Successful': successful, 'Failed': failed})
 
   def getDirectorySize(self, lfns, longOutput=False, rawFileTables=False):
     """ Get the total size of the requested directories. If long flag

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -986,10 +986,6 @@ class FileManagerBase(object):
         replicas[lfn] = {}
         for se, repDict in seDict.iteritems():
           pfn = repDict.get('PFN', '')
-          # if not pfn or self.db.lfnPfnConvention:
-          #  res = self._resolvePFN( lfn, se )
-          #  if res['OK']:
-          #    pfn = res['Value']
           replicas[lfn][se] = pfn
 
     result = S_OK(replicas)
@@ -1032,16 +1028,6 @@ class FileManagerBase(object):
     replicas = result['Value']
 
     return S_OK({"Successful": replicas, 'Failed': failed})
-
-  def _resolvePFN(self, lfn, se):
-    resSE = self.db.seManager.getSEDefinition(se)
-    if not resSE['OK']:
-      return resSE
-    pfnDict = dict(resSE['Value']['SEDict'])
-    if "PFNPrefix" in pfnDict:
-      return S_OK(pfnDict['PFNPrefix'] + lfn)
-    pfnDict['FileName'] = lfn
-    return pfnunparse(pfnDict)
 
   def getReplicaStatus(self, lfns, connection=False):
     """ Get replica status from the catalog """

--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -1013,16 +1013,7 @@ class FileManagerBase(object):
       return result
     replicas = result['Value']
 
-    result = S_OK({"Successful": replicas, 'Failed': failed})
-
-    if self.db.lfnPfnConvention:
-      sePrefixDict = {}
-      resSE = self.db.seManager.getSEPrefixes()
-      if resSE['OK']:
-        sePrefixDict = resSE['Value']
-      result['Value']['SEPrefixes'] = sePrefixDict
-
-    return result
+    return S_OK({"Successful": replicas, 'Failed': failed})
 
   def getReplicasByMetadata(self, metaDict, path, allStatus, credDict, connection=False):
     """ Get file replicas for files corresponding to the given metadata """
@@ -1040,16 +1031,7 @@ class FileManagerBase(object):
       return result
     replicas = result['Value']
 
-    result = S_OK({"Successful": replicas, 'Failed': failed})
-
-    if self.db.lfnPfnConvention:
-      sePrefixDict = {}
-      resSE = self.db.seManager.getSEPrefixes()
-      if resSE['OK']:
-        sePrefixDict = resSE['Value']
-      result['Value']['SEPrefixes'] = sePrefixDict
-
-    return result
+    return S_OK({"Successful": replicas, 'Failed': failed})
 
   def _resolvePFN(self, lfn, se):
     resSE = self.db.seManager.getSEDefinition(se)

--- a/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerBase.py
@@ -19,7 +19,6 @@ class SEManagerBase(object):
     if self.db:
       self.db.seNames = {}
       self.db.seids = {}
-      self.db.seDefinitions = {}
     self.lock = threading.Lock()
     self.seUpdatePeriod = 600
 
@@ -30,16 +29,8 @@ class SEManagerBase(object):
   def setUpdatePeriod(self, period):
     self.seUpdatePeriod = period
 
-  def setSEDefinitions(self, seDefinitions):
-    self.db.seDefinitions = seDefinitions
-    self.seNames = {}
-    for seID, seDef in self.db.seDefinitions.iteritems():
-      seName = seDef['SEName']
-      self.seNames[seName] = seID
-
   def setDatabase(self, database):
     self.db = database
     self.db.seNames = {}
     self.db.seids = {}
-    self.db.seDefinitions = {}
     self._refreshSEs()

--- a/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
@@ -40,10 +40,8 @@ class SEManagerDB(SEManagerBase):
       if seName not in seNames:
         del self.db.seNames[seName]
         del self.db.seids[seId]
-        del self.db.seDefinitions[seId]
 
     for seid, seName in res['Value']:
-      self.getSEDefinition(seid)
       self.db.seNames[seName] = seid
       self.db.seids[seid] = seName
     gLogger.debug("SEManager RefreshSEs lock released. Used %.3f seconds." % (time.time() - waitTime))
@@ -79,7 +77,6 @@ class SEManagerDB(SEManagerBase):
     seid = res['lastRowId']
     self.db.seids[seid] = seName
     self.db.seNames[seName] = seid
-    self.getSEDefinition(seid)
     gLogger.debug("SEManager AddSE lock released. Used %.3f seconds. %s" % (time.time() - waitTime, seName))
     self.lock.release()
     return S_OK(seid)
@@ -100,7 +97,6 @@ class SEManagerDB(SEManagerBase):
     if seid != 'Missing':
       self.db.seNames.pop(seName)
       self.db.seids.pop(seid)
-      self.db.seDefinitions.pop(seid)
     gLogger.debug("SEManager RemoveSE lock released. Used %.3f seconds. %s" % (time.time() - waitTime, seName))
     self.lock.release()
     return S_OK()
@@ -129,65 +125,3 @@ class SEManagerDB(SEManagerBase):
     if not force:
       pass
     return self.__removeSE(seName)
-
-  def getSEDefinition(self, seID):
-    """ Get the Storage Element definition
-    """
-    if isinstance(seID, str):
-      result = self.getSEID(seID)
-      if not result['OK']:
-        return result
-      seID = result['Value']
-
-    if seID in self.db.seDefinitions:
-      if (time.time() - self.db.seDefinitions[seID]['LastUpdate']) < self.seUpdatePeriod:
-        if self.db.seDefinitions[seID]['SEDict']:
-          return S_OK(self.db.seDefinitions[seID])
-      se = self.db.seDefinitions[seID]['SEName']
-    else:
-      result = self.getSEName(seID)
-      if not result['OK']:
-        return result
-      se = result['Value']
-      self.db.seDefinitions[seID] = {}
-      self.db.seDefinitions[seID]['SEName'] = se
-      self.db.seDefinitions[seID]['SEDict'] = {}
-      self.db.seDefinitions[seID]['LastUpdate'] = 0.
-
-    # We have to refresh the SE definition from the CS
-    result = gConfig.getSections('/Resources/StorageElements/%s' % se)
-    if not result['OK']:
-      return result
-    pluginSection = result['Value'][0]
-    result = gConfig.getOptionsDict('/Resources/StorageElements/%s/%s' % (se, pluginSection))
-    if not result['OK']:
-      return result
-    seDict = result['Value']
-    self.db.seDefinitions[seID]['SEDict'] = seDict
-    # Get VO paths if any
-    voPathDict = None
-    result = gConfig.getOptionsDict('/Resources/StorageElements/%s/%s/VOPath' % (se, pluginSection))
-    if result['OK']:
-      voPathDict = result['Value']
-    if seDict:
-      # A.T. Ports can be multiple, this can be better done using the Storage plugin
-      # to provide the replica prefix to keep implementations in one place
-      if 'Port' in seDict:
-        ports = seDict['Port']
-        if ',' in ports:
-          portList = [x.strip() for x in ports.split(',')]
-          random.shuffle(portList)
-          seDict['Port'] = portList[0]
-      tmpDict = dict(seDict)
-      tmpDict['FileName'] = ''
-      result = pfnunparse(tmpDict)
-      if result['OK']:
-        self.db.seDefinitions[seID]['SEDict']['PFNPrefix'] = result['Value']
-      if voPathDict is not None:
-        for vo in voPathDict:
-          tmpDict['Path'] = voPathDict[vo]
-          result = pfnunparse(tmpDict)
-          if result['OK']:
-            self.db.seDefinitions[seID]['SEDict'].setdefault("VOPrefix", {})[vo] = result['Value']
-    self.db.seDefinitions[seID]['LastUpdate'] = time.time()
-    return S_OK(self.db.seDefinitions[seID])

--- a/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
@@ -191,23 +191,3 @@ class SEManagerDB(SEManagerBase):
             self.db.seDefinitions[seID]['SEDict'].setdefault("VOPrefix", {})[vo] = result['Value']
     self.db.seDefinitions[seID]['LastUpdate'] = time.time()
     return S_OK(self.db.seDefinitions[seID])
-
-  def getSEPrefixes(self, connection=False):
-
-    result = self._refreshSEs(connection)
-    if not result['OK']:
-      return result
-
-    resultDict = {}
-
-    for seID in self.db.seDefinitions:
-      resultDict[self.db.seDefinitions[seID]['SEName']] = \
-          self.db.seDefinitions[seID]['SEDict'].get('PFNPrefix', '')
-
-      # Check if some paths are specific for VO's and add these definitions
-      if self.db.seDefinitions[seID]['SEDict'].get('VOPrefix'):
-        resultDict.setdefault('VOPrefix', {})
-        resultDict['VOPrefix'][self.db.seDefinitions[seID]['SEName']] = \
-            self.db.seDefinitions[seID]['SEDict'].get('VOPrefix')
-
-    return S_OK(resultDict)

--- a/DataManagementSystem/DB/FileCatalogDB.py
+++ b/DataManagementSystem/DB/FileCatalogDB.py
@@ -714,8 +714,7 @@ class FileCatalogDB(DB):
       return res
     failed.update(res['Value']['Failed'])
     successful = res['Value']['Successful']
-    return S_OK({'Successful': successful, 'Failed': failed,
-                 'SEPrefixes': res['Value'].get('SEPrefixes', {})})
+    return S_OK({'Successful': successful, 'Failed': failed})
 
   def getReplicaStatus(self, lfns, credDict):
     """
@@ -964,8 +963,7 @@ class FileCatalogDB(DB):
       return res
     failed.update(res['Value']['Failed'])
     successful = res['Value']['Successful']
-    return S_OK({'Successful': successful, 'Failed': failed,
-                 'SEPrefixes': res['Value'].get('SEPrefixes', {})})
+    return S_OK({'Successful': successful, 'Failed': failed})
 
   def getDirectorySize(self, lfns, longOutput, fromFiles, credDict):
     """

--- a/DataManagementSystem/DB/FileCatalogDB.py
+++ b/DataManagementSystem/DB/FileCatalogDB.py
@@ -44,7 +44,6 @@ class FileCatalogDB(DB):
     self.gids = {}
     self.seNames = {}
     self.seids = {}
-    self.seDefinitions = {}
 
     # Obtain some general configuration of the database
     self.uniqueGUID = databaseConfig['UniqueGUID']


### PR DESCRIPTION
The SE management has nothing to do in the DFC, as discussed already a long time.
So I remove it, and do what I said in the ticket https://github.com/DIRACGrid/DIRAC/issues/4227

BEGINRELEASENOTES

*DMS
CHANGE: remove all the SE mangling in the DFC (SEPrefix, resolvePFN, SEDefinition)

ENDRELEASENOTES
