### PR TITLE
[v7r1] add check of availability of directories for sync CAs

### DIFF
--- a/Core/scripts/dirac-configure.py
+++ b/Core/scripts/dirac-configure.py
@@ -400,9 +400,13 @@ if not skipCADownload:
     result = bdc.syncCAs()
     if result['OK']:
       result = bdc.syncCRLs()
-  except BaseException:
+    if not result['OK']:
+      DIRAC.gLogger.warn('Failed to sync CAs and CRLs: %s' % result['Message'])
+  except ImportError:
     DIRAC.gLogger.exception('Could not import BundleDeliveryClient')
-    pass
+  except Exception as e:
+    DIRAC.gLogger.warn('Failed to sync CAs and CRLs: %s' % str(e))
+
   if not skipCAChecks:
     Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
 

--- a/Core/scripts/dirac-configure.py
+++ b/Core/scripts/dirac-configure.py
@@ -75,6 +75,7 @@ from DIRAC.Core.Base import Script
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.ConfigurationSystem.Client.Helpers import cfgInstallPath, cfgPath, Registry
 from DIRAC.Core.Utilities.SiteSEMapping import getSEsForSite
+from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClient
 
 
 __RCSID__ = "$Id$"
@@ -395,17 +396,12 @@ if not skipCADownload:
     DIRAC.gLogger.fatal('Fail to create directory:', dirName)
     DIRAC.exit(-1)
   try:
-    from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClient
     bdc = BundleDeliveryClient()
     result = bdc.syncCAs()
     if result['OK']:
       result = bdc.syncCRLs()
-    if not result['OK']:
-      DIRAC.gLogger.warn('Failed to sync CAs and CRLs: %s' % result['Message'])
-  except ImportError:
-    DIRAC.gLogger.exception('Could not import BundleDeliveryClient')
   except Exception as e:
-    DIRAC.gLogger.warn('Failed to sync CAs and CRLs: %s' % str(e))
+    DIRAC.gLogger.error('Failed to sync CAs and CRLs: %s' % str(e))
 
   if not skipCAChecks:
     Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -81,7 +81,7 @@ class BundleDeliveryClient(Client):
     if os.path.isdir(dirToSyncTo):
       for p in [os.W_OK, os.R_OK]:
         if not os.access(dirToSyncTo, p):
-          return S_ERROR('%s have no access to update %s' % (getpass.getuser(), dirToSyncTo))
+          return S_ERROR('%s does not have the permissions to update %s' % (getpass.getuser(), dirToSyncTo))
     else:
       self.log.info("Creating dir %s" % dirToSyncTo)
       mkDir(dirToSyncTo)

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -10,7 +10,7 @@ import getpass
 import tarfile
 import cStringIO
 
-from DIRAC import S_OK, gLogger
+from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.Core.DISET.TransferClient import TransferClient
 from DIRAC.Core.Security import Locations, Utilities

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -1,5 +1,8 @@
 """ Client for interacting with Framework/BundleDelivery service
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import os
 import io
@@ -27,12 +30,23 @@ class BundleDeliveryClient(Client):
     self.log = gLogger.getSubLogger("BundleDelivery")
 
   def __getTransferClient(self):
+    """ Get transfer client
+
+        :return: TransferClient()
+    """
     if self.transferClient:
       return self.transferClient
     return TransferClient("Framework/BundleDelivery",
                           skipCACheck=skipCACheck())
 
   def __getHash(self, bundleID, dirToSyncTo):
+    """ Get hash for bundle in directory
+
+        :param str bundleID: bundle ID
+        :param str dirToSyncTo: path to sync directory
+
+        :return: str
+    """
     try:
       with io.open(os.path.join(dirToSyncTo, ".dab.%s" % bundleID), "rb") as fd:
         bdHash = fd.read().strip()
@@ -41,6 +55,12 @@ class BundleDeliveryClient(Client):
       return ""
 
   def __setHash(self, bundleID, dirToSyncTo, bdHash):
+    """ Set hash for bundle in directory
+
+        :param str bundleID: bundle ID
+        :param str dirToSyncTo: path to sync directory
+        :param str bdHash: new hash
+    """
     try:
       fileName = os.path.join(dirToSyncTo, ".dab.%s" % bundleID)
       with io.open(fileName, "wb") as fd:
@@ -49,6 +69,13 @@ class BundleDeliveryClient(Client):
       self.log.error("Could not save hash after synchronization", "%s: %s" % (fileName, str(e)))
 
   def syncDir(self, bundleID, dirToSyncTo):
+    """ Synchronize directory
+
+        :param str bundleID: bundle ID
+        :param str dirToSyncTo: path to sync directory
+
+        :return: S_OK(bool)/S_ERROR()
+    """
     dirCreated = False
     if not os.path.isdir(dirToSyncTo):
       self.log.info("Creating dir %s" % dirToSyncTo)
@@ -74,13 +101,23 @@ class BundleDeliveryClient(Client):
     self.log.info("Synchronizing dir with remote bundle")
     with tarfile.open(name='dummy', mode="r:gz", fileobj=buff) as tF:
       for tarinfo in tF:
-        tF.extract(tarinfo, dirToSyncTo)
+        try:
+          tF.extract(tarinfo, dirToSyncTo)
+        except OSError as e:
+          if e.errno != errno.EROFS:
+            raise e
+          self.log.warn("%s are read only, not synching." % dirToSyncTo)
+
     buff.close()
     self.__setHash(bundleID, dirToSyncTo, newHash)
     self.log.info("Dir has been synchronized")
     return S_OK(True)
 
   def syncCAs(self):
+    """ Synchronize CAs
+
+        :return: S_OK(bool)/S_ERROR()
+    """
     X509_CERT_DIR = False
     if 'X509_CERT_DIR' in os.environ:
       X509_CERT_DIR = os.environ['X509_CERT_DIR']
@@ -94,6 +131,10 @@ class BundleDeliveryClient(Client):
     return result
 
   def syncCRLs(self):
+    """ Synchronize CRLs
+
+        :return: S_OK(bool)/S_ERROR()
+    """
     X509_CERT_DIR = False
     if 'X509_CERT_DIR' in os.environ:
       X509_CERT_DIR = os.environ['X509_CERT_DIR']
@@ -104,9 +145,10 @@ class BundleDeliveryClient(Client):
     return result
 
   def getCAs(self):
-    """
-    This method can be used to create the CAs. If the file can not be created, it will be downloaded from
-    the server.
+    """ This method can be used to create the CAs. If the file can not be created,
+        it will be downloaded from the server.
+
+        :return: S_OK(str)/S_ERROR()
     """
     retVal = Utilities.generateCAFile()
     if not retVal['OK']:
