### PR TITLE
[v6r22] Place to execute _prepareRemoteHost is changed

### DIFF
--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -319,10 +319,6 @@ class SSHComputingElement(ComputingElement):
     if not self.workArea.startswith('/'):
       self.workArea = os.path.join(self.sharedArea, self.workArea)
 
-    result = self._prepareRemoteHost()
-    if not result['OK']:
-      return result
-
     self.submitOptions = ''
     if 'SubmitOptions' in self.ceParameters:
       self.submitOptions = self.ceParameters['SubmitOptions']
@@ -331,6 +327,10 @@ class SSHComputingElement(ComputingElement):
       if self.ceParameters['RemoveOutput'].lower() in ['no', 'false', '0']:
         self.removeOutput = False
     self.preamble = self.ceParameters.get('Preamble', '')
+
+    result = self._prepareRemoteHost()
+    if not result['OK']:
+      return result
 
     return S_OK()
 


### PR DESCRIPTION
In the current code, when there is a problem in the _prepareRemoteHost, 
self.preamble is not set. This cause problem when submitJob is executed:
https://github.com/DIRACGrid/DIRAC/blob/eececa18abc346cf0262a43452f1d3cc2a2999bd/Resources/Computing/SSHComputingElement.py#L497-L503

This caused problem in Belle II environment
(SiteDirector could not submit jobs to some of sites)

BEGINRELEASENOTES

*Resources
FIX: Moved _prepareRemoteHost in SSHComputingElement

ENDRELEASENOTES
