### PR TITLE
[v7r1] RSS DB schema change to include a VO column

### DIFF
--- a/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -214,6 +214,7 @@ class PilotCache(rmsBase):
 
   site = Column('Site', String(64), nullable=False, primary_key=True)
   ce = Column('CE', String(64), nullable=False, primary_key=True)
+  vo = Column('VO', String(64), nullable=False, primary_key=True, server_default='all')
   status = Column('Status', String(16), nullable=False)
   pilotjobeff = Column('PilotJobEff', Float(asdecimal=False), nullable=False, server_default='0')
   pilotsperjob = Column('PilotsPerJob', Float(asdecimal=False), nullable=False, server_default='0')
@@ -229,6 +230,7 @@ class PilotCache(rmsBase):
 
     self.site = dictionary.get('Site', self.site)
     self.ce = dictionary.get('CE', self.ce)
+    self.vo = dictionary.get('VO', self.vo)
     self.status = dictionary.get('Status', self.status)
     self.pilotjobeff = dictionary.get('PilotJobEff', self.pilotjobeff)
     self.pilotsperjob = dictionary.get('PilotsPerJob', self.pilotsperjob)
@@ -239,7 +241,7 @@ class PilotCache(rmsBase):
   def toList(self):
     """ Simply returns a list of column values
     """
-    return [self.site, self.ce, self.status, self.pilotjobeff, self.pilotsperjob, self.lastchecktime]
+    return [self.site, self.ce, self.vo, self.status, self.pilotjobeff, self.pilotsperjob, self.lastchecktime]
 
 
 class PolicyResult(rmsBase):
@@ -254,6 +256,7 @@ class PolicyResult(rmsBase):
   statustype = Column('StatusType', String(16), nullable=False, server_default='', primary_key=True)
   element = Column('Element', String(32), nullable=False, primary_key=True)
   name = Column('Name', String(64), nullable=False, primary_key=True)
+  vo = Column('VO', String(64), nullable=False, primary_key=True, server_default='all')
   status = Column('Status', String(16), nullable=False)
   reason = Column('Reason', String(512), nullable=False, server_default='Unspecified')
   dateeffective = Column('DateEffective', DateTime, nullable=False)
@@ -271,6 +274,7 @@ class PolicyResult(rmsBase):
     self.statustype = dictionary.get('StatusType', self.statustype)
     self.element = dictionary.get('Element', self.element)
     self.name = dictionary.get('Name', self.name)
+    self.vo = dictionary.get('VO', self.vo)
     self.status = dictionary.get('Status', self.status)
     self.reason = dictionary.get('Reason', self.reason)
     self.dateeffective = dictionary.get('DateEffective', self.dateeffective.replace(microsecond=0)
@@ -284,7 +288,7 @@ class PolicyResult(rmsBase):
     """ Simply returns a list of column values
     """
     return [self.policyname, self.statustype, self.element, self.name,
-            self.status, self.reason, self.dateeffective, self.lastchecktime]
+            self.vo, self.status, self.reason, self.dateeffective, self.lastchecktime]
 
 
 class SpaceTokenOccupancyCache(rmsBase):

--- a/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -52,7 +52,9 @@ rssBase = declarative_base()
 
 
 class ElementStatusBase(object):
