### PR TITLE
[v7r0] PilotCSToJson fix  checksumming

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -356,7 +356,7 @@ class PilotCStoJSONSynchronizer(object):
         filename = self.jsonFile
         script = json.dumps(pilotDict)
         with open(filename, 'w') as jf:
-          json.dump(script, jf)
+          jf.write(script)
 
       else:  # we assume the method is asked to upload the pilots scripts
         # ALWAYS open binary when sending a file
@@ -392,7 +392,7 @@ class PilotCStoJSONSynchronizer(object):
 
   def _syncChecksum(self):
     """Upload the checksum file to the fileservers."""
-    with open('checksums.sha512', 'wb') as chksums:
+    with open('checksums.sha512', 'wt') as chksums:
       for filename, chksum in sorted(self._checksumDict.items()):
         # same as the output from sha512sum commands
         chksums.write('%s  %s\n' % (chksum, filename))

--- a/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/test/Test_PilotCStoJSONSynchronizer.py
@@ -19,6 +19,8 @@ class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
 
   def setUp(self):
     # Creating test configuration file
+    self.clearCFG()
+
     self.testCfgFileName = 'test.cfg'
     cfgContent = '''
     DIRAC
@@ -129,8 +131,12 @@ class PilotCStoJSONSynchronizerTestCase(unittest.TestCase):
         os.remove(aFile)
       except OSError:
         pass
-    # SUPER UGLY: one must recreate the CFG objects of gConfigurationData
-    # not to conflict with other tests that might be using a local dirac.cfg
+    self.clearCFG()
+
+  @staticmethod
+  def clearCFG():
+    """SUPER UGLY: one must recreate the CFG objects of gConfigurationData
+    not to conflict with other tests that might be using a local dirac.cfg"""
     gConfigurationData.localCFG = CFG()
     gConfigurationData.remoteCFG = CFG()
     gConfigurationData.mergedCFG = CFG()
@@ -150,8 +156,12 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
 
   @patch('DIRAC.WorkloadManagementSystem.Utilities.PilotCStoJSONSynchronizer.requests', new=Mock())
   def test_syncchecksum(self):
+    # If the hashes need to be changed because the pilot or test.cfg file change, they should be created with the
+    # sha512sum command line tool, and the files should be checked for correctness
     expectedHash = '00e67a2d45e2c2508a935500a4765e1a5f1ce661f23c1fb329987c8211bde754ed' + \
                    '79f6b02cdeabd429979a82014c474c5ce2f46a879f17e2a6ce4bcac683e2e4'
+    expectedPJHash = '6f0a45fc703ca03ad3f277173c3464dafcaad2b85fa6643f66a02721e69233cd' + \
+                     'ec6c50c75eb779740788b5211f740631944f8d703d4149f6526d149c761c02f4'
     synchroniser = PilotCStoJSONSynchronizer()
     synchroniser.pilotFileServer = 'value'
     synchroniser._checksumFile(self.testCfgFileName)
@@ -160,6 +170,8 @@ class Test_PilotCStoJSONSynchronizer_sync(PilotCStoJSONSynchronizerTestCase):
     synchroniser._syncChecksum()
     assert self.testCfgFileName in synchroniser._checksumDict
     assert synchroniser._checksumDict[self.testCfgFileName] == expectedHash
+    assert open('checksums.sha512', 'rb').read().split('\n')[0] == '%s  %s' % (expectedPJHash, 'pilot.json'), \
+        'pilot.json content: ' + repr(open('pilot.json', 'rb').read())
     assert open('checksums.sha512', 'rb').read().split('\n')[1] == '%s  %s' % (expectedHash, self.testCfgFileName)
     # this tests if the checksums file was also "uploaded"
     assert 'checksums.sha512' in list(synchroniser._checksumDict)


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: PilotCS2Json: fix writing of local pilot.json file, which is used to calculate the hash
FIX: PilotCS2Json: write checksum file in text mode

ENDRELEASENOTES

In the test: clear CFG before and after the test to ensure expected hash is created