### PR TITLE
[v6r22] Fix serverName in ServerUtils.getPilotAgentsDB()

### DIFF
--- a/WorkloadManagementSystem/Client/ServerUtils.py
+++ b/WorkloadManagementSystem/Client/ServerUtils.py
@@ -31,7 +31,7 @@ def getDBOrClient(DB, serverName):
 
 
 def getPilotAgentsDB():
-  serverName = 'WorkloadManagement/Pilots'
+  serverName = 'WorkloadManagement/PilotManager'
   PilotAgentsDB = None
   try:
     from DIRAC.WorkloadManagementSystem.DB.PilotAgentsDB import PilotAgentsDB


### PR DESCRIPTION

BEGINRELEASENOTES
*WorkloadManagement
FIX: server name in ServerUtils.getPilotAgentsDB()
ENDRELEASENOTES
