### PR TITLE
[v7r0] Add pilot3 compatibility to SingularityCE

### DIFF
--- a/Resources/Computing/SingularityComputingElement.py
+++ b/Resources/Computing/SingularityComputingElement.py
@@ -43,6 +43,8 @@ cd /tmp
 ./dirac-install.py %(install_args)s
 source bashrc
 dirac-configure -F %(config_args)s -I
+# Add compatibility with pilot3 where config is in pilot.cfg
+ln -s etc/dirac.cfg pilot.cfg
 # Run next wrapper (to start actual job)
 bash %(next_wrapper)s
 # Write the payload errorcode to a file for the outer scripts


### PR DESCRIPTION
The config file change in pilot3 (from "etc/dirac.cfg" to "pilot.cfg") triggers a bug in the SingularityCE as the new config name is passed through to the JobWrapper, but the version installed in the container still uses the old name. This creates a symlink in the container for compatibility with both (as changing the JobWrapper options correctly in just this case is too complicated). Could be back-ported to older versions if needed.

BEGINRELEASENOTES
*Resources
FIX: Add pilot.cfg symlink in SingularityCE for Pilot3 compatibility.
ENDRELEASENOTES
