### PR TITLE
[integration] Fix Github API change for creating releases 

### DIFF
--- a/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
+++ b/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
@@ -588,7 +588,6 @@ class GithubInterface(object):
       releaseNotes = rnf.read()
 
     releaseDict = dict(tag_name=self.tagName,
-                       target_commitish="unused",
                        name=self.tagName,
                        body=releaseNotes,
                        prerelease=False,

--- a/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
+++ b/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
@@ -79,7 +79,8 @@ def githubSetup():
   try:
     from GitTokens import GITHUBTOKEN
     if GITHUBTOKEN:
-      SESSION.headers.update({'Authorization': 'token %s ' % GITHUBTOKEN})
+      SESSION.headers.update({'Accept': 'application/vnd.github.v3+json',
+                              'Authorization': 'token %s ' % GITHUBTOKEN})
   except ImportError:
     raise ImportError(G_ERROR)
 


### PR DESCRIPTION
The `create release` API has changes a bit: `target_commitish` should be only used when creating a tag from a branch and not when tag is already present then you get an error
```
ERROR - GetReleaseNotes.Requests: Unable to access API: {"message":"Validation Failed","errors":[{"resource":"Release","code":"invalid","field":"target_commitish"}],"documentation_url":"https://docs.github.com/rest/reference/repos#create-a-release"}
```

And it is now recommended to use a the header `application/vnd.github.v3+json` when doing a POST or GET, see [here](
https://docs.github.com/en/rest/reference/repos#list-organization-repositories)

BEGINRELEASENOTES

*docs
FIX: update the release notes generator to comply with GitHub API update

ENDRELEASENOTES

Please merge this ASAP