### PR TITLE
[v7r1] Fix handling of job status when changed by requests

### DIFF
--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -308,7 +308,7 @@ class ReqClient(Client):
     res = monitorServer.getJobSummary(int(jobID))
     if not res["OK"]:
       self.log.error("finalizeRequest: Failed to get job status", "JobID: %d" % jobID)
-      return S_ERROR("finalizeRequest: Failed to get job %d status" % jobID)
+      return res
     elif not res['Value']:
       self.log.info("finalizeRequest: job %d does not exist (anymore): finalizing" % jobID)
       return S_OK()
@@ -322,7 +322,7 @@ class ReqClient(Client):
         res = monitorServer.getJobLoggingInfo(int(jobID))
         if not res['OK']:
           self.log.error("finalizeRequest: Failed to get job logging info", "JobID: %d" % jobID)
-          return S_ERROR("finalizeRequest: Failed to get job %d logging info" % jobID)
+          return res
         # Check the last status was Stalled and get the one before
         if len(res['Value']) >= 2 and res['Value'][-1][0] == JobStatus.STALLED:
           jobStatus, jobMinorStatus, jobAppStatus = res['Value'][-2][:3]
@@ -353,8 +353,8 @@ class ReqClient(Client):
         self.log.info("finalizeRequest: Updating job status for %d to %s/Requests done" % (jobID, newJobStatus))
       else:
         self.log.info(
-            "finalizeRequest: Updating job minor status for %d to Requests done (current status is %s)" %
-            (jobID, jobStatus))
+            "finalizeRequest: Updating job minor status",
+            "for %d to Requests done (current status is %s)" % (jobID, jobStatus))
       stateUpdate = stateServer.setJobStatus(jobID, newJobStatus, "Requests done", "", 'RMS')
       if jobAppStatus and stateUpdate['OK']:
         stateUpdate = stateServer.setJobApplicationStatus(jobID, jobAppStatus, 'RMS')

--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -304,7 +304,7 @@ class ReqClient(Client):
 
     # The request is 'Done', let's update the job status. If we fail, we should re-try later
     monitorServer = RPCClient("WorkloadManagement/JobMonitoring", useCertificates=useCertificates)
-    res = monitorServer.getJobPrimarySummary(int(jobID))
+    res = monitorServer.getJobSummary(int(jobID))
     if not res["OK"]:
       self.log.error("finalizeRequest: Failed to get job status", "JobID: %d" % jobID)
       return S_ERROR("finalizeRequest: Failed to get job %d status" % jobID)
@@ -312,9 +312,19 @@ class ReqClient(Client):
       self.log.info("finalizeRequest: job %d does not exist (anymore): finalizing" % jobID)
       return S_OK()
     else:
-      jobStatus = res["Value"]["Status"]
-      newJobStatus = jobStatus
+      jobStatus = res["Value"]['Status']
       jobMinorStatus = res["Value"]["MinorStatus"]
+      jobAppStatus = ''
+      newJobStatus = ''
+      if jobStatus == 'Stalled':
+        # If job is stalled, find the previous status from the logging info
+        res = monitorServer.getJobLoggingInfo(int(jobID))
+        if not res['OK']:
+          self.log.error("finalizeRequest: Failed to get job logging info", "JobID: %d" % jobID)
+          return S_ERROR("finalizeRequest: Failed to get job %d logging info" % jobID)
+        if len(res['Value']) >= 2:
+          jobStatus, jobMinorStatus, jobAppStatus = res['Value'][-2][:3]
+          newJobStatus = jobStatus
 
       # update the job pending request digest in any case since it is modified
       self.log.info("finalizeRequest: Updating request digest for job %d" % jobID)
@@ -330,27 +340,25 @@ class ReqClient(Client):
       else:
         self.log.error("finalizeRequest: Failed to get request digest for %s: %s" % (requestID,
                                                                                      digest["Message"]))
-      stateUpdate = None
       if jobStatus == 'Completed':
         # What to do? Depends on what we have in the minorStatus
         if jobMinorStatus == "Pending Requests":
           newJobStatus = 'Done'
-
         elif jobMinorStatus == "Application Finished With Errors":
           newJobStatus = 'Failed'
 
-      if newJobStatus != jobStatus:
+      if newJobStatus:
         self.log.info("finalizeRequest: Updating job status for %d to %s/Requests done" % (jobID, newJobStatus))
-        stateUpdate = stateServer.setJobStatus(jobID, newJobStatus, "Requests done", "")
       else:
         self.log.info(
-            "finalizeRequest: Updating job minor status for %d to Requests done (status is %s)" %
+            "finalizeRequest: Updating job minor status for %d to Requests done (current status is %s)" %
             (jobID, jobStatus))
