### PR TITLE
[v7r0] Fail-fast for pipelines running against outdated commits

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Fail-fast for outdated pipelines
+      run: .github/workflows/fail-fast.sh
     - name: Prepare environment
       run: |
         conda env create --name dirac-testing environment.yml

--- a/.github/workflows/diracinstall.yml
+++ b/.github/workflows/diracinstall.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Fail-fast for outdated pipelines
+      run: .github/workflows/fail-fast.sh
     - name: prepare environment
       run: |
         conda config --set add_pip_as_python_dependency false

--- a/.github/workflows/fail-fast.sh
+++ b/.github/workflows/fail-fast.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+if [[ "$(jq --raw-output '.pull_request' "${GITHUB_EVENT_PATH}")" == "null" ]]; then
+    git fetch "origin" 2>/dev/null >/dev/null
+    LATEST_SHA256=$(git rev-parse "$(jq --raw-output '.ref' "${GITHUB_EVENT_PATH}" | sed 's@^refs/heads/@refs/remotes/origin/@')")
+    CURRENT_SHA256=$(git rev-parse HEAD)
+else
+    git remote add "fail-fast-remote" "$(jq --raw-output '.pull_request.head.repo.clone_url' "${GITHUB_EVENT_PATH}")" 2>/dev/null >/dev/null
+    git fetch "fail-fast-remote" 2>/dev/null >/dev/null
+    LATEST_SHA256=$(git rev-parse "refs/remotes/fail-fast-remote/$(jq --raw-output '.pull_request.head.ref' "${GITHUB_EVENT_PATH}")")
+    CURRENT_SHA256=$(jq --raw-output '.pull_request.head.sha' "${GITHUB_EVENT_PATH}")
+fi
+
+if [[ "${LATEST_SHA256}" != "${CURRENT_SHA256}" ]]; then
+    echo "Latest commit is ${LATEST_SHA256}, exiting to avoid wasting CI resources"
+    exit 1
+fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Fail-fast for outdated pipelines
+      run: .github/workflows/fail-fast.sh
     - name: Clean up GitHub actions environment
       run: |
         # Prepare wrapper script

--- a/.github/workflows/pilotWrapper.yml
+++ b/.github/workflows/pilotWrapper.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Fail-fast for outdated pipelines
+      run: .github/workflows/fail-fast.sh
     - name: prepare environment
       run: |
         conda config --set add_pip_as_python_dependency false


### PR DESCRIPTION
As pull requests tend to be merged in batches it's easy to overload the CI. This PR adds a step to check if the current pipeline is running against an outdated commit. If this is the case, it fails early rather than wasting CI resources.

It might be useful to run this script between each stage of the integration tests but I'll only do that if it continues to be a problem.