### PR TITLE
[v6r22] DMS: dm.getFile only checks metadata of files with replicas

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -358,6 +358,7 @@ class DataManager(object):
         'lfn' is the logical file name for the desired file
     """
     log = self.log.getSubLogger('getFile')
+    fileMetadata = {}
     if isinstance(lfn, list):
       lfns = lfn
     elif isinstance(lfn, basestring):
@@ -372,11 +373,13 @@ class DataManager(object):
       return res
     failed = res['Value']['Failed']
     lfnReplicas = res['Value']['Successful']
-    res = self.fileCatalog.getFileMetadata(lfnReplicas.keys())
-    if not res['OK']:
-      return res
-    failed.update(res['Value']['Failed'])
-    fileMetadata = res['Value']['Successful']
+    # If some files have replicas, check their metadata
+    if lfnReplicas:
+      res = self.fileCatalog.getFileMetadata(lfnReplicas.keys())
+      if not res['OK']:
+        return res
+      failed.update(res['Value']['Failed'])
+      fileMetadata = res['Value']['Successful']
     successful = {}
     for lfn in fileMetadata:
       res = self.__getFile(


### PR DESCRIPTION
Allows for better error handling.
Currently, if you do `DataManager.getFile` of a file that does not exist, you get
```
{'Errno': 1604, 'Message': 'FileCatalog error ( 1604 : Failed to perform getFileMetadata from any catalog)', 'OK': False, 'CallStack': ['  File "/tmp/testFix.py", line 10, in <module>\n    print dm.getFile(lfn)\n', '  File "/opt/dirac/DIRAC/DataManagementSystem/Client/DataManager.py", line 375, in getFile\n    res = self.fileCatalog.getFileMetadata(lfnReplicas.keys())\n', '  File "/opt/dirac/DIRAC/Resources/Catalog/FileCatalog.py", line 323, in r_execute\n    return S_ERROR( DErrno.EFCERR, "Failed to perform %s from any catalog" % self.call )\n']}
```

Now you get

```
{'OK': True, 'Value': {'Successful': {}, 'Failed': {'/lhcb/nonExisitng': 'No such file or directory'}}}
```

BEGINRELEASENOTES
*DMS
CHANGE: DM.getFile only checks metadata of files with replicas


ENDRELEASENOTES
