### PR TITLE
[v6r22] Check for runsvdir more carefully

### DIFF
--- a/FrameworkSystem/Client/ComponentInstaller.py
+++ b/FrameworkSystem/Client/ComponentInstaller.py
@@ -1618,9 +1618,8 @@ class ComponentInstaller(object):
         return S_ERROR(result['Message'])
       processList = result['Value'][1].split('\n')
 
-      # it is pointless to look for more detailed command.
-      # Nobody uses runsvdir.... so if it is there, it is us.
-      cmdFound = any(['runsvdir' in process for process in processList])
+      cmdFound = any(['runsvdir' in process and self.startDir in process
+                      for process in processList])
 
       if not cmdFound:
         gLogger.notice('Starting runsvdir ...')


### PR DESCRIPTION
@chaen This is needed to fix the integration tests after #4415 as `runsvdir` is already running in the `diracgrid/slc6-dirac` container. Thoughts?

BEGINRELEASENOTES

*Core
FIX: Improve runsvdir detection

ENDRELEASENOTES
