### PR TITLE
[v7r1] More JSON serialization preparation

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -14,8 +14,9 @@ jobs:
         command:
           - pytest
           - DIRAC_USE_M2CRYPTO=Yes pytest
-          - pytest Core/Security/test
-          - DIRAC_USE_M2CRYPTO=Yes pytest Core/Security/test
+          # Security tests are flakey due to reference counting bugs in pyGSI/src/crypto/asn1.c
+          - pytest Core/Security/test || (echo "Retrying..." pytest Core/Security/test) || (echo "Retrying again..." pytest Core/Security/test)
+          - DIRAC_USE_M2CRYPTO=Yes pytest Core/Security/test || (echo "Retrying..." DIRAC_USE_M2CRYPTO=Yes pytest Core/Security/test) || (echo "Retrying again..." DIRAC_USE_M2CRYPTO=Yes pytest Core/Security/test)
           - tests/checkDocs.sh
           # TODO This should cover more than just tests/CI
           - find tests/CI -name '*.sh' -print0 | xargs -0 -n1 shellcheck --external-source

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -598,7 +598,7 @@ and this is thread %s
     return S_OK()
 
   def _getBaseStub(self):
-    """ Returns a tuple with (self._destinationSrv, newKwargs)
+    """ Returns a list with [self._destinationSrv, newKwargs]
         self._destinationSrv is what was given as first parameter of the init serviceName
 
         newKwargs is an updated copy of kwargs:
@@ -611,7 +611,7 @@ and this is thread %s
     # independently decide whether to use their cert or not anyway.
     if 'useCertificates' in newKwargs:
       del newKwargs['useCertificates']
-    return (self._destinationSrv, newKwargs)
+    return [self._destinationSrv, newKwargs]
 
   def __nonzero__(self):
     return True

--- a/Core/DISET/private/InnerRPCClient.py
+++ b/Core/DISET/private/InnerRPCClient.py
@@ -37,7 +37,8 @@ class InnerRPCClient(BaseClient):
     retVal = self._connect()
 
     # Generate the stub which contains all the connection and call options
-    stub = (self._getBaseStub(), functionName, args)
+    # JSON: cast args to list for serialization purposes
+    stub = [self._getBaseStub(), functionName, list(args)]
     if not retVal['OK']:
       retVal['rpcStub'] = stub
       return retVal

--- a/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/Core/DISET/private/Transports/M2SSLTransport.py
@@ -96,7 +96,7 @@ class SSLTransport(BaseTransport):
       except socket.error as e:
         # Other exception are probably SSL-related, in that case we
         # abort and the exception is forwarded to the caller.
-        error = e
+        error = repr(e)
 
         if self.oSocket is not None:
           self.oSocket.close()

--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -21,8 +21,11 @@ import types
 import datetime
 import os
 
+import functools
 import inspect
 import traceback
+
+from collections import defaultdict
 from pprint import pprint
 
 
@@ -30,14 +33,56 @@ from pprint import pprint
 # call stack
 DIRAC_DEBUG_DENCODE_CALLSTACK = bool(os.environ.get('DIRAC_DEBUG_DENCODE_CALLSTACK', False))
 
+# This global dictionary contains
+# {<method name> : set (<class names)}
+# (a method name can be reused in other classes)
+# DO NOT EDIT BY HAND, use ignoreEncodeWarning decorator
+DENCODE_WARNING_IGNORED_METHODS = defaultdict(set)
+
 # Depth of the stack to look for with inspect
 CONTEXT_DEPTH = 100
+
+
+def ignoreEncodeWarning(meth):
+  """ Decorator to put around method that should not anymore throw warnings
+
+      :warning: do not use around functions
+
+      :warning: for a class method, put it after the @classmethod decorator
+
+      :param meth: decorated method
+  """
+
+  @functools.wraps(meth)
+  def inner(*args, **kwargs):
+    """ Add the method and the class name to the DENCODE_WARNING_IGNORED_METHODS dict """
+
+    # The first parameter in args is "self"
+    # Find out the class Name
+    objInst = args[0]
+    className = objInst.__class__.__name__
+    if className == 'type':  # This happens for class method
+      className = objInst.__name__
+
+    # if the decorated method is an exported method, just remove the 'export_' bit
+    methName = meth.__name__.replace('export_', '')
+
+    # Add the method name and the object name to the dictionary
+    DENCODE_WARNING_IGNORED_METHODS[methName].add(className)
+    return meth(*args, **kwargs)
+
+  return inner
 
 
 def printDebugCallstack(headerMessage):
   """ Prints information about the current stack as well as the caller parameters.
       The purpose of this method is to track down all the places in DIRAC that might
       not survive the change to JSON encoding.
+
+      Some methods are ignored:
+
+      * all the AccountingDB method: why ?
+      * all the method in DENCODE_WARNING_IGNORED_METHODS (see ignoreEncodeWarning)
 
       :param headerMessage: message to be displayed first
       :returns: None
@@ -58,6 +103,52 @@ def printDebugCallstack(headerMessage):
   tb = traceback.format_stack()
   frames = inspect.stack(context=CONTEXT_DEPTH)
 
+  # Flag set to true only if we figure it's an RPC call
+  # In that case, we display more info
+  isRPCCall = False
+
+  # For each entry in the stack, check if the method name is in the list of method to be ignored
+  for frameRecord in reversed(frames):
+    frameFuncName = frameRecord[3]
+    # If the method is in the list of ignored method,
+    # check that the method is from the good class
+    if frameFuncName in DENCODE_WARNING_IGNORED_METHODS:
+      try:
+        # Take the frame object https://docs.python.org/2.7/reference/datamodel.html
+        frameObj = frameRecord[0]
+        # Check that the self attribute of the function points to a class which is listed
+        # as to be ignored
+        className = frameObj.f_locals['self'].__class__.__name__
+        # if that is the case, then we return
+        if className in DENCODE_WARNING_IGNORED_METHODS[frameFuncName]:
+          return
+      # Exception may be thrown when trying to get the className
+      except (KeyError, AttributeError):
+        pass
+
+    # Else, if we are answering an RPC call
+    elif frameFuncName == '_executeAction':
+      # This requires special handling because the only way to know
+      # which method was called server side is to check at the proposalTuple
+
+      frameObj = frameRecord[0]
+
+      # The _executeAction method takes as parameter the handlerObj and the proposalTuple
+
+      # Extract the method name from the proposalTuple
+      funcName = frameObj.f_locals['proposalTuple'][1][1]
+
+      # Extract the class name from the handlerObj
+      className = frameObj.f_locals['handlerObj'].__class__.__name__
+
+      if funcName in DENCODE_WARNING_IGNORED_METHODS and className in DENCODE_WARNING_IGNORED_METHODS[funcName]:
+        return
+      else:
+        # If it is not to be ignored, save the parameters to display them
+        isRPCCall = True
+        rpcDetails = "RPC call service %s method %s" % (className, funcName)
+        break
+
   # The datetime are encoded as tuple. Since datetime are taken care of
   # in JSerializer, just don't print a warning here
   # Note: -3 because we have to go past (de/encodeTuple and the Traceback module)
@@ -70,7 +161,6 @@ def printDebugCallstack(headerMessage):
     return
 
   print('=' * 45, headerMessage, '=' * 45)
-
   # print the traceback that leads us here
   # remove the last element which is the traceback module call
   for line in tb[:-1]:
@@ -93,11 +183,12 @@ def printDebugCallstack(headerMessage):
           # Take the calling frame
           frame = next(framesIter)
           print("Calling frame: %s" % (frame[1:3],))
+          if isRPCCall:
+            print(rpcDetails)
           print("With arguments ", end=' ')
           pprint(dencArgs)
           break
-
-  except BaseException:
+  except Exception:
     pass
   print("=" * 100)
   print()

--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -81,7 +81,7 @@ def printDebugCallstack(headerMessage):
 
       Some methods are ignored:
 
-      * all the AccountingDB method: why ?
+      * all the AccountingDB method: https://github.com/DIRACGrid/DIRAC/issues/4319
       * all the method in DENCODE_WARNING_IGNORED_METHODS (see ignoreEncodeWarning)
 
       :param headerMessage: message to be displayed first

--- a/Core/Utilities/JEncode.py
+++ b/Core/Utilities/JEncode.py
@@ -184,3 +184,18 @@ def decode(encodedData):
       but it is for compatibility
   """
   return json.loads(encodedData, cls=DJSONDecoder), len(encodedData)
+
+
+def strToIntDict(inDict):
+  """ Because JSON will transform dict with int keys to str keys,
+      this utility method is just to cast it back.
+      This shows useful in cases when sending dict indexed on
+      jobID or requestID for example
+
+      :param inDict: dictionnary with string as keys e.g. {'1': 1, '2': 2}
+
+      :returns: dictionnary with int as keys e.g. {1: 1, 2: 2}
+
+  """
+
+  return dict((int(key), value) for key, value in inDict.iteritems())

--- a/Core/Utilities/JEncode.py
+++ b/Core/Utilities/JEncode.py
@@ -192,7 +192,7 @@ def strToIntDict(inDict):
       This shows useful in cases when sending dict indexed on
       jobID or requestID for example
 
-      :param inDict: dictionnary with string as keys e.g. {'1': 1, '2': 2}
+      :param inDict: dictionnary with strings as keys e.g. {'1': 1, '2': 2}
 
       :returns: dictionnary with int as keys e.g. {1: 1, 2: 2}
 