@@ -122,9 +164,10 @@ class BundleDeliveryClient(Client):
       return retVal
 
   def getCLRs(self):
-    """
-    This method can be used to create the CAs. If the file can not be created, it will be downloaded from
-    the server.
+    """ This method can be used to create the CAs. If the file can not be created,
+        it will be downloaded from the server.
+
+        :return: S_OK(str)/S_ERROR()
     """
     retVal = Utilities.generateRevokedCertsFile()
     if not retVal['OK']:

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import os
 import io
+import getpass
 import tarfile
 import cStringIO
 
@@ -77,7 +78,11 @@ class BundleDeliveryClient(Client):
         :return: S_OK(bool)/S_ERROR()
     """
     dirCreated = False
-    if not os.path.isdir(dirToSyncTo):
+    if so.path.isdir(dirToSyncTo):
+      for p in [os.W_OK, os.R_OK]:
+        if not os.access(dirToSyncTo, p):
+          return S_ERROR('%s have no access to update %s' % (getpass.getuser(), dirToSyncTo))
+    else:
       self.log.info("Creating dir %s" % dirToSyncTo)
       mkDir(dirToSyncTo)
       dirCreated = True
@@ -101,12 +106,7 @@ class BundleDeliveryClient(Client):
     self.log.info("Synchronizing dir with remote bundle")
     with tarfile.open(name='dummy', mode="r:gz", fileobj=buff) as tF:
       for tarinfo in tF:
-        try:
-          tF.extract(tarinfo, dirToSyncTo)
-        except OSError as e:
-          if e.errno != errno.EROFS:
-            raise e
-          self.log.warn("%s are read only, not synching." % dirToSyncTo)
+        tF.extract(tarinfo, dirToSyncTo)
 
     buff.close()
     self.__setHash(bundleID, dirToSyncTo, newHash)

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -109,6 +109,11 @@ class BundleDeliveryClient(Client):
         try:
           tF.extract(tarinfo, dirToSyncTo)
         except OSError as e:
+          self.log.error("Could not sync dir:", str(e))
+          if dirCreated:
+            self.log.info("Removing dir %s" % dirToSyncTo)
+            os.unlink(dirToSyncTo)
+          buff.close()
           return S_ERROR("Certificates directory update failed: %s" % str(e))
 
     buff.close()

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -172,7 +172,7 @@ class BundleDeliveryClient(Client):
       return retVal
 
   def getCLRs(self):
-    """ This method can be used to create the CAs. If the file can not be created,
+    """ This method can be used to create the CRLs. If the file can not be created,
         it will be downloaded from the server.
 
         :return: S_OK(str)/S_ERROR()

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -78,7 +78,7 @@ class BundleDeliveryClient(Client):
         :return: S_OK(bool)/S_ERROR()
     """
     dirCreated = False
-    if so.path.isdir(dirToSyncTo):
+    if os.path.isdir(dirToSyncTo):
       for p in [os.W_OK, os.R_OK]:
         if not os.access(dirToSyncTo, p):
           return S_ERROR('%s have no access to update %s' % (getpass.getuser(), dirToSyncTo))
@@ -106,7 +106,10 @@ class BundleDeliveryClient(Client):
     self.log.info("Synchronizing dir with remote bundle")
     with tarfile.open(name='dummy', mode="r:gz", fileobj=buff) as tF:
       for tarinfo in tF:
-        tF.extract(tarinfo, dirToSyncTo)
+        try:
+          tF.extract(tarinfo, dirToSyncTo)
+        except OSError as e:
+          return S_ERROR("Certificates directory update failed: %s" % str(e))
 
     buff.close()
     self.__setHash(bundleID, dirToSyncTo, newHash)

--- a/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -81,6 +81,7 @@ class BundleDeliveryClient(Client):
     if os.path.isdir(dirToSyncTo):
       for p in [os.W_OK, os.R_OK]:
         if not os.access(dirToSyncTo, p):
+          self.log.error('%s does not have the permissions to update %s' % (getpass.getuser(), dirToSyncTo))
           return S_ERROR('%s does not have the permissions to update %s' % (getpass.getuser(), dirToSyncTo))
     else:
       self.log.info("Creating dir %s" % dirToSyncTo)


### PR DESCRIPTION
This PR to implement the proposal from the issue #4734 to to get more readable message in the case described there.

BEGINRELEASENOTES

*Core:
FIX: modify logging when CAs & CRLs sync

*Framework:
FIX: add check of availability of directories for sync CAs in BundleDeliveryClient

ENDRELEASENOTES