### PR TITLE
[v7r0] Fixes for DMS Matrix, HTCondorCE.killJob

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-protocol-matrix.py
+++ b/DataManagementSystem/scripts/dirac-dms-protocol-matrix.py
@@ -58,6 +58,7 @@ if __name__ == '__main__':
   from DIRAC import gConfig, gLogger
   from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
   from DIRAC.Resources.Storage.StorageElement import StorageElement
+  from DIRAC.Core.Security.ProxyInfo import getVOfromProxyGroup
 
   fromSE = []
   targetSE = []
@@ -129,7 +130,15 @@ if __name__ == '__main__':
   ses = {}
   for se in set(fromSE + targetSE):
     ses[se] = StorageElement(seForSeBases[se])
-  lfn = '/lhcb/toto.xml'
+
+  ret = getVOfromProxyGroup()
+  if not ret['OK'] or not ret.get('Value', ''):
+    gLogger.error('Aborting, Bad Proxy:', ret.get('Message', 'Proxy does not belong to a VO!'))
+    exit(1)
+  vo = ret['Value']
+  gLogger.notice('Using the Virtual Organization:', vo)
+  # dummy LFN, still has to follow lfn convention
+  lfn = '/%s/toto.xml' % vo
 
   # Create a matrix of protocol src/dest
 

--- a/DataManagementSystem/scripts/dirac-dms-protocol-matrix.py
+++ b/DataManagementSystem/scripts/dirac-dms-protocol-matrix.py
@@ -173,3 +173,4 @@ if __name__ == '__main__':
       for dst in targetSE:
         srcRow.append(tpMatrix[src].get(dst, 'NA'))
       csvWriter.writerow(srcRow)
+  gLogger.notice('Wrote Matrix to', outputFile)

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -82,12 +82,14 @@ def condorIDAndPathToResultFromJobRef(jobRef):
 
   :return: tuple composed of the jobURL, the path to the job results and the condorID of the given jobRef
   """
-  jobURL, stamp = jobRef.split(":::")
+  splits = jobRef.split(":::")
+  jobURL = splits[0]
+  stamp = splits[1] if len(splits) > 1 else ''
   _, _, ceName, condorID = jobURL.split("/")
 
   # Reconstruct the path leading to the result (log, output)
   # Construction of the path can be found in submitJob()
-  pathToResult = logDir(ceName, stamp)
+  pathToResult = logDir(ceName, stamp) if len(stamp) >= 3 else ''
 
   return jobURL, pathToResult, condorID
 
@@ -294,6 +296,8 @@ Queue %(nJobs)s
   def killJob(self, jobIDList):
     """ Kill the specified jobs
     """
+    if not jobIDList:
+      return S_OK()
     if isinstance(jobIDList, basestring):
       jobIDList = [jobIDList]
 


### PR DESCRIPTION

BEGINRELEASENOTES

*DMS
FIX: allow dirac-dms-protocol-matrix be run for non LHCb VOs

*WMS
FIX: Fix exception when calling HTCondorCE killJob, used when killing pilots with dirac-admin-kill-pilot for example. Fixes #4590 

ENDRELEASENOTES
