### PR TITLE
[v7r1] File catalog metadata methods split 

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -37,13 +37,13 @@ class DirectoryMetadata:
     result = self.db.fmeta.getFileMetadataFields(credDict)
     if not result['OK']:
       return result
-    if pName in result['Value'].keys():
+    if pName in result['Value']:
       return S_ERROR('The metadata %s is already defined for Files' % pName)
 
     result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
-    if pName in result['Value'].keys():
+    if pName in result['Value']:
       if pType.lower() == result['Value'][pName].lower():
         return S_OK('Already exists')
       return S_ERROR('Attempt to add an existing metadata with different type: %s/%s' %
@@ -268,7 +268,7 @@ class DirectoryMetadata:
           failedMeta[meta] = result['Value']
 
     if failedMeta:
-      metaExample = failedMeta.keys()[0]
+      metaExample = list(failedMeta)[0]
       result = S_ERROR('Failed to remove %d metadata, e.g. %s' % (len(failedMeta), failedMeta[metaExample]))
       result['FailedMetadata'] = failedMeta
     else:
@@ -398,7 +398,7 @@ class DirectoryMetadata:
     dirDict = {}
     for dirID, meta in result['Value']:
       dirDict[dirID] = meta
-    dirList = dirDict.keys()
+    dirList = list(dirDict)
 
     # Exclude child directories from the list
     for dirID in dirList:
@@ -407,7 +407,7 @@ class DirectoryMetadata:
         return result
       if not result['Value']:
         continue
-      childIDs = result['Value'].keys()
+      childIDs = list(result['Value'])
       for childID in childIDs:
         if childID in dirList:
           del dirList[dirList.index(childID)]
@@ -612,7 +612,7 @@ class DirectoryMetadata:
 
     # Now check the meta data for the requested directory and its parents
     finalMetaDict = dict(metaDict)
-    for meta in metaDict.keys():
+    for meta in metaDict:
       result = self.__checkDirsForMetadata(meta, metaDict[meta], pathString)
       if not result['OK']:
         return result
@@ -652,7 +652,7 @@ class DirectoryMetadata:
         result = self.db.dtree.getSubdirectoriesByID(pathDirID, includeParent=True)
         if not result['OK']:
           return result
-        pathDirList = result['Value'].keys()
+        pathDirList = list(result['Value'])
 
     finalList = []
     dirSelect = False
@@ -710,7 +710,7 @@ class DirectoryMetadata:
       return result
 
     dirDict = result['Value']
-    dirList = dirDict.keys()
+    dirList = list(dirDict)
     fileList = []
     result = self.db.dtree.getFilesInDirectory(dirList, credDict)
     if not result['OK']:
@@ -815,7 +815,7 @@ class DirectoryMetadata:
       if not result['OK']:
         return result
       if result['Value']:
-        pathDirs = result['Value'].keys()
+        pathDirs = list(result['Value'])
       result = self.db.dtree.getPathIDsByID(pathDirID)
       if not result['OK']:
         return result
@@ -827,7 +827,7 @@ class DirectoryMetadata:
     if not result['OK']:
       return result
     metaFields = result['Value']
-    comFields = metaFields.keys()
+    comFields = list(metaFields)
 
     # Commented out to return compatible data also for selection metadata
     # for m in metaDict:

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -234,7 +234,6 @@ class DirectoryMetadata:
   def removeMetadata(self, dpath, metadata, credDict):
     """ Remove the specified metadata for the given directory
 
-        Remove the specified metadata for the given directory for users own VO.
         :param str dpath: directory path
         :param dict metadata: metadata dictionary
         :param dict credDict: client credential dictionary

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -11,7 +11,7 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Time import queryTime
 
 
-class DirectoryMetadata:
+class DirectoryMetadata(object):
 
   def __init__(self, database=None):
 

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -135,7 +135,7 @@ class DirectoryMetadata(object):
 
         :return: S_OK/S_ERROR
     """
-    result = self.getMetadataFields(credDict)
+    result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
     metaTypeDict = result['Value']
@@ -167,7 +167,7 @@ class DirectoryMetadata(object):
 
         :return: S_OK/S_ERROR, Value dictionary of the meta set definition contents
     """
-    result = self.getMetadataFields(credDict)
+    result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
     metaTypeDict = result['Value']
@@ -212,7 +212,7 @@ class DirectoryMetadata(object):
 
         :return: S_OK/S_ERROR
     """
-    result = self.getMetadataFields(credDict)
+    result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
     metaFields = result['Value']
@@ -258,7 +258,7 @@ class DirectoryMetadata(object):
         :return: standard Dirac result object
     """
 
-    result = self.getMetadataFields(credDict)
+    result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
     metaFields = result['Value']
@@ -378,7 +378,7 @@ class DirectoryMetadata(object):
       return result
     pathIDs = result['Value']
 
-    result = self.getMetadataFields(credDict)
+    result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
     metaFields = result['Value']
@@ -601,7 +601,7 @@ class DirectoryMetadata(object):
 
         :return: S_OK/S_ERROR , Value dictionary of metadata
     """
-    result = self.getMetadataFields(credDict)
+    result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
     metaTypeDict = result['Value']
@@ -937,7 +937,7 @@ class DirectoryMetadata(object):
         pathDirs += result['Value']
 
     # Get the list of metadata fields to inspect
-    result = self.getMetadataFields(credDict)
+    result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
     metaFields = result['Value']
@@ -994,7 +994,7 @@ class DirectoryMetadata(object):
     dirListString = ','.join([str(d) for d in dirs])
 
     # Get the list of metadata fields to inspect
-    result = self.getMetadataFields(credDict)
+    result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
     metaFields = result['Value']

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -36,7 +36,7 @@ class DirectoryMetadata:
     if pname in result['Value'].keys():
       return S_ERROR('The metadata %s is already defined for Files' % pname)
 
-    result = self.getMetadataFields(credDict)
+    result = self._getMetadataFields(credDict)
     if not result['OK']:
       return result
     if pname in result['Value'].keys():
@@ -92,6 +92,18 @@ class DirectoryMetadata:
 
   def getMetadataFields(self, credDict):
     """ Get all the defined metadata fields
+
+        :param dict credDict: client credential dictionary
+        :return: S_OK/S_ERROR, Value is the metadata:metadata type dictionary
+    """
+
+    return self._getMetadataFields(credDict)
+
+  def _getMetadataFields(self, credDict):
+    """ Get all the defined metadata fields as they are defined in the database
+
+        :param dict credDict: client credential dictionary
+        :return: S_OK/S_ERROR, Value is the metadata:metadata type dictionary
     """
 
     req = "SELECT MetaName,MetaType FROM FC_MetaFields"
@@ -212,7 +224,14 @@ class DirectoryMetadata:
 
   def removeMetadata(self, dpath, metadata, credDict):
     """ Remove the specified metadata for the given directory
+
+        Remove the specified metadata for the given directory for users own VO.
+        :param str dpath: directory path
+        :param dict metadata: metadata dictionary
+        :param dict credDict: client credential dictionary
+        :return: standard Dirac result object
     """
+
     result = self.getMetadataFields(credDict)
     if not result['OK']:
       return result
@@ -263,7 +282,7 @@ class DirectoryMetadata:
                                   [dirID, metaName, str(metaValue)])
     return result
 
