### PR TITLE
[v7r0] XRoot: remove dots in virtual user name

### DIFF
--- a/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/Resources/Storage/GFAL2_XROOTStorage.py
@@ -93,7 +93,8 @@ class GFAL2_XROOTStorage(GFAL2_StorageBase):
     try:
       proxyLoc = getProxyLocation()
       if proxyLoc:
-        proxyLoc = os.path.basename(proxyLoc)
+        # xroot does not support dots in the virtual user
+        proxyLoc = os.path.basename(proxyLoc).replace('.', '')
         urlDict['Host'] = '%s@%s' % (proxyLoc, urlDict['Host'])
     except Exception as e:
       self.log.warn("Exception trying to add virtual user in the url", repr(e))


### PR DESCRIPTION
Dots in the virtual username results in

```
bash-4.2$ gfal-stat  root://virtual.with.dot@server.fr//pnfs/myFile.txt
gfal-stat error: 103 (Software caused connection abort) - Failed to stat file (Software caused connection abort)
```

Issue opened against xroot https://github.com/xrootd/xrootd/issues/1283

BEGINRELEASENOTES

*Resources
FIX: remove dots in xroot virtual username


ENDRELEASENOTES
