### PR TITLE
[v7r0] Fix installation of m2crypto in the CI's conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,9 @@
 name: dirac-development
 
 channels:
+  - diracgrid
   - conda-forge
+  - defaults
 
 dependencies:
   # runtime
@@ -15,9 +17,9 @@ dependencies:
   - fts-rest
   - future
   - gitpython >=2.1.0
-  #- m2crypto >=0.36  # 0.36 does not have a conda package yet, so go with pip in the meantime
+  - m2crypto >=0.36  # 0.36 does not have a conda package yet, so go with pip in the meantime
   - matplotlib >=2.1.0,<3.0
-  - mysql-connector-c  # Included as it's a dependency of MySQL-python which is installed with pip
+  - mysql-python
   - numpy >=1.10.1,<1.16  # Limit to 1.15 as Python 2 pylint has bugs with numpy 1.16
   - pexpect >=4.0.1
   - pillow
@@ -60,6 +62,3 @@ dependencies:
   - simplejson >=3.8.1
   - tornado >=5.0.0,<6.0.0
   - typing >=3.6.6
-  - pip:
-    - MySQL-python
-    - M2Crypto>=0.36

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - fts-rest
   - future
   - gitpython >=2.1.0
-  - m2crypto >=0.36  # 0.36 does not have a conda package yet, so go with pip in the meantime
+  - m2crypto >=0.36
   - matplotlib >=2.1.0,<3.0
   - mysql-python
   - numpy >=1.10.1,<1.16  # Limit to 1.15 as Python 2 pylint has bugs with numpy 1.16


### PR DESCRIPTION
Fixes the M2Crypto installation inside the "basic" CI tests by uploading new build to a `diracgrid` channel on anaconda.org:

https://anaconda.org/diracgrid/m2crypto

This is needed because of DIRAC v7r0 and v7r1 needs to be able to use OpenSSL 1.0.2 which hasn't been supported by conda-forge for a long time. I'm currently writing documentation about how it was generated which will be useful for DIRACOS v2 (I hope we don't use this mechanism very often, but it will be useful to have).

The issue with the pip build is that:
* swig needs to be reran to compile the M2Crypto binaries successfully
* M2Crypto hard codes `/usr/include/openssl` by default
* It's tricky to pass the flag needed to change the base directory of the desired OpenSSL installation

It could be hacked by making the `environment.yaml` file a mess, but I think this is better.