### PR TITLE
[v7r0] make diracdoctools python3 compatible

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/source directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: false
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: []
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,16 +8,16 @@ version: 2
 # Build documentation in the docs/source directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
-  fail_on_warning: false
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 2.7
   install:
-    - requirements: docs/requirements_py3.txt
+    - requirements: docs/requirements.txt
     - method: pip
       path: docs/
       extra_requirements:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,3 +18,7 @@ python:
   version: 3.7
   install:
     - requirements: docs/requirements_py3.txt
+    - method: pip
+      path: docs/
+      extra_requirements:
+        - diracdoctools

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,4 +17,4 @@ formats: []
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
+    - requirements: docs/requirements_py3.txt

--- a/AccountingSystem/Service/DataStoreHandler.py
+++ b/AccountingSystem/Service/DataStoreHandler.py
@@ -1,7 +1,7 @@
 """ DataStore is the service for inserting accounting reports (rows) in the Accounting DB
 
     This service CAN be duplicated iff the first is a "master" and all the others are slaves.
-    See the information about :ref`datastorehelpers`.
+    See the information about :ref:`datastorehelpers`.
 
 .. literalinclude:: ../ConfigTemplate.cfg
   :start-after: ##BEGIN DataStore

--- a/docs/diracdoctools/Config.py
+++ b/docs/diracdoctools/Config.py
@@ -1,5 +1,7 @@
 """Configuration for the documentation scripts."""
 
+from __future__ import absolute_import
+
 import argparse
 import logging
 import os

--- a/docs/diracdoctools/CustomizedDocs/CustomTransformation.py
+++ b/docs/diracdoctools/CustomizedDocs/CustomTransformation.py
@@ -1,4 +1,4 @@
-"""Additional docstring for the DErrno module."""
+"""Additional docstring for the Transformation module."""
 
 import textwrap
 

--- a/docs/diracdoctools/Utilities.py
+++ b/docs/diracdoctools/Utilities.py
@@ -1,5 +1,9 @@
 """Utilities used by the documentation scripts."""
 
+from __future__ import absolute_import
+
+from builtins import open
+
 import logging
 import os
 import sys

--- a/docs/diracdoctools/Utilities.py
+++ b/docs/diracdoctools/Utilities.py
@@ -53,6 +53,14 @@ def writeLinesToFile(filename, lines):
   if oldContent is None or oldContent != newContent:
     with open(filename, 'w') as rst:
       LOG.info('Writing new content for %s', os.path.join(os.getcwd(), filename))
+      try:  # decode only needed/possible in python2
+        newContent = newContent.decode('utf-8')
+      except AttributeError:
+        # ignore decode if newContent is python3 str
+        pass
+      except (UnicodeDecodeError) as e:
+        LOG.error('Failed to decode newContent with "utf-8": %r', e)
+        raise
       rst.write(newContent)
   else:
     LOG.debug('Not updating file content for %s', os.path.join(os.getcwd(), filename))

--- a/docs/diracdoctools/cmd/concatcfg.py
+++ b/docs/diracdoctools/cmd/concatcfg.py
@@ -11,8 +11,13 @@ import sys
 from diracdoctools.Config import Configuration
 from diracdoctools.Utilities import makeLogger
 
-from DIRAC.Core.Utilities.CFG import CFG
-from DIRAC import S_OK, S_ERROR
+# Try/except for python3 compatibility to ignore errors in ``import DIRAC`` while they last
+# ultimate protection against not having the symbols imported is also done in the ``run`` function
+try:
+  from DIRAC.Core.Utilities.CFG import CFG
+  from DIRAC import S_OK, S_ERROR
+except ImportError:
+  pass
 
 
 LOG = makeLogger('ConcatCFG')
@@ -121,10 +126,12 @@ def run(configFile='docs.conf', logLevel=logging.INFO, debug=False):
   :param bool debug: unused
   :returns: return value 1 or 0
   """