-        stateUpdate = stateServer.setJobStatus(jobID, jobStatus, "Requests done", "")
-
+      stateUpdate = stateServer.setJobStatus(jobID, newJobStatus, "Requests done", "", 'RMS')
+      if jobAppStatus and stateUpdate['OK']:
+        stateUpdate = stateServer.setJobApplicationStatus(jobID, jobAppStatus, 'RMS')
       if not stateUpdate["OK"]:
         self.log.error("finalizeRequest: Failed to set job status",
-                       "JobID: %d status: %s" % (jobID, stateUpdate['Message']))
+                       "JobID: %d, error: %s" % (jobID, stateUpdate['Message']))
         return stateUpdate
 
     return S_OK(newJobStatus)

--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -6,6 +6,7 @@
 
 """
 
+import six
 import os
 import time
 import random
@@ -16,12 +17,15 @@ import datetime
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RPCClient import RPCClient
 from DIRAC.Core.Utilities.List import randomize, fromChar
+from DIRAC.Core.Utilities.JEncode import strToIntDict
+from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
 from DIRAC.ConfigurationSystem.Client import PathFinder
-from DIRAC.Core.Base.Client import Client
+from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.private.RequestValidator import RequestValidator
 
 
+@createClient('RequestManagement/ReqManager')
 class ReqClient(Client):
   """ReqClient is a class manipulating and operation on Requests.
 
@@ -29,7 +33,6 @@ class ReqClient(Client):
   :param dict requestProxiesDict: RPC client to ReqestProxy
   :param ~DIRAC.RequestManagementSystem.private.RequestValidator.RequestValidator requestValidator: RequestValidator instance
   """
-
   __requestProxiesDict = {}
   __requestValidator = None
 
@@ -137,6 +140,7 @@ class ReqClient(Client):
       return getRequest
     return S_OK(Request(getRequest["Value"]))
 
+  @ignoreEncodeWarning
   def getBulkRequests(self, numberOfRequest=10, assigned=True):
     """ get bulk requests from RequestDB
 
@@ -158,8 +162,10 @@ class ReqClient(Client):
       return getRequests
 
     jsonReq = getRequests["Value"]["Successful"]
-    reqInstances = dict((rId, Request(jsonReq[rId])) for rId in jsonReq)
-    return S_OK({"Successful": reqInstances, "Failed": getRequests["Value"]["Failed"]})
+    # Do not forget to cast back str keys to int
+    reqInstances = {int(rId): Request(jsonReq[rId]) for rId in jsonReq}
+    failed = strToIntDict(getRequests["Value"]["Failed"])
+    return S_OK({"Successful": reqInstances, "Failed": failed})
 
   def peekRequest(self, requestID):
     """ peek request """
