### PR TITLE
[v7r0] Add a new SiteDirector option to stop trying to get pilot outputs endlessly

### DIFF
--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -403,19 +403,24 @@ Queue %(nJobs)s
 
     if not self.useLocalSchedd:
       iwd = None
-      status, stdout_q = commands.getstatusoutput('condor_q %s %s -af SUBMIT_Iwd' % (self.remoteScheddOptions,
-                                                                                     condorID))
-      self.log.verbose('condor_q:', stdout_q)
-      if status != 0:
-        return S_ERROR(stdout_q)
-      if self.workingDirectory in stdout_q:
-        iwd = stdout_q
-        try:
-          os.makedirs(iwd)
-        except OSError as e:
-          self.log.verbose(str(e))
+      if pathToResult:
+        iwd = os.path.join(self.workingDirectory, pathToResult)
+      else:
+        status, stdout_q = commands.getstatusoutput('condor_q %s %s -af SUBMIT_Iwd' % (self.remoteScheddOptions,
+                                                                                       condorID))
+        self.log.verbose('condor_q:', stdout_q)
+        if status != 0:
+          return S_ERROR(stdout_q)
+        if self.workingDirectory in stdout_q:
+          iwd = stdout_q
+
       if iwd is None:
         return S_ERROR("Failed to find condor job %s" % condorID)
+
+      try:
+        os.makedirs(iwd)
+      except OSError as e:
+        self.log.verbose(str(e))
 
       cmd = ['condor_transfer_data', '-pool', '%s:9619' % self.ceName, '-name', self.ceName, condorID]
       result = executeGridCommand(self.proxy, cmd, self.gridEnv)

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -97,6 +97,8 @@ class SiteDirector(AgentModule):
     self.queueCECache = {}
     self.queueSlots = {}
     self.failedQueues = defaultdict(int)
+    # failedPilotOutput stores the number of times the Site Director failed to get a given pilot output
+    self.failedPilotOutput = defaultdict(int)
     self.firstPass = True
     self.maxJobsInFillMode = MAX_JOBS_IN_FILLMODE
     self.maxPilotsToSubmit = MAX_PILOTS_TO_SUBMIT
@@ -136,6 +138,8 @@ class SiteDirector(AgentModule):
     # Every N cycles, the number of slots available in the queues is updated
     self.availableSlotsUpdateCycleFactor = 10
     self.maxQueueLength = 86400 * 3
+    # Maximum number of times the Site Director is going to try to get a pilot output before stopping
+    self.maxRetryGetPilotOutput = 3
 
     self.pilotWaitingFlag = True
     self.pilotLogLevel = 'INFO'
@@ -220,6 +224,7 @@ class SiteDirector(AgentModule):
                                                           self.pilotStatusUpdateCycleFactor)
     self.availableSlotsUpdateCycleFactor = self.am_getOption('AvailableSlotsUpdateCycleFactor',
                                                              self.availableSlotsUpdateCycleFactor)
+    self.maxRetryGetPilotOutput = self.am_getOption('MaxRetryGetPilotOutput', self.maxRetryGetPilotOutput)
 
     # Flags
     self.addPilotsToEmptySites = self.am_getOption('AddPilotsToEmptySites', self.addPilotsToEmptySites)
@@ -1428,24 +1433,35 @@ class SiteDirector(AgentModule):
   def _getPilotOutput(self, pRef, pilotDict, ce, ceName):
     """ Retrieves the pilot output for a pilot and stores it in the pilotAgentsDB
     """
-
     self.log.info('Retrieving output for pilot %s' % pRef)
+    output = None
+    error = None
+
     pilotStamp = pilotDict[pRef]['PilotStamp']
     pRefStamp = pRef
     if pilotStamp:
       pRefStamp = pRef + ':::' + pilotStamp
+
     result = ce.getJobOutput(pRefStamp)
     if not result['OK']:
-      self.log.error('Failed to get pilot output',
-                     '%s: %s' % (ceName, result['Message']))
+      self.failedPilotOutput[pRefStamp] += 1
+      self.log.error('Failed to get pilot output', '%s: %s' % (ceName, result['Message']))
+      self.log.verbose('Retries left: %d' % max(0, self.maxRetryGetPilotOutput - self.failedPilotOutput[pRefStamp]))
+
+      if (self.maxRetryGetPilotOutput - self.failedPilotOutput[pRefStamp]) <= 0:
+        output = 'Output is no longer available'
+        error = 'Error is no longer available'
+      else:
+        return
     else:
       output, error = result['Value']
-      if output:
-        result = pilotAgentsDB.storePilotOutput(pRef, output, error)
-        if not result['OK']:
-          self.log.error('Failed to store pilot output', result['Message'])
-      else:
-        self.log.warn('Empty pilot output not stored to PilotDB')
+
+    if output:
+      result = pilotAgentsDB.storePilotOutput(pRef, output, error)
+      if not result['OK']:
+        self.log.error('Failed to store pilot output', result['Message'])
+    else:
+      self.log.warn('Empty pilot output not stored to PilotDB')
 
   def sendPilotAccounting(self, pilotDict):
     """ Send pilot accounting record
@@ -1510,7 +1526,6 @@ class SiteDirector(AgentModule):
                                     numTotal,
                                     numSucceeded,
                                     status):
-
     """ Send pilot submission accounting record
 
         :param str siteName:     Site name

--- a/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -216,6 +216,8 @@ Agents
     PilotStatusUpdateCycleFactor = 10
     # Every N cycles we update the number of available slots in the queues
     AvailableSlotsUpdateCycleFactor = 10
+    # Maximum number of times the Site Director is going to try to get a pilot output before stopping
+    MaxRetryGetPilotOutput = 3
     # To submit pilots to empty sites in any case
     AddPilotsToEmptySites = False
     # Should the SiteDirector consider platforms when deciding to submit pilots?


### PR DESCRIPTION
+ When the option "GetPilotOutput" of a Site Director agent is enabled, this one tries to get the pilot outputs of the sites it manages, even if they are old.
Old pilot outputs may be completely deleted and may not be retrieved.
Thus, the Site Director endlessly tries to find pilot outputs that don't exist anymore and this operation may take a long time...

To prevent the Site Director continuing to search for an old pilot output that doesn't exist anymore, I just give it a pilot output with the following content: 
"Pilot output is no longer available"

Is this okay? 
I noticed that in `v7r0` but I think this is older than that, which version should I target?   

+ And a small improvement to retrieve some pilot outputs in HTCondorCEs using the fact that paths to the pilot outputs are now deterministic. 

BEGINRELEASENOTES
*WorkloadManagement
NEW: option to only retry to get pilot outputs a limited number of times
*Resources
ADD: retrieve pilot output paths in getJobOutput using the pilot IDs instead of calling condor
ENDRELEASENOTES
