### PR TITLE
[v7r0] Pass useCertificates to WMSClient in Dirac API 

### DIFF
--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -359,7 +359,7 @@ class Dirac(API):
 
     elif mode.lower() == 'wms':
       self.log.verbose('Will submit job to WMS')  # this will happen by default anyway
-      result = WMSClient().submitJob(jdlAsString, jobDescriptionObject)
+      result = WMSClient(useCertificates=self.useCertificates).submitJob(jdlAsString, jobDescriptionObject)
       if not result['OK']:
         self.log.error('Job submission failure', result['Message'])
       elif self.jobRepo:
@@ -404,7 +404,7 @@ class Dirac(API):
 
     jdl = self.__forceLocal(jdl)
 
-    jobID = WMSClient().submitJob(jdl, jobDescriptionObject)
+    jobID = WMSClient(useCertificates=self.useCertificates).submitJob(jdl, jobDescriptionObject)
 
     if not jobID['OK']:
       self.log.error('Job submission failure', jobID['Message'])
@@ -1776,7 +1776,7 @@ class Dirac(API):
       return ret
     jobID = ret['Value']
 
-    result = WMSClient().deleteJob(jobID)
+    result = WMSClient(useCertificates=self.useCertificates).deleteJob(jobID)
     if result['OK']:
       if self.jobRepo:
         for jobID in result['Value']:
@@ -1806,7 +1806,7 @@ class Dirac(API):
       return ret
     jobID = ret['Value']
 
-    result = WMSClient().rescheduleJob(jobID)
+    result = WMSClient(useCertificates=self.useCertificates).rescheduleJob(jobID)
     if result['OK']:
       if self.jobRepo:
         repoDict = {}
@@ -1835,7 +1835,7 @@ class Dirac(API):
       return ret
     jobID = ret['Value']
 
-    result = WMSClient().killJob(jobID)
+    result = WMSClient(useCertificates=self.useCertificates).killJob(jobID)
     if result['OK']:
       if self.jobRepo:
         for jobID in result['Value']:

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -124,14 +124,14 @@ class Dirac(API):
           return self._errorReport('Expected int or string, not list')
       return S_OK(jobID)
     except Exception as x:
-      return self._errorReport(str(x), 'Expected %sinteger or string for existing jobID' %
+      return self._errorReport(str(x), 'Expected %s integer or string for existing jobID' %
                                '(list of) ' if multiple else '')
 
   #############################################################################
   # Repository specific methods
   #############################################################################
   def getRepositoryJobs(self, printOutput=False):
-    """ Retireve all the jobs in the repository
+    """ Retrieve all the jobs in the repository
 
        Example Usage:
 
@@ -287,7 +287,7 @@ class Dirac(API):
   #############################################################################
 
   def submitJob(self, job, mode='wms'):
-    """Submit jobs to DIRAC (by default to the Worload Management System).
+    """Submit jobs to DIRAC (by default to the Workload Management System).
        These can be either:
 
         - Instances of the Job Class
@@ -335,7 +335,7 @@ class Dirac(API):
           self.log.error('>>>> Error in %s() <<<<\n%s' % (method, '\n'.join(errorList)))
         return S_ERROR(formulationErrors)
 
-      # Run any VO specific checks if desired prior to submission, this may or may not be overidden
+      # Run any VO specific checks if desired prior to submission, this may or may not be overridden
       # in a derived class for example
       try:
         result = self.preSubmissionChecks(job, mode)
@@ -447,7 +447,7 @@ class Dirac(API):
   #############################################################################
   def __runJobAgent(self, jobID):
     """ This internal method runs a tailored job agent for the local execution
-        of a previously submitted WMS job. The type of CEUniqueID can be overidden
+        of a previously submitted WMS job. The type of CEUniqueID can be overridden
         via the configuration.
     """
     agentName = 'WorkloadManagement/JobAgent'
@@ -709,7 +709,7 @@ class Dirac(API):
         All output files are written to the local directory.
 
         This is a method for running local tests. It skips the creation of a JobWrapper,
-        but preparing an environment that mimicks it.
+        but preparing an environment that mimics it.
 
     :param job: a job object
     :type job: ~DIRAC.Interfaces.API.Job.Job
@@ -1612,7 +1612,7 @@ class Dirac(API):
 
        This method allows the retrieval of an existing job input sandbox for
        debugging purposes.  By default the sandbox is downloaded to the current
-       directory but this can be overidden via the outputDir parameter. All files
+       directory but this can be overridden via the outputDir parameter. All files
        are extracted into a InputSandbox<JOBID> directory that is automatically created.
 
        Example Usage:
@@ -1662,7 +1662,7 @@ class Dirac(API):
 
        This method allows the retrieval of an existing job output sandbox.
        By default the sandbox is downloaded to the current directory but
-       this can be overidden via the outputDir parameter. All files are
+       this can be overridden via the outputDir parameter. All files are
        extracted into a <JOBID> directory that is automatically created.
 
        Example Usage:


### PR DESCRIPTION
The `DIRAC.Interfaces.API.DIRAC.Dirac` class has a `useCertificates=False` argument in the initialiser:

https://github.com/DIRACGrid/DIRAC/blob/50dee195dd30279feb73f92a37f811ed292d97ca/Interfaces/API/Dirac.py#L82-L83

This is passed to the `SandboxStoreClient`:

https://github.com/DIRACGrid/DIRAC/blob/50dee195dd30279feb73f92a37f811ed292d97ca/Interfaces/API/Dirac.py#L1658

but none of the other clients. This PR makes it so that it is also passed to the `WMSClient`.

Without this PR, `Dirac().submitJob` cannot be used when using server certificates for authentication as `WMSClient` has a default value of `useCertificates=False`:

https://github.com/DIRACGrid/DIRAC/blob/50dee195dd30279feb73f92a37f811ed292d97ca/WorkloadManagementSystem/Client/WMSClient.py#L35-L42

which overrides and local settings in the CS.

Also fixes a bunch of typos as a separate commit.

BEGINRELEASENOTES

*Interfaces
FIX: Pass useCertificates to WMSClient in Dirac API 

ENDRELEASENOTES
