### PR TITLE
[v6r22][URGENT] freeze stomp.py version 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,8 @@ rst2pdf>=0.93
 simplejson>=3.8.1
 six>=1.10
 sqlalchemy>=1.0.9
-stomp.py>=3.1.5
+# more recent version are python 3 only
+stomp.py==4.1.22
 suds-jurko>=0.6
 sphinx
 # typing comes in via m2crypto. newer versions of typing caused an error in hypothesis


### PR DESCRIPTION
Newer releases are python3 only. This results in pylint tests failing with `Instance of 'StompConnection11' has no 'start' member`
Also in https://github.com/DIRACGrid/DIRACOS/pull/109