### PR TITLE
[v6r22] Fix getRequestCountersWeb error in DIRACOS

### DIFF
--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -688,7 +688,7 @@ class RequestDB( object ):
           else:
             summaryQuery = summaryQuery.filter( eval( '%s.%s' % ( objectType, key ) ) == value )
 
-      summaryQuery = summaryQuery.group_by( groupingAttribute )
+      summaryQuery = summaryQuery.group_by( eval(groupingAttribute ) )
 
       try:
         requestLists = summaryQuery.all()


### PR DESCRIPTION

On DIRAC v6r22, RequestDB.getRequestCountersWeb works with lcgBundles v14r11 while shows following error when switched to DIRACOS v1r3:

`( \'Error getting the webCounters %s\' % e )\n'], 'Message': u"Error getting the webCounters Can't resolve label reference for ORDER BY / GROUP BY. Textual SQL expression 'Operation.Type' should be explicitly declared as text('Operation.Type')`

Supposed due to different versions of sql alchemy.
This PR enables the function to work with both environment.

BEGINRELEASENOTES
*RMS
FIX: fix getRequestCountersWeb error in DIRACOS
ENDRELEASENOTES
