### PR TITLE
[v6r22] Fetch all non finished FTS3Operation in FTS3Agent

### DIFF
--- a/DataManagementSystem/DB/FTS3DB.py
+++ b/DataManagementSystem/DB/FTS3DB.py
@@ -464,6 +464,7 @@ class FTS3DB(object):
           .filter(FTS3Operation.status.in_(['Active', 'Processed']))\
           .filter(FTS3Operation.assignment.is_(None))\
           .filter(FTS3Job.assignment.is_(None))\
+          .order_by(FTS3Operation.lastUpdate.asc())\
           .limit(limit)\
           .distinct()
 


### PR DESCRIPTION

As discussed in #4727, FTS3Agent.getNonFinishedOperations() should rotate FTS3Operation list by lastUpdate.asc() to cover all operations to fetch.

BEGINRELEASENOTES

*DMS
FIX: FTS3Agent: Rotate FTS3Operations list to fetch all 

ENDRELEASENOTES
