### PR TITLE
[v7r0] Fix SLURM Resource Usage

### DIFF
--- a/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
@@ -29,9 +29,9 @@ class SLURMResourceUsage(ResourceUsage):
     """
     # sacct displays accounting data for all jobs and job steps
     # -j is the given job, -o the information of interest, -X to get rid of intermediate steps
-    # -P to make the output parseable (remove tabs, spaces, columns)
+    # -n to remove the header, -P to make the output parseable (remove tabs, spaces, columns)
     # --delimiter to specify character that splits the fields
-    cmd = 'sacct -j %s -o JobID,CPUTimeRAW,AllocCPUS,ElapsedRaw,Timelimit -X -P --delimiter=,' % (self.jobID)
+    cmd = 'sacct -j %s -o JobID,CPUTimeRAW,AllocCPUS,ElapsedRaw,Timelimit -X -n -P --delimiter=,' % (self.jobID)
     result = runCommand(cmd)
     if not result['OK']:
       return result


### PR DESCRIPTION
A small fix to `SLURMResourceUsage`, I forgot the option to remove the header from the output which creates an error when parsing the output. It stops the `JobAgent` when using Slurm with `fillingMode`.

BEGINRELEASENOTES
*Resources
FIX: Slurm Resource Usage
ENDRELEASENOTES
