### PR TITLE
Add killed and deleted jobs to lists of job states and final states

### DIFF
--- a/WorkloadManagementSystem/Client/JobStatus.py
+++ b/WorkloadManagementSystem/Client/JobStatus.py
@@ -33,7 +33,12 @@ JOB_STATES = [SUBMITTING,
               COMPLETING,
               DONE,
               COMPLETED,
-              FAILED]
+              FAILED,
+              DELETED,
+              KILLED]
+
 JOB_FINAL_STATES = [DONE,
                     COMPLETED,
-                    FAILED]
+                    FAILED,
+                    DELETED,
+                    KILLED]

--- a/WorkloadManagementSystem/Client/JobStatus.py
+++ b/WorkloadManagementSystem/Client/JobStatus.py
@@ -39,6 +39,4 @@ JOB_STATES = [SUBMITTING,
 
 JOB_FINAL_STATES = [DONE,
                     COMPLETED,
-                    FAILED,
-                    DELETED,
-                    KILLED]
+                    FAILED]


### PR DESCRIPTION
Dear Dirac Developers,

For some reason, the job states `DELETED` and `KILLED` are defined in the `JobStatus.py`, but they are not included into the lists `JOB_STATES` and `FINAL_JOB_STATES`. I don't know why that is, in this PR I added them, view this as a suggestion.

I am just a Dirac user at Belle II and wanted to find out possible job states for script that I am writing and so I checked the Dirac code, where I found this file. These lists are used in `JobDB.py` and `JobStateUpdateHandler.py`, If for some reason the `DELETED` and `KILLED` jobs are to be ignored in those files, I would still keep a list of all possible job states and just make sure at the place where they are used that deleted and killed jobs are ignored. Or maybe make another subset and use that. As a user, I would like to be able to import JobStatus and use the list of all possible job statuses, so I think it is important to keep a list with all known job statuses, instead of having them just as global variables.

I am not sure if this PR is to the correct branch, since the `JobStatus.py` also exists e.g. v7r1, I just used the default branch. Maybe I should have made a github issue or write and email, but I thought it might be easier to just do a PR if I have a code change idea.

By the way, I also think one could use a python set for the job statuses (`{...}` instead of `[...]`), to avoid accidental duplicates and make it easy to to unions and differences of different job state sets. Or maybe the most elegent is an enum type, which I have seen in other code bases used for job states. But Ithose ideas are irrelevant to this PR.

Best regards,
Michael Eliachevitch ([meliache@uni-bonn.de](mailto:meliache@uni-bonn.de))