### PR TITLE
[v7r0] WMS: PilotCStoJSONSynchronizer uses a workDirectory

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -364,9 +364,9 @@ class PilotCStoJSONSynchronizer(object):
 
     else:
       if pilotDict:  # this is for the pilot.json file
-        filename = self.jsonFile
+        filename = os.path.join(self.workDir, self.jsonFile)
         script = json.dumps(pilotDict)
-        with open(os.path.join(self.workDir, filename), 'w') as jf:
+        with open(filename, 'w') as jf:
           jf.write(script)
 
       else:  # we assume the method is asked to upload the pilots scripts

--- a/dirac.cfg
+++ b/dirac.cfg
@@ -378,6 +378,18 @@ Operations
         }
       }
     }
+    # Options for the pilot3 
+    # See https://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.html
+    Pilot
+    {
+      pilotRepo = https://github.com/DIRACGrid/Pilot.git   # git repository of the pilot
+      pilotScriptsPath = Pilot # Path to the code, inside the Git repository                                               |
+      pilotRepoBranch = master # Branch to use
+      pilotVORepo = https://github.com/MyDIRAC/VOPilot.git # git repository of the pilot extension
+      pilotVOScriptsPath = VOPilot # Path to the code, inside the Git repository
+      pilotVORepoBranch = master # Branch to use
+      workDir = /tmp/pilot3Files # Local work directory on the masterCS for synchronisation
+    }
     Services
     {
       #See http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Catalog/index.html

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -62,7 +62,9 @@ Other options that can be set also in the Operations part of the CS include:
 | *pilotVORepoBranch*                | Branch to use, inside the Git repository,  | pilotVORepoBranch = master                                              |
 |                                    | of the pilot code extension to be used     | The value above is the default                                          |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
-
+| *workDir*                          | Local directory of the master CS where the | workDir = /tmp/pilotSyncDir                                             |
+|                                    | files will be downloaded before the upload | There is no default (so /opt/dirac/runit/Configuration/Server)          |
++------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 
 Starting the old Pilot 2 via SiteDirectors
 ==========================================


### PR DESCRIPTION
Currently, the pilot3 files are downloaded wherever the `cwd` of the ConfigurationServer is. This allows to specify `workDir` in the configuration. Default behaviour remains the same
@fstagni I've added some of the options in the `dirac.cfg`, but it's probably far from complete. Can you please check ? 

This was tested on the LHCb certification instance

BEGINRELEASENOTES

*WMS
NEW: add a workDir to PilotCStoJSONSynchronizer

ENDRELEASENOTES
