### PR TITLE
[v7r1] Fix use of io.open in BundleDeliveryClient

### DIFF
--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -43,7 +43,7 @@ class BundleDeliveryClient(Client):
   def __setHash(self, bundleID, dirToSyncTo, bdHash):
     try:
       fileName = os.path.join(dirToSyncTo, ".dab.%s" % bundleID)
-      with io.open(fileName, "wb") as fd:
+      with open(fileName, "wt") as fd:
         fd.write(bdHash)
     except Exception as e:
       self.log.error("Could not save hash after synchronization", "%s: %s" % (fileName, str(e)))
@@ -113,7 +113,7 @@ class BundleDeliveryClient(Client):
       # if we can not found the file, we return the directory, where the file should be
       transferClient = self.__getTransferClient()
       casFile = os.path.join(os.path.dirname(retVal['Message']), "cas.pem")
-      with io.open(casFile, "w") as fd:
+      with open(casFile, "w") as fd:
         result = transferClient.receiveFile(fd, 'CAs')
         if not result['OK']:
           return result
@@ -131,7 +131,7 @@ class BundleDeliveryClient(Client):
       # if we can not found the file, we return the directory, where the file should be
       transferClient = self.__getTransferClient()
       casFile = os.path.join(os.path.dirname(retVal['Message']), "crls.pem")
-      with io.open(casFile, "w") as fd:
+      with open(casFile, "w") as fd:
         result = transferClient.receiveFile(fd, 'CRLs')
         if not result['OK']:
           return result


### PR DESCRIPTION
In https://github.com/DIRACGrid/DIRAC/pull/4643 various uses of `io.open` where added. In `BundleDeliveryClient` this was incorrect as the written object was still a `str` type instead of `unicode`. The exception is caught by the `except BaseException` and has the effect of causing the CAs and CRLs to be downloaded every time as the `.dab.CAs` and `.dab.CRLs` files are always empty causing the hash to never match with the server version.

As DIRAC isn't going to convert every `str` object to `unicode` before migrating to Python 3 it makes sense to stick to `open()` instead of using `io.open()`.

BEGINRELEASENOTES

*Framework
FIX: Fix hashing of local CA and CRL bundles

ENDRELEASENOTES
