### PR TITLE
[v7r0] Restore task kwargs in PoolComputingElement.submitJob()

### DIFF
--- a/Resources/Computing/PoolComputingElement.py
+++ b/Resources/Computing/PoolComputingElement.py
@@ -124,17 +124,18 @@ class PoolComputingElement(ComputingElement):
     if not res['OK']:
       self.log.error("Could not dump cfg to pilot.cfg", res['Message'])
 
+    # Here we define task kwargs: adding complex objects like thread.Lock can trigger errors in the task
+    taskKwargs = {'InnerCESubmissionType': self.innerCESubmissionType}
     if self.innerCESubmissionType == 'Sudo':
       for nUser in range(MAX_NUMBER_OF_SUDO_UNIX_USERS):
         if nUser not in self.userNumberPerTask.values():
           break
-      kwargs['NUser'] = nUser
-      kwargs['PayloadUser'] = os.environ['USER'] + 'p%s' % str(nUser).zfill(2)
-    kwargs['InnerCESubmissionType'] = self.innerCESubmissionType
+      taskKwargs['NUser'] = nUser
+      taskKwargs['PayloadUser'] = os.environ['USER'] + 'p%s' % str(nUser).zfill(2)
 
     result = self.pPool.createAndQueueTask(executeJob,
                                            args=(executableFile, proxy, self.taskID),
-                                           kwargs=kwargs,
+                                           kwargs=taskKwargs,
                                            taskID=self.taskID,
                                            usePoolCallbacks=True)
     self.processorsPerTask[self.taskID] = processorsForJob

--- a/Resources/Computing/PoolComputingElement.py
+++ b/Resources/Computing/PoolComputingElement.py
@@ -131,7 +131,8 @@ class PoolComputingElement(ComputingElement):
         if nUser not in self.userNumberPerTask.values():
           break
       taskKwargs['NUser'] = nUser
-      taskKwargs['PayloadUser'] = os.environ['USER'] + 'p%s' % str(nUser).zfill(2)
+      if 'USER' in os.environ:
+        taskKwargs['PayloadUser'] = os.environ['USER'] + 'p%s' % str(nUser).zfill(2)
 
     result = self.pPool.createAndQueueTask(executeJob,
                                            args=(executableFile, proxy, self.taskID),

--- a/Resources/Computing/SudoComputingElement.py
+++ b/Resources/Computing/SudoComputingElement.py
@@ -4,6 +4,7 @@
 import os
 import pwd
 import stat
+import errno
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities import DErrno
@@ -64,6 +65,11 @@ class SudoComputingElement(ComputingElement):
           baseCounter = int(baseUsername[-2:])
           self.log.info("Base username from BaseUsername in ceParameters : %s" % baseUsername)
         except Exception:
+          # Last chance to get PayloadUsername
+          if 'USER' not in os.environ:
+            self.log.error('PayloadUser, BaseUsername and os.environ["USER"] are not properly defined')
+            return S_ERROR(errno.EINVAL, 'No correct payload username provided')
+
           baseUsername = os.environ['USER'] + '00p00'
           baseCounter = 0
           self.log.info('Base username from $USER + 00p00 : %s' % baseUsername)
@@ -132,7 +138,7 @@ class SudoComputingElement(ComputingElement):
     # Run the executable (the wrapper in fact)
     cmd = "/usr/bin/sudo -u %s " % payloadUsername
     cmd += "PATH=$PATH "
-    cmd += "DIRACSYSCONFIG=/scratch/%s/pilot.cfg " % os.environ['USER']
+    cmd += "DIRACSYSCONFIG=/scratch/%s/pilot.cfg " % os.environ.get('USER', '')
     cmd += "LD_LIBRARY_PATH=$LD_LIBRARY_PATH "
     cmd += "PYTHONPATH=$PYTHONPATH "
     cmd += "X509_CERT_DIR=$X509_CERT_DIR "


### PR DESCRIPTION
Changes made in https://github.com/DIRACGrid/DIRAC/pull/4716/commits/1b0bb781113dccdb93ea0c094dc6976622547a6b#diff-6f078601851c19591c520ff380368f56R133 has broken the PoolCE.
By not creating `kwargs` from scratch before passing it to `createAndTaskQueue`, the `ProcessPool` fails to process the task:

```
Traceback (most recent call last):
  File "/cvmfs/lhcb.cern.ch/lib/lhcb/LHCBDIRAC/v10r0p12/diracos/usr/lib64/python2.7/multiprocessing/queues.py", line 268, in _feed
    send(obj)
TypeError: can't pickle thread.lock objects
```

Indeed, `kwargs` contains a logger object that cannot be serialized.
Thus, I have just restored the original mechanism: creating `kwargs` from scratch before adding the required arguments and passing it to the `ProcessPool`.
I have renamed `kwargs` in `taskKwargs` to avoid any such mistake again.

BEGINRELEASENOTES
*Resources
FIX: create "task kwargs" with the required arguments in PoolCE before passing them to the ProcessPool
ENDRELEASENOTES