@@ -234,7 +240,7 @@ class ReqClient(Client):
     :param self: self reference
     :param int requestID: id of the request
     """
-    if isinstance(requestID, basestring):
+    if isinstance(requestID, six.string_types):
       requestID = int(requestID)
     self.log.debug("getRequestStatus: attempting to get status for '%d' request." % requestID)
     requestStatus = self._getRPC().getRequestStatus(requestID)
@@ -298,7 +304,7 @@ class ReqClient(Client):
 
     # The request is 'Done', let's update the job status. If we fail, we should re-try later
     monitorServer = RPCClient("WorkloadManagement/JobMonitoring", useCertificates=useCertificates)
-    res = monitorServer.getJobSummary(int(jobID))
+    res = monitorServer.getJobPrimarySummary(int(jobID))
     if not res["OK"]:
       self.log.error("finalizeRequest: Failed to get job status", "JobID: %d" % jobID)
       return S_ERROR("finalizeRequest: Failed to get job %d status" % jobID)
@@ -306,19 +312,9 @@ class ReqClient(Client):
       self.log.info("finalizeRequest: job %d does not exist (anymore): finalizing" % jobID)
       return S_OK()
     else:
-      jobStatus = res["Value"]['Status']
+      jobStatus = res["Value"]["Status"]
+      newJobStatus = jobStatus
       jobMinorStatus = res["Value"]["MinorStatus"]
-      jobAppStatus = ''
-      newJobStatus = ''
-      if jobStatus == 'Stalled':
-        # If job is stalled, find the previous status from the logging info
-        res = monitorServer.getJobLoggingInfo(int(jobID))
-        if not res['OK']:
-          self.log.error("finalizeRequest: Failed to get job logging info", "JobID: %d" % jobID)
-          return S_ERROR("finalizeRequest: Failed to get job %d logging info" % jobID)
-        if len(res['Value']) >= 2:
-          jobStatus, jobMinorStatus, jobAppStatus = res['Value'][-2][:3]
-          newJobStatus = jobStatus
 
       # update the job pending request digest in any case since it is modified
       self.log.info("finalizeRequest: Updating request digest for job %d" % jobID)
@@ -334,25 +330,27 @@ class ReqClient(Client):
       else:
         self.log.error("finalizeRequest: Failed to get request digest for %s: %s" % (requestID,
                                                                                      digest["Message"]))
+      stateUpdate = None
       if jobStatus == 'Completed':
         # What to do? Depends on what we have in the minorStatus
         if jobMinorStatus == "Pending Requests":
           newJobStatus = 'Done'
+
         elif jobMinorStatus == "Application Finished With Errors":
           newJobStatus = 'Failed'
 
-      if newJobStatus:
+      if newJobStatus != jobStatus:
         self.log.info("finalizeRequest: Updating job status for %d to %s/Requests done" % (jobID, newJobStatus))
+        stateUpdate = stateServer.setJobStatus(jobID, newJobStatus, "Requests done", "")
       else:
         self.log.info(
-            "finalizeRequest: Updating job minor status for %d to Requests done (current status is %s)" %
+            "finalizeRequest: Updating job minor status for %d to Requests done (status is %s)" %
             (jobID, jobStatus))
-      stateUpdate = stateServer.setJobStatus(jobID, newJobStatus, "Requests done", "", 'RMS')
-      if jobAppStatus and stateUpdate['OK']:
-        stateUpdate = stateServer.setJobApplicationStatus(jobID, jobAppStatus, 'RMS')
+        stateUpdate = stateServer.setJobStatus(jobID, jobStatus, "Requests done", "")
+
       if not stateUpdate["OK"]:
         self.log.error("finalizeRequest: Failed to set job status",
-                       "JobID: %d, error: %s" % (jobID, stateUpdate['Message']))
+                       "JobID: %d status: %s" % (jobID, stateUpdate['Message']))
         return stateUpdate
 
     return S_OK(newJobStatus)
@@ -367,12 +365,19 @@ class ReqClient(Client):
                               "Failed" : { jobIDn: errMsg, jobIDm: errMsg, ...}  )
     """
     self.log.verbose("getRequestIDsForJobs: attempt to get request(s) for job %s" % jobIDs)
-    requests = self._getRPC().getRequestIDsForJobs(jobIDs)
-    if not requests["OK"]:
+    res = self._getRPC().getRequestIDsForJobs(jobIDs)
+    if not res["OK"]:
       self.log.error("getRequestIDsForJobs: unable to get request(s) for jobs",
-                     "%s: %s" % (jobIDs, requests["Message"]))
-    return requests
+                     "%s: %s" % (jobIDs, res["Message"]))
+      return res
 
+    # Cast the JobIDs back to int
+    successful = strToIntDict(res['Value']['Successful'])
+    failed = strToIntDict(res['Value']['Failed'])
+
+    return S_OK({'Successful': successful, 'Failed': failed})
+
+  @ignoreEncodeWarning
   def readRequestsForJobs(self, jobIDs):
     """ read requests for jobs
 
@@ -386,10 +391,11 @@ class ReqClient(Client):
       return readReqsForJobs
     ret = readReqsForJobs["Value"]
     # # create Requests out of JSONs for successful reads
-    if "Successful" in ret:
-      for jobID, fromJSON in ret["Successful"].items():
-        ret["Successful"][jobID] = Request(fromJSON)
-    return S_OK(ret)
+    # Do not forget to cast back str keys to int
+    successful = {int(jobID): Request(jsonReq) for jobID, jsonReq in ret['Successful'].iteritems()}
+    failed = strToIntDict(ret['Failed'])
+
+    return S_OK({'Successful': successful, 'Failed': failed})
 
   def resetFailedRequest(self, requestID, allR=False):
     """ Reset a failed request to "Waiting" status
@@ -422,7 +428,7 @@ class ReqClient(Client):
       return self.putRequest(req)
     return S_OK("Not reset")
 
-#============= Some useful functions to be shared ===========
+# ============= Some useful functions to be shared ===========
 
 
 output = ''
@@ -443,7 +449,7 @@ def prettyPrint(mainItem, key='', offset=0):
     for item in mainItem:
       prettyPrint(item, offset=offset + 2)
     output += "%s%s\n" % (blanks, ']' if isinstance(mainItem, list) else ')')
