### PR TITLE
[v6r22] Accept single LFN in getTransformationFiles()

### DIFF
--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -172,7 +172,7 @@ class TransformationClient(Client):
         if not log("For conditions %s: result for limit %d, offset %d: %d files" %
                    (condDictStr, limit, offsetToApply, len(res['Value']))):
           gLogger.verbose("For condition keys %s (trans %s): result for limit %d, offset %d: %d files" %
-                          (str(condDict.keys()), condDict.get('TransformationID', 'None'),
+                          (str(sorted(condDict)), condDict.get('TransformationID', 'None'),
                            limit, offsetToApply, len(res['Value'])))
         if res['Value']:
           transformationFiles += res['Value']
@@ -355,7 +355,7 @@ class TransformationClient(Client):
 
     rpcClient = self._getRPC()
     # gets current status, errorCount and fileID
-    tsFiles = self.getTransformationFiles({'TransformationID': transName, 'LFN': newLFNsStatus.keys()})
+    tsFiles = self.getTransformationFiles({'TransformationID': transName, 'LFN': list(newLFNsStatus)})
     if not tsFiles['OK']:
       return tsFiles
     tsFiles = tsFiles['Value']

--- a/TransformationSystem/Client/TransformationClient.py
+++ b/TransformationSystem/Client/TransformationClient.py
@@ -134,8 +134,11 @@ class TransformationClient(Client):
       timeStamp = 'LastUpdate'
     # getting transformationFiles - incrementally
     if 'LFN' in condDict:
+      if isinstance(condDict['LFN'], basestring):
+        lfnList = [condDict['LFN']]
+      else:
+        lfnList = sorted(condDict['LFN'])
       # If a list of LFNs is given, use chunks of 1000 only
-      lfnList = sorted(condDict['LFN'])
       limit = limit if limit else 1000
     else:
       # By default get by chunks of 10000 files


### PR DESCRIPTION
BEGINRELEASENOTES
*TS
FIX:  as the service was accepting the conditions `'LFN'`as a string, allow this on the client side... It was working before but after the recent fix it was no longer working (due to the `sorted()`)... This doesn't seem to pose any problem with the LHCb system as all calls apparently use a list, but this is an additional safety in case other VOs don't...
ENDRELEASENOTES
