### PR TITLE
[v7r0]  Fix cleaning empty directory, revive DataManager tests

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -177,6 +177,11 @@ class DataManager(object):
     if not res['OK']:
       return res
 
+    if not res['Value']:
+      # folder is empty, just remove it and return
+      res = returnSingleResult(self.fileCatalog.removeDirectory(folder, recursive=True))
+      return res
+
     # create a list of folders so that empty folders are also deleted
     listOfFolders = []
     areDirs = self.fileCatalog.isDirectory(res['Value'])

--- a/FrameworkSystem/scripts/dirac-install-component.py
+++ b/FrameworkSystem/scripts/dirac-install-component.py
@@ -66,6 +66,8 @@ if len(args) != 2:
 cType = None
 system = args[0]
 component = args[1]
+compOrMod = module if module else component
+
 
 result = gComponentInstaller.getSoftwareComponents(getCSExtensions())
 if not result['OK']:
@@ -75,7 +77,7 @@ else:
   availableComponents = result['Value']
 
 for compType in availableComponents:
-  if system in availableComponents[compType] and component in availableComponents[compType][system]:
+  if system in availableComponents[compType] and compOrMod in availableComponents[compType][system]:
     cType = compType[:-1].lower()
     break
 

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -132,11 +132,11 @@ class DataManagerTestCase(unittest.TestCase):
     self.assertTrue('Successful' in putRes['Value'])
     self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
-    # Check that the replica removal was successful
-    self.assertTrue(removeReplicaRes['OK'])
-    self.assertTrue('Successful' in removeReplicaRes['Value'])
-    self.assertTrue(lfn in removeReplicaRes['Value']['Successful'])
-    self.assertTrue(removeReplicaRes['Value']['Successful'][lfn])
+    # Check that the replica removal failed, because it is the only copy
+    self.assertTrue(removeReplicaRes['OK'], removeReplicaRes.get('Message', 'All OK'))
+    self.assertTrue('Failed' in removeReplicaRes['Value'])
+    self.assertTrue(lfn in removeReplicaRes['Value']['Failed'])
+    self.assertTrue(removeReplicaRes['Value']['Failed'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
     self.assertTrue('Successful' in removeRes['Value'])
@@ -149,9 +149,9 @@ class DataManagerTestCase(unittest.TestCase):
     fileSize = 10000
     storageElementName = 'SE-1'
     fileGuid = makeGuid()
-    fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid)
+    checkSum = None
+    fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid, checkSum)
     registerRes = self.dataManager.registerFile(fileTuple)
-    # removeCatalogReplicaRes = self.dataManager.removeCatalogReplica(storageElementName,lfn)
     removeFileRes = self.dataManager.removeFile(lfn)
 
     # Check that the file registration was done correctly
@@ -159,11 +159,6 @@ class DataManagerTestCase(unittest.TestCase):
     self.assertTrue('Successful' in registerRes['Value'])
     self.assertTrue(lfn in registerRes['Value']['Successful'])
     self.assertTrue(registerRes['Value']['Successful'][lfn])
-    # Check that the replica removal was successful
-    # self.assertTrue(removeCatalogReplicaRes['OK'])
-    # self.assertTrue(removeCatalogReplicaRes['Value'].has_key('Successful'))
-    # self.assertTrue(removeCatalogReplicaRes['Value']['Successful'].has_key(lfn))
-    # self.assertTrue(removeCatalogReplicaRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeFileRes['OK'])
     self.assertTrue('Successful' in removeFileRes['Value'])
@@ -178,7 +173,8 @@ class DataManagerTestCase(unittest.TestCase):
     fileSize = 10000
     storageElementName = 'SE-1'
     fileGuid = makeGuid()
-    fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid)
+    checkSum = None
+    fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid, checkSum)
     registerRes = self.dataManager.registerFile(fileTuple)
     seName = 'SE-1'
     replicaTuple = (lfn, physicalFile, seName)

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -24,6 +24,22 @@ def tempFile():
   return fileName
 
 
+def checkPut(putRes, lfn):
+  """.Check that the put was successful."""
+  assert putRes['OK'], putRes.get('Message', 'All OK')
+  assert 'Successful' in putRes['Value']
+  assert lfn in putRes['Value']['Successful']
+  assert putRes['Value']['Successful'][lfn]
+
+
+def checkMultiple(res, lfn, sub):
+  """Check if lfn is in Successful or Failed, given by sub."""
+  assert res['OK'], res.get('Message', 'All OK')
+  assert sub in res['Value']
+  assert lfn in res['Value'][sub]
+  assert res['Value'][sub][lfn]
+
+
 def test_putAndRegister(dm, tempFile):
   print('\n\n#########################################################'
         '################\n\n\t\t\tPut and register test\n')
@@ -33,15 +49,9 @@ def test_putAndRegister(dm, tempFile):
   removeRes = dm.removeFile(lfn)
 
   # Check that the put was successful
-  assert putRes['OK'], putRes.get('Message', 'All OK')
-  assert 'Successful' in putRes['Value']
-  assert lfn in putRes['Value']['Successful']
-  assert putRes['Value']['Successful'][lfn]
+  checkPut(putRes, lfn)
   # Check that the removal was successful
-  assert removeRes['OK'], removeRes.get('Message', 'All OK')
-  assert 'Successful' in removeRes['Value']
-  assert lfn in removeRes['Value']['Successful']
-  assert removeRes['Value']['Successful'][lfn]
+  checkMultiple(removeRes, lfn, 'Successful')
 
 
 def test_putAndRegisterReplicate(dm, tempFile):
@@ -54,20 +64,11 @@ def test_putAndRegisterReplicate(dm, tempFile):
   removeRes = dm.removeFile(lfn)
 
   # Check that the put was successful
-  assert putRes['OK'], putRes.get('Message', 'All OK')
-  assert 'Successful' in putRes['Value']
-  assert lfn in putRes['Value']['Successful']
-  assert putRes['Value']['Successful'][lfn]
+  checkPut(putRes, lfn)
   # Check that the replicate was successful
-  assert replicateRes['OK'], replicateRes.get('Message', 'All OK')
-  assert 'Successful' in replicateRes['Value']
-  assert lfn in replicateRes['Value']['Successful']
-  assert replicateRes['Value']['Successful'][lfn]
+  checkMultiple(replicateRes, lfn, 'Successful')
   # Check that the removal was successful
-  assert removeRes['OK'], removeRes.get('Message', 'All OK')
-  assert 'Successful' in removeRes['Value']
-  assert lfn in removeRes['Value']['Successful']
-  assert removeRes['Value']['Successful'][lfn]
+  checkMultiple(removeRes, lfn, 'Successful')
 
 
 def test_putAndRegisterGetReplicaMetadata(dm, tempFile):
@@ -80,23 +81,14 @@ def test_putAndRegisterGetReplicaMetadata(dm, tempFile):
   removeRes = dm.removeFile(lfn)
 
   # Check that the put was successful
-  assert putRes['OK'], putRes.get('Message', 'All OK')
-  assert 'Successful' in putRes['Value']
-  assert lfn in putRes['Value']['Successful']
-  assert putRes['Value']['Successful'][lfn]
+  checkPut(putRes, lfn)
   # Check that the metadata query was successful
-  assert metadataRes['OK'], metadataRes.get('Message', 'All OK')
-  assert 'Successful' in metadataRes['Value']
-  assert lfn in metadataRes['Value']['Successful']
-  assert metadataRes['Value']['Successful'][lfn]
+  checkMultiple(metadataRes, lfn, 'Successful')
   metadataDict = metadataRes['Value']['Successful'][lfn]
   for key in ['Cached', 'Migrated', 'Size']:
     assert key in metadataDict
   # Check that the removal was successful
-  assert removeRes['OK'], removeRes.get('Message', 'All OK')
-  assert 'Successful' in removeRes['Value']
-  assert lfn in removeRes['Value']['Successful']
-  assert removeRes['Value']['Successful'][lfn]
+  checkMultiple(removeRes, lfn, 'Successful')
 
 
 def test_putAndRegsiterGetAccessUrl(dm, tempFile):
@@ -108,22 +100,9 @@ def test_putAndRegsiterGetAccessUrl(dm, tempFile):
   getAccessUrlRes = dm.getReplicaAccessUrl(lfn, diracSE)
   print(getAccessUrlRes)
   removeRes = dm.removeFile(lfn)
-
-  # Check that the put was successful
-  assert putRes['OK'], putRes.get('Message', 'All OK')
-  assert 'Successful' in putRes['Value']
-  assert lfn in putRes['Value']['Successful']
-  assert putRes['Value']['Successful'][lfn]
-  # Check that the access url was successful
-  assert getAccessUrlRes['OK'], getAccessUrlRes.get('Message', 'All OK')
-  assert 'Successful' in getAccessUrlRes['Value']
-  assert lfn in getAccessUrlRes['Value']['Successful']
-  assert getAccessUrlRes['Value']['Successful'][lfn]
-  # Check that the removal was successful
-  assert removeRes['OK'], removeRes.get('Message', 'All OK')
-  assert 'Successful' in removeRes['Value']
-  assert lfn in removeRes['Value']['Successful']
-  assert removeRes['Value']['Successful'][lfn]
+  checkPut(putRes, lfn)
+  checkMultiple(getAccessUrlRes, lfn, 'Successful')
+  checkMultiple(removeRes, lfn, 'Successful')
 
 
 def test_putAndRegisterRemoveReplica(dm, tempFile):
