### PR TITLE
[v7r1] Allows the transition to JSON serialization to start

### DIFF
--- a/Core/DISET/private/Transports/BaseTransport.py
+++ b/Core/DISET/private/Transports/BaseTransport.py
@@ -27,11 +27,11 @@ from hashlib import md5
 
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
-from DIRAC.Core.Utilities import DEncode
+from DIRAC.Core.Utilities import MixedEncode
 
 
 class BaseTransport(object):
-  """ Invokes DEncode for marshaling/unmarshaling of data calls in transit
+  """ Invokes MixedEncode for marshaling/unmarshaling of data calls in transit
   """
 
   bAllowReuseAddress = True
@@ -159,7 +159,7 @@ class BaseTransport(object):
 
   def sendData(self, uData, prefix=False):
     self.__updateLastActionTimestamp()
-    sCodedData = DEncode.encode(uData)
+    sCodedData = MixedEncode.encode(uData)
     if prefix:
       dataToSend = "%s%s:%s" % (prefix, len(sCodedData), sCodedData)
     else:
@@ -250,7 +250,7 @@ class BaseTransport(object):
           data = pkgMem.read(pkgSize)
           self.byteStream = pkgMem.read()
       try:
-        data = DEncode.decode(data)[0]
+        data = MixedEncode.decode(data)[0]
       except Exception as e:
         return S_ERROR("Could not decode received data: %s" % str(e))
       if idleReceive:

--- a/Core/Utilities/MixedEncode.py
+++ b/Core/Utilities/MixedEncode.py
@@ -1,0 +1,39 @@
+""" Transition methods to allow to move from DEncode to JEncode
+
+"""
+import os
+from DIRAC.Core.Utilities import DEncode, JEncode
+
+
+def encode(inData):
+  """ Encode the input data
+
+      :param inData: data to be encoded
+
+      :return: an encoded string
+  """
+  if os.getenv('DIRAC_USE_JSON_ENCODE', 'NO').lower() in ('yes', 'true'):
+    return JEncode.encode(inData)
+  return DEncode.encode(inData)
+
+
+def decode(encodedData):
+  """ Decode the encoded string
+
+      :param encodedData: encoded string
+
+      :return: the decoded objects, encoded object length
+
+  """
+  if os.getenv('DIRAC_USE_JSON_DECODE', 'NO').lower() in ('yes', 'true'):
+    try:
+      # 'null' is a special case.
+      # None is encoded as 'null' as JSON
+      # that DEncode would understand as None, since it starts with 'n'
+      # but the length of the decoded string will not be correct
+      if encodedData == 'null':
+        raise Exception
+      return DEncode.decode(encodedData)
+    except Exception:
+      return JEncode.decode(encodedData)
+  return DEncode.decode(encodedData)

--- a/Core/Utilities/test/Test_Encode.py
+++ b/Core/Utilities/test/Test_Encode.py
@@ -15,6 +15,7 @@ import sys
 
 from DIRAC.Core.Utilities.DEncode import encode as disetEncode, decode as disetDecode, g_dEncodeFunctions
 from DIRAC.Core.Utilities.JEncode import encode as jsonEncode, decode as jsonDecode, JSerializable
+from DIRAC.Core.Utilities.MixedEncode import encode as mixEncode, decode as mixDecode
 
 from hypothesis import given
 from hypothesis.strategies import builds, integers, lists, recursive, floats, text,\
@@ -30,9 +31,21 @@ parametrize = mark.parametrize
 
 disetTuple = (disetEncode, disetDecode)
 jsonTuple = (jsonEncode, jsonDecode)
+mixTuple = (mixEncode, mixDecode)
 
-enc_dec_imp = (disetTuple, jsonTuple)
-enc_dec_ids = ('disetTuple', 'jsonTuple')
+enc_dec_imp = (disetTuple, jsonTuple, (mixTuple, 'No', 'No'), (mixTuple, 'Yes', 'No'), (mixTuple, 'Yes', 'Yes'))
+enc_dec_ids = (
+    'disetTuple',
+    'jsonTuple',
+    'mixTuple',
+    'mixTuple (DIRAC_USE_JSON_DECODE=Yes)',
+    'mixTuple (DIRAC_USE_JSON_ENCODE=Yes')
+
+enc_dec_imp_without_json = (disetTuple, (mixTuple, 'No', 'No'), (mixTuple, 'Yes', 'No'))
+enc_dec_ids_without_json = (
+    'disetTuple',
+    'mixTuple',
+    'mixTuple (DIRAC_USE_JSON_DECODE=Yes)')
 
 
 def myDatetimes():
@@ -88,14 +101,14 @@ def test_everyBaseTypeIsTested():
     getattr(current_module, testFuncName)
 
 
-def agnosticTestFunction(enc_dec, data):
+def agnosticTestFunction(enc_dec_tuple, data):
   """ Function called by all the other to test that
       decode(encode) returns the original data
 
       :param enc_dec: tuple of function (encoding, decoding)
       :param data: data to be worked on
   """
-  encode, decode = enc_dec
+  encode, decode = enc_dec_tuple
   encodedData = encode(data)
   decodedData, lenData = decode(encodedData)
 
@@ -105,21 +118,41 @@ def agnosticTestFunction(enc_dec, data):
   return decodedData
 
 
+def base_enc_dec(request, monkeypatch):
+  """ base function to generate the (encoding, decoding) tuple and potentially setting the environment variables
+
+      :param request: fixture request. Will contain either an encoding/decoding tuple, or the same tuple plus two env variables to be set
+  """
+
+  if len(request.param) == 2:
+    return request.param
+
+  enc_dec_tuple, use_json_decode, use_json_encode = request.param
+  monkeypatch.setenv("DIRAC_USE_JSON_DECODE", use_json_decode)
+  monkeypatch.setenv("DIRAC_USE_JSON_ENCODE", use_json_encode)
+  return enc_dec_tuple
+
+
 @fixture(scope="function", params=enc_dec_imp, ids=enc_dec_ids)
-def enc_dec(request):
-  """ Fixture to generate the (encoding, decoding) tuple """
+def enc_dec(request, monkeypatch):
+  """ Fixture to generate the (encoding, decoding) tuple for all the serialization types"""
+  return base_enc_dec(request, monkeypatch)
 
-  return request.param
+
+@fixture(scope="function", params=enc_dec_imp_without_json, ids=enc_dec_ids_without_json)
+def enc_dec_without_json(request, monkeypatch):
+  """ Fixture to generate the (encoding, decoding) tuple for all the serialization types which
+      do not involve json encoding
+  """
+  return base_enc_dec(request, monkeypatch)
 
 
-# @parametrize('enc_dec', enc_dec_imp)
 @given(data=booleans())
 def test_BaseType_Bool(enc_dec, data):
   """ Test for boolean"""
   agnosticTestFunction(enc_dec, data)
 
 
-# @parametrize('enc_dec', enc_dec_imp)
 @given(data=myDatetimes())
 def test_BaseType_DateTime(enc_dec, data):
   """ Test for data time"""
@@ -128,14 +161,12 @@ def test_BaseType_DateTime(enc_dec, data):
 
 
 # Json does not serialize keys as integers but as string
-@parametrize('enc_dec', [disetTuple])
 @given(data=dictionaries(integers(), integers()))
-def test_BaseType_Dict(enc_dec, data):
+def test_BaseType_Dict(enc_dec_without_json, data):
   """ Test for basic dict"""
-  agnosticTestFunction(enc_dec, data)
+  agnosticTestFunction(enc_dec_without_json, data)
 
 
-# @parametrize('enc_dec', enc_dec_imp)
 @given(data=integers(max_value=sys.maxsize))
 def test_BaseType_Int(enc_dec, data):
   """ Test for integer"""
@@ -144,7 +175,6 @@ def test_BaseType_Int(enc_dec, data):
 # CAUTION: DEncode is not precise for floats !!
 
 
-# @parametrize('enc_dec', enc_dec_imp)
 @given(data=floats(allow_nan=False))
 def test_BaseType_Float(enc_dec, data):
   """ Test that float is approximatly stable"""
@@ -155,27 +185,23 @@ def test_BaseType_Float(enc_dec, data):
   assert lenData == len(encodedData)
 
 
-# @parametrize('enc_dec', enc_dec_imp)
 @given(data=lists(integers()))
 def test_BaseType_List(enc_dec, data):
   """ Test for List """
   agnosticTestFunction(enc_dec, data)
 
 
-# @parametrize('enc_dec', enc_dec_imp)
 @given(data=integers(min_value=sys.maxsize + 1))
 def test_BaseType_Long(enc_dec, data):
   """ Test long type"""
   agnosticTestFunction(enc_dec, data)
 
 
-# @parametrize('enc_dec', enc_dec_imp)
 def test_BaseType_None(enc_dec, ):
   """ Test None case """
   agnosticTestFunction(enc_dec, None)
 
 
-# @parametrize('enc_dec', enc_dec_imp)
 @given(data=text(printable))
 def test_BaseType_String(enc_dec, data):
   """ Test basic strings"""
@@ -185,14 +211,12 @@ def test_BaseType_String(enc_dec, data):
 
 
 # Tuple are not serialized in JSON
-@parametrize('enc_dec', [disetTuple])
 @given(data=tuples(integers()))
-def test_BaseType_Tuple(enc_dec, data):
+def test_BaseType_Tuple(enc_dec_without_json, data):
   """ Test basic tuple """
-  agnosticTestFunction(enc_dec, data)
+  agnosticTestFunction(enc_dec_without_json, data)
 
 
-# @parametrize('enc_dec', enc_dec_imp)
 @given(data=text())
 def test_BaseType_Unicode(enc_dec, data):
   """ Test unicode data """
@@ -200,11 +224,10 @@ def test_BaseType_Unicode(enc_dec, data):
 
 
 # Json will not pass this because of tuples and integers as dict keys
-@parametrize('enc_dec', [disetTuple])
 @given(data=nestedStrategy)
-def test_nestedStructure(enc_dec, data):
+def test_nestedStructure(enc_dec_without_json, data):
   """ Test nested structure """
-  agnosticTestFunction(enc_dec, data)
+  agnosticTestFunction(enc_dec_without_json, data)
 
 
 # DEncode raises KeyError.....

--- a/Core/Utilities/test/Test_Encode.py
+++ b/Core/Utilities/test/Test_Encode.py
@@ -17,7 +17,7 @@ from DIRAC.Core.Utilities.DEncode import encode as disetEncode, decode as disetD
 from DIRAC.Core.Utilities.JEncode import encode as jsonEncode, decode as jsonDecode, JSerializable
 from DIRAC.Core.Utilities.MixedEncode import encode as mixEncode, decode as mixDecode
 
-from hypothesis import given
+from hypothesis import given, settings, HealthCheck
 from hypothesis.strategies import builds, integers, lists, recursive, floats, text,\
     booleans, none, dictionaries, tuples, datetimes
 
@@ -121,7 +121,8 @@ def agnosticTestFunction(enc_dec_tuple, data):
 def base_enc_dec(request, monkeypatch):
   """ base function to generate the (encoding, decoding) tuple and potentially setting the environment variables
 