--- a/Core/Utilities/JEncode.py
+++ b/Core/Utilities/JEncode.py
@@ -198,4 +198,4 @@ def strToIntDict(inDict):
 
   """
 
-  return dict((int(key), value) for key, value in inDict.iteritems())
+  return {int(key): value for key, value in inDict.iteritems()}

--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -19,6 +19,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getDNForUsername
 from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
 from DIRAC.Core.Security.Properties import FULL_DELEGATION, LIMITED_DELEGATION, TRUSTED_HOST
 from DIRAC.Core.Utilities import DErrno
+from DIRAC.Core.Utilities.JEncode import strToIntDict
 
 
 from DIRAC.DataManagementSystem.DB.FTS3DB import FTS3DB
@@ -159,7 +160,7 @@ class FTS3ManagerHandler(RequestHandler):
        :param fileStatusDict: { fileID : { status , error } }
        :param ftsGUID: (not mandatory) If specified, only update the rows where the ftsGUID matches this value.
     """
-
+    fileStatusDict = strToIntDict(fileStatusDict)
     return cls.fts3db.updateFileStatus(fileStatusDict, ftsGUID)
 
   types_updateJobStatus = [dict]
@@ -170,7 +171,7 @@ class FTS3ManagerHandler(RequestHandler):
 
        :param jobStatusDict: { jobID : { status , error } }
     """
-
+    jobStatusDict = strToIntDict(jobStatusDict)
     return cls.fts3db.updateJobStatus(jobStatusDict)
 
   types_getNonFinishedOperations = [six.integer_types, basestring]

--- a/FrameworkSystem/Client/SecurityLogClient.py
+++ b/FrameworkSystem/Client/SecurityLogClient.py
@@ -24,8 +24,8 @@ class SecurityLogClient(object):
                  action, timestamp=False):
     if not timestamp:
       timestamp = Time.dateTime()
-    msg = (timestamp, success, sourceIP, sourcePort, sourceIdentity,
-           destinationIP, destinationPort, destinationService, action)
+    msg = [timestamp, success, sourceIP, sourcePort, sourceIdentity,
+           destinationIP, destinationPort, destinationService, action]
     if gConfig.getValue("/Registry/EnableSysLog", False):
       strMsg = "Time=%s Accept=%s Source=%s:%s SourceID=%s Destination=%s:%s Service=%s Action=%s"
       syslog.syslog(strMsg % msg)

--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -163,7 +163,7 @@ class ReqClient(Client):
 
     jsonReq = getRequests["Value"]["Successful"]
     # Do not forget to cast back str keys to int
-    reqInstances = dict((int(rId), Request(jsonReq[rId])) for rId in jsonReq)
+    reqInstances = {int(rId): Request(jsonReq[rId]) for rId in jsonReq}
     failed = strToIntDict(getRequests["Value"]["Failed"])
     return S_OK({"Successful": reqInstances, "Failed": failed})
 
@@ -392,7 +392,7 @@ class ReqClient(Client):
     ret = readReqsForJobs["Value"]
     # # create Requests out of JSONs for successful reads
     # Do not forget to cast back str keys to int
-    successful = dict((int(jobID), Request(jsonReq)) for jobID, jsonReq in ret['Successful'].iteritems())
+    successful = {int(jobID): Request(jsonReq) for jobID, jsonReq in ret['Successful'].iteritems()}
     failed = strToIntDict(ret['Failed'])
 
     return S_OK({'Successful': successful, 'Failed': failed})
@@ -457,9 +457,9 @@ def prettyPrint(mainItem, key='', offset=0):
   else:
     output += "%s%s%s\n" % (blanks, key, str(mainItem))
   output = output.replace('[\n%s{' % blanks, '[{').replace('}\n%s]' % blanks, '}]') \
-                 .replace('(\n%s{' % blanks, '({').replace('}\n%s)' % blanks, '})') \
-                 .replace('(\n%s(' % blanks, '((').replace(')\n%s)' % blanks, '))') \
-                 .replace('(\n%s[' % blanks, '[').replace(']\n%s)' % blanks, ']')
+      .replace('(\n%s{' % blanks, '({').replace('}\n%s)' % blanks, '})') \
+      .replace('(\n%s(' % blanks, '((').replace(')\n%s)' % blanks, '))') \
+      .replace('(\n%s[' % blanks, '[').replace(']\n%s)' % blanks, ']')
 
 
 def printFTSJobs(request):

--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -18,6 +18,7 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RPCClient import RPCClient
 from DIRAC.Core.Utilities.List import randomize, fromChar
 from DIRAC.Core.Utilities.JEncode import strToIntDict
+from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
 from DIRAC.ConfigurationSystem.Client import PathFinder
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.RequestManagementSystem.Client.Request import Request
@@ -139,6 +140,7 @@ class ReqClient(Client):
       return getRequest
     return S_OK(Request(getRequest["Value"]))
 
+  @ignoreEncodeWarning
   def getBulkRequests(self, numberOfRequest=10, assigned=True):
     """ get bulk requests from RequestDB
 
@@ -375,6 +377,7 @@ class ReqClient(Client):
 
     return S_OK({'Successful': successful, 'Failed': failed})
 
