### PR TITLE
[v7r0] transformation scripts command line parsing, Components with underscores

### DIFF
--- a/FrameworkSystem/Client/ComponentInstaller.py
+++ b/FrameworkSystem/Client/ComponentInstaller.py
@@ -1130,7 +1130,7 @@ class ComponentInstaller(object):
 
         for cType in self.componentTypes:
           if body.find('dirac-%s' % (cType)) != -1:
-            system, compT = component.split('_')[0:2]
+            system, compT = component.split('_', 1)
             if system not in resultDict[resultIndexes[cType]]:
               resultDict[resultIndexes[cType]][system] = []
             resultDict[resultIndexes[cType]][system].append(compT)

--- a/TransformationSystem/scripts/dirac-transformation-archive.py
+++ b/TransformationSystem/scripts/dirac-transformation-archive.py
@@ -5,14 +5,14 @@
 from __future__ import print_function
 import sys
 
-from DIRAC.Core.Base.Script import parseCommandLine
+from DIRAC.Core.Base.Script import parseCommandLine, getPositionalArgs
 parseCommandLine()
 
-if len( sys.argv ) < 2:
+if not getPositionalArgs():
   print('Usage: dirac-transformation-archive transID [transID] [transID]')
   sys.exit()
 else:
-  transIDs = [int( arg ) for arg in sys.argv[1:]]
+  transIDs = [int(arg) for arg in getPositionalArgs()]
 
 from DIRAC.TransformationSystem.Agent.TransformationCleaningAgent     import TransformationCleaningAgent
 from DIRAC.TransformationSystem.Client.TransformationClient           import TransformationClient

--- a/TransformationSystem/scripts/dirac-transformation-clean.py
+++ b/TransformationSystem/scripts/dirac-transformation-clean.py
@@ -11,7 +11,7 @@ parseCommandLine()
 from DIRAC.TransformationSystem.Agent.TransformationCleaningAgent     import TransformationCleaningAgent
 from DIRAC.TransformationSystem.Client.TransformationClient         import TransformationClient
 
-if len( sys.argv ) < 2:
+if not getPositionalArgs():
   print('Usage: dirac-transformation-clean transID [transID] [transID]')
   sys.exit()
 else:

--- a/TransformationSystem/scripts/dirac-transformation-clean.py
+++ b/TransformationSystem/scripts/dirac-transformation-clean.py
@@ -5,7 +5,7 @@
 from __future__ import print_function
 import sys
 
-from DIRAC.Core.Base.Script import parseCommandLine
+from DIRAC.Core.Base.Script import parseCommandLine, getPositionalArgs
 parseCommandLine()
 
 from DIRAC.TransformationSystem.Agent.TransformationCleaningAgent     import TransformationCleaningAgent
@@ -15,8 +15,7 @@ if len( sys.argv ) < 2:
   print('Usage: dirac-transformation-clean transID [transID] [transID]')
   sys.exit()
 else:
-  transIDs = [int( arg ) for arg in sys.argv[1:]]
-
+  transIDs = [int(arg) for arg in getPositionalArgs()]
 
 agent = TransformationCleaningAgent( 'Transformation/TransformationCleaningAgent',
                                      'Transformation/TransformationCleaningAgent',

--- a/TransformationSystem/scripts/dirac-transformation-remove-output.py
+++ b/TransformationSystem/scripts/dirac-transformation-remove-output.py
@@ -5,14 +5,14 @@
 from __future__ import print_function
 import sys
 
-from DIRAC.Core.Base.Script import parseCommandLine
+from DIRAC.Core.Base.Script import parseCommandLine, getPositionalArgs
 parseCommandLine()
 
-if len( sys.argv ) < 2:
+if not getPositionalArgs():
   print('Usage: dirac-transformation-remove-output transID [transID] [transID]')
   sys.exit()
 else:
-  transIDs = [int( arg ) for arg in sys.argv[1:]]
+  transIDs = [int(arg) for arg in getPositionalArgs()]
 
 from DIRAC.TransformationSystem.Agent.TransformationCleaningAgent     import TransformationCleaningAgent
 from DIRAC.TransformationSystem.Client.TransformationClient           import TransformationClient

--- a/TransformationSystem/scripts/dirac-transformation-verify-outputdata.py
+++ b/TransformationSystem/scripts/dirac-transformation-verify-outputdata.py
@@ -5,14 +5,14 @@
 from __future__ import print_function
 import sys
 
-from DIRAC.Core.Base.Script import parseCommandLine
+from DIRAC.Core.Base.Script import parseCommandLine, getPositionalArgs
 parseCommandLine()
 
-if len( sys.argv ) < 2:
+if not getPositionalArgs():
   print('Usage: dirac-transformation-verify-outputdata transID [transID] [transID]')
   sys.exit()
 else:
-  transIDs = [int( arg ) for arg in sys.argv[1:]]
+  transIDs = [int(arg) for arg in getPositionalArgs()]
 
 from DIRAC.TransformationSystem.Agent.ValidateOutputDataAgent       import ValidateOutputDataAgent
 from DIRAC.TransformationSystem.Client.TransformationClient         import TransformationClient


### PR DESCRIPTION
 ComponentInstaller: allow underscores in installed components

The previous split would drop things after an underscore in the installed components name (e.g., Bdii2CSAgent_GLUE2), this leads to bad displays and log file displaying in the webapp SystemAdministrator. (Show Errors -> Show Log fails to find log file)

I am not sure if this change affects anyone negatively? Maybe somewhere something other then SystemName_ComponentName would be in the startup directory, where superfluous characters need to be dropped, or they should be ignored?




BEGINRELEASENOTES

*Framework
FIX: ComponentInstaller did not allow having underscores in the IntanceNames affecting the WebApp SystemAdministrator log file display via show errors -> show log

*TS
FIX: fix parsing of command line flags (e.g., -ddd) for dirac-transformation-archive/clean/remove-output/verify-outputdata

ENDRELEASENOTES
