### PR TITLE
[v7r0] M2Crypto various fixes

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         command:
           - pytest
-          - DIRAC_USE_M2CRYPTO=Yes pytest
+          - DIRAC_USE_M2CRYPTO=Yes DIRAC_M2CRYPTO_SPLIT_HANDSHAKE=Yes pytest
           - pytest Core/Security/test
-          - DIRAC_USE_M2CRYPTO=Yes pytest Core/Security/test
+          - DIRAC_USE_M2CRYPTO=Yes DIRAC_M2CRYPTO_SPLIT_HANDSHAKE=Yes pytest Core/Security/test
           - tests/checkDocs.sh
           # TODO This should cover more than just tests/CI
           # Excluded codes related to sourcing files

--- a/Core/DISET/private/Transports/SSL/M2Utils.py
+++ b/Core/DISET/private/Transports/SSL/M2Utils.py
@@ -136,7 +136,7 @@ def getM2SSLContext(ctx=None, **kwargs):
 def getM2PeerInfo(conn):
   """ Gets the details of the current peer as a standard dict. The peer
       details are obtained from the supplied M2 SSL Connection obj "conn".
-      The details returned are those from ~X509Chain.getCredentials:
+      The details returned are those from ~X509Chain.getCredentials, without Registry info:
 
          DN - Full peer DN as string
          x509Chain - Full chain of peer
@@ -147,7 +147,7 @@ def getM2PeerInfo(conn):
       Returns a dict of details.
   """
   chain = X509Chain.generateX509ChainFromSSLConnection(conn)
-  creds = chain.getCredentials()
+  creds = chain.getCredentials(withRegistryInfo=False)
   if not creds['OK']:
     raise RuntimeError("Failed to get SSL peer info (%s)." % creds['Message'])
   peer = creds['Value']

--- a/Core/Security/m2crypto/X509Chain.py
+++ b/Core/Security/m2crypto/X509Chain.py
@@ -941,10 +941,13 @@ class X509Chain(object):
     return S_OK(False)
 
   @needCertList
-  def getCredentials(self, ignoreDefault=False):
+  def getCredentials(self, ignoreDefault=False, withRegistryInfo=True):
     """ Returns a summary of the credentials contained in the current chain
 
         :params ignoreDefault: (default False) If True and if no DIRAC group is found in the proxy, lookup the CS
+        :params withRegistryInfo: (default True) if set to True, will enhance the returned dict with info
+                                  from the registry
+
 
         :returns: S_OK with the credential dict. Some parameters of the dict are always there, other depends
                 on the nature of the Chain
@@ -962,13 +965,13 @@ class X509Chain(object):
                 Only for proxy:
                   * identity: If it is a normal proxy, it is the DN of the certificate.
                               If it is a PUSP, it contains the identity as in :py:meth:`.isPUSP`
-                  * username: DIRAC username associated to the DN
+                  * username: DIRAC username associated to the DN (needs withRegistryInfo)
                               (see :py:func:`DIRAC.ConfigurationSystem.Client.Helpers.Registry.getUsernameForDN`)
                   * group: DIRAC group, depending on ignoreDefault param(see :py:meth:`.getDIRACGroup`)
                   * validGroup: True if the group found is in the list of groups the user belongs to
                   * groupProperty: (only if validGroup) get the properties of the group
 
-                For Host certificate:
+                For Host certificate (needs withRegistryInfo):
                   * group: always `hosts`
                   * hostname: name of the host as registered in the CS
                              (see :py:func:`DIRAC.ConfigurationSystem.Client.Helpers.Registry.getHostnameForDN`)
@@ -976,7 +979,7 @@ class X509Chain(object):
                   * groupProperties: host options
                                     (see :py:func:`DIRAC.ConfigurationSystem.Client.Helpers.Registry.getHostOption`)
 
-                If it is a user certificate:
+                If it is a user certificate (needs withRegistryInfo):
                   * username: like for proxy
                   * validDN: like proxy
     """
