### PR TITLE
[v7r1]Fix discrepancy in CE _reset()

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -194,6 +194,7 @@ class ARCComputingElement(ComputingElement):
     self.queue = self.ceParameters['Queue']
     if 'GridEnv' in self.ceParameters:
       self.gridEnv = self.ceParameters['GridEnv']
+    return S_OK()
 
   #############################################################################
   def submitJob(self, executableFile, proxy, numberOfJobs=1, processors=1):

--- a/Resources/Computing/CREAMComputingElement.py
+++ b/Resources/Computing/CREAMComputingElement.py
@@ -100,6 +100,7 @@ class CREAMComputingElement(ComputingElement):
     self.queue = self.ceParameters.get("CEQueueName", self.ceParameters['Queue'])
     self.outputURL = self.ceParameters.get('OutputURL', 'gsiftp://localhost')
     self.gridEnv = self.ceParameters.get('GridEnv', self.gridEnv)
+    return S_OK()
 
   #############################################################################
   def submitJob(self, executableFile, proxy, numberOfJobs=1, processors=1):

--- a/Resources/Computing/ComputingElement.py
+++ b/Resources/Computing/ComputingElement.py
@@ -186,7 +186,7 @@ class ComputingElement(object):
   def _reset(self):
     """ Make specific CE parameter adjustments after they are collected or added
     """
-    pass
+    return S_OK()
 
   def loadBatchSystem(self):
     """ Instantiate object representing the backend batch system
@@ -231,8 +231,7 @@ class ComputingElement(object):
       if key in FLOAT_PARAMETERS:
         self.ceParameters[key] = float(self.ceParameters[key])
 
-    self._reset()
-    return S_OK()
+    return self._reset()
 
   def getParameterDict(self):
     """  Get the CE complete parameter dictionary

--- a/Resources/Computing/ComputingElementFactory.py
+++ b/Resources/Computing/ComputingElementFactory.py
@@ -58,8 +58,11 @@ class ComputingElementFactory(object):
       ceDict = {'CEType': ceTypeLocal}
       if ceParametersDict:
         ceDict.update(ceParametersDict)
-      computingElement.setParameters(ceDict)
-    except BaseException as x:
+      result = computingElement.setParameters(ceDict)
+      if not result['OK']:
+        return result
+
+    except Exception as x:
       msg = 'ComputingElementFactory could not instantiate %s object: %s' % (subClassName, str(x))
       self.log.exception()
       self.log.warn(msg)

--- a/Resources/Computing/GlobusComputingElement.py
+++ b/Resources/Computing/GlobusComputingElement.py
@@ -53,6 +53,7 @@ class GlobusComputingElement(ComputingElement):
     self.queue = self.ceParameters['Queue']
     self.outputURL = self.ceParameters.get('OutputURL', 'gsiftp://localhost')
     self.gridEnv = self.ceParameters.get('GridEnv', self.gridEnv)
+    return S_OK()
 
   #############################################################################
   def submitJob(self, executableFile, proxy, numberOfJobs=1):

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -237,6 +237,7 @@ Queue %(nJobs)s
 
     self.log.debug("Using local schedd: %r " % self.useLocalSchedd)
     self.log.debug("Remote scheduler option: '%s' " % self.remoteScheddOptions)
+    return S_OK()
 
   #############################################################################
   def submitJob(self, executableFile, proxy, numberOfJobs=1):

--- a/Resources/Computing/LocalComputingElement.py
+++ b/Resources/Computing/LocalComputingElement.py
@@ -11,6 +11,7 @@ import stat
 import shutil
 import tempfile
 import getpass
+import errno
 from urlparse import urlparse
 
 from DIRAC import S_OK, S_ERROR
@@ -68,6 +69,7 @@ class LocalComputingElement(ComputingElement):
 
     result = self._prepareHost()
     if not result['OK']:
+      self.log.error('Failed to initialize CE', self.ceName)
       return result
 
     self.submitOptions = ''
@@ -123,12 +125,12 @@ class LocalComputingElement(ComputingElement):
     self.log.verbose('Creating working directories')
     result = systemCall(30, cmdTuple)
     if not result['OK']:
-      self.log.warn('Failed creating working directories: %s' % result['Message'][1])
+      self.log.error('Failed creating working directories', '(%s)' % result['Message'][1])
       return result
-    status, output, _error = result['Value']
+    status, output, error = result['Value']
     if status != 0:
-      self.log.warn('Failed to create directories: %s' % output)
-      return S_ERROR('Failed to create directories: %s' % output)
+      self.log.error('Failed to create directories', '(%s)' % error)
+      return S_ERROR(errno.EACCES, 'Failed to create directories')
 
     return S_OK()
 

--- a/Resources/Computing/PoolComputingElement.py
+++ b/Resources/Computing/PoolComputingElement.py
@@ -83,6 +83,7 @@ class PoolComputingElement(ComputingElement):
     self.processors = int(self.ceParameters.get('NumberOfProcessors', self.processors))
     self.ceParameters['MaxTotalJobs'] = self.processors
     self.useSudo = self.ceParameters.get('SudoExecution', False)
+    return S_OK()
 
   def getProcessorsInUse(self):
     """ Get the number of currently allocated processor cores

--- a/Resources/Computing/SSHBatchComputingElement.py
+++ b/Resources/Computing/SSHBatchComputingElement.py
@@ -70,6 +70,7 @@ class SSHBatchComputingElement(SSHComputingElement):
         self.sshHost.append(hPar.strip())
       else:
         self.log.error('Failed to initialize host', host)
+        return result
 
     self.submitOptions = ''
     if 'SubmitOptions' in self.ceParameters:
@@ -79,6 +80,8 @@ class SSHBatchComputingElement(SSHComputingElement):
       if self.ceParameters['RemoveOutput'].lower() in ['no', 'false', '0']:
         self.removeOutput = False
     self.preamble = self.ceParameters.get('Preamble', '')
+
+    return S_OK()
 
   #############################################################################
   def submitJob(self, executableFile, proxy, numberOfJobs=1):


### PR DESCRIPTION
There is a discrepancy between the definition of the `_reset()` method in LocalCE and SSHCE, and in the others.
LocalCE and SSHCE return a value (`S_OK`/`S_ERROR`) while the others don't.

https://github.com/DIRACGrid/DIRAC/blob/integration/Resources/Computing/CREAMComputingElement.py#L102
https://github.com/DIRACGrid/DIRAC/blob/integration/Resources/Computing/LocalComputingElement.py#L71

Errors are not handled as ComputingElement ignores the value returned by _reset.

https://github.com/DIRACGrid/DIRAC/blob/integration/Resources/Computing/ComputingElement.py#L234

In this PR, I add a value to return in every definition of `_reset` and the value that it returns is considered.

BEGINRELEASENOTES
*Resources
FIX: discrepancy in CE._reset()
ENDRELEASENOTES
