### PR TITLE
[v6r22] Catch LFNs with two slash characters

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DirectoryTreeBase.py
@@ -532,6 +532,10 @@ class DirectoryTreeBase:
           pDir = os.path.dirname(path)
           if not pDir:
             return S_ERROR('Illegal Path')
+          if pDir == path:
+            # If pDir == path, then we're stuck in a loop
+            # There is probably a "//" in the path
+            return S_ERROR('Bad Path (double /?)')
           result = self.getDirectoryPermissions(pDir, credDict)
           return result
       else:


### PR DESCRIPTION
Fixes #4578. I added a second if statement so we can have a specific error message for this case.

BEGINRELEASENOTES
*DataManagementSystem
FIX: Throw an error if LFN contains '//'
ENDRELEASENOTES
