### PR TITLE
[integration] CA sync: Use warning log instead exception

### DIFF
--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -77,7 +77,13 @@ class BundleDeliveryClient(Client):
     self.log.info("Synchronizing dir with remote bundle")
     with tarfile.open(name='dummy', mode="r:gz", fileobj=buff) as tF:
       for tarinfo in tF:
-        tF.extract(tarinfo, dirToSyncTo)
+        try:
+          tF.extract(tarinfo, dirToSyncTo)
+        except OSError as e:
+          if e.errno != errno.EROFS:
+            raise e
+          self.log.warn("%s are read only, not synching." % dirToSyncTo)
+
     buff.close()
     self.__setHash(bundleID, dirToSyncTo, newHash)
     self.log.info("Dir has been synchronized")

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -30,12 +30,23 @@ class BundleDeliveryClient(Client):
     self.log = gLogger.getSubLogger("BundleDelivery")
 
   def __getTransferClient(self):
+    """ Get transfer client
+
+        :return: TransferClient()
+    """
     if self.transferClient:
       return self.transferClient
     return TransferClient("Framework/BundleDelivery",
                           skipCACheck=skipCACheck())
 
   def __getHash(self, bundleID, dirToSyncTo):
+    """ Get hash for bundle in directory
+
+        :param str bundleID: bundle ID
+        :param str dirToSyncTo: path to sync directory
+
+        :return: str
+    """
     try:
       with io.open(os.path.join(dirToSyncTo, ".dab.%s" % bundleID), "rb") as fd:
         bdHash = fd.read().strip()
@@ -44,6 +55,12 @@ class BundleDeliveryClient(Client):
       return ""
 
   def __setHash(self, bundleID, dirToSyncTo, bdHash):
+    """ Set hash for bundle in directory
+
+        :param str bundleID: bundle ID
+        :param str dirToSyncTo: path to sync directory
+        :param str bdHash: new hash
+    """
     try:
       fileName = os.path.join(dirToSyncTo, ".dab.%s" % bundleID)
       with io.open(fileName, "wb") as fd:
@@ -52,6 +69,13 @@ class BundleDeliveryClient(Client):
       self.log.error("Could not save hash after synchronization", "%s: %s" % (fileName, str(e)))
 
   def syncDir(self, bundleID, dirToSyncTo):
+    """ Synchronize directory
+
+        :param str bundleID: bundle ID
+        :param str dirToSyncTo: path to sync directory
+
+        :return: S_OK(bool)/S_ERROR()
+    """
     dirCreated = False
     if not os.path.isdir(dirToSyncTo):
       self.log.info("Creating dir %s" % dirToSyncTo)
@@ -90,6 +114,10 @@ class BundleDeliveryClient(Client):
     return S_OK(True)
 
   def syncCAs(self):
+    """ Synchronize CAs
+
+        :return: S_OK(bool)/S_ERROR()
+    """
     X509_CERT_DIR = False
     if 'X509_CERT_DIR' in os.environ:
       X509_CERT_DIR = os.environ['X509_CERT_DIR']
@@ -103,6 +131,10 @@ class BundleDeliveryClient(Client):
     return result
 
   def syncCRLs(self):
+    """ Synchronize CRLs
+
+        :return: S_OK(bool)/S_ERROR()
+    """
     X509_CERT_DIR = False
     if 'X509_CERT_DIR' in os.environ:
       X509_CERT_DIR = os.environ['X509_CERT_DIR']
@@ -113,9 +145,10 @@ class BundleDeliveryClient(Client):
     return result
 
   def getCAs(self):
-    """
-    This method can be used to create the CAs. If the file can not be created, it will be downloaded from
-    the server.
+    """ This method can be used to create the CAs. If the file can not be created,
+        it will be downloaded from the server.
+
+        :return: S_OK(str)/S_ERROR()
     """
     retVal = Utilities.generateCAFile()
     if not retVal['OK']:
@@ -131,9 +164,10 @@ class BundleDeliveryClient(Client):
       return retVal
 
   def getCLRs(self):
-    """
-    This method can be used to create the CAs. If the file can not be created, it will be downloaded from
-    the server.
+    """ This method can be used to create the CAs. If the file can not be created,
+        it will be downloaded from the server.
+
+        :return: S_OK(str)/S_ERROR()
     """
     retVal = Utilities.generateRevokedCertsFile()
     if not retVal['OK']:


### PR DESCRIPTION
This PR to implement the proposal from the issue #4734 to to get more readable message in the case described there.

BEGINRELEASENOTES

*Framework
FIX: replaces the exception "Read only.." with a log when synchronizing the CAs, docs

ENDRELEASENOTES
