### PR TITLE
[v6r22] Fix MatchingDelay interval

### DIFF
--- a/WorkloadManagementSystem/Client/Matcher.py
+++ b/WorkloadManagementSystem/Client/Matcher.py
@@ -27,7 +27,7 @@ class Matcher(object):
   """ Logic for matching
   """
 
-  def __init__(self, pilotAgentsDB=None, jobDB=None, tqDB=None, jlDB=None, opsHelper=None):
+  def __init__(self, pilotAgentsDB=None, jobDB=None, tqDB=None, jlDB=None, opsHelper=None, limiter=None):
     """ c'tor
     """
     if pilotAgentsDB:
@@ -54,7 +54,10 @@ class Matcher(object):
 
     self.log = gLogger.getSubLogger("Matcher")
 
-    self.limiter = Limiter(jobDB=self.jobDB, opsHelper=self.opsHelper)
+    if limiter:
+      self.limiter = limiter
+    else:
+      self.limiter = Limiter(jobDB=self.jobDB, opsHelper=self.opsHelper)
 
     self.siteClient = SiteStatus()
 


### PR DESCRIPTION

BEGINRELEASENOTES
In our environment WMS Matcher doesn't look keeping MatchingDelay interval among jobs.
As far as I checked, when MatherHandler.expert_requestJob() is called Matcher instance is created with own Limiter instance.
Since these Limiter instances do not share the information, requested interval does not work.

This PR proposes to keep common Limiter instance in MatcherHandler so that the negative condition can be properly propagated.

*WMS
FIX: fix MatchingDelay interval

ENDRELEASENOTES
