### PR TITLE
[v7r0] Glue2: fix problem for ARC CEs without execution environments

### DIFF
--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -134,7 +134,7 @@ def __getGlue2ShareInfo(host, shareEndpoints, shareInfoDict, cesDict):
                 'GlueHostOperatingSystemRelease': '',
                 'GlueHostArchitecturePlatformType': 'x86_64',
                 'GlueHostBenchmarkSI00': '2500',  # needed for the queue to be used by the sitedirector
-                'MANAGER': '',
+                'MANAGER': 'manager:unknownBatchSystem',  # doesn't matter what this is for ARC, is eventually discarded
                 }]
   try:
     # take the CE with the lowest MainMemory
@@ -169,7 +169,7 @@ def __getGlue2ShareInfo(host, shareEndpoints, shareInfoDict, cesDict):
 
   # ARC CEs do not have endpoints, we have to try something else to get the information about the queue etc.
   if not shareEndpoints and shareInfoDict['GLUE2ShareID'].startswith('urn:ogf'):
-    exeInfo = dict(resExeInfo['Value'])  # silence pylint about tuples
+    exeInfo = dict(exeInfo[0])  # silence pylint about tuples
     ceType = 'ARC'
     managerName = exeInfo.pop('MANAGER', '').split(' ', 1)[0].rsplit(':', 1)[1]
     managerName = managerName.capitalize() if managerName == 'condor' else managerName


### PR DESCRIPTION
resExeInfo is an internal loop variable that shouldn't be used outside of its loop
MANAGER has to be something compatible with the split/rsplit expectations
The result is the second entry in norgugrid-MANAGER-queueName, which is discarded in ARCComputingElement

Supersede #4696 , @fstagni can you try with this patch?

BEGINRELEASENOTES

*Core
FIX: Glue2: Fix crash in bdii2CSAgent, when ARC CEs do not have an ExecutionEnvironment

ENDRELEASENOTES

PS: should this go to v7r0?
