### PR TITLE
[v7r0] Fix indentation in DataManager.getReplicas

### DIFF
--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1737,7 +1737,7 @@ class DataManager(object):
       for se in se_lfn:
         seObj = StorageElement(se, vo=self.voName)
         succPfn = seObj.getURL(se_lfn[se],
-                                protocol=self.registrationProtocol).get('Value', {}).get('Successful', {})
+                               protocol=self.registrationProtocol).get('Value', {}).get('Successful', {})
         for lfn in succPfn:
           catalogReplicas[lfn][se] = succPfn[lfn]
 

--- a/DataManagementSystem/Client/DataManager.py
+++ b/DataManagementSystem/Client/DataManager.py
@@ -1727,22 +1727,19 @@ class DataManager(object):
       for lfn in catalogReplicas:
         catalogReplicas[lfn] = dict.fromkeys(catalogReplicas[lfn], True)
     elif not self.useCatalogPFN:
-      if res['OK']:
-        se_lfn = {}
+      se_lfn = {}
 
-        # We group the query to getURL by storage element to gain in speed
-        for lfn in catalogReplicas:
-          for se in catalogReplicas[lfn]:
-            se_lfn.setdefault(se, []).append(lfn)
+      # We group the query to getURL by storage element to gain in speed
+      for lfn in catalogReplicas:
+        for se in catalogReplicas[lfn]:
+          se_lfn.setdefault(se, []).append(lfn)
 
-        for se in se_lfn:
-          seObj = StorageElement(se, vo=self.voName)
-          succPfn = seObj.getURL(se_lfn[se],
-                                 protocol=self.registrationProtocol).get('Value', {}).get('Successful', {})
-          for lfn in succPfn:
-            # catalogReplicas still points res["value"]["Successful"] so res
-            # will be updated
-            catalogReplicas[lfn][se] = succPfn[lfn]
+      for se in se_lfn:
+        seObj = StorageElement(se, vo=self.voName)
+        succPfn = seObj.getURL(se_lfn[se],
+                                protocol=self.registrationProtocol).get('Value', {}).get('Successful', {})
+        for lfn in succPfn:
+          catalogReplicas[lfn][se] = succPfn[lfn]
 
     result = {'Successful': catalogReplicas, 'Failed': failed}
     if active:


### PR DESCRIPTION
If there are no LFNs passed `res` can be unset. It looks like it's only there as a relic of the 5 year old commit that changed `getReplicas` to work in chunks of 1000 LFNs (2ef9189b5bfa94fd99fa98f4048f36fc89174996).

BEGINRELEASENOTES

* DataManagement
FIX: Allow no LFNs to be passed to `getReplicas`

ENDRELEASENOTES