@@ -136,20 +115,11 @@ def test_putAndRegisterRemoveReplica(dm, tempFile):
   removeRes = dm.removeFile(lfn)
 
   # Check that the put was successful
-  assert putRes['OK'], putRes.get('Message', 'All OK')
-  assert 'Successful' in putRes['Value']
-  assert lfn in putRes['Value']['Successful']
-  assert putRes['Value']['Successful'][lfn]
+  checkPut(putRes, lfn)
   # Check that the replica removal failed, because it is the only copy
-  assert removeReplicaRes['OK'], removeReplicaRes.get('Message', 'All OK')
-  assert 'Failed' in removeReplicaRes['Value']
-  assert lfn in removeReplicaRes['Value']['Failed']
-  assert removeReplicaRes['Value']['Failed'][lfn]
+  checkMultiple(removeReplicaRes, lfn, 'Failed')
   # Check that the removal was successful
-  assert removeRes['OK'], removeRes.get('Message', 'All OK')
-  assert 'Successful' in removeRes['Value']
-  assert lfn in removeRes['Value']['Successful']
-  assert removeRes['Value']['Successful'][lfn]
+  checkMultiple(removeRes, lfn, 'Successful')
 
 
 def test_registerFile(dm, tempFile):
@@ -163,16 +133,8 @@ def test_registerFile(dm, tempFile):
   registerRes = dm.registerFile(fileTuple)
   removeFileRes = dm.removeFile(lfn)
 
-  # Check that the file registration was done correctly
-  assert registerRes['OK'], registerRes.get('Message', 'All OK')
-  assert 'Successful' in registerRes['Value']
-  assert lfn in registerRes['Value']['Successful']
-  assert registerRes['Value']['Successful'][lfn]
-  # Check that the removal was successful
-  assert removeFileRes['OK'], removeFileRes.get('Message', 'All OK')
-  assert 'Successful' in removeFileRes['Value']
-  assert lfn in removeFileRes['Value']['Successful']
-  assert removeFileRes['Value']['Successful'][lfn]
+  checkMultiple(registerRes, lfn, 'Successful')
+  checkMultiple(removeFileRes, lfn, 'Successful')
 
 
 def test_registerReplica(dm, tempFile):
@@ -191,21 +153,9 @@ def test_registerReplica(dm, tempFile):
   registerReplicaRes = dm.registerReplica(replicaTuple)
   removeFileRes = dm.removeFile(lfn)
 
-  # Check that the file registration was done correctly
-  assert registerRes['OK'], registerRes.get('Message', 'All OK')
-  assert 'Successful' in registerRes['Value']
-  assert lfn in registerRes['Value']['Successful']
-  assert registerRes['Value']['Successful'][lfn]
-  # Check that the replica registration was successful
-  assert registerReplicaRes['OK'], registerReplicaRes.get('Message', 'All OK')
-  assert 'Successful' in registerReplicaRes['Value']
-  assert lfn in registerReplicaRes['Value']['Successful']
-  assert registerReplicaRes['Value']['Successful'][lfn]
-  # Check that the removal was successful
-  assert removeFileRes['OK'], removeFileRes.get('Message', 'All OK')
-  assert 'Successful' in removeFileRes['Value']
-  assert lfn in removeFileRes['Value']['Successful']
-  assert removeFileRes['Value']['Successful'][lfn]
+  checkMultiple(registerRes, lfn, 'Successful')
+  checkMultiple(registerReplicaRes, lfn, 'Successful')
+  checkMultiple(removeFileRes, lfn, 'Successful')
 
 
 def test_putAndRegisterGet(dm, tempFile):
@@ -220,18 +170,7 @@ def test_putAndRegisterGet(dm, tempFile):
   if os.path.exists(localFilePath):
     os.remove(localFilePath)
 
-  # Check that the put was successful
-  assert putRes['OK'], putRes.get('Message', 'All OK')
-  assert 'Successful' in putRes['Value']
-  assert lfn in putRes['Value']['Successful']
-  assert putRes['Value']['Successful'][lfn]
-  # Check that the replica removal was successful
-  assert getRes['OK'], getRes.get('Message', 'All OK')
-  assert 'Successful' in getRes['Value']
-  assert lfn in getRes['Value']['Successful']
+  checkMultiple(putRes, lfn, 'Successful')
+  checkMultiple(getRes, lfn, 'Successful')
   assert getRes['Value']['Successful'][lfn] == localFilePath
