### PR TITLE
[v7r0] add cfg option to commands to standardize behaviour

### DIFF
--- a/docs/source/AdministratorGuide/Configuration/ConfigurationStructure/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfigurationStructure/index.rst
@@ -55,10 +55,18 @@ in the order of preference of the option resolution:
      dirac-wms-job-submit job.jdl -o /DIRAC/Setup=Dirac-Production
 
 *Command line argument specifying a CFG file*
-  If a filename with the *.cfg* extension is passed as an argument to any DIRAC command
-  it will be interpreted as a configuration file. For example::
+  A config file can be passed to any dirac command with the ``--cfg`` flag::
   
-     dirac-wms-job-submit job.jdl my.cfg
+     dirac-wms-job-submit job.jdl --cfg my.cfg
+
+  .. versionchanged:: v7r0
+
+     The passing of ``.cfg`` files was changed to require the ``--cfg`` flag.
+
+  .. deprecated:: v7r0
+
+     If a filename with the ``.cfg`` extension is passed as an argument to any DIRAC command
+     it will be interpreted as a configuration file, if the ``DIRAC_NO_CFG`` environment variable is not set.
 
 *Value of $DIRACSYSCONFIG environment variable*
   if the DIRACSYSCONFIG variable is set, it should point to a cfg file (written in *CFG* format)

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -25,6 +25,9 @@ DIRAC_GFAL_GRIDFTP_SESSION_REUSE
 DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
   If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
 
+DIRAC_NO_CFG
+  If set to anything, cfg files on the command line must be passed to the command using the --cfg option.
+
 DIRAC_USE_M2CRYPTO
   If ``true`` or ``yes`` DIRAC uses m2crypto instead of pyGSI for handling certificates, proxies, etc.
 


### PR DESCRIPTION
We propose this fix in response to user requirements to be able to upload/download/replicate .cfg files using the DIRAC command line tools. We are aware that there is a workaround, but it should just work properly to avoid the issue from resurfacing on a regular basis. 
We are aware that fully removing the non-option parsing of config files will require updates to other parts of the DIRAC code (pilot3). This would go into a later release (v7r4?).
BEGINRELEASENOTES
*Configuration
CHANGE: Add --cfg option for config files, deprecating old non-option version.
ENDRELEASENOTES