-      :param request: fixture request. Will contain either an encoding/decoding tuple, or the same tuple plus two env variables to be set
+      :param request: fixture request. Will contain either an encoding/decoding tuple,
+       or the same tuple plus two env variables to be set
   """
 
   if len(request.param) == 2:
@@ -259,6 +260,7 @@ class Serializable(JSerializable):
     return all([getattr(self, attr) == getattr(other, attr) for attr in self._attrToSerialize])
 
 
+@settings(suppress_health_check=(HealthCheck.too_slow,))
 @given(data=nestedStrategyJson)
 def test_Serializable(data):
   """ Test if a simple serializable class with one random argument

--- a/Core/Utilities/test/Test_Encode.py
+++ b/Core/Utilities/test/Test_Encode.py
@@ -20,7 +20,7 @@ from hypothesis import given
 from hypothesis.strategies import builds, integers, lists, recursive, floats, text,\
     booleans, none, dictionaries, tuples, datetimes
 
-from pytest import mark, approx, raises
+from pytest import mark, approx, raises, fixture
 parametrize = mark.parametrize
 
 
@@ -32,6 +32,7 @@ disetTuple = (disetEncode, disetDecode)
 jsonTuple = (jsonEncode, jsonDecode)
 
 enc_dec_imp = (disetTuple, jsonTuple)