@@ -996,20 +999,22 @@ class X509Chain(object):
         credDict['identity'] = result['Identity']
         credDict['subproxyUser'] = result['SubproxyUser']
 
-      retVal = Registry.getUsernameForDN(credDict['identity'])
-      if not retVal['OK']:
-        return S_OK(credDict)
-      credDict['username'] = retVal['Value']
-      credDict['validDN'] = True
+      if withRegistryInfo:
+        retVal = Registry.getUsernameForDN(credDict['identity'])
+        if not retVal['OK']:
+          return S_OK(credDict)
+        credDict['username'] = retVal['Value']
+        credDict['validDN'] = True
       retVal = self.getDIRACGroup(ignoreDefault=ignoreDefault)
       if retVal['OK']:
         diracGroup = retVal['Value']
         credDict['group'] = diracGroup
-        retVal = Registry.getGroupsForUser(credDict['username'])
-        if retVal['OK'] and diracGroup in retVal['Value']:
-          credDict['validGroup'] = True
-          credDict['groupProperties'] = Registry.getPropertiesForGroup(diracGroup)
-    else:
+        if withRegistryInfo:
+          retVal = Registry.getGroupsForUser(credDict['username'])
+          if retVal['OK'] and diracGroup in retVal['Value']:
+            credDict['validGroup'] = True
+            credDict['groupProperties'] = Registry.getPropertiesForGroup(diracGroup)
+    elif withRegistryInfo:
       retVal = Registry.getHostnameForDN(credDict['subject'])
       if retVal['OK']:
         credDict['group'] = 'hosts'

--- a/docs/source/AdministratorGuide/ServerInstallations/InstallingDiracServer.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/InstallingDiracServer.rst
@@ -189,19 +189,8 @@ Reload the configuration and restart::
 Server Certificates
 -------------------
 
