### PR TITLE
Update to customize the JobType of user jobs

### DIFF
--- a/WorkloadManagementSystem/Client/JobDescription.py
+++ b/WorkloadManagementSystem/Client/JobDescription.py
@@ -159,8 +159,9 @@ class JobDescription(object):
     result = self.__checkMaxInputData(maxInputData)
     if not result['OK']:
       return result
+    userJobTypes = Operations().getValue("Transformations/UserJobType", ['User'])
     transformationTypes = Operations().getValue("Transformations/DataProcessing", [])
-    result = self.__checkMultiChoiceInDescription("JobType", ['User', 'Test', 'Hospital'] + transformationTypes)
+    result = self.__checkMultiChoiceInDescription("JobType", ['Test', 'Hospital'] + userJobTypes + transformationTypes)
     return S_OK()
 
   def setVar(self, varName, varValue):

--- a/WorkloadManagementSystem/Client/JobState/JobManifest.py
+++ b/WorkloadManagementSystem/Client/JobState/JobManifest.py
@@ -184,8 +184,9 @@ class JobManifest(object):
     if not result['OK']:
       return result
 
+    userJobTypes = Operations().getValue("Transformations/UserJobType", ['User'])
     transformationTypes = Operations().getValue("Transformations/DataProcessing", [])
-    result = self.__checkMultiChoice("JobType", ['User', 'Test', 'Hospital'] + transformationTypes)
+    result = self.__checkMultiChoice("JobType", ['Test', 'Hospital'] + userJobTypes + transformationTypes)
     if not result['OK']:
       return result
     return S_OK()


### PR DESCRIPTION
This PR is updates of JobManifest and JobDescription, and they enable to customize the JobType of user jobs.
I welcome your comments, especially about where the UserJobType parameter should put in CS with you.

BEGINRELEASENOTES
*WMS
CHANGE: Updated to customize the JobType of user jobs in JobDescription and JobManifest
ENDRELEASENOTES
