### PR TITLE
[v7r0] Few fixes for CStoJSON

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -61,6 +61,11 @@ class PilotCStoJSONSynchronizer(object):
     self.casLocation = getCAsLocation()
     self._checksumDict = {}
 
+    # If this is set to True, we will attempt to upload the files
+    # to all the servers in the list. Obviously, it will only work
+    # for the DIRAC web servers (see _upload)
+    self.uploadToWebApp = True
+
     self.log = gLogger.getSubLogger(__name__)
 
   def sync(self):
@@ -92,6 +97,7 @@ class PilotCStoJSONSynchronizer(object):
     self.pilotVOScriptPath = ops.getValue("Pilot/pilotVOScriptsPath", self.pilotVOScriptPath)
     self.pilotRepoBranch = ops.getValue("Pilot/pilotRepoBranch", self.pilotRepoBranch)
     self.pilotVORepoBranch = ops.getValue("Pilot/pilotVORepoBranch", self.pilotVORepoBranch)
+    self.uploadToWebApp = ops.getValue("Pilot/uploadToWebApp", True)
 
     res = self._syncJSONFile()
     if not res['OK']:
@@ -358,6 +364,10 @@ class PilotCStoJSONSynchronizer(object):
     # or even send multiple files:
     # http://docs.python-requests.org/en/master/user/advanced/#post-multiple-multipart-encoded-files
     # But well, maybe too much optimization :-)
+
+    if not self.uploadToWebApp:
+      self.log.verbose("Skipping upload")
+      return
 
     if not self.pilotFileServer:
       self.log.warn("No pilotFileServer, nowhere to upload")

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -335,8 +335,10 @@ class PilotCStoJSONSynchronizer(object):
       tarPath = os.path.join(self.workDir, 'pilot.tar')
       with tarfile.TarFile(name=tarPath, mode='w') as tf:
         for ptf in tarFiles:
+          # This copy makes sure that all the files in the tarball are accessible
+          # in the work directory. It should be kept
           shutil.copyfile(ptf, os.path.join(self.workDir, os.path.basename(ptf)))
-          tf.add(os.path.basename(ptf), recursive=False)
+          tf.add(ptf, arcname=os.path.basename(ptf), recursive=False)
 
       self._upload(filename='pilot.tar', pilotScript=tarPath)
 
@@ -376,7 +378,7 @@ class PilotCStoJSONSynchronizer(object):
 
       for pfServer in self.pilotFileServer.replace(' ', '').split(','):
         try:
-          data = {'filename': filename, 'data': script}
+          data = {'filename': os.path.basename(filename), 'data': script}
           resp = requests.post('https://%s/DIRAC/upload' % pfServer,
                                data=data,
                                verify=self.casLocation,

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -336,7 +336,7 @@ class PilotCStoJSONSynchronizer(object):
                                          "dirac-install.py")):
         self._upload(filename='dirac-install.py',
                      pilotScript=os.path.join(pilotLocalRepo, "Core/scripts/dirac-install.py"))
-        tarFiles.append('dirac-install.py')
+        tarFiles.append(os.path.join(pilotLocalRepo, "Core/scripts/dirac-install.py"))
 
       tarPath = os.path.join(self.workDir, 'pilot.tar')
       with tarfile.TarFile(name=tarPath, mode='w') as tf:

--- a/dirac.cfg
+++ b/dirac.cfg
@@ -388,6 +388,7 @@ Operations
       pilotVORepo = https://github.com/MyDIRAC/VOPilot.git # git repository of the pilot extension
       pilotVOScriptsPath = VOPilot # Path to the code, inside the Git repository
       pilotVORepoBranch = master # Branch to use
+      uploadToWebApp = True # Try to upload the files from the CS to the list of servers
       workDir = /tmp/pilot3Files # Local work directory on the masterCS for synchronisation
     }
     Services

--- a/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
+++ b/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
@@ -526,6 +526,16 @@ class GithubInterface(object):
       with open(self.footerMessage, 'r') as hmf:
         footerMessage = hmf.read()
 
+    # If there are no CHANGELOGS, which can happen
+    # just add the header/footer
+    # CAUTION: no [tag] will be written
+    if not prs:
+      if headerMessage:
+        releaseNotes += '%s\n\n' % headerMessage
+      if footerMessage:
+        releaseNotes += '%s\n' % footerMessage
+      return releaseNotes
+
     prMarker = '#' if self.useGithub else '!'
     for baseBranch, pr in prs.iteritems():
       releaseNotes += '[%s]\n\n' % baseBranch

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -62,6 +62,9 @@ Other options that can be set also in the Operations part of the CS include:
 | *pilotVORepoBranch*                | Branch to use, inside the Git repository,  | pilotVORepoBranch = master                                              |
 |                                    | of the pilot code extension to be used     | The value above is the default                                          |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
+| *uploadToWebApp*                   | Whether to try to upload the files to the  | uploadToWebApp = True                                                   |
+|                                    | list of server specified                   | The value above is the default                                          |
++------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 | *workDir*                          | Local directory of the master CS where the | workDir = /tmp/pilotSyncDir                                             |
 |                                    | files will be downloaded before the upload | There is no default (so /opt/dirac/runit/Configuration/Server)          |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+


### PR DESCRIPTION
Add an absolute path fix in CS2Json and add the possibility to disable the upload. 

Also a change in the release notes generation (@petricm @andresailer ). If there were no PR merged, the release notes would still generate the header and setter. This is useful for example if you release an extension and just changed the base DIRAC version. 

BEGINRELEASENOTES
*WMS
NEW: uploadToWebApp flag to disable the json upload for the CSToJson
FIX: Fix an absolute path in the CSToJSON

*Docs:
CHANGE: allow to generate only header/footer in the release notes if no PR were merged

ENDRELEASENOTES
