### PR TITLE
[v7r0] PilotCSToJsonSynchronizer: implement checksumming

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -85,7 +85,9 @@ class PilotCStoJSONSynchronizer(object):
     self.pilotRepoBranch = ops.getValue("Pilot/pilotRepoBranch", self.pilotRepoBranch)
     self.pilotVORepoBranch = ops.getValue("Pilot/pilotVORepoBranch", self.pilotVORepoBranch)
 
-    self._syncJSONFile()
+    res = self._syncJSONFile()
+    if not res['OK']:
+      return res
     self.log.notice('-- Synchronizing the pilot scripts with the content of the repository --',
                     '(%s)' % self.pilotRepo)
     self._syncScripts()
@@ -96,13 +98,17 @@ class PilotCStoJSONSynchronizer(object):
   def _syncJSONFile(self):
     """ Creates the pilot dictionary from the CS, ready for encoding as JSON
     """
-    pilotDict = self._getCSDict()
+    res = self._getCSDict()
+    if not res['OK']:
+      return res
+    pilotDict = res['Value']
     self._upload(pilotDict=pilotDict)
+    return S_OK()
 
   def _getCSDict(self):
     """ Gets minimal info for running a pilot, from the CS
     :returns: pilotDict (containing pilots run info)
-    :rtype: dict
+    :rtype: S_OK, S_ERROR, value is pilotDict
     """
 
     pilotDict = {'Setups': {}, 'CEs': {}, 'GenericPilotDNs': []}
@@ -180,7 +186,7 @@ class PilotCStoJSONSynchronizer(object):
 
     self.log.debug("Got pilotDict", str(pilotDict))
 
-    return pilotDict
+    return S_OK(pilotDict)
 
   def _getPilotOptionsPerSetup(self, setup, pilotDict):
     """ Given a setup, returns its pilot options in a dictionary

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -387,6 +387,6 @@ class PilotCStoJSONSynchronizer(object):
   def _syncChecksum(self):
     """Upload the checksum file to the fileservers."""
     with open('checksums.sha512', 'wb') as chksums:
-      for filename, chksum in self._checksumDict.items():
-        chksums.write('%s: %s' % (chksum, filename))
-    self._upload(filename='checksums.sha512')
+      for filename, chksum in sorted(self._checksumDict.items()):
+        chksums.write('%s: %s\n' % (chksum, filename))
+    self._upload(filename='checksums.sha512', pilotScript='checksums.sha512')

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -388,5 +388,6 @@ class PilotCStoJSONSynchronizer(object):
     """Upload the checksum file to the fileservers."""
     with open('checksums.sha512', 'wb') as chksums:
       for filename, chksum in sorted(self._checksumDict.items()):
-        chksums.write('%s: %s\n' % (chksum, filename))
+        # same as the output from sha512sum commands
+        chksums.write('%s  %s\n' % (chksum, filename))
     self._upload(filename='checksums.sha512', pilotScript='checksums.sha512')

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -3,6 +3,7 @@
 
 import unittest
 import os
+from mock import patch, MagicMock as Mock
 
 from DIRAC.WorkloadManagementSystem.Utilities.PilotCStoJSONSynchronizer import PilotCStoJSONSynchronizer
 from DIRAC.ConfigurationSystem.private.ConfigurationClient import ConfigurationClient
@@ -47,7 +48,8 @@ class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
         }
       }
     }
-    Operations{
+    Operations
+    {
       Defaults
       {
         Pilot
@@ -92,6 +94,25 @@ class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
         }
       }
     }
+    Resources
+    {
+      Sites
+      {
+        Tests
+        {
+           Tests.Testing.tst
+           {
+             CEs
+             {
+                test1.Testing.tst
+                {
+                  CEType = Tester
+                }
+             }
+           }
+        }
+      }
+    }
     '''
     with open(self.testCfgFileName, 'w') as f:
       f.write(cfgContent)
@@ -101,10 +122,11 @@ class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
     self.wm = gConfig.getValue('DIRAC/Setups/' + self.setup + '/WorkloadManagement', '')
 
   def tearDown(self):
-    try:
-      os.remove(self.testCfgFileName)
-    except OSError:
-      pass
+    for aFile in [self.testCfgFileName, 'checksums.sha512', 'pilot.json']:
+      try:
+        os.remove(aFile)
+      except OSError:
+        pass
     # SUPER UGLY: one must recreate the CFG objects of gConfigurationData
     # not to conflict with other tests that might be using a local dirac.cfg
     gConfigurationData.localCFG = CFG()
@@ -117,8 +139,22 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
 
   def test_success(self):
     synchroniser = PilotCStoJSONSynchronizer()
-    res = synchroniser._syncJSONFile()
-    self.assertTrue(res is None)
+    synchroniser.pilotFileServer = 'value'
+    with patch('DIRAC.WorkloadManagementSystem.Utilities.PilotCStoJSONSynchronizer.requests',
+               new=Mock()):
+      res = synchroniser._syncJSONFile()
+      self.assertTrue(res is None)
+    assert 'pilot.json' in synchroniser._checksumDict
+
+  def test_syncchecksum(self):
+    expectedHash = '00e67a2d45e2c2508a935500a4765e1a5f1ce661f23c1fb329987c8211bde754ed' + \
+                   '79f6b02cdeabd429979a82014c474c5ce2f46a879f17e2a6ce4bcac683e2e4'
+    synchroniser = PilotCStoJSONSynchronizer()
+    synchroniser._checksumFile(self.testCfgFileName)
+    synchroniser._syncChecksum()
+    assert self.testCfgFileName in synchroniser._checksumDict
+    assert synchroniser._checksumDict[self.testCfgFileName] == expectedHash
+    assert open('checksums.sha512', 'rb').read() == '%s: %s' % (expectedHash, self.testCfgFileName)
 
 
 if __name__ == '__main__':

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -144,7 +144,7 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     synchroniser = PilotCStoJSONSynchronizer()
     synchroniser.pilotFileServer = 'value'
     res = synchroniser._syncJSONFile()
-    assert res['OK']
+    assert res['OK'], res['Message']
     # ensure pilot.json was "uploaded"
     assert 'pilot.json' in synchroniser._checksumDict
 
@@ -156,7 +156,7 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     synchroniser.pilotFileServer = 'value'
     synchroniser._checksumFile(self.testCfgFileName)
     res = synchroniser._syncJSONFile()
-    assert res['OK']
+    assert res['OK'], res['Message']
     synchroniser._syncChecksum()
     assert self.testCfgFileName in synchroniser._checksumDict
     assert synchroniser._checksumDict[self.testCfgFileName] == expectedHash

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -160,7 +160,7 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     synchroniser._syncChecksum()
     assert self.testCfgFileName in synchroniser._checksumDict
     assert synchroniser._checksumDict[self.testCfgFileName] == expectedHash
-    assert open('checksums.sha512', 'rb').read().split('\n')[1] == '%s: %s' % (expectedHash, self.testCfgFileName)
+    assert open('checksums.sha512', 'rb').read().split('\n')[1] == '%s  %s' % (expectedHash, self.testCfgFileName)
     # this tests if the checksums file was also "uploaded"
     assert 'checksums.sha512' in list(synchroniser._checksumDict)
 

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -144,7 +144,7 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     synchroniser = PilotCStoJSONSynchronizer()
     synchroniser.pilotFileServer = 'value'
     res = synchroniser._syncJSONFile()
-    self.assertTrue(res is None)
+    assert res['OK']
     # ensure pilot.json was "uploaded"
     assert 'pilot.json' in synchroniser._checksumDict
 
@@ -156,7 +156,7 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     synchroniser.pilotFileServer = 'value'
     synchroniser._checksumFile(self.testCfgFileName)
     res = synchroniser._syncJSONFile()
-    assert res is None
+    assert res['OK']
     synchroniser._syncChecksum()
     assert self.testCfgFileName in synchroniser._checksumDict
     assert synchroniser._checksumDict[self.testCfgFileName] == expectedHash


### PR DESCRIPTION
Addresses #4483 

I started with implementing on the server side, using sha512 (should be available a;ready in python 2.6, https://docs.python.org/2.6/library/hashlib.html) and very simple reading of the file contents.
I don't think these files are going to be very large? So efficient calculation and memory issues maybe don't have to be taken into considerations here?

~~I will look at the pilot side next~~
Also implemented the pilotwrapper side

BEGINRELEASENOTES

*WMS
NEW: Add checksum calculation for PilotCSToJsonSynchroniser
NEW: Add checksum checks to PilotWrapper
FIX: Fix download checks in PilotWrapper in case the webserver does not return 404 but not the expected file content either.

ENDRELEASENOTES


- [x] Implement calculation of checksums on server side
- [x] Implement checksum checking in the Pilotwrapper
