### PR TITLE
[v7r1] Fix MySQLDB _connect() method

### DIFF
--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -15,7 +15,7 @@ ERR=0
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Core TESTS ****\n"
 pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Core/Test_ElasticsearchDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
-
+pytest $SERVERINSTALLDIR/DIRAC/tests/Integration/Core/Test_MySQLDB.py 2>&1 | tee -a $SERVER_TEST_OUTPUT; (( ERR |= $? ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** FRAMEWORK TESTS (partially skipped) ****\n"


### PR DESCRIPTION
The `MySQLDB._connect()` does not ensure the connection with a DB is established properly and always return `S_OK()`:
https://github.com/DIRACGrid/DIRAC/blob/integration/Core/Utilities/MySQL.py#L583

This PR fixes the method by trying to establish a connection with the DB.
It may take several minutes so it does not retry a lot of times if it doesn't work.
If the connection fails, then the method returns an error.

BEGINRELEASENOTES
*Core
FIX: MySQLDB _connect method
*tests
CHANGE: integrate test_MySQLDB to all_integration_server_tests
ENDRELEASENOTES
