### PR TITLE
[v7r1] Few fixes for the integration tests on jenkins

### DIFF
--- a/StorageManagementSystem/DB/StorageManagementDB.sql
+++ b/StorageManagementSystem/DB/StorageManagementDB.sql
@@ -9,7 +9,11 @@
 
 use StorageManagementDB;
 
+DROP TABLE IF EXISTS TaskReplicas;
+DROP TABLE IF EXISTS StageRequests;
+DROP TABLE IF EXISTS CacheReplicas;
 DROP TABLE IF EXISTS Tasks;
+
 CREATE TABLE Tasks(
   TaskID INTEGER AUTO_INCREMENT,
   Status VARCHAR(32) DEFAULT 'New',
@@ -23,7 +27,6 @@ CREATE TABLE Tasks(
   INDEX(TaskID,Status)
 )ENGINE=INNODB;
 
-DROP TABLE IF EXISTS TaskReplicas;
 CREATE TABLE TaskReplicas(
   TaskID INTEGER(8) NOT NULL REFERENCES Tasks(TaskID),
   ReplicaID INTEGER(8) NOT NULL REFERENCES CacheReplicas(ReplicaID),
@@ -33,7 +36,7 @@ CREATE TABLE TaskReplicas(
 CREATE TRIGGER taskreplicasAfterInsert AFTER INSERT ON TaskReplicas FOR EACH ROW UPDATE CacheReplicas SET CacheReplicas.Links=CacheReplicas.Links+1 WHERE CacheReplicas.ReplicaID=NEW.ReplicaID;
 CREATE TRIGGER taskreplicasAfterDelete AFTER DELETE ON TaskReplicas FOR EACH ROW UPDATE CacheReplicas SET CacheReplicas.Links=CacheReplicas.Links-1 WHERE CacheReplicas.ReplicaID=OLD.ReplicaID;
 
-DROP TABLE IF EXISTS CacheReplicas;
+
 CREATE TABLE CacheReplicas(
   ReplicaID INTEGER AUTO_INCREMENT,
   Type VARCHAR(32) NOT NULL,
@@ -52,7 +55,7 @@ CREATE TABLE CacheReplicas(
   INDEX(ReplicaID,Status,SE)
 )ENGINE=INNODB;
 
-DROP TABLE IF EXISTS StageRequests;
+
 CREATE TABLE StageRequests(
   ReplicaID INTEGER(8) NOT NULL REFERENCES CacheReplicas(ReplicaID),
   StageStatus VARCHAR(32) DEFAULT 'StageSubmitted',

--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -66,11 +66,11 @@ fi
 
 # Creating default structure
 mkdir -p "$WORKSPACE/TestCode" # Where the test code resides
-readonly TESTCODE=${_}
+TESTCODE=${_}
 mkdir -p "$WORKSPACE/ServerInstallDIR" # Where servers are installed
-readonly SERVERINSTALLDIR=${_}
+SERVERINSTALLDIR=${_}
 mkdir -p "$WORKSPACE/ClientInstallDIR" # Where clients are installed
-readonly CLIENTINSTALLDIR=${_}
+CLIENTINSTALLDIR=${_}
 
 # Location of the CFG file to be used (this can be replaced by the extensions)
 INSTALL_CFG_FILE="${TESTCODE}/DIRAC/tests/Jenkins/install.cfg"

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -892,8 +892,9 @@ diracMVDFCDB(){
 dropDBs(){
   echo '==> [dropDBs]'
 
-  dbs=$(cut -d ' ' -f 2 < databases | cut -d '.' -f 1 | grep -v ^RequestDB | grep -v ^FileCatalogDB)
-  python "${TESTCODE}/DIRAC/tests/Jenkins/dirac-drop-db.py" "$dbs" "${DEBUG}"
+  # make dbs a real array to avoid future mistake with escaping
+  mapfile -t dbs < <(cut -d ' ' -f 2 < /tmp/databases.txt | cut -d '.' -f 1 | grep -v ^RequestDB | grep -v ^FileCatalogDB)
+  python "${TESTCODE}/DIRAC/tests/Jenkins/dirac-drop-db.py" "${dbs[@]}" "${DEBUG}"
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
A whole bunch of small fixes. Including the controversial `readonly` variables. I really do not want to spend time debugging it, but as long as we have them, running the jenkins integartion tests are impossible as such. Up to everybody to measure pro/cons of having them readonly

BEGINRELEASENOTES

*Tests
FIX: dropDBs uses real array; 
FIX: remove readonly variables

*SMS
FIX: drop the tables in the correct order to avoid foreign key errors


ENDRELEASENOTES
