### PR TITLE
[v7r2] Extensive py3 check for selected directories

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -24,6 +24,7 @@ jobs:
           #     SC1091: Not following sourced file
           - find tests/CI -name '*.sh' -print0 | xargs -0 -n1 shellcheck --exclude=SC1090,SC1091 --external-source
           - tests/runPylint.sh
+          - tests/py3Check.sh
           - CHECK=pylintPY3K tests/runPylint.sh
           - |
             if [[ "${REFERENCE_BRANCH}" != "" ]]; then

--- a/tests/.pylintrc3k
+++ b/tests/.pylintrc3k
@@ -1,3 +1,4 @@
 [MASTER]
 load-plugins=caniusepython3.pylint_checker
-
+[MESSAGES CONTROL]
+disable=native-string

--- a/tests/py3Check.sh
+++ b/tests/py3Check.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+file="tests/py3CheckDirs.txt"
+exitCode=0
+while IFS= read -r directory
+do
+    find ${directory} -name "*.py" -and -not -name 'pep8_*' -and -not -path "./WorkloadManagementSystem/PilotAgent/*" -exec pylint --rcfile=tests/.pylintrc3k --py3k --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" --extension-pkg-whitelist=GSI,numpy {} +
+    exitCode=$(($?+exitCode))
+done <"$file"
+
+exit $exitCode


### PR DESCRIPTION
BEGINRELEASENOTES
*tests
NEW: Add full pylint py3k test for selected directories

ENDRELEASENOTES

If you want a folder to be checked for all possible python3 compatibility warnings please add it to `tests/py3CheckDirs.txt`(currently none set ) and execute `tests/py3Check.sh`. Unicode warnings are disabled as it is a separate topic. 