### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -58,5 +58,7 @@ jobs:
       run: ./run_in_container bash -c 'source DIRAC/tests/CI/run_docker_setup.sh && testServer'
     - name: Client tests
       run: ./run_in_container bash -c 'source DIRAC/tests/CI/run_docker_setup.sh && testClient'
+    - name: Elasticsearch logs
+      run: ./run_in_container bash -c 'source DIRAC/tests/CI/run_docker_setup.sh && docker logs elasticsearch'
     - name: Check test status
       run: ./run_in_container bash -c 'source DIRAC/tests/CI/run_docker_setup.sh && checkErrors'

--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -21,6 +21,10 @@ services:
       - 9200:9200
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=true
+      - cluster.routing.allocation.disk.watermark.flood_stage=200mb
+      - cluster.routing.allocation.disk.watermark.low=500mb
+      - cluster.routing.allocation.disk.watermark.high=300mb
       # Elasticsearch allocates 1GB of memory by default. As resources are limited
       # and elasticsearch performance isn't critical in CI, limit this to 256MB
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"


### PR DESCRIPTION
The CI started failing as elastic search stops accepting more data once disk usage is at 95%. For some reason the amount of available disk space has been decreasing recently causing this to now happen (https://github.com/actions/virtual-environments/issues/709).

I've also added a stage for showing the logs from elasticsearch to make problems easier to debug in future.