### PR TITLE
[v7r0] WMS.Limiter: move some variables to class static level, fix matchingdelay

### DIFF
--- a/WorkloadManagementSystem/Client/Limiter.py
+++ b/WorkloadManagementSystem/Client/Limiter.py
@@ -15,14 +15,16 @@ from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 
 class Limiter(object):
 
+  # static variables shared between all instances of this class
+  csDictCache = DictCache()
+  condCache = DictCache()
+  delayMem = {}
+
   def __init__(self, jobDB=None, opsHelper=None):
     """ Constructor
     """
     self.__runningLimitSection = "JobScheduling/RunningLimit"
     self.__matchingDelaySection = "JobScheduling/MatchingDelay"
-    self.csDictCache = DictCache()
-    self.condCache = DictCache()
-    self.delayMem = {}
 
     if jobDB:
       self.jobDB = jobDB


### PR DESCRIPTION
I think this fixes the matching delay functionality. 

BEGINRELEASENOTES
*WMS
FIX: Fix the matching delay functionality, fixes #2983 

ENDRELEASENOTES
