### PR TITLE
[v7r0] Ensure JobParameters.getNumberOfProcessors always returns an integer

### DIFF
--- a/WorkloadManagementSystem/Utilities/JobParameters.py
+++ b/WorkloadManagementSystem/Utilities/JobParameters.py
@@ -73,9 +73,9 @@ def getNumberOfProcessors(siteName=None, gridCE=None, queue=None):
   # 3) looks in CS for "NumberOfProcessors" Queue or CE or site option
   grid = siteName.split('.')[0]
   csPaths = [
-    "/Resources/Sites/%s/%s/CEs/%s/Queues/%s/NumberOfProcessors" % (grid, siteName, gridCE, queue),
-    "/Resources/Sites/%s/%s/CEs/%s/NumberOfProcessors" % (grid, siteName, gridCE),
-    "/Resources/Sites/%s/%s/NumberOfProcessors" % (grid, siteName, gridCE),
+      "/Resources/Sites/%s/%s/CEs/%s/Queues/%s/NumberOfProcessors" % (grid, siteName, gridCE, queue),
+      "/Resources/Sites/%s/%s/CEs/%s/NumberOfProcessors" % (grid, siteName, gridCE),
+      "/Resources/Sites/%s/%s/NumberOfProcessors" % (grid, siteName),
   ]
   for csPath in csPaths:
     gLogger.info("Looking in", csPath)


### PR DESCRIPTION
In LHCb there has been an issue with a VAC site returning a value from MJF for the number of processors like `\n1\n` and recent changes in the pilot (https://github.com/DIRACGrid/Pilot/pull/110) causes this to be parsed incorrectly. This fixes the problem by making sure the return value of `JobParameters.getNumberOfProcessors` is always an `int`.


BEGINRELEASENOTES

*WorkloadManagementSystem
FIX: Ensure JobParameters.getNumberOfProcessors always returns an integer

ENDRELEASENOTES
