### PR TITLE
[v7r1] Install of ES DBs: only search in *DB.py files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ nosetests.xml
 coverage.xml
 Local_*
 .hypothesis
+virtualmachine/.vagrant/
 
 integration_test_results/
 tests/CI/CLIENTCONFIG

--- a/FrameworkSystem/Client/ComponentInstaller.py
+++ b/FrameworkSystem/Client/ComponentInstaller.py
@@ -2191,6 +2191,9 @@ touch %(controlDir)s/%(system)s/%(component)s/stop_%(type)s
   def getAvailableSQLDatabases(self, extensions):
     """
     Find the sql files
+
+    :param list extensions: list of DIRAC extensions
+    :return: dict of MySQL DBs
     """
     dbDict = {}
     for extension in extensions + ['']:
@@ -2211,8 +2214,8 @@ touch %(controlDir)s/%(system)s/%(component)s/stop_%(type)s
     Find the ES DBs definitions, by introspection.
 
     This method makes a few assumptions:
-    - the files defining modules interacting with ES DBs are found in the *System/DB/ directories
-    - the files defining modules interacting with ES DBs are named *DB.py (e.g. MonitoringDB.py)
+    - the files defining modules interacting with ES DBs are found in the xyzSystem/DB/ directories
+    - the files defining modules interacting with ES DBs are named xyzDB.py (e.g. MonitoringDB.py)
     - the modules define ES DBs classes with the same name of the module (e.g. class MonitoringDB())
     - the classes are inheriting from the ElasticDB module (e.g. class MonitoringDB(ElasticDB))
 

--- a/FrameworkSystem/Client/ComponentInstaller.py
+++ b/FrameworkSystem/Client/ComponentInstaller.py
@@ -2209,33 +2209,49 @@ touch %(controlDir)s/%(system)s/%(component)s/stop_%(type)s
   def getAvailableESDatabases(self, extensions):
     """
     Find the ES DBs definitions, by introspection.
+
+    This method makes a few assumptions:
+    - the files defining modules interacting with ES DBs are found in the *System/DB/ directories
+    - the files defining modules interacting with ES DBs are named *DB.py (e.g. MonitoringDB.py)
+    - the modules define ES DBs classes with the same name of the module (e.g. class MonitoringDB())
+    - the classes are inheriting from the ElasticDB module (e.g. class MonitoringDB(ElasticDB))
+
     Result should be something like::
 
        {'MonitoringDB': {'Type': 'ES', 'System': 'Monitoring', 'Extension': ''},
         'ElasticJobDB': {'Type': 'ES', 'System': 'WorkloadManagement', 'Extension': ''}}
 
+    :param list extensions: list of DIRAC extensions
+    :return: dict of ES DBs
     """
     dbDict = {}
     for extension in extensions + ['']:
 
+      # Find *DB.py definitions
       pyDBs = glob.glob(os.path.join(rootPath,
                                      ('%sDIRAC' % extension).replace('DIRACDIRAC', 'DIRAC'),
-                                     '*', 'DB', '*.py'))
+                                     '*', 'DB', '*DB.py'))
       pyDBs = [x.replace('.py', '') for x in pyDBs if '__init__' not in x]
 
+      # Find sql files
       sqlDBs = glob.glob(os.path.join(rootPath,
                                       ('%sDIRAC' % extension).replace('DIRACDIRAC', 'DIRAC'),
                                       '*', 'DB', '*.sql'))
       sqlDBs = [x.replace('.sql', '') for x in sqlDBs]
 
+      # Find *DB.py files that do not have a sql part
       possible = set(pyDBs) - set(sqlDBs)
       databases = []
       for p in possible:
-        p_mod = p.replace(rootPath, '').lstrip('/').replace('/', '.')
-        mdb_mod = importlib.import_module(p_mod, p_mod.split('.')[-1])
-        cl = getattr(mdb_mod, p_mod.split('.')[-1])
-        if 'ElasticDB' in str(inspect.getmro(cl)):
-          databases.append(p)
+        # Introspect all possible ones
+        try:
+          p_mod = p.replace(rootPath, '').lstrip('/').replace('/', '.')
+          mdb_mod = importlib.import_module(p_mod, p_mod.split('.')[-1])
+          cl = getattr(mdb_mod, p_mod.split('.')[-1])
+          if 'ElasticDB' in str(inspect.getmro(cl)):
+            databases.append(p)
+        except (AttributeError, ImportError):
+          pass
 
       for dbPath in databases:
         dbName = os.path.basename(dbPath)

--- a/virtualmachine/Vagrantfile
+++ b/virtualmachine/Vagrantfile
@@ -1,0 +1,104 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+
+# NOTE: this is WIP
+# would provide a VM for DIRAC clients, based on centos7
+# host DIRAC code is mounted in /opt/dirac/versions/hostcode
+# ../certs (relative to DIRAC code) will be mounted in /home/vagrant/.globus
+
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "centos/7"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "..", "/opt/dirac/versions/hostcode"
+  config.vm.synced_folder "../../certs", "/home/vagrant/.globus"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+
+  # WIP: possible conf below, not fully needed
+
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   #!/bin/bash
+
+  #   # Create DIRAC dirs
+  #   mkdir -p /opt/dirac/DIRAC && \
+  #   mkdir -p /opt/dirac/etc/grid-security/certificates && \
+  #   cd /opt/dirac
+
+  #   # Installing DIRAC in /opt/dirac
+  #   curl -L -o dirac-install https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py && \
+  #   chmod +x dirac-install && \
+  #   ./dirac-install -r $DIRAC_VERSION -t client && \
+  #   rm -rf /opt/dirac/.installCache && \
+  #   rm dirac-install && \
+  #   ln -s /etc/grid-security/certificates/ /opt/dirac/etc/grid-security/certificates
+
+  #   source bashrc
+
+  #   # Create self-signed host certificate from auto-generated CA
+  #   WORKDIR /opt/dirac/etc/grid-security
+  #   RUN source /opt/dirac/bashrc && openssl genrsa -out hostkey.pem 2048
+  #   RUN curl -L -o openssl_config https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/tests/openssl_config_DIRACDockerDevBox && \
+  #       source /opt/dirac/bashrc && \
+  #       openssl req -new -x509 -key hostkey.pem -out hostcert.pem -days 365 -config openssl_config && \
+  #       cp hostcert.pem certificates/ && \
+  #       cp hostkey.pem certificates/
+  # SHELL
+end


### PR DESCRIPTION
I also added a Vagrantfile. I use it from time to time and I decided to add it here.

BEGINRELEASENOTES

*Framework
FIX: Install of ES DBs: only search in *DB.py files

ENDRELEASENOTES
