### PR TITLE
[v7r2] Run pytest test collection for Python 3

### DIFF
--- a/.github/workflows/basic-python3.yml
+++ b/.github/workflows/basic-python3.yml
@@ -21,7 +21,7 @@ jobs:
       run: .github/workflows/fail-fast.sh
     - name: Prepare environment
       run: |
-        conda env create --name dirac-testing environment-py3.yml
+        conda env create --name dirac-testing --file environment-py3.yml
     - name: Run tests
       run: |
         source "${CONDA}/bin/activate"

--- a/.github/workflows/basic-python3.yml
+++ b/.github/workflows/basic-python3.yml
@@ -1,0 +1,33 @@
+name: Python 3 tests
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: False
+      matrix:
+        command:
+          # Only collect tests for now
+          - pytest --no-cov --collect-only
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fail-fast for outdated pipelines
+      run: .github/workflows/fail-fast.sh
+    - name: Prepare environment
+      run: |
+        conda env create --name dirac-testing environment-py3.yml
+    - name: Run tests
+      run: |
+        source "${CONDA}/bin/activate"
+        conda activate dirac-testing
+        set -euxo pipefail
+        export PYTHONPATH=${PWD%/*}
+        ${{ matrix.command }}
+      env:
+        REFERENCE_BRANCH: ${{ github['base_ref'] || github['head_ref'] }}

--- a/AccountingSystem/private/MainReporter.py
+++ b/AccountingSystem/private/MainReporter.py
@@ -46,8 +46,8 @@ class MainReporter(object):
       epoch = requestToHash[key]
       requestToHash[key] = epoch - epoch % granularity
     md5Hash = hashlib.md5()
-    md5Hash.update(repr(requestToHash))
-    md5Hash.update(self.setup)
+    md5Hash.update(repr(requestToHash).encode())
+    md5Hash.update(self.setup.encode())
     return md5Hash.hexdigest()
 
   def generate(self, reportRequest, credDict):

--- a/AccountingSystem/scripts/dirac-accounting-decode-fileid.py
+++ b/AccountingSystem/scripts/dirac-accounting-decode-fileid.py
@@ -13,7 +13,7 @@ __RCSID__ = "$Id$"
 
 import pprint
 import sys
-import urlparse
+from six.moves.urllib import parse as urlparse
 import cgi
 from DIRAC import gLogger
 from DIRAC.Core.Base import Script

--- a/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/ConfigurationSystem/Client/Helpers/Operations.py
@@ -74,7 +74,7 @@ from __future__ import division
 from __future__ import print_function
 
 import six
-import thread
+from six.moves import _thread as thread
 import os
 from diraccfg import CFG
 from DIRAC import S_OK, S_ERROR, gConfig

--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
-import urlparse
+from six.moves.urllib import parse as urlparse
 from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
 
 import six

--- a/ConfigurationSystem/Client/PathFinder.py
+++ b/ConfigurationSystem/Client/PathFinder.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
-import urlparse
+from six.moves.urllib import parse as urlparse
 
 from DIRAC.Core.Utilities import List
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -17,7 +17,7 @@ __RCSID__ = "$Id$"
 
 import re
 import socket
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 import six
 

--- a/ConfigurationSystem/private/ConfigurationData.py
+++ b/ConfigurationSystem/private/ConfigurationData.py
@@ -7,7 +7,7 @@ from __future__ import division
 import os.path
 import zlib
 import zipfile
-import thread
+from six.moves import _thread as thread
 import time
 import DIRAC
 

--- a/ConfigurationSystem/private/Refresher.py
+++ b/ConfigurationSystem/private/Refresher.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 __RCSID__ = "$Id$"
 
 import threading
-import thread
+from six.moves import _thread as thread
 import time
 import random
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -16,7 +16,7 @@ import signal
 import re
 import os
 import shlex
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC.Core.Base import Script
 from DIRAC import gLogger, exit as DIRACExit, S_OK

--- a/Core/DISET/MessageClient.py
+++ b/Core/DISET/MessageClient.py
@@ -33,7 +33,7 @@ class MessageClient(BaseClient):
 
   def __generateUniqueClientName(self):
     hashStr = ":".join((Time.toString(), str(random.random()), Network.getFQDN(), gLogger.getName()))
-    hexHash = md5(hashStr).hexdigest()
+    hexHash = md5(hashStr.encode()).hexdigest()
     return hexHash
 
   def setUniqueName(self, uniqueName):

--- a/Core/DISET/RequestHandler.py
+++ b/Core/DISET/RequestHandler.py
@@ -9,6 +9,7 @@ __RCSID__ = "$Id$"
 import os
 import time
 import psutil
+import six
 
 import DIRAC
 
@@ -344,7 +345,7 @@ class RequestHandler(object):
 #
 ####
 
-  __connectionCallbackTypes = {'new': [basestring, dict],
+  __connectionCallbackTypes = {'new': list(six.string_types) + [dict],
                                'connected': [],
                                'drop': []}
 
@@ -499,7 +500,7 @@ class RequestHandler(object):
 
     return S_OK(dInfo)
 
-  types_echo = [basestring]
+  types_echo = [six.string_types]
 
   @staticmethod
   def export_echo(data):

--- a/Core/DISET/private/BaseClient.py
+++ b/Core/DISET/private/BaseClient.py
@@ -9,7 +9,7 @@ __RCSID__ = "$Id$"
 
 import six
 import time
-import thread
+from six.moves import _thread as thread
 import DIRAC
 from DIRAC.Core.DISET.private.Protocols import gProtocolDict
 from DIRAC.FrameworkSystem.Client.Logger import gLogger

--- a/Core/DISET/private/FileHelper.py
+++ b/Core/DISET/private/FileHelper.py
@@ -7,7 +7,7 @@ import six
 import os
 import hashlib
 import threading
-import cStringIO
+from six import StringIO
 import tarfile
 import tempfile
 
@@ -132,7 +132,7 @@ class FileHelper(object):
     """ Receive the input from a DISET client and return it as a string
     """
 
-    stringIO = cStringIO.StringIO()
+    stringIO = StringIO()
     result = self.networkToDataSink(stringIO, maxFileSize=maxFileSize)
     if not result['OK']:
       return result
@@ -184,7 +184,7 @@ class FileHelper(object):
     """ Send a given string to the DISET client over the network
     """
 
-    stringIO = cStringIO.StringIO(stringVal)
+    stringIO = StringIO(stringVal)
 
     iPacketSize = self.packetSize
     ioffset = 0
@@ -234,7 +234,7 @@ class FileHelper(object):
     return S_OK()
 
   def BufferToNetwork(self, stringToSend):
-    sIO = cStringIO.StringIO(stringToSend)
+    sIO = StringIO(stringToSend)
     try:
       return self.DataSourceToNetwork(sIO)
     finally:

--- a/Core/DISET/private/GatewayService.py
+++ b/Core/DISET/private/GatewayService.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 
 import sys
-import cStringIO
+from six import BytesIO
 import os
 
 # TODO: Remove ThreadPool later
@@ -312,7 +312,7 @@ class TransferRelay(TransferClient):
     gLogger.error("[%s] %s" % (self.__currentMethod, msg), dynMsg)
 
   def getDataFromClient(self, clientFileHelper):
-    sIO = cStringIO.StringIO()
+    sIO = BytesIO()
     self.infoMsg("About to get data from client")
     result = clientFileHelper.networkToDataSink(sIO, self.__transferBytesLimit)
     if not result['OK']:
@@ -363,7 +363,7 @@ class TransferRelay(TransferClient):
     _, srvTransport = result['Value']
     srvFileHelper = FileHelper(srvTransport)
     srvFileHelper.setDirection("receive")
-    sIO = cStringIO.StringIO()
+    sIO = BytesIO()
     result = srvFileHelper.networkToDataSink(sIO, self.__transferBytesLimit)
     if not result['OK']:
       self.errMsg("Could not receive data from server", result['Message'])

--- a/Core/DISET/private/Transports/BaseTransport.py
+++ b/Core/DISET/private/Transports/BaseTransport.py
@@ -25,7 +25,7 @@ __RCSID__ = "$Id$"
 
 import time
 import select
-import cStringIO
+from six import BytesIO
 from hashlib import md5
 
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK
@@ -235,7 +235,7 @@ class BaseTransport(object):
         self.byteStream = pkgData[pkgSize:]
       else:
         # If we still need to read stuff
-        pkgMem = cStringIO.StringIO()
+        pkgMem = BytesIO()
         pkgMem.write(pkgData)
         # Receive while there's still data to be received
         while readSize < pkgSize:

--- a/Core/DISET/private/Transports/BaseTransport.py
+++ b/Core/DISET/private/Transports/BaseTransport.py
@@ -55,7 +55,7 @@ class BaseTransport(object):
     self.remoteAddress = False
     self.appData = ""
     self.startedKeepAlives = set()
-    self.keepAliveId = md5(str(stServerAddress) + str(bServerMode)).hexdigest()
+    self.keepAliveId = md5((str(stServerAddress) + str(bServerMode)).encode()).hexdigest()
     self.receivedMessages = []
     self.sentKeepAlives = 0
     self.waitingForKeepAlivePong = False

--- a/Core/LCG/GGUSTicketsClient.py
+++ b/Core/LCG/GGUSTicketsClient.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import urllib2
+from six.moves.urllib_error import URLError
 
 from suds import WebFault
 from suds.client import Client
@@ -76,7 +76,7 @@ class GGUSTicketsClient(object):
       ticketList = self.gclient.service.TicketGetList(query)
     except WebFault as e:
       return S_ERROR(e)
-    except urllib2.URLError as e:
+    except URLError as e:
       return S_ERROR(e)
 
     return self.globalStatistics(ticketList)

--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -19,7 +19,6 @@ __RCSID__ = "$Id$"
 
 from past.builtins import long
 import six
-import types
 import datetime
 import os
 
@@ -29,6 +28,22 @@ import traceback
 
 from collections import defaultdict
 from pprint import pprint
+
+
+# This is a hack for Python 3 to make it possible to import DEncode
+# There is not point in porting DEncode to Python 3 as it will be removed as
+# part of the HTTPS transition.
+class types(object):
+    IntType = int
+    LongType = long if six.PY2 else int
+    FloatType = float
+    BooleanType = bool
+    StringType = str
+    UnicodeType = type(u"")
+    NoneType = type(None)
+    ListType = list
+    TupleType = tuple
+    DictType = dict
 
 
 # Setting this environment variable to any value will enable the dump of the debugging

--- a/Core/Utilities/File.py
+++ b/Core/Utilities/File.py
@@ -78,13 +78,13 @@ def makeGuid(fileName=None):
   myMd5 = hashlib.md5()
   if fileName:
     try:
-      with open(fileName, 'r') as fd:
+      with open(fileName, 'rb') as fd:
         data = fd.read(10 * 1024 * 1024)
         myMd5.update(data)
     except BaseException:
       return None
   else:
-    myMd5.update(str(random.getrandbits(128)))
+    myMd5.update(str(random.getrandbits(128)).encode())
 
   md5HexString = myMd5.hexdigest().upper()
   return generateGuid(md5HexString, "MD5")
@@ -112,7 +112,7 @@ def generateGuid(checksum, checksumtype):
 
   # Failed to use the check sum, generate a new guid
   myMd5 = hashlib.md5()
-  myMd5.update(str(random.getrandbits(128)))
+  myMd5.update(str(random.getrandbits(128)).encode())
   md5HexString = myMd5.hexdigest()
   guid = "%s-%s-%s-%s-%s" % (md5HexString[0:8],
                              md5HexString[8:12],

--- a/Core/Utilities/Grid.py
+++ b/Core/Utilities/Grid.py
@@ -147,7 +147,7 @@ def ldapsearchBDII(filt=None, attr=None, host=None, base=None, selectionString="
 def ldapSite(site, attr=None, host=None):
   """ Site information from bdii.
 
-:param  site: Site as it defined in GOCDB or part of it with globing, for example: \UKI-*
+:param  site: Site as it defined in GOCDB or part of it with globing, for example: \\UKI-*
 :return: standard DIRAC answer with Value equals to list of sites.
 
 Each site is dictionary which contains attributes of site.

--- a/Core/Utilities/LockRing.py
+++ b/Core/Utilities/LockRing.py
@@ -21,10 +21,11 @@ class LockRing(object):
     self.__events = {}
 
   def __genName(self, container):
-    name = md5(str(time.time() + random.random())).hexdigest()
+    # TODO: Shouldn't this be a UUID?
+    name = md5(str(time.time() + random.random()).encode()).hexdigest()
     retries = 10
     while name in container and retries:
-      name = md5(str(time.time() + random.random())).hexdigest()
+      name = md5(str(time.time() + random.random()).encode()).hexdigest()
       retries -= 1
     return name
 

--- a/Core/Utilities/LockRing.py
+++ b/Core/Utilities/LockRing.py
@@ -5,7 +5,7 @@ from __future__ import division
 import random
 import time
 import threading
-import thread
+from six.moves import _thread as thread
 from hashlib import md5
 
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK

--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -161,11 +161,15 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Time import fromString
 from DIRAC.Core.Utilities import DErrno
 
-# This is for proper initialization of embedded server, it should only be called once
-try:
-  MySQLdb.server_init(['--defaults-file=/opt/dirac/etc/my.cnf', '--datadir=/opt/mysql/db'], ['mysqld'])
-except MySQLdb.ProgrammingError:
-  pass
+# The mysql_server_init function called here is deprecated and not used by mysqlclient
+# https://dev.mysql.com/doc/c-api/8.0/en/mysql-server-init.html
+# TODO: Check if any changes are needed
+if six.PY2:
+  # This is for proper initialization of embedded server, it should only be called once
+  try:
+    MySQLdb.server_init(['--defaults-file=/opt/dirac/etc/my.cnf', '--datadir=/opt/mysql/db'], ['mysqld'])
+  except MySQLdb.ProgrammingError:
+    pass
 
 gInstancesCount = 0
 

--- a/Core/Utilities/Network.py
+++ b/Core/Utilities/Network.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 __RCSID__ = "$Id$"
 
 import socket
-import urlparse
+from six.moves.urllib import parse as urlparse
 import os
 import struct
 import array

--- a/Core/Utilities/Pfn.py
+++ b/Core/Utilities/Pfn.py
@@ -20,7 +20,7 @@ __RCSID__ = "$Id:$"
 import os
 # # from DIRAC
 from DIRAC import S_OK, S_ERROR, gLogger
-import urlparse
+from six.moves.urllib import parse as urlparse
 
 
 def pfnunparse(pfnDict, srmSpecific=True):

--- a/Core/Utilities/Plotting/Plots.py
+++ b/Core/Utilities/Plotting/Plots.py
@@ -5,10 +5,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-try:
-  from StringIO import StringIO
-except ImportError:
-  from io import BytesIO as StringIO
+from six import BytesIO
 import errno
 from DIRAC.Core.Utilities.Graphs import barGraph, lineGraph, pieGraph, qualityGraph, textGraph, histogram
 
@@ -53,7 +50,7 @@ def generateErrorMessagePlot(msgText):
   :param str msgText: the text which will appear on the plot.
   :return: the plot.
   """
-  fn = StringIO()
+  fn = BytesIO()
   textGraph(msgText, fn, {})
   data = fn.getvalue()
   fn.close()

--- a/Core/Utilities/PrettyPrint.py
+++ b/Core/Utilities/PrettyPrint.py
@@ -11,7 +11,7 @@ from __future__ import division
 __RCSID__ = '$Id$'
 
 import six
-import StringIO
+from six import StringIO
 
 
 def int_with_commas(inputValue):
@@ -159,7 +159,7 @@ def printTable(fields, records, sortField='', numbering=True,
     totalLength += (numberWidth + separatorWidth)
 
   # Accumulate the table output in the stringBuffer now
-  stringBuffer = StringIO.StringIO()
+  stringBuffer = StringIO()
   topLength = (numberWidth + separatorWidth) if numbering else 0
   stringBuffer.write(' ' * (topLength))
 

--- a/Core/Utilities/ProcessPool.py
+++ b/Core/Utilities/ProcessPool.py
@@ -110,7 +110,6 @@ import os
 import signal
 from six.moves import queue as Queue
 import errno
-from types import FunctionType, TypeType, ClassType
 
 try:
   from DIRAC.FrameworkSystem.Client.Logger import gLogger
@@ -518,6 +517,8 @@ class ProcessTask(object):
 
     :param self: self reference
     """
+    from types import FunctionType, ClassType
+
     self.__done = True
     try:
       # # it's a function?

--- a/Core/Utilities/ProcessPool.py
+++ b/Core/Utilities/ProcessPool.py
@@ -108,7 +108,7 @@ import time
 import threading
 import os
 import signal
-import Queue
+from six.moves import queue as Queue
 import errno
 from types import FunctionType, TypeType, ClassType
 

--- a/Core/Utilities/ThreadPool.py
+++ b/Core/Utilities/ThreadPool.py
@@ -75,7 +75,7 @@ __RCSID__ = "$Id$"
 
 import time
 import sys
-import Queue
+from six.moves import queue as Queue
 import threading
 try:
   from DIRAC.FrameworkSystem.Client.Logger import gLogger

--- a/Core/Utilities/ThreadScheduler.py
+++ b/Core/Utilities/ThreadScheduler.py
@@ -45,7 +45,7 @@ class ThreadScheduler(object):
             'func': taskFunc,
             'args': taskArgs,
             }
-    md.update(str(task))
+    md.update(str(task).encode())
     taskId = md.hexdigest()
     if taskId in self.__taskDict:
       return S_ERROR("Task %s is already added" % taskId)

--- a/Core/Utilities/Time.py
+++ b/Core/Utilities/Time.py
@@ -30,7 +30,7 @@ from __future__ import absolute_import
 from __future__ import division
 import time as nativetime
 import datetime
-from types import StringTypes
+import six
 import sys
 
 __RCSID__ = "$Id$"
@@ -194,7 +194,7 @@ def fromString(myDate=None):
   See notice on toString method
   On Error, return None
   """
-  if StringTypes.__contains__(type(myDate)):
+  if isinstance(myDate, six.string_types):
     if myDate.find(' ') > 0:
       dateTimeTuple = myDate.split(' ')
       dateTuple = dateTimeTuple[0].split('-')

--- a/Core/Utilities/test/Test_Encode.py
+++ b/Core/Utilities/test/Test_Encode.py
@@ -324,13 +324,13 @@ def test_types():
   import types as pythonTypes
   from DIRAC.Core.Utilities.DEncode import types as DIRACTypes
 
-  assert pythonTypes.IntType is pythonTypes.IntType
-  assert pythonTypes.LongType is pythonTypes.LongType
-  assert pythonTypes.FloatType is pythonTypes.FloatType
-  assert pythonTypes.BooleanType is pythonTypes.BooleanType
-  assert pythonTypes.StringType is pythonTypes.StringType
-  assert pythonTypes.UnicodeType is pythonTypes.UnicodeType
-  assert pythonTypes.NoneType is pythonTypes.NoneType
-  assert pythonTypes.ListType is pythonTypes.ListType
-  assert pythonTypes.TupleType is pythonTypes.TupleType
-  assert pythonTypes.DictType is pythonTypes.DictType
+  assert DIRACTypes.IntType is pythonTypes.IntType
+  assert DIRACTypes.LongType is pythonTypes.LongType
+  assert DIRACTypes.FloatType is pythonTypes.FloatType
+  assert DIRACTypes.BooleanType is pythonTypes.BooleanType
+  assert DIRACTypes.StringType is pythonTypes.StringType
+  assert DIRACTypes.UnicodeType is pythonTypes.UnicodeType
+  assert DIRACTypes.NoneType is pythonTypes.NoneType
+  assert DIRACTypes.ListType is pythonTypes.ListType
+  assert DIRACTypes.TupleType is pythonTypes.TupleType
+  assert DIRACTypes.DictType is pythonTypes.DictType

--- a/Core/Utilities/test/Test_Encode.py
+++ b/Core/Utilities/test/Test_Encode.py
@@ -23,8 +23,8 @@ from DIRAC.Core.Utilities.MixedEncode import encode as mixEncode, decode as mixD
 from hypothesis import given, settings, HealthCheck
 from hypothesis.strategies import builds, integers, lists, recursive, floats, text,\
     booleans, none, dictionaries, tuples, datetimes
-
-from pytest import mark, approx, raises, fixture
+import six
+from pytest import mark, approx, raises, fixture, skip
 parametrize = mark.parametrize
 
 
@@ -314,3 +314,23 @@ def test_nestedSerializable(data):
   subObj = Serializable(instAttr=data)
   objData = Serializable(instAttr=subObj)
   agnosticTestFunction(jsonTuple, objData)
+
+
+def test_types():
+  """ Ensure that the DEncode types object matches the Python 2 types module
+  """
+  if not six.PY2:
+    skip("This test only makes sense on Python 2")
+  import types as pythonTypes
+  from DIRAC.Core.Utilities.DEncode import types as DIRACTypes
+
+  assert pythonTypes.IntType is pythonTypes.IntType
+  assert pythonTypes.LongType is pythonTypes.LongType
+  assert pythonTypes.FloatType is pythonTypes.FloatType
+  assert pythonTypes.BooleanType is pythonTypes.BooleanType
+  assert pythonTypes.StringType is pythonTypes.StringType
+  assert pythonTypes.UnicodeType is pythonTypes.UnicodeType
+  assert pythonTypes.NoneType is pythonTypes.NoneType
+  assert pythonTypes.ListType is pythonTypes.ListType
+  assert pythonTypes.TupleType is pythonTypes.TupleType
+  assert pythonTypes.DictType is pythonTypes.DictType

--- a/Core/scripts/dirac-externals-requirements.py
+++ b/Core/scripts/dirac-externals-requirements.py
@@ -15,7 +15,12 @@ from __future__ import print_function
 
 import os
 import sys
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 
 from diraccfg import CFG
 from DIRAC.Core.Base import Script

--- a/Core/scripts/dirac-externals-requirements.py
+++ b/Core/scripts/dirac-externals-requirements.py
@@ -19,7 +19,7 @@ import sys
 try:
   import commands
 except ImportError:
-  # Python 3's subprocess module contains a compatability layer
+  # Python 3's subprocess module contains a compatibility layer
   import subprocess as commands
 
 from diraccfg import CFG

--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -6,7 +6,12 @@ from __future__ import absolute_import
 from __future__ import division
 __RCSID__ = "$Id$"
 
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import os.path
 import time
 import sys

--- a/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
@@ -332,7 +332,7 @@ class DatasetManager(object):
     lfnIDList = idLfnDict.keys()
     lfnList = sorted(idLfnDict.values())
     myMd5 = hashlib.md5()
-    myMd5.update(str(lfnList))
+    myMd5.update(str(lfnList).encode())
     datasetHash = myMd5.hexdigest().upper()
     numberOfFiles = len(lfnList)
     result = self.db.fileManager.getFileSize(lfnList)

--- a/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/test/Test_VOMSSecurityManager.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/test/Test_VOMSSecurityManager.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 
 # pylint: disable=protected-access,missing-docstring,invalid-name,too-many-lines
 
-from types import ListType
 import unittest
 import stat
 
@@ -146,7 +145,7 @@ class mock_FileManager(object):
     return S_OK({'Successful': dict((lfn, lfn in fileTree) for lfn in lfns), 'Failed': {}})
 
   def getFileMetadata(self, lfns):
-    if not isinstance(lfns, ListType):
+    if not isinstance(lfns, list):
       lfns = [lfns]
 
     retParam = ['Size', 'Checksum', 'ChecksumType', 'UID',
@@ -170,7 +169,7 @@ class mock_FileManager(object):
     return S_OK({'Successful': successful, 'Failed': failed})
 
   def getPathPermissions(self, lfns, credDict):
-    if not isinstance(lfns, ListType):
+    if not isinstance(lfns, list):
       lfns = [lfns]
 
     successful = {}

--- a/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/DataManagementSystem/Service/FileCatalogHandler.py
@@ -16,7 +16,7 @@ __RCSID__ = "$Id$"
 
 # imports
 import six
-import cStringIO
+from six import StringIO
 import csv
 import os
 from types import IntType, LongType, DictType, StringTypes, BooleanType, ListType
@@ -759,7 +759,7 @@ class FileCatalogHandler(RequestHandler):
     retVal = self.getSEDump(seName)
 
     try:
-      csvOutput = cStringIO.StringIO()
+      csvOutput = StringIO()
       writer = csv.writer(csvOutput, delimiter='|')
       for lfn in retVal:
         writer.writerow(lfn)

--- a/DataManagementSystem/Service/StorageElementHandler.py
+++ b/DataManagementSystem/Service/StorageElementHandler.py
@@ -34,6 +34,7 @@ import stat
 import re
 import errno
 import shlex
+import six
 
 # from DIRAC
 from DIRAC import gLogger, S_OK, S_ERROR
@@ -234,7 +235,7 @@ class StorageElementHandler(RequestHandler):
 
     return S_OK(resultDict)
 
-  types_exists = [basestring]
+  types_exists = [six.string_types]
 
   def export_exists(self, fileID):
     """ Check existence of the fileID """
@@ -242,7 +243,7 @@ class StorageElementHandler(RequestHandler):
       return S_OK(True)
     return S_OK(False)
 
-  types_getMetadata = [basestring]
+  types_getMetadata = [six.string_types]
 
   def export_getMetadata(self, fileID):
     """ Get metadata for the file or directory specified by fileID
@@ -269,7 +270,7 @@ class StorageElementHandler(RequestHandler):
     """
     return getTotalDiskSpace()
 
-  types_createDirectory = [basestring]
+  types_createDirectory = [six.string_types]
 
   def export_createDirectory(self, dir_path):
     """ Creates the directory on the storage
@@ -292,7 +293,7 @@ class StorageElementHandler(RequestHandler):
       gLogger.error("StorageElementHandler.createDirectory: %s" % errStr, repr(x))
       return S_ERROR(errStr)
 
-  types_listDirectory = [basestring, basestring]
+  types_listDirectory = [six.string_types, six.string_types]
 
   def export_listDirectory(self, dir_path, mode):
     """ Return the dir_path directory listing
@@ -430,7 +431,7 @@ class StorageElementHandler(RequestHandler):
       gLogger.error('Failed to send bulk to network', res['Message'])
     return res
 
-  types_remove = [basestring, basestring]
+  types_remove = [six.string_types, six.string_types]
 
   def export_remove(self, fileID, token):
     """ Remove fileID from the storage. token is used for access rights confirmation. """
@@ -452,7 +453,7 @@ class StorageElementHandler(RequestHandler):
     else:
       return S_ERROR('File removal %s not authorized' % fileID)
 
-  types_getDirectorySize = [basestring]
+  types_getDirectorySize = [six.string_types]
 
   def export_getDirectorySize(self, fileID):
     """ Get the size occupied by the given directory
@@ -468,7 +469,7 @@ class StorageElementHandler(RequestHandler):
     else:
       return S_ERROR("Directory does not exists")
 
-  types_removeDirectory = [basestring, basestring]
+  types_removeDirectory = [six.string_types, six.string_types]
 
   def export_removeDirectory(self, fileID, token):
     """ Remove the given directory from the storage
@@ -489,7 +490,7 @@ class StorageElementHandler(RequestHandler):
           gLogger.error(str(error))
           return S_ERROR("Failed to remove directory %s" % dir_path)
 
-  types_removeFileList = [list, basestring]
+  types_removeFileList = [list, six.string_types]
 
   def export_removeFileList(self, fileList, token):
     """ Remove files in the given list

--- a/DataManagementSystem/scripts/dirac-dms-create-removal-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-create-removal-request.py
@@ -65,7 +65,10 @@ if targetSE == 'All':
 for lfnList in breakListIntoChunks(lfns, 100):
 
   oRequest = Request()
-  requestName = "%s_%s" % (md5(repr(time.time())).hexdigest()[:16], md5(repr(time.time())).hexdigest()[:16])
+  requestName = "%s_%s" % (
+    md5(repr(time.time()).encode()).hexdigest()[:16],
+    md5(repr(time.time()).encode()).hexdigest()[:16],
+  )
   oRequest.RequestName = requestName
 
   oOperation = Operation()

--- a/DataManagementSystem/scripts/dirac-dms-create-removal-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-create-removal-request.py
@@ -66,8 +66,8 @@ for lfnList in breakListIntoChunks(lfns, 100):
 
   oRequest = Request()
   requestName = "%s_%s" % (
-    md5(repr(time.time()).encode()).hexdigest()[:16],
-    md5(repr(time.time()).encode()).hexdigest()[:16],
+      md5(repr(time.time()).encode()).hexdigest()[:16],
+      md5(repr(time.time()).encode()).hexdigest()[:16],
   )
   oRequest.RequestName = requestName
 

--- a/DataManagementSystem/scripts/dirac-dms-move-replica-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-move-replica-request.py
@@ -91,8 +91,8 @@ if __name__ == "__main__":
 
     request = Request()
     request.RequestName = "%s_%s" % (
-      md5(repr(time.time()).encode()).hexdigest()[:16],
-      md5(repr(time.time()).encode()).hexdigest()[:16],
+        md5(repr(time.time()).encode()).hexdigest()[:16],
+        md5(repr(time.time()).encode()).hexdigest()[:16],
     )
 
     moveReplica = Operation()

--- a/DataManagementSystem/scripts/dirac-dms-move-replica-request.py
+++ b/DataManagementSystem/scripts/dirac-dms-move-replica-request.py
@@ -90,7 +90,10 @@ if __name__ == "__main__":
     count += 1
 
     request = Request()
-    request.RequestName = "%s_%s" % (md5(repr(time.time())).hexdigest()[:16], md5(repr(time.time())).hexdigest()[:16])
+    request.RequestName = "%s_%s" % (
+      md5(repr(time.time()).encode()).hexdigest()[:16],
+      md5(repr(time.time()).encode()).hexdigest()[:16],
+    )
 
     moveReplica = Operation()
     moveReplica.Type = 'MoveReplica'

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import os
 import io
 import tarfile
-import cStringIO
+from six import BytesIO
 
 from DIRAC import S_OK, gLogger
 from DIRAC.Core.Base.Client import Client, createClient
@@ -59,7 +59,7 @@ class BundleDeliveryClient(Client):
       dirCreated = True
     currentHash = self.__getHash(bundleID, dirToSyncTo)
     self.log.info("Current hash for bundle %s in dir %s is '%s'" % (bundleID, dirToSyncTo, currentHash))
-    buff = cStringIO.StringIO()
+    buff = BytesIO()
     transferClient = self.__getTransferClient()
     result = transferClient.receiveFile(buff, [bundleID, currentHash])
     if not result['OK']:

--- a/FrameworkSystem/DB/ProxyDB.py
+++ b/FrameworkSystem/DB/ProxyDB.py
@@ -1232,7 +1232,7 @@ class ProxyDB(DB):
     numUses = max(1, min(numUses, maxUses))
     m = hashlib.md5()
     rndData = "%s.%s.%s.%s" % (time.time(), random.random(), numUses, lifeTime)
-    m.update(rndData)
+    m.update(rndData.encode())
     token = m.hexdigest()
     fieldsSQL = ", ".join(("Token", "RequesterDN", "RequesterGroup", "ExpirationTime", "UsesLeft"))
     valuesSQL = ", ".join((self._escapeString(token)['Value'],

--- a/FrameworkSystem/DB/UserProfileDB.py
+++ b/FrameworkSystem/DB/UserProfileDB.py
@@ -546,7 +546,7 @@ class UserProfileDB(DB):
     """
     if not hashTag:
       hashTag = hashlib.md5()
-      hashTag.update("%s;%s;%s" % (Time.dateTime(), userIds, tagName))
+      hashTag.update(("%s;%s;%s" % (Time.dateTime(), userIds, tagName)).encode())
       hashTag = hashTag.hexdigest()
 
     result = self.insertFields('up_HashTags', ['UserId', 'GroupId', 'VOId', 'TagName', 'HashTag'],

--- a/FrameworkSystem/Service/BundleDeliveryHandler.py
+++ b/FrameworkSystem/Service/BundleDeliveryHandler.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 __RCSID__ = "$Id$"
 
 import six
-import cStringIO
+from six import BytesIO
 import tarfile
 import os
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
@@ -72,7 +72,7 @@ class BundleManager(object):
     for bId in dirsToBundle:
       bundlePaths = dirsToBundle[bId]
       gLogger.info("Updating %s bundle %s" % (bId, bundlePaths))
-      buffer_ = cStringIO.StringIO()
+      buffer_ = BytesIO()
       filesToBundle = sorted(File.getGlobbedFiles(bundlePaths))
       if filesToBundle:
         commonPath = File.getCommonPath(filesToBundle)
@@ -141,7 +141,7 @@ class BundleDeliveryHandler(RequestHandler):
       fileHelper.markAsTransferred()
       return S_OK(bundleVersion)
 
-    buffer_ = cStringIO.StringIO(gBundleManager.getBundleData(bId))
+    buffer_ = BytesIO(gBundleManager.getBundleData(bId))
     result = fileHelper.DataSourceToNetwork(buffer_)
     buffer_.close()
     if not result['OK']:

--- a/FrameworkSystem/Service/PlottingHandler.py
+++ b/FrameworkSystem/Service/PlottingHandler.py
@@ -48,7 +48,11 @@ class PlottingHandler(RequestHandler):
 
   def __calculatePlotHash(self, data, metadata, subplotMetadata):
     m = hashlib.md5()
-    m.update(repr({'Data': data, 'PlotMetadata': metadata, 'SubplotMetadata': subplotMetadata}))
+    m.update(repr({
+      'Data': data,
+      'PlotMetadata': metadata,
+      'SubplotMetadata': subplotMetadata
+    }).encode())
     return m.hexdigest()
 
   types_generatePlot = [[dict, list], dict]

--- a/FrameworkSystem/Service/PlottingHandler.py
+++ b/FrameworkSystem/Service/PlottingHandler.py
@@ -49,9 +49,9 @@ class PlottingHandler(RequestHandler):
   def __calculatePlotHash(self, data, metadata, subplotMetadata):
     m = hashlib.md5()
     m.update(repr({
-      'Data': data,
-      'PlotMetadata': metadata,
-      'SubplotMetadata': subplotMetadata
+        'Data': data,
+        'PlotMetadata': metadata,
+        'SubplotMetadata': subplotMetadata
     }).encode())
     return m.hexdigest()
 

--- a/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -11,7 +11,12 @@ import socket
 import os
 import re
 import time
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import getpass
 import importlib
 import shutil

--- a/FrameworkSystem/private/SecurityFileLog.py
+++ b/FrameworkSystem/private/SecurityFileLog.py
@@ -6,7 +6,7 @@ import os
 import re
 import time
 import gzip
-import Queue
+from six.moves import queue as Queue
 import threading
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler

--- a/FrameworkSystem/private/monitoring/MonitoringCatalog.py
+++ b/FrameworkSystem/private/monitoring/MonitoringCatalog.py
@@ -278,7 +278,7 @@ class MonitoringCatalog(object):
     m = hashlib.md5()
     acDict['name'] = acName
     acDict['sourceId'] = sourceId
-    m.update(str(acDict))
+    m.update(str(acDict).encode())
     retList = self.__select("filename", "activities", acDict)
     if len(retList) > 0:
       return retList[0][0]

--- a/FrameworkSystem/private/monitoring/PlotCache.py
+++ b/FrameworkSystem/private/monitoring/PlotCache.py
@@ -46,8 +46,8 @@ class PlotCache(object):
 
   def __generateName(self, *args, **kwargs):
     m = hashlib.md5()
-    m.update(repr(args))
-    m.update(repr(kwargs))
+    m.update(repr(args).encode())
+    m.update(repr(kwargs).encode())
     return m.hexdigest()
 
   def __isCurrentTime(self, toSecs):

--- a/FrameworkSystem/private/monitoring/RRDManager.py
+++ b/FrameworkSystem/private/monitoring/RRDManager.py
@@ -200,8 +200,8 @@ class RRDManager(object):
     Generates a random name
     """
     m = hashlib.md5()
-    m.update(str(args))
-    m.update(str(kwargs))
+    m.update(str(args).encode())
+    m.update(str(kwargs).encode())
     return m.hexdigest()
 
   def __generateRRDGraphVar(self, entryName, activity, timeSpan, plotWidth):

--- a/FrameworkSystem/private/standardLogging/Handler/ServerHandler.py
+++ b/FrameworkSystem/private/standardLogging/Handler/ServerHandler.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 __RCSID__ = "$Id$"
 
 import logging
-import Queue
+from six.moves import queue as Queue
 import threading
 
 from DIRAC.Core.Utilities import Network

--- a/FrameworkSystem/private/standardLogging/Message.py
+++ b/FrameworkSystem/private/standardLogging/Message.py
@@ -21,7 +21,7 @@ def tupleToMessage(varTuple):
 class Message:
 
   def __init__(self, systemName, level, time, msgText, variableText, frameInfo, subSystemName=''):
-    import thread
+    from six.moves import _thread as thread
     self.systemName = systemName
     self.level = level
     self.time = time

--- a/FrameworkSystem/private/standardLogging/test/TestLogUtilities.py
+++ b/FrameworkSystem/private/standardLogging/test/TestLogUtilities.py
@@ -5,7 +5,7 @@ Test Logger Wrapper
 __RCSID__ = "$Id$"
 
 import logging
-from StringIO import StringIO
+from six import StringIO
 
 from DIRAC.FrameworkSystem.private.standardLogging.LoggingRoot import LoggingRoot
 from DIRAC.FrameworkSystem.private.standardLogging.Logging import Logging

--- a/FrameworkSystem/private/standardLogging/test/Test_LoggingRoot_ConfigForExternalLibs.py
+++ b/FrameworkSystem/private/standardLogging/test/Test_LoggingRoot_ConfigForExternalLibs.py
@@ -9,7 +9,7 @@ Test Config for External Libraries:
 __RCSID__ = "$Id$"
 
 import logging
-from StringIO import StringIO
+from six import StringIO
 import pytest
 
 from DIRAC.FrameworkSystem.private.standardLogging.test.TestLogUtilities import gLogger, cleaningLog, gLoggerReset

--- a/FrameworkSystem/private/standardLogging/test/Test_Logging_FormatOptions.py
+++ b/FrameworkSystem/private/standardLogging/test/Test_Logging_FormatOptions.py
@@ -4,7 +4,7 @@ Test properties of log records
 
 __RCSID__ = "$Id$"
 
-import thread
+from six.moves import _thread as thread
 import pytest
 
 from DIRAC.FrameworkSystem.private.standardLogging.test.TestLogUtilities import gLogger, gLoggerReset

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -31,7 +31,7 @@ import glob
 import tarfile
 import urllib
 import shlex
-import StringIO
+from six import StringIO
 
 import DIRAC
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
@@ -353,7 +353,7 @@ class Dirac(API):
         self.log.error(msg)
         return S_ERROR(msg)
 
-      jobDescriptionObject = StringIO.StringIO(job._toXML())  # pylint: disable=protected-access
+      jobDescriptionObject = StringIO(job._toXML())  # pylint: disable=protected-access
       jdlAsString = job._toJDL(jobDescriptionObject=jobDescriptionObject)  # pylint: disable=protected-access
 
     if mode.lower() == 'local':

--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -33,7 +33,7 @@ import re
 import os
 import urllib
 import shlex
-import StringIO
+from six import StringIO
 
 from DIRAC import S_OK, gLogger
 from DIRAC.Core.Base.API import API
@@ -1127,7 +1127,7 @@ class Job(API):
             self.log.warn("Job description XML file not found")
       self.addToInputSandbox.append(scriptName)
 
-    elif isinstance(jobDescriptionObject, StringIO.StringIO):
+    elif isinstance(jobDescriptionObject, StringIO):
       self.log.verbose("jobDescription is passed in as a StringIO object")
 
     else:

--- a/Interfaces/API/test/Test_JobAPI.py
+++ b/Interfaces/API/test/Test_JobAPI.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 __RCSID__ = "$Id$"
 
 import pytest
-import StringIO
+from six import StringIO
 
 from DIRAC.Interfaces.API.Job import Job
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
@@ -42,7 +42,7 @@ def test_basicJob():
     with open('./Interfaces/API/test/testWFSIO.jdl') as fd:
       expected = fd.read()
 
-  jdlSIO = job._toJDL(jobDescriptionObject=StringIO.StringIO(job._toXML()))
+  jdlSIO = job._toJDL(jobDescriptionObject=StringIO(job._toXML()))
   assert jdlSIO == expected
 
 

--- a/MonitoringSystem/private/MainReporter.py
+++ b/MonitoringSystem/private/MainReporter.py
@@ -81,8 +81,8 @@ class MainReporter(object):
       epoch = requestToHash[key]
       requestToHash[key] = epoch - epoch % granularity
     md5Hash = hashlib.md5()
-    md5Hash.update(repr(requestToHash))
-    md5Hash.update(self.__setup)
+    md5Hash.update(repr(requestToHash).encode())
+    md5Hash.update(self.__setup.encode())
     return md5Hash.hexdigest()
 
   def generate(self, reportRequest, credDict):

--- a/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -152,7 +152,7 @@ class ReqProxyHandler(RequestHandler):
     :param str requestJSON:  request serialized to JSON format
     """
     try:
-      requestFile = os.path.join(self.cacheDir(), md5(requestJSON).hexdigest())
+      requestFile = os.path.join(self.cacheDir(), md5(requestJSON.encode()).hexdigest())
       with open(requestFile, "w+") as request:
         request.write(requestJSON)
       return S_OK(requestFile)

--- a/ResourceStatusSystem/Agent/ElementInspectorAgent.py
+++ b/ResourceStatusSystem/Agent/ElementInspectorAgent.py
@@ -19,7 +19,7 @@ __RCSID__ = '$Id$'
 
 import datetime
 import math
-import Queue
+from six.moves import queue as Queue
 
 from DIRAC import S_ERROR, S_OK
 from DIRAC.Core.Base.AgentModule import AgentModule

--- a/ResourceStatusSystem/Agent/SiteInspectorAgent.py
+++ b/ResourceStatusSystem/Agent/SiteInspectorAgent.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 __RCSID__ = '$Id$'
 
 import math
-import Queue
+from six.moves import queue as Queue
 
 from DIRAC import S_OK
 from DIRAC.Core.Base.AgentModule import AgentModule

--- a/ResourceStatusSystem/Agent/test/Test_Agent_ElementInspectorAgent.py
+++ b/ResourceStatusSystem/Agent/test/Test_Agent_ElementInspectorAgent.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-import Queue
+from six.moves import queue as Queue
 
 # imports
 import pytest

--- a/ResourceStatusSystem/Agent/test/Test_Agent_SiteInspectorAgent.py
+++ b/ResourceStatusSystem/Agent/test/Test_Agent_SiteInspectorAgent.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-import Queue
+from six.moves import queue as Queue
 
 # imports
 import pytest

--- a/ResourceStatusSystem/Command/DowntimeCommand.py
+++ b/ResourceStatusSystem/Command/DowntimeCommand.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 
 __RCSID__ = '$Id$'
 
-import urllib2
+from six.moves.urllib_error import URLError
 import re
 
 from datetime import datetime, timedelta
@@ -210,11 +210,11 @@ class DowntimeCommand(Command):
     # WARNING: checking all the DT that are ongoing or starting in given <hours> from now
     try:
       results = self.gClient.getStatus(element, name=elementNames, startingInHours=hours)
-    except urllib2.URLError:
+    except URLError:
       try:
         # Let's give it a second chance..
         results = self.gClient.getStatus(element, name=elementNames, startingInHours=hours)
-      except urllib2.URLError as e:
+      except URLError as e:
         return S_ERROR(e)
 
     if not results['OK']:

--- a/ResourceStatusSystem/Command/GGUSTicketsCommand.py
+++ b/ResourceStatusSystem/Command/GGUSTicketsCommand.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 
 __RCSID__ = '$Id$'
 
-import urllib2
+from six.moves.urllib_error import URLError
 
 from DIRAC import S_ERROR, S_OK
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getGOCSiteName, getGOCSites
@@ -91,7 +91,7 @@ class GGUSTicketsCommand(Command):
 
     try:
       results = self.gClient.getTicketsList(gocName)
-    except urllib2.URLError as e:
+    except URLError as e:
       return S_ERROR('%s %s' % (gocName, e))
 
     if not results['OK']:

--- a/ResourceStatusSystem/Command/VOBOXAvailabilityCommand.py
+++ b/ResourceStatusSystem/Command/VOBOXAvailabilityCommand.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 # FIXME: NOT Usable ATM
 # missing doNew, doCache, doMaster
 
-import urlparse
+from six.moves.urllib import parse as urlparse
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.DISET.RPCClient import RPCClient

--- a/Resources/Computing/BOINCComputingElement.py
+++ b/Resources/Computing/BOINCComputingElement.py
@@ -16,7 +16,7 @@ import bz2
 import base64
 import tempfile
 
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement

--- a/Resources/Computing/BatchSystems/Condor.py
+++ b/Resources/Computing/BatchSystems/Condor.py
@@ -14,7 +14,12 @@ from __future__ import absolute_import
 from __future__ import division
 import re
 import tempfile
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import os
 
 __RCSID__ = "$Id$"

--- a/Resources/Computing/BatchSystems/GE.py
+++ b/Resources/Computing/BatchSystems/GE.py
@@ -18,7 +18,12 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 import re
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import os
 
 __RCSID__ = "$Id$"

--- a/Resources/Computing/BatchSystems/Host.py
+++ b/Resources/Computing/BatchSystems/Host.py
@@ -11,7 +11,12 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import os
 import glob
 import shutil

--- a/Resources/Computing/BatchSystems/LSF.py
+++ b/Resources/Computing/BatchSystems/LSF.py
@@ -13,7 +13,12 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 import re
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import os
 
 __RCSID__ = "$Id$"

--- a/Resources/Computing/BatchSystems/OAR.py
+++ b/Resources/Computing/BatchSystems/OAR.py
@@ -12,7 +12,12 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import os
 import json
 

--- a/Resources/Computing/BatchSystems/SLURM.py
+++ b/Resources/Computing/BatchSystems/SLURM.py
@@ -12,7 +12,12 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import os
 import re
 

--- a/Resources/Computing/BatchSystems/Torque.py
+++ b/Resources/Computing/BatchSystems/Torque.py
@@ -12,7 +12,12 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import os
 
 __RCSID__ = "$Id$"

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -48,7 +48,12 @@ from __future__ import print_function
 import six
 import os
 import tempfile
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import errno
 
 from DIRAC import S_OK, S_ERROR, gConfig

--- a/Resources/Computing/LocalComputingElement.py
+++ b/Resources/Computing/LocalComputingElement.py
@@ -15,7 +15,7 @@ import shutil
 import tempfile
 import getpass
 import errno
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC import gConfig

--- a/Resources/Computing/SSHBatchComputingElement.py
+++ b/Resources/Computing/SSHBatchComputingElement.py
@@ -17,7 +17,7 @@ import six
 import os
 import socket
 import stat
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC import rootPath

--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -18,7 +18,7 @@ import json
 import stat
 import shutil
 import errno
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC import rootPath

--- a/Resources/MessageQueue/MQConsumer.py
+++ b/Resources/MessageQueue/MQConsumer.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import Queue
+from six.moves import queue as Queue
 from DIRAC import S_ERROR, S_OK, gLogger
 from DIRAC.Resources.MessageQueue.Utilities import getDestinationAddress, getMQService, generateDefaultCallback
 from DIRAC.Core.Utilities.DErrno import EMQNOM

--- a/Resources/MessageQueue/Utilities.py
+++ b/Resources/MessageQueue/Utilities.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
-import Queue
+from six.moves import queue as Queue
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 

--- a/Resources/MessageQueue/test/Test_MQ_Utilities.py
+++ b/Resources/MessageQueue/test/Test_MQ_Utilities.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 
 import DIRAC.Resources.MessageQueue.Utilities as module
 import unittest
-import Queue
+from six.moves import queue as Queue
 
 from mock import MagicMock
 

--- a/Resources/ProxyProvider/test/Test_DIRACCAProxyProvider.py
+++ b/Resources/ProxyProvider/test/Test_DIRACCAProxyProvider.py
@@ -9,7 +9,12 @@ import os
 import re
 import sys
 import shutil
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import unittest
 import tempfile
 

--- a/Resources/ProxyProvider/test/Test_DIRACCAProxyProvider.py
+++ b/Resources/ProxyProvider/test/Test_DIRACCAProxyProvider.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 import shutil
-# TODO: This should be moderised to use subprocess(32)
+# TODO: This should be modernised to use subprocess(32)
 try:
   import commands
 except ImportError:

--- a/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -15,7 +15,7 @@ __RCSID__ = "$Id$"
 
 import time
 import datetime
-from Queue import Queue
+from six.moves.queue import Queue
 
 from DIRAC import S_OK
 

--- a/TransformationSystem/Agent/TransformationAgent.py
+++ b/TransformationSystem/Agent/TransformationAgent.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 
 from past.builtins import long
 import time
-import Queue
+from six.moves import queue as Queue
 import os
 import datetime
 import pickle

--- a/TransformationSystem/Client/TaskManager.py
+++ b/TransformationSystem/Client/TaskManager.py
@@ -11,7 +11,7 @@ __RCSID__ = "$Id$"
 
 import six
 import time
-import StringIO
+from six import StringIO
 import json
 import copy
 import os
@@ -991,7 +991,7 @@ class WorkflowTasks(TaskBase):
       self._logError("No valid job description found")
       return S_ERROR("No valid job description found")
 
-    workflowFileObject = StringIO.StringIO(oJob._toXML())
+    workflowFileObject = StringIO(oJob._toXML())
     jdl = oJob._toJDL(jobDescriptionObject=workflowFileObject)
     return self.submissionClient.submitJob(jdl, workflowFileObject)
 

--- a/TransformationSystem/Utilities/JobInfo.py
+++ b/TransformationSystem/Utilities/JobInfo.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 
 from pprint import pformat
-from itertools import izip_longest
+from six.moves import zip_longest
 
 from DIRAC import gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
@@ -55,14 +55,14 @@ class JobInfo(object):
     if self.otherTasks:
       info += ' (Last task %s)' % self.otherTasks
     if self.inputFiles:
-      ifInfo = ['<<< %s (%s, %s, Errors %s)' % _ for _ in izip_longest(self.inputFiles,
+      ifInfo = ['<<< %s (%s, %s, Errors %s)' % _ for _ in zip_longest(self.inputFiles,
                                                                        self.inputFilesExist,
                                                                        self.transFileStatus,
                                                                        self.errorCounts)]
       info += '\n'.join(ifInfo)
     if self.outputFiles:
       info += "\n::: OutputFiles: "
-      efInfo = ["%s (%s)" % _ for _ in izip_longest(self.outputFiles, self.outputFileStatus)]
+      efInfo = ["%s (%s)" % _ for _ in zip_longest(self.outputFiles, self.outputFileStatus)]
       info += ", ".join(efInfo)
     if self.pendingRequest:
       info += "\n PENDING REQUEST IGNORE THIS JOB!!!"

--- a/TransformationSystem/Utilities/TransformationInfo.py
+++ b/TransformationSystem/Utilities/TransformationInfo.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 
 from collections import OrderedDict, defaultdict
-from itertools import izip_longest
+from six.moves import zip_longest
 
 from DIRAC import gLogger, S_OK
 from DIRAC.Core.Utilities.List import breakListIntoChunks
@@ -131,7 +131,7 @@ class TransformationInfo(object):
     descendants = self.__findAllDescendants(jobInfo.outputFiles)
     existingOutputFiles = [
         lfn for lfn,
-        status in izip_longest(
+        status in zip_longest(
             jobInfo.outputFiles,
             jobInfo.outputFileStatus) if status == "Exists"]
     filesToDelete = existingOutputFiles + descendants

--- a/TransformationSystem/test/Test_JobInfo.py
+++ b/TransformationSystem/test/Test_JobInfo.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 import unittest
 import sys
-from StringIO import StringIO
+from six import StringIO
 
 from mock import MagicMock as Mock
 

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -290,7 +290,7 @@ class SiteDirector(AgentModule):
     """ Generate a hash of the queue description
     """
     myMD5 = hashlib.md5()
-    myMD5.update(str(queueDict))
+    myMD5.update(str(queueDict).encode())
     hexstring = myMD5.hexdigest()
     return hexstring
 

--- a/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -13,7 +13,7 @@ import tarfile
 import hashlib
 import tempfile
 import re
-import StringIO
+from six import BytesIO
 
 from DIRAC import gLogger, S_OK, S_ERROR, gConfig
 
@@ -99,7 +99,7 @@ class SandboxStoreClient(object):
         a fileList item can be:
           - a string, which is an lfn name
           - a file name (real), that is supposed to be on disk, in the current directory
-          - a fileObject that should be a StringIO.StringIO type of object
+          - a fileObject that should be a BytesIO type of object
 
         Parameters:
           - assignTo : Dict containing { 'Job:<jobid>' : '<sbType>', ... }
@@ -126,7 +126,7 @@ class SandboxStoreClient(object):
           else:
             errorFiles.append(sFile)
 
-      elif isinstance(sFile, StringIO.StringIO):
+      elif isinstance(sFile, BytesIO):
         files2Upload.append(sFile)
       else:
         return S_ERROR("Objects of type %s can't be part of InputSandbox" % type(sFile))
@@ -144,7 +144,7 @@ class SandboxStoreClient(object):
       for sFile in files2Upload:
         if isinstance(sFile, six.string_types):
           tf.add(os.path.realpath(sFile), os.path.basename(sFile), recursive=True)
-        elif isinstance(sFile, StringIO.StringIO):
+        elif isinstance(sFile, BytesIO):
           tarInfo = tarfile.TarInfo(name='jobDescription.xml')
           tarInfo.size = len(sFile.buf)
           tf.addfile(tarinfo=tarInfo, fileobj=sFile)

--- a/WorkloadManagementSystem/Client/WMSClient.py
+++ b/WorkloadManagementSystem/Client/WMSClient.py
@@ -6,7 +6,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import StringIO
+from six import StringIO
 import time
 
 from DIRAC import S_OK, S_ERROR, gLogger
@@ -97,7 +97,7 @@ class WMSClient(object):
     stringIOFiles = []
     stringIOFilesSize = 0
     if jobDescriptionObject is not None:
-      if isinstance(jobDescriptionObject, StringIO.StringIO):
+      if isinstance(jobDescriptionObject, StringIO):
         stringIOFiles = [jobDescriptionObject]
         stringIOFilesSize = len(jobDescriptionObject.buf)
         gLogger.debug("Size of the stringIOFiles: " + str(stringIOFilesSize))

--- a/WorkloadManagementSystem/Client/test/Test_Client_WorkloadManagementSystem.py
+++ b/WorkloadManagementSystem/Client/test/Test_Client_WorkloadManagementSystem.py
@@ -8,7 +8,7 @@ from __future__ import division
 import os
 import unittest
 import importlib
-import StringIO
+from six import BytesIO
 
 from mock import MagicMock
 
@@ -99,7 +99,7 @@ class SandboxStoreTestCaseSuccess(ClientsTestCase):
     ourSSC = importlib.import_module('DIRAC.WorkloadManagementSystem.Client.SandboxStoreClient')
     ourSSC.TransferClient = MagicMock()
     ssc = SandboxStoreClient()
-    fileList = [StringIO.StringIO('try')]
+    fileList = [BytesIO('try')]
     res = ssc.uploadFilesAsSandbox(fileList)
     print(res)
 

--- a/__init__.py
+++ b/__init__.py
@@ -102,21 +102,6 @@ if patchLevel:
 if preVersion:
   version = "%s-pre%s" % (version, preVersion)
 
-# Check of python version
-
-__pythonMajorVersion = ("2", )
-__pythonMinorVersion = ("7")
-
-pythonVersion = pyPlatform.python_version_tuple()
-if str(pythonVersion[0]) not in __pythonMajorVersion or str(pythonVersion[1]) not in __pythonMinorVersion:
-  print("Python Version %s not supported by DIRAC" % pyPlatform.python_version())
-  print("Supported versions are: ")
-  for major in __pythonMajorVersion:
-    for minor in __pythonMinorVersion:
-      print("%s.%s.x" % (major, minor))
-
-  sys.exit(1)
-
 errorMail = "dirac.alarms@gmail.com"
 alarmMail = "dirac.alarms@gmail.com"
 

--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -33,6 +33,7 @@ dependencies:
   - stomp.py =4.1.23
   - suds-jurko >=0.6
   - xmltodict
+  - pycurl
   # testing and development
   - autopep8
   - caniusepython3
@@ -61,6 +62,7 @@ dependencies:
   - mysqlclient
   - pip:
     - diraccfg
+    - subprocess32
     # This is a fork of tornado with a patch to allow for configurable iostream
     # It should eventually be part of DIRACGrid
     - git+https://github.com/chaen/tornado.git@iostreamConfigurable

--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -1,0 +1,72 @@
+name: dirac-development
+
+channels:
+  - diracgrid
+  - conda-forge
+  - defaults
+
+dependencies:
+  # runtime
+  - python =3.8
+  - pip
+  - boto3
+  - certifi
+  - cmreshandler >1.0.0b4
+  - docutils
+  - elasticsearch-dsl
+  - future
+  - gitpython >=2.1.0
+  - m2crypto >=0.36
+  - matplotlib
+  - numpy
+  - pexpect >=4.0.1
+  - pillow
+  - psutil >=4.2.0
+  - pyasn1 >0.4.1
+  - pyasn1-modules
+  - python-json-logger >=0.1.8
+  - pytz >=2015.7
+  - recommonmark
+  - requests >=2.9.1
+  - six >=1.10
+  - sqlalchemy >=1.0.9
+  - stomp.py =4.1.23
+  - suds-jurko >=0.6
+  - xmltodict
+  # testing and development
+  - autopep8
+  - caniusepython3
+  - coverage
+  - hypothesis
+  - ipython
+  - mock
+  - parameterized
+  - pylint >=1.6.5
+  - pyparsing >=2.0.6
+  - pytest >=3.6
+  - pytest-cov >=2.2.0
+  - pytest-mock
+  - shellcheck
+  # docs
+  - pygments >=1.5
+  - sphinx
+  # unused
+  - funcsigs
+  - jinja2
+  # - readline >=6.2.4 in the standard library
+  - simplejson >=3.8.1
+  #- tornado >=5.0.0,<6.0.0
+  - typing >=3.6.6
+  - openssl
+  - mysqlclient
+  - pip:
+    - diraccfg
+    # This is a fork of tornado with a patch to allow for configurable iostream
+    # It should eventually be part of DIRACGrid
+    - git+https://github.com/chaen/tornado.git@iostreamConfigurable
+    # This is an extension of Tornado to use M2Crypto
+    # It should eventually be part of DIRACGrid
+    - git+https://github.com/chaen/tornado_m2crypto
+    # fts-rest doesn't support Python 3, this branch changed has just enough to
+    # make it importing possible
+    - git+https://gitlab.cern.ch/cburr/fts-rest.git@python3

--- a/tests/Integration/Framework/Test_ProxyDB.py
+++ b/tests/Integration/Framework/Test_ProxyDB.py
@@ -12,7 +12,12 @@ import sys
 import stat
 import shutil
 import tempfile
-import commands
+# TODO: This should be moderised to use subprocess(32)
+try:
+  import commands
+except ImportError:
+  # Python 3's subprocess module contains a compatability layer
+  import subprocess as commands
 import unittest
 
 from diraccfg import CFG

--- a/tests/Integration/Framework/Test_ProxyDB.py
+++ b/tests/Integration/Framework/Test_ProxyDB.py
@@ -12,7 +12,7 @@ import sys
 import stat
 import shutil
 import tempfile
-# TODO: This should be moderised to use subprocess(32)
+# TODO: This should be modernised to use subprocess(32)
 try:
   import commands
 except ImportError:


### PR DESCRIPTION
This PR adds `pytest --collect-only` to the CI for Python 3 and none of the changes should make a difference in Python 2. More changes will be needed before the tests work but this will at least ensure that it's possible to import most of DIRAC. All of the changes should be transparent in Python 2 and future PRs can then start enabling parts of the unit tests by adding `-k mytests` to the command.

I've constructed it to be easy to review as individual commits instead of in one go. I've split them into two groups:

### Simple renaming of modules that is handled using `six`

* 62b10d7: Replace "import thread" with "from six.moves import _thread as thread"
* b9b6299: Replace "import urlparse" with "import six.moves.urllib.parse"
* 4bdc9b0: Replace "import Queue" with "from six.moves import queue as Queue"
* 331c7ed: Replace "itertools.izip_longest" with "six.moves.zip_longest"
* 58d240d: Get urllib2.URLError from six.moves.urllib_error
* 7ece6c3: Replace StringIO with six.StringIO and six.BytesIO
    * In Python 2 `six.StringIO` and `six.BytesIO` are both `StringIO.StringIO`. In Python 3 they are `io.StringIO` and `io.BytesIO` but it's not practical to use these in Python 2 as StringIO requires unicode objects as input which isn't worth it. I've tried to guess at which one will be appropriate for Python 3 but more changes will definitely be needed here to make the tests pass once they're being executed.

### Other changes

* 8a4eaf1: Fallback to `subprocess.getstatusoutput` for `commands.getstatusoutput`
    * These should be rewritten to use `subprocess32` properly rather than using the long-deprecated `getstatusoutput`. (the `subprocess32` doesn't include Python 3's `subprocess.getstatusoutput`)
* d285b56: Encode strings as UTF-8 before using hashlib.md5
* 604de9c: Allow importing DEncode in Python 3 without actually porting it
* 0716316: Minimal types fixes to make pytest discovery functional
* 69f058b: Fix string type checking in Core/Utilities/Time.py
* 846d8a6: Escape backslash in Core/Utilities/Grid.py
* 4f3f839: Remove Python version check on import
    * DIRAC errors on import for anything except Python 2.7 but I don't see any reason to keep this check given `dirac-install` will force people to get Python 2.7 from DIRACOS.
* 5a66509: Remove MySQLdb.server_init if using mysqlclient
    * `MySQL-python` was abandoned a long time ago and never supported Python 3. It looks like `mysqlclient` is almost a drop in replacement so that's what I've gone with for now. The only change it seems to need is this commit.
* c8c1f9d: Run pytest discovery with Python 3
    * I add a new `environment-py3.yml` file to manage the Python 3 dependencies. It's ugly to list them in yet another place but I think it's necessary given things won't be exactly the same.
    * `fts-rest` Doesn't seem to support Python 3 at all. I've made enough changes in a fork to make it possible import and that's what I use here. Porting it properly to using `six` should only take a few hours but I didn't find any tests and we should ask the developers to see what their plans are.

BEGINRELEASENOTES

*Python 3
NEW: Run pytest test collection for Python 3

ENDRELEASENOTES