### PR TITLE
[v6r22] Add warning about no MQ in Monitoring

### DIFF
--- a/MonitoringSystem/Client/MonitoringReporter.py
+++ b/MonitoringSystem/Client/MonitoringReporter.py
@@ -188,4 +188,6 @@ class MonitoringReporter(object):
         gLogger.error("Fail to create Producer:", result['Message'])
       else:
         mqProducer = result['Value']
+    else:
+      gLogger.warn("No MQ setup for Monitoring in CS. You are running Monitoring without failover:", result['Message'])
     return mqProducer


### PR DESCRIPTION
As discussed a warning log about not having MQ setup in Monitoring. I don't this this needs release notes.
