### PR TITLE
[v6r22] ComputingElement: make WaitingToRunningRatio be configurable from CED…

### DIFF
--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -46,7 +46,7 @@ from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 __RCSID__ = "$Id$"
 
 INTEGER_PARAMETERS = ['CPUTime', 'NumberOfProcessors']
-FLOAT_PARAMETERS = []
+FLOAT_PARAMETERS = ['WaitingToRunningRatio']
 LIST_PARAMETERS = ['Tag', 'RequiredTag']
 WAITING_TO_RUNNING_RATIO = 0.5
 MAX_WAITING_JOBS = 1

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -378,6 +378,7 @@ class SiteDirector(AgentModule):
             queueCECache[queueName]['CE'] = result['Value']
             queueCE = queueCECache[queueName]['CE']
 
+          self.queueDict[queueName]['ParametersDict'].update(queueCE.ceParameters)
           self.queueDict[queueName]['CE'] = queueCE
           self.queueDict[queueName]['CEName'] = ce
           self.queueDict[queueName]['CEType'] = ceDict['CEType']


### PR DESCRIPTION
…efaults

And forward the ceParameters to the queue parameters so the CEDefaults
are used if there are no settings for the queue

BEGINRELEASENOTES
*Resources
FIX: Enable setting of WaitingToRunningRatio from Global CE Defaults, fixes #4368 

*WMS
FIX: Fix bug preventing use of global CE Defaults in SiteDirector, fixes #4368 

ENDRELEASENOTES
