### PR TITLE
[v7r0] Framework/Monitoring: print error only when there really is one

### DIFF
--- a/FrameworkSystem/private/monitoring/MonitoringCatalog.py
+++ b/FrameworkSystem/private/monitoring/MonitoringCatalog.py
@@ -50,7 +50,8 @@ class MonitoringCatalog(object):
       except Exception as e:
         self.log.exception("Exception executing statement", "query: %s, values: %s" % (query, values))
         time.sleep(0.01)
-    self.log.error("Could not execute query, big mess ahead", "query: %s, values: %s" % (query, values))
+    if not executed:
+      self.log.error("Could not execute query, big mess ahead", "query: %s, values: %s" % (query, values))
     return cursor
 
   def __createTables(self):

--- a/Resources/Storage/OccupancyPlugins/WLCGAccountingHTTPJson.py
+++ b/Resources/Storage/OccupancyPlugins/WLCGAccountingHTTPJson.py
@@ -43,6 +43,6 @@ class WLCGAccountingHTTPJson(WLCGAccountingJson):
       with open(filePath, 'wt') as fd:
         res = requests.get(occupancyLFN)
         res.raise_for_status()
-        fd.write(res.content())
+        fd.write(res.content)
     except Exception as e:
       self.log.debug("Exception while copying", repr(e))


### PR DESCRIPTION
BEGINRELEASENOTES
*Framework
FIX: MonitoringCatalog only prints an error when there is really one

ENDRELEASENOTES
