### PR TITLE
[v6r22] do not try to compile the WebApp

### DIFF
--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -391,21 +391,6 @@ class SystemAdministratorHandler(RequestHandler):
         error.append('Failed to install Oracle client module')
         return S_ERROR('\n'.join(error))
 
-    if webPortal:
-      # we have a to compile the new web portal...
-      webappCompileScript = os.path.join(
-          gComponentInstaller.instancePath, 'pro', "WebAppDIRAC/scripts", "dirac-webapp-compile.py")
-      outfile = "%s.out" % webappCompileScript
-      err = "%s.err" % webappCompileScript
-      result = systemCall(False, ['dirac-webapp-compile', ' > ', outfile, ' 2> ', err])
-      if not result['OK']:
-        return result
-      if result['Value'][0] != 0:
-        error = result['Value'][1].split('\n')
-        error.extend(result['Value'][2].split('\n'))
-        error.append('Failed to compile the java script!')
-        return S_ERROR('\n'.join(error))
-
     return S_OK()
 
   types_revertSoftware = []


### PR DESCRIPTION
BEGINRELEASENOTES

*Framework
CHANGE: Web portal compilation is done during the DIRAC distribution, it is not required to compile during the installation

ENDRELEASENOTES