-Server certificates are used for validating the identity of the host a given client is connecting to. By default
-grid host certificate include host/ in the CN (common name) field. This is not a problem for DIRAC components
-since DISET only keeps the host name after the **/** if present.
-
-However if the certificate is used for the Web Portal, the client validating the certificate is your browser. All browsers
-will rise a security alarm if the host name in the url does not match the CN field in the certificate presented by the server.
-In particular this means that *host/*, or other similar parts should nto be present, and that it is preferable to use
-DNS aliases and request a certificate under this alias in order to be able to migrate the server to a new host without
-having to change your URLs. DIRAC will accept both real host names and any valid aliases without complains.
-
-Finally, you will have to instruct you users on the procedure to upload the public key of the CA signing the certificate
-of the host where the Web Portal is running. This depends from CA to CA, but typically only means clicking on a certain
-link on the web portal of the CA.
+Server certificates are used for validating the identity of the host a given client is connecting to. We follow the RFC 6125.
+Basically, that means that the DNS name used to contact the host must be present in the ``SubjectAlternativeName``. 
 
 -----------------
 Using your own CA

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -25,5 +25,8 @@ DIRAC_GFAL_GRIDFTP_SESSION_REUSE
 DIRAC_USE_M2CRYPTO
   If ``true`` or ``yes`` DIRAC uses m2crypto instead of pyGSI for handling certificates, proxies, etc.
 
+DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
+  If ``true`` or ``yes`` the SSL handshake is done in a new thread (default No)
+
 DIRAC_VOMSES
   Can be set to point to a folder containing VOMSES information. See :ref:`multi_vo_dirac`

--- a/docs/source/AdministratorGuide/technologyPreviews.rst
+++ b/docs/source/AdministratorGuide/technologyPreviews.rst
@@ -12,7 +12,8 @@ M2Crypto
 ========
 
 We aim at replacing the home made wrapper of openssl pyGSI with the standard M2Crypto library. It is by default disabled.
-You can enable it by setting the environment variable `DIRAC_USE_M2CRYPTO` to `Yes`.
+You can enable it by setting the environment variable ``DIRAC_USE_M2CRYPTO`` to ``Yes``.
+There is also a change of behavior in the way sockets connections are handled server side. The current (new) behavior is to perform the SSL handshake in the main thread and only delegate the execution of the method to another thread. The pyGSI behavior was to delegate the SSL handshake to the new thread, which is probably a better thing to do. You can revert back this behavior by setting `DIRAC_M2CRYPTO_SPLIT_HANDSHAKE` to `Yes`, but this has not been heavily tested yet. 
 
 Possible issues
 ---------------
@@ -20,5 +21,7 @@ Possible issues
 M2Crypto (or any standard tool that respects TLS..) will be stricter than PyGSI. So you may need to adapt your environment a bit. Here are a few hints:
 
 * SAN in your certificates: if you are contacting a machine using its aliases, make sure that all the aliases are in the SubjectAlternativeName (SAN) field of the certificates
-* FQDN in the configuration: SAN normally contains only FQDN, so make sure you use the FQDN in the CS as well (e.g. `mymachine.cern.ch` and not `mymachine`)
+* FQDN in the configuration: SAN normally contains only FQDN, so make sure you use the FQDN in the CS as well (e.g. ``mymachine.cern.ch`` and not ``mymachine``)
 * ComponentInstaller screwed: like any change you do on your hosts, the ComponentInstaller will duplicate the entry. So if you change the CS to put FQDN, the machine will appear twice. 
+
+In case your services are not fast enough, and the socket backlog is full (``ss -pnl``), try setting ``DIRAC_M2CRYPTO_SPLIT_HANDSHAKE`` to ``Yes``.

--- a/tests/CI/run_docker_setup.sh
+++ b/tests/CI/run_docker_setup.sh
@@ -156,10 +156,12 @@ function prepareEnvironment() {
 
   if [ -n "${SERVER_USE_M2CRYPTO+x}" ]; then
     echo "export DIRAC_USE_M2CRYPTO=${SERVER_USE_M2CRYPTO}" >> "${SERVERCONFIG}"
+    echo "export DIRAC_M2CRYPTO_SPLIT_HANDSHAKE=Yes" >> "${SERVERCONFIG}"
   fi
 
   if [ -n "${CLIENT_USE_M2CRYPTO+x}" ]; then
     echo "export DIRAC_USE_M2CRYPTO=${CLIENT_USE_M2CRYPTO}" >> "${CLIENTCONFIG}"
+    echo "export DIRAC_M2CRYPTO_SPLIT_HANDSHAKE=Yes" >> "${CLIENTCONFIG}"
   fi
 
   docker-compose -f ./docker-compose.yml up -d


### PR DESCRIPTION
TLDR;
=====
Based on hotfixes in LHCb. It works.

More details
=========

When enabling M2Crypto in production, some heavily loaded services were basically blocked. I tracked this down to two issues:
* when retrieving the remote credentials, I was doing several `Registry` lookup to have more info about the peer. This is useless, so disabled that in 852d25aa7922485275444d675d7010bd280a1473 and 810971ee6945ef77702ef71597eb8f387c48bd42
* The SSL handshake was done in the `ServiceReactor` thread (the main one) and only the actual work was delegated to a task thread. This lead to the socket backlog being filled rapidly. Funnily enough, on the tests I've done, it turns out to be faster this way, but probably isn't sustainable at big scale. So I've changed that and now do the SSL handshake in the task thread. However, since this was not tested as much as the original implementation, this change is enabled by an environment variable `DIRAC_M2CRYPTO_SPLIT_HANDSHAKE` which defaults to `No`. If it works as expected, I will turn the default in the next patch release, and in the one after, remove the option altogether. I've changed the tests to set it to `Yes`

BEGINRELEASENOTES
*Core
FIX: M2SSLTransport catch exceptions and convert them into S_ERROR
CHANGE: M2SSLTransport: allow to do the SSL handshake in threads
CHANGE: Do not query the Registry when doing the handshake

ENDRELEASENOTES

