### PR TITLE
[v7r1] BaseTransport: group -> extraCredentials

### DIFF
--- a/Core/DISET/private/Transports/BaseTransport.py
+++ b/Core/DISET/private/Transports/BaseTransport.py
@@ -118,8 +118,13 @@ class BaseTransport(object):
     """
     return self.peerCredentials
 
-  def setExtraCredentials(self, group):
-    self.peerCredentials['extraCredentials'] = group
+  def setExtraCredentials(self, extraCredentials):
+    """ Add extra credentials to peerCredentials
+
+        :param extraCredentials: group or tuple with DN and group
+        :type extraCredentials: str or tuple
+    """
+    self.peerCredentials['extraCredentials'] = extraCredentials
 
   def serverMode(self):
     return self.bServerMode


### PR DESCRIPTION
In the `setExtraCredentials` method the value of the `group` argument besides the group it can be a tuple with the user DN and the group. 

BEGINRELEASENOTES

*Core
FIX: rename setExtraCredentials methods argument, docs

ENDRELEASENOTES