-  logging.getLogger().setLevel(logLevel)
-  concat = ConcatCFG(configFile=configFile)
-  return concat.updateCompleteDiracCFG()
-
+  try:
+    logging.getLogger().setLevel(logLevel)
+    concat = ConcatCFG(configFile=configFile)
+    return concat.updateCompleteDiracCFG()
+  except (ImportError, NameError):
+    return 1
 
 if __name__ == '__main__':
   sys.exit(run())

--- a/docs/diracdoctools/environmentSetup.py
+++ b/docs/diracdoctools/environmentSetup.py
@@ -3,6 +3,7 @@
 Sets environment variables.
 """
 
+from __future__ import absolute_import
 
 import os
 

--- a/docs/diracdoctools/fakeEnvironment.py
+++ b/docs/diracdoctools/fakeEnvironment.py
@@ -6,6 +6,7 @@
    GSI
 
 '''
+from __future__ import absolute_import
 
 import sys
 import mock

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # cannot use DIRAC requirements because of inability to install pycurl (from FTS dependency) on RTD
 #-r https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/requirements.txt
--e git+https://github.com/DIRACGrid/DIRAC/@integration#egg=diracdoctools&subdirectory=docs
+#-e git+https://github.com/DIRACGrid/DIRAC/@integration#egg=diracdoctools&subdirectory=docs
 M2Crypto==0.32
 Sphinx>=1.8.0
 elasticsearch_dsl

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@
 #-e git+https://github.com/DIRACGrid/DIRAC/@integration#egg=diracdoctools&subdirectory=docs
 M2Crypto==0.32
 Sphinx>=1.8.0
+boto3
 elasticsearch_dsl
 future
 futures

--- a/docs/requirements_py3.txt
+++ b/docs/requirements_py3.txt
@@ -1,6 +1,6 @@
 # cannot use DIRAC requirements because of inability to install pycurl (from FTS dependency) on RTD
 #-r https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/requirements.txt
--e git+https://github.com/DIRACGrid/DIRAC/@integration#egg=diracdoctools&subdirectory=docs
+#-e git+https://github.com/DIRACGrid/DIRAC/@integration#egg=diracdoctools&subdirectory=docs
 M2Crypto==0.32
 Sphinx>=1.8.0
 elasticsearch_dsl

--- a/docs/requirements_py3.txt
+++ b/docs/requirements_py3.txt
@@ -3,6 +3,7 @@
 #-e git+https://github.com/DIRACGrid/DIRAC/@integration#egg=diracdoctools&subdirectory=docs
 M2Crypto==0.32
 Sphinx>=1.8.0
+boto3
 elasticsearch_dsl
 future
 futures

--- a/docs/requirements_py3.txt
+++ b/docs/requirements_py3.txt
@@ -1,0 +1,20 @@
+# cannot use DIRAC requirements because of inability to install pycurl (from FTS dependency) on RTD
+#-r https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/requirements.txt
+-e git+https://github.com/DIRACGrid/DIRAC/@integration#egg=diracdoctools&subdirectory=docs
+M2Crypto==0.32
+Sphinx>=1.8.0
+elasticsearch_dsl
+future
+futures
+matplotlib
+mock
+mysqlclient  # replacing mysql-python
+psutil
+pyasn1>0.4.1
+pyasn1_modules
+pyparsing
+pytz
+recommonmark
+sqlalchemy
+subprocess32
+suds-community  # replacing suds-jurko


### PR DESCRIPTION
I ran pylint3k, and then with python3 on readthedocs to see if it works.
After a bit more tweaking:
With these changes one could use either python3 and python2 to build the dirac documentation.
Of course for python3, code documentation and command reference are severely limited because `import DIRAC` is not possible at the moment.
And since `import DIRAC` actually calls `sys.exit`, without commenting that line one cannot even get any documentation build. Temporarily removed the line and added the necessary try/except blocks.


BEGINRELEASENOTES

*Docs:
NEW: the DiracDocTools are now also compatible with python3
NEW: added ".readthedocs.yml" config

ENDRELEASENOTES
