### PR TITLE
[v7r0] Remove direct access to SandboxMetadataDB in the SandboxStoreClient

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -94,7 +94,7 @@ class ARCComputingElement(ComputingElement):
     # For the XRSL additional string from configuration - only done at initialisation time
     # If this string changes, the corresponding (ARC) site directors have to be restarted
     #
-    # Variable = XRSLExtraString (or for multi processor mode)
+    # Variable = XRSLExtraString (or XRSLMPExtraString for multi processor mode)
     # Default value = ''
     #   If you give a value, I think it should be of the form
     #          (aaa = "xxx")


### PR DESCRIPTION
  SandboxStoreClient has got a problem with some recent update of the DIRACOS when MySQLdb module was added: it tries to import it and, if successful, it attempts to connect to the SandboxMetadataDB. If the db access is impossible, the connection takes several minutes to return with error and then the client proceeds with the service access. As a result suddenly the job submission with the command line became terribly slow. Looking at the code of the SandboxStoreClient, methods that are using direct db access are actually not used anywhere. Therefore, the direct db access and the methods that were using it are dropped in this PR. 

BEGINRELEASENOTES

*WorkloadManagement
CHANGE: SandboxStoreClient - remove direct access to SandboxMetadataDB

ENDRELEASENOTES
