### PR TITLE
[integration] Core: install_site uses curl instead of wget

### DIFF
--- a/Core/scripts/install_site.sh
+++ b/Core/scripts/install_site.sh
@@ -55,7 +55,7 @@ fi
 
 # Get the version of dirac-install requested - if none is requested, the version will come from integration
 #
-wget --no-check-certificate -O dirac-install "https://github.com/DIRACGrid/DIRAC/raw/$DIRACVERSION/Core/scripts/dirac-install.py" || exit
+curl -L -o dirac-install "https://github.com/DIRACGrid/DIRAC/raw/$DIRACVERSION/Core/scripts/dirac-install.py" || exit
 #
 # define the target Dir
 #


### PR DESCRIPTION
CC7 does not have wget by default

BEGINRELEASENOTES

*Core
CHANGE: install_site uses curl instead of wget

ENDRELEASENOTES
