### PR TITLE
[v7r0] Change the closing of socket in M2Crypto

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@ python_files=Test_*.py assert*.py
 # The reason here is that we do nasty things with the pythonpath
 # in order to make sure that M2Crypto and pyGSI do not step
 # on each other's feet
-addopts = -rx -v --color=yes --showlocals --tb=long --ignore=tests --ignore=Core/Security/test --cov=. --cov-report term-missing
+addopts = -rx -v --color=yes --showlocals --tb=long --ignore=tests --ignore=Core/Security/test


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: M2Crypto closes the socket after dereferencing the Connection instance

ENDRELEASENOTES
