### PR TITLE
[v7r0] Small fixes

### DIFF
--- a/Core/DISET/AuthManager.py
+++ b/Core/DISET/AuthManager.py
@@ -223,7 +223,7 @@ class AuthManager(object):
     :param credDict: Credentials to ckeck
     :return: Boolean with the result
     """
-    if self.KW_EXTRA_CREDENTIALS in credDict and isinstance(credDict[self.KW_EXTRA_CREDENTIALS], tuple):
+    if self.KW_EXTRA_CREDENTIALS in credDict and isinstance(credDict[self.KW_EXTRA_CREDENTIALS], (tuple, list)):
       if self.KW_DN in credDict:
         retVal = Registry.getHostnameForDN(credDict[self.KW_DN])
         if retVal['OK']:

--- a/Core/DISET/RequestHandler.py
+++ b/Core/DISET/RequestHandler.py
@@ -114,7 +114,7 @@ class RequestHandler(object):
                         of action to execute. The second position is the action itself.
     """
     actionTuple = proposalTuple[1]
-    gLogger.debug("Executing %s:%s action" % actionTuple)
+    gLogger.debug("Executing %s:%s action" % tuple(actionTuple))
     startTime = time.time()
     actionType = actionTuple[0]
     self.serviceInfoDict['actionTuple'] = actionTuple

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -96,7 +96,10 @@ class ARCComputingElement(ComputingElement):
     # For the XRSL additional string from configuration - only done at initialisation time
     # If this string changes, the corresponding (ARC) site directors have to be restarted
     #
-    # Variable = XRSLExtraString (or XRSLMPExtraString for multi processor mode)
+    # Variable = XRSLExtraString (or
+    #
+    #
+    # for multi processor mode)
     # Default value = ''
     #   If you give a value, I think it should be of the form
     #          (aaa = "xxx")
@@ -142,9 +145,7 @@ class ARCComputingElement(ComputingElement):
         if result != '':
           xrslExtraString = result
           gLogger.debug("Found %s : %s" % (xtraVariable, xrslExtraString))
-    if xrslExtraString == '':
-      gLogger.always("No %s found in configuration for %s" % (xtraVariable, self.ceHost))
-    else:
+    if xrslExtraString:
       gLogger.always("%s : %s" % (xtraVariable, xrslExtraString))
       gLogger.always(" --- to be added to pilots going to CE : %s" % self.ceHost)
     return xrslExtraString

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -96,10 +96,7 @@ class ARCComputingElement(ComputingElement):
     # For the XRSL additional string from configuration - only done at initialisation time
     # If this string changes, the corresponding (ARC) site directors have to be restarted
     #
-    # Variable = XRSLExtraString (or
-    #
-    #
-    # for multi processor mode)
+    # Variable = XRSLExtraString (or for multi processor mode)
     # Default value = ''
     #   If you give a value, I think it should be of the form
     #          (aaa = "xxx")

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1212,6 +1212,9 @@ class SiteDirector(AgentModule):
       self.log.exception("Exception during pilot modules files compression", lException=be)
 
     location = Operations().getValue("Pilot/pilotFileServer", '')
+    # Do not instruct pilot to download files if Pilot3 flag is not set
+    if not self.pilot3:
+      location = ''
     localPilot = pilotWrapperScript(pilotFilesCompressedEncodedDict=pilotFilesCompressedEncodedDict,
                                     pilotOptions=pilotOptions,
                                     pilotExecDir=pilotExecDir,


### PR DESCRIPTION
  Several small fixes to make backward compatibility of a v7r1 client accessing v7r0 service.

BEGINRELEASENOTES

*WMS
FIX: SiteDirector - do not add downloading files ti the pilot if Pilot3 flag is False

*Core
FIX: RequestHandler - fix log output for the case where the ActionTuple is actually a string
FIX: AuthManager - manage the case where ExtraCredentials are in a form of a list

ENDRELEASENOTES