-  """ Prototype for tables
+  """ 
+  Prototype for tables.
+  Schema change - add a VO column.
   """
 
   __table_args__ = {'mysql_engine': 'InnoDB',
@@ -60,6 +62,7 @@ class ElementStatusBase(object):
 
   name = Column('Name', String(64), nullable=False, primary_key=True)
   statustype = Column('StatusType', String(128), nullable=False, server_default='all', primary_key=True)
+  vo = Column('VO', String(64), nullable=False, primary_key=True, server_default='all')
   status = Column('Status', String(8), nullable=False, server_default='')
   reason = Column('Reason', String(512), nullable=False, server_default='Unspecified')
   dateeffective = Column('DateEffective', DateTime, nullable=False)
@@ -81,6 +84,7 @@ class ElementStatusBase(object):
 
     self.name = dictionary.get('Name', self.name)
     self.statustype = dictionary.get('StatusType', self.statustype)
+    self.vo = dictionary.get('VO', self.vo)
     self.status = dictionary.get('Status', self.status)
     self.reason = dictionary.get('Reason', self.reason)
     self.dateeffective = dictionary.get('DateEffective', self.dateeffective)
@@ -97,7 +101,7 @@ class ElementStatusBase(object):
   def toList(self):
     """ Simply returns a list of column values
     """
-    return [self.name, self.statustype, self.status, self.reason,
+    return [self.name, self.statustype, self.vo, self.status, self.reason,
             self.dateeffective, self.tokenexpiration, self.elementtype,
             self.lastchecktime, self.tokenowner]
 
@@ -113,6 +117,7 @@ class ElementStatusBaseWithID(ElementStatusBase):
   id = Column('ID', BigInteger, nullable=False, autoincrement=True, primary_key=True)
   name = Column('Name', String(64), nullable=False)
   statustype = Column('StatusType', String(128), nullable=False, server_default='all')
+  vo = Column('VO', String(64), nullable=False, server_default='all')
   status = Column('Status', String(8), nullable=False, server_default='')
   reason = Column('Reason', String(512), nullable=False, server_default='Unspecified')
   dateeffective = Column('DateEffective', DateTime, nullable=False)
@@ -135,7 +140,7 @@ class ElementStatusBaseWithID(ElementStatusBase):
   def toList(self):
     """ Simply returns a list of column values
     """
-    return [self.id, self.name, self.statustype, self.status, self.reason,
+    return [self.id, self.name, self.statustype,  self.vo, self.status, self.reason,
             self.dateeffective, self.tokenexpiration, self.elementtype,
             self.lastchecktime, self.tokenowner]
 

--- a/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -52,7 +52,7 @@ rssBase = declarative_base()
 
 
 class ElementStatusBase(object):
-  """ 
+  """
   Prototype for tables.
   Schema change - add a VO column.
   """
@@ -140,7 +140,7 @@ class ElementStatusBaseWithID(ElementStatusBase):
   def toList(self):
     """ Simply returns a list of column values
     """
-    return [self.id, self.name, self.statustype,  self.vo, self.status, self.reason,
+    return [self.id, self.name, self.statustype, self.vo, self.status, self.reason,
             self.dateeffective, self.tokenexpiration, self.elementtype,
             self.lastchecktime, self.tokenowner]
 

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
@@ -193,8 +193,8 @@ class ResourceManagementClientChain(TestClientResourceManagementTestCase):
     self.assertTrue(res['OK'])
 
     res = self.rmClient.selectPilotCache('TestName12345')
-    # check if the result has changed
-    self.assertEqual(res['Value'][0][2], 'newStatus')
+    # check if the result has changed. New schema, vo column added, hence pos 3.
+    self.assertEqual(res['Value'][0][3], 'newStatus')
 
     # TEST deletePilotCache
     # ...............................................................................
@@ -230,8 +230,8 @@ class ResourceManagementClientChain(TestClientResourceManagementTestCase):
     self.assertTrue(res['OK'])
 
     res = self.rmClient.selectPolicyResult('element', 'TestName12345', 'policyName', 'statusType')
-    # check if the result has changed
-    self.assertEqual(res['Value'][0][4], 'newStatus')
+    # check if the result has changed.
+    self.assertEqual(res['Value'][0][5], 'newStatus')
 
     # TEST deletePolicyResult
     # ...............................................................................

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
@@ -63,7 +63,8 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][2], 'Active')
+    self.assertEqual(res['Value'][0][2], 'all')
+    self.assertEqual(res['Value'][0][3], 'Active')
 
     # try to select the previously entered element from the Log table (it should NOT be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')
@@ -95,7 +96,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestSite1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][2], 'Active')
+    self.assertEqual(res['Value'][0][3], 'Active')
     print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
 
     # try to select the previously entered element from the Log table (it should NOT be there)
@@ -128,7 +129,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][2], 'Banned')
+    self.assertEqual(res['Value'][0][3], 'Banned')
     print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
 
     # try to select the previously entered element from the Log table (now it should be there)
@@ -137,7 +138,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][1], 'TestName1234')
     self.assertEqual(res['Value'][0][2], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Banned')
+    self.assertEqual(res['Value'][0][4], 'Banned')
 
     # try to select the previously entered element from the Log table
     # with a reduced list of columns
@@ -173,7 +174,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][2], 'Active')
+    self.assertEqual(res['Value'][0][3], 'Active')
     print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
 
     # try to select the previously entered element from the Log table (now it should be there)
