### PR TITLE
WIP - updating the getCEState to be GLUE2 compliant

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -30,7 +30,7 @@ from DIRAC.Resources.Computing.ComputingElement import ComputingElement
 # arc.Logger_getRootLogger().setThreshold(arc.VERBOSE)
 
 CE_NAME = 'ARC'
-MANDATORY_PARAMETERS = ['Queue']  # Probably not mandatory for ARC CEs
+MANDATORY_PARAMETERS = ['Queue']  # Mandatory for ARC CEs in GLUE2?
 
 
 class ARCComputingElement(ComputingElement):
@@ -334,9 +334,19 @@ class ARCComputingElement(ComputingElement):
     else:
       # The system which works properly at present for ARC CEs that are configured correctly.
       # But for this we need the VO to be known - ask me (Raja) for the whole story if interested.
-      cmd = 'ldapsearch -x -LLL -H ldap://%s:2135 -b mds-vo-name=resource,o=grid "(GlueVOViewLocalID=%s)"' % (
-          self.ceHost, vo.lower())
-      res = shellCall(0, cmd)
+      # cmd = 'ldapsearch -x -LLL -H ldap://%s:2135 -b mds-vo-name=resource,o=grid "(GlueVOViewLocalID=%s)"' % (
+      #     self.ceHost, vo.lower())
+      cmd1 = 'ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135  -b \'o=glue\' "(&(objectClass=GLUE2MappingPolicy)(GLUE2PolicyRule=vo:%s))"' % (self.ceHost, vo.lower())
+      if self.queue:
+        cmd2 = ' | grep GLUE2MappingPolicyShareForeignKey | grep %s' % (self.queue)
+      else:
+        gLogger.error('ARCComputingElement: No queue ...')
+      cmd3 = ' | sed \'s/GLUE2MappingPolicyShareForeignKey: /GLUE2ShareID=/\' | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135 -b \'o=glue\'  | egrep \'(ShareWaiting|ShareRunning)\'' % (self.ceHost)
+      if self.cmd2 :
+        res = shellCall(0, cmd1 + cmd2 + cmd3)
+      else:
+        res = S_ERROR('Unknown queue (%s) failure for site %s' % (self.queue, self.ceHost))
+        return res
       if not res['OK']:
         gLogger.debug("Could not query CE %s - is it down?" % self.ceHost)
         return res


### PR DESCRIPTION

BEGINRELEASENOTES

This is a WIP as I realise that my 2FA for aiadm is no longer valid (new phone) and I cannot test this out on the certification instance.

This is a change to enable GLUE2 queries on ARC CEs, which is now strongly recommended as GLUE1 publishing is stopped in ARC6.

ENDRELEASENOTES
