### PR TITLE
[v7r0] dirac-admin-add-host adds host to ComponentMonitoring

### DIFF
--- a/ConfigurationSystem/Client/CSAPI.py
+++ b/ConfigurationSystem/Client/CSAPI.py
@@ -121,7 +121,7 @@ class CSAPI(object):
   def describeUsers(self, users=None):
     """ describe users by nickname
 
-        :param list users: list of users' nickanames
+        :param list users: list of users' nicknames
         :return: a S_OK(description) of the users in input
     """
     if users is None:
@@ -240,14 +240,14 @@ class CSAPI(object):
     """
     Add a user to the cs
 
-      :param str username: group name
-      :param dict properties: dictionary describing user properties:
+    :param str username: username
+    :param dict properties: dictionary describing user properties:
 
-        - DN
-        - groups
-        - <extra params>
+      - DN
+      - groups
+      - <extra params>
 
-      :return: True/False
+    :return: True/False
     """
     if not self.__initialized['OK']:
       return self.__initialized
@@ -279,14 +279,15 @@ class CSAPI(object):
     """
     Modify a user
 
-      :param str username: group name
-      :param dict properties: dictionary describing user properties:
+    :param str username: group name
+    :param dict properties: dictionary describing user properties:
 
         - DN
         - Groups
         - <extra params>
 
-      :return: S_OK, Value = True/False
+    :param bool createIfNonExistant: if true, registers the users if it did not exist
+    :return: S_OK, Value = True/False
     """
     if not self.__initialized['OK']:
       return self.__initialized
@@ -341,14 +342,14 @@ class CSAPI(object):
     """
     Add a group to the cs
 
-      :param str groupname: group name
-      :param dict properties: dictionary describing group properties:
+    :param str groupname: group name
+    :param dict properties: dictionary describing group properties:
 
         - Users
         - Properties
         - <extra params>
 
-      :return: True/False
+    :return: S_OK, Value = True/False
     """
     if not self.__initialized['OK']:
       return self.__initialized
@@ -366,14 +367,15 @@ class CSAPI(object):
     """
     Modify a group
 
-      :param str groupname: group name
-      :param dict properties: dictionary describing group properties:
+    :param str groupname: group name
+    :param dict properties: dictionary describing group properties:
 
         - Users
         - Properties
         - <extra params>
 
-      :return: True/False
+    :param bool createIfNonExistant: if true, creates the group if it did not exist
+    :return: S_OK, Value = True/False
     """
     if not self.__initialized['OK']:
       return self.__initialized
@@ -401,14 +403,15 @@ class CSAPI(object):
   def addHost(self, hostname, properties):
     """
     Add a host to the cs
-      :param str hostname: hostname name
-      :param dict properties: dictionary describing host properties:
+
+    :param str hostname: host name
+    :param dict properties: dictionary describing host properties:
 
         - DN
         - Properties
         - <extra params>
 
-      :return: True/False
+    :return: S_OK, Value = True/False
     """
     if not self.__initialized['OK']:
       return self.__initialized
@@ -528,14 +531,16 @@ class CSAPI(object):
   def modifyHost(self, hostname, properties, createIfNonExistant=False):
     """
     Modify a host
-      :param str hostname: hostname name
-      :param dict properties: dictionary describing host properties:
+
+    :param str hostname: hostname name
+    :param dict properties: dictionary describing host properties:
 
         - DN
         - Properties
         - <extra params>
 
-      :return: True/False
+    :param bool createIfNonExistant: if true, creates the host if it did not exist
+    :return: S_OK, Value = True/False
     """
     if not self.__initialized['OK']:
       return self.__initialized

--- a/ConfigurationSystem/Client/Config.py
+++ b/ConfigurationSystem/Client/Config.py
@@ -6,8 +6,13 @@ __RCSID__ = "$Id$"
 
 from DIRAC.ConfigurationSystem.private.ConfigurationClient import ConfigurationClient
 
+#: Global gConfig object of type :class:`~DIRAC.ConfigurationSystem.private.ConfigurationClient.ConfigurationClient`
 gConfig = ConfigurationClient()
 
 
 def getConfig():
+  """
+  :returns: gConfig
+  :rtype: ~DIRAC.ConfigurationSystem.private.ConfigurationClient.ConfigurationClient
+  """
   return gConfig

--- a/Interfaces/scripts/dirac-admin-add-host.py
+++ b/Interfaces/scripts/dirac-admin-add-host.py
@@ -81,7 +81,7 @@ if exitCode == 0:
   cmc = ComponentMonitoringClient()
   ret = cmc.hostExists(dict(HostName=hostName))
   if not ret['OK']:
-    Script.gLogger.error('Cannot check if host is registered in ComponentMoniroting', ret['Message'])
+    Script.gLogger.error('Cannot check if host is registered in ComponentMonitoring', ret['Message'])
   elif ret['Value']:
     Script.gLogger.info('Host already registered in ComponentMonitoring')
   else:

--- a/Interfaces/scripts/dirac-admin-add-host.py
+++ b/Interfaces/scripts/dirac-admin-add-host.py
@@ -76,6 +76,19 @@ else:
     errorList.append( ( "commit", result[ 'Message' ] ) )
     exitCode = 255
 
+if exitCode == 0:
+  from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient import ComponentMonitoringClient
+  cmc = ComponentMonitoringClient()
+  ret = cmc.hostExists(dict(HostName=hostName))
+  if not ret['OK']:
+    Script.gLogger.error('Cannot check if host is registered in ComponentMoniroting', ret['Message'])
+  elif ret['Value']:
+    Script.gLogger.info('Host already registered in ComponentMonitoring')
+  else:
+    ret = cmc.addHost(dict(HostName=hostName, CPU='TO_COME'))
+    if not ret['OK']:
+      Script.gLogger.error('Failed to add Host to ComponentMonitoring', ret['Message'])
+
 for error in errorList:
   Script.gLogger.error( "%s: %s" % error )
 


### PR DESCRIPTION
I have been installing a number of servers recently, and one annoyance is that new hosts don't show up in the WebApp SystemAdministrator unless they are in the ComponentMonitoring.
This PR adds the addition of new hosts to the ComponentMonitoring, so they show up immediately.

Plus some tweaks to the documentation for gConfig and CSAPI.

BEGINRELEASENOTES

*Interfaces
CHANGE: ``dirac-admin-add-host`` now inserts hosts into the ComponentMonitoring if the host is not yet known


ENDRELEASENOTES
