### PR TITLE
[v6r22] SystemAdministrator: do not start runsvdir if not needed

### DIFF
--- a/FrameworkSystem/Client/ComponentInstaller.py
+++ b/FrameworkSystem/Client/ComponentInstaller.py
@@ -1617,11 +1617,11 @@ class ComponentInstaller(object):
           DIRAC.exit(-1)
         return S_ERROR(result['Message'])
       processList = result['Value'][1].split('\n')
-      cmd = 'runsvdir %s' % self.startDir
-      cmdFound = False
-      for process in processList:
-        if process.find(cmd) != -1:
-          cmdFound = True
+
+      # it is pointless to look for more detailed command.
+      # Nobody uses runsvdir.... so if it is there, it is us.
+      cmdFound = any(['runsvdir' in process for process in processList])
+
       if not cmdFound:
         gLogger.notice('Starting runsvdir ...')
         os.system("runsvdir %s 'log:  DIRAC runsv' &" % self.startDir)


### PR DESCRIPTION
Partially solves https://github.com/DIRACGrid/DIRAC/issues/4408

BEGINRELEASENOTES

*Subsystem
CHANGE: the ComponentInstaller is a bit more relaxed when looking for runsvdir

ENDRELEASENOTES
