### PR TITLE
[v7r0] DMS: add WLCGAccountingHTTPJson occupancy plugin

### DIFF
--- a/Resources/Storage/OccupancyPlugins/WLCGAccountingHTTPJson.py
+++ b/Resources/Storage/OccupancyPlugins/WLCGAccountingHTTPJson.py
@@ -1,0 +1,48 @@
+"""
+Defines the plugin to take storage space information given by WLCG Accounting Json
+https://twiki.cern.ch/twiki/bin/view/LCG/AccountingTaskForce#Storage_Space_Accounting
+https://twiki.cern.ch/twiki/pub/LCG/AccountingTaskForce/storage_service_v4.txt
+https://docs.google.com/document/d/1yzCvKpxsbcQC5K9MyvXc-vBF1HGPBk4vhjw3MEXoXf8
+
+When this is used, the OccupancyLFN has to be the full HTTP(s) URL
+
+"""
+
+import requests
+
+from DIRAC.Resources.Storage.OccupancyPlugins.WLCGAccountingJson import WLCGAccountingJson
+
+
+class WLCGAccountingHTTPJson(WLCGAccountingJson):
+  """ .. class:: WLCGAccountingHTTPJson
+
+  Occupancy plugin to return the space information given by WLCG HTTP Accounting Json
+
+  """
+
+  def __init__(self, se):
+    """
+        c'tor
+
+        :param se: reference to the StorageElement object from which we are called
+    """
+
+    super(WLCGAccountingHTTPJson, self).__init__(se)
+
+    self.log = se.log.getSubLogger('WLCGAccountingHTTPJson')
+
+  def _downloadJsonFile(self, occupancyLFN, filePath):
+    """ Download the json file at the location using requests
+
+        :param occupancyLFN: this is actually a full https URL
+        :param filePath: destination path for the file
+
+    """
+
+    try:
+      with open(filePath, 'wt') as fd:
+        res = requests.get(occupancyLFN)
+        res.raise_for_status()
+        fd.write(res.content())
+    except Exception as e:
+      self.log.debug("Exception while copying", repr(e))

--- a/Resources/Storage/OccupancyPlugins/WLCGAccountingJson.py
+++ b/Resources/Storage/OccupancyPlugins/WLCGAccountingJson.py
@@ -3,6 +3,8 @@
   https://twiki.cern.ch/twiki/bin/view/LCG/AccountingTaskForce#Storage_Space_Accounting
   https://twiki.cern.ch/twiki/pub/LCG/AccountingTaskForce/storage_service_v4.txt
   https://docs.google.com/document/d/1yzCvKpxsbcQC5K9MyvXc-vBF1HGPBk4vhjw3MEXoXf8
+
+  When this is used, the OccupancyLFN has to be the full path on the storage, and not just the LFN
 """
 import json
 import os
@@ -19,10 +21,35 @@ class WLCGAccountingJson(object):
 
   Occupancy plugin to return the space information given by WLCG Accouting Json
   """
+
   def __init__(self, se):
     self.se = se
     self.log = se.log.getSubLogger('WLCGAccountingJson')
     self.name = self.se.name
+
+  def _downloadJsonFile(self, occupancyLFN, filePath):
+    """ Download the json file at the location
+
+        :param occupancyLFN: lfn for the file
+        :param filePath: destination path for the file
+
+    """
+    for storage in self.se.storages:
+      try:
+        ctx = gfal2.creat_context()
+        params = ctx.transfer_parameters()
+        params.overwrite = True
+        res = storage.updateURL(occupancyLFN)
+        if not res['OK']:
+          continue
+        occupancyURL = res['Value']
+        ctx.filecopy(params, occupancyURL, 'file://' + filePath)
+        return
+      except gfal2.GError as e:
+        detailMsg = "Failed to copy file %s to destination url %s: [%d] %s" % (
+            occupancyURL, filePath, e.code, e.message)
+        self.log.debug("Exception while copying", detailMsg)
+        continue
 
   def getOccupancy(self, **kwargs):
     """ Returns the space information given by WLCG Accouting Json
@@ -37,25 +64,7 @@ class WLCGAccountingJson(object):
     tmpDirName = tempfile.mkdtemp()
     filePath = os.path.join(tmpDirName, os.path.basename(occupancyLFN))
 
-    for storage in self.se.storages:
-      try:
-        ctx = gfal2.creat_context()
-        params = ctx.transfer_parameters()
-        params.overwrite = True
-        res = storage.updateURL(occupancyLFN)
-        if not res['OK']:
-          continue
-        occupancyURL = res['Value']
-        ctx.filecopy(params, occupancyURL, 'file://' + filePath)
-
-      except gfal2.GError as e:
-        detailMsg = "Failed to copy file %s to destination url %s: [%d] %s" % (
-            occupancyURL, filePath, e.code, e.message)
-        self.log.debug("Exception while copying", detailMsg)
-        continue
-
-      else:
-        break
+    self._downloadJsonFile(occupancyLFN, filePath)
 
     if not os.path.isfile(filePath):
       return S_ERROR('No WLCGAccountingJson file of %s is downloaded.' % (self.name))

--- a/docs/source/AdministratorGuide/Resources/storage.rst
+++ b/docs/source/AdministratorGuide/Resources/storage.rst
@@ -10,6 +10,7 @@ DIRAC provides an abstraction of a SE interface that allows to access different 
 
     CERN-USER
     {
+      OccupancyPlugin = WLCGAccountingJson
       OccupancyLFN = /lhcb/spaceReport.json
       SpaceReservation = LHCb_USER
       ReadAccess = Active
@@ -54,6 +55,7 @@ Configuration options are:
 * ``CheckAccess``: default `True`. Allowed for Check if no RSS enabled
 * ``RemoveAccess``: default `True`. Allowed for Remove if no RSS enabled
 * ``OccupancyLFN``: default (`/<vo>/occupancy.json`). LFN where the json file containing the space reporting is to be found
+* ``OccupancyPlugin``: default (`empty`). Plugin to find the occupancy of a given storage.
 * ``SpaceReservation``: just a name of a zone of the physical storage which can have some space reserved. Extends the SRM ``SpaceToken`` concept.
 
 VO specific paths
@@ -252,6 +254,13 @@ For example::
 The LFN of this file is by default `/<vo>/occupancy.json`, but can be overwritten with the `OccupancyLFN` option of the SE.
 
 The ``SpaceReservation`` option allows to specify a physical zone of the storage which would have space reservation (for example ``LHCb_USER``, ``LHCb_PROD``, etc). It extends the concept of ``SpaceToken`` that SRM has. This option is only used if the StoragePlugin does not return itself a ``SpaceReservation`` value.
+
+The ``OccupancyPlugin`` allows to change the way space occupancy is measured. Several plugins are available (please refer to the module documentation):
+
+* BDIIOccupancy: :py:mod:`~DIRAC.Resources.Storage.OccupancyPlugins.BDIIOccupancy`
+* WLCGAccountingJson: :py:mod:`~DIRAC.Resources.Storage.OccupancyPlugins.WLCGAccountingJson`
+* WLCGAccountingHTTPJson: :py:mod:`~DIRAC.Resources.Storage.OccupancyPlugins.WLCGAccountingHTTPJson` (likely to become the default in the future)
+
 
 
 .. _multiProtocol:


### PR DESCRIPTION
This allows to fetch the space report accounting generated natively by the new DPM (so based on HTTP)

BEGINRELEASENOTES
*Resources
NEW: WLCGAccountingHTTPJson plugin

ENDRELEASENOTES
