### PR TITLE
[v7r1] DN properties

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/ConfigurationSystem/Client/Helpers/Registry.py
@@ -393,26 +393,25 @@ def getCAForUsername(username):
   return S_ERROR("No CA found for user %s" % username)
 
 
-def getDNProperty(userDN, value):
+def getDNProperty(userDN, value, defaultValue=None):
   """ Get property from DNProperties section by user DN
 
       :param str userDN: user DN
       :param str value: option that need to get
+      :param defaultValue: default value
 
-      :return: S_OK(str,list)/S_ERROR() -- str or list that contain option value
+      :return: S_OK()/S_ERROR() -- str or list that contain option value
   """
   result = getUsernameForDN(userDN)
   if not result['OK']:
     return result
   pathDNProperties = "%s/Users/%s/DNProperties" % (gBaseRegistrySection, result['Value'])
   result = gConfig.getSections(pathDNProperties)
-  if not result['OK']:
-    return result
-  for section in result['Value']:
-    if userDN == gConfig.getValue("%s/%s/DN" % (pathDNProperties, section)):
-      return S_OK(gConfig.getValue("%s/%s/%s" % (pathDNProperties, section, value)))
-
-  return S_ERROR('No properties found for %s' % userDN)
+  if result['OK']:
+    for section in result['Value']:
+      if userDN == gConfig.getValue("%s/%s/DN" % (pathDNProperties, section)):
+        return S_OK(gConfig.getValue("%s/%s/%s" % (pathDNProperties, section, value), defaultValue))
+  return S_OK(defaultValue)
 
 
 def getProxyProvidersForDN(userDN):
@@ -422,11 +421,7 @@ def getProxyProvidersForDN(userDN):
 
       :return: S_OK(list)/S_ERROR()
   """
-  result = getDNProperty(userDN, 'ProxyProviders')
-  if not result['OK']:
-    return result
-  ppList = result['Value'] or []
-  return S_OK(ppList if isinstance(ppList, list) else ppList.split())
+  return getDNProperty(userDN, 'ProxyProviders', [])
 
 
 def getDNFromProxyProviderForUserID(proxyProvider, userID):

--- a/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/ConfigurationSystem/Client/Helpers/Registry.py
@@ -402,15 +402,16 @@ def getDNProperty(userDN, value):
       :return: S_OK(basestring,list)/S_ERROR() -- basestring or list that contain option value
   """
   result = getUsernameForDN(userDN)
-  if result['OK']:
-    result = gConfig.getSections("%s/Users/%s/DNProperties" % (gBaseRegistrySection, result['Value']))
-    if result['OK']:
-      for section in "%s/Users/%s/DNProperties/%s" % (gBaseRegistrySection, user, result['Value']):
-        if userDN == gConfig.getValue("%s/DN" % section):
-          return S_OK(gConfig.getValue("%s/%s" % (section, value)))
+  if not result['OK']:
+    return result
+  result = gConfig.getSections("%s/Users/%s/DNProperties" % (gBaseRegistrySection, result['Value']))
+  if not result['OK']:
+    return result
+  for section in "%s/Users/%s/DNProperties/%s" % (gBaseRegistrySection, user, result['Value']):
+    if userDN == gConfig.getValue("%s/DN" % section):
+      return S_OK(gConfig.getValue("%s/%s" % (section, value)))
 
-  return S_ERROR('No properties found for %s%s' %
-                 (userDN, '' if result['OK'] else ': %s' % result['Message']))
+  return S_ERROR('No properties found for %s' % userDN)
 
 
 def getProxyProvidersForDN(userDN):

--- a/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/ConfigurationSystem/Client/Helpers/Registry.py
@@ -409,7 +409,7 @@ def getDNProperty(userDN, value):
   if not result['OK']:
     return result
   for section in result['Value']:
-    if userDN == gConfig.getValue("%s/%s/DN" % (pathDNProperties, section):
+    if userDN == gConfig.getValue("%s/%s/DN" % (pathDNProperties, section)):
       return S_OK(gConfig.getValue("%s/%s/%s" % (pathDNProperties, section, value)))
 
   return S_ERROR('No properties found for %s' % userDN)

--- a/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/ConfigurationSystem/Client/Helpers/Registry.py
@@ -396,10 +396,10 @@ def getCAForUsername(username):
 def getDNProperty(userDN, value):
   """ Get property from DNProperties section by user DN
 
-      :param basestring userDN: user DN
-      :param basestring value: option that need to get
+      :param str userDN: user DN
+      :param str value: option that need to get
 
-      :return: S_OK(basestring,list)/S_ERROR() -- basestring or list that contain option value
+      :return: S_OK(str,list)/S_ERROR() -- str or list that contain option value
   """
   result = getUsernameForDN(userDN)
   if not result['OK']:

--- a/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/ConfigurationSystem/Client/Helpers/Registry.py
@@ -404,12 +404,13 @@ def getDNProperty(userDN, value):
   result = getUsernameForDN(userDN)
   if not result['OK']:
     return result
-  result = gConfig.getSections("%s/Users/%s/DNProperties" % (gBaseRegistrySection, result['Value']))
+  pathDNProperties = "%s/Users/%s/DNProperties" % (gBaseRegistrySection, result['Value'])
+  result = gConfig.getSections(pathDNProperties)
   if not result['OK']:
     return result
-  for section in "%s/Users/%s/DNProperties/%s" % (gBaseRegistrySection, user, result['Value']):
-    if userDN == gConfig.getValue("%s/DN" % section):
-      return S_OK(gConfig.getValue("%s/%s" % (section, value)))
+  for section in result['Value']:
+    if userDN == gConfig.getValue("%s/%s/DN" % (pathDNProperties, section):
+      return S_OK(gConfig.getValue("%s/%s/%s" % (pathDNProperties, section, value)))
 
   return S_ERROR('No properties found for %s' % userDN)
 

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Registry/Users/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Registry/Users/index.rst
@@ -1,3 +1,5 @@
+.. _registryUsers:
+
 Registry / Users - Subsections
 ==============================
 
@@ -10,12 +12,24 @@ be included are mandatory and others are considered as helpers:
 | *<DIRAC_USER_NAME>/DN*     | Distinguish name obtained from user certificate | DN = /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev |
 |                            | (Mandatory)                                     |                                                              |
 +----------------------------+-------------------------------------------------+--------------------------------------------------------------+
-| *<DIRAC_USER_NAME>/CN*     | Canonical name of certification authority who   | CN = /C=FR/O=CNRS/CN=GRID2-FR                                |
-|                            | sign the certificate.                           |                                                              |
-+----------------------------+-------------------------------------------------+--------------------------------------------------------------+
 | *<DIRAC_USER_NAME>/Email*  | User e-mail  (Mandatory)                        | Email = atsareg@in2p3.fr                                     |
 +----------------------------+-------------------------------------------------+--------------------------------------------------------------+
 | *<DIRAC_USER_NAME>/mobile* | Cellular phone number                           | mobile = +030621555555                                       |
 +----------------------------+-------------------------------------------------+--------------------------------------------------------------+
 | *<DIRAC_USER_NAME>/Quota*  | Quota assigned to the user. Expressed in MBs.   | Quota = 300                                                  |
 +----------------------------+-------------------------------------------------+--------------------------------------------------------------+
+
+DNProperties - subsection
+-------------------------
+
+In `Registry / Users / <DIRAC_USER_NAME> / DNProperties` subsection describes the properties associated with each DN. It contains a sections with any name, that contains the DN name attribute and properties associated with that DN.
+
++-----------------------------------+-------------------------------------------------+--------------------------------------------------------------+
+| **Name**                          | **Description**                                 | **Example**                                                  |
++-----------------------------------+-------------------------------------------------+--------------------------------------------------------------+
+| *<DN_SUBSECTION>/DN*              | Distinguish name obtained from user certificate | DN = /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev |
+|                                   | (Mandatory)                                     |                                                              |
++-----------------------------------+-------------------------------------------------+--------------------------------------------------------------+
+| *<DN_SUBSECTION>/ProxyProviders*  | Proxy provider that can genarate the proxy      | ProxyProviders = MY_DIRACCA                                  |
+|                                   | certificate with DN in DN attribute.            |                                                              |
++-----------------------------------+-------------------------------------------------+--------------------------------------------------------------+

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Registry/Users/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Registry/Users/index.rst
@@ -30,6 +30,6 @@ In `Registry / Users / <DIRAC_USER_NAME> / DNProperties` subsection describes th
 | *<DN_SUBSECTION>/DN*              | Distinguish name obtained from user certificate | DN = /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Andrei Tsaregorodtsev |
 |                                   | (Mandatory)                                     |                                                              |
 +-----------------------------------+-------------------------------------------------+--------------------------------------------------------------+
-| *<DN_SUBSECTION>/ProxyProviders*  | Proxy provider that can genarate the proxy      | ProxyProviders = MY_DIRACCA                                  |
+| *<DN_SUBSECTION>/ProxyProviders*  | Proxy provider that can generate the proxy      | ProxyProviders = MY_DIRACCA                                  |
 |                                   | certificate with DN in DN attribute.            |                                                              |
 +-----------------------------------+-------------------------------------------------+--------------------------------------------------------------+

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Registry/Users/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Registry/Users/index.rst
@@ -22,7 +22,7 @@ be included are mandatory and others are considered as helpers:
 DNProperties - subsection
 -------------------------
 
-In `Registry / Users / <DIRAC_USER_NAME> / DNProperties` subsection describes the properties associated with each DN. It contains a sections with any name, that contains the DN name attribute and properties associated with that DN.
+The `Registry/Users/<DIRAC_USER_NAME>/DNProperties` subsection describes the properties associated with each DN attribute.
 
 +-----------------------------------+-------------------------------------------------+--------------------------------------------------------------+
 | **Name**                          | **Description**                                 | **Example**                                                  |

--- a/tests/Integration/Framework/Test_ProxyDB.py
+++ b/tests/Integration/Framework/Test_ProxyDB.py
@@ -58,8 +58,9 @@ Registry
       DN = /C=DN/O=DIRACCA/OU=None/CN=user_ca/emailAddress=user_ca@diracgrid.org
       DNProperties
       {
-        -C_DN-O_DIRACCA-OU_None-CN_user_ca-emailAddress_user_ca@diracgrid.org
+        DN.1
         {
+          DN = /C=DN/O=DIRACCA/OU=None/CN=user_ca/emailAddress=user_ca@diracgrid.org
           ProxyProviders = DIRAC_CA
           Groups = dirac_user
         }
@@ -70,8 +71,9 @@ Registry
       DN = /C=CC/O=DN/O=DIRAC/CN=user
       DNProperties
       {
-        -C_CC-O_DN-O_DIRAC-CN_user
+        DN.1
         {
+          DN = /C=CC/O=DN/O=DIRAC/CN=user
           ProxyProviders =
           Groups = dirac_user
         }
@@ -82,8 +84,9 @@ Registry
       DN = /C=CC/O=DN/O=DIRAC/CN=user_1
       DNProperties
       {
-        -C_CC-O_DN-O_DIRAC-CN_user_1
+        DN.1
         {
+          DN = /C=CC/O=DN/O=DIRAC/CN=user_1
           ProxyProviders =
           Groups = dirac_user
         }
@@ -92,12 +95,6 @@ Registry
     user_2
     {
       DN = /C=CC/O=DN/O=DIRAC/CN=user_2
-      DNProperties
-      {
-        -C_CC-O_DN-O_DIRAC-CN_user_2
-        {
-        }
-      }
     }
     user_3
     {


### PR DESCRIPTION
This PR provides a description of the DN properties that can be set in the `Registry/Users` subsection. A `DN` attribute has also been added for greater readability.

BEGINRELEASENOTES

*Configuration
CHANGE: change search DN properties logic

*docs
NEW: add DNProperties description to Registry/Users subsection

*tests
FIX: align ProxyDB test to current changes

ENDRELEASENOTES
