### PR TITLE
[v7r0][URGENT] GSI: add loadCRLFromFile alias for loadChainFromFile for X509CRL

### DIFF
--- a/Core/Security/pygsi/X509CRL.py
+++ b/Core/Security/pygsi/X509CRL.py
@@ -48,6 +48,9 @@ class X509CRL( object ):
       return S_ERROR( DErrno.EOF, "%s: %s" % ( crlLocation, repr( e ).replace( ',)', ')' ) ) )
     return self.loadChainFromString( pemData )
 
+  # Make an alias for compatibility with the M2Crypto implementation
+  loadCRLFromFile = loadChainFromFile
+
   def loadChainFromString( self, pemData ):
     """
     Load a x509CRL certificate from a string containing the pem data


### PR DESCRIPTION
https://github.com/DIRACGrid/WebAppDIRAC/pull/400 is the correct thing to do, but only works with M2Crypto implementation. I've added an alias for pyGSI implementation. tested working in LHCb
@atsareg @fstagni  in practice, it means the previous release is broken if the WebApp does not use M2Crypto. You may want to advertise it, together with this fix

BEGINRELEASENOTES

*Core
NEW: add loadCRLFromFile to pyGSI implementation of X509CRL

ENDRELEASENOTES
