### PR TITLE
Changed the version to integration until there's a tagged and deploye…

### DIFF
--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -104,7 +104,7 @@ class JobWrapper(object):
     if result['OK']:
       self.diracVersion = result['Value']
     else:
-      self.diracVersion = 'DIRAC version %s' % DIRAC.buildVersion
+      self.diracVersion = 'DIRAC version %s' % DIRAC.version
     self.maxPeekLines = gConfig.getValue(self.section + '/MaxJobPeekLines', 20)
     if self.maxPeekLines < 0:
       self.maxPeekLines = 0

--- a/__init__.py
+++ b/__init__.py
@@ -37,7 +37,6 @@
     - patchLevel:    DIRAC Patch level number
     - preVersion:    DIRAC Pre release number
     - version:       DIRAC version string
-    - buildVersion:  DIRAC version string
 
     - errorMail:     mail address for important errors
     - alarmMail:     mail address for important alarms
@@ -90,19 +89,16 @@ import _strptime
 
 # Define Version
 
-majorVersion = 7
-minorVersion = 2
+majorVersion = 'integration'
+minorVersion = 0
 patchLevel = 0
 preVersion = 7
 
 version = "v%sr%s" % (majorVersion, minorVersion)
-buildVersion = "v%dr%d" % (majorVersion, minorVersion)
 if patchLevel:
   version = "%sp%s" % (version, patchLevel)
-  buildVersion = "%s build %s" % (buildVersion, patchLevel)
 if preVersion:
   version = "%s-pre%s" % (version, preVersion)
-  buildVersion = "%s pre %s" % (buildVersion, preVersion)
 
 # Check of python version
 

--- a/docs/source/DeveloperGuide/CodeTesting/index.rst
+++ b/docs/source/DeveloperGuide/CodeTesting/index.rst
@@ -553,7 +553,7 @@ For example, to re-run the server and client tests:
     docker exec -it -u dirac -w /home/dirac -e INSTALLROOT=/home/dirac -e INSTALLTYPE=client client \
       bash TestCode/DIRAC/tests/CI/run_tests.sh
 
-Once finished the containers can be removed using ``docker rm --force server client elasticsearch mysql``.
+Once finished the containers can be removed using ``docker rm --force server client elasticsearch mysql s3-direct``.
 
 
 Validation and System tests

--- a/releases.cfg
+++ b/releases.cfg
@@ -24,11 +24,6 @@ Releases
     Modules = DIRAC
     DIRACOS = master
   }
-  v7r2-pre7
-  {
-    Modules = DIRAC, VMDIRAC:v2r4p3, RESTDIRAC:v0r5, COMDIRAC:v0r19, WebAppDIRAC:v4r1p15, OAuthDIRAC:v0r1-pre6
-    DIRACOS = v1r12
-  }
   v7r1p1
   {
     Modules = DIRAC, VMDIRAC:v2r4p3, RESTDIRAC:v0r5, COMDIRAC:v0r19, WebAppDIRAC:v4r0p24, OAuthDIRAC:v0r1-pre6

--- a/tests/CI/run_docker_setup.sh
+++ b/tests/CI/run_docker_setup.sh
@@ -137,11 +137,17 @@ function prepareEnvironment() {
         echo "export DIRAC_RELEASE=integration"
       } >> "${SERVERCONFIG}"
   else
-      majorVersion=$(grep "majorVersion =" "${DIRAC_BASE_DIR}/__init__.py" | cut -d "=" -f 2)
-      minorVersion=$(grep "minorVersion =" "${DIRAC_BASE_DIR}/__init__.py" | cut -d "=" -f 2)
-      {
-        echo "export DIRACBRANCH=${DIRACBRANCH:-v${majorVersion// }r${minorVersion// }}"
-      } >> "${SERVERCONFIG}"
+      majorVersion=$(grep "majorVersion =" "${DIRAC_BASE_DIR}/__init__.py" | cut -d "=" -f 2 | cut -d " " -f 2 | cut -d "'" -f 2)
+      if [[ "$majorVersion" = "integration" ]]; then
+        {
+          echo "export DIRAC_RELEASE=integration"
+        } >> "${SERVERCONFIG}"
+      else
+        minorVersion=$(grep "minorVersion =" "${DIRAC_BASE_DIR}/__init__.py" | cut -d "=" -f 2 | cut -d " " -f 2 | cut -d "'" -f 2)
+        {
+          echo "export DIRACBRANCH=${DIRACBRANCH:-v${majorVersion// }r${minorVersion// }}"
+        } >> "${SERVERCONFIG}"
+      fi
   fi
 
   if [[ -n "${EXTRA_ENVIRONMENT_CONFIG+x}" ]]; then


### PR DESCRIPTION
…d one


Which means that now calling 
```
docker run --rm -it --privileged --name dirac-testing-host   -e CI_PROJECT_DIR=/repo/DIRAC -e CI_REGISTRY_IMAGE=diracgrid   -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/repo/DIRAC -w /repo   diracgrid/docker-compose-dirac:latest bash   DIRAC/tests/CI/run_docker_setup.sh
```
would work also for the integration branch.