### PR TITLE
[v7r0] Remove direct access to SandboxMetadataDB in the SandboxStoreClient

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -1647,8 +1647,7 @@ class Dirac(API):
     except Exception as x:
       return self._errorReport(repr(x), 'Could not create directory in %s' % (dirPath))
 
-    result = SandboxStoreClient(smdb=False,
-                                useCertificates=self.useCertificates).downloadSandboxForJob(jobID,
+    result = SandboxStoreClient(useCertificates=self.useCertificates).downloadSandboxForJob(jobID,
                                                                                             'Input',
                                                                                             dirPath)
     if not result['OK']:
@@ -1696,8 +1695,7 @@ class Dirac(API):
     mkDir(dirPath)
 
     # New download
-    result = SandboxStoreClient(smdb=False,
-                                useCertificates=self.useCertificates).downloadSandboxForJob(jobID,
+    result = SandboxStoreClient(useCertificates=self.useCertificates).downloadSandboxForJob(jobID,
                                                                                             'Output',
                                                                                             dirPath,
                                                                                             inMemory=False,

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -94,7 +94,7 @@ class ARCComputingElement(ComputingElement):
     # For the XRSL additional string from configuration - only done at initialisation time
     # If this string changes, the corresponding (ARC) site directors have to be restarted
     #
-    # Variable = XRSLExtraString (or for multi processor mode)
+    # Variable = XRSLExtraString (or XRSLMPExtraString for multi processor mode)
     # Default value = ''
     #   If you give a value, I think it should be of the form
     #          (aaa = "xxx")

--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -27,7 +27,16 @@ class SandboxStoreClient(object):
   __validSandboxTypes = ('Input', 'Output')
   __smdb = None
 
-  def __init__(self, rpcClient=None, transferClient=None, smdb=None, **kwargs):
+  def __init__(self, rpcClient=None, transferClient=None, smdb=False, **kwargs):
+    """ Constructor
+
+        :param object rpcClient: SandboxStore service client (None by default)
+        :param object transferClient: client to upload/download sandboxes (None by default)
+        :param object smdb: SandboxMetadataDB object, or
+                            True if SandboxMetadataDB is to be instantiated for direct access or
+                            False if no direct access to the SandboxMetadataDB is done (default)
+
+    """
 
     self.__serviceName = "WorkloadManagement/SandboxStore"
     self.__rpcClient = rpcClient
@@ -37,7 +46,7 @@ class SandboxStoreClient(object):
     SandboxStoreClient.__smdb = smdb
     if 'delegatedGroup' in kwargs:
       self.__vo = getVOForGroup(kwargs['delegatedGroup'])
-    if SandboxStoreClient.__smdb is None:
+    if SandboxStoreClient.__smdb is True:
       try:
         from DIRAC.WorkloadManagementSystem.DB.SandboxMetadataDB import SandboxMetadataDB
         SandboxStoreClient.__smdb = SandboxMetadataDB()

--- a/WorkloadManagementSystem/Executor/JobSanity.py
+++ b/WorkloadManagementSystem/Executor/JobSanity.py
@@ -32,7 +32,7 @@ class JobSanity(OptimizerExecutor):
   def initializeOptimizer(cls):
     """Initialize specific parameters for JobSanityAgent.
     """
-    cls.sandboxClient = SandboxStoreClient(useCertificates=True)
+    cls.sandboxClient = SandboxStoreClient(useCertificates=True, smdb=True)
     return S_OK()
 
   def optimizeJob(self, jid, jobState):


### PR DESCRIPTION
SandboxStoreClient has got a problem with some recent update of the DIRACOS when MySQLdb module was added: it tries to import it and, if successful, it attempts to connect to the SandboxMetadataDB. If the db access is impossible, the connection takes several minutes to return with error and then the client proceeds with the service access. As a result suddenly the job submission with the command line became terribly slow. In this PR the SandboxMetadataDB instantiation by default is disabled. The only place where it is requested explicitly is the JobSanity executor.

BEGINRELEASENOTES

*WorkloadManagement
CHANGE: SandboxStoreClient - remove direct access to SandboxMetadataDB by default
CHANGE: JobSanity - instantiate SandboxStoreClient with direct access to SandboxMetadataDB

*Interfaces
Change: Dirac - instantiate SandboxStoreClient without smdb=False which is now a default

ENDRELEASENOTES