### PR TITLE
[v7r0] Do not read suspensionReason from VOMS as it's not used anywhere

### DIFF
--- a/Core/Security/VOMSService.py
+++ b/Core/Security/VOMSService.py
@@ -132,7 +132,6 @@ class VOMSService(object):
         resultDict[dn] = user
         resultDict[dn]['CA'] = cert['issuerString']
         resultDict[dn]['certSuspended'] = cert['suspended']
-        resultDict[dn]['certSuspensionReason'] = cert['suspensionReason']
         resultDict[dn]['mail'] = user['emailAddress']
         resultDict[dn]['Roles'] = user['fqans']
         attributes = user.get('attributes')


### PR DESCRIPTION
BEGINRELEASENOTES
*Core
FIX: Do not read suspensionReason from VOMS as it's not used anywhere and needs special permissions to give this information

ENDRELEASENOTES

Summary from Andrea Ceccanti

> The problem derives from the changes introduced to meet the CERN GDPR compliance requirements. Now the API returns only limited information to any authenticated user, basically the certificate subject and group and role information. To get all the info you should use a certificate linked to more privileges in VOMS.

>To disseminate this information if you want to go to VOMS admin and then:
> 1. Go to the ACL management panel (by clicking on the acl link)
> 2. Click on "Add entry"
> 3. Choose "Add entry for VO members with a specific role" from the dialog
> 4. Choose the role (e.g., production) from the role selection dialog (the group should be /lhcb)
> 5. Enable the PERSONAL_INFO_READ permission for that role
> 6. Click "Add entry"