### PR TITLE
[v7r0]Remove rst2pdf from dirac-create-distribution-tarball

### DIFF
--- a/Core/scripts/dirac-create-distribution-tarball.py
+++ b/Core/scripts/dirac-create-distribution-tarball.py
@@ -531,11 +531,6 @@ class TarModuleCreator(object):
           fd.write(parts['whole'])
       except Exception as excp:
         return S_ERROR("Could not write %s: %s" % (htmlFileName, repr(excp).replace(',)', ')')))
-      # To pdf
-      pdfCmd = "rst2pdf '%s' -o '%s.pdf'" % (relNotesRST, baseFileName)
-      gLogger.verbose("Executing %s" % pdfCmd)
-      if os.system(pdfCmd):
-        gLogger.warn("Could not generate PDF version of %s" % baseNotesPath)
     # Unlink if not necessary
     if False and not cliParams.relNotes:
       try:

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - python-json-logger >=0.1.8
   - pytz >=2015.7
   - requests >=2.9.1
-  - rst2pdf >=0.93
   - six >=1.10
   - sqlalchemy >=1.0.9
   - subprocess32

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - pip
   - certifi
   - cmreshandler >1.0.0b4
+  - docutils
   - elasticsearch-dsl ~=6.3.1
   - fts-rest
   - future
@@ -18,6 +19,7 @@ dependencies:
   - mysql-connector-c  # Included as it's a dependency of MySQL-python which is installed with pip
   - numpy >=1.10.1,<1.16  # Limit to 1.15 as Python 2 pylint has bugs with numpy 1.16
   - pexpect >=4.0.1
+  - pillow
   - psutil >=4.2.0
   - pyasn1 >0.4.1
   - pyasn1-modules

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ pytest-mock
 pytz>=2015.7
 readline>=6.2.4
 requests>=2.9.1
-rst2pdf>=0.93
 simplejson>=3.8.1
 six>=1.10
 sqlalchemy>=1.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ M2Crypto==0.32
 autopep8==1.3.3
 certifi
 coverage
+docutils
 elasticsearch-dsl~=6.3.1
 CMRESHandler>=1.0.0b4
 funcsigs
@@ -23,6 +24,7 @@ jinja2
 ipython==5.3.0
 numpy>=1.10.1
 pexpect>=4.0.1
+pillow
 psutil>=4.2.0
 pyasn1>0.4.1
 pyasn1_modules


### PR DESCRIPTION
It's useless, not python3 compatible, and some dependency are breaking DIRACOS.

BEGINRELEASENOTES
*Core
CHANGE: remove rst2pdf from dirac-create-distribution-tarball

ENDRELEASENOTES