-  def getDirectoryMetaParameters(self, dpath, credDict, inherited=True, owndata=True):
+  def getDirectoryMetaParameters(self, dpath, credDict, inherited=True):
     """ Get meta parameters for the given directory
     """
     if inherited:
@@ -303,7 +322,7 @@ class DirectoryMetadata:
 
     return S_OK(metaDict)
 
-  def getDirectoryMetadata(self, path, credDict, inherited=True, owndata=True):
+  def getDirectoryMetadata(self, path, credDict, inherited=True, ownData=True):
     """ Get metadata for the given directory aggregating metadata for the directory itself
         and for all the parent directories if inherited flag is True. Get also the non-indexed
         metadata parameters.
@@ -325,7 +344,7 @@ class DirectoryMetadata:
     dirID = pathIDs[-1]
     if not inherited:
       pathIDs = pathIDs[-1:]
-    if not owndata:
+    if not ownData:
       pathIDs = pathIDs[:-1]
     pathString = ','.join([str(x) for x in pathIDs])
 

--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -206,7 +206,7 @@ class DirectoryMetadata:
       return S_ERROR('Path not found: %s' % dpath)
     dirID = result['Value']
 
-    dirmeta = self.getDirectoryMetadata(dpath, credDict, owndata=False)
+    dirmeta = self.getDirectoryMetadata(dpath, credDict, ownData=False)
     if not dirmeta['OK']:
       return dirmeta
 
@@ -372,7 +372,7 @@ class DirectoryMetadata:
       metaTypeDict[meta] = metaFields[meta]
 
     # Get also non-searchable data
-    result = self.getDirectoryMetaParameters(path, credDict, inherited, ownData)
+    result = self.getDirectoryMetaParameters(path, credDict, inherited)
     if result['OK']:
       metaDict.update(result['Value'])
       for meta in result['Value']:

--- a/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
@@ -78,6 +78,7 @@ class FileMetadata:
     """ Remove metadata field
 
         :param str pName: meta parameter name
