### PR TITLE
[v6r22] removed easily avoided proxy cross check

### DIFF
--- a/DataManagementSystem/scripts/dirac-dms-remove-catalog-files.py
+++ b/DataManagementSystem/scripts/dirac-dms-remove-catalog-files.py
@@ -28,9 +28,9 @@ if not res['OK']:
 properties = res['Value'].get( 'groupProperties', [] )
 
 if not allowUsers:
-  if not 'FileCatalogManagement' in properties:
-    gLogger.error( "You need to use a proxy from a group with FileCatalogManagement" )
-    dexit( 5 )
+  if 'FileCatalogManagement' not in properties:
+    gLogger.error("You need to use a proxy from a group with FileCatalogManagement")
+    dexit(5)
 
 from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 fc = FileCatalog()

--- a/DataManagementSystem/scripts/dirac-dms-remove-catalog-files.py
+++ b/DataManagementSystem/scripts/dirac-dms-remove-catalog-files.py
@@ -17,15 +17,20 @@ Usage:
 
 Script.parseCommandLine()
 
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+allowUsers = Operations().getValue("DataManagement/AllowUserReplicaManagement", False)
+
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 res = getProxyInfo()
 if not res['OK']:
   gLogger.fatal( "Can't get proxy info", res['Message'] )
   dexit( 1 )
 properties = res['Value'].get( 'groupProperties', [] )
-if not 'FileCatalogManagement' in properties:
-  gLogger.error( "You need to use a proxy from a group with FileCatalogManagement" )
-  dexit( 5 )
+
+if not allowUsers:
+  if not 'FileCatalogManagement' in properties:
+    gLogger.error( "You need to use a proxy from a group with FileCatalogManagement" )
+    dexit( 5 )
 
 from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 fc = FileCatalog()

--- a/DataManagementSystem/scripts/dirac-dms-remove-catalog-replicas.py
+++ b/DataManagementSystem/scripts/dirac-dms-remove-catalog-replicas.py
@@ -30,9 +30,9 @@ if not res['OK']:
 properties = res['Value'].get( 'groupProperties', [] )
 
 if not allowUsers:
-  if not 'FileCatalogManagement' in properties:
-    gLogger.error( "You need to use a proxy from a group with FileCatalogManagement" )
-    dexit( 5 )
+  if 'FileCatalogManagement' not in properties:
+    gLogger.error("You need to use a proxy from a group with FileCatalogManagement")
+    dexit(5)
 
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 dm = DataManager()

--- a/DataManagementSystem/scripts/dirac-dms-remove-catalog-replicas.py
+++ b/DataManagementSystem/scripts/dirac-dms-remove-catalog-replicas.py
@@ -19,15 +19,21 @@ Usage:
 
 Script.parseCommandLine()
 
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+allowUsers = Operations().getValue("DataManagement/AllowUserReplicaManagement", False)
+
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 res = getProxyInfo()
 if not res['OK']:
   gLogger.fatal( "Can't get proxy info", res['Message'] )
   dexit( 1 )
 properties = res['Value'].get( 'groupProperties', [] )
-if not 'FileCatalogManagement' in properties:
-  gLogger.error( "You need to use a proxy from a group with FileCatalogManagement" )
-  dexit( 5 )
+
+if not allowUsers:
+  if not 'FileCatalogManagement' in properties:
+    gLogger.error( "You need to use a proxy from a group with FileCatalogManagement" )
+    dexit( 5 )
+
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 dm = DataManager()
 import os, sys

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Operations/DataManagement/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Operations/DataManagement/index.rst
@@ -15,6 +15,7 @@ Operations / DataManagement
 * ThirdPartyProtocols (['srm']): list of the possible protocols to be used in replications
 * AccessProtocols (['srm', 'dips']): list of the possible protocols to be used to perform the read operations and to get the space occupancy. Overwritten at the level of a StorageElement configuration.
 * WriteProtocols (['srm', 'dips']): list of the possible protocols to be used to perform the write and remove operations. Overwritten at the level of a StorageElement configuration.
+* AllowUserReplicaManagement (False): if set to True, clients without the FileCatalogManagement property can use the dirac-dms-remove-catalog-* commands to manipulate the file catalog.
 * FTSVersion (FTS2): version of FTS to use. Possibilities: FTS3 or FTS2 (deprecated)
 * FTSPlacement section:
 


### PR DESCRIPTION
BEGINRELEASENOTES

*DataManagementSystem
CHANGE: 
dirac-dms-remove-catalog-files and dirac-dms-remove-catalog-files introduce an extra check on proxy properties that causes inconsistent behaviour wrt to other DIRAC tools  performing the same tasks when used in a multi-VO setup. 

ENDRELEASENOTES
