### PR TITLE
[v7r1] JobWrapper and JobAgent: fixes for setting of the job status

### DIFF
--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -341,7 +341,6 @@ class JobAgent(AgentModule):
       result = self._submitJob(jobID, params, ceDict, optimizerParams, proxyChain,
                                processors, wholeNode, maxNumberOfProcessors, mpTag)
       if not result['OK']:
-        self.__report(jobID, 'Failed', result['Message'])
         return self.__finish(result['Message'])
       elif 'PayloadFailed' in result:
         # Do not keep running and do not overwrite the Payload error
@@ -530,8 +529,10 @@ class JobAgent(AgentModule):
         return S_OK()  # Without this, the job is marked as failed
       else:
         if 'Value' in submission:
-          self.log.error('Error in DIRAC JobWrapper:', 'exit code = %s' % (str(submission['Value'])))
-      return S_ERROR('%s CE Error: %s' % (self.ceName, submission['Message']))
+	  self.log.error('Error in DIRAC JobWrapper or inner CE execution:',
+			 'exit code = %s' % (str(submission['Value'])))
+      self.log.error("CE Error", "%s : %s" % (self.ceName, submission['Message']))
+      return submission
 
     return ret
 

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -529,8 +529,8 @@ class JobAgent(AgentModule):
         return S_OK()  # Without this, the job is marked as failed
       else:
         if 'Value' in submission:
-	  self.log.error('Error in DIRAC JobWrapper or inner CE execution:',
-			 'exit code = %s' % (str(submission['Value'])))
+          self.log.error('Error in DIRAC JobWrapper or inner CE execution:',
+                         'exit code = %s' % (str(submission['Value'])))
       self.log.error("CE Error", "%s : %s" % (self.ceName, submission['Message']))
       return submission
 

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -10,8 +10,6 @@
 from __future__ import print_function
 __RCSID__ = "$Id$"
 
-from past.builtins import long
-import six
 import os
 import stat
 import re
@@ -23,6 +21,8 @@ import tarfile
 import glob
 import urllib
 import json
+
+import six
 
 import DIRAC
 from DIRAC import S_OK, S_ERROR, gConfig, gLogger
@@ -269,7 +269,7 @@ class JobWrapper(object):
       if isinstance(value, dict):
         infoString = self.__dictAsInfoString(value, infoString, "%s/%s" % (currentBase, key))
       elif isinstance(value, (list, tuple)):
-        if len(value) and value[0] == '[':
+	if value and value[0] == '[':
           infoString += "%s/%s = %s\n" % (currentBase, key, " ".join(value))
         else:
           infoString += "%s/%s = %s\n" % (currentBase, key, ", ".join(value))
@@ -279,7 +279,7 @@ class JobWrapper(object):
     return infoString
 
   #############################################################################
-  def execute(self, arguments):
+  def execute(self):
     """The main execution method of the Job Wrapper
     """
     self.log.info('Job Wrapper is starting execution phase for job %s' % (self.jobID))
@@ -446,7 +446,7 @@ class JobWrapper(object):
 
     if watchdog.currentStats:
       self.log.info('Statistics collected by the Watchdog:\n ',
-                    '\n  '.join(['%s: %s' % items for items in watchdog.currentStats.iteritems()]))
+		    '\n  '.join(['%s: %s' % items for items in watchdog.currentStats.items()]))  # can be an iterator
     if outputs:
       status = threadResult['Value'][0]  # the status of the payload execution
       # Send final heartbeat of a configurable number of lines here
@@ -606,15 +606,15 @@ class JobWrapper(object):
       resolvedData = result
 
     # add input data size to accounting report (since resolution successful)
-    for lfn, mdata in resolvedData['Value']['Successful'].iteritems():
+    for lfn, mdata in resolvedData['Value']['Successful'].items():  # can be an iterator
       if 'Size' in mdata:
         lfnSize = mdata['Size']
-        if not isinstance(lfnSize, long):
+	if not isinstance(lfnSize, six.integer_types):
           try:
