### PR TITLE
[v7r0] M2Crypto: fix isVOMS

### DIFF
--- a/Core/Security/m2crypto/X509Certificate.py
+++ b/Core/Security/m2crypto/X509Certificate.py
@@ -356,13 +356,19 @@ class X509Certificate(object):
 
       :returns: S_OK(bool) if voms extensions are found
     """
-    try:
-      self.__certObj.get_ext('vomsExtensions')
-      return S_OK(True)
-    except LookupError:
-      # no extension found
-      pass
-    return S_OK(False)
+
+    # `get_ext` would be the correct thing to do.
+    # However, it does not work for the moment, as the extension
+    # is not registered with an alias
+    # https://gitlab.com/m2crypto/m2crypto/issues/231
+    # try:
+    #   self.__certObj.get_ext('vomsExtensions')
+    #   return S_OK(True)
+    # except LookupError:
+    #   # no extension found
+    #   pass
+
+    return S_OK(asn1_utils.hasVOMSExtension(self.__certObj))
 
   @executeOnlyIfCertLoaded
   def getVOMSData(self):

--- a/Core/Security/m2crypto/asn1_utils.py
+++ b/Core/Security/m2crypto/asn1_utils.py
@@ -119,6 +119,20 @@ def _decodeASN1String(rdnNameAttrValue):
   raise PyAsn1Error("Could not find a correct decoding type")
 
 
+def hasVOMSExtension(m2cert):
+  """ Utility fonction to check if the certificate has VOMS extensions
+
+      :param m2cert: M2Crypto X509 object, a certificate
+
+      :returns: boolean
+  """
+  try:
+    retrieveExtension(m2cert, VOMS_EXTENSION_OID)
+    return True
+  except LookupError:
+    return False
+
+
 def decodeVOMSExtension(m2cert):
   """ Decode the content of the VOMS extension
 

--- a/Core/Security/test/Test_X509Certificate.py
+++ b/Core/Security/test/Test_X509Certificate.py
@@ -21,7 +21,8 @@ from .x509TestUtilities import deimportDIRAC, CERTS, CERTCONTENTS, getCertOption
 from pytest import mark, fixture, skip
 parametrize = mark.parametrize
 
-X509CERTTYPES = ('GSI_X509Certificate', 'M2_X509Certificate')
+X509CERTTYPES = ('M2_X509Certificate', 'GSI_X509Certificate')
+
 
 # This fixture will return a pyGSI or M2Crypto X509Certificate class
 # https://docs.pytest.org/en/latest/fixture.html#automatic-grouping-of-tests-by-fixture-instances
@@ -343,6 +344,7 @@ def test_getExtensions_on_cert(cert_file, get_X509Certificate_class):
 
 ###########################################################################
 # Temporary. For the time being, we need a real proxy !
+
 def test_getVOMSData(get_X509Certificate_class):
   """" Load a valid certificate and check the output is a positive integer"""
 
@@ -352,3 +354,13 @@ def test_getVOMSData(get_X509Certificate_class):
   res = x509Cert.getVOMSData()
   assert res['OK']
   assert res['Value'] == VOMS_PROXY_ATTR
+
+
+def test_hasVOMSExtensions(get_X509Certificate_class):
+  """" Load a certificate generated with voms-proxy-fake and check hasVOMSExtension is True"""
+
+  x509Cert = get_X509Certificate_class()
+  x509Cert.load(VOMSPROXY)
+  res = x509Cert.hasVOMSExtensions()
+  assert res['OK']
+  assert res['Value']

--- a/Core/Security/test/x509TestUtilities.py
+++ b/Core/Security/test/x509TestUtilities.py
@@ -275,7 +275,7 @@ def deimportDIRAC():
       sys.modules.pop(mod)
 
 
-X509CHAINTYPES = ('GSI_X509Chain', 'M2_X509Chain')
+X509CHAINTYPES = ('M2_X509Chain', 'GSI_X509Chain')
 
 # This fixture will return a pyGSI or M2Crypto X509Chain class
 # https://docs.pytest.org/en/latest/fixture.html#automatic-grouping-of-tests-by-fixture-instances
@@ -302,7 +302,7 @@ def get_X509Chain_class(request):
   deimportDIRAC()
 
 
-X509REQUESTTYPES = ('GSI_X509Request', 'M2_X509Request')
+X509REQUESTTYPES = ('M2_X509Request', 'GSI_X509Request')
 
 # This fixture will return a pyGSI or M2Crypto X509Request class
 # https://docs.pytest.org/en/latest/fixture.html#automatic-grouping-of-tests-by-fixture-instances


### PR DESCRIPTION
I finally understood why it was not showing up in the unit tests. It's because `openssl` keeps some memory, and since the pyGSI tests were running before the `M2Crypto` one, the name `vomsExtensions` was known. I changed the order in which we test to make sure M2Crypto starts from scratch.
Also, the test `isVOMS` is now done by retrieving the extension by OID.

BEGINRELEASENOTES
*Core
FIX: X509Chain.isVOMS returns correct value
ENDRELEASENOTES
