### PR TITLE
[v7r0] Create installation symlinks in the target directory

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2503,7 +2503,7 @@ def checkoutFromGit(moduleName, sourceURL, tagVersion, destinationDir=None):
 
   # replacing the code
   if os.path.exists(fDirName + '/' + moduleName):
-    cmd = "ln -s %s/%s" % (codeRepo, moduleName)
+    cmd = "ln -s %s/%s %s" % (codeRepo, moduleName, os.path.join(cliParams.targetPath, moduleName))
   else:
     cmd = "mv %s %s" % (fDirName, os.path.join(cliParams.targetPath, moduleName))
   logNOTICE("Executing: %s" % cmd)

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -310,7 +310,7 @@ function installDIRAC(){
   cp "$TESTCODE/DIRAC/Core/scripts/dirac-install.py" "$CLIENTINSTALLDIR/dirac-install"
   chmod +x "$CLIENTINSTALLDIR/dirac-install"
 
-  export CLIENT_ALTERNATIVE_MODULES=${CLIENT_ALTERNATIVE_MODULES:-ALTERNATIVE_MODULES}
+  export CLIENT_ALTERNATIVE_MODULES=${CLIENT_ALTERNATIVE_MODULES:-${ALTERNATIVE_MODULES}}
   if [ "$CLIENT_ALTERNATIVE_MODULES" ]; then
     echo "Installing from non-release code"
     if [[ -d "$CLIENT_ALTERNATIVE_MODULES" ]]; then


### PR DESCRIPTION
This was resulting in the `LHCbDIRAC` being partially installed in `etc/grid-security`.

Targets v7r0 so as that branch is used by some integration tests.