### PR TITLE
[v7r0] FTS3DB, ReqDB: add pool_recycle to create_engine

### DIFF
--- a/DataManagementSystem/DB/FTS3DB.py
+++ b/DataManagementSystem/DB/FTS3DB.py
@@ -182,7 +182,8 @@ class FTS3DB(object):
          self.dbPort,
          self.dbName),
         echo=runDebug,
-        pool_size=pool_size)
+        pool_size=pool_size,
+        pool_recycle=3600)
 
     metadata.bind = self.engine
 

--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -182,8 +182,9 @@ class RequestDB( object ):
 
 
     runDebug = ( gLogger.getLevel() == 'DEBUG' )
-    self.engine = create_engine( 'mysql://%s:%s@%s:%s/%s' % ( self.dbUser, self.dbPass, self.dbHost, self.dbPort, self.dbName ),
-                                 echo = runDebug )
+    self.engine = create_engine('mysql://%s:%s@%s:%s/%s' %
+                                (self.dbUser, self.dbPass, self.dbHost, self.dbPort, self.dbName),
+                                echo=runDebug, pool_recycle=3600)
 
     metadata.bind = self.engine
 


### PR DESCRIPTION
BEGINRELEASENOTES

*RMS
CHANGE: ReqDB: Add pool_recycle=3600 parameter for sql engine setup, might prevent occasional "Mysql Server has gone away" errors

*DMS
CHANGE: FTS3DB: Add pool_recycle=3600 parameter for sql engine setup, might prevent occasional "Mysql Server has gone away" errors

ENDRELEASENOTES


PS:
We occasionally get this error:

```
2020-01-08 13:16:22 UTC DataManagement/FTS3Manager NOTICE: Returning response ([::ffff:128.142.152.229]:59950)[ilc_fcadmin:sailer] (0.03 secs) ERROR: persistOperation: unexpected exception (_mysql_exceptions.OperationalError) (2006, 'MySQL server has gone away')
```

I think this is because during periods without activity the mysql server will after 8 hours (wait_timeout parameter) close connections. sqlalchemy can be instructed to drop connections after a given time.
https://docs.sqlalchemy.org/en/13/core/pooling.html#setting-pool-recycle

This parameter is already present in the other calls to create_engine.