### PR TITLE
[v7r0] Escape comma with __comma__ in CS values

### DIFF
--- a/ConfigurationSystem/private/ConfigurationClient.py
+++ b/ConfigurationSystem/private/ConfigurationClient.py
@@ -88,7 +88,7 @@ class ConfigurationClient(object):
 
     if requestedType in (list, tuple, set):
       try:
-        return S_OK(requestedType(List.fromChar(optionValue, ',')))
+        return S_OK(requestedType([ss.replace('__comma__',',') for ss in List.fromChar(optionValue, ',')]))
       except Exception as e:
         return S_ERROR("Can't convert value (%s) to comma separated list \n%s" % (str(optionValue),
                                                                                   repr(e)))
@@ -112,8 +112,9 @@ class ConfigurationClient(object):
         return S_ERROR("Can't convert value (%s) to Dict \n%s" % (str(optionValue),
                                                                   repr(e)))
     else:
+      optValue = optionValue.replace('__comma__',',')
       try:
-        return S_OK(requestedType(optionValue))
+        return S_OK(requestedType(optValue))
       except Exception as e:
         return S_ERROR(
             "Type mismatch between default (%s) and configured value (%s) \n%s" %

--- a/ConfigurationSystem/private/ConfigurationClient.py
+++ b/ConfigurationSystem/private/ConfigurationClient.py
@@ -142,7 +142,8 @@ class ConfigurationClient(object):
     optionList = gConfigurationData.getOptionsFromCFG(sectionPath)
     if isinstance(optionList, list):
       for option in optionList:
-        optionsDict[option] = gConfigurationData.extractOptionFromCFG("%s/%s" % (sectionPath, option))
+        optionsDict[option] = gConfigurationData.extractOptionFromCFG("%s/%s" %
+                                                                      (sectionPath, option)).replace('__comma__', ',')
       return S_OK(optionsDict)
     else:
       return S_ERROR("Path %s does not exist or it's not a section" % sectionPath)

--- a/ConfigurationSystem/private/ConfigurationClient.py
+++ b/ConfigurationSystem/private/ConfigurationClient.py
@@ -88,7 +88,7 @@ class ConfigurationClient(object):
 
     if requestedType in (list, tuple, set):
       try:
-        return S_OK(requestedType([ss.replace('__comma__',',') for ss in List.fromChar(optionValue, ',')]))
+        return S_OK(requestedType([ss.replace('__comma__', ',') for ss in List.fromChar(optionValue, ',')]))
       except Exception as e:
         return S_ERROR("Can't convert value (%s) to comma separated list \n%s" % (str(optionValue),
                                                                                   repr(e)))
@@ -112,7 +112,7 @@ class ConfigurationClient(object):
         return S_ERROR("Can't convert value (%s) to Dict \n%s" % (str(optionValue),
                                                                   repr(e)))
     else:
-      optValue = optionValue.replace('__comma__',',')
+      optValue = optionValue.replace('__comma__', ',')
       try:
         return S_OK(requestedType(optValue))
       except Exception as e:

--- a/Core/Utilities/CFG.py
+++ b/Core/Utilities/CFG.py
@@ -427,9 +427,11 @@ class CFG(object):
 
     if defaultType == list:
       try:
-        return List.fromChar(optionValue, ',')
+        return [ss.replace('__comma__', ',') for ss in List.fromChar(optionValue, ',')]
       except Exception:
         return defaultValue
+    elif isinstance(defaultValue, basestring):
+      return optionValue.replace('__comma__',',')
     elif defaultType == bool:
       try:
         return optionValue.lower() in ("y", "yes", "true", "1")

--- a/Core/Utilities/CFG.py
+++ b/Core/Utilities/CFG.py
@@ -431,7 +431,7 @@ class CFG(object):
       except Exception:
         return defaultValue
     elif isinstance(defaultValue, basestring):
-      return optionValue.replace('__comma__',',')
+      return optionValue.replace('__comma__', ',')
     elif defaultType == bool:
       try:
         return optionValue.lower() in ("y", "yes", "true", "1")


### PR DESCRIPTION
  This is a simple modification of the interpretation of the CS values which allows to have comma separated list options where the list elements can themselves contain commas. This helps to cope with the case, for example, when a user has a DN containing comma (yes, it happens !). 
Then the comma in the DN can be escaped by replacing it with "\_\_comma\_\_" string. Otherwise, the changes in the PR do not affect existing configurations in any way.

BEGINRELEASENOTES

*Core
CHANGE: CFG.py - allow escaping commas in the option values

*Configuration
CHANGE: ConfigurationClient - allow escaping commas in the option values

ENDRELEASENOTES