-  # Check that the removal was successful
-  assert removeRes['OK'], removeRes.get('Message', 'All OK')
-  assert 'Successful' in removeRes['Value']
-  assert lfn in removeRes['Value']['Successful']
-  assert removeRes['Value']['Successful'][lfn]
+  checkMultiple(removeRes, lfn, 'Successful')

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -49,17 +49,17 @@ class DataManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
     self.assertIn('Successful', putRes['Value'])
     self.assertIn(lfn, putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replicate was successful
-    self.assertTrue(replicateRes['OK'])
+    self.assertTrue(replicateRes['OK'], replicateRes.get('Message', 'All OK'))
     self.assertIn('Successful', replicateRes['Value'])
     self.assertIn(lfn, replicateRes['Value']['Successful'])
     self.assertTrue(replicateRes['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in removeRes['Value'])
     self.assertIn(lfn, removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
@@ -74,12 +74,12 @@ class DataManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
     self.assertIn('Successful', putRes['Value'])
     self.assertIn(lfn, putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the metadata query was successful
-    self.assertTrue(metadataRes['OK'])
+    self.assertTrue(metadataRes['OK'], metadataRes.get('Message', 'All OK'))
     self.assertIn('Successful', metadataRes['Value'])
     self.assertIn(lfn, metadataRes['Value']['Successful'])
     self.assertTrue(metadataRes['Value']['Successful'][lfn])
@@ -87,7 +87,7 @@ class DataManagerTestCase(unittest.TestCase):
     for key in ['Cached', 'Migrated', 'Size']:
       self.assertIn(key, metadataDict)
     # Check that the removal was successful
-    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
     self.assertIn('Successful', removeRes['Value'])
     self.assertIn(lfn, removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
@@ -103,17 +103,17 @@ class DataManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in putRes['Value'])
     self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the access url was successful
-    self.assertTrue(getAccessUrlRes['OK'])
+    self.assertTrue(getAccessUrlRes['OK'], getAccessUrlRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in getAccessUrlRes['Value'])
     self.assertTrue(lfn in getAccessUrlRes['Value']['Successful'])
     self.assertTrue(getAccessUrlRes['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in removeRes['Value'])
     self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
@@ -128,7 +128,7 @@ class DataManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in putRes['Value'])
     self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
@@ -138,7 +138,7 @@ class DataManagerTestCase(unittest.TestCase):
     self.assertTrue(lfn in removeReplicaRes['Value']['Failed'])
     self.assertTrue(removeReplicaRes['Value']['Failed'][lfn])
     # Check that the removal was successful
-    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in removeRes['Value'])
     self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
@@ -155,12 +155,12 @@ class DataManagerTestCase(unittest.TestCase):
     removeFileRes = self.dataManager.removeFile(lfn)
 
     # Check that the file registration was done correctly
-    self.assertTrue(registerRes['OK'])
+    self.assertTrue(registerRes['OK'], registerRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in registerRes['Value'])
     self.assertTrue(lfn in registerRes['Value']['Successful'])
     self.assertTrue(registerRes['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assertTrue(removeFileRes['OK'])
+    self.assertTrue(removeFileRes['OK'], removeFileRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in removeFileRes['Value'])
     self.assertTrue(lfn in removeFileRes['Value']['Successful'])
     self.assertTrue(removeFileRes['Value']['Successful'][lfn])
@@ -184,12 +184,12 @@ class DataManagerTestCase(unittest.TestCase):
     removeFileRes = self.dataManager.removeFile(lfn)
 
     # Check that the file registration was done correctly
-    self.assertTrue(registerRes['OK'])
+    self.assertTrue(registerRes['OK'], registerRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in registerRes['Value'])
     self.assertTrue(lfn in registerRes['Value']['Successful'])
     self.assertTrue(registerRes['Value']['Successful'][lfn])
     # Check that the replica registration was successful
-    self.assertTrue(registerReplicaRes['OK'])
+    self.assertTrue(registerReplicaRes['OK'], registerReplicaRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in registerReplicaRes['Value'])
     self.assertTrue(lfn in registerReplicaRes['Value']['Successful'])
     self.assertTrue(registerReplicaRes['Value']['Successful'][lfn])
@@ -204,7 +204,7 @@ class DataManagerTestCase(unittest.TestCase):
     # self.assertTrue(removeCatalogReplicaRes2['Value']['Successful'].has_key(lfn))
     # self.assertTrue(removeCatalogReplicaRes2['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assertTrue(removeFileRes['OK'])
+    self.assertTrue(removeFileRes['OK'], removeFilesRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in removeFileRes['Value'])
     self.assertTrue(lfn in removeFileRes['Value']['Successful'])
     self.assertTrue(removeFileRes['Value']['Successful'][lfn])
@@ -222,17 +222,17 @@ class DataManagerTestCase(unittest.TestCase):
       os.remove(localFilePath)
 
     # Check that the put was successful
-    self.assertTrue(putRes['OK'])
+    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in putRes['Value'])
     self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
-    self.assertTrue(getRes['OK'])
+    self.assertTrue(getRes['OK'], getRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in getRes['Value'])
     self.assertTrue(lfn in getRes['Value']['Successful'])
     self.assertEqual(getRes['Value']['Successful'][lfn], localFilePath)
     # Check that the removal was successful
-    self.assertTrue(removeRes['OK'])
+    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
     self.assertTrue('Successful' in removeRes['Value'])
     self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -45,23 +45,23 @@ class DataManagerTestCase(unittest.TestCase):
     lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterReplicate/testFile.%s' % time.time()
     diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    replicateRes = self.dataManager.replicateAndRegister(lfn,'SE-2') #,sourceSE='',destPath='',localCache='')
+    replicateRes = self.dataManager.replicateAndRegister(lfn, 'SE-2')  # ,sourceSE='',destPath='',localCache='')
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertIn('Successful', putRes['Value'])
+    self.assertIn(lfn, putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replicate was successful
     self.assertTrue(replicateRes['OK'])
-    self.assertTrue(replicateRes['Value'].has_key('Successful'))
-    self.assertTrue(replicateRes['Value']['Successful'].has_key(lfn))
+    self.assertIn('Successful', replicateRes['Value'])
+    self.assertIn(lfn, replicateRes['Value']['Successful'])
     self.assertTrue(replicateRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertIn(lfn, removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterGetReplicaMetadata(self):
@@ -70,29 +70,27 @@ class DataManagerTestCase(unittest.TestCase):
     lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterGetReplicaMetadata/testFile.%s' % time.time()
     diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    metadataRes = self.dataManager.getReplicaMetadata(lfn,diracSE)
+    metadataRes = self.dataManager.getReplicaMetadata(lfn, diracSE)
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertIn('Successful', putRes['Value'])
+    self.assertIn(lfn, putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the metadata query was successful
     self.assertTrue(metadataRes['OK'])
-    self.assertTrue(metadataRes['Value'].has_key('Successful'))
-    self.assertTrue(metadataRes['Value']['Successful'].has_key(lfn))
+    self.assertIn('Successful', metadataRes['Value'])
+    self.assertIn(lfn, metadataRes['Value']['Successful'])
     self.assertTrue(metadataRes['Value']['Successful'][lfn])
     metadataDict = metadataRes['Value']['Successful'][lfn]
-    self.assertTrue(metadataDict.has_key('Cached'))
-    self.assertTrue(metadataDict.has_key('Migrated'))
-    self.assertTrue(metadataDict.has_key('Size'))
+    for key in ['Cached', 'Migrated', 'Size']:
+      self.assertIn(key, metadataDict)
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertIn('Successful', removeRes['Value'])
+    self.assertIn(lfn, removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
-
 
   def test_putAndRegsiterGetAccessUrl(self):
     print('\n\n#########################################################'
@@ -100,24 +98,24 @@ class DataManagerTestCase(unittest.TestCase):
     lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterGetAccessUrl/testFile.%s' % time.time()
     diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    getAccessUrlRes = self.dataManager.getReplicaAccessUrl(lfn,diracSE)
+    getAccessUrlRes = self.dataManager.getReplicaAccessUrl(lfn, diracSE)
     print(getAccessUrlRes)
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in putRes['Value'])
+    self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the access url was successful
     self.assertTrue(getAccessUrlRes['OK'])
-    self.assertTrue(getAccessUrlRes['Value'].has_key('Successful'))
-    self.assertTrue(getAccessUrlRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in getAccessUrlRes['Value'])
+    self.assertTrue(lfn in getAccessUrlRes['Value']['Successful'])
     self.assertTrue(getAccessUrlRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterRemoveReplica(self):
@@ -126,40 +124,40 @@ class DataManagerTestCase(unittest.TestCase):
     lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterRemoveReplica/testFile.%s' % time.time()
     diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    removeReplicaRes = self.dataManager.removeReplica(diracSE,lfn)
+    removeReplicaRes = self.dataManager.removeReplica(diracSE, lfn)
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in putRes['Value'])
+    self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
     self.assertTrue(removeReplicaRes['OK'])
-    self.assertTrue(removeReplicaRes['Value'].has_key('Successful'))
-    self.assertTrue(removeReplicaRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeReplicaRes['Value'])
+    self.assertTrue(lfn in removeReplicaRes['Value']['Successful'])
     self.assertTrue(removeReplicaRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_registerFile(self):
     lfn = '/jenkins/test/unit-test/DataManager/registerFile/testFile.%s' % time.time()
     physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
     fileSize = 10000
-    storageElementName = 'CERN-RAW'
+    storageElementName = 'SE-1'
     fileGuid = makeGuid()
-    fileTuple = (lfn,physicalFile,fileSize,storageElementName,fileGuid)
+    fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid)
     registerRes = self.dataManager.registerFile(fileTuple)
     # removeCatalogReplicaRes = self.dataManager.removeCatalogReplica(storageElementName,lfn)
     removeFileRes = self.dataManager.removeFile(lfn)
 
     # Check that the file registration was done correctly
     self.assertTrue(registerRes['OK'])
-    self.assertTrue(registerRes['Value'].has_key('Successful'))
-    self.assertTrue(registerRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in registerRes['Value'])
+    self.assertTrue(lfn in registerRes['Value']['Successful'])
     self.assertTrue(registerRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
     # self.assertTrue(removeCatalogReplicaRes['OK'])
@@ -168,8 +166,8 @@ class DataManagerTestCase(unittest.TestCase):
     # self.assertTrue(removeCatalogReplicaRes['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeFileRes['OK'])
-    self.assertTrue(removeFileRes['Value'].has_key('Successful'))
-    self.assertTrue(removeFileRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeFileRes['Value'])
+    self.assertTrue(lfn in removeFileRes['Value']['Successful'])
     self.assertTrue(removeFileRes['Value']['Successful'][lfn])
 
   def test_registerReplica(self):
@@ -178,12 +176,12 @@ class DataManagerTestCase(unittest.TestCase):
     lfn = '/jenkins/test/unit-test/DataManager/registerReplica/testFile.%s' % time.time()
     physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
     fileSize = 10000
-    storageElementName = 'CERN-RAW'
+    storageElementName = 'SE-1'
     fileGuid = makeGuid()
-    fileTuple = (lfn,physicalFile,fileSize,storageElementName,fileGuid)
+    fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid)
     registerRes = self.dataManager.registerFile(fileTuple)
     seName = 'SE-1'
-    replicaTuple = (lfn,physicalFile,seName)
+    replicaTuple = (lfn, physicalFile, seName)
     registerReplicaRes = self.dataManager.registerReplica(replicaTuple)
     # removeCatalogReplicaRes1 = self.dataManager.removeCatalogReplica(storageElementName,lfn)
     # removeCatalogReplicaRes2 = self.dataManager.removeCatalogReplica(seName,lfn)
@@ -191,13 +189,13 @@ class DataManagerTestCase(unittest.TestCase):
 
     # Check that the file registration was done correctly
     self.assertTrue(registerRes['OK'])
-    self.assertTrue(registerRes['Value'].has_key('Successful'))
-    self.assertTrue(registerRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in registerRes['Value'])
+    self.assertTrue(lfn in registerRes['Value']['Successful'])
     self.assertTrue(registerRes['Value']['Successful'][lfn])
     # Check that the replica registration was successful
     self.assertTrue(registerReplicaRes['OK'])
-    self.assertTrue(registerReplicaRes['Value'].has_key('Successful'))
-    self.assertTrue(registerReplicaRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in registerReplicaRes['Value'])
+    self.assertTrue(lfn in registerReplicaRes['Value']['Successful'])
     self.assertTrue(registerReplicaRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
     # self.assertTrue(removeCatalogReplicaRes1['OK'])
@@ -211,8 +209,8 @@ class DataManagerTestCase(unittest.TestCase):
     # self.assertTrue(removeCatalogReplicaRes2['Value']['Successful'][lfn])
     # Check that the removal was successful
     self.assertTrue(removeFileRes['OK'])
-    self.assertTrue(removeFileRes['Value'].has_key('Successful'))
-    self.assertTrue(removeFileRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeFileRes['Value'])
+    self.assertTrue(lfn in removeFileRes['Value']['Successful'])
     self.assertTrue(removeFileRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterGet(self):
@@ -223,28 +221,29 @@ class DataManagerTestCase(unittest.TestCase):
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     getRes = self.dataManager.getFile(lfn)
     removeRes = self.dataManager.removeFile(lfn)
-    localFilePath = "%s/%s" % (os.getcwd(),os.path.basename(lfn))
+    localFilePath = "%s/%s" % (os.getcwd(), os.path.basename(lfn))
     if os.path.exists(localFilePath):
       os.remove(localFilePath)
 
     # Check that the put was successful
     self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in putRes['Value'])
+    self.assertTrue(lfn in putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the replica removal was successful
     self.assertTrue(getRes['OK'])
-    self.assertTrue(getRes['Value'].has_key('Successful'))
-    self.assertTrue(getRes['Value']['Successful'].has_key(lfn))
-    self.assertEqual(getRes['Value']['Successful'][lfn],localFilePath)
+    self.assertTrue('Successful' in getRes['Value'])
+    self.assertTrue(lfn in getRes['Value']['Successful'])
+    self.assertEqual(getRes['Value']['Successful'][lfn], localFilePath)
     # Check that the removal was successful
     self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue('Successful' in removeRes['Value'])
+    self.assertTrue(lfn in removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
+
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase(DataManagerTestCase)
-  #suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(DirectoryTestCase))
+  # suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(DirectoryTestCase))
   testResult = unittest.TextTestRunner(verbosity=2).run(suite)
   exit(testResult)

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -1,3 +1,15 @@
+"""This module contains tests for the DataManager client.
+
+The tests upload files, remove them, replicate them, check metadata calls, and cleanDirectory
+
+Requirements:
+
+* Running FileCatalog instance, containing an LFN folder '/Jenkins', writable by the jenkins_user proxy
+* Two running StorageElements SE-1 and SE-2
+* A jenkins_user proxy
+
+"""
+
 from __future__ import print_function
 
 import os

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -10,15 +10,15 @@ parseCommandLine()
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.Core.Utilities.File import makeGuid
 
+
 class DataManagerTestCase(unittest.TestCase):
-  """ Base class for the Data Manager test cases
-  """
+  """Base class for the Data Manager test cases."""
+
   def setUp(self):
     self.dataManager = DataManager()
     self.fileName = '/tmp/temporaryLocalFile'
-    file = open(self.fileName,'w')
-    file.write("%s" % time.time())
-    file.close()
+    with open(self.fileName, 'w') as theTemp:
+      theTemp.write(str(time.time()))
 
   def test_putAndRegister(self):
     print('\n\n#########################################################'
@@ -29,14 +29,14 @@ class DataManagerTestCase(unittest.TestCase):
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
-    self.assertTrue(putRes['OK'])
-    self.assertTrue(putRes['Value'].has_key('Successful'))
-    self.assertTrue(putRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
+    self.assertIn('Successful', putRes['Value'])
+    self.assertIn(lfn, putRes['Value']['Successful'])
     self.assertTrue(putRes['Value']['Successful'][lfn])
     # Check that the removal was successful
-    self.assertTrue(removeRes['OK'])
-    self.assertTrue(removeRes['Value'].has_key('Successful'))
-    self.assertTrue(removeRes['Value']['Successful'].has_key(lfn))
+    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
+    self.assertIn('Successful', removeRes['Value'])
+    self.assertIn(lfn, removeRes['Value']['Successful'])
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_putAndRegisterReplicate(self):

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import os
 import time
-import unittest
+import pytest
 
 from DIRAC.Core.Base.Script import parseCommandLine
 parseCommandLine()
@@ -11,235 +11,227 @@ from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.Core.Utilities.File import makeGuid
 
 
-class DataManagerTestCase(unittest.TestCase):
-  """Base class for the Data Manager test cases."""
-
-  def setUp(self):
-    self.dataManager = DataManager()
-    self.fileName = '/tmp/temporaryLocalFile'
-    with open(self.fileName, 'w') as theTemp:
-      theTemp.write(str(time.time()))
-
-  def test_putAndRegister(self):
-    print('\n\n#########################################################'
-          '################\n\n\t\t\tPut and register test\n')
-    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegister/testFile.%s' % time.time()
-    diracSE = 'SE-1'
-    putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    removeRes = self.dataManager.removeFile(lfn)
-
-    # Check that the put was successful
-    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
-    self.assertIn('Successful', putRes['Value'])
-    self.assertIn(lfn, putRes['Value']['Successful'])
-    self.assertTrue(putRes['Value']['Successful'][lfn])
-    # Check that the removal was successful
-    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
-    self.assertIn('Successful', removeRes['Value'])
-    self.assertIn(lfn, removeRes['Value']['Successful'])
-    self.assertTrue(removeRes['Value']['Successful'][lfn])
-
-  def test_putAndRegisterReplicate(self):
-    print('\n\n#########################################################'
-          '################\n\n\t\t\tReplication test\n')
-    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterReplicate/testFile.%s' % time.time()
-    diracSE = 'SE-1'
-    putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    replicateRes = self.dataManager.replicateAndRegister(lfn, 'SE-2')  # ,sourceSE='',destPath='',localCache='')
-    removeRes = self.dataManager.removeFile(lfn)
-
-    # Check that the put was successful
-    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
-    self.assertIn('Successful', putRes['Value'])
-    self.assertIn(lfn, putRes['Value']['Successful'])
-    self.assertTrue(putRes['Value']['Successful'][lfn])
-    # Check that the replicate was successful
-    self.assertTrue(replicateRes['OK'], replicateRes.get('Message', 'All OK'))
-    self.assertIn('Successful', replicateRes['Value'])
-    self.assertIn(lfn, replicateRes['Value']['Successful'])
-    self.assertTrue(replicateRes['Value']['Successful'][lfn])
-    # Check that the removal was successful
-    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in removeRes['Value'])
-    self.assertIn(lfn, removeRes['Value']['Successful'])
-    self.assertTrue(removeRes['Value']['Successful'][lfn])
-
-  def test_putAndRegisterGetReplicaMetadata(self):
-    print('\n\n#########################################################'
-          '################\n\n\t\t\tGet metadata test\n')
-    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterGetReplicaMetadata/testFile.%s' % time.time()
-    diracSE = 'SE-1'
-    putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    metadataRes = self.dataManager.getReplicaMetadata(lfn, diracSE)
-    removeRes = self.dataManager.removeFile(lfn)
-
-    # Check that the put was successful
-    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
-    self.assertIn('Successful', putRes['Value'])
-    self.assertIn(lfn, putRes['Value']['Successful'])
-    self.assertTrue(putRes['Value']['Successful'][lfn])
-    # Check that the metadata query was successful
-    self.assertTrue(metadataRes['OK'], metadataRes.get('Message', 'All OK'))
-    self.assertIn('Successful', metadataRes['Value'])
-    self.assertIn(lfn, metadataRes['Value']['Successful'])
-    self.assertTrue(metadataRes['Value']['Successful'][lfn])
-    metadataDict = metadataRes['Value']['Successful'][lfn]
-    for key in ['Cached', 'Migrated', 'Size']:
-      self.assertIn(key, metadataDict)
-    # Check that the removal was successful
-    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
-    self.assertIn('Successful', removeRes['Value'])
-    self.assertIn(lfn, removeRes['Value']['Successful'])
-    self.assertTrue(removeRes['Value']['Successful'][lfn])
-
-  def test_putAndRegsiterGetAccessUrl(self):
-    print('\n\n#########################################################'
-          '################\n\n\t\t\tGet Access Url test\n')
-    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterGetAccessUrl/testFile.%s' % time.time()
-    diracSE = 'SE-1'
-    putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    getAccessUrlRes = self.dataManager.getReplicaAccessUrl(lfn, diracSE)
-    print(getAccessUrlRes)
-    removeRes = self.dataManager.removeFile(lfn)
-
-    # Check that the put was successful
-    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in putRes['Value'])
-    self.assertTrue(lfn in putRes['Value']['Successful'])
-    self.assertTrue(putRes['Value']['Successful'][lfn])
-    # Check that the access url was successful
-    self.assertTrue(getAccessUrlRes['OK'], getAccessUrlRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in getAccessUrlRes['Value'])
-    self.assertTrue(lfn in getAccessUrlRes['Value']['Successful'])
-    self.assertTrue(getAccessUrlRes['Value']['Successful'][lfn])
-    # Check that the removal was successful
-    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in removeRes['Value'])
-    self.assertTrue(lfn in removeRes['Value']['Successful'])
-    self.assertTrue(removeRes['Value']['Successful'][lfn])
-
-  def test_putAndRegisterRemoveReplica(self):
-    print('\n\n#########################################################'
-          '################\n\n\t\t\tRemove replica test\n')
-    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterRemoveReplica/testFile.%s' % time.time()
-    diracSE = 'SE-1'
-    putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    removeReplicaRes = self.dataManager.removeReplica(diracSE, lfn)
-    removeRes = self.dataManager.removeFile(lfn)
-
-    # Check that the put was successful
-    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in putRes['Value'])
-    self.assertTrue(lfn in putRes['Value']['Successful'])
-    self.assertTrue(putRes['Value']['Successful'][lfn])
-    # Check that the replica removal failed, because it is the only copy
-    self.assertTrue(removeReplicaRes['OK'], removeReplicaRes.get('Message', 'All OK'))
-    self.assertTrue('Failed' in removeReplicaRes['Value'])
-    self.assertTrue(lfn in removeReplicaRes['Value']['Failed'])
-    self.assertTrue(removeReplicaRes['Value']['Failed'][lfn])
-    # Check that the removal was successful
-    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in removeRes['Value'])
-    self.assertTrue(lfn in removeRes['Value']['Successful'])
-    self.assertTrue(removeRes['Value']['Successful'][lfn])
-
-  def test_registerFile(self):
-    lfn = '/Jenkins/test/unit-test/DataManager/registerFile/testFile.%s' % time.time()
-    physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
-    fileSize = 10000
-    storageElementName = 'SE-1'
-    fileGuid = makeGuid()
-    checkSum = None
-    fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid, checkSum)
-    registerRes = self.dataManager.registerFile(fileTuple)
-    removeFileRes = self.dataManager.removeFile(lfn)
-
-    # Check that the file registration was done correctly
-    self.assertTrue(registerRes['OK'], registerRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in registerRes['Value'])
-    self.assertTrue(lfn in registerRes['Value']['Successful'])
-    self.assertTrue(registerRes['Value']['Successful'][lfn])
-    # Check that the removal was successful
-    self.assertTrue(removeFileRes['OK'], removeFileRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in removeFileRes['Value'])
-    self.assertTrue(lfn in removeFileRes['Value']['Successful'])
-    self.assertTrue(removeFileRes['Value']['Successful'][lfn])
-
-  def test_registerReplica(self):
-    print('\n\n#########################################################'
-          '################\n\n\t\t\tRegister replica test\n')
-    lfn = '/Jenkins/test/unit-test/DataManager/registerReplica/testFile.%s' % time.time()
-    physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
-    fileSize = 10000
-    storageElementName = 'SE-1'
-    fileGuid = makeGuid()
-    checkSum = None
-    fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid, checkSum)
-    registerRes = self.dataManager.registerFile(fileTuple)
-    seName = 'SE-1'
-    replicaTuple = (lfn, physicalFile, seName)
-    registerReplicaRes = self.dataManager.registerReplica(replicaTuple)
-    # removeCatalogReplicaRes1 = self.dataManager.removeCatalogReplica(storageElementName,lfn)
-    # removeCatalogReplicaRes2 = self.dataManager.removeCatalogReplica(seName,lfn)
-    removeFileRes = self.dataManager.removeFile(lfn)
-
-    # Check that the file registration was done correctly
-    self.assertTrue(registerRes['OK'], registerRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in registerRes['Value'])
-    self.assertTrue(lfn in registerRes['Value']['Successful'])
-    self.assertTrue(registerRes['Value']['Successful'][lfn])
-    # Check that the replica registration was successful
-    self.assertTrue(registerReplicaRes['OK'], registerReplicaRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in registerReplicaRes['Value'])
-    self.assertTrue(lfn in registerReplicaRes['Value']['Successful'])
-    self.assertTrue(registerReplicaRes['Value']['Successful'][lfn])
-    # Check that the replica removal was successful
-    # self.assertTrue(removeCatalogReplicaRes1['OK'])
-    # self.assertTrue(removeCatalogReplicaRes1['Value'].has_key('Successful'))
-    # self.assertTrue(removeCatalogReplicaRes1['Value']['Successful'].has_key(lfn))
-    # self.assertTrue(removeCatalogReplicaRes1['Value']['Successful'][lfn])
-    # Check that the replica removal was successful
-    # self.assertTrue(removeCatalogReplicaRes2['OK'])
-    # self.assertTrue(removeCatalogReplicaRes2['Value'].has_key('Successful'))
-    # self.assertTrue(removeCatalogReplicaRes2['Value']['Successful'].has_key(lfn))
-    # self.assertTrue(removeCatalogReplicaRes2['Value']['Successful'][lfn])
-    # Check that the removal was successful
-    self.assertTrue(removeFileRes['OK'], removeFilesRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in removeFileRes['Value'])
-    self.assertTrue(lfn in removeFileRes['Value']['Successful'])
-    self.assertTrue(removeFileRes['Value']['Successful'][lfn])
-
-  def test_putAndRegisterGet(self):
-    print('\n\n#########################################################'
-          '################\n\n\t\t\tGet file test\n')
-    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterGet/testFile.%s' % time.time()
-    diracSE = 'SE-1'
-    putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    getRes = self.dataManager.getFile(lfn)
-    removeRes = self.dataManager.removeFile(lfn)
-    localFilePath = "%s/%s" % (os.getcwd(), os.path.basename(lfn))
-    if os.path.exists(localFilePath):
-      os.remove(localFilePath)
-
-    # Check that the put was successful
-    self.assertTrue(putRes['OK'], putRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in putRes['Value'])
-    self.assertTrue(lfn in putRes['Value']['Successful'])
-    self.assertTrue(putRes['Value']['Successful'][lfn])
-    # Check that the replica removal was successful
-    self.assertTrue(getRes['OK'], getRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in getRes['Value'])
-    self.assertTrue(lfn in getRes['Value']['Successful'])
-    self.assertEqual(getRes['Value']['Successful'][lfn], localFilePath)
-    # Check that the removal was successful
-    self.assertTrue(removeRes['OK'], removeRes.get('Message', 'All OK'))
-    self.assertTrue('Successful' in removeRes['Value'])
-    self.assertTrue(lfn in removeRes['Value']['Successful'])
-    self.assertTrue(removeRes['Value']['Successful'][lfn])
+@pytest.fixture
+def dm():
+  return DataManager()
 
 
-if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase(DataManagerTestCase)
-  # suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(DirectoryTestCase))
-  testResult = unittest.TextTestRunner(verbosity=2).run(suite)
-  exit(testResult)
+@pytest.fixture
+def tempFile():
+  fileName = '/tmp/temporaryLocalFile'
+  with open(fileName, 'w') as theTemp:
+    theTemp.write(str(time.time()))
+  return fileName
+
+
+def test_putAndRegister(dm, tempFile):
+  print('\n\n#########################################################'
+        '################\n\n\t\t\tPut and register test\n')
+  lfn = '/Jenkins/test/unit-test/DataManager/putAndRegister/testFile.%s' % time.time()
+  diracSE = 'SE-1'
+  putRes = dm.putAndRegister(lfn, tempFile, diracSE)
+  removeRes = dm.removeFile(lfn)
+
+  # Check that the put was successful
+  assert putRes['OK'], putRes.get('Message', 'All OK')
+  assert 'Successful' in putRes['Value']
+  assert lfn in putRes['Value']['Successful']
+  assert putRes['Value']['Successful'][lfn]
+  # Check that the removal was successful
+  assert removeRes['OK'], removeRes.get('Message', 'All OK')
+  assert 'Successful' in removeRes['Value']
+  assert lfn in removeRes['Value']['Successful']
+  assert removeRes['Value']['Successful'][lfn]
+
+
+def test_putAndRegisterReplicate(dm, tempFile):
+  print('\n\n#########################################################'
+        '################\n\n\t\t\tReplication test\n')
+  lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterReplicate/testFile.%s' % time.time()
+  diracSE = 'SE-1'
+  putRes = dm.putAndRegister(lfn, tempFile, diracSE)
+  replicateRes = dm.replicateAndRegister(lfn, 'SE-2')  # ,sourceSE='',destPath='',localCache='')
+  removeRes = dm.removeFile(lfn)
+
+  # Check that the put was successful
+  assert putRes['OK'], putRes.get('Message', 'All OK')
+  assert 'Successful' in putRes['Value']
+  assert lfn in putRes['Value']['Successful']
+  assert putRes['Value']['Successful'][lfn]
+  # Check that the replicate was successful
+  assert replicateRes['OK'], replicateRes.get('Message', 'All OK')
+  assert 'Successful' in replicateRes['Value']
+  assert lfn in replicateRes['Value']['Successful']
+  assert replicateRes['Value']['Successful'][lfn]
+  # Check that the removal was successful
+  assert removeRes['OK'], removeRes.get('Message', 'All OK')
+  assert 'Successful' in removeRes['Value']
+  assert lfn in removeRes['Value']['Successful']
+  assert removeRes['Value']['Successful'][lfn]
+
+
+def test_putAndRegisterGetReplicaMetadata(dm, tempFile):
+  print('\n\n#########################################################'
+        '################\n\n\t\t\tGet metadata test\n')
+  lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterGetReplicaMetadata/testFile.%s' % time.time()
+  diracSE = 'SE-1'
+  putRes = dm.putAndRegister(lfn, tempFile, diracSE)
+  metadataRes = dm.getReplicaMetadata(lfn, diracSE)
+  removeRes = dm.removeFile(lfn)
+
+  # Check that the put was successful
+  assert putRes['OK'], putRes.get('Message', 'All OK')
+  assert 'Successful' in putRes['Value']
+  assert lfn in putRes['Value']['Successful']
+  assert putRes['Value']['Successful'][lfn]
+  # Check that the metadata query was successful
+  assert metadataRes['OK'], metadataRes.get('Message', 'All OK')
+  assert 'Successful' in metadataRes['Value']
+  assert lfn in metadataRes['Value']['Successful']
+  assert metadataRes['Value']['Successful'][lfn]
+  metadataDict = metadataRes['Value']['Successful'][lfn]
+  for key in ['Cached', 'Migrated', 'Size']:
+    assert key in metadataDict
+  # Check that the removal was successful
+  assert removeRes['OK'], removeRes.get('Message', 'All OK')
+  assert 'Successful' in removeRes['Value']
+  assert lfn in removeRes['Value']['Successful']
+  assert removeRes['Value']['Successful'][lfn]
+
+
+def test_putAndRegsiterGetAccessUrl(dm, tempFile):
+  print('\n\n#########################################################'
+        '################\n\n\t\t\tGet Access Url test\n')
+  lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterGetAccessUrl/testFile.%s' % time.time()
+  diracSE = 'SE-1'
+  putRes = dm.putAndRegister(lfn, tempFile, diracSE)
+  getAccessUrlRes = dm.getReplicaAccessUrl(lfn, diracSE)
+  print(getAccessUrlRes)
+  removeRes = dm.removeFile(lfn)
+
+  # Check that the put was successful
+  assert putRes['OK'], putRes.get('Message', 'All OK')
+  assert 'Successful' in putRes['Value']
+  assert lfn in putRes['Value']['Successful']
+  assert putRes['Value']['Successful'][lfn]
+  # Check that the access url was successful
+  assert getAccessUrlRes['OK'], getAccessUrlRes.get('Message', 'All OK')
+  assert 'Successful' in getAccessUrlRes['Value']
+  assert lfn in getAccessUrlRes['Value']['Successful']
+  assert getAccessUrlRes['Value']['Successful'][lfn]
+  # Check that the removal was successful
+  assert removeRes['OK'], removeRes.get('Message', 'All OK')
+  assert 'Successful' in removeRes['Value']
+  assert lfn in removeRes['Value']['Successful']
+  assert removeRes['Value']['Successful'][lfn]
+
+
+def test_putAndRegisterRemoveReplica(dm, tempFile):
+  print('\n\n#########################################################'
+        '################\n\n\t\t\tRemove replica test\n')
+  lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterRemoveReplica/testFile.%s' % time.time()
+  diracSE = 'SE-1'
+  putRes = dm.putAndRegister(lfn, tempFile, diracSE)
+  removeReplicaRes = dm.removeReplica(diracSE, lfn)
+  removeRes = dm.removeFile(lfn)
+
+  # Check that the put was successful
+  assert putRes['OK'], putRes.get('Message', 'All OK')
+  assert 'Successful' in putRes['Value']
+  assert lfn in putRes['Value']['Successful']
+  assert putRes['Value']['Successful'][lfn]
+  # Check that the replica removal failed, because it is the only copy
+  assert removeReplicaRes['OK'], removeReplicaRes.get('Message', 'All OK')
+  assert 'Failed' in removeReplicaRes['Value']
+  assert lfn in removeReplicaRes['Value']['Failed']
+  assert removeReplicaRes['Value']['Failed'][lfn]
+  # Check that the removal was successful
+  assert removeRes['OK'], removeRes.get('Message', 'All OK')
+  assert 'Successful' in removeRes['Value']
+  assert lfn in removeRes['Value']['Successful']
+  assert removeRes['Value']['Successful'][lfn]
+
+
+def test_registerFile(dm, tempFile):
+  lfn = '/Jenkins/test/unit-test/DataManager/registerFile/testFile.%s' % time.time()
+  physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
+  fileSize = 10000
+  storageElementName = 'SE-1'
+  fileGuid = makeGuid()
+  checkSum = None
+  fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid, checkSum)
+  registerRes = dm.registerFile(fileTuple)
+  removeFileRes = dm.removeFile(lfn)
+
+  # Check that the file registration was done correctly
+  assert registerRes['OK'], registerRes.get('Message', 'All OK')
+  assert 'Successful' in registerRes['Value']
+  assert lfn in registerRes['Value']['Successful']
+  assert registerRes['Value']['Successful'][lfn]
+  # Check that the removal was successful
+  assert removeFileRes['OK'], removeFileRes.get('Message', 'All OK')
+  assert 'Successful' in removeFileRes['Value']
+  assert lfn in removeFileRes['Value']['Successful']
+  assert removeFileRes['Value']['Successful'][lfn]
+
+
+def test_registerReplica(dm, tempFile):
+  print('\n\n#########################################################'
+        '################\n\n\t\t\tRegister replica test\n')
+  lfn = '/Jenkins/test/unit-test/DataManager/registerReplica/testFile.%s' % time.time()
+  physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
+  fileSize = 10000
+  storageElementName = 'SE-1'
+  fileGuid = makeGuid()
+  checkSum = None
+  fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid, checkSum)
+  registerRes = dm.registerFile(fileTuple)
+  seName = 'SE-1'
+  replicaTuple = (lfn, physicalFile, seName)
+  registerReplicaRes = dm.registerReplica(replicaTuple)
+  removeFileRes = dm.removeFile(lfn)
+
+  # Check that the file registration was done correctly
+  assert registerRes['OK'], registerRes.get('Message', 'All OK')
+  assert 'Successful' in registerRes['Value']
+  assert lfn in registerRes['Value']['Successful']
+  assert registerRes['Value']['Successful'][lfn]
+  # Check that the replica registration was successful
+  assert registerReplicaRes['OK'], registerReplicaRes.get('Message', 'All OK')
+  assert 'Successful' in registerReplicaRes['Value']
+  assert lfn in registerReplicaRes['Value']['Successful']
+  assert registerReplicaRes['Value']['Successful'][lfn]
+  # Check that the removal was successful
+  assert removeFileRes['OK'], removeFileRes.get('Message', 'All OK')
+  assert 'Successful' in removeFileRes['Value']
+  assert lfn in removeFileRes['Value']['Successful']
+  assert removeFileRes['Value']['Successful'][lfn]
+
+
+def test_putAndRegisterGet(dm, tempFile):
+  print('\n\n#########################################################'
+        '################\n\n\t\t\tGet file test\n')
+  lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterGet/testFile.%s' % time.time()
+  diracSE = 'SE-1'
+  putRes = dm.putAndRegister(lfn, tempFile, diracSE)
+  getRes = dm.getFile(lfn)
+  removeRes = dm.removeFile(lfn)
+  localFilePath = os.path.join(os.getcwd(), os.path.basename(lfn))
+  if os.path.exists(localFilePath):
+    os.remove(localFilePath)
+
+  # Check that the put was successful
+  assert putRes['OK'], putRes.get('Message', 'All OK')
+  assert 'Successful' in putRes['Value']
+  assert lfn in putRes['Value']['Successful']
+  assert putRes['Value']['Successful'][lfn]
+  # Check that the replica removal was successful
+  assert getRes['OK'], getRes.get('Message', 'All OK')
+  assert 'Successful' in getRes['Value']
+  assert lfn in getRes['Value']['Successful']
+  assert getRes['Value']['Successful'][lfn] == localFilePath
+  # Check that the removal was successful
+  assert removeRes['OK'], removeRes.get('Message', 'All OK')
+  assert 'Successful' in removeRes['Value']
+  assert lfn in removeRes['Value']['Successful']
+  assert removeRes['Value']['Successful'][lfn]

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -1,10 +1,11 @@
-# FIXME: to be took back to life
-
 from __future__ import print_function
 
 import os
 import time
 import unittest
+
+from DIRAC.Core.Base.Script import parseCommandLine
+parseCommandLine()
 
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.Core.Utilities.File import makeGuid

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -1,12 +1,16 @@
 # FIXME: to be took back to life
 
 from __future__ import print_function
-import unittest, time, os
+
+import os
+import time
+import unittest
+
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.Core.Utilities.File import makeGuid
 
-class ReplicaManagerTestCase(unittest.TestCase):
-  """ Base class for the Replica Manager test cases
+class DataManagerTestCase(unittest.TestCase):
+  """ Base class for the Data Manager test cases
   """
   def setUp(self):
     self.dataManager = DataManager()
@@ -18,8 +22,8 @@ class ReplicaManagerTestCase(unittest.TestCase):
   def test_putAndRegister(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tPut and register test\n')
-    lfn = '/lhcb/test/unit-test/ReplicaManager/putAndRegister/testFile.%s' % time.time()
-    diracSE = 'GRIDKA-RAW'
+    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegister/testFile.%s' % time.time()
+    diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     removeRes = self.dataManager.removeFile(lfn)
 
@@ -37,10 +41,10 @@ class ReplicaManagerTestCase(unittest.TestCase):
   def test_putAndRegisterReplicate(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tReplication test\n')
-    lfn = '/lhcb/test/unit-test/ReplicaManager/putAndRegisterReplicate/testFile.%s' % time.time()
-    diracSE = 'GRIDKA-RAW'
+    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterReplicate/testFile.%s' % time.time()
+    diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
-    replicateRes = self.dataManager.replicateAndRegister(lfn,'CNAF-DST') #,sourceSE='',destPath='',localCache='')
+    replicateRes = self.dataManager.replicateAndRegister(lfn,'SE-2') #,sourceSE='',destPath='',localCache='')
     removeRes = self.dataManager.removeFile(lfn)
 
     # Check that the put was successful
@@ -62,8 +66,8 @@ class ReplicaManagerTestCase(unittest.TestCase):
   def test_putAndRegisterGetReplicaMetadata(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tGet metadata test\n')
-    lfn = '/lhcb/test/unit-test/ReplicaManager/putAndRegisterGetReplicaMetadata/testFile.%s' % time.time()
-    diracSE = 'GRIDKA-RAW'
+    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterGetReplicaMetadata/testFile.%s' % time.time()
+    diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     metadataRes = self.dataManager.getReplicaMetadata(lfn,diracSE)
     removeRes = self.dataManager.removeFile(lfn)
@@ -92,8 +96,8 @@ class ReplicaManagerTestCase(unittest.TestCase):
   def test_putAndRegsiterGetAccessUrl(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tGet Access Url test\n')
-    lfn = '/lhcb/test/unit-test/ReplicaManager/putAndRegisterGetAccessUrl/testFile.%s' % time.time()
-    diracSE = 'GRIDKA-RAW'
+    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterGetAccessUrl/testFile.%s' % time.time()
+    diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     getAccessUrlRes = self.dataManager.getReplicaAccessUrl(lfn,diracSE)
     print(getAccessUrlRes)
@@ -118,8 +122,8 @@ class ReplicaManagerTestCase(unittest.TestCase):
   def test_putAndRegisterRemoveReplica(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tRemove replica test\n')
-    lfn = '/lhcb/test/unit-test/ReplicaManager/putAndRegisterRemoveReplica/testFile.%s' % time.time()
-    diracSE = 'GRIDKA-RAW'
+    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterRemoveReplica/testFile.%s' % time.time()
+    diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     removeReplicaRes = self.dataManager.removeReplica(diracSE,lfn)
     removeRes = self.dataManager.removeFile(lfn)
@@ -141,7 +145,7 @@ class ReplicaManagerTestCase(unittest.TestCase):
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_registerFile(self):
-    lfn = '/lhcb/test/unit-test/ReplicaManager/registerFile/testFile.%s' % time.time()
+    lfn = '/jenkins/test/unit-test/DataManager/registerFile/testFile.%s' % time.time()
     physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
     fileSize = 10000
     storageElementName = 'CERN-RAW'
@@ -170,14 +174,14 @@ class ReplicaManagerTestCase(unittest.TestCase):
   def test_registerReplica(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tRegister replica test\n')
-    lfn = '/lhcb/test/unit-test/ReplicaManager/registerReplica/testFile.%s' % time.time()
+    lfn = '/jenkins/test/unit-test/DataManager/registerReplica/testFile.%s' % time.time()
     physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
     fileSize = 10000
     storageElementName = 'CERN-RAW'
     fileGuid = makeGuid()
     fileTuple = (lfn,physicalFile,fileSize,storageElementName,fileGuid)
     registerRes = self.dataManager.registerFile(fileTuple)
-    seName = 'GRIDKA-RAW'
+    seName = 'SE-1'
     replicaTuple = (lfn,physicalFile,seName)
     registerReplicaRes = self.dataManager.registerReplica(replicaTuple)
     # removeCatalogReplicaRes1 = self.dataManager.removeCatalogReplica(storageElementName,lfn)
@@ -213,8 +217,8 @@ class ReplicaManagerTestCase(unittest.TestCase):
   def test_putAndRegisterGet(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tGet file test\n')
-    lfn = '/lhcb/test/unit-test/ReplicaManager/putAndRegisterGet/testFile.%s' % time.time()
-    diracSE = 'GRIDKA-RAW'
+    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterGet/testFile.%s' % time.time()
+    diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     getRes = self.dataManager.getFile(lfn)
     removeRes = self.dataManager.removeFile(lfn)
@@ -239,6 +243,7 @@ class ReplicaManagerTestCase(unittest.TestCase):
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
 if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase(ReplicaManagerTestCase)
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(DataManagerTestCase)
   #suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(DirectoryTestCase))
   testResult = unittest.TextTestRunner(verbosity=2).run(suite)
+  exit(testResult)

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -42,7 +42,7 @@ class DataManagerTestCase(unittest.TestCase):
   def test_putAndRegisterReplicate(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tReplication test\n')
-    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterReplicate/testFile.%s' % time.time()
+    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterReplicate/testFile.%s' % time.time()
     diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     replicateRes = self.dataManager.replicateAndRegister(lfn, 'SE-2')  # ,sourceSE='',destPath='',localCache='')
@@ -67,7 +67,7 @@ class DataManagerTestCase(unittest.TestCase):
   def test_putAndRegisterGetReplicaMetadata(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tGet metadata test\n')
-    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterGetReplicaMetadata/testFile.%s' % time.time()
+    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterGetReplicaMetadata/testFile.%s' % time.time()
     diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     metadataRes = self.dataManager.getReplicaMetadata(lfn, diracSE)
@@ -95,7 +95,7 @@ class DataManagerTestCase(unittest.TestCase):
   def test_putAndRegsiterGetAccessUrl(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tGet Access Url test\n')
-    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterGetAccessUrl/testFile.%s' % time.time()
+    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterGetAccessUrl/testFile.%s' % time.time()
     diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     getAccessUrlRes = self.dataManager.getReplicaAccessUrl(lfn, diracSE)
@@ -121,7 +121,7 @@ class DataManagerTestCase(unittest.TestCase):
   def test_putAndRegisterRemoveReplica(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tRemove replica test\n')
-    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterRemoveReplica/testFile.%s' % time.time()
+    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterRemoveReplica/testFile.%s' % time.time()
     diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     removeReplicaRes = self.dataManager.removeReplica(diracSE, lfn)
@@ -144,7 +144,7 @@ class DataManagerTestCase(unittest.TestCase):
     self.assertTrue(removeRes['Value']['Successful'][lfn])
 
   def test_registerFile(self):
-    lfn = '/jenkins/test/unit-test/DataManager/registerFile/testFile.%s' % time.time()
+    lfn = '/Jenkins/test/unit-test/DataManager/registerFile/testFile.%s' % time.time()
     physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
     fileSize = 10000
     storageElementName = 'SE-1'
@@ -173,7 +173,7 @@ class DataManagerTestCase(unittest.TestCase):
   def test_registerReplica(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tRegister replica test\n')
-    lfn = '/jenkins/test/unit-test/DataManager/registerReplica/testFile.%s' % time.time()
+    lfn = '/Jenkins/test/unit-test/DataManager/registerReplica/testFile.%s' % time.time()
     physicalFile = 'srm://host:port/srm/managerv2?SFN=/sa/path%s' % lfn
     fileSize = 10000
     storageElementName = 'SE-1'
@@ -216,7 +216,7 @@ class DataManagerTestCase(unittest.TestCase):
   def test_putAndRegisterGet(self):
     print('\n\n#########################################################'
           '################\n\n\t\t\tGet file test\n')
-    lfn = '/jenkins/test/unit-test/DataManager/putAndRegisterGet/testFile.%s' % time.time()
+    lfn = '/Jenkins/test/unit-test/DataManager/putAndRegisterGet/testFile.%s' % time.time()
     diracSE = 'SE-1'
     putRes = self.dataManager.putAndRegister(lfn, self.fileName, diracSE)
     getRes = self.dataManager.getFile(lfn)

--- a/tests/Integration/all_integration_client_tests.sh
+++ b/tests/Integration/all_integration_client_tests.sh
@@ -70,3 +70,25 @@ pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/TransformationSystem/Test_Clien
 echo -e "*** $(date -u)  **** PS TESTS ****\n"
 pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ProductionSystem/Test_Client_Production.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
 pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/ProductionSystem/Test_Client_TS_Prod.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))
+
+#-------------------------------------------------------------------------------#
+echo -e "*** $(date -u) **** DataManager TESTS ****\n"
+
+echo -e "*** $(date -u)  Getting a privileged user\n" 2>&1 | tee -a clientTestOutputs.txt
+dirac-proxy-init -g jenkins_fcadmin -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG 2>&1 | tee -a clientTestOutputs.txt
+
+cat >> dataManager_create_folders <<EOF
+
+mkdir /Jenkins
+chgrp -R jenkins_user Jenkins
+chmod -R 774 Jenkins
+exit
+
+EOF
+
+dirac-dms-filecatalog-cli < dataManager_create_folders
+
+echo -e "*** $(date -u)  Getting a non privileged user\n" 2>&1 | tee -a clientTestOutputs.txt
+dirac-proxy-init -g jenkins_user -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG 2>&1 | tee -a clientTestOutputs.txt
+
+pytest $CLIENTINSTALLDIR/DIRAC/tests/Integration/DataManagementSystem/Test_DataManager.py 2>&1 | tee -a clientTestOutputs.txt; (( ERR |= $? ))

--- a/tests/Jenkins/dirac-cfg-update-server.py
+++ b/tests/Jenkins/dirac-cfg-update-server.py
@@ -361,6 +361,9 @@ if not res['OK']:
   exit(1)
 csAPI.setOption('Registry/VO/Jenkins/VOMSName', 'myVOMS')
 
+csAPI.setOption('Registry/Groups/jenkins_fcadmin/VO', 'Jenkins')
+csAPI.setOption('Registry/Groups/jenkins_user/VO', 'Jenkins')
+
 
 # Final action: commit in CS
 res = csAPI.commit()

--- a/tests/Jenkins/dirac-cfg-update-server.py
+++ b/tests/Jenkins/dirac-cfg-update-server.py
@@ -139,7 +139,13 @@ for st in ['Resources/Sites/DIRAC/',
            'Resources/Sites/DIRAC/DIRAC.Jenkins.ch',
            'Resources/Sites/DIRAC/DIRAC.Jenkins.ch/jenkins.cern.ch',
            'Resources/Sites/DIRAC/DIRAC.Jenkins.ch/jenkins.cern.ch/Queues'
-           'Resources/Sites/DIRAC/DIRAC.Jenkins.ch/jenkins.cern.ch/Queues/jenkins-queue_not_important']:
+           'Resources/Sites/DIRAC/DIRAC.Jenkins.ch/jenkins.cern.ch/Queues/jenkins-queue_not_important',
+           'Resources/StorageElements',
+           'Resources/StorageElements/SE-1',
+           'Resources/StorageElements/SE-1/DIP',
+           'Resources/StorageElements/SE-2',
+           'Resources/StorageElements/SE-2/DIP',
+           ]:
   res = csAPI.createSection(st)
 if not res['OK']:
   print(res['Message'])
@@ -151,6 +157,20 @@ csAPI.setOption(
     '200000')
 csAPI.setOption('Resources/Sites/DIRAC/DIRAC.Jenkins.ch/CEs/jenkins.cern.ch/Queues/jenkins-queue_not_important/SI00',
                 '2400')
+
+csAPI.setOption('Resources/StorageElements/SE-1/AccessProtocol', 'dips')
+csAPI.setOption('Resources/StorageElements/SE-1/DIP/Host', 'server')
+csAPI.setOption('Resources/StorageElements/SE-1/DIP/Port', '9148')
+csAPI.setOption('Resources/StorageElements/SE-1/DIP/Protocol', 'dips')
+csAPI.setOption('Resources/StorageElements/SE-1/DIP/Path', '/DataManagement/SE-1')
+csAPI.setOption('Resources/StorageElements/SE-1/DIP/Access', 'remote')
+
+csAPI.setOption('Resources/StorageElements/SE-2/AccessProtocol', 'dips')
+csAPI.setOption('Resources/StorageElements/SE-2/DIP/Host', 'server')
+csAPI.setOption('Resources/StorageElements/SE-2/DIP/Port', '9147')
+csAPI.setOption('Resources/StorageElements/SE-2/DIP/Protocol', 'dips')
+csAPI.setOption('Resources/StorageElements/SE-2/DIP/Path', '/DataManagement/SE-2')
+csAPI.setOption('Resources/StorageElements/SE-2/DIP/Access', 'remote')
 
 
 # Now setting up the following option:

--- a/tests/Jenkins/dirac-cfg-update-server.py
+++ b/tests/Jenkins/dirac-cfg-update-server.py
@@ -363,4 +363,7 @@ csAPI.setOption('Registry/VO/Jenkins/VOMSName', 'myVOMS')
 
 
 # Final action: commit in CS
-csAPI.commit()
+res = csAPI.commit()
+if not res['OK']:
+  print(res['Message'])
+  exit(1)

--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -319,6 +319,7 @@ function fullInstallDIRAC(){
   dirac-rss-set-status --element Resource --name JENKINS-FTS3 --status Active --reason "Why not?"
   dirac-rss-set-status --element Resource --name FileCatalog --status Active --reason "Why not?"
   dirac-rss-set-status --element Site --name DIRAC.Jenkins.ch --status Active --reason "Why not?"
+  dirac-admin-allow-se SE-1 SE-2 --All
 
   #agents
   findAgents

--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -236,6 +236,12 @@ function fullInstallDIRAC(){
     exit 1
   fi
 
+  # add 2 storageelements
+  if ! diracSEs; then
+    echo "ERROR: diracSEs failed"
+    exit 1
+  fi
+
   echo "==> Restarting Framework ProxyManager"
   dirac-restart-component Framework ProxyManager $DEBUG
 
@@ -295,6 +301,10 @@ function fullInstallDIRAC(){
 
   echo "==> Restarting ResourceStatus Publisher"
   dirac-restart-component ResourceStatus Publisher $DEBUG
+
+  echo "==> Restarting DataManagement StorageElement(s)"
+  dirac-restart-component DataManagement SE-1 $DEBUG
+  dirac-restart-component DataManagement SE-2 $DEBUG
 
   # populate RSS
   echo "==> Populating RSS DB"

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -632,6 +632,16 @@ function diracUserAndGroup(){
     exit 1
   fi
 
+  if ! dirac-admin-add-group -G jenkins_fcadmin -U adminusername,ciuser,trialUser -P FileCatalogManagement,NormalUser "$DEBUG"; then
+    echo 'ERROR: dirac-admin-add-group failed'
+    exit 1
+  fi
+
+  if ! dirac-admin-add-group -G jenkins_user -U adminusername,ciuser,trialUser -P NormalUser "$DEBUG"; then
+    echo 'ERROR: dirac-admin-add-group failed'
+    exit 1
+  fi
+
   if ! dirac-admin-add-shifter DataManager adminusername prod "$DEBUG"; then
     echo 'ERROR: dirac-admin-add-shifter failed'
     exit 1

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -722,7 +722,7 @@ function diracAddSite(){
 diracServices(){
   echo '==> [diracServices]'
 
-  services=$(cut -d '.' -f 1 < services | grep -v PilotsLogging | grep -v IRODSStorageElementHandler | grep -v ^ConfigurationSystem | grep -v Plotting | grep -v RAWIntegrity | grep -v RunDBInterface | grep -v ComponentMonitoring | sed 's/System / /g' | sed 's/Handler//g' | sed 's/ /\//g')
+  services=$(cut -d '.' -f 1 < services | grep -v PilotsLogging | grep -v StorageElementHandler | grep -v ^ConfigurationSystem | grep -v Plotting | grep -v RAWIntegrity | grep -v RunDBInterface | grep -v ComponentMonitoring | sed 's/System / /g' | sed 's/Handler//g' | sed 's/ /\//g')
 
   # group proxy, will be uploaded explicitly
   #  echo '==> getting/uploading proxy for prod'
@@ -736,6 +736,29 @@ diracServices(){
     fi
   done
 }
+
+
+diracSEs(){
+  echo '==> [diracSEs]'
+
+  echo "==> Installing SE-1"
+  seDir=$SERVERINSTALLDIR/Storage/SE-1
+  mkdir -p $seDir
+  if ! dirac-install-component DataManagement SE-1 -m StorageElement -p BasePath=$seDir -p Port=9148 "$DEBUG"; then
+    echo 'ERROR: dirac-install-component failed'
+    exit 1
+  fi
+
+  echo "==> Installing SE-2"
+  seDir=$SERVERINSTALLDIR/Storage/SE-2
+  mkdir -p $seDir
+  if ! dirac-install-component DataManagement SE-2 -m StorageElement -p BasePath=$seDir -p Port=9147 "$DEBUG"; then
+    echo 'ERROR: dirac-install-component failed'
+    exit 1
+  fi
+
+}
+
 
 #-------------------------------------------------------------------------------
 # diracUninstallServices:


### PR DESCRIPTION

Currently trying to revive the DataManager tests, installing two local SEs and copying files. Adding some tests for cleaning directories once this is working.

BEGINRELEASENOTES

*DMS
FIX: dirac-dms-clean-directory: also works on single empty directory, fixes #4420 

*Framework
FIX: dirac-install-component: fix bug prohibiting use of the -m/--module parameter

ENDRELEASENOTES
