### PR TITLE
[WIP][v7r0] More fixes for M2Crypto

### DIFF
--- a/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/Core/DISET/private/Transports/M2SSLTransport.py
@@ -91,7 +91,10 @@ class SSLTransport(BaseTransport):
         self.remoteAddress = self.oSocket.getpeername()
 
         return S_OK()
-      except (socket.error, SSLVerificationError, SSL.SSLError) as e:
+      # warning: do NOT catch SSL related error here
+      # They should be propagated upwards and caught by the BaseClient
+      # not to enter the retry loop
+      except socket.error as e:
         error = "%s:%s" % (e, repr(e))
 
         if self.oSocket is not None:

--- a/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/Core/DISET/private/Transports/M2SSLTransport.py
@@ -141,10 +141,28 @@ class SSLTransport(BaseTransport):
   def renewServerContext(self):
     """ Renews the server context.
         This reloads the certificates and re-initialises the SSL context.
-    """
+
+        NOTE: Chris 15.05.20
+        I noticed python segfault on a regular time interval. The stack trace always looks like that::
+
+          #0  0x00007fdb5bbe2388 in ?? () from /opt/dirac/pro/diracos/usr/lib64/python2.7/lib-dynload/../../libcrypto.so.10
+          #1  0x00007fdb5bbd8742 in X509_STORE_load_locations () from /opt/dirac/pro/diracos/usr/lib64/python2.7/lib-dynload/../../libcrypto.so.10
+          #2  0x00007fdb57edcc9d in _wrap_ssl_ctx_load_verify_locations (self=<optimized out>, args=<optimized out>) at SWIG/_m2crypto_wrap.c:20602
+          #3  0x00007fdb644ec484 in PyEval_EvalFrameEx () from /opt/dirac/versions/v10r0_1587978031/diracos/usr/bin/../lib64/libpython2.7.so.1.0
+
+        I could not find anything fundamentaly wrong, and the context renewal is the only place I could think of.
+
+        GSI based SSLTransport did the following: renew the context, and renew the Connection object using the same raw socket
+        This still seems very fishy to me though, especially that the ServiceReactor still has the old object in self.__listeningConnections[svcName]['socket']]
+
+        Here, we were are refreshing the CA store. What was missing was the call to the parent class, thus entering some sort of infinite loop.
+        The parent's call seems to have fixed it.
+    """  # noqa # pylint: disable=line-too-long
     if not self.serverMode():
       raise RuntimeError("SSLTransport is in client mode.")
+    super(SSLTransport, self).renewServerContext()
     self.__ctx = getM2SSLContext(self.__ctx, **self.__kwargs)
+
     return S_OK()
 
   def handshake_singleStep(self):

--- a/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/Core/DISET/private/Transports/M2SSLTransport.py
@@ -275,7 +275,7 @@ class SSLTransport(BaseTransport):
 
   # Depending on the DIRAC_M2CRYPTO_SPLIT_HANDSHAKE we either do the
   # handshake separately or not
-  if os.getenv('DIRAC_M2CRYPTO_SPLIT_HANDSHAKE', 'NO').lower() in ('yes', 'true'):
+  if os.getenv('DIRAC_M2CRYPTO_SPLIT_HANDSHAKE', 'Yes').lower() in ('yes', 'true'):
     acceptConnection = acceptConnection_multipleSteps
     handshake = handshake_multipleSteps
     setClientSocket = setClientSocket_multipleSteps

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -26,7 +26,7 @@ DIRAC_USE_M2CRYPTO
   If ``true`` or ``yes`` DIRAC uses m2crypto instead of pyGSI for handling certificates, proxies, etc.
 
 DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
-  If ``true`` or ``yes`` the SSL handshake is done in a new thread (default No)
+  If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
 
 DIRAC_VOMSES
   Can be set to point to a folder containing VOMSES information. See :ref:`multi_vo_dirac`

--- a/docs/source/AdministratorGuide/technologyPreviews.rst
+++ b/docs/source/AdministratorGuide/technologyPreviews.rst
@@ -13,7 +13,7 @@ M2Crypto
 
 We aim at replacing the home made wrapper of openssl pyGSI with the standard M2Crypto library. It is by default disabled.
 You can enable it by setting the environment variable ``DIRAC_USE_M2CRYPTO`` to ``Yes``.
-There is also a change of behavior in the way sockets connections are handled server side. The current (new) behavior is to perform the SSL handshake in the main thread and only delegate the execution of the method to another thread. The pyGSI behavior was to delegate the SSL handshake to the new thread, which is probably a better thing to do. You can revert back this behavior by setting `DIRAC_M2CRYPTO_SPLIT_HANDSHAKE` to `Yes`, but this has not been heavily tested yet. 
+When answering a call, the service main thread delegates the work and the SSL handshake to a task thread. This is how it should be for high performance. However, this behavior was added a bit late with respect to testing, so if you want to SSL handshake to happen in the main thread, you can set `DIRAC_M2CRYPTO_SPLIT_HANDSHAKE=No`. Note that this possibility will disappear soon.
 
 Possible issues
 ---------------
@@ -24,4 +24,3 @@ M2Crypto (or any standard tool that respects TLS..) will be stricter than PyGSI.
 * FQDN in the configuration: SAN normally contains only FQDN, so make sure you use the FQDN in the CS as well (e.g. ``mymachine.cern.ch`` and not ``mymachine``)
 * ComponentInstaller screwed: like any change you do on your hosts, the ComponentInstaller will duplicate the entry. So if you change the CS to put FQDN, the machine will appear twice. 
 
-In case your services are not fast enough, and the socket backlog is full (``ss -pnl``), try setting ``DIRAC_M2CRYPTO_SPLIT_HANDSHAKE`` to ``Yes``.


### PR DESCRIPTION
Still based on hotfixes in LHCb on heavily loaded services

BEGINRELEASENOTES
*Core
FIX: M2SSLTransport does not catch all the exceptions
FIX: M2SSLTransport calls parent class when renewing context
ENDRELEASENOTES
