### PR TITLE
[v7r1] DownloadInputData improvements

### DIFF
--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -244,14 +244,15 @@ class DownloadInputData:
     availableBytes = diskSpace * 1024 * 1024  # bytes
     # below can be a configuration option sent via the job wrapper in the future
     # Moved from 3 to 5 GB (PhC 130822) for standard output file
-    data = 5 * 1024 * 1024 * 1024  # 5GB in bytes
+    bufferGBs = 5.0
+    data = bufferGBs * 1024 * 1024 * 1024  # bufferGBs in bytes
     if (data + totalSize) < availableBytes:
       msg = 'Enough disk space available (%s bytes)' % (availableBytes)
       self.log.verbose(msg)
       return S_OK(msg)
     else:
-      msg = 'Not enough disk space available for download %s (including 3GB buffer) > %s bytes' \
-          % ((data + totalSize), availableBytes)
+      msg = 'Not enough disk space available for download %s (including %dGB buffer) > %s bytes' \
+          % ((data + totalSize), bufferGBs, availableBytes)
       self.log.warn(msg)
       return S_ERROR(msg)
 

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -310,16 +310,11 @@ class DownloadInputData(object):
         return S_OK(fileDict)
 
     localFile = os.path.join(downloadDir, fileName)
-    result = StorageElement(seName).getFile(lfn, localPath=downloadDir)
+    result = returnSingleResult(StorageElement(seName).getFile(lfn, localPath=downloadDir))
     if not result['OK']:
       self.log.warn('Problem getting lfn', '%s from %s:\n%s' % (lfn, seName, result['Message']))
+      self.__cleanFailedFile(lfn, downloadDir)
       return result
-    if lfn in result['Value']['Failed']:
-      self.log.warn('Problem getting lfn', '%s from %s:\n%s' % (lfn, seName, result['Value']['Failed'][lfn]))
-      return S_ERROR(result['Value']['Failed'][lfn])
-    if lfn not in result['Value']['Successful']:
-      self.log.warn("%s got from %s not in Failed nor Successful???\n" % (lfn, seName))
-      return S_ERROR("Return from StorageElement.getFile() incomplete")
 
     if os.path.exists(localFile):
       self.log.verbose("File successfully downloaded locally", "(%s to %s)" % (lfn, localFile))
@@ -347,5 +342,16 @@ class DownloadInputData(object):
       self.log.warn("Failed to set job parameters", jobParam['Message'])
 
     return jobParam
+
+  def __cleanFailedFile(self, lfn, downloadDir):
+    """ Try to remove a file after a failed download attempt """
+    filePath = os.path.join(downloadDir, os.path.basename(lfn))
+    self.log.info("Trying to remove file after failed download", "Local path: %s " % filePath)
+    if os.path.exists(filePath):
+      try:
+        os.remove(filePath)
+        self.log.info("Removed file remnant after failed download", "Local path: %s " % filePath)
+      except OSError as e:
+        self.log.info("Failed to remove file after failed download", repr(e))
 
 # EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -18,18 +18,17 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.WorkloadManagementSystem.Client.JobStateUpdateClient import JobStateUpdateClient
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.Core.Utilities.Os import getDiskSpace
+from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 
 COMPONENT_NAME = 'DownloadInputData'
 
 
 def _isCached(lfn, seName):
-  result = StorageElement(seName).getFileMetadata(lfn)
+  result = returnSingleResult(StorageElement(seName).getFileMetadata(lfn))
   if not result['OK']:
     return False
-  if lfn in result['Value']['Failed']:
-    return False
-  metadata = result['Value']['Successful'][lfn]
+  metadata = result['Value']
   return metadata.get('Cached', metadata['Accessible'])
 
 

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -91,11 +91,11 @@ class DownloadInputData(object):
         failedReplicas.add(lfn)
         continue
 
-      # Get and remove size and GUIS
+      # Get and remove size and GUID
       size = reps.pop('Size')
       guid = reps.pop('GUID')
       # Remove all other items that are not SEs
-      for item in reps.keys():
+      for item in list(reps):  # note the pop below
         if item not in self.availableSEs:
           reps.pop(item)
       downloadReplicas[lfn] = {'SE': [], 'Size': size, 'GUID': guid}
@@ -124,7 +124,6 @@ class DownloadInputData(object):
         if len(reps['SE']) > 1:
           # if more than one SE is available randomly select one
           random.shuffle(reps['SE'])