+  @ignoreEncodeWarning
   def readRequestsForJobs(self, jobIDs):
     """ read requests for jobs
 

--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -35,7 +35,6 @@ from DIRAC.RequestManagementSystem.Client.File import File
 from DIRAC.ConfigurationSystem.Client.Utilities import getDBParameters
 
 
-
 __RCSID__ = "$Id $"
 
 
@@ -45,138 +44,135 @@ metadata = MetaData()
 
 # Description of the file table
 
-fileTable = Table( 'File', metadata,
-                   Column( 'FileID', Integer, primary_key = True ),
-                   Column( 'OperationID', Integer,
-                           ForeignKey( 'Operation.OperationID', ondelete = 'CASCADE' ),
-                           nullable = False ),
-                   Column( 'Status', Enum( 'Waiting', 'Done', 'Failed', 'Scheduled' ), server_default = 'Waiting' ),
-                   Column( 'LFN', String( 255 ), index = True ),
-                   Column( 'PFN', String( 255 ) ),
-                   Column( 'ChecksumType', Enum( 'ADLER32', 'MD5', 'SHA1', '' ), server_default = '' ),
-                   Column( 'Checksum', String( 255 ) ),
-                   Column( 'GUID', String( 36 ) ),
-                   Column( 'Size', BigInteger ),
-                   Column( 'Attempt', Integer ),
-                   Column( 'Error', String( 255 ) ),
-                   mysql_engine = 'InnoDB' )
+fileTable = Table('File', metadata,
+                  Column('FileID', Integer, primary_key=True),
+                  Column('OperationID', Integer,
+                         ForeignKey('Operation.OperationID', ondelete='CASCADE'),
+                         nullable=False),
+                  Column('Status', Enum('Waiting', 'Done', 'Failed', 'Scheduled'), server_default='Waiting'),
+                  Column('LFN', String(255), index=True),
+                  Column('PFN', String(255)),
+                  Column('ChecksumType', Enum('ADLER32', 'MD5', 'SHA1', ''), server_default=''),
+                  Column('Checksum', String(255)),
+                  Column('GUID', String(36)),
+                  Column('Size', BigInteger),
+                  Column('Attempt', Integer),
+                  Column('Error', String(255)),
+                  mysql_engine='InnoDB')
 
 # Map the File object to the fileTable, with a few special attributes
 
-mapper( File, fileTable, properties = {'_Status': fileTable.c.Status,
-                                       '_LFN': fileTable.c.LFN,
-                                       '_ChecksumType' : fileTable.c.ChecksumType,
-                                       '_GUID' : fileTable.c.GUID} )
+mapper(File, fileTable, properties={'_Status': fileTable.c.Status,
+                                    '_LFN': fileTable.c.LFN,
+                                    '_ChecksumType': fileTable.c.ChecksumType,
+                                    '_GUID': fileTable.c.GUID})
 
 
 # Description of the Operation table
 
-operationTable = Table( 'Operation', metadata,
-                        Column( 'TargetSE', String( 255 ) ),
-                        Column( 'CreationTime', DateTime ),
-                        Column( 'SourceSE', String( 255 ) ),
-                        Column( 'Arguments', BLOB ),
-                        Column( 'Error', String( 255 ) ),
-                        Column( 'Type', String( 64 ), nullable = False ),
-                        Column( 'Order', Integer, nullable = False ),
-                        Column( 'Status',
-                                Enum( 'Waiting', 'Assigned', 'Queued', 'Done', 'Failed', 'Canceled', 'Scheduled' ),
-                                server_default = 'Queued' ),
-                        Column( 'LastUpdate', DateTime ),
-                        Column( 'SubmitTime', DateTime ),
-                        Column( 'Catalog', String( 255 ) ),
-                        Column( 'OperationID', Integer, primary_key = True ),
-                        Column( 'RequestID', Integer,
-                                ForeignKey( 'Request.RequestID', ondelete = 'CASCADE' ),
-                                nullable = False ),
-                        mysql_engine = 'InnoDB' )
+operationTable = Table('Operation', metadata,
+                       Column('TargetSE', String(255)),
+                       Column('CreationTime', DateTime),
+                       Column('SourceSE', String(255)),
+                       Column('Arguments', BLOB),
+                       Column('Error', String(255)),
+                       Column('Type', String(64), nullable=False),
+                       Column('Order', Integer, nullable=False),
+                       Column('Status',
+                              Enum('Waiting', 'Assigned', 'Queued', 'Done', 'Failed', 'Canceled', 'Scheduled'),
+                              server_default='Queued'),
+                       Column('LastUpdate', DateTime),
+                       Column('SubmitTime', DateTime),
+                       Column('Catalog', String(255)),
+                       Column('OperationID', Integer, primary_key=True),
+                       Column('RequestID', Integer,
+                              ForeignKey('Request.RequestID', ondelete='CASCADE'),
+                              nullable=False),
+                       mysql_engine='InnoDB')
 
 
 # Map the Operation object to the operationTable, with a few special attributes
 
-mapper( Operation, operationTable, properties = {'_CreationTime': operationTable.c.CreationTime,
-                                                 '_Order': operationTable.c.Order,
-                                                 '_Status': operationTable.c.Status,
-                                                 '_LastUpdate': operationTable.c.LastUpdate,
-                                                 '_SubmitTime': operationTable.c.SubmitTime,
-                                                 '_Catalog': operationTable.c.Catalog,
-                                                 '__files__':relationship( File,
-                                                                           backref = backref( '_parent', lazy = 'immediate' ),
-                                                                           lazy = 'immediate',
-                                                                           passive_deletes = True,
-                                                                           cascade = "all, delete-orphan" )} )
+mapper(Operation, operationTable, properties={'_CreationTime': operationTable.c.CreationTime,
+                                              '_Order': operationTable.c.Order,
+                                              '_Status': operationTable.c.Status,
+                                              '_LastUpdate': operationTable.c.LastUpdate,
+                                              '_SubmitTime': operationTable.c.SubmitTime,
+                                              '_Catalog': operationTable.c.Catalog,
+                                              '__files__': relationship(File,
+                                                                        backref=backref('_parent', lazy='immediate'),
+                                                                        lazy='immediate',
+                                                                        passive_deletes=True,
+                                                                        cascade="all, delete-orphan")})
 
 
 # Description of the Request Table
 
-requestTable = Table( 'Request', metadata,
-                      Column( 'DIRACSetup', String( 32 ) ),
-                      Column( 'CreationTime', DateTime ),
-                      Column( 'JobID', Integer, server_default = '0' ),
-                      Column( 'OwnerDN', String( 255 ) ),
-                      Column( 'RequestName', String( 255 ), nullable = False ),
-                      Column( 'Error', String( 255 ) ),
-                      Column( 'Status',
-                              Enum( 'Waiting', 'Assigned', 'Done', 'Failed', 'Canceled', 'Scheduled' ),
-                              server_default = 'Waiting' ),
-                      Column( 'LastUpdate', DateTime ),
-                      Column( 'OwnerGroup', String( 32 ) ),
-                      Column( 'SubmitTime', DateTime ),
-                      Column( 'RequestID', Integer, primary_key = True ),
-                      Column( 'SourceComponent', BLOB ),
-                      Column( 'NotBefore', DateTime ),
-                      mysql_engine = 'InnoDB' )
+requestTable = Table('Request', metadata,
+                     Column('DIRACSetup', String(32)),
+                     Column('CreationTime', DateTime),
+                     Column('JobID', Integer, server_default='0'),
+                     Column('OwnerDN', String(255)),
+                     Column('RequestName', String(255), nullable=False),
+                     Column('Error', String(255)),
+                     Column('Status',
+                            Enum('Waiting', 'Assigned', 'Done', 'Failed', 'Canceled', 'Scheduled'),
+                            server_default='Waiting'),
+                     Column('LastUpdate', DateTime),
+                     Column('OwnerGroup', String(32)),
+                     Column('SubmitTime', DateTime),
+                     Column('RequestID', Integer, primary_key=True),
+                     Column('SourceComponent', BLOB),
+                     Column('NotBefore', DateTime),
+                     mysql_engine='InnoDB')
 
 # Map the Request object to the requestTable, with a few special attributes
 
-mapper( Request, requestTable, properties = {'_CreationTime': requestTable.c.CreationTime,
-                                             '_Status': requestTable.c.Status,
-                                             '_LastUpdate': requestTable.c.LastUpdate,
-                                             '_SubmitTime': requestTable.c.SubmitTime,
-                                             '_NotBefore': requestTable.c.NotBefore,
-                                             '__operations__' : relationship( Operation,
-                                                                              backref = backref( '_parent',
-                                                                                                 lazy = 'immediate' ),
-                                                                              order_by = operationTable.c.Order,
-                                                                              lazy = 'immediate',
-                                                                              passive_deletes = True,
-                                                                              cascade = "all, delete-orphan" )} )
-
+mapper(Request, requestTable, properties={'_CreationTime': requestTable.c.CreationTime,
+                                          '_Status': requestTable.c.Status,
+                                          '_LastUpdate': requestTable.c.LastUpdate,
+                                          '_SubmitTime': requestTable.c.SubmitTime,
+                                          '_NotBefore': requestTable.c.NotBefore,
+                                          '__operations__': relationship(Operation,
+                                                                         backref=backref('_parent',
+                                                                                         lazy='immediate'),
+                                                                         order_by=operationTable.c.Order,
+                                                                         lazy='immediate',
+                                                                         passive_deletes=True,
+                                                                         cascade="all, delete-orphan")})
 
 
 ########################################################################
-class RequestDB( object ):
+class RequestDB(object):
   """
   .. class:: RequestDB
 
   db holding requests
   """
 
-
-  def __getDBConnectionInfo( self, fullname ):
+  def __getDBConnectionInfo(self, fullname):
     """ Collect from the CS all the info needed to connect to the DB.
         This should be in a base class eventually
     """
 
-    result = getDBParameters( fullname )
-    if not result[ 'OK' ]:
-      raise Exception( 'Cannot get database parameters: %s' % result[ 'Message' ] )
+    result = getDBParameters(fullname)
+    if not result['OK']:
+      raise Exception('Cannot get database parameters: %s' % result['Message'])
 
-    dbParameters = result[ 'Value' ]
-    self.dbHost = dbParameters[ 'Host' ]
-    self.dbPort = dbParameters[ 'Port' ]
-    self.dbUser = dbParameters[ 'User' ]
-    self.dbPass = dbParameters[ 'Password' ]
-    self.dbName = dbParameters[ 'DBName' ]
+    dbParameters = result['Value']
+    self.dbHost = dbParameters['Host']
+    self.dbPort = dbParameters['Port']
+    self.dbUser = dbParameters['User']
+    self.dbPass = dbParameters['Password']
+    self.dbName = dbParameters['DBName']
 
-
-  def __init__( self ):
+  def __init__(self):
     """c'tor
 
     :param self: self reference
     """
 
-    self.log = gLogger.getSubLogger( 'RequestDB' )
+    self.log = gLogger.getSubLogger('RequestDB')
     # Initialize the connection info
     self.__getDBConnectionInfo( 'RequestManagement/ReqDB' )
 
@@ -189,90 +185,86 @@ class RequestDB( object ):
 
     metadata.bind = self.engine
 
-    self.DBSession = sessionmaker( bind = self.engine )
+    self.DBSession = sessionmaker(bind=self.engine)
 
-
-  def createTables( self ):
+  def createTables(self):
     """ create tables """
     try:
-      metadata.create_all( self.engine )
+      metadata.create_all(self.engine)
     except Exception as e:
-      return S_ERROR( e )
+      return S_ERROR(e)
     return S_OK()
 
-
-  def cancelRequest( self, requestID ):
+  def cancelRequest(self, requestID):
     session = self.DBSession()
     try:
-      updateRet = session.execute( update( Request )\
-                         .where( Request.RequestID == requestID )\
-                         .values( {Request._Status : 'Canceled',
-                                   Request._LastUpdate : datetime.datetime.utcnow()\
-                                                        .strftime( Request._datetimeFormat )} ) )
+      updateRet = session.execute(update(Request)
+                                  .where(Request.RequestID == requestID)
+                                  .values({Request._Status: 'Canceled',
+                                           Request._LastUpdate: datetime.datetime.utcnow()
+                                           .strftime(Request._datetimeFormat)}))
       session.commit()
 
       # No row was changed
       if not updateRet.rowcount:
-        return S_ERROR( "No such request %s" % requestID )
+        return S_ERROR("No such request %s" % requestID)
 
       return S_OK()
 
     except Exception as e:
       session.rollback()
-      self.log.exception( "cancelRequest: unexpected exception", lException = e )
-      return S_ERROR( "cancelRequest: unexpected exception %s" % e )
+      self.log.exception("cancelRequest: unexpected exception", lException=e)
+      return S_ERROR("cancelRequest: unexpected exception %s" % e)
     finally:
       session.close()
 
-
-  def putRequest( self, request ):
+  def putRequest(self, request):
     """ update or insert request into db
 
     :param ~Request.Request request: Request instance
     """
 
-    session = self.DBSession( expire_on_commit = False )
+    session = self.DBSession(expire_on_commit=False)
     try:
 
       try:
-        if hasattr( request, 'RequestID' ):
+        if hasattr(request, 'RequestID'):
 
-          status = session.query( Request._Status )\
-                          .filter( Request.RequestID == request.RequestID )\
+          status = session.query(Request._Status)\
+                          .filter(Request.RequestID == request.RequestID)\
                           .one()
 
           if status[0] == 'Canceled':
-            self.log.info( "Request %s(%s) was canceled, don't put it back" % ( request.RequestID, request.RequestName ) )
-            return S_OK( request.RequestID )
+            self.log.info("Request %s(%s) was canceled, don't put it back" % (request.RequestID, request.RequestName))
+            return S_OK(request.RequestID)
 
-      except NoResultFound, e:
+      except NoResultFound as e:
         pass
 
       # Since the object request is not attached to the session, we merge it to have an update
       # instead of an insert with duplicate primary key
-      request = session.merge( request )
-      session.add( request )
+      request = session.merge(request)
+      session.add(request)
       session.commit()
       session.expunge_all()
 
-      return S_OK( request.RequestID )
+      return S_OK(request.RequestID)
 
     except Exception as e:
       session.rollback()
-      self.log.exception( "putRequest: unexpected exception", lException = e )
-      return S_ERROR( "putRequest: unexpected exception %s" % e )
+      self.log.exception("putRequest: unexpected exception", lException=e)
+      return S_ERROR("putRequest: unexpected exception %s" % e)
     finally:
       session.close()
 
-
-  def getScheduledRequest( self, operationID ):
+  def getScheduledRequest(self, operationID):
     session = self.DBSession()
     try:
-      requestID = session.query( Request.RequestID )\
-                           .join( Request.__operations__ )\
-                           .filter( Operation.OperationID == operationID )\
-                           .one()
-      return self.getRequest( requestID[0] )
+      requestID = session.query(Request.RequestID)\
+          .join(Request.__operations__)\
+          .filter(Operation.OperationID == operationID)\
+          .one()
+      return self.getRequest(requestID[0])
     except NoResultFound:
       return S_OK()
     finally:
@@ -293,8 +285,7 @@ class RequestDB( object ):
 #     finally:
 #       session.close()
 
-
-  def getRequest( self, reqID = 0, assigned = True ):
+  def getRequest(self, reqID=0, assigned=True):
     """ read request for execution
 
     :param reqID: request's ID (default 0) If 0, take a pseudo random one
