### PR TITLE
[v7r0] Updating the getCEState to be GLUE2 compliant - take 3

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -342,12 +342,13 @@ class ARCComputingElement(ComputingElement):
         gLogger.error('ARCComputingElement: No queue ...')
         res = S_ERROR('Unknown queue (%s) failure for site %s' % (self.queue, self.ceHost))
         return res
-      cmd1 = 'ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135  -b \'o=glue\' "(&(objectClass=GLUE2MappingPolicy)(GLUE2PolicyRule=vo:%s))"' \
-         % (self.ceHost, vo.lower())
-      cmd2 = ' | grep GLUE2MappingPolicyShareForeignKey | grep %s' % (self.queue.split("-")[-1])
-      cmd3 = ' | sed \'s/GLUE2MappingPolicyShareForeignKey: /GLUE2ShareID=/\' | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135 -b \'o=glue\' ' \
-         ' | egrep \'(ShareWaiting|ShareRunning)\'' % (self.ceHost)
-      res = shellCall(0, cmd1 + cmd2 + cmd3)
+      cmd1 = "ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135  -b \'o=glue\' " % self.ceHost
+      cmd2 = '"(&(objectClass=GLUE2MappingPolicy)(GLUE2PolicyRule=vo:%s))"' % vo.lower()
+      cmd3 = ' | grep GLUE2MappingPolicyShareForeignKey | grep %s' % (self.queue.split("-")[-1])
+      cmd4 = ' | sed \'s/GLUE2MappingPolicyShareForeignKey: /GLUE2ShareID=/\' '
+      cmd5 = ' | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135 -b \'o=glue\' ' % self.ceHost
+      cmd6 = ' | egrep \'(ShareWaiting|ShareRunning)\''
+      res = shellCall(0, cmd1 + cmd2 + cmd3 + cmd4 + cmd5 + cmd6)
       if not res['OK']:
         gLogger.debug("Could not query CE %s - is it down?" % self.ceHost)
         return res

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -343,7 +343,7 @@ class ARCComputingElement(ComputingElement):
         res = S_ERROR('Unknown queue (%s) failure for site %s' % (self.queue, self.ceHost))
         return res
       cmd1 = 'ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135  -b \'o=glue\' "(&(objectClass=GLUE2MappingPolicy)(GLUE2PolicyRule=vo:%s))"' % (self.ceHost, vo.lower())
-      cmd2 = ' | grep GLUE2MappingPolicyShareForeignKey | grep %s' % (self.queue)
+      cmd2 = ' | grep GLUE2MappingPolicyShareForeignKey | grep %s' % (self.queue.split("-")[-1])
       cmd3 = ' | sed \'s/GLUE2MappingPolicyShareForeignKey: /GLUE2ShareID=/\' | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135 -b \'o=glue\'  | egrep \'(ShareWaiting|ShareRunning)\'' % (self.ceHost)
       res = shellCall(0, cmd1 + cmd2 + cmd3)
       if not res['OK']:

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -345,7 +345,7 @@ class ARCComputingElement(ComputingElement):
       cmd1 = 'ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135  -b \'o=glue\' "(&(objectClass=GLUE2MappingPolicy)(GLUE2PolicyRule=vo:%s))"' \
          % (self.ceHost, vo.lower())
       cmd2 = ' | grep GLUE2MappingPolicyShareForeignKey | grep %s' % (self.queue.split("-")[-1])
-      cmd3 = ' | sed \'s/GLUE2MappingPolicyShareForeignKey: /GLUE2ShareID=/\' | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135 -b \'o=glue\' '
+      cmd3 = ' | sed \'s/GLUE2MappingPolicyShareForeignKey: /GLUE2ShareID=/\' | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135 -b \'o=glue\' ' \
          ' | egrep \'(ShareWaiting|ShareRunning)\'' % (self.ceHost)
       res = shellCall(0, cmd1 + cmd2 + cmd3)
       if not res['OK']:

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -351,8 +351,8 @@ class ARCComputingElement(ComputingElement):
         return res
       try:
         ldapValues = res['Value'][1].split("\n")
-        running = [lValue for lValue in ldapValues if 'GlueCEStateRunningJobs' in lValue]
-        waiting = [lValue for lValue in ldapValues if 'GlueCEStateWaitingJobs' in lValue]
+        running = [lValue for lValue in ldapValues if 'GLUE2ComputingShareRunningJobs' in lValue]
+        waiting = [lValue for lValue in ldapValues if 'GLUE2ComputingShareWaitingJobs' in lValue]
         result['RunningJobs'] = int(running[0].split(":")[1])
         result['WaitingJobs'] = int(waiting[0].split(":")[1])
       except IndexError:

--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -342,9 +342,11 @@ class ARCComputingElement(ComputingElement):
         gLogger.error('ARCComputingElement: No queue ...')
         res = S_ERROR('Unknown queue (%s) failure for site %s' % (self.queue, self.ceHost))
         return res
-      cmd1 = 'ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135  -b \'o=glue\' "(&(objectClass=GLUE2MappingPolicy)(GLUE2PolicyRule=vo:%s))"' % (self.ceHost, vo.lower())
+      cmd1 = 'ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135  -b \'o=glue\' "(&(objectClass=GLUE2MappingPolicy)(GLUE2PolicyRule=vo:%s))"' \
+         % (self.ceHost, vo.lower())
       cmd2 = ' | grep GLUE2MappingPolicyShareForeignKey | grep %s' % (self.queue.split("-")[-1])
-      cmd3 = ' | sed \'s/GLUE2MappingPolicyShareForeignKey: /GLUE2ShareID=/\' | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135 -b \'o=glue\'  | egrep \'(ShareWaiting|ShareRunning)\'' % (self.ceHost)
+      cmd3 = ' | sed \'s/GLUE2MappingPolicyShareForeignKey: /GLUE2ShareID=/\' | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135 -b \'o=glue\' '
+         ' | egrep \'(ShareWaiting|ShareRunning)\'' % (self.ceHost)
       res = shellCall(0, cmd1 + cmd2 + cmd3)
       if not res['OK']:
         gLogger.debug("Could not query CE %s - is it down?" % self.ceHost)


### PR DESCRIPTION
This is a WIP as the certification instance is still not properly up and I do not know if the code actually works (my custom printout has not yet triggered). This replaces PR #4658 and PR #4659

BEGINRELEASENOTES

*Resources
CHANGE: ArcCE: This is a change to enable GLUE2 queries on ARC CEs, which is now strongly recommended as GLUE1 publishing is stopped in ARC6.

ENDRELEASENOTES