+        :param dict credDict: client credential dictionary
 
         :return: S_OK/S_ERROR
     """

--- a/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
@@ -12,7 +12,7 @@ from DIRAC.DataManagementSystem.Client.MetaQuery import FILE_STANDARD_METAKEYS, 
     FILEINFO_TABLE_METAKEYS
 
 
-class FileMetadata:
+class FileMetadata(object):
 
   def __init__(self, database=None):
 

--- a/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
@@ -41,13 +41,13 @@ class FileMetadata(object):
     result = self.db.dmeta.getMetadataFields(credDict)
     if not result['OK']:
       return result
-    if pName in result['Value'].keys():
+    if pName in result['Value']:
       return S_ERROR('The metadata %s is already defined for Directories' % pName)
 
     result = self.getFileMetadataFields(credDict)
     if not result['OK']:
       return result
-    if pName in result['Value'].keys():
+    if pName in result['Value']:
       if pType.lower() == result['Value'][pName].lower():
         return S_OK('Already exists')
       else:
@@ -206,7 +206,7 @@ class FileMetadata(object):
           failedMeta[meta] = result['Value']
 
     if failedMeta:
-      metaExample = failedMeta.keys()[0]
+      metaExample = list(failedMeta)[0]
       result = S_ERROR('Failed to remove %d metadata, e.g. %s' % (len(failedMeta), failedMeta[metaExample]))
       result['FailedMetadata'] = failedMeta
     else:
@@ -709,7 +709,7 @@ class FileMetadata(object):
     result = self.getFileMetadataFields(credDict)
     if not result['OK']:
       return result
-    fileMetaKeys = result['Value'].keys() + FILE_STANDARD_METAKEYS.keys()
+    fileMetaKeys = list(result['Value']) + list(FILE_STANDARD_METAKEYS)
     fileMetaDict = dict(item for item in metaDict.iteritems() if item[0] in fileMetaKeys)
 
     fileList = []

--- a/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
@@ -38,13 +38,13 @@ class FileMetadata(object):
     if pName in FILE_STANDARD_METAKEYS:
       return S_ERROR('Illegal use of reserved metafield name')
 
-    result = self.db.dmeta.getMetadataFields(credDict)
+    result = self.db.dmeta._getMetadataFields(credDict)
     if not result['OK']:
       return result
     if pName in result['Value']:
       return S_ERROR('The metadata %s is already defined for Directories' % pName)
 
-    result = self.getFileMetadataFields(credDict)
+    result = self._getFileMetadataFields(credDict)
     if not result['OK']:
       return result
     if pName in result['Value']:
@@ -137,7 +137,7 @@ class FileMetadata(object):
 
         :return: S_OK/S_ERROR
     """
-    result = self.getFileMetadataFields(credDict)
+    result = self._getFileMetadataFields(credDict)
     if not result['OK']:
       return result
     metaFields = result['Value']
@@ -177,7 +177,7 @@ class FileMetadata(object):
 
         :return: S_OK/S_ERROR
     """
-    result = self.getFileMetadataFields(credDict)
+    result = self._getFileMetadataFields(credDict)
     if not result['OK']:
       return result
     metaFields = result['Value']
@@ -273,7 +273,7 @@ class FileMetadata(object):
         :return: S_OK/S_ERROR, Value - dict of metadata for each input file
     """
     # First file metadata
-    result = self.getFileMetadataFields(credDict)
+    result = self._getFileMetadataFields(credDict)
     if not result['OK']:
       return result
     metaFields = result['Value']
@@ -308,7 +308,7 @@ class FileMetadata(object):
         :return: S_OK/S_ERROR, Value - dict of metadata
     """
     # First file metadata
-    result = self.getFileMetadataFields(credDict)
+    result = self._getFileMetadataFields(credDict)
     if not result['OK']:
       return result
     metaFields = result['Value']
@@ -706,7 +706,7 @@ class FileMetadata(object):
 
     # 2.- Get known file metadata fields
 #     fileMetaDict = {}
-    result = self.getFileMetadataFields(credDict)
+    result = self._getFileMetadataFields(credDict)
     if not result['OK']:
       return result
     fileMetaKeys = list(result['Value']) + list(FILE_STANDARD_METAKEYS)


### PR DESCRIPTION
Split getMetadataFields methods for files and directories into an interface and implementation part to allow overriding implementation in derived classes. Plus added few doc strings

BEGINRELEASENOTES
*DMS
CHANGE: FileMetadata - split  getFileMetadataFields into getFileMetadataFields and _getFileMetadataFields
CHANGE: DirectoryMetadata - split  getMetadataFields into getMetadataFields and _getMetadataFields

ENDRELEASENOTES