@@ -302,8 +293,8 @@ class RequestDB( object ):
     """
 
     # expire_on_commit is set to False so that we can still use the object after we close the session
-    session = self.DBSession( expire_on_commit = False )
-    log = self.log.getSubLogger( 'getRequest' if assigned else 'peekRequest' )
+    session = self.DBSession(expire_on_commit=False)
+    log = self.log.getSubLogger('getRequest' if assigned else 'peekRequest')
 
     requestID = None
 
@@ -312,48 +303,48 @@ class RequestDB( object ):
       if reqID:
         requestID = reqID
 
-        log.verbose( "selecting request '%s'%s" % ( reqID, ' (Assigned)' if assigned else '' ) )
+        log.verbose("selecting request '%s'%s" % (reqID, ' (Assigned)' if assigned else ''))
         status = None
         try:
-          status = session.query( Request._Status )\
-                          .filter( Request.RequestID == reqID )\
+          status = session.query(Request._Status)\
+                          .filter(Request.RequestID == reqID)\
                           .one()
-        except NoResultFound, e:
-          return S_ERROR( "getRequest: request '%s' not exists" % reqID )
+        except NoResultFound as e:
+          return S_ERROR("getRequest: request '%s' not exists" % reqID)
 
         if status and status == "Assigned" and assigned:
-          return S_ERROR( "getRequest: status of request '%s' is 'Assigned', request cannot be selected" % reqID )
+          return S_ERROR("getRequest: status of request '%s' is 'Assigned', request cannot be selected" % reqID)
 
       else:
-        now = datetime.datetime.utcnow().replace( microsecond = 0 )
+        now = datetime.datetime.utcnow().replace(microsecond=0)
         reqIDs = set()
         try:
-          reqAscIDs = session.query( Request.RequestID )\
-                             .filter( Request._Status == 'Waiting' )\
-                             .filter( Request._NotBefore < now )\
-                             .order_by( Request._LastUpdate )\
-                             .limit( 100 )\
+          reqAscIDs = session.query(Request.RequestID)\
+                             .filter(Request._Status == 'Waiting')\
+                             .filter(Request._NotBefore < now)\
+                             .order_by(Request._LastUpdate)\
+                             .limit(100)\
                              .all()
 
-          reqIDs = set( [reqID[0] for reqID in reqAscIDs] )
+          reqIDs = set([reqID[0] for reqID in reqAscIDs])
 
-          reqDescIDs = session.query( Request.RequestID )\
-                              .filter( Request._Status == 'Waiting' )\
-                              .filter( Request._NotBefore < now )\
-                              .order_by( Request._LastUpdate.desc() )\
-                              .limit( 50 )\
+          reqDescIDs = session.query(Request.RequestID)\
+                              .filter(Request._Status == 'Waiting')\
+                              .filter(Request._NotBefore < now)\
+                              .order_by(Request._LastUpdate.desc())\
+                              .limit(50)\
                               .all()
 
-          reqIDs |= set( [reqID[0] for reqID in reqDescIDs] )
+          reqIDs |= set([reqID[0] for reqID in reqDescIDs])
         # No Waiting requests
-        except NoResultFound, e:
+        except NoResultFound as e:
           return S_OK()
 
         if not reqIDs:
           return S_OK()
 
-        reqIDs = list( reqIDs )
-        random.shuffle( reqIDs )
+        reqIDs = list(reqIDs)
+        random.shuffle(reqIDs)
         requestID = reqIDs[0]
 
       # If we are here, the request MUST exist, so no try catch
@@ -364,30 +355,32 @@ class RequestDB( object ):
                        .one()
 
       if not reqID:
-        log.verbose( "selected request %s('%s')%s" % ( request.RequestID, request.RequestName, ' (Assigned)' if assigned else '' ) )
-
+        log.verbose(
+            "selected request %s('%s')%s" %
+            (request.RequestID,
+             request.RequestName,
+             ' (Assigned)' if assigned else ''))
 
       if assigned:
-        session.execute( update( Request )\
-                         .where( Request.RequestID == requestID )\
-                         .values( {Request._Status : 'Assigned',
-                                   Request._LastUpdate : datetime.datetime.utcnow()\
-                                                        .strftime( Request._datetimeFormat )} )
-                       )
+        session.execute(update(Request)
+                        .where(Request.RequestID == requestID)
+                        .values({Request._Status: 'Assigned',
+                                 Request._LastUpdate: datetime.datetime.utcnow()
+                                 .strftime(Request._datetimeFormat)})
+                        )
         session.commit()
 
       session.expunge_all()
-      return S_OK( request )
+      return S_OK(request)
 
     except Exception as e:
       session.rollback()
-      log.exception( "getRequest: unexpected exception", lException = e )
-      return S_ERROR( "getRequest: unexpected exception : %s" % e )
+      log.exception("getRequest: unexpected exception", lException=e)
+      return S_ERROR("getRequest: unexpected exception : %s" % e)
     finally:
       session.close()
 
-
-  def getBulkRequests( self, numberOfRequest = 10, assigned = True ):
+  def getBulkRequests(self, numberOfRequest=10, assigned=True):
     """ read as many requests as requested for execution
 
     :param int numberOfRequest: Number of Request we want (default 10)
