### PR TITLE
[v7r0] JobDB, JobCleaningAgent: add HeartBeatLoggingInfo cleanup functionality

### DIFF
--- a/WorkloadManagementSystem/Agent/JobCleaningAgent.py
+++ b/WorkloadManagementSystem/Agent/JobCleaningAgent.py
@@ -14,6 +14,14 @@
   :caption: JobCleaningAgent options
 
 
+Cleaning HeartBeatLoggingInfo
+-----------------------------
+
+If the HeartBeatLoggingInfo table of the JobDB is too large, the information for finished jobs can be removed (including
+for transformation related jobs). In vanilla DIRAC the HeartBeatLoggingInfo is only used by the StalledJobAgent. For
+this purpose the options MaxHBJobsAtOnce and RemoveStatusDelayHB/[Done|Killed|Failed] should be set to values larger
+than 0.
+
 """
 
 from __future__ import absolute_import
@@ -66,6 +74,7 @@ class JobCleaningAgent(AgentModule):
     self.prodTypes = []
 
     self.removeStatusDelay = {}
+    self.removeStatusDelayHB = {}
 
   #############################################################################
   def initialize(self):
@@ -94,6 +103,11 @@ class JobCleaningAgent(AgentModule):
     self.removeStatusDelay['Failed'] = self.am_getOption('RemoveStatusDelay/Failed', 7)
     self.removeStatusDelay['Any'] = self.am_getOption('RemoveStatusDelay/Any', -1)
 
+    self.removeStatusDelayHB['Done'] = self.am_getOption('RemoveStatusDelayHB/Done', -1)
+    self.removeStatusDelayHB['Killed'] = self.am_getOption('RemoveStatusDelayHB/Killed', -1)
+    self.removeStatusDelayHB['Failed'] = self.am_getOption('RemoveStatusDelayHB/Failed', -1)
+    self.maxHBJobsAtOnce = self.am_getOption('MaxHBJobsAtOnce', 0)
+
     return S_OK()
 
   def _getAllowedJobTypes(self):
@@ -117,6 +131,7 @@ class JobCleaningAgent(AgentModule):
     result = self.removeJobsByStatus({'Status': 'Deleted'})
     if not result['OK']:
       return result
+
     # Get all the Job types that can be cleaned
     result = self._getAllowedJobTypes()
     if not result['OK']:
@@ -140,6 +155,12 @@ class JobCleaningAgent(AgentModule):
       result = self.removeJobsByStatus(condDict, delTime)
       if not result['OK']:
         gLogger.warn('Failed to remove jobs in status %s' % status)
+
+    if self.maxHBJobsAtOnce > 0:
+      for status, delay in self.removeStatusDelayHB.items():
+        if delay > 0:
+          self.removeHeartBeatLoggingInfo(status, delay)
+
     return S_OK()
 
   def removeJobsByStatus(self, condDict, delay=False):
@@ -284,3 +305,19 @@ class JobCleaningAgent(AgentModule):
     oRequest.addOperation(removeFile)
 
     return ReqClient().putRequest(oRequest)
+
+  def removeHeartBeatLoggingInfo(self, status, delayDays):
+    """Remove HeartBeatLoggingInfo for jobs with given status after given number of days.
+
+    :param str status: Job Status
+    :param int delayDays: number of days after which information is removed
+    :returns: None
+    """
+    gLogger.info("Removing HeartBeatLoggingInfo for Jobs with %s and older than %s day(s)" % (status, delayDays))
+    delTime = str(Time.dateTime() - delayDays * Time.day)
+    result = self.jobDB.removeInfoFromHeartBeatLogging(status, delTime, self.maxHBJobsAtOnce)
+    if not result['OK']:
+      gLogger.error('Failed to delete from HeartBeatLoggingInfo', result['Message'])
+    else:
+      gLogger.info('Deleted HeartBeatLogging info')
+    return

--- a/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -139,6 +139,9 @@ Agents
     #Maximum number of jobs to be processed in one cycle
     MaxJobsAtOnce = 500
 
+    # Maximum number of jobs to be processed in one cycle for HeartBeatLoggingInfo removal
+    MaxHBJobsAtOnce = 0
+
     # Delete jobs individually, if True
     JobByJob = False
 
@@ -155,6 +158,16 @@ Agents
        Failed = 7
        # Number of days after which any jobs, irrespective of status is removed (-1 for disabling this feature)
        Any = -1
+    }
+
+    RemoveStatusDelayHB
+    {
+       # Number of days after which HeartBeatLoggingInfo for Done jobs are removed, positive to enable
+       Done = -1
+       # Number of days after which HeartBeatLoggingInfo for Killed jobs are removed
+       Killed = -1
+       # Number of days after which HeartBeatLoggingInfo for Failed jobs are removed
+       Failed = -1
     }
 
     # Which production type jobs _not_ to remove, takes default from Operations/Transformations/DataProcessing

--- a/tests/Integration/WorkloadManagementSystem/Test_JobDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_JobDB.py
@@ -8,6 +8,8 @@
 
 from __future__ import print_function, absolute_import
 
+from datetime import datetime, timedelta
+
 __RCSID__ = "$Id$"
 
 from DIRAC.Core.Base.Script import parseCommandLine
@@ -102,3 +104,40 @@ def test_getCounters():
 
   res = jobDB.getCounters('Jobs', ['Status', 'MinorStatus'], {}, '2007-04-22 00:00:00')
   assert res['OK'] is True
+
+
+def test_heartBeatLogging():
+
+  res = jobDB.insertNewJobIntoDB(jdl, 'owner', '/DN/OF/owner', 'ownerGroup', 'someSetup')
+  assert res['OK'] is True
+  jobID = res['JobID']
+
+  res = jobDB.setJobStatus(jobID, status='Running')
+  assert res['OK'] is True
+  res = jobDB.setHeartBeatData(jobID, staticDataDict={}, dynamicDataDict={'CPU': 2345})
+  assert res['OK'] is True
+  res = jobDB.setHeartBeatData(jobID, staticDataDict={}, dynamicDataDict={'Memory': 5555})
+  assert res['OK'] is True
+  res = jobDB.getHeartBeatData(jobID)
+  assert res['OK'] is True
+  assert len(res['Value']) == 2, str(res)
+
+  for name, value, _hbt in res['Value']:
+    if name == 'Memory':
+      assert value == '5555.0'
+    elif name == 'CPU':
+      assert value == '2345.0'
+    else:
+      assert False, 'Unknown entry: %s: %s' % (name, value)
+
+  res = jobDB.setJobStatus(jobID, status='Done')
+  assert res['OK'] is True
+
+  tomorrow = datetime.today() + timedelta(1)
+  delTime = datetime.strftime(tomorrow, '%Y-%m-%d')
+  res = jobDB.removeInfoFromHeartBeatLogging(status='Done', delTime=delTime, maxLines=100)
+  assert res['OK'] is True, str(res)
+
+  res = jobDB.getHeartBeatData(jobID)
+  assert res['OK'] is True, str(res)
+  assert not res['Value'], str(res)


### PR DESCRIPTION
BEGINRELEASENOTES

*WMS
NEW: JobCleaningAgent: Add possibility to remove HeartBeatLoggingInfo before jobs are completely removed.

ENDRELEASENOTES

By the way, I couldn't find anything in LHCbDIRAC which uses information from the HeartBeatLoggingInfo table:
https://gitlab.cern.ch/search?utf8=%E2%9C%93&search=heartbeat&group_id=&project_id=3588&search_code=true&repository_ref=master&nav_source=navbar
