### PR TITLE
[v6r22] Read ES IndexPrefix from CS, if none given use setup name

### DIFF
--- a/MonitoringSystem/DB/MonitoringDB.py
+++ b/MonitoringSystem/DB/MonitoringDB.py
@@ -10,6 +10,8 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Base.ElasticDB import ElasticDB
 from DIRAC.Core.Utilities.ElasticSearchDB import generateFullIndexName
 from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
+from DIRAC.ConfigurationSystem.Client.Config import gConfig
+from DIRAC.ConfigurationSystem.Client.PathFinder import getDatabaseSection
 
 from DIRAC.MonitoringSystem.private.TypeLoader import TypeLoader
 
@@ -20,7 +22,9 @@ class MonitoringDB(ElasticDB):
   """
 
   def __init__(self, name='Monitoring/MonitoringDB', readOnly=False):
-    super(MonitoringDB, self).__init__('MonitoringDB', name, CSGlobals.getSetup().lower())
+    section = getDatabaseSection("Monitoring/MonitoringDB")
+    indexPrefix = gConfig.getValue("%s/IndexPrefix" % section, CSGlobals.getSetup()).lower()
+    super(MonitoringDB, self).__init__('MonitoringDB', name, indexPrefix)
     self.__readonly = readOnly
     self.__documents = {}
     self.__loadIndexes()

--- a/MonitoringSystem/DB/MonitoringDB.py
+++ b/MonitoringSystem/DB/MonitoringDB.py
@@ -1,5 +1,13 @@
 """
 Wrapper on top of ElasticDB. It is used to manage the DIRAC monitoring types.
+
+**Configuration Parameters**:
+
+The following options can be set in ``Systems/Monitoring/<Setup>/Databases/MonitoringDB``
+
+* *IndexPrefix*:  Prefix used to prepend to indices created in the ES instance. If this
+                  is not present in the CS, the indices are prefixed with the setup name.
+
 """
 
 __RCSID__ = "$Id$"


### PR DESCRIPTION
BEGINRELEASENOTES
*MonitoringSystem
CHANGE: Read the IndexPrefix for the CS and use this index prefix when creating ES indices, if not given use the name of the setup

ENDRELEASENOTES

This is needed or us, since we have an ES instance es-ilcdirac with IT, but our setup name in DIRAC is ilc. The problem is that IT wants that the index prefix matches instance name.
