### PR TITLE
[v7r0] Docs: GITLABTOKEN not mandatory to generate changelog

### DIFF
--- a/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
+++ b/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
@@ -82,7 +82,8 @@ def gitlabSetup():
   LOGGER.info('Setting up GitLab')
   try:
     from GitTokens import GITLABTOKEN
-    SESSION.headers.update({'PRIVATE-TOKEN': GITLABTOKEN})
+    if GITLABTOKEN:
+      SESSION.headers.update({'PRIVATE-TOKEN': GITLABTOKEN})
   except ImportError:
     raise ImportError(G_ERROR)
 


### PR DESCRIPTION

BEGINRELEASENOTES
*Docs
CHANGE: dirac-docs-get-release-notes.py does not require a GITLABTOKEN
ENDRELEASENOTES