-        # get SE and pfn from tuple
         reps['SE'] = reps['SE'][0]
       totalSize += int(reps.get('Size', 0))
       if verbose:

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -143,6 +143,7 @@ class DownloadInputData(object):
       self.log.warn('Problem checking available disk space:\n%s' % (result))
       return result
 
+    # FIXME: this can never happen at the moment
     if not result['Value']:
       self.log.warn("Not enough disk space available for download",
                     "%s / %s bytes" % (result['Value'], totalSize))

--- a/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -32,7 +32,7 @@ def _isCached(lfn, seName):
   return metadata.get('Cached', metadata['Accessible'])
 
 
-class DownloadInputData:
+class DownloadInputData(object):
   """
    retrieve InputData LFN from localSEs (if available) or from elsewhere.
   """

--- a/WorkloadManagementSystem/Client/test/Test_Client_DownloadInputData.py
+++ b/WorkloadManagementSystem/Client/test/Test_Client_DownloadInputData.py
@@ -1,0 +1,234 @@
+"""Test for WMS clients."""
+# pylint: disable=protected-access, missing-docstring, invalid-name, line-too-long
+
+from __future__ import print_function
+import pytest
+
+from mock import MagicMock
+
+from DIRAC import S_OK, S_ERROR
+from DIRAC.WorkloadManagementSystem.Client.DownloadInputData import DownloadInputData
+
+MODULE_NAME = 'DIRAC.WorkloadManagementSystem.Client.DownloadInputData'
+
+# pylint: disable=redefined-outer-name, unused-argument
+
+
+@pytest.fixture(autouse=True)
+def setUpLogger():
+  from DIRAC import gLogger
+  gLogger.setLevel('DEBUG')
+
+
+@pytest.fixture
+def mockSE(mocker):
+  mockObjectSE = MagicMock()
+  mockObjectSE.getFileMetadata.return_value = S_OK({'Successful': {'/a/lfn/1.txt': {'Cached': 1, 'Accessible': 1}},
+                                                    'Failed': {}})
+  mockObjectSE.getFile.return_value = S_OK({'Successful': {'/a/lfn/1.txt': {}}, 'Failed': {}})
+  mockObjectSE.getStatus.return_value = S_OK({'Read': True, 'DiskSE': True})
+  mockObjectSE.status.return_value = {'Read': True, 'DiskSE': True}
+
+  theMockSE = MagicMock()
+  theMockSE.return_value = mockObjectSE
+  mocker.patch(MODULE_NAME + '.StorageElement', new=theMockSE)
+  return theMockSE
+
+
+@pytest.fixture
+def dli():
+  theDLI = DownloadInputData({'InputData': [],
+                              'Configuration': {'LocalSEList': ['SE_Local']},
+                              'InputDataDirectory': 'CWD',
+                              'FileCatalog': S_OK({'Successful': {'/a/lfn/1.txt': {'Size': 10,
+                                                                                   'GUID': 'aGUID',
+                                                                                   'SE_Local': '',
+                                                                                   'SE_Remote': '',
+                                                                                   'SE_Bad': '',
+                                                                                   'SE_Tape': '',
+                                                                                   }}})})
+  theDLI.availableSEs = ['SE_Local', 'SE_Remote']
+  return theDLI
+
+
+@pytest.fixture
+def osPathExists(mocker):
+  osPathMock = MagicMock(return_value=True)
+  mocker.patch('%s.os.path.exists' % MODULE_NAME, new=osPathMock)
+  return osPathMock
+
+
+def test_DLIDownloadFromSE_fail(dli, mockSE, osPathExists):
+  osPathExists.return_value = False
+  res = dli._downloadFromSE('/a/lfn/1.txt', 'mySE', {'mySE': []}, 'aGuid')
+  assert not res['OK']
+
+
+def test_DLIDownloadFromSE_local(dli, mockSE, osPathExists):
+  res = dli._downloadFromSE('/a/lfn/1.txt', 'mySE', {'mySE': []}, 'aGuid')
+  assert res['OK'], res
+  assert res['Value']['protocol'] == 'LocalData'
+
+
+def test_DLIDownloadFromSE_realDown(dli, mockSE, osPathExists):
+  osPathExists.side_effect = (False, False, True)
+  res = dli._downloadFromSE('/a/lfn/1.txt', 'mySE', {'mySE': []}, 'aGuid')
+  assert res['OK'], res.get('Message', 'No Error')
+  assert res['Value']['protocol'] == 'Downloaded'
+  assert 'path' in res['Value']
+  assert res['Value']['path'].endswith('1.txt')
+
+
+def test_DLIDownloadFromSE_realDown_Fail(dli, mockSE, osPathExists):
+  mockObjectSE = mockSE.return_value
+  mockObjectSE.getFile.return_value = S_OK({'Successful': {},
+                                            'Failed': {'/a/lfn/1.txt': {}}})
+  mockObjectSE.getStatus.return_value = S_OK({'Read': True, 'DiskSE': True})
+
+  osPathExists.return_value = False
+  res = dli._downloadFromSE('/a/lfn/1.txt', 'mySE', {'mySE': []}, 'aGuid')
+  assert not res['OK'], res.get('Message', 'No Error')
+
+
+def test_DLIDownloadFromBestSE_isLocal(dli, mockSE, osPathExists):
+  res = dli._downloadFromBestSE('/a/lfn/1.txt', {'mySE': []}, 'aGuid')
+  assert res['OK'], res.get('Message', 'No error')
+  assert res['Value']['protocol'] == 'LocalData'
+
+
+def test_DLIDownloadFromBestSE_Fail(dli, mockSE, osPathExists):
+  osPathExists.return_value = False
+  res = dli._downloadFromBestSE('/a/lfn/1.txt', {'mySE': []}, 'aGuid')
+  assert not res['OK']
+
+
+def test_DLI_execute(dli, mockSE):
+  dli._downloadFromSE = MagicMock(return_value=S_OK({'path': '/local/path/1.txt'}))
+  res = dli.execute(dataToResolve=['/a/lfn/1.txt'])
+  assert res['OK']
+  assert not res['Value']['Failed']
+  assert '/a/lfn/1.txt' in res['Value']['Successful'], res
+
+
+def test_DLI_execute_getFileMetadata_Fails(dli, mockSE):
+  """When getFileMetadata fails for the first SE, we should fall back to the second."""
+  mockObjectSE = mockSE.return_value
+  mockObjectSE.getFileMetadata.return_value = S_OK({'Successful': {},
+                                                    'Failed': {'/a/lfn/1.txt': 'Error Getting MetaData'}})
+
+  dli._downloadFromSE = MagicMock(return_value=S_OK({'path': '/local/path/1.txt'}))
+  dli._isCache = MagicMock(return_value=True)
+  res = dli.execute(dataToResolve=['/a/lfn/1.txt'])
+  assert res['OK']
+  assert not res['Value']['Failed']
+  assert '/a/lfn/1.txt' in res['Value']['Successful'], res
+  assert res['Value']['Successful']['/a/lfn/1.txt']['path'] == '/local/path/1.txt', res
+
+
+def test_DLI_execute_getFileMetadata_Lost(dli, mockSE):
+  """When getFileMetadata fails for the first SE, we should fall back to the second."""
+  mockObjectSE = mockSE.return_value
+  mockObjectSE.getFileMetadata.return_value = S_OK({'Successful':
+                                                    {'/a/lfn/1.txt':
+                                                     {'Cached': 1, 'Accessible': 0,
+                                                      'Lost': True,
+                                                      }},
+                                                    'Failed': {}})
+  dli._downloadFromSE = MagicMock(return_value=S_OK({'path': '/local/path/1.txt'}))
+  dli._isCache = MagicMock(return_value=True)
+  res = dli.execute(dataToResolve=['/a/lfn/1.txt'])
+  assert res['OK']
+  assert not res['Value']['Failed']
+  assert '/a/lfn/1.txt' in res['Value']['Successful'], res
+  assert res['Value']['Successful']['/a/lfn/1.txt']['path'] == '/local/path/1.txt', res
+
+
+def test_DLI_execute_getFileMetadata_Unavailable(dli, mockSE):
+  """When getFileMetadata fails for the first SE, we should fall back to the second."""
+  mockObjectSE = mockSE.return_value
+  mockObjectSE.getFileMetadata.return_value = S_OK({'Successful':
+                                                    {'/a/lfn/1.txt':
+                                                     {'Cached': 0, 'Accessible': 0,
+                                                      'Unavailable': True,
+                                                      }},
+                                                    'Failed': {}})
+  dli._downloadFromSE = MagicMock(return_value=S_OK({'path': '/local/path/1.txt'}))
+  dli._isCache = MagicMock(return_value=True)
+  res = dli.execute(dataToResolve=['/a/lfn/1.txt'])
+  assert res['OK']
+  assert not res['Value']['Failed']
+  assert '/a/lfn/1.txt' in res['Value']['Successful'], res
+  assert res['Value']['Successful']['/a/lfn/1.txt']['path'] == '/local/path/1.txt', res
+
+
+def test_DLI_execute_getFileMetadata_Cached(dli, mockSE):
+  """When getFileMetadata fails for the first SE, we should fall back to the second."""
+  mockObjectSE = mockSE.return_value
+  mockObjectSE.getFileMetadata.return_value = S_OK({'Successful':
+                                                    {'/a/lfn/1.txt':
+                                                     {'Cached': 0, 'Accessible': 0,
+                                                      'Unavailable': False,
+                                                      }},
+                                                    'Failed': {}})
+  dli._downloadFromSE = MagicMock(return_value=S_OK({'path': '/local/path/1.txt'}))
+  dli._isCache = MagicMock(return_value=True)
+  res = dli.execute(dataToResolve=['/a/lfn/1.txt'])
+  assert res['OK']
+  assert not res['Value']['Failed']
+  assert '/a/lfn/1.txt' in res['Value']['Successful'], res
+  assert res['Value']['Successful']['/a/lfn/1.txt']['path'] == '/local/path/1.txt', res
+
+
+def test_DLI_execute_FirstDownFailed(dli, mockSE):
+  """When getFileMetadata fails for the first SE, we should fall back to the second."""
+  mockObjectSE = mockSE.return_value
+  mockObjectSE.getFileMetadata.return_value = S_OK({'Successful':
+                                                    {'/a/lfn/1.txt': {'Cached': 1, 'Accessible': 0}},
+                                                    'Failed': {}})
+  dli._downloadFromSE = MagicMock(side_effect=[S_ERROR('Failed to down'),
+                                               S_OK({'path': '/local/path/1.txt'})])
+  dli._isCache = MagicMock(return_value=True)
+  res = dli.execute(dataToResolve=['/a/lfn/1.txt'])
+  assert res['OK']
+  assert not res['Value']['Failed']
+  assert '/a/lfn/1.txt' in res['Value']['Successful'], res
+  assert res['Value']['Successful']['/a/lfn/1.txt']['path'] == '/local/path/1.txt', res
+
+
+def test_DLI_execute_AllDownFailed(dli, mockSE):
+  """When getFileMetadata fails for the first SE, we should fall back to the second."""
+  mockObjectSE = mockSE.return_value
+  mockObjectSE.getFileMetadata.return_value = S_OK({'Successful':
+                                                    {'/a/lfn/1.txt': {'Cached': 1, 'Accessible': 0}},
+                                                    'Failed': {}})
+  dli._downloadFromSE = MagicMock(return_value=S_ERROR('Failed to down'))
+  dli._isCache = MagicMock(return_value=True)
+  res = dli.execute(dataToResolve=['/a/lfn/1.txt'])
+  assert res['OK']
+  assert res['Value']['Failed']
+  assert '/a/lfn/1.txt' in res['Value']['Failed'], res
+  assert res['Value']['Failed'][0] == '/a/lfn/1.txt', res
+
+
+def test_DLI_execute_NoLocal(dli, mockSE):
+  """Data only at the remote SE."""
+  dli = DownloadInputData({'InputData': [],
+                           'Configuration': {'LocalSEList': ['SE_Local', 'SE_Tape']},
+                           'InputDataDirectory': 'CWD',
+                           'FileCatalog':
+                           S_OK({'Successful': {'/a/lfn/1.txt': {'Size': 10, 'GUID': 'aGUID',
+                                                                 'SE_Tape': '',
+                                                                 }}})})
+  dli.availableSEs = ['SE_Local', 'SE_Remote', 'SE_Tape']
+  mockObjectSE = mockSE.return_value
+  statDict = {'Read': True, 'TapeSE': True, 'DiskSE': False}
+  mockObjectSE.getStatus.return_value = S_OK(statDict)
+  mockObjectSE.status.return_value = statDict
+  dli._downloadFromSE = MagicMock(return_value=S_ERROR('Failed to down'))
+  dli._isCache = MagicMock(return_value=True)
+
+  res = dli.execute(dataToResolve=['/a/lfn/1.txt'])
+  assert res['OK']
+  assert res['Value']['Failed']
+  assert '/a/lfn/1.txt' in res['Value']['Failed'], res
+  assert res['Value']['Failed'][0] == '/a/lfn/1.txt', res

--- a/WorkloadManagementSystem/Client/test/Test_Client_WorkloadManagementSystem.py
+++ b/WorkloadManagementSystem/Client/test/Test_Client_WorkloadManagementSystem.py
@@ -10,9 +10,6 @@ import StringIO
 
 from mock import MagicMock
 
-from DIRAC.DataManagementSystem.Client.test.mock_DM import dm_mock
-from DIRAC import S_OK
-from DIRAC.WorkloadManagementSystem.Client.DownloadInputData import DownloadInputData
 from DIRAC.WorkloadManagementSystem.Client.Matcher import Matcher
 from DIRAC.WorkloadManagementSystem.Client.SandboxStoreClient import SandboxStoreClient
 
@@ -25,24 +22,6 @@ class ClientsTestCase(unittest.TestCase):
 
     from DIRAC import gLogger
     gLogger.setLevel('DEBUG')
-
-    self.mockDM = MagicMock()
-    self.mockDM.return_value = dm_mock
-
-    mockObjectSE = MagicMock()
-    mockObjectSE.getFileMetadata.return_value = S_OK({'Successful': {'/a/lfn/1.txt': {'Cached': 0},
-                                                                     '/a/lfn/2.txt': {'Cached': 1}},
-                                                      'Failed': {}})
-    mockObjectSE.getFile.return_value = S_OK({'Successful': {'/a/lfn/1.txt': {}},
-                                              'Failed': {}})
-    mockObjectSE.getStatus.return_value = S_OK({'Read': True, 'DiskSE': True})
-
-    self.mockSE = MagicMock()
-    self.mockSE.return_value = mockObjectSE
-
-    self.dli = DownloadInputData({'InputData': [],
-                                  'Configuration': 'boh',
-                                  'FileCatalog': S_OK({'Successful': []})})
 
     self.pilotAgentsDBMock = MagicMock()
     self.jobDBMock = MagicMock()
@@ -64,46 +43,6 @@ class ClientsTestCase(unittest.TestCase):
 
 #############################################################################
 
-
-class DownloadInputDataSuccess(ClientsTestCase):
-
-  def test_DLIDownloadFromSE(self):
-    ourDLI = importlib.import_module('DIRAC.WorkloadManagementSystem.Client.DownloadInputData')
-    ourDLI.StorageElement = self.mockSE
-
-    res = self.dli._downloadFromSE('/a/lfn/1.txt', 'mySE', {'mySE': []}, 'aGuid')
-    # file won't exist at this point
-    self.assertFalse(res['OK'])
-
-    open('1.txt', 'w').close()
-    res = self.dli._downloadFromSE('/a/lfn/1.txt', 'mySE', {'mySE': []}, 'aGuid')
-    # file would be already local, so no real download
-    self.assertTrue(res['OK'])
-    try:
-      os.remove('1.txt')
-    except OSError:
-      pass
-
-    # I can't figure out how to simulate a real download here
-
-  def test_DLIDownloadFromBestSE(self):
-    ourDLI = importlib.import_module('DIRAC.WorkloadManagementSystem.Client.DownloadInputData')
-    ourDLI.StorageElement = self.mockSE
-
-    res = self.dli._downloadFromBestSE('/a/lfn/1.txt', {'mySE': []}, 'aGuid')
-    # file won't exist at this point
-    self.assertFalse(res['OK'])
-
-    open('1.txt', 'w').close()
-    res = self.dli._downloadFromBestSE('/a/lfn/1.txt', {'mySE': []}, 'aGuid')
-    # file would be already local, so no real download
-    self.assertTrue(res['OK'])
-    try:
-      os.remove('1.txt')
-    except OSError:
-      pass
-
-#############################################################################
 
 
 class MatcherTestCase(ClientsTestCase):
@@ -170,7 +109,6 @@ class SandboxStoreTestCaseSuccess(ClientsTestCase):
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase(ClientsTestCase)
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(MatcherTestCase))
-  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(DownloadInputDataSuccess))
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(SandboxStoreTestCaseSuccess))
   testResult = unittest.TextTestRunner(verbosity=2).run(suite)
 


### PR DESCRIPTION
This PR contains some simplifications for the DownloadInputData module by using `returnSingleResult`, and some changes in behaviour.

- [x] If getFileMetadata fails, the lfn is no longer ignored, but instead other potential SEs are tried to for downloading. I think this approach is more sensible, because if the download fails for the first SE the other SEs are also tried.
  - [ ] One could add these metadata checks also for the other SEs, but would they matter? the `cached` status is checked in any case

- [x] Added a cleanup after failed downloads, in case some partial file is present, this would otherwise prevent downloads

I use a copy of this in iLCDirac. I started on v7r0, but there should be certification for this maybe? I also added unit tests


BEGINRELEASENOTES

*WMS
CHANGE: DownloadInputData no longer fails if ``getFileMetadata`` fails for the first SE, tries others if available

ENDRELEASENOTES