+enc_dec_ids = ('disetTuple', 'jsonTuple')
 
 
 def myDatetimes():
@@ -104,14 +105,21 @@ def agnosticTestFunction(enc_dec, data):
   return decodedData
 
 
-@parametrize('enc_dec', enc_dec_imp)
+@fixture(scope="function", params=enc_dec_imp, ids=enc_dec_ids)
+def enc_dec(request):
+  """ Fixture to generate the (encoding, decoding) tuple """
+
+  return request.param
+
+
+# @parametrize('enc_dec', enc_dec_imp)
 @given(data=booleans())
 def test_BaseType_Bool(enc_dec, data):
   """ Test for boolean"""
   agnosticTestFunction(enc_dec, data)
 
 
-@parametrize('enc_dec', enc_dec_imp)
+# @parametrize('enc_dec', enc_dec_imp)
 @given(data=myDatetimes())
 def test_BaseType_DateTime(enc_dec, data):
   """ Test for data time"""
@@ -127,7 +135,7 @@ def test_BaseType_Dict(enc_dec, data):
   agnosticTestFunction(enc_dec, data)
 
 
-@parametrize('enc_dec', enc_dec_imp)
+# @parametrize('enc_dec', enc_dec_imp)
 @given(data=integers(max_value=sys.maxsize))
 def test_BaseType_Int(enc_dec, data):
   """ Test for integer"""
