### PR TITLE
[v7r1] ARCCE: gLogger was replaced by self.log

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -339,7 +339,7 @@ class ARCComputingElement(ComputingElement):
       # cmd = 'ldapsearch -x -LLL -H ldap://%s:2135 -b mds-vo-name=resource,o=grid "(GlueVOViewLocalID=%s)"' % (
       #     self.ceHost, vo.lower())
       if not self.queue:
-        gLogger.error('ARCComputingElement: No queue ...')
+        self.log.error('ARCComputingElement: No queue ...')
         res = S_ERROR('Unknown queue (%s) failure for site %s' % (self.queue, self.ceHost))
         return res
       cmd1 = "ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135  -b \'o=glue\' " % self.ceHost


### PR DESCRIPTION
In #4666 a `gLogger` was (correctly) used, which when merged into v7r1 would give an exception (as pylint points out) because gLogger was removed at some point in v7r1 from the ARCComputingElement.

Would have been spotted by a merge PR.

BEGINRELEASENOTES

*Resources  
FIX: ARCComputingElement: fix use of `gLogger`, which was replaced by `self.log` 

ENDRELEASENOTES