-  elif isinstance(mainItem, basestring):
+  elif isinstance(mainItem, six.string_types):
     if '\n' in mainItem:
       prettyPrint(mainItem.strip('\n').split('\n'), offset=offset)
     else:
@@ -451,9 +457,9 @@ def prettyPrint(mainItem, key='', offset=0):
   else:
     output += "%s%s%s\n" % (blanks, key, str(mainItem))
   output = output.replace('[\n%s{' % blanks, '[{').replace('}\n%s]' % blanks, '}]') \
-                 .replace('(\n%s{' % blanks, '({').replace('}\n%s)' % blanks, '})') \
-                 .replace('(\n%s(' % blanks, '((').replace(')\n%s)' % blanks, '))') \
-                 .replace('(\n%s[' % blanks, '[').replace(']\n%s)' % blanks, ']')
+      .replace('(\n%s{' % blanks, '({').replace('}\n%s)' % blanks, '})') \
+      .replace('(\n%s(' % blanks, '((').replace(')\n%s)' % blanks, '))') \
+      .replace('(\n%s[' % blanks, '[').replace(']\n%s)' % blanks, ']')
 
 
 def printFTSJobs(request):
@@ -488,27 +494,10 @@ def printFTSJobs(request):
                    job.status) for job in associatedFTS3Jobs))
         return
 
-      # If we are here, the attempt with the new FTS3 system did not work, let's try the old FTS system
-      gLogger.debug("Could not instantiate FTS3Client", res)
-      from DIRAC.DataManagementSystem.Client.FTSClient import FTSClient
-      ftsClient = FTSClient()
-      res = ftsClient.ping()
-      if not res['OK']:
-        gLogger.debug("Could not instantiate FtsClient", res)
-        return
-
-      res = ftsClient.getFTSJobsForRequest(request.RequestID)
-      if res['OK']:
-        ftsJobs = res['Value']
-        if ftsJobs:
-          gLogger.always('         FTS jobs associated: %s' % ','.join('%s (%s)' % (job.FTSGUID, job.Status)
-                                                                       for job in ftsJobs))
-
-  # ImportError can be thrown for the old client
   # AttributeError can be thrown because the deserialization will not have
   # happened correctly on the new fts3 (CC7 typically), and the error is not
   # properly propagated
-  except (ImportError, AttributeError) as err:
+  except AttributeError as err:
     gLogger.debug("Could not instantiate FtsClient because of Exception", repr(err))
 
 

--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -115,13 +115,12 @@ class TransformationClient(Client):
     while True:
       res = rpcClient.getTransformationFiles(condDict, older, newer, timeStamp, orderAttribute, limit, offsetToApply)
       if not res['OK']:
+        retries -= 1
         gLogger.error("Error getting files for transformation %s (offset %d), %s" %
                       (str(transID), offsetToApply,
-                       ('retry %d times' % retries) if retries else 'give up'), res['Message'])
-        retries -= 1
-        if retries:
-          continue
-        return res
+                       ('retry %d more times' % retries) if retries else 'give up'), res['Message'])
+        if not retries:
+          return res
       else:
         retries = 5
         condDictStr = str(condDict)

--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -115,12 +115,13 @@ class TransformationClient(Client):
     while True:
       res = rpcClient.getTransformationFiles(condDict, older, newer, timeStamp, orderAttribute, limit, offsetToApply)
       if not res['OK']:
-        retries -= 1
         gLogger.error("Error getting files for transformation %s (offset %d), %s" %
                       (str(transID), offsetToApply,
-                       ('retry %d more times' % retries) if retries else 'give up'), res['Message'])
-        if not retries:
-          return res
+                       ('retry %d times' % retries) if retries else 'give up'), res['Message'])
+        retries -= 1
+        if retries:
+          continue
+        return res
       else:
         retries = 5
         condDictStr = str(condDict)