@@ -136,7 +144,7 @@ def test_BaseType_Int(enc_dec, data):
 # CAUTION: DEncode is not precise for floats !!
 
 
-@parametrize('enc_dec', enc_dec_imp)
+# @parametrize('enc_dec', enc_dec_imp)
 @given(data=floats(allow_nan=False))
 def test_BaseType_Float(enc_dec, data):
   """ Test that float is approximatly stable"""
@@ -147,27 +155,27 @@ def test_BaseType_Float(enc_dec, data):
   assert lenData == len(encodedData)
 
 
-@parametrize('enc_dec', enc_dec_imp)
+# @parametrize('enc_dec', enc_dec_imp)
 @given(data=lists(integers()))
 def test_BaseType_List(enc_dec, data):
   """ Test for List """
   agnosticTestFunction(enc_dec, data)
 
 
-@parametrize('enc_dec', enc_dec_imp)
+# @parametrize('enc_dec', enc_dec_imp)
 @given(data=integers(min_value=sys.maxsize + 1))
 def test_BaseType_Long(enc_dec, data):
   """ Test long type"""
   agnosticTestFunction(enc_dec, data)
 
 
-@parametrize('enc_dec', enc_dec_imp)
+# @parametrize('enc_dec', enc_dec_imp)
 def test_BaseType_None(enc_dec, ):
   """ Test None case """
   agnosticTestFunction(enc_dec, None)
 
 
