### PR TITLE
[v7r0] Fix getting available memory limits when MJF is not available

### DIFF
--- a/WorkloadManagementSystem/Utilities/JobParameters.py
+++ b/WorkloadManagementSystem/Utilities/JobParameters.py
@@ -22,18 +22,32 @@ def getJobFeatures():
     fname = os.path.join(os.environ['JOBFEATURES'], item)
     try:
       val = urllib2.urlopen(fname).read()
-    except BaseException:
+    except Exception:
       val = 0
     features[item] = val
   return features
 
 
 def getProcessorFromMJF():
-  return int(getJobFeatures().get('allocated_cpu'))
+  jobFeatures = getJobFeatures()
+  if jobFeatures:
+    try:
+      return int(jobFeatures['allocated_cpu'])
+    except KeyError:
+      gLogger.error("MJF is available but allocated_cpu is not an integer",
+                    repr(jobFeatures.get('allocated_cpu')))
+  return None
 
 
 def getMemoryFromMJF():
-  return int(getJobFeatures().get('max_rss_bytes'))
+  jobFeatures = getJobFeatures()
+  if jobFeatures:
+    try:
+      return int(jobFeatures['max_rss_bytes'])
+    except KeyError:
+      gLogger.error("MJF is available but max_rss_bytes is not an integer",
+                    repr(jobFeatures.get('max_rss_bytes')))
+  return None
 
 
 def getMemoryFromProc():


### PR DESCRIPTION
I've been conservative and made sure it still returns `None` but if changing `getProcessorFromMJF` is acceptable it might be preferable for this to be simplified to:
```diff
-  return int(getJobFeatures().get('allocated_cpu'))
+  return int(getJobFeatures().get('allocated_cpu', 0))
```


BEGINRELEASENOTES

*WorkloadManagement
FIX: Crash getting available memory limits when MJF is not available

ENDRELEASENOTES
