### PR TITLE
[v6r22] mysql57 entries too long for the table field

### DIFF
--- a/FrameworkSystem/DB/SystemLoggingDB.py
+++ b/FrameworkSystem/DB/SystemLoggingDB.py
@@ -388,7 +388,7 @@ class SystemLoggingDB( DB ):
     messageSubSystemName = message.getSubSystemName()
 
     fieldsList = [ 'MessageTime', 'VariableText' ]
-    messageList = [ messageDate, message.getVariableMessage() ]
+    messageList = [messageDate, message.getVariableMessage()[:255]]
 
     inValues = [ userDN, userGroup ]
     inFields = [ 'OwnerDN', 'OwnerGroup' ]

--- a/TransformationSystem/DB/TransformationDB.sql
+++ b/TransformationSystem/DB/TransformationDB.sql
@@ -35,7 +35,7 @@ CREATE TABLE Transformations (
     AgentType CHAR(32) DEFAULT 'Manual',
     Status  CHAR(32) DEFAULT 'New',
     FileMask VARCHAR(255),
-    TransformationGroup varchar(64) NOT NULL default 'General',
+    TransformationGroup varchar(255) NOT NULL default 'General',
     TransformationFamily varchar(64) default '0',
     GroupSize INT NOT NULL DEFAULT 1,
     InheritedFrom INTEGER DEFAULT 0,

--- a/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -80,7 +80,7 @@ class JobLoggingDB(DB):
     cmd = "INSERT INTO LoggingInfo (JobId, Status, MinorStatus, ApplicationStatus, " + \
           "StatusTime, StatusTimeOrder, StatusSource) VALUES (%d,'%s','%s','%s','%s',%f,'%s')" % \
         (int(jobID), status, minor, application[:255],
-         str(_date), time_order, source)
+         str(_date), time_order, source[:32])
 
     return self._update(cmd)
 


### PR DESCRIPTION
Some issues we had to fix after we moved to mysql 5.7

BEGINRELEASENOTES

*Framework
FIX: SystemLoggingDB: reduce too long messages to 255 characters (see also  #1780 ?)
*WMS
FIX: JobLoggingDB: Limit StatusSource to 32 characters
*TS
CHANGE: TransformationDB.Transformations TransformationGroup column increased to 255 characters (`ALTER TABLE Transformations MODIFY TransformationGroup VARCHAR(255) NOT NULL default 'General';`)

ENDRELEASENOTES

Other issues not related to code changes:

For tables created a long time ago, these were changed in v6r6 but not written in the migration notes
* The SystemLoggingDB MessageRepository LogLevel column was changed to varchar(15) instead of int. (see also  #1095) 
* ALTER TABLE `ac_type_ILC-Production_Job` MODIFY COLUMN `DiskSpace` BIGINT;

Also if one is using parametric jobs, make sure the query cache is disabled in mysql 5.7 (which is the default, but our config from 5.6 was carried over and it was active there. Leads to an error in dirac
"'Lost connection to MySQL server during query'"
and on the server error logs
"2020-03-12T12:58:03.986117Z 7899 [Note] Aborted connection 7899 to db: 'SandboxMetadataDB' user: 'Dirac' host: 'voilcdirac03.cern.ch' (Got an error reading communication packets)" 