-@parametrize('enc_dec', enc_dec_imp)
+# @parametrize('enc_dec', enc_dec_imp)
 @given(data=text(printable))
 def test_BaseType_String(enc_dec, data):
   """ Test basic strings"""
@@ -184,7 +192,7 @@ def test_BaseType_Tuple(enc_dec, data):
   agnosticTestFunction(enc_dec, data)
 
 
-@parametrize('enc_dec', enc_dec_imp)
+# @parametrize('enc_dec', enc_dec_imp)
 @given(data=text())
 def test_BaseType_Unicode(enc_dec, data):
   """ Test unicode data """
@@ -201,7 +209,7 @@ def test_nestedStructure(enc_dec, data):
 
 # DEncode raises KeyError.....
 # Others raise TypeError
-@parametrize('enc_dec', enc_dec_imp)
+# @parametrize('enc_dec', enc_dec_imp)
 def test_NonSerializable(enc_dec):
   """ Test that a class that does not inherit from the serializable class
       raises TypeError

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -22,6 +22,12 @@ DIRAC_GFAL_GRIDFTP_SESSION_REUSE
   If set to ``true`` or ``yes`` the GRIDFT SESSION RESUSE option will be set to True, should be set on server
   installations. See the information in the :ref:`resourcesStorageElement` page.
 
+DIRAC_USE_JSON_DECODE
+  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page
+
+DIRAC_USE_JSON_ENCODE
+  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page
+
 DIRAC_USE_M2CRYPTO
   If ``true`` or ``yes`` DIRAC uses m2crypto instead of pyGSI for handling certificates, proxies, etc.
 

--- a/docs/source/AdministratorGuide/technologyPreviews.rst
+++ b/docs/source/AdministratorGuide/technologyPreviews.rst
@@ -22,3 +22,21 @@ M2Crypto (or any standard tool that respects TLS..) will be stricter than PyGSI.
 * SAN in your certificates: if you are contacting a machine using its aliases, make sure that all the aliases are in the SubjectAlternativeName (SAN) field of the certificates
 * FQDN in the configuration: SAN normally contains only FQDN, so make sure you use the FQDN in the CS as well (e.g. `mymachine.cern.ch` and not `mymachine`)
 * ComponentInstaller screwed: like any change you do on your hosts, the ComponentInstaller will duplicate the entry. So if you change the CS to put FQDN, the machine will appear twice. 
+
+
+.. _jsonSerialization:
+
+JSON Serialization
+==================
+
+We aim at replacing the DEncode serialization over the network with json serialization. In order to be smooth, the transition needs to happen in several steps:
+* DISET -> DISET: as it is now. We encode DISET, and decode DISET
+* DISET -> DISET, JSON: we send DISET, try to decode with DISET, fallback to JSON if it fails. This step is to make sure all clients will be ready to understand JSON whenever it comes.
+* JSON -> DISET, JSON: we send JSON, attempt to decode with DISET, fallback to JSON if it fails. This step is to make sure that if we still have some old clients lying around, we are still able to understand them.
+* JSON -> JSON: final step, goodbye DISET.
+
+The changes from one stage to the next is controlled by environment variables, and it can go to your own pace:
+* `DIRAC_USE_JSON_DECODE`: must be the first one. Enables the DISET,JSON decoding
+* `DIRAC_USE_JSON_ENCODE`: `DIRAC_USE_JSON_DECODE` must still be enabled ! Sends JSON instead of DISET.
+
+The last stage (JSON only) will be the default of the following release, so before upgrading you will have to go through the previous steps.


### PR DESCRIPTION
This PR introduces the necessary code and tools to do the transition to JSON serialization. 
Basically, instead of doing 4 releases (i.e. transition of about 40 months), we control the changes with environment variable. Of course, this needs that all the JSON tasks that are still opened are addressed.

BEGINRELEASENOTES
*Core
NEW: Allows for json serialization transition

ENDRELEASENOTES