@@ -398,8 +391,8 @@ class RequestDB( object ):
     """
 
     # expire_on_commit is set to False so that we can still use the object after we close the session
-    session = self.DBSession( expire_on_commit = False )
-    log = self.log.getSubLogger( 'getBulkRequest' if assigned else 'peekBulkRequest' )
+    session = self.DBSession(expire_on_commit=False)
+    log = self.log.getSubLogger('getBulkRequest' if assigned else 'peekBulkRequest')
 
     requestDict = {}
 
@@ -407,93 +400,87 @@ class RequestDB( object ):
       # If we are here, the request MUST exist, so no try catch
       # the joinedload is to force the non-lazy loading of all the attributes, especially _parent
       try:
-        now = datetime.datetime.utcnow().replace( microsecond = 0 )
-        requestIDs = session.query( Request.RequestID )\
-                          .with_for_update()\
-                          .filter( Request._Status == 'Waiting' )\
-                          .filter( Request._NotBefore < now )\
-                          .order_by( Request._LastUpdate )\
-                          .limit( numberOfRequest )\
-                          .all()
+        now = datetime.datetime.utcnow().replace(microsecond=0)
+        requestIDs = session.query(Request.RequestID)\
+            .with_for_update()\
+            .filter(Request._Status == 'Waiting')\
+            .filter(Request._NotBefore < now)\
+            .order_by(Request._LastUpdate)\
+            .limit(numberOfRequest)\
+            .all()
 
         requestIDs = [ridTuple[0] for ridTuple in requestIDs]
-        log.debug( "Got request ids %s" % requestIDs )
+        log.debug("Got request ids %s" % requestIDs)
 
         requests = session.query(Request) \
                           .options(joinedload('__operations__').joinedload('__files__')) \
                           .filter(Request.RequestID.in_(requestIDs))\
                           .all()
-        log.debug( "Got %s Request objects " % len( requests ) )
-        requestDict = dict( ( req.RequestID, req ) for req in requests )
+        log.debug("Got %s Request objects " % len(requests))
+        requestDict = dict((req.RequestID, req) for req in requests)
       # No Waiting requests
-      except NoResultFound, e:
+      except NoResultFound as e:
         pass
 
       if assigned and requestDict:
-        session.execute( update( Request )\
-                         .where( Request.RequestID.in_( requestDict.keys() ) )\
-                         .values( {Request._Status : 'Assigned',
-                                   Request._LastUpdate : datetime.datetime.utcnow()\
-                                                        .strftime( Request._datetimeFormat )} )
-                       )
+        session.execute(update(Request)
+                        .where(Request.RequestID.in_(requestDict.keys()))
+                        .values({Request._Status: 'Assigned',
+                                 Request._LastUpdate: datetime.datetime.utcnow()
+                                 .strftime(Request._datetimeFormat)})
+                        )
       session.commit()
 
       session.expunge_all()
 
     except Exception as e:
       session.rollback()
-      log.exception( "unexpected exception", lException = e )
-      return S_ERROR( "getBulkRequest: unexpected exception : %s" % e )
+      log.exception("unexpected exception", lException=e)
+      return S_ERROR("getBulkRequest: unexpected exception : %s" % e)
     finally:
       session.close()
 
-    return S_OK( requestDict )
+    return S_OK(requestDict)
 
-
-
-  def peekRequest( self, requestID ):
+  def peekRequest(self, requestID):
     """ get request (ro), no update on states
 
     :param requestID: Request.RequestID
     """
-    return self.getRequest( requestID, False )
+    return self.getRequest(requestID, False)
 
-
-
-  def getRequestIDsList( self, statusList = None, limit = None, since = None, until = None, getJobID = False ):
+  def getRequestIDsList(self, statusList=None, limit=None, since=None, until=None, getJobID=False):
     """ select requests with status in :statusList: """
-    statusList = statusList if statusList else list( Request.FINAL_STATES )
+    statusList = statusList if statusList else list(Request.FINAL_STATES)
     limit = limit if limit else 100
     session = self.DBSession()
     requestIDs = []
     try:
       if getJobID:
-        reqQuery = session.query( Request.RequestID, Request._Status, Request._LastUpdate, Request.JobID )\
-                          .filter( Request._Status.in_( statusList ) )
+        reqQuery = session.query(Request.RequestID, Request._Status, Request._LastUpdate, Request.JobID)\
+                          .filter(Request._Status.in_(statusList))
       else:
-        reqQuery = session.query( Request.RequestID, Request._Status, Request._LastUpdate )\
-                          .filter( Request._Status.in_( statusList ) )
+        reqQuery = session.query(Request.RequestID, Request._Status, Request._LastUpdate)\
+                          .filter(Request._Status.in_(statusList))
       if since:
-        reqQuery = reqQuery.filter( Request._LastUpdate > since )
+        reqQuery = reqQuery.filter(Request._LastUpdate > since)
       if until:
-        reqQuery = reqQuery.filter( Request._LastUpdate < until )
+        reqQuery = reqQuery.filter(Request._LastUpdate < until)
 
-      reqQuery = reqQuery.order_by( Request._LastUpdate )\
-                         .limit( limit )
-      requestIDs = [ tuple( reqIDTuple ) for reqIDTuple in reqQuery.all() ]
+      reqQuery = reqQuery.order_by(Request._LastUpdate)\
+                         .limit(limit)
+      requestIDs = [list(reqIDTuple) for reqIDTuple in reqQuery.all()]
 
     except Exception as e:
       session.rollback()
-      self.log.exception( "getRequestIDsList: unexpected exception", lException = e )
-      return S_ERROR( "getRequestIDsList: unexpected exception : %s" % e )
+      self.log.exception("getRequestIDsList: unexpected exception", lException=e)
+      return S_ERROR("getRequestIDsList: unexpected exception : %s" % e)
     finally:
       session.close()
 
-    return S_OK( requestIDs )
+    return S_OK(requestIDs)
 
-
-
-  def deleteRequest( self, requestID ):
+  def deleteRequest(self, requestID):
     """ delete request given its ID
 
     :param str requestID: request.RequestID
@@ -503,58 +490,55 @@ class RequestDB( object ):
     session = self.DBSession()
 
     try:
-      session.query( Request ).filter( Request.RequestID == requestID ).delete()
+      session.query(Request).filter(Request.RequestID == requestID).delete()
       session.commit()
     except Exception as e:
       session.rollback()
-      self.log.exception( "deleteRequest: unexpected exception", lException = e )
-      return S_ERROR( "deleteRequest: unexpected exception : %s" % e )
+      self.log.exception("deleteRequest: unexpected exception", lException=e)
+      return S_ERROR("deleteRequest: unexpected exception : %s" % e)
     finally:
       session.close()
 
     return S_OK()
 
-
-  def getDBSummary( self ):
+  def getDBSummary(self):
     """ get db summary """
     # # this will be returned
-    retDict = { "Request" : {}, "Operation" : {}, "File" : {} }
+    retDict = {"Request": {}, "Operation": {}, "File": {}}
 
     session = self.DBSession()
 
     try:
-      requestQuery = session.query( Request._Status, func.count( Request.RequestID ) )\
-                            .group_by( Request._Status )\
+      requestQuery = session.query(Request._Status, func.count(Request.RequestID))\
+                            .group_by(Request._Status)\
                             .all()
 
       for status, count in requestQuery:
         retDict["Request"][status] = count
 
-      operationQuery = session.query( Operation.Type, Operation._Status, func.count( Operation.OperationID ) )\
-                              .group_by( Operation.Type, Operation._Status )\
+      operationQuery = session.query(Operation.Type, Operation._Status, func.count(Operation.OperationID))\
+                              .group_by(Operation.Type, Operation._Status)\
                               .all()
 
       for oType, status, count in operationQuery:
-        retDict['Operation'].setdefault( oType, {} )[status] = count
+        retDict['Operation'].setdefault(oType, {})[status] = count
 
-
-      fileQuery = session.query( File._Status, func.count( File.FileID ) )\
-                         .group_by( File._Status )\
+      fileQuery = session.query(File._Status, func.count(File.FileID))\
+                         .group_by(File._Status)\
                          .all()
 
       for status, count in fileQuery:
         retDict["File"][status] = count
 
     except Exception as e:
-      self.log.exception( "getDBSummary: unexpected exception", lException = e )
-      return S_ERROR( "getDBSummary: unexpected exception : %s" % e )
+      self.log.exception("getDBSummary: unexpected exception", lException=e)
+      return S_ERROR("getDBSummary: unexpected exception : %s" % e)
     finally:
       session.close()
 
-    return S_OK( retDict )
+    return S_OK(retDict)
 
-
-  def getRequestSummaryWeb( self, selectDict, sortList, startItem, maxItems ):
+  def getRequestSummaryWeb(self, selectDict, sortList, startItem, maxItems):
     """ Returns a list of Request for the web portal
 
     :param dict selectDict: parameter on which to restrain the query {key : Value}
@@ -566,29 +550,25 @@ class RequestDB( object ):
     :param int maxItems: max items (for pagination)
     """
 
-
-    parameterList = [ 'RequestID', 'RequestName', 'JobID', 'OwnerDN', 'OwnerGroup',
-                      'Status', "Error", "CreationTime", "LastUpdate"]
-
+    parameterList = ['RequestID', 'RequestName', 'JobID', 'OwnerDN', 'OwnerGroup',
+                     'Status', "Error", "CreationTime", "LastUpdate"]
 
     resultDict = {}
 
     session = self.DBSession()
 
     try:
-      summaryQuery = session.query( Request.RequestID, Request.RequestName,
-                                    Request.JobID, Request.OwnerDN, Request.OwnerGroup,
-                                    Request._Status, Request.Error,
-                                    Request._CreationTime, Request._LastUpdate )
-
-
+      summaryQuery = session.query(Request.RequestID, Request.RequestName,
+                                   Request.JobID, Request.OwnerDN, Request.OwnerGroup,
+                                   Request._Status, Request.Error,
+                                   Request._CreationTime, Request._LastUpdate)
 
       for key, value in selectDict.items():
 
         if key == 'ToDate':
-          summaryQuery = summaryQuery.filter( Request._LastUpdate < value )
+          summaryQuery = summaryQuery.filter(Request._LastUpdate < value)
         elif key == 'FromDate':
-          summaryQuery = summaryQuery.filter( Request._LastUpdate > value )
+          summaryQuery = summaryQuery.filter(Request._LastUpdate > value)
         else:
 
           tableName = 'Request'
@@ -600,56 +580,55 @@ class RequestDB( object ):
           elif key == 'Status':
             key = '_Status'
 
-          if isinstance( value, list ):
-            summaryQuery = summaryQuery.filter( eval( '%s.%s.in_(%s)' % ( tableName, key, value ) ) )
+          if isinstance(value, list):
+            summaryQuery = summaryQuery.filter(eval('%s.%s.in_(%s)' % (tableName, key, value)))
           else:
-            summaryQuery = summaryQuery.filter( eval( '%s.%s' % ( tableName, key ) ) == value )
+            summaryQuery = summaryQuery.filter(eval('%s.%s' % (tableName, key)) == value)
 
       if sortList:
