### PR TITLE
[v6r22] roll back to system tar in case of tarfile module failure

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -1488,18 +1488,24 @@ def downloadAndExtractTarball(tarsURL, pkgName, pkgVer, checkHash=True, cache=Fa
   #  tf.extract( member )
   # os.chdir(cwd)
   if not isSource:
-    with closing(tarfile.open(tarPath, mode="r:*")) as tar:
-      for tarinfo in tar:  # pylint: disable=not-an-iterable
-        try:
-          tar.extract(tarinfo, cliParams.targetPath)  # pylint: disable=no-member
-        except IOError:
-          os.remove(tarinfo.name)
-          tar.extract(tarinfo, cliParams.targetPath)  # pylint: disable=no-member
-        finally:
+    try:
+      with closing(tarfile.open(tarPath, mode="r:*")) as tar:
+        for tarinfo in tar:  # pylint: disable=not-an-iterable
           try:
-            os.chmod(tarinfo.name, tarinfo.mode)
-          except OSError:  # the file can be a link
-            pass
+            tar.extract(tarinfo, cliParams.targetPath)  # pylint: disable=no-member
+          except IOError:
+            os.remove(tarinfo.name)
+            tar.extract(tarinfo, cliParams.targetPath)  # pylint: disable=no-member
+          finally:
+            try:
+              os.chmod(tarinfo.name, tarinfo.mode)
+            except OSError:  # the file can be a link
+              pass
+    except Exception as e:
+      logWARN("Trying do extract using system tar: %s" % repr(e))
+      tarCmd = "tar xzf '%s' -C '%s'" % (tarPath, cliParams.targetPath)
+      os.system(tarCmd)
+
     # Delete tar
     if cache:
       if not os.path.isdir(cacheDir):


### PR DESCRIPTION
BEGINRELEASENOTES

Please follow the template:
*Core
FIX: Try to untar using system tar in case tarfile module is failing

ENDRELEASENOTES
