### PR TITLE
[v7r1] JobStates and docs

### DIFF
--- a/WorkloadManagementSystem/Client/JobStatus.py
+++ b/WorkloadManagementSystem/Client/JobStatus.py
@@ -50,7 +50,9 @@ JOB_STATES = [SUBMITTING,
               COMPLETING,
               DONE,
               COMPLETED,
-              FAILED]
+              FAILED,
+              DELETED,
+              KILLED]
 
 #: Job States when the payload work has finished
 JOB_FINAL_STATES = [DONE,

--- a/WorkloadManagementSystem/Client/JobStatus.py
+++ b/WorkloadManagementSystem/Client/JobStatus.py
@@ -1,25 +1,42 @@
 """
-Define job statuses with global variables at a single place
+This module contains constants and lists for the the possible job states.
 """
 __RCSID__ = "$Id$"
 
+#:
 SUBMITTING = 'Submitting'
+#:
 SUBMITTED = 'Submitted'
+#:
 RECEIVED = 'Received'
+#:
 CHECKING = 'Checking'
+#:
 STAGING = 'Staging'
+#:
 WAITING = 'Waiting'
+#:
 MATCHED = 'Matched'
+#:
 RESCHEDULED = 'Rescheduled'
+#:
 RUNNING = 'Running'
+#:
 STALLED = 'Stalled'
+#:
 COMPLETING = 'Completing'
+#:
 DONE = 'Done'
+#:
 COMPLETED = 'Completed'
+#:
 FAILED = 'Failed'
+#:
 DELETED = 'Deleted'
+#:
 KILLED = 'Killed'
 
+#: Possible job states
 JOB_STATES = [SUBMITTING,
               SUBMITTED,
               RECEIVED,
@@ -34,6 +51,8 @@ JOB_STATES = [SUBMITTING,
               DONE,
               COMPLETED,
               FAILED]
+
+#: Job States when the payload work has finished
 JOB_FINAL_STATES = [DONE,
                     COMPLETED,
                     FAILED]


### PR DESCRIPTION
I cherry-picked the commit from #4552 and added comments for the constants so they show up in the sphinx documentation, this page is pretty empty at the moment
https://dirac.readthedocs.io/en/rel-v7r1/CodeDocumentation/WorkloadManagementSystem/Client/JobStatus.html

BEGINRELEASENOTES

*WMS
CHANGE: Add Deleted and Killed to JOB_STATES list

ENDRELEASENOTES
