### PR TITLE
[integration] Use also time in addition to date to get list of PRs since last tag

### DIFF
--- a/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
+++ b/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
@@ -26,7 +26,9 @@ add this section to the config file
 from __future__ import print_function
 import os
 from collections import defaultdict
-from datetime import datetime, timedelta
+import datetime
+import dateutil.parser
+import pytz
 import argparse
 from pprint import pformat
 import logging
@@ -147,7 +149,7 @@ class GithubInterface(object):
     self.sinceLatestTag = False
     self.headerMessage = None
     self.footerMessage = None
-    self.startDate = str(datetime.now() - timedelta(days=14))[:10]
+    self.startDate = datetime.datetime.now() - datetime.timedelta(days=14)
     self.printLevel = logging.WARNING
     logging.getLogger().setLevel(self.printLevel)
     self.useGitlab = False
@@ -306,7 +308,12 @@ class GithubInterface(object):
       self.startDate = None
       del parsed.date
     else:
-      self.startDate = parsed.date
+      if not isinstance(parsed.date, datetime.date):
+        parsed.date = dateutil.parser.isoparse(parsed.date)
+      if parsed.date.tzinfo is None or parsed.date.tzinfo.utcoffset(parsed.date) is None:
+        self.startDate = pytz.utc.localize(parsed.date)
+      else:
+        self.startDate = parsed.date
       log.info('Starting from: %s', self.startDate)
 
     self.openPRs = parsed.openPRs
@@ -403,8 +410,8 @@ class GithubInterface(object):
     """
     glURL = self._gitlab('repository/tags')
     allTags = req2Json(glURL)
-
-    return max([tag['commit']['created_at'] for tag in allTags])
+    lastTag = max([tag['commit']['created_at'] for tag in allTags])
+    return dateutil.parser.isoparse(lastTag)
 
   def getGithubLatestTagDate(self):
     """ Get the latest tag creation date from gitlab
@@ -432,7 +439,7 @@ class GithubInterface(object):
     latestTagCommitSha = latestTag['commit']['sha']
     commitInfo = req2Json(url=self._github("git/commits/%s" % latestTagCommitSha))
 
-    startDate = commitInfo['committer']['date'][:10]
+    startDate = dateutil.parser.isoparse(commitInfo['committer']['date'])
 
     log.info("Found latest tag date %s", startDate)
 
@@ -461,7 +468,8 @@ class GithubInterface(object):
 
       mergeDate = pr.get('merged_at', None)
       mergeDate = mergeDate if mergeDate is not None else '9999-99-99'
-      if mergeDate[:10] < self.startDate:
+      mergeDate=dateutil.parser.isoparse(mergeDate)
+      if mergeDate < self.startDate:
         continue
       rawReleaseNotes[baseBranch].update({prID: dict(comment=comment, mergeDate=mergeDate)})
 


### PR DESCRIPTION
BEGINRELEASENOTES
*docs
FIX: Use also time in addition to date to get list of PRs since last tag

ENDRELEASENOTES
This is problem in diracos where you can have a pattern of merge tag merge in the same day and this causes problems. In addition the flag `--date` can now take any iso date as input.
