### PR TITLE
Symlink bashrc when UseVersionsDir is enabled

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2033,6 +2033,7 @@ def createPermanentDirLinks():
   """
   if cliParams.useVersionsDir:
     try:
+      # Directories
       for directory in ['startup', 'runit', 'data', 'work', 'control', 'sbin', 'etc', 'webRoot']:
         fake = os.path.join(cliParams.targetPath, directory)
         real = os.path.join(cliParams.basePath, directory)
@@ -2046,6 +2047,12 @@ def createPermanentDirLinks():
               if not os.path.exists(os.path.join(real, fd)):
                 os.makedirs(os.path.join(real, fd))
           os.rename(fake, fake + '.bak')
+        os.symlink(real, fake)
+
+      # Files
+      for filename in ['bashrc']:
+        fake = os.path.join(cliParams.targetPath, filename)
+        real = os.path.join(cliParams.basePath, filename)
         os.symlink(real, fake)
     except Exception as x:
       logERROR(str(x))


### PR DESCRIPTION
Fixes #4565 

BEGINRELEASENOTES

*Core
CHANGE: Create symlinks to `bashrc` when using `versions` directory structure with `dirac-install.py`

ENDRELEASENOTES
