### PR TITLE
[integration] added example of DIRAC_NO_CFG into bashrc

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2214,7 +2214,8 @@ def createBashrc():
       lines.append('# export DIRAC_USE_M2CRYPTO=true')
       lines.append('# export DIRAC_USE_NEWTHREADPOOL=yes')
       lines.append('# export DIRAC_VOMSES=$DIRAC/etc/grid-security/vomses')
-
+      lines.append('# export DIRAC_NO_CFG=true')
+      
       lines.append('')
       f = open(bashrcFile, 'w')
       f.write('\n'.join(lines))

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2215,7 +2215,6 @@ def createBashrc():
       lines.append('# export DIRAC_USE_NEWTHREADPOOL=yes')
       lines.append('# export DIRAC_VOMSES=$DIRAC/etc/grid-security/vomses')
       lines.append('# export DIRAC_NO_CFG=true')
-      
       lines.append('')
       f = open(bashrcFile, 'w')
       f.write('\n'.join(lines))


### PR DESCRIPTION

BEGINRELEASENOTES
*Core
CHANGE: Add an example for DIRAC_NO_CFG to bashrc.
ENDRELEASENOTES