@@ -182,8 +183,8 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][1], 'TestName1234')
     self.assertEqual(res['Value'][0][2], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Banned')
-    self.assertEqual(res['Value'][1][3], 'Active')  # this is the last one
+    self.assertEqual(res['Value'][0][4], 'Banned')
+    self.assertEqual(res['Value'][1][4], 'Active')  # this is the last one
 
     print("modifing once more the previously entered element")
     res = rssClient.modifyStatusElement('Resource', 'Status', 'TestName1234', 'statusType',
@@ -197,7 +198,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][2], 'Probing')
+    self.assertEqual(res['Value'][0][3], 'Probing')
     print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
 
     # try to select the previously entered element from the Log table (now it should be there)
@@ -206,9 +207,9 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][1], 'TestName1234')
     self.assertEqual(res['Value'][0][2], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Banned')
-    self.assertEqual(res['Value'][1][3], 'Active')
-    self.assertEqual(res['Value'][2][3], 'Probing')  # this is the last one
+    self.assertEqual(res['Value'][0][4], 'Banned')
+    self.assertEqual(res['Value'][1][4], 'Active')
+    self.assertEqual(res['Value'][2][4], 'Probing')  # this is the last one
 
     # try to select the previously entered element from the Log table (now it should be there)
     # with a reduced list of columns
@@ -234,10 +235,10 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][2], 'Probing')
-    self.assertEqual(res['Value'][0][3], 'a new reason')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
-    self.assertNotEqual(res['Value'][0][7], res['Value'][0][4])
+    self.assertEqual(res['Value'][0][3], 'Probing')
+    self.assertEqual(res['Value'][0][4], 'a new reason')
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
+    self.assertNotEqual(res['Value'][0][8], res['Value'][0][5])
 
     # try to select the previously entered element from the Log table (now it should be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')
@@ -245,10 +246,10 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][1], 'TestName1234')
     self.assertEqual(res['Value'][0][2], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Banned')
-    self.assertEqual(res['Value'][1][3], 'Active')
-    self.assertEqual(res['Value'][2][3], 'Probing')
-    self.assertEqual(res['Value'][3][3], 'Probing')  # this is the last one
+    self.assertEqual(res['Value'][0][4], 'Banned')
+    self.assertEqual(res['Value'][1][4], 'Active')
+    self.assertEqual(res['Value'][2][4], 'Probing')
+    self.assertEqual(res['Value'][3][4], 'Probing')  # this is the last one
 
     # try to select the previously entered element from the Log table (now it should be there)
     # Using also Meta
@@ -344,7 +345,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     # check if the name that we got is equal to the previously added 'TestName123456789'
     self.assertEqual(res['Value'][0][0], 'TestName123456789')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][2], 'Active')
+    self.assertEqual(res['Value'][0][3], 'Active')
 
     # try to re-add the same element but with different value
     res = rssClient.addIfNotThereStatusElement('Resource', 'Status', 'TestName123456789', 'statusType',
@@ -358,7 +359,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     # check if the name that we got is equal to the previously added 'TestName123456789'
     self.assertEqual(res['Value'][0][0], 'TestName123456789')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][2], 'Active')  # NOT Banned
+    self.assertEqual(res['Value'][0][3], 'Active')  # NOT Banned
 
     # delete it
     res = rssClient.deleteStatusElement('Resource', 'Status', 'TestName123456789')

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
@@ -97,7 +97,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertEqual(res['Value'][0][0], 'TestSite1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
     self.assertEqual(res['Value'][0][3], 'Active')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
 
     # try to select the previously entered element from the Log table (it should NOT be there)
     res = rssClient.selectStatusElement('Site', 'Log', 'TestSite1234')
@@ -130,7 +130,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
     self.assertEqual(res['Value'][0][3], 'Banned')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
 
     # try to select the previously entered element from the Log table (now it should be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')
@@ -175,7 +175,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
     self.assertEqual(res['Value'][0][3], 'Active')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
 
     # try to select the previously entered element from the Log table (now it should be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')
@@ -199,7 +199,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
     self.assertEqual(res['Value'][0][3], 'Probing')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
 
     # try to select the previously entered element from the Log table (now it should be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')


### PR DESCRIPTION
Add a VO column to Resource Status and Resource Management DB tables. 

BEGINRELEASENOTES
*ResourceStatusSystem
CHANGE: add a VO column to all tables as apart of the primary key and a default value='all'


ENDRELEASENOTES
TODO:
- [ ] we'll include the required schema updates for existing instances in the release notes