### PR TITLE
[v7r2] use concurrent futures by default

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
           # IMPLICIT: - HOST_OS: cc7
           ###### Thread pool
           # IMPLICIT: - USE_NEWTHREADPOOL: default
-          - USE_NEWTHREADPOOL: yes
+          - USE_NEWTHREADPOOL: No
           ###### M2Crypto
           # IMPLICIT: - SERVER_USE_M2CRYPTO: Yes
           #             CLIENT_USE_M2CRYPTO: Yes

--- a/Core/DISET/private/GatewayService.py
+++ b/Core/DISET/private/GatewayService.py
@@ -22,7 +22,7 @@ import os
 
 # TODO: Remove ThreadPool later
 useThreadPoolExecutor = False
-if os.getenv('DIRAC_USE_NEWTHREADPOOL', 'NO').lower() in ('yes', 'true'):
+if os.getenv('DIRAC_USE_NEWTHREADPOOL', 'YES').lower() in ('yes', 'true'):
   from concurrent.futures import ThreadPoolExecutor
   useThreadPoolExecutor = True
 else:

--- a/Core/DISET/private/MessageBroker.py
+++ b/Core/DISET/private/MessageBroker.py
@@ -11,7 +11,7 @@ import os
 
 # TODO: Remove ThreadPool later
 useThreadPoolExecutor = False
-if os.getenv('DIRAC_USE_NEWTHREADPOOL', 'NO').lower() in ('yes', 'true'):
+if os.getenv('DIRAC_USE_NEWTHREADPOOL', 'YES').lower() in ('yes', 'true'):
   from concurrent.futures import ThreadPoolExecutor
   useThreadPoolExecutor = True
 else:

--- a/Core/DISET/private/Service.py
+++ b/Core/DISET/private/Service.py
@@ -14,7 +14,7 @@ import threading
 
 # TODO: Remove ThreadPool later
 useThreadPoolExecutor = False
-if os.getenv('DIRAC_USE_NEWTHREADPOOL', 'NO').lower() in ('yes', 'true'):
+if os.getenv('DIRAC_USE_NEWTHREADPOOL', 'YES').lower() in ('yes', 'true'):
   from concurrent.futures import ThreadPoolExecutor
   useThreadPoolExecutor = True
 else:


### PR DESCRIPTION

BEGINRELEASENOTES

Please follow the template:
*Core
CHANGE: Use concurrent.future.ThreadPoolEcecutor by default.

ENDRELEASENOTES