--- a/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -155,13 +155,12 @@ class JobStateUpdateHandler(RequestHandler):
         as a key and status information dictionary as values
     """
 
-    status = ""
-    minor = ""
-    application = ""
-    appCounter = ""
+    status = ''
+    minor = ''
+    application = ''
+    appCounter = ''
     endDate = ''
     startDate = ''
-    startFlag = ''
     jobID = int(jobID)
 
     result = jobDB.getJobAttributes(jobID, ['Status'])
@@ -171,10 +170,9 @@ class JobStateUpdateHandler(RequestHandler):
     if not result['Value']:
       # if there is no matching Job it returns an empty dictionary
       return S_ERROR('No Matching Job')
-
-    new_status = result['Value']['Status']
-    if new_status == "Stalled":
-      status = 'Running'
+    # If the current status is Stalled and we get an update, it should probably be "Running"
+    if result['Value']['Status'] == JobStatus.STALLED:
+      status = JobStatus.RUNNING
 
     # Get the latest WN time stamps of status updates
     result = logDB.getWMSTimeStamps(int(jobID))
@@ -183,61 +181,51 @@ class JobStateUpdateHandler(RequestHandler):
     lastTime = max([float(t) for s, t in result['Value'].items() if s != 'LastTime'])
     lastTime = Time.toString(Time.fromEpoch(lastTime))
 
-    # Get the last status values
     dates = sorted(statusDict)
     # We should only update the status if its time stamp is more recent than the last update
-    for date in [date for date in dates if date >= lastTime]:
-      sDict = statusDict[date]
-      if sDict['Status']:
-        status = sDict['Status']
+    if dates[-1] >= lastTime:
+      # Get the last status values
+      for date in [date for date in dates if date >= lastTime]:
+        sDict = statusDict[date]
+        status = sDict.get('Status', status)
         if status in JobStatus.JOB_FINAL_STATES:
           endDate = date
-        if status == JobStatus.RUNNING:
-          startFlag = JobStatus.RUNNING
-      if sDict['MinorStatus']:
-        minor = sDict['MinorStatus']
-        if minor == "Application" and startFlag == JobStatus.RUNNING:
+        minor = sDict.get('MinorStatus', minor)
+        # Pick up the start date
+        if minor == "Application" and status == JobStatus.RUNNING and not startDate:
           startDate = date
-      if sDict['ApplicationStatus']:
-        application = sDict['ApplicationStatus']
-      counter = sDict.get('ApplicationCounter')
-      if counter:
-        appCounter = counter
-    attrNames = []
-    attrValues = []
-    if status:
-      attrNames.append('Status')
-      attrValues.append(status)
-    if minor:
-      attrNames.append('MinorStatus')
-      attrValues.append(minor)
-    if application:
-      attrNames.append('ApplicationStatus')
-      attrValues.append(application)
-    if appCounter:
-      attrNames.append('ApplicationCounter')
-      attrValues.append(appCounter)
-    result = jobDB.setJobAttributes(jobID, attrNames, attrValues, update=True)
-    if not result['OK']:
-      return result
+        application = sDict.get('ApplicationStatus', application)
+        appCounter = sDict.get('ApplicationCounter', appCounter)
 
-    if endDate:
-      result = jobDB.setEndExecTime(jobID, endDate)
-    if startDate:
-      result = jobDB.setStartExecTime(jobID, startDate)
+      attrNames = []
+      attrValues = []
+      if status:
+        attrNames.append('Status')
+        attrValues.append(status)
+      if minor:
+        attrNames.append('MinorStatus')
+        attrValues.append(minor)
+      if application:
+        attrNames.append('ApplicationStatus')
+        attrValues.append(application)
+      if appCounter:
+        attrNames.append('ApplicationCounter')
+        attrValues.append(appCounter)
+      result = jobDB.setJobAttributes(jobID, attrNames, attrValues, update=True)
+      if not result['OK']:
+        return result
+
+      if endDate:
+        result = jobDB.setEndExecTime(jobID, endDate)
+      if startDate:
+        result = jobDB.setStartExecTime(jobID, startDate)
 
     # Update the JobLoggingDB records
     for date in dates:
       sDict = statusDict[date]
-      status = sDict['Status']
-      if not status:
-        status = 'idem'
-      minor = sDict['MinorStatus']
-      if not minor:
-        minor = 'idem'
-      application = sDict['ApplicationStatus']
-      if not application:
-        application = 'idem'
+      status = sDict['Status'] if sDict['Status'] else 'idem'
+      minor = sDict['MinorStatus'] if sDict['MinorStatus'] else 'idem'
+      application = sDict['ApplicationStatus'] if sDict['ApplicationStatus'] else 'idem'
       source = sDict['Source']
       result = logDB.addLoggingRecord(jobID, status, minor, application, date, source)
       if not result['OK']:


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: When the job status was updated from a failover request, the job status was by mistake set to `Running` when the job was initially `Stalled`. This was however not visible in the job logging info that was correct.

This is fixed in the `JobStateUpdateHandler`.

*RMS
When finalising the request, one should take into account the fact that if the job is `Stalled` one must find its previous status. This is fixed in `ReqClient`

For examples look into release.notes

ENDRELEASENOTES
