### PR TITLE
[v7r1] Make M2Crypto the default over pyGSI

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -13,10 +13,10 @@ jobs:
       matrix:
         command:
           - pytest
-          - DIRAC_USE_M2CRYPTO=Yes pytest
+          - DIRAC_USE_M2CRYPTO=No pytest
           # Security tests are flakey due to reference counting bugs in pyGSI/src/crypto/asn1.c
           - pytest Core/Security/test || (echo "Retrying..."; pytest Core/Security/test) || (echo "Retrying again..."; pytest Core/Security/test)
-          - DIRAC_USE_M2CRYPTO=Yes pytest Core/Security/test || (echo "Retrying..."; DIRAC_USE_M2CRYPTO=Yes pytest Core/Security/test) || (echo "Retrying again..."; DIRAC_USE_M2CRYPTO=Yes pytest Core/Security/test)
+          - DIRAC_USE_M2CRYPTO=No pytest Core/Security/test || (echo "Retrying..."; DIRAC_USE_M2CRYPTO=No pytest Core/Security/test) || (echo "Retrying again..."; DIRAC_USE_M2CRYPTO=No pytest Core/Security/test)
           - tests/checkDocs.sh
           # TODO This should cover more than just tests/CI
           # Excluded codes related to sourcing files

--- a/Core/DISET/private/Transports/SSLTransport.py
+++ b/Core/DISET/private/Transports/SSLTransport.py
@@ -12,7 +12,7 @@ from DIRAC.Core.Security.X509Certificate import X509Certificate  # pylint: disab
 
 # Eventhough SSLTransport is not used in this file, it is imported in other module from there,
 # so do not remove these imports !
-if os.getenv('DIRAC_USE_M2CRYPTO', 'NO').lower() in ('yes', 'true'):
+if os.getenv('DIRAC_USE_M2CRYPTO', 'yes').lower() in ('yes', 'true'):
   from DIRAC.Core.DISET.private.Transports.M2SSLTransport import SSLTransport
 else:
   from DIRAC.Core.DISET.private.Transports.GSISSLTransport import SSLTransport

--- a/Core/Security/__init__.py
+++ b/Core/Security/__init__.py
@@ -32,7 +32,7 @@ locals().pop('X509Request')
 # If we want to use M2Crypto, we add the m2crypto subpackage to the search path
 # This allows imports like 'from DIRAC.Core.Security.X509Chian...' to work transparently
 # Nice kind of tricks you find in libraries like xml...
-if os.getenv('DIRAC_USE_M2CRYPTO', 'NO').lower() in ('yes', 'true'):
+if os.getenv('DIRAC_USE_M2CRYPTO', 'yes').lower() in ('yes', 'true'):
   __path__ = extend_path(__path__, __name__ + '.m2crypto')
 else:
   __path__ = extend_path(__path__, __name__ + '.pygsi')

--- a/Core/Security/test/Test_pygsiToM2Crypto.py
+++ b/Core/Security/test/Test_pygsiToM2Crypto.py
@@ -60,9 +60,9 @@ def test_dynamic_import(DIRAC_USE_M2CRYPTO, x509Module, set_env):
   if DIRAC_USE_M2CRYPTO:
     os.environ['DIRAC_USE_M2CRYPTO'] = DIRAC_USE_M2CRYPTO
 
-  expectedSubPackage = 'pygsi'
-  if DIRAC_USE_M2CRYPTO == 'YES':
-    expectedSubPackage = 'm2crypto'
+  expectedSubPackage = 'm2crypto'
+  if DIRAC_USE_M2CRYPTO in ('ANY', 'NO'):
+    expectedSubPackage = 'pygsi'
 
   importlib.import_module(fullModuleName)
 

--- a/docs/diracdoctools/environmentSetup.py
+++ b/docs/diracdoctools/environmentSetup.py
@@ -2,12 +2,3 @@
 
 Sets environment variables.
 """
-
-
-import os
-
-
-# Set this environment variable such that the documentation
-# generated for the various X509* classes is the one with M2Crypto
-if 'DIRAC_USE_M2CRYPTO' not in os.environ:
-  os.environ['DIRAC_USE_M2CRYPTO'] = 'Yes'

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -12,7 +12,7 @@ DIRAC_DEBUG_DENCODE_CALLSTACK
   If set, debug information for the encoding and decoding will be printed out
 
 DIRAC_DEBUG_STOMP
-  If set, the stomp library will print out debug information 
+  If set, the stomp library will print out debug information
 
 DIRAC_DEPRECATED_FAIL
   If set, the use of functions or objects that are marked ``@deprecated`` will fail. Useful for example in continuous
@@ -29,7 +29,8 @@ DIRAC_USE_JSON_ENCODE
   Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page
 
 DIRAC_USE_M2CRYPTO
-  If ``true`` or ``yes`` DIRAC uses m2crypto instead of pyGSI for handling certificates, proxies, etc.
+  If anything else than ``true`` or ``yes`` (default) DIRAC will revert back to using pyGSI instead of m2crypto for handling certificates, proxies, etc.
+
 
 DIRAC_VOMSES
   Can be set to point to a folder containing VOMSES information. See :ref:`multi_vo_dirac`

--- a/docs/source/AdministratorGuide/technologyPreviews.rst
+++ b/docs/source/AdministratorGuide/technologyPreviews.rst
@@ -11,8 +11,8 @@ This page keeps a list of such technologies.
 M2Crypto
 ========
 
-We aim at replacing the home made wrapper of openssl pyGSI with the standard M2Crypto library. It is by default disabled.
-You can enable it by setting the environment variable `DIRAC_USE_M2CRYPTO` to `Yes`.
+We aim at replacing the home made wrapper of openssl pyGSI with the standard M2Crypto library. It is by default enabled.
+You can disable it by setting the environment variable `DIRAC_USE_M2CRYPTO` to `No`.
 
 Possible issues
 ---------------


### PR DESCRIPTION
First part of https://github.com/DIRACGrid/DIRAC/issues/4272

BEGINRELEASENOTES
*Core
CHANGE:  use M2Crypto by default
ENDRELEASENOTES