-            lfnSize = long(lfnSize)
-          except Exception as x:
+	    lfnSize = int(lfnSize)
+	  except ValueError as x:
             lfnSize = 0
-            self.log.info('File size for LFN:%s was not a long integer, setting size to 0' % (lfn))
+	    self.log.info('File size for LFN was not an integer, setting size to 0', lfn)
         self.inputDataSize += lfnSize
 
     configDict = {'JobID': self.jobID,
@@ -657,7 +657,7 @@ class JobWrapper(object):
     self.log.verbose(replicas)
 
     failedGUIDs = []
-    for lfn, reps in replicas['Value']['Successful'].iteritems():
+    for lfn, reps in replicas['Value']['Successful'].items():  # can be an iterator
       if 'GUID' not in reps:
         failedGUIDs.append(lfn)
 
@@ -666,8 +666,7 @@ class JobWrapper(object):
 
     if failedGUIDs:
       return S_ERROR('File metadata is not available')
-    else:
-      return replicas
+    return replicas
 
   #############################################################################
   def __getReplicaMetadata(self, lfns):
@@ -687,11 +686,11 @@ class JobWrapper(object):
     badLFNs = []
     catalogResult = repsResult['Value']
 
-    for lfn, cause in catalogResult.get('Failed', {}).iteritems():
+    for lfn, cause in catalogResult.get('Failed', {}).items():  # can be an iterator
       badLFNCount += 1
       badLFNs.append('LFN:%s Problem: %s' % (lfn, cause))
 
-    for lfn, replicas in catalogResult.get('Successful', {}).iteritems():
+    for lfn, replicas in catalogResult.get('Successful', {}).items():  # can be an iterator
       if not replicas:
         badLFNCount += 1
         badLFNs.append('LFN:%s Problem: Null replica value' % (lfn))
@@ -719,7 +718,7 @@ class JobWrapper(object):
       self.log.warn(failed)
       return S_ERROR('Missing GUIDs')
 
-    for lfn, reps in repsResult['Value']['Successful'].iteritems():
+    for lfn, reps in repsResult['Value']['Successful'].items():  # can be an iterator
       guidDict['Value']['Successful'][lfn].update(reps)
 
     catResult = guidDict
@@ -846,7 +845,7 @@ class JobWrapper(object):
     for i in outputSandbox:
       if i not in okFiles:
         if not '%s.tar' % i in okFiles:
-          if not re.search('\*', i):
+	  if not re.search(r'\*', i):
             if i not in missing:
               missing.append(i)
 
@@ -874,7 +873,7 @@ class JobWrapper(object):
 
     # Check whether list of outputData has a globbable pattern
     globbedOutputList = List.uniqueElements(getGlobbedFiles(nonlfnList))
-    if not globbedOutputList == nonlfnList and globbedOutputList:
+    if globbedOutputList != nonlfnList and globbedOutputList:
       self.log.info('Found a pattern in the output data file list, files to upload are:',
                     ', '.join(globbedOutputList))
       nonlfnList = globbedOutputList
@@ -1100,7 +1099,7 @@ class JobWrapper(object):
           with tarfile.open(possibleTarFile, 'r') as tarFile:
             for member in tarFile.getmembers():
               tarFile.extract(member, os.getcwd())
-      except BaseException as x:
+      except Exception as x:
         return S_ERROR('Could not untar %s with exception %s' % (possibleTarFile, str(x)))
 
     if userFiles:
@@ -1165,7 +1164,7 @@ class JobWrapper(object):
       self.log.info('EXECUTION_RESULT[CPU] missing in sendJobAccounting')
       finalStat = os.times()
       EXECUTION_RESULT['CPU'] = []
-      for i in range(len(finalStat)):
+      for i, _ in enumerate(finalStat):
         EXECUTION_RESULT['CPU'].append(finalStat[i] - self.initialTiming[i])
 
     cpuString = ' '.join(['%.2f' % x for x in EXECUTION_RESULT['CPU']])
@@ -1402,7 +1401,7 @@ class ExecutionThread(threading.Thread):
     EXECUTION_RESULT['Timing'] = timing
     finalStat = os.times()
     EXECUTION_RESULT['CPU'] = []
-    for i in range(len(finalStat)):
+    for i, _ in enumerate(finalStat):
       EXECUTION_RESULT['CPU'].append(finalStat[i] - initialStat[i])
     cpuString = ' '.join(['%.2f' % x for x in EXECUTION_RESULT['CPU']])
     log.info('EXECUTION_RESULT[CPU] after Execution of spObject.systemCall', cpuString)

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -1276,7 +1276,7 @@ class JobWrapper(object):
           print(str(reqToJSON['Value']))
         else:
           self.log.error("Something went wrong creating the JSON from request", reqToJSON['Message'])
-	return S_ERROR(request)
+	return S_ERROR()
       else:
 	# We try several times to put the request before failing the job:
 	# it is very important that requests go through,

--- a/WorkloadManagementSystem/JobWrapper/JobWrapperTemplate.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapperTemplate.py
@@ -44,6 +44,7 @@ class JobWrapperError(Exception):
 
   def __init__(self, value):
     self.value = value
+    super(JobWrapperError, self).__init__()
 
   def __str__(self):
     return str(self.value)
@@ -139,7 +140,7 @@ def execute(arguments):
   gJobReport.commit()
 
   try:
-    result = job.execute(arguments)
+    result = job.execute()
     if not result['OK']:
       gLogger.error('Failed to execute job', result['Message'])
       raise JobWrapperError((result['Message'], result['Errno']))

--- a/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -115,6 +115,12 @@ class JobWrapperTestCaseSuccess(JobWrapperTestCase):
       # so in this case the "execute" is considered an error
     os.remove('script-RESC.sh')
 
+  def test_finalize(self):
+    jw = JobWrapper()
+    jw.jobArgs = {'Executable': '/bin/ls'}
+    res = jw.finalize()
+    self.assertTrue(res == 1)  # by default failed flag is True
+
 
 #############################################################################
 # Test Suite run

--- a/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -83,21 +83,21 @@ class JobWrapperTestCaseSuccess(JobWrapperTestCase):
   def test_execute(self, _patch1, _patch2):
     jw = JobWrapper()
     jw.jobArgs = {'Executable': '/bin/ls'}
-    res = jw.execute('')
+    res = jw.execute()
     print('jw.execute() returns', str(res))
     self.assertTrue(res['OK'])
 
     shutil.copy('WorkloadManagementSystem/JobWrapper/test/script-OK.sh', 'script-OK.sh')
     jw = JobWrapper()
     jw.jobArgs = {'Executable': 'script-OK.sh'}
-    res = jw.execute('')
+    res = jw.execute()
     self.assertTrue(res['OK'])
     os.remove('script-OK.sh')
 
     shutil.copy('WorkloadManagementSystem/JobWrapper/test/script.sh', 'script.sh')
     jw = JobWrapper()
     jw.jobArgs = {'Executable': 'script.sh', 'Arguments': '111'}
-    res = jw.execute('')
+    res = jw.execute()
     self.assertTrue(res['OK'])  # In this case the application finished with errors,
     # but the JobWrapper executed successfully
     os.remove('script.sh')
@@ -105,7 +105,7 @@ class JobWrapperTestCaseSuccess(JobWrapperTestCase):
     shutil.copy('WorkloadManagementSystem/JobWrapper/test/script-RESC.sh', 'script-RESC.sh')  # this will reschedule
     jw = JobWrapper()
     jw.jobArgs = {'Executable': 'script-RESC.sh'}
-    res = jw.execute('')
+    res = jw.execute()
     if res['OK']:  # FIXME: This may happen depending on the shell - not the best test admittedly!
       print("We should not be here, unless the 'Execution thread status' is equal to 1")
       self.assertTrue(res['OK'])


### PR DESCRIPTION

BEGINRELEASENOTES

*Subsystem
FIX: JobWrapper: try to send the failover requests BEFORE declaring the job status
FIX: JobAgent: do not override the job status after the job has finished

ENDRELEASENOTES
