### PR TITLE
[v7r0] Fix HTCondor cleanup

### DIFF
--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -488,8 +488,9 @@ Queue %(nJobs)s
     if status:
       self.log.error("Failure during HTCondorCE __cleanup", stdout)
 
-    # remove all out/err/log files older than "DaysToKeepLogs" days
-    findPars = dict(workDir=self.workingDirectory, days=self.daysToKeepLogs)
+    # remove all out/err/log files older than "DaysToKeepLogs" days in the CE part of the working Directory
+    workDir = os.path.join(self.workingDirectory, self.ceName)
+    findPars = dict(workDir=workDir, days=self.daysToKeepLogs)
     # remove all out/err/log files older than "DaysToKeepLogs" days
     status, stdout = commands.getstatusoutput(
         r'find %(workDir)s -mtime +%(days)s -type f \( -name "*.out" -o -name "*.err" -o -name "*.log" \) -delete ' %


### PR DESCRIPTION
Every pilots outputs, errors and logs from HTCondor are stored in a specific directory: `workingDirectory`.

To avoid to get too many files stored in this directory, files are regularly deleted.
The number of days we want to keep these files in configurable in each CE section. 
However in reality, as the `workingDirectory` is the same for every CE, each of them is able to delete the pilots files of other CEs which can create issues to retrieve the pilot outputs:

```
WorkloadManagement/SiteDirector INFO: Retrieving output for pilot htcondorce://ce/1234.56
WorkloadManagement/SiteDirector ERROR: Failed to get pilot output ce: Failed to find condor job 1234.56
``` 

Since `v7r0`, the pilot files of a same CE are stored in `workinDirectory/<ceName>`. Thus, a given CE has the possibility to only delete its files and not the others.

The counterpart is that, when updating from `v6` to `v7`, pilots files stored in the old structure of directory would need to be manually deleted. 

BEGINRELEASENOTES
*Resources
FIX: HTCondorCE cleanup only the pilots files related to the CE 

ENDRELEASENOTES
