### PR TITLE
[v7r1] SEManager: refresh SEs in getSEName if SE not found

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
@@ -116,8 +116,23 @@ class SEManagerDB(SEManagerBase):
     return self.getSEID(seName)
 
   def getSEName(self, seID):
-    if seID in self.db.seids.keys():
+    """Return the name of the SE.
+
+    Refresh list of SEs if not found, an SE might have been added by a different FileCatalog instance.
+
+    :param int seID: ID of a storage element
+    :return: S_OK/S_ERROR
+    """
+    if seID in self.db.seids:
       return S_OK(self.db.seids[seID])
+    gLogger.info("getSEName: seID not found, refreshing", "ID: %s" % seID)
+    result = self._refreshSEs(connection=False)
+    if not result['OK']:
+      gLogger.error("getSEName: refreshing failed", result['Message'])
+      return result
+    if seID in self.db.seids:
+      return S_OK(self.db.seids[seID])
+    gLogger.error("getSEName: seID not found after refreshing", "ID: %s" % seID)
     return S_ERROR('SE id %d not found' % seID)
 
   def deleteSE(self, seName, force=True):


### PR DESCRIPTION
See this https://github.com/DIRACGrid/DIRAC/issues/4653#issuecomment-658633588 for the problem that is solved with this PR

Targeting v7r1 because of refactoring of FC components, this also affects v6r22 and v7r0

BEGINRELEASENOTES

*DMS
FIX: Fix problem where a FileCatalog instance was not aware of SEs added by a different instance. SEManager.getSEName now refreshes if an seID is not known. Fixes #4653

ENDRELEASENOTES