-        summaryQuery = summaryQuery.order_by( eval( 'Request.%s.%s()' % ( sortList[0][0], sortList[0][1].lower() ) ) )
+        summaryQuery = summaryQuery.order_by(eval('Request.%s.%s()' % (sortList[0][0], sortList[0][1].lower())))
 
       try:
         requestLists = summaryQuery.all()
-      except NoResultFound, e:
+      except NoResultFound as e:
         resultDict['ParameterNames'] = parameterList
         resultDict['Records'] = []
 
-        return S_OK( resultDict )
+        return S_OK(resultDict)
       except Exception as e:
-        return S_ERROR( 'Error getting the webSummary %s' % e )
+        return S_ERROR('Error getting the webSummary %s' % e)
 
-      nRequests = len( requestLists )
+      nRequests = len(requestLists)
 
-      if startItem <= len( requestLists ):
+      if startItem <= len(requestLists):
         firstIndex = startItem
       else:
-        return S_ERROR( 'getRequestSummaryWeb: Requested index out of range' )
+        return S_ERROR('getRequestSummaryWeb: Requested index out of range')
 
-      if ( startItem + maxItems ) <= len( requestLists ):
+      if (startItem + maxItems) <= len(requestLists):
         secondIndex = startItem + maxItems
       else:
-        secondIndex = len( requestLists )
+        secondIndex = len(requestLists)
 
       records = []
-      for i in range( firstIndex, secondIndex ):
+      for i in range(firstIndex, secondIndex):
         row = requestLists[i]
-        records.append( [ str( x ) for x in row] )
+        records.append([str(x) for x in row])
 
       resultDict['ParameterNames'] = parameterList
       resultDict['Records'] = records
       resultDict['TotalRecords'] = nRequests
 
-      return S_OK( resultDict )
+      return S_OK(resultDict)
 #
     except Exception as e:
-      self.log.exception( "getRequestSummaryWeb: unexpected exception", lException = e )
-      return S_ERROR( "getRequestSummaryWeb: unexpected exception : %s" % e )
+      self.log.exception("getRequestSummaryWeb: unexpected exception", lException=e)
+      return S_ERROR("getRequestSummaryWeb: unexpected exception : %s" % e)
 
     finally:
       session.close()
 
-
-  def getRequestCountersWeb( self, groupingAttribute, selectDict ):
+  def getRequestCountersWeb(self, groupingAttribute, selectDict):
     """ For the web portal.
         Returns a dictionary {value : counts} for a given key.
         The key can be any field from the RequestTable. or "Type",
@@ -668,50 +647,47 @@ class RequestDB( object ):
       groupingAttribute = 'Request.%s' % groupingAttribute
 
     try:
-      summaryQuery = session.query( eval( groupingAttribute ), func.count( Request.RequestID ) )
+      summaryQuery = session.query(eval(groupingAttribute), func.count(Request.RequestID))
 
       for key, value in selectDict.items():
         if key == 'ToDate':
-          summaryQuery = summaryQuery.filter( Request._LastUpdate < value )
+          summaryQuery = summaryQuery.filter(Request._LastUpdate < value)
         elif key == 'FromDate':
-          summaryQuery = summaryQuery.filter( Request._LastUpdate > value )
+          summaryQuery = summaryQuery.filter(Request._LastUpdate > value)
         else:
 
           objectType = 'Request'
           if key == 'Type':
-            summaryQuery = summaryQuery.join( Request.__operations__ )
+            summaryQuery = summaryQuery.join(Request.__operations__)
             objectType = 'Operation'
           elif key == 'Status':
             key = '_Status'
 
-          if isinstance( value, list ):
-            summaryQuery = summaryQuery.filter( eval( '%s.%s.in_(%s)' % ( objectType, key, value ) ) )
+          if isinstance(value, list):
+            summaryQuery = summaryQuery.filter(eval('%s.%s.in_(%s)' % (objectType, key, value)))
           else:
-            summaryQuery = summaryQuery.filter( eval( '%s.%s' % ( objectType, key ) ) == value )
+            summaryQuery = summaryQuery.filter(eval('%s.%s' % (objectType, key)) == value)
 
-      summaryQuery = summaryQuery.group_by( groupingAttribute )
+      summaryQuery = summaryQuery.group_by(groupingAttribute)
 
       try:
         requestLists = summaryQuery.all()
-        resultDict = dict( requestLists )
-      except NoResultFound, e:
+        resultDict = dict(requestLists)
+      except NoResultFound as e:
         pass
       except Exception as e:
-        return S_ERROR( 'Error getting the webCounters %s' % e )
+        return S_ERROR('Error getting the webCounters %s' % e)
 
-
-
-      return S_OK( resultDict )
+      return S_OK(resultDict)
 
     except Exception as e:
-      self.log.exception( "getRequestSummaryWeb: unexpected exception", lException = e )
-      return S_ERROR( "getRequestSummaryWeb: unexpected exception : %s" % e )
+      self.log.exception("getRequestSummaryWeb: unexpected exception", lException=e)
+      return S_ERROR("getRequestSummaryWeb: unexpected exception : %s" % e)
 
     finally:
       session.close()
 
-
-  def getDistinctValues( self, tableName, columnName ):
+  def getDistinctValues(self, tableName, columnName):
     """ For a given table and a given field, return the list of of distinct values in the DB"""
 
     session = self.DBSession()
@@ -719,54 +695,52 @@ class RequestDB( object ):
     if columnName == 'Status':
       columnName = '_Status'
     try:
-      result = session.query( distinct( eval ( "%s.%s" % ( tableName, columnName ) ) ) ).all()
+      result = session.query(distinct(eval("%s.%s" % (tableName, columnName)))).all()
       distinctValues = [dist[0] for dist in result]
-    except NoResultFound, e:
+    except NoResultFound as e:
       pass
     except Exception as e:
-      self.log.exception( "getDistinctValues: unexpected exception", lException = e )
-      return S_ERROR( "getDistinctValues: unexpected exception : %s" % e )
+      self.log.exception("getDistinctValues: unexpected exception", lException=e)
+      return S_ERROR("getDistinctValues: unexpected exception : %s" % e)
 
     finally:
       session.close()
 
-    return S_OK( distinctValues )
+    return S_OK(distinctValues)
 
-
-  def getRequestIDsForJobs( self, jobIDs ):
+  def getRequestIDsForJobs(self, jobIDs):
     """ read request ids for jobs given jobIDs
 
     :param jobIDs: list of jobIDs
     :type jobIDs: python:list
     """
-    self.log.debug( "getRequestIDsForJobs: got %s jobIDs to check" % str( jobIDs ) )
+    self.log.debug("getRequestIDsForJobs: got %s jobIDs to check" % str(jobIDs))
     if not jobIDs:
-      return S_ERROR( "Must provide jobID list as argument." )
-    if isinstance( jobIDs, six.integer_types ):
-      jobIDs = [ jobIDs ]
-    jobIDs = set( jobIDs )
+      return S_ERROR("Must provide jobID list as argument.")
+    if isinstance(jobIDs, six.integer_types):
+      jobIDs = [jobIDs]
+    jobIDs = set(jobIDs)
 
-    reqDict = { "Successful": {}, "Failed": {} }
+    reqDict = {"Successful": {}, "Failed": {}}
 
     session = self.DBSession()
 
     try:
-      ret = session.query( Request.JobID, Request.RequestID )\
-                   .filter( Request.JobID.in_( jobIDs ) )\
-                  .all()
+      ret = session.query(Request.JobID, Request.RequestID)\
+                   .filter(Request.JobID.in_(jobIDs))\
+          .all()
 
-      reqDict['Successful'] = dict( ( jobId, reqID ) for jobId, reqID in ret )
-      reqDict['Failed'] = dict( ( jobid, 'Request not found' ) for jobid in jobIDs - set( reqDict['Successful'] ) )
+      reqDict['Successful'] = dict((jobId, reqID) for jobId, reqID in ret)
+      reqDict['Failed'] = dict((jobid, 'Request not found') for jobid in jobIDs - set(reqDict['Successful']))
     except Exception as e:
-      self.log.exception( "getRequestIDsForJobs: unexpected exception", lException = e )
-      return S_ERROR( "getRequestIDsForJobs: unexpected exception : %s" % e )
+      self.log.exception("getRequestIDsForJobs: unexpected exception", lException=e)
+      return S_ERROR("getRequestIDsForJobs: unexpected exception : %s" % e)
     finally:
       session.close()
 
-    return S_OK( reqDict )
+    return S_OK(reqDict)
 
-
-  def readRequestsForJobs( self, jobIDs = None ):
+  def readRequestsForJobs(self, jobIDs=None):
     """ read request for jobs
 
     :param jobIDs: list of JobIDs
@@ -774,50 +748,48 @@ class RequestDB( object ):
     :return: S_OK( "Successful" : { jobID1 : Request, jobID2: Request, ... }
                    "Failed" : { jobID3: "error message", ... } )
     """
-    self.log.debug( "readRequestForJobs: got %s jobIDs to check" % str( jobIDs ) )
+    self.log.debug("readRequestForJobs: got %s jobIDs to check" % str(jobIDs))
     if not jobIDs:
-      return S_ERROR( "Must provide jobID list as argument." )
-    if isinstance( jobIDs, six.integer_types ):
-      jobIDs = [ jobIDs ]
-    jobIDs = set( jobIDs )
+      return S_ERROR("Must provide jobID list as argument.")
+    if isinstance(jobIDs, six.integer_types):
+      jobIDs = [jobIDs]
+    jobIDs = set(jobIDs)
 
-    reqDict = { "Successful": {}, "Failed": {} }
+    reqDict = {"Successful": {}, "Failed": {}}
 
     # expire_on_commit is set to False so that we can still use the object after we close the session
-    session = self.DBSession( expire_on_commit = False )
+    session = self.DBSession(expire_on_commit=False)
 
     try:
       ret = session.query(Request.JobID, Request) \
                    .options(joinedload('__operations__').joinedload('__files__')) \
                    .filter(Request.JobID.in_(jobIDs)).all()
 
-      reqDict['Successful'] = dict( ( jobId, reqObj ) for jobId, reqObj in ret )
+      reqDict['Successful'] = dict((jobId, reqObj) for jobId, reqObj in ret)
 
-      reqDict['Failed'] = dict( ( jobid, 'Request not found' ) for jobid in jobIDs - set( reqDict['Successful'] ) )
+      reqDict['Failed'] = dict((jobid, 'Request not found') for jobid in jobIDs - set(reqDict['Successful']))
       session.expunge_all()
     except Exception as e:
-      self.log.exception( "readRequestsForJobs: unexpected exception", lException = e )
-      return S_ERROR( "readRequestsForJobs: unexpected exception : %s" % e )
+      self.log.exception("readRequestsForJobs: unexpected exception", lException=e)
+      return S_ERROR("readRequestsForJobs: unexpected exception : %s" % e)
     finally:
       session.close()
 
-    return S_OK( reqDict )
+    return S_OK(reqDict)
 
-
-  def getRequestStatus( self, requestID ):
+  def getRequestStatus(self, requestID):
     """ get request status for a given request ID """
-    self.log.debug( "getRequestStatus: checking status for '%s' request" % requestID )
+    self.log.debug("getRequestStatus: checking status for '%s' request" % requestID)
     session = self.DBSession()
     try:
-      status = session.query( Request._Status ).filter( Request.RequestID == requestID ).one()
-    except  NoResultFound:
-      return S_ERROR( "Request %s does not exist" % requestID )
+      status = session.query(Request._Status).filter(Request.RequestID == requestID).one()
+    except NoResultFound:
+      return S_ERROR("Request %s does not exist" % requestID)
     finally:
       session.close()
-    return S_OK( status[0] )
+    return S_OK(status[0])
 
-
-  def getRequestFileStatus( self, requestID, lfnList ):
+  def getRequestFileStatus(self, requestID, lfnList):
     """ get status for files in request given its id
 
     :param str requestID: Request.RequestID
@@ -827,71 +799,68 @@ class RequestDB( object ):
 
     session = self.DBSession()
     try:
-      res = dict.fromkeys( lfnList, "UNKNOWN" )
-      requestRet = session.query( File._LFN, File._Status )\
-                       .join( Request.__operations__ )\
-                       .join( Operation.__files__ )\
-                       .filter( Request.RequestID == requestID )\
-                       .filter( File._LFN.in_( lfnList ) )\
-                       .all()
+      res = dict.fromkeys(lfnList, "UNKNOWN")
+      requestRet = session.query(File._LFN, File._Status)\
+          .join(Request.__operations__)\
+          .join(Operation.__files__)\
+          .filter(Request.RequestID == requestID)\
+          .filter(File._LFN.in_(lfnList))\
+          .all()
 
       for lfn, status in requestRet:
         res[lfn] = status
-      return S_OK( res )
+      return S_OK(res)
 
     except Exception as e:
-      self.log.exception( "getRequestFileStatus: unexpected exception", lException = e )
-      return S_ERROR( "getRequestFileStatus: unexpected exception : %s" % e )
+      self.log.exception("getRequestFileStatus: unexpected exception", lException=e)
+      return S_ERROR("getRequestFileStatus: unexpected exception : %s" % e)
     finally:
       session.close()
 
-
-  def getRequestInfo( self, requestID ):
+  def getRequestInfo(self, requestID):
     """ get request info given Request.RequestID """
 
     session = self.DBSession()
 
     try:
 
-      requestInfoQuery = session.query( Request.RequestID, Request._Status, Request.RequestName,
-                                        Request.JobID, Request.OwnerDN, Request.OwnerGroup,
-                                        Request.DIRACSetup, Request.SourceComponent, Request._CreationTime,
-                                        Request._SubmitTime, Request._LastUpdate )\
-                                .filter( Request.RequestID == requestID )
-
+      requestInfoQuery = session.query(Request.RequestID, Request._Status, Request.RequestName,
+                                       Request.JobID, Request.OwnerDN, Request.OwnerGroup,
+                                       Request.DIRACSetup, Request.SourceComponent, Request._CreationTime,
+                                       Request._SubmitTime, Request._LastUpdate)\
+          .filter(Request.RequestID == requestID)
 
       try:
         requestInfo = requestInfoQuery.one()
       except NoResultFound:
-        return S_ERROR( 'No such request' )
+        return S_ERROR('No such request')
 
-      return S_OK( tuple( requestInfo ) )
+      return S_OK(list(requestInfo))
 
     except Exception as e:
-      self.log.exception( "getRequestInfo: unexpected exception", lException = e )
-      return S_ERROR( "getRequestInfo: unexpected exception : %s" % e )
+      self.log.exception("getRequestInfo: unexpected exception", lException=e)
+      return S_ERROR("getRequestInfo: unexpected exception : %s" % e)
 
     finally:
       session.close()
 
-  def getDigest( self, requestID ):
+  def getDigest(self, requestID):
     """ get digest for request given its id
 
     :param str requestName: request id
     """
-    self.log.debug( "getDigest: will create digest for request '%s'" % requestID )
-    request = self.getRequest( requestID, False )
+    self.log.debug("getDigest: will create digest for request '%s'" % requestID)
+    request = self.getRequest(requestID, False)
     if not request["OK"]:
-      self.log.error( "getDigest: %s" % request["Message"] )
+      self.log.error("getDigest: %s" % request["Message"])
       return request
     request = request["Value"]
-    if not isinstance( request, Request ):
-      self.log.info( "getDigest: request '%s' not found" )
+    if not isinstance(request, Request):
+      self.log.info("getDigest: request '%s' not found")
       return S_OK()
     return request.getDigest()
 
-
-  def getRequestIDForName( self, requestName ):
+  def getRequestIDForName(self, requestName):
     """ read request id for given name
         if the name is not unique, an error is returned
 
@@ -901,22 +870,22 @@ class RequestDB( object ):
 
     reqID = 0
     try:
-      ret = session.query( Request.RequestID )\
-                   .filter( Request.RequestName == requestName )\
+      ret = session.query(Request.RequestID)\
+                   .filter(Request.RequestName == requestName)\
                    .all()
       if not ret:
-        return S_ERROR( 'No such request %s' % requestName )
-      elif len( ret ) > 1:
-        return S_ERROR( 'RequestName %s not unique (%s matches)' % ( requestName, len( ret ) ) )
+        return S_ERROR('No such request %s' % requestName)
+      elif len(ret) > 1:
+        return S_ERROR('RequestName %s not unique (%s matches)' % (requestName, len(ret)))
 
       reqID = ret[0][0]
 
-    except NoResultFound, e:
-      return S_ERROR( 'No such request' )
+    except NoResultFound as e:
+      return S_ERROR('No such request')
     except Exception as e:
-      self.log.exception( "getRequestIDsForName: unexpected exception", lException = e )
-      return S_ERROR( "getRequestIDsForName: unexpected exception : %s" % e )
+      self.log.exception("getRequestIDsForName: unexpected exception", lException=e)
+      return S_ERROR("getRequestIDsForName: unexpected exception : %s" % e)
     finally:
       session.close()
 
-    return S_OK( reqID )
+    return S_OK(reqID)

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -19,6 +19,7 @@ import math
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
 from DIRAC.Core.Utilities import DErrno
+from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
 # # from RMS
 from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.private.RequestValidator import RequestValidator
@@ -188,6 +189,7 @@ class ReqManagerHandler(RequestHandler):
   types_getBulkRequests = [int, bool]
 
   @classmethod
+  @ignoreEncodeWarning
   def export_getBulkRequests(cls, numberOfRequest, assigned):
     """ Get a request of given type from the database
 
@@ -317,6 +319,7 @@ class ReqManagerHandler(RequestHandler):
   types_readRequestsForJobs = [list]
 
   @classmethod
+  @ignoreEncodeWarning
   def export_readRequestsForJobs(cls, jobIDs):
     """ read requests for jobs given list of jobIDs """
     requests = cls.__requestDB.readRequestsForJobs(jobIDs)

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -191,6 +191,9 @@ class ReqManagerHandler(RequestHandler):
   def export_getBulkRequests(cls, numberOfRequest, assigned):
     """ Get a request of given type from the database
 
+        :warning: the dictionnary may contain string keys instead of int (json serialization)
+                  Do not forget to cast it back
+
         :param numberOfRequest: size of the bulk (default 10)
         :return: S_OK( {Failed : message, Successful : list of Request.toJSON()} )
     """
@@ -303,7 +306,12 @@ class ReqManagerHandler(RequestHandler):
 
   @classmethod
   def export_getRequestIDsForJobs(cls, jobIDs):
