### PR TITLE
[v7r0] Increase integration tests timeout to 45 minutes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ jobs:
   Integration:
     runs-on: ubuntu-latest
     if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     strategy:
       fail-fast: False


### PR DESCRIPTION
As the tests have been expanded we've started coming very close to the 30 minute timeout for each job. The majority of the time is spent in the server installation and optimising this would be worthwhile but for now I suggest increasing the timeout.