### PR TITLE
[v7r0] Fix SLC6 integration tests and allow installation from local DIRACOS tarball

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,6 +31,7 @@ jobs:
         echo "IFS=\$'\n\t'" >> run_in_container
         echo -n "exec docker exec -w /repo " >> run_in_container
         # Set environment variables
+        echo -n "-e HOST_OS=${{ matrix.HOST_OS }} " >> run_in_container
         echo -n "-e CI_PROJECT_DIR=/repo " >> run_in_container
         echo -n "-e CI_COMMIT_REF_NAME=$GITHUB_REF " >> run_in_container
         echo -n "-e CI_REGISTRY_IMAGE=diracgrid " >> run_in_container

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,6 +34,7 @@ jobs:
         echo -n "-e HOST_OS=${{ matrix.HOST_OS }} " >> run_in_container
         echo -n "-e CI_PROJECT_DIR=/repo " >> run_in_container
         echo -n "-e CI_COMMIT_REF_NAME=$GITHUB_REF " >> run_in_container
+        echo -n "-e CI_MERGE_REQUEST_TARGET_BRANCH_NAME=$GITHUB_BASE_REF " >> run_in_container
         echo -n "-e CI_REGISTRY_IMAGE=diracgrid " >> run_in_container
         echo -n "-e MYSQL_VER=${{ matrix.MYSQL_VER }} " >> run_in_container
         echo -n "-e ES_VER=${{ matrix.ES_VER }} " >> run_in_container

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2319,14 +2319,24 @@ def installDiracOS(releaseConfig):
 
   :param str releaseConfig: the version of the DIRAC OS
   """
-  diracos, diracOSVersion = releaseConfig.getDiracOSVersion(cliParams.diracOSVersion)
+  tarsURL = None
+  if cliParams.diracOSVersion and cliParams.diracOSVersion.endswith('.tar.gz'):
+    logNOTICE('Using specified DIRACOS tarball from %s' % cliParams.diracOSVersion)
+    tarsURL = os.path.dirname(cliParams.diracOSVersion)
+    tarsFnSplit = os.path.basename(cliParams.diracOSVersion)[:-len('.tar.gz')].split('-')
+    if len(tarsFnSplit) < 2:
+      logERROR('DIRACOS tarball filename should be of the form %s-%s.tar.gz!')
+      sys.exit(1)
+    diracos = tarsFnSplit[0]
+    diracOSVersion = '-'.join(tarsFnSplit[1:])
+  else:
+    diracos, diracOSVersion = releaseConfig.getDiracOSVersion(cliParams.diracOSVersion)
   if not diracOSVersion:
     logERROR("No diracos defined")
     return False
-  tarsURL = None
   if cliParams.installSource:
     tarsURL = cliParams.installSource
-  else:
+  elif not tarsURL:
     # if ":" is not present in diracos name, we take the diracos tarball from vanilla DIRAC location
     if diracos.lower() == 'diracos':
       retVal = releaseConfig.getDiracOsLocation(diracosDefault=True)

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2319,24 +2319,14 @@ def installDiracOS(releaseConfig):
 
   :param str releaseConfig: the version of the DIRAC OS
   """
-  tarsURL = None
-  if cliParams.diracOSVersion and cliParams.diracOSVersion.endswith('.tar.gz'):
-    logNOTICE('Using specified DIRACOS tarball from %s' % cliParams.diracOSVersion)
-    tarsURL = os.path.dirname(cliParams.diracOSVersion)
-    tarsFnSplit = os.path.basename(cliParams.diracOSVersion)[:-len('.tar.gz')].split('-')
-    if len(tarsFnSplit) < 2:
-      logERROR('DIRACOS tarball filename should be of the form %s-%s.tar.gz!')
-      sys.exit(1)
-    diracos = tarsFnSplit[0]
-    diracOSVersion = '-'.join(tarsFnSplit[1:])
-  else:
-    diracos, diracOSVersion = releaseConfig.getDiracOSVersion(cliParams.diracOSVersion)
+  diracos, diracOSVersion = releaseConfig.getDiracOSVersion(cliParams.diracOSVersion)
   if not diracOSVersion:
     logERROR("No diracos defined")
     return False
+  tarsURL = None
   if cliParams.installSource:
     tarsURL = cliParams.installSource
-  elif not tarsURL:
+  else:
     # if ":" is not present in diracos name, we take the diracos tarball from vanilla DIRAC location
     if diracos.lower() == 'diracos':
       retVal = releaseConfig.getDiracOsLocation(diracosDefault=True)

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -676,6 +676,8 @@ class ReleaseConfig(object):
     for arg in args:
       if len(arg) > 4 and arg.find(".cfg") == len(arg) - 4 and ':::' not in arg:
         fileName = arg
+      else:
+        continue
 
       logNOTICE("Defaults for LocalInstallation are in %s" % fileName)
       try:

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -758,12 +758,12 @@ class ReleaseConfig(object):
     keysToConsider = []
     if not useVanillaDiracOS:
       keysToConsider += [
-        "Installations/%s/DIRACOS" % self.projectName,
-        "Projects/%s/DIRACOS" % self.projectName,
+          "Installations/%s/DIRACOS" % self.projectName,
+          "Projects/%s/DIRACOS" % self.projectName,
       ]
     keysToConsider += [
-      "Installations/DIRAC/DIRACOS",
-      "Projects/DIRAC/DIRACOS",
+        "Installations/DIRAC/DIRACOS",
+        "Projects/DIRAC/DIRACOS",
     ]
 
     for key in keysToConsider:

--- a/tests/CI/CONFIG
+++ b/tests/CI/CONFIG
@@ -31,6 +31,7 @@ export TESTREPO=${TESTREPO:-antolu}
 export TESTBRANCH=${TESTBRANCH:-ci}
 
 export DIRACOSVER=${DIRACOSVER:-master}
+export DIRACOS_TARBALL_PATH=${DIRACOS_TARBALL_PATH:-}
 
 # Versions of external services
 export MYSQL_VER=${MYSQL_VER:-5.7}

--- a/tests/CI/install_client.sh
+++ b/tests/CI/install_client.sh
@@ -51,13 +51,4 @@ if [ -z "$DIRAC_RELEASE" ]; then
     export DIRAC_RELEASE=$projectVersion
 fi
 
-if [ "$ALTERNATIVE_MODULES" ]; then
-  echo "Installing from non-release code"
-  if [[ -d $ALTERNATIVE_MODULES ]]; then
-    INSTALLOPTIONS+="--module=$ALTERNATIVE_MODULES:::DIRAC:::local"
-  else
-    INSTALLOPTIONS+="--module=$ALTERNATIVE_MODULES"
-  fi
-fi
-
 installDIRAC

--- a/tests/CI/run_docker_setup.sh
+++ b/tests/CI/run_docker_setup.sh
@@ -46,25 +46,44 @@ function prepareEnvironment() {
     echo "export DIRACOSVER=${DIRACOSVER}"
   } >> "${SERVERCONFIG}"
   if [[ -n $CI_PROJECT_DIR ]]; then
-      echo "I guess we're in GitLab CI, using local repository in branch ${CI_COMMIT_REF_NAME}"
+      echo "I guess we're in GitLab CI/CD or GitHub Actions, using local repository in branch ${CI_COMMIT_REF_NAME}"
+      echo "if this is a merge request, the target is ${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}"
       export TESTREPO=$CI_PROJECT_DIR
       export ALTERNATIVE_MODULES=$CI_PROJECT_DIR
 
-      # find the latest version
+      # find the latest version, unless it's integration
       if [ "${CI_COMMIT_REF_NAME}" = 'refs/heads/integration' ]; then
-          export DIRACBRANCH=integration
+          export DIRAC_RELEASE=integration
+
+          {
+            echo "export TESTREPO=${TESTREPO}"
+            echo "export ALTERNATIVE_MODULES=${ALTERNATIVE_MODULES}"
+            echo "export DIRAC_RELEASE=${DIRAC_RELEASE}"
+          } >> "${SERVERCONFIG}"
+
+      elif [ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}" = 'integration' ]; then
+          export DIRAC_RELEASE=integration
+
+          {
+            echo "export TESTREPO=${TESTREPO}"
+            echo "export ALTERNATIVE_MODULES=${ALTERNATIVE_MODULES}"
+            echo "export DIRAC_RELEASE=${DIRAC_RELEASE}"
+          } >> "${SERVERCONFIG}"
+
       else
           majorVersion=$(grep "majorVersion =" "${TESTREPO}/__init__.py" | cut -d "=" -f 2)
           minorVersion=$(grep "minorVersion =" "${TESTREPO}/__init__.py" | cut -d "=" -f 2)
           export DIRACBRANCH=v${majorVersion// }r${minorVersion// }
           echo "Deduced DIRACBRANCH ${DIRACBRANCH} from __init__.py"
+
+          {
+            echo "export TESTREPO=${TESTREPO}"
+            echo "export ALTERNATIVE_MODULES=${ALTERNATIVE_MODULES}"
+            echo "export DIRACBRANCH=${DIRACBRANCH}"
+          } >> "${SERVERCONFIG}"
+
       fi
 
-      {
-        echo "export TESTREPO=${TESTREPO}"
-        echo "export ALTERNATIVE_MODULES=${ALTERNATIVE_MODULES}"
-        echo "export DIRACBRANCH=${DIRACBRANCH}"
-      } >> "${SERVERCONFIG}"
   fi
   cp "${SERVERCONFIG}" "${CLIENTCONFIG}"
 

--- a/tests/CI/run_docker_setup.sh
+++ b/tests/CI/run_docker_setup.sh
@@ -44,6 +44,7 @@ function prepareEnvironment() {
   cp ./CONFIG "${SERVERCONFIG}"
   {
     echo "export DIRACOSVER=${DIRACOSVER}"
+    echo "export DIRACOS_TARBALL_PATH=${DIRACOS_TARBALL_PATH}"
   } >> "${SERVERCONFIG}"
   if [[ -n $CI_PROJECT_DIR ]]; then
       echo "I guess we're in GitLab CI/CD or GitHub Actions, using local repository in branch ${CI_COMMIT_REF_NAME}"

--- a/tests/CI/run_docker_setup.sh
+++ b/tests/CI/run_docker_setup.sh
@@ -42,6 +42,9 @@ function prepareEnvironment() {
 
   # GitLab variables
   cp ./CONFIG "${SERVERCONFIG}"
+  {
+    echo "export DIRACOSVER=${DIRACOSVER}"
+  } >> "${SERVERCONFIG}"
   if [[ -n $CI_PROJECT_DIR ]]; then
       echo "I guess we're in GitLab CI, using local repository in branch ${CI_COMMIT_REF_NAME}"
       export TESTREPO=$CI_PROJECT_DIR

--- a/tests/CI/run_docker_setup.sh
+++ b/tests/CI/run_docker_setup.sh
@@ -100,9 +100,11 @@ function installServer() {
   docker cp server:"$WORKSPACE/ServerInstallDIR/user/client.pem" - | docker cp - client:"$WORKSPACE/ServerInstallDIR/user/"
   docker cp server:"$WORKSPACE/ServerInstallDIR/user/client.key" - | docker cp - client:"$WORKSPACE/ServerInstallDIR/user/"
   docker exec client bash -c "cp $WORKSPACE/ServerInstallDIR/user/client.* $USER_HOME/.globus/"
-  docker cp server:/tmp/x509up_u1000 - | docker cp - client:/tmp/
+  server_uid=$(docker exec -u dirac server bash -c 'echo $UID')
+  client_uid=$(docker exec -u dirac client bash -c 'echo $UID')
+  docker cp "server:/tmp/x509up_u${server_uid}" - | docker cp - client:/tmp/
   docker exec client bash -c "chown -R dirac:dirac /home/dirac"
-  docker exec client bash -c "chown -R dirac:dirac /tmp/x509up_u1000"
+  docker exec client bash -c "chown -R dirac:dirac /tmp/x509up_u${client_uid}"
 }
 
 function installClient() {

--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -100,6 +100,7 @@ function installSite(){
   generateCA
   generateCertificates
 
+  echo -n > "$SERVERINSTALLDIR/dirac-ci-install.cfg"
   getCFGFile
 
   echo "==> Fixing install.cfg file"

--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -119,18 +119,14 @@ function installSite(){
 
   installOptions="$DEBUG "
 
-  # If DIRACOSVER is not defined, use LcgBundle
   if [ "$DIRACOSVER" ]; then
-    if [ "$DIRACOSVER" == True ]; then
-      echo "Installing with DIRACOS"
-      installOptions+="--dirac-os "
-    else
-      echo "Installing with DIRACOS $DIRACOSVER"
-      installOptions+="--dirac-os --dirac-os-version=$DIRACOSVER "
-    fi
-  else
-    echo "Installing using externals + lcgBundle"
-    installOptions+="-t fullserver "
+    installOptions+="--dirac-os --dirac-os-version=$DIRACOSVER "
+  fi
+
+  if [ "$DIRACOS_TARBALL_PATH" ]; then
+    {
+      echo "DIRACOS = $DIRACOS_TARBALL_PATH"
+    } >> "$SERVERINSTALLDIR/dirac-ci-install.cfg"
   fi
 
   if [ "$ALTERNATIVE_MODULES" ]; then
@@ -144,7 +140,7 @@ function installSite(){
 
   echo "==> Installing with options $installOptions $SERVERINSTALLDIR/install.cfg"
 
-  if ! "$SERVERINSTALLDIR/dirac-install.py" $installOptions "$SERVERINSTALLDIR/install.cfg"; then
+  if ! "$SERVERINSTALLDIR/dirac-install.py" $installOptions "$SERVERINSTALLDIR/install.cfg" "$SERVERINSTALLDIR/dirac-ci-install.cfg"; then
     echo "ERROR: dirac-install.py failed"
     exit 1
   fi

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -299,6 +299,8 @@ function getCFGFile(){
 #   --UseServerCertificate -o /DIRAC/Security/CertFile=some/location.pem -o /DIRAC/Security/KeyFile=some/location.pem
 
 function installDIRAC(){
+  echo -n > "$CLIENTINSTALLDIR/dirac-ci-install.cfg"
+
   echo '==> Installing DIRAC client'
   if ! cd "$CLIENTINSTALLDIR"; then
     echo "ERROR: cannot change to $CLIENTINSTALLDIR"

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -308,6 +308,7 @@ function installDIRAC(){
   cp "$TESTCODE/DIRAC/Core/scripts/dirac-install.py" "$CLIENTINSTALLDIR/dirac-install"
   chmod +x "$CLIENTINSTALLDIR/dirac-install"
 
+  export CLIENT_ALTERNATIVE_MODULES=${CLIENT_ALTERNATIVE_MODULES:-ALTERNATIVE_MODULES}
   if [ "$CLIENT_ALTERNATIVE_MODULES" ]; then
     echo "Installing from non-release code"
     if [[ -d "$CLIENT_ALTERNATIVE_MODULES" ]]; then
@@ -321,7 +322,13 @@ function installDIRAC(){
     INSTALLOPTIONS+=" --dirac-os --dirac-os-version=$DIRACOSVER "
   fi
 
-  if ! ./dirac-install -r $DIRAC_RELEASE -t client $INSTALLOPTIONS $DEBUG; then
+  if [ "$DIRACOS_TARBALL_PATH" ]; then
+    {
+      echo "DIRACOS = $DIRACOS_TARBALL_PATH"
+    } >> "$CLIENTINSTALLDIR/dirac-ci-install.cfg"
+  fi
+
+  if ! ./dirac-install -r $DIRAC_RELEASE -t client $INSTALLOPTIONS "$CLIENTINSTALLDIR/dirac-ci-install.cfg" $DEBUG; then
     echo 'ERROR: DIRAC client installation failed'
     exit 1
   fi

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -311,10 +311,14 @@ function installDIRAC(){
   if [ "$CLIENT_ALTERNATIVE_MODULES" ]; then
     echo "Installing from non-release code"
     if [[ -d "$CLIENT_ALTERNATIVE_MODULES" ]]; then
-      INSTALLOPTIONS+="--module=$CLIENT_ALTERNATIVE_MODULES:::DIRAC:::local"
+      INSTALLOPTIONS+=" --module=$CLIENT_ALTERNATIVE_MODULES:::DIRAC:::local"
     else
-      INSTALLOPTIONS+="--module=$CLIENT_ALTERNATIVE_MODULES"
+      INSTALLOPTIONS+=" --module=$CLIENT_ALTERNATIVE_MODULES"
     fi
+  fi
+
+  if [ "$DIRACOSVER" ]; then
+    INSTALLOPTIONS+=" --dirac-os --dirac-os-version=$DIRACOSVER "
   fi
 
   if ! ./dirac-install -r $DIRAC_RELEASE -t client $INSTALLOPTIONS $DEBUG; then


### PR DESCRIPTION
Currently all integration tests are being ran with CentOS 7 due to `HOST_OS` not being propagated correctly. This exposes an issue with the images which is fixed in https://github.com/DIRACGrid/management/pull/1.

This PR also allows `--dirac-os-version` to be a path so that DIRAC OS tarballs can be tested without them being uploaded to EOS (will be used in an upcoming DIRAC OS PR).

BEGINRELEASENOTES

*Core
NEW: Allow `--dirac-os-version` argument to `dirac-install.py` to be a path or URL to a tarball

ENDRELEASENOTES