-    """ Select the request IDs for supplied jobIDs """
+    """ Select the request IDs for supplied jobIDs
+
+        :warning: the dictionnary may contain string keys instead of int (json serialization)
+          Do not forget to cast it back
+
+    """
     return cls.__requestDB.getRequestIDsForJobs(jobIDs)
 
   types_readRequestsForJobs = [list]

--- a/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -193,7 +193,7 @@ class ReqManagerHandler(RequestHandler):
   def export_getBulkRequests(cls, numberOfRequest, assigned):
     """ Get a request of given type from the database
 
-        :warning: the dictionnary may contain string keys instead of int (json serialization)
+        :warning: the dictionary may contain string keys instead of int (json serialization)
                   Do not forget to cast it back
 
         :param numberOfRequest: size of the bulk (default 10)

--- a/ResourceStatusSystem/Agent/TokenAgent.py
+++ b/ResourceStatusSystem/Agent/TokenAgent.py
@@ -97,7 +97,7 @@ class TokenAgent(AgentModule):
     tokenExpLimit = datetime.utcnow() + timedelta(hours=self.notifyHours)
 
     tokenElements = self.rsClient.selectStatusElement(element, 'Status',
-                                                      meta={'older': ('TokenExpiration', tokenExpLimit)})
+                                                      meta={'older': ['TokenExpiration', tokenExpLimit]})
 
     if not tokenElements['OK']:
       return tokenElements

--- a/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/StorageManagementSystem/DB/StorageManagementDB.py
@@ -512,7 +512,8 @@ class StorageManagementDB(DB):
     res = self._query(req, connection)
     if not res['OK']:
       return res
-    tasks = res['Value']
+    # Cast to list to be able to serialize
+    tasks = [list(row) for row in res['Value']]
     resultDict = {}
     for row in tasks:
       resultDict[row[0]] = dict(zip(self.TASKPARAMS[1:], row[1:]))
@@ -558,7 +559,8 @@ class StorageManagementDB(DB):
     res = self._query(req, connection)
     if not res['OK']:
       return res
-    cacheReplicas = res['Value']
+    # Cast to list to be able to serialize
+    cacheReplicas = [list(row) for row in res['Value']]
     resultDict = {}
     for row in cacheReplicas:
       resultDict[row[0]] = dict(zip(self.REPLICAPARAMS[1:], row[1:]))
@@ -602,7 +604,8 @@ class StorageManagementDB(DB):
     res = self._query(req, connection)
     if not res['OK']:
       return res
-    stageRequests = res['Value']
+    # Cast to list to be able to serialize
+    stageRequests = [list(row) for row in res['Value']]
     resultDict = {}
     for row in stageRequests:
       resultDict[row[0]] = dict(zip(self.STAGEPARAMS[1:], row[1:]))

--- a/WorkloadManagementSystem/Client/JobReport.py
+++ b/WorkloadManagementSystem/Client/JobReport.py
@@ -135,7 +135,7 @@ class JobReport(object):
     parameters = []
     for pname, value in self.jobParameters.items():
       pvalue, _timeStamp = value
-      parameters.append((pname, pvalue))
+      parameters.append([pname, pvalue])
 
     if parameters:
       result = JobStateUpdateClient().setJobParameters(self.jobID, parameters)

--- a/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -860,7 +860,7 @@ class Watchdog(object):
       for k, v in vals.items():
         if v:
           self.log.info(str(k) + ' = ' + str(v))
-          parameters.append((k, v))
+          parameters.append([k, v])
       if report:
         self.__setJobParamList(parameters)
 

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
@@ -254,7 +254,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     # Using also Meta
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234',
                                         meta={'columns': ['Status', 'StatusType'],
-                                              'newer': ('DateEffective', Datetime)})
+                                              'newer': ['DateEffective', Datetime]})
     # check if the select query was executed properly
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'Banned')
@@ -270,7 +270,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     # Using also Meta
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234',
                                         meta={'columns': ['Status', 'StatusType'],
-                                              'older': ('DateEffective', Datetime)})
+                                              'older': ['DateEffective', Datetime]})
     # check if the select query was executed properly
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'], [])
@@ -279,8 +279,8 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     # Using Meta with order
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234',
                                         meta={'columns': ['Status', 'StatusType'],
-                                              'newer': ('DateEffective', Datetime),
-                                              'order': ('status', 'DESC')})
+                                              'newer': ['DateEffective', Datetime],
+                                              'order': ['status', 'DESC']})
     # check if the select query was executed properly
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'Probing')
@@ -296,7 +296,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     # Using Meta with limit
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234',
                                         meta={'columns': ['Status', 'StatusType'],
-                                              'newer': ('DateEffective', Datetime),
+                                              'newer': ['DateEffective', Datetime],
                                               'order': 'status',
                                               'limit': 1})
     # check if the select query was executed properly

--- a/tests/Integration/all_integration_client_tests.sh
+++ b/tests/Integration/all_integration_client_tests.sh
@@ -17,8 +17,8 @@ dirac-proxy-init -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Accounting TESTS ****\n"
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/AccountingSystem/Test_DataStoreClient.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/AccountingSystem/Test_ReportsClient.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/AccountingSystem/Test_DataStoreClient.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/AccountingSystem/Test_ReportsClient.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
@@ -28,28 +28,28 @@ echo -e "*** $(date -u)  Getting a non privileged user\n" 2>&1 | tee -a clientTe
 dirac-proxy-init -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG 2>&1 | tee -a clientTestOutputs.txt
 
 echo -e "*** $(date -u)  Starting RMS Client test as a non privileged user\n" 2>&1 | tee -a clientTestOutputs.txt
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 echo -e "*** $(date -u)  getting the prod role again\n" 2>&1 | tee -a clientTestOutputs.txt
 dirac-proxy-init -g prod -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG 2>&1 | tee -a clientTestOutputs.txt
 echo -e "*** $(date -u)  Starting RMS Client test as an admin user\n" 2>&1 | tee -a clientTestOutputs.txt
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RSS TESTS ****\n"
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_SiteStatus.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_Publisher.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_SiteStatus.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_Publisher.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** WMS TESTS ****\n"
-# python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsLoggingClient.py 2>&1 | tee -a clientTestOutputs.txt
+# pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsLoggingClient.py 2>&1 | tee -a clientTestOutputs.txt
 python $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_SandboxStoreClient.py $WORKSPACE/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobWrapper.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
-python -m pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsClient.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobWrapper.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsClient.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 ## no real tests
 python $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/createJobXMLDescriptions.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 $CLIENTINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_dirac-jobexec.sh 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -14,33 +14,33 @@ set -o pipefail
 ERR=0
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Core TESTS ****\n"
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Core/Test_ElasticsearchDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Core/Test_ElasticsearchDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** FRAMEWORK TESTS (partially skipped) ****\n"
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_InstalledComponentsDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_InstalledComponentsDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 python $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_ProxyDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 #pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Framework/Test_LoggingDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RSS TESTS ****\n"
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_FullChain.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/ResourceStatusSystem/Test_FullChain.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** WMS TESTS ****\n"
 python $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py $WORKSPACE/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobLoggingDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_TaskQueueDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_ElasticJobDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobLoggingDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_TaskQueueDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_ElasticJobDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** DMS TESTS ****\n"
 ## DFC
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_DataIntegrityDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_DataIntegrityDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 echo "Test DFC DB" 2>&1 | tee -a $SERVER_TEST_OUTPUT
 python $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
@@ -76,7 +76,7 @@ pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_Clien
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RMS TESTS ****\n"
-python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_ReqDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/RequestManagementSystem/Test_ReqDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** MONITORING TESTS ****\n"
@@ -90,4 +90,4 @@ python $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/Storage/Test_Resource
 python $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/ProxyProvider/Test_DIRACCAProxyProvider.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 # Can only run if there's a Stomp MQ local...
-# python -m pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/MessageQueue/Test_ActiveClose.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
+# pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Resources/MessageQueue/Test_ActiveClose.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))


### PR DESCRIPTION
Storage management: https://github.com/DIRACGrid/DIRAC/issues/4322
SecurityLogClient: https://github.com/DIRACGrid/DIRAC/issues/4324
RSS: https://github.com/DIRACGrid/DIRAC/issues/4321



Replaces https://github.com/DIRACGrid/DIRAC/pull/4366

@fstagni @chrisburr : one important change here in the tests is that I call pytest directly instead of as a python module. The only difference it makes is that the local dir is not part of the pythonpath (http://doc.pytest.org/en/latest/usage.html#calling-pytest-through-python-m-pytest) 
All my tests still run fine, so I guess it's ok 

BEGINRELEASENOTES

*Framework
CHANGE: (JSON) use of list instead of tuples for SecurityLog 

*WMS
CHANGE: (JSON) use of list instead of tuples for JobReport and Watchdog

*StorageManagement
CHANGE: (JSON)  use lists instead of tuples

*RMS
CHANGE: (JSON) correct casts for serialization

*DMS
CHANGE: (JSON) correct casts for serialization for FTS

*RSS
CHANGE: (JSON) db ordering uses list instead of tuples

*Core
FIX: M2Crypto transport cast socket.error to strings
CHANGE: (JSON) rpcStub uses list instead of tuples 
NEW: add utilities for JSON Serialization (strToIntDict and ignoreEncodeWarning)

*Tests
CHANGE: call pytest directly instead of as a module

ENDRELEASENOTES
