### PR TITLE
[v7r1]Glue2 restructuring (faster mostly), warning on unknown CEs

### DIFF
--- a/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -191,9 +191,9 @@ class Bdii2CSAgent(AgentModule):
         body += "dirac-admin-add-resources --vo %s --ce\n" % vo
 
       if unknownCEs:
-        body += '\n ================================== \n'
+        body += '\n\n'
         body += 'There is no (longer) information about the following CEs for the %s VO.\n' % vo
-        body += '\n'.join(unknownCEs)
+        body += '\n'.join(sorted(unknownCEs))
         body += '\n\n'
 
       if body:
@@ -335,7 +335,8 @@ class Bdii2CSAgent(AgentModule):
       body = '\n'.join(["%s/%s %s -> %s" % entry for entry in changeList])
       if body and self.addressTo and self.addressFrom:
         notification = NotificationClient()
-        result = notification.sendMail(self.addressTo, self.subject, body, self.addressFrom, localAttempt=False)
+        result = notification.sendMail(self.addressTo, self.subject, body, self.addressFrom, localAttempt=False,
+                                       avoidSpam=True)
 
       if body:
         self.log.info('The following configuration changes were detected:')

--- a/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -155,7 +155,7 @@ class Bdii2CSAgent(AgentModule):
         self.log.error('Failed to get unused CEs', result['Message'])
         continue  # next VO
       siteDict = result['Value']
-      unknownCEs = result['UnknownCEs']
+      unknownCEs = set(result['UnknownCEs']) - set(bannedCEs)
 
       body = ''
       for site in siteDict:

--- a/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -44,7 +44,7 @@ class Bdii2CSAgent(AgentModule):
     self.voBdiiSEDict = {}
     self.host = 'lcg-bdii.cern.ch:2170'
     self.glue2URLs = []
-    self.glue2Only = False
+    self.glue2Only = True
 
     self.csAPI = None
 

--- a/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -143,8 +143,8 @@ class Bdii2CSAgent(AgentModule):
 
       knownCEs = set()
       for _site, ces in res['Value'].items():
-        knownCEs.union(ces.keys())
-      knownCEs = knownCEs.union(set(bannedCEs))
+        knownCEs.update(ces)
+      knownCEs.update(bannedCEs)
 
       result = self.__getBdiiCEInfo(vo)
       if not result['OK']:
@@ -371,7 +371,7 @@ class Bdii2CSAgent(AgentModule):
     if not result['OK']:
       return result
     knownSEs = set(result['Value'])
-    knownSEs = knownSEs.union(set(bannedSEs))
+    knownSEs.update(bannedSEs)
 
     for vo in self.voName:
       result = self.__getBdiiSEInfo(vo)

--- a/ConfigurationSystem/Agent/test/Test_Bdii2CS.py
+++ b/ConfigurationSystem/Agent/test/Test_Bdii2CS.py
@@ -23,12 +23,13 @@ ALTBDII = { 'site2': {'CEs': { 'ce2': { 'Queues': { 'queue2': "SomeOtherValues" 
 class Bdii2CSTests( unittest.TestCase ):
 
   def setUp( self ):
-    with patch( "DIRAC.ConfigurationSystem.Agent.Bdii2CSAgent.AgentModule.__init__", new=Mock() ):
-      self.agent = Bdii2CSAgent.Bdii2CSAgent( agentName="Configuration/testing", loadName="Configuration/testing" )
-
-      ## as we ignore the init from the baseclass some agent variables might not be present so we set them here
-      ## in any case with this we can check that log is called with proper error messages
-      self.agent.log = Mock()
+    with patch("DIRAC.ConfigurationSystem.Agent.Bdii2CSAgent.AgentModule.__init__", new=Mock()), \
+         patch("DIRAC.ConfigurationSystem.Agent.Bdii2CSAgent.AgentModule.am_getModuleParam",
+               new=Mock(return_value='fullName')):
+      self.agent = Bdii2CSAgent.Bdii2CSAgent(agentName="Configuration/testing", loadName="Configuration/testing")
+    # as we ignore the init from the baseclass some agent variables might not be present so we set them here
+    # in any case with this we can check that log is called with proper error messages
+    self.agent.log = Mock()
 
 
   def tearDown( self ):

--- a/ConfigurationSystem/Agent/test/Test_Bdii2CS.py
+++ b/ConfigurationSystem/Agent/test/Test_Bdii2CS.py
@@ -87,8 +87,8 @@ class Bdii2CSTests( unittest.TestCase ):
                 ] )
               ) as infoMock:
       ret = self.agent._Bdii2CSAgent__getBdiiCEInfo( "vo" ) #pylint: disable=no-member
-      infoMock.assert_any_call("vo", host="server2", glue2=False)
-      infoMock.assert_any_call("vo", host="server2", glue2=False)
+      infoMock.assert_any_call("vo", host="server2", glue2=True)
+      infoMock.assert_any_call("vo", host="server2", glue2=True)
       self.assertTrue( any ( "Failed getting information from server2" in str(args) \
                              for args in self.agent.log.error.call_args_list ),
                        self.agent.log.error.call_args_list )
@@ -106,8 +106,8 @@ class Bdii2CSTests( unittest.TestCase ):
                 ] )
               ) as infoMock:
       ret = self.agent._Bdii2CSAgent__getBdiiCEInfo( "vo" ) #pylint: disable=no-member
-      infoMock.assert_any_call("vo", host=self.agent.host, glue2=False)
-      infoMock.assert_any_call("vo", host="server2", glue2=False)
+      infoMock.assert_any_call("vo", host=self.agent.host, glue2=True)
+      infoMock.assert_any_call("vo", host="server2", glue2=True)
       self.assertTrue( any ( "Failed getting information from server2" in str(args) \
                              for args in self.agent.log.error.call_args_list ),
                        self.agent.log.error.call_args_list )

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -155,7 +155,7 @@ def getGridCEs(vo, bdiiInfo=None, ceBlackList=None, hostURL=None, glue2=False):
   return result
 
 
-def getSiteUpdates(vo, bdiiInfo=None, log=None):
+def getSiteUpdates(vo, bdiiInfo=None, log=None, glue2=True):
   """ Get all the necessary updates for the already defined sites and CEs
 
       :param str vo: VO name
@@ -180,7 +180,7 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None):
 
   ceBdiiDict = bdiiInfo
   if bdiiInfo is None:
-    result = getBdiiCEInfo(vo)
+    result = getBdiiCEInfo(vo, glue2=glue2)
     if not result['OK']:
       return result
     ceBdiiDict = result['Value']

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -101,6 +101,7 @@ def getGridCEs(vo, bdiiInfo=None, ceBlackList=None, hostURL=None, glue2=False):
       :return: S_OK(set)/S_ERROR()
   """
   knownCEs = set()
+  cesInInformation = set()
   if ceBlackList is not None:
     knownCEs = knownCEs.union(set(ceBlackList))
 
@@ -114,6 +115,7 @@ def getGridCEs(vo, bdiiInfo=None, ceBlackList=None, hostURL=None, glue2=False):
   siteDict = {}
   for site in ceBdiiDict:
     siteCEs = set(ceBdiiDict[site]['CEs'].keys())
+    cesInInformation.update(siteCEs)
     newCEs = siteCEs - knownCEs
     if not newCEs:
       continue
@@ -146,6 +148,20 @@ def getGridCEs(vo, bdiiInfo=None, ceBlackList=None, hostURL=None, glue2=False):
 
   result = S_OK(siteDict)
   result['BdiiInfo'] = ceBdiiDict
+
+  gLogger.notice("CEsinINfo: %s" % cesInInformation)
+  gLogger.notice("Known: %s" % knownCEs)
+  gLogger.notice("no Info %s" % (knownCEs - cesInInformation))
+
+  unknownCEs = knownCEs - cesInInformation
+  gLogger.notice(unknownCEs)
+  if unknownCEs:
+    gLogger.notice("There is currently no information for the following CEs:")
+    for ce in sorted(unknownCEs):
+      gLogger.notice("   ", ce)
+  else:
+    gLogger.notice("We know it all.")
+
   return result
 
 

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -98,7 +98,8 @@ def getGridCEs(vo, bdiiInfo=None, ceBlackList=None, hostURL=None, glue2=False):
       :param str hostURL: host URL
       :param bool glue2: use glue2
 
-      :return: S_OK(set)/S_ERROR()
+
+      :return: Dictionary with keys: OK, Value, BdiiInfo, UnknownCEs
   """
   knownCEs = set()
   cesInInformation = set()
@@ -149,19 +150,8 @@ def getGridCEs(vo, bdiiInfo=None, ceBlackList=None, hostURL=None, glue2=False):
   result = S_OK(siteDict)
   result['BdiiInfo'] = ceBdiiDict
 
-  gLogger.notice("CEsinINfo: %s" % cesInInformation)
-  gLogger.notice("Known: %s" % knownCEs)
-  gLogger.notice("no Info %s" % (knownCEs - cesInInformation))
-
   unknownCEs = knownCEs - cesInInformation
-  gLogger.notice(unknownCEs)
-  if unknownCEs:
-    gLogger.notice("There is currently no information for the following CEs:")
-    for ce in sorted(unknownCEs):
-      gLogger.notice("   ", ce)
-  else:
-    gLogger.notice("We know it all.")
-
+  result['UnknownCEs'] = unknownCEs
   return result
 
 

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -318,9 +318,18 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None):
             if 'CPUScalingReferenceSI00' in cap:
               newSI00 = cap.split('=')[-1]
 
+          # tags, processors
+          tag = queueDict.get('Tag', '')
+          numberOfProcessors = queueDict.get('NumberOfProcessors', '')
+          newNOP = queueInfo.get('NumberOfProcessors', 1)
+
           # Adding queue info to the CS
           addToChangeSet((queueSection, 'maxCPUTime', maxCPUTime, newMaxCPUTime), changeSet)
           addToChangeSet((queueSection, 'SI00', si00, newSI00), changeSet)
+          if newNOP > 1:
+            addToChangeSet((queueSection, 'NumberOfProcessors', numberOfProcessors, newNOP), changeSet)
+            newTag = ','.join(sorted(set(tag.split(',')).union({'MultiProcessor'}))).strip(',')
+            addToChangeSet((queueSection, 'Tag', tag, newTag), changeSet)
           if maxTotalJobs == "Unknown":
             newTotalJobs = min(1000, int(int(queueInfo.get('GlueCEInfoTotalCPUs', 0)) / 2))
             newWaitingJobs = max(2, int(newTotalJobs * 0.1))

--- a/ConfigurationSystem/ConfigTemplate.cfg
+++ b/ConfigurationSystem/ConfigTemplate.cfg
@@ -48,7 +48,7 @@ Agents
     # URLs for Glue2, if filled and GLUE2Only is False, the agent will look under theses URLs for Glue2 information
     GLUE2URLs =
     # If True, only look for Glue2 information. If True, uses URLs from the Host option
-    GLUE2Only = False
+    GLUE2Only = True
   }
   ##END
   ##BEGIN VOMS2CSAgent

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -22,7 +22,7 @@ from DIRAC.ConfigurationSystem.Client.Utilities import getGridCEs, getSiteUpdate
 from DIRAC.Core.Utilities.Subprocess import systemCall
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
-from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getSiteCEMapping, getDIRACSiteName
+from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getQueues, getDIRACSiteName
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOs, getVOOption
 
 
@@ -73,13 +73,14 @@ def checkUnusedCEs():
 
   gLogger.notice('looking for new computing resources in the BDII database...')
 
-  res = getSiteCEMapping()
+  res = getQueues(community=vo)
   if not res['OK']:
     gLogger.error('ERROR: failed to get CEs from CS', res['Message'])
     DIRACExit(-1)
+
   knownCEs = []
-  for site in res['Value']:
-    knownCEs = knownCEs + res['Value'][site]
+  for _site, ces in res['Value'].items():
+    knownCEs.extend(ces.keys())
 
   result = getGridCEs(vo, ceBlackList=knownCEs, hostURL=hostURL, glue2=glue2)
   if not result['OK']:
@@ -89,7 +90,7 @@ def checkUnusedCEs():
 
   siteDict = result['Value']
   if siteDict:
-    gLogger.notice('New resources available:\n')
+    gLogger.notice('New resources available:')
     for site in siteDict:
       diracSite = 'Unknown'
       result = getDIRACSiteName(site)

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -88,6 +88,11 @@ def checkUnusedCEs():
     DIRACExit(-1)
   ceBdiiDict = result['BdiiInfo']
 
+  unknownCEs = result['UnknownCEs']
+  if unknownCEs:
+    gLogger.notice('There is no (longer) information about the following CEs for the %s VO:' % vo)
+    gLogger.notice('\n'.join(sorted(unknownCEs)))
+
   siteDict = result['Value']
   if siteDict:
     gLogger.notice('New resources available:')

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -35,7 +35,8 @@ def processScriptSwitches():
   Script.registerSwitch("C", "ce", "Process Computing Elements")
   Script.registerSwitch("S", "se", "Process Storage Elements")
   Script.registerSwitch("H:", "host=", "use this url for information querying")
-  Script.registerSwitch("G", "glue2", "query GLUE2 information schema")
+  Script.registerSwitch("G", "glue2", "DEPRECATED: query GLUE2 information schema")
+  Script.registerSwitch("g", "glue1", "query GLUE1 information schema")
 
   Script.setUsageMessage('\n'.join([__doc__.split('\n')[1],
                                     'WARNING: StorageElements only for SRM-style'
@@ -61,7 +62,9 @@ def processScriptSwitches():
     if sw[0] in ("H", "host"):
       hostURL = sw[1]
     if sw[0] in ("G", "glue2"):
-      glue2 = True
+      gLogger.notice(" The '-G' flag is deprecated, Glue2 is the default now")
+    if sw[0] in ("g", "glue1"):
+      glue2 = False
 
 
 ceBdiiDict = None

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -78,9 +78,9 @@ def checkUnusedCEs():
     gLogger.error('ERROR: failed to get CEs from CS', res['Message'])
     DIRACExit(-1)
 
-  knownCEs = []
+  knownCEs = set()
   for _site, ces in res['Value'].items():
-    knownCEs.extend(ces.keys())
+    knownCEs.update(ces)
 
   result = getGridCEs(vo, ceBlackList=knownCEs, hostURL=hostURL, glue2=glue2)
   if not result['OK']:

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -112,13 +112,12 @@ def checkUnusedCEs():
           gLogger.notice('      %s, %s' % (siteDict[site][ce]['CEType'], '%s_%s_%s' % siteDict[site][ce]['System']))
   else:
     gLogger.notice('No new resources available, exiting')
-    DIRACExit(0)
+    return
 
   inp = raw_input("\nDo you want to add sites ? [default=yes] [yes|no]: ")
   inp = inp.strip()
   if not inp and inp.lower().startswith('n'):
-    gLogger.notice('Nothing else to be done, exiting')
-    DIRACExit(0)
+    return
 
   gLogger.notice('\nAdding new sites/CEs interactively\n')
 
@@ -257,9 +256,9 @@ def updateCS(changeSet):
 
 def updateSites():
 
-  global vo, dry, ceBdiiDict
+  global vo, dry, ceBdiiDict, glue2
 
-  result = getSiteUpdates(vo, bdiiInfo=ceBdiiDict)
+  result = getSiteUpdates(vo, bdiiInfo=ceBdiiDict, glue2=glue2)
   if not result['OK']:
     gLogger.error('Failed to get site updates', result['Message'])
     DIRACExit(-1)

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -232,6 +232,7 @@ def __getGlue2ExecutionEnvironmentInfoForSite(sitename, foreignKeys, exeInfos):
   architecture = exeInfo.get('GLUE2ExecutionEnvironmentPlatform', '')
   architecture = 'x86_64' if architecture == 'amd64' else architecture
   architecture = 'x86_64' if architecture == 'UNDEFINEDVALUE' else architecture
+  architecture = 'x86_64' if "Intel(R) Xeon(R)" in architecture else architecture
   osFamily = exeInfo.get('GLUE2ExecutionEnvironmentOSFamily', '')  # e.g. linux
   osName = exeInfo.get('GLUE2ExecutionEnvironmentOSName', '')
   osVersion = exeInfo.get('GLUE2ExecutionEnvironmentOSVersion', '')

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -172,10 +172,14 @@ def __getGlue2ShareInfo(host, shareInfoLists):
             if otherInfo.startswith('CREAMCEId'):
               queueName = otherInfo.split('/', 1)[1]
 
-        # cern HTCondorCE
-        elif ceType.endswith('HTCondorCE'):
+        # HTCondorCE, htcondorce
+        elif ceType.lower().endswith('htcondorce'):
           ceType = 'HTCondorCE'
           queueName = 'condor'
+
+        else:
+          sLog.error('Unknown CE Type, please check the available information', ceType)
+          continue
 
         queueInfo['GlueCEImplementationName'] = ceType
         ceName = endpoint.split('_', 1)[0]

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -135,7 +135,7 @@ def __getGlue2ShareInfo(host, shareInfoLists):
       queueInfo['GlueCECapability'] = ['CPUScalingReferenceSI00=2552']
 
       try:
-        maxNOPfromCS = gConfig.getValue('/Resources/Computing/CEDefaults/MaxNumberOfProcessors', 8)
+        maxNOPfromCS = gConfig.getValue('/Resources/Computing/CEDefaults/GLUE2ComputingShareMaxSlotsPerJob_limit', 8)
         maxNOPfromGLUE = int(shareInfoDict.get('GLUE2ComputingShareMaxSlotsPerJob', 1))
         numberOfProcs = min(maxNOPfromGLUE, maxNOPfromCS)
         queueInfo['NumberOfProcessors'] = numberOfProcs

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -187,7 +187,8 @@ def __getGlue2ShareInfo(host, shareInfoLists):
             if otherInfo.startswith('CREAMCEId'):
               queueName = otherInfo.split('/', 1)[1]
               # creamCEs are EOL soon, ignore any info they have
-              queueInfo.pop('NumberOfProcessors', None)
+              if queueInfo.pop('NumberOfProcessors', 1) != 1:
+                sLog.verbose('Ignoring MaxSlotsPerJob option for CreamCE', endpoint)
 
         # HTCondorCE, htcondorce
         elif ceType.lower().endswith('htcondorce'):

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -108,7 +108,10 @@ def __getGlue2ShareInfo(host, shareInfoLists):
   executionEnvironments = []
   for _siteName, shareInfoDicts in shareInfoLists.items():
     for shareInfoDict in shareInfoDicts:
-      executionEnvironment = shareInfoDict['GLUE2ComputingShareExecutionEnvironmentForeignKey']
+      executionEnvironment = shareInfoDict.get('GLUE2ComputingShareExecutionEnvironmentForeignKey', [])
+      if not executionEnvironment:
+        sLog.error('No entry for GLUE2ComputingShareExecutionEnvironmentForeignKey', pformat(shareInfoDict))
+        continue
       if isinstance(executionEnvironment, basestring):
         executionEnvironment = [executionEnvironment]
       executionEnvironments.extend(executionEnvironment)
@@ -147,7 +150,7 @@ def __getGlue2ShareInfo(host, shareInfoLists):
                    siteName + ' ' + shareInfoDict.get('GLUE2ComputingShareMaxSlotsPerJob'))
         queueInfo['NumberOfProcessors'] = 1
 
-      executionEnvironment = shareInfoDict['GLUE2ComputingShareExecutionEnvironmentForeignKey']
+      executionEnvironment = shareInfoDict.get('GLUE2ComputingShareExecutionEnvironmentForeignKey', [])
       if isinstance(executionEnvironment, basestring):
         executionEnvironment = [executionEnvironment]
       resExeInfo = __getGlue2ExecutionEnvironmentInfoForSite(siteName, executionEnvironment, exeInfos)

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -51,6 +51,8 @@ def getGlue2CEInfo(vo, host):
   listOfSitesWithPolicies = set()
   shareFilter = ''
   for policyValues in polRes:
+    if 'GLUE2DomainID' not in policyValues['attr']['dn']:
+      continue
     shareID = policyValues['attr'].get('GLUE2MappingPolicyShareForeignKey', None)
     policyID = policyValues['attr']['GLUE2PolicyID']
     siteName = policyValues['attr']['dn'].split('GLUE2DomainID=')[1].split(',', 1)[0]
@@ -69,6 +71,8 @@ def getGlue2CEInfo(vo, host):
     return shareRes
   shareInfoLists = {}
   for shareInfo in shareRes['Value']:
+    if 'GLUE2DomainID' not in shareInfo['attr']['dn']:
+      continue
     if 'GLUE2ComputingShare' not in shareInfo['objectClass']:
       gLogger.debug('Share %r is not a ComputingShare: \n%s' % (shareID, pformat(shareInfo)))
       continue

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -128,7 +128,7 @@ def __getGlue2ShareInfo(host, shareInfoLists):
       queueInfo['GlueCEPolicyMaxWallClockTime'] = str(int(shareInfoDict
                                                           .get('GLUE2ComputingShareMaxWallTime', 86400)) / 60)
       queueInfo['GlueCEInfoTotalCPUs'] = shareInfoDict.get('GLUE2ComputingShareMaxRunningJobs', '10000')
-      queueInfo['GlueCECapability'] = []
+      queueInfo['GlueCECapability'] = ['CPUScalingReferenceSI00=2552']
       executionEnvironment = shareInfoDict['GLUE2ComputingShareExecutionEnvironmentForeignKey']
       if isinstance(executionEnvironment, basestring):
         executionEnvironment = [executionEnvironment]

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -148,7 +148,7 @@ def __getGlue2ShareInfo(host, shareInfoLists):
                    'GlueHostOperatingSystemRelease': '',
                    'GlueHostArchitecturePlatformType': 'x86_64',
                    'GlueHostBenchmarkSI00': '2500',  # needed for the queue to be used by the sitedirector
-                   'MANAGER': '',
+                   'MANAGER': 'manager:unknownBatchSystem',  # need some value for ARC
                    }
       else:
         sLog.error('Found information for execution environment for %s' % siteName)

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -85,7 +85,7 @@ def getGlue2CEInfo(vo, host):
 
   siteInfo = __getGlue2ShareInfo(host, shareInfoLists)
   if not siteInfo['OK']:
-    sLog.error("Could not get CE info for %s:" % shareID, siteInfo['Message'])
+    sLog.error("Could not get CE info for", shareID + "  " + siteInfo['Message'])
     return siteInfo
   siteDict = siteInfo['Value']
   sLog.debug("Found Sites:\n%s" % pformat(siteDict))
@@ -93,7 +93,7 @@ def getGlue2CEInfo(vo, host):
   if sitesWithoutShares:
     sLog.error("Found some sites without any shares", pformat(sitesWithoutShares))
   else:
-    sLog.notice("All good")
+    sLog.notice("Found information for all known sites")
   return S_OK(siteDict)
 
 
@@ -113,8 +113,8 @@ def __getGlue2ShareInfo(host, shareInfoLists):
       executionEnvironments.extend(executionEnvironment)
   resExeInfo = __getGlue2ExecutionEnvironmentInfo(host, executionEnvironments)
   if not resExeInfo['OK']:
-    sLog.error("Cannot get execution environment info for %r" % str(executionEnvironments)[:100],
-               resExeInfo['Message'])
+    sLog.error("Cannot get execution environment info for:",
+               str(executionEnvironments)[:100] + "  " + resExeInfo['Message'])
     return resExeInfo
   exeInfos = resExeInfo['Value']
 
@@ -141,7 +141,7 @@ def __getGlue2ShareInfo(host, shareInfoLists):
 
       exeInfo = resExeInfo.get('Value')
       if not exeInfo:
-        sLog.error('Did not find information for execution environment %s, using dummy values' % siteName)
+        sLog.error('Using dummy values. Did not find information for execution environment', siteName)
         exeInfo = {'GlueHostMainMemoryRAMSize': '1999',  # intentionally identifiably dummy value
                    'GlueHostOperatingSystemVersion': '',
                    'GlueHostOperatingSystemName': '',
@@ -151,7 +151,7 @@ def __getGlue2ShareInfo(host, shareInfoLists):
                    'MANAGER': 'manager:unknownBatchSystem',  # need some value for ARC
                    }
       else:
-        sLog.error('Found information for execution environment for %s' % siteName)
+        sLog.info('Found information for execution environment for', siteName)
 
       # sometimes the time is still in hours
       maxCPUTime = int(queueInfo['GlueCEPolicyMaxCPUTime'])
@@ -200,7 +200,7 @@ def __getGlue2ShareInfo(host, shareInfoLists):
           ceInfo['Queues'] = existingQueues
           cesDict[ceName].update(ceInfo)
       except Exception:
-        sLog.error('Exception in ARC part for %s' % siteName)
+        sLog.error('Exception in ARC part for site:', siteName)
       siteDict[siteName]['CEs'].update(cesDict)
 
   return S_OK(siteDict)

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -10,11 +10,10 @@ Known problems:
  * Some execution environment IDs are used more than once
 
 Print outs with "SCHEMA PROBLEM" point -- in my opinion -- to errors in the
-published information, like a foreign key pointing to non-existant entry.
+published information, like a foreign key pointing to non-existent entry.
 
 """
 
-import six
 from pprint import pformat
 
 from DIRAC import gLogger
@@ -39,174 +38,192 @@ def getGlue2CEInfo(vo, host):
   """
 
   # get all Policies allowing given VO
-  filt = "(&(objectClass=GLUE2Policy)(GLUE2PolicyRule=VO:%s))" % vo
-  polResVO = __ldapsearchBDII(filt=filt, attr=None, host=host, base="o=glue", selectionString="GLUE2")
+  filt = "(&(objectClass=GLUE2Policy)(|(GLUE2PolicyRule=VO:%s)(GLUE2PolicyRule=vo:%s)))" % (vo, vo)
+  polRes = __ldapsearchBDII(filt=filt, attr=None, host=host, base="o=glue", selectionString="GLUE2")
 
-  # get all Policies allowing given vo, yes, lowercase is a Thing...
-  filt = "(&(objectClass=GLUE2Policy)(GLUE2PolicyRule=vo:%s))" % vo
-  polResvo = __ldapsearchBDII(filt=filt, attr=None, host=host, base="o=glue", selectionString="GLUE2")
-
-  # if both failed, we abort here
-  if not (polResvo['OK'] or polResVO['OK']):
+  if not polRes['OK']:
     return S_ERROR("Failed to get policies for this VO")
-
-  polRes = list(polResVO.get('Value', []) + polResvo.get('Value', []))
+  polRes = polRes['Value']
 
   gLogger.notice("Found %s policies for this VO %s" % (len(polRes), vo))
-  siteDict = {}
   # get all shares for this policy
+  # create an or'ed list of all the shares and then call the search
+  listOfSitesWithPolicies = set()
+  shareFilter = ''
   for policyValues in polRes:
     shareID = policyValues['attr'].get('GLUE2MappingPolicyShareForeignKey', None)
     policyID = policyValues['attr']['GLUE2PolicyID']
     siteName = policyValues['attr']['dn'].split('GLUE2DomainID=')[1].split(',', 1)[0]
+    listOfSitesWithPolicies.add(siteName)
     if shareID is None:  # policy not pointing to ComputingInformation
       gLogger.debug("Policy %s does not point to computing information" % (policyID,))
       continue
     gLogger.verbose("%s policy %s pointing to %s " % (siteName, policyID, shareID))
     gLogger.debug("Policy values:\n%s" % pformat(policyValues))
-    filt = "(&(objectClass=GLUE2Share)(GLUE2ShareID=%s))" % shareID
-    shareRes = __ldapsearchBDII(filt=filt, attr=None, host=host, base="o=glue", selectionString="GLUE2")
-    if not shareRes['OK']:
-      gLogger.error("Could not get share information for %s: %s" % (shareID, shareRes['Message']))
-      continue
-    if not shareRes['Value']:
-      gLogger.info("SCHEMA PROBLEM: Did not not find any share information for %s" % (shareID, ))
-      continue
-    siteDict.setdefault(siteName, {'CEs': {}})
-    for shareInfo in shareRes['Value']:
-      if 'GLUE2ComputingShare' not in shareInfo['objectClass']:
-        gLogger.debug('Share %r is not a ComputingShare: \n%s' % (shareID, pformat(shareInfo)))
-        continue
-      gLogger.debug("Found computing share:\n%s" % pformat(shareInfo))
-      shareEndpoints = shareInfo['attr'].get('GLUE2ShareEndpointForeignKey', [])
-      ceInfo = __getGlue2ShareInfo(host, shareEndpoints, shareInfo['attr'], siteDict[siteName]['CEs'])
-      if not ceInfo['OK']:
-        gLogger.error("Could not get CE info for %s:" % shareID, ceInfo['Message'])
-        continue
-      gLogger.debug("Found ceInfo:\n%s" % pformat(siteDict[siteName]['CEs']))
+    shareFilter += '(GLUE2ShareID=%s)' % shareID
 
+  filt = '(&(objectClass=GLUE2Share)(|%s))' % shareFilter
+  shareRes = __ldapsearchBDII(filt=filt, attr=None, host=host, base="o=glue", selectionString="GLUE2")
+  if not shareRes['OK']:
+    gLogger.error("Could not get share information", shareRes['Message'])
+    return shareRes
+  shareInfoLists = {}
+  for shareInfo in shareRes['Value']:
+    if 'GLUE2ComputingShare' not in shareInfo['objectClass']:
+      gLogger.debug('Share %r is not a ComputingShare: \n%s' % (shareID, pformat(shareInfo)))
+      continue
+    gLogger.debug("Found computing share:\n%s" % pformat(shareInfo))
+    siteName = shareInfo['attr']['dn'].split('GLUE2DomainID=')[1].split(',', 1)[0]
+    shareInfoLists.setdefault(siteName, []).append(shareInfo['attr'])
+
+  siteInfo = __getGlue2ShareInfo(host, shareInfoLists)
+  if not siteInfo['OK']:
+    gLogger.error("Could not get CE info for %s:" % shareID, siteInfo['Message'])
+    return siteInfo
+  siteDict = siteInfo['Value']
   gLogger.debug("Found Sites:\n%s" % pformat(siteDict))
+  sitesWithoutShares = set(siteDict) - listOfSitesWithPolicies
+  if sitesWithoutShares:
+    gLogger.error("Found some sites without any shares", pformat(sitesWithoutShares))
+  else:
+    gLogger.notice("All good")
+  return S_OK(siteDict)
+
+
+def __getGlue2ShareInfo(host, shareInfoLists):
+  """ get information from endpoints, which are the CE at a Site
+
+  :param str host: BDII host to query
+  :param dict shareInfoDict: dictionary of GLUE2 parameters belonging to the ComputingShare
+  :returns: result structure S_OK/S_ERROR
+  """
+  executionEnvironments = []
+  for _siteName, shareInfoDicts in shareInfoLists.items():
+    for shareInfoDict in shareInfoDicts:
+      executionEnvironment = shareInfoDict['GLUE2ComputingShareExecutionEnvironmentForeignKey']
+      if isinstance(executionEnvironment, basestring):
+        executionEnvironment = [executionEnvironment]
+      executionEnvironments.extend(executionEnvironment)
+  resExeInfo = __getGlue2ExecutionEnvironmentInfo(host, executionEnvironments)
+  if not resExeInfo['OK']:
+    gLogger.error("SCHEMA PROBLEM: Cannot get execution environment info for %r" % str(executionEnvironments)[:100],
+                  resExeInfo['Message'])
+    return resExeInfo
+  exeInfos = resExeInfo['Value']
+
+  siteDict = {}
+  for siteName, shareInfoDicts in shareInfoLists.items():
+    siteDict[siteName] = {'CEs': {}}
+    for shareInfoDict in shareInfoDicts:
+      ceInfo = {}
+      ceInfo['MaxWaitingJobs'] = shareInfoDict.get('GLUE2ComputingShareMaxWaitingJobs', '-1')  # This is not used
+      ceInfo['Queues'] = {}
+      queueInfo = {}
+      queueInfo['GlueCEStateStatus'] = shareInfoDict['GLUE2ComputingShareServingState']
+      queueInfo['GlueCEPolicyMaxCPUTime'] = str(int(shareInfoDict.get('GLUE2ComputingShareMaxCPUTime', 86400)) / 60)
+      queueInfo['GlueCEPolicyMaxWallClockTime'] = str(int(shareInfoDict
+                                                          .get('GLUE2ComputingShareMaxWallTime', 86400)) / 60)
+      queueInfo['GlueCEInfoTotalCPUs'] = shareInfoDict.get('GLUE2ComputingShareMaxRunningJobs', '10000')
+      queueInfo['GlueCECapability'] = []
+      executionEnvironment = shareInfoDict['GLUE2ComputingShareExecutionEnvironmentForeignKey']
+      if isinstance(executionEnvironment, basestring):
+        executionEnvironment = [executionEnvironment]
+      resExeInfo = __getGlue2ExecutionEnvironmentInfoForSite(siteName, executionEnvironment, exeInfos)
+      if not resExeInfo['OK']:
+        continue
+
+      exeInfo = resExeInfo.get('Value')
+      if not exeInfo:
+        gLogger.warn('Did not find information for execution environment %s, using dummy values' % siteName)
+        exeInfo = {'GlueHostMainMemoryRAMSize': '1999',  # intentionally identifiably dummy value
+                   'GlueHostOperatingSystemVersion': '',
+                   'GlueHostOperatingSystemName': '',
+                   'GlueHostOperatingSystemRelease': '',
+                   'GlueHostArchitecturePlatformType': 'x86_64',
+                   'GlueHostBenchmarkSI00': '2500',  # needed for the queue to be used by the sitedirector
+                   'MANAGER': '',
+                   }
+
+      # sometimes the time is still in hours
+      maxCPUTime = int(queueInfo['GlueCEPolicyMaxCPUTime'])
+      if maxCPUTime in [12, 24, 36, 48, 168]:
+        queueInfo['GlueCEPolicyMaxCPUTime'] = str(maxCPUTime * 60)
+        queueInfo['GlueCEPolicyMaxWallClockTime'] = str(int(queueInfo['GlueCEPolicyMaxWallClockTime']) * 60)
+
+      ceInfo.update(exeInfo)
+      shareEndpoints = shareInfoDict.get('GLUE2ShareEndpointForeignKey', [])
+      if isinstance(shareEndpoints, basestring):
+        shareEndpoints = [shareEndpoints]
+      cesDict = {}
+      for endpoint in shareEndpoints:
+        ceType = endpoint.rsplit('.', 1)[1]
+        # get queue Name, in CREAM this is behind GLUE2entityOtherInfo...
+        if ceType == 'CREAM':
+          for otherInfo in shareInfoDict['GLUE2EntityOtherInfo']:
+            if otherInfo.startswith('CREAMCEId'):
+              queueName = otherInfo.split('/', 1)[1]
+
+        # cern HTCondorCE
+        elif ceType.endswith('HTCondorCE'):
+          ceType = 'HTCondorCE'
+          queueName = 'condor'
+
+        queueInfo['GlueCEImplementationName'] = ceType
+        ceName = endpoint.split('_', 1)[0]
+        cesDict.setdefault(ceName, {})
+        existingQueues = dict(cesDict[ceName].get('Queues', {}))
+        existingQueues[queueName] = queueInfo
+        ceInfo['Queues'] = existingQueues
+        cesDict[ceName].update(ceInfo)
+
+      # ARC CEs do not have endpoints, we have to try something else to get the information about the queue etc.
+      if not shareEndpoints and shareInfoDict['GLUE2ShareID'].startswith('urn:ogf'):
+        exeInfo = dict(exeInfo)  # silence pylint about tuples
+        queueInfo['GlueCEImplementationName'] = 'ARC'
+        managerName = exeInfo.pop('MANAGER', '').split(' ', 1)[0].rsplit(':', 1)[1]
+        managerName = managerName.capitalize() if managerName == 'condor' else managerName
+        queueName = 'nordugrid-%s-%s' % (managerName, shareInfoDict['GLUE2ComputingShareMappingQueue'])
+        ceName = shareInfoDict['GLUE2ShareID'].split('ComputingShare:')[1].split(':')[0]
+        cesDict.setdefault(ceName, {})
+        existingQueues = dict(cesDict[ceName].get('Queues', {}))
+        existingQueues[queueName] = queueInfo
+        ceInfo['Queues'] = existingQueues
+        cesDict[ceName].update(ceInfo)
+
+      siteDict[siteName]['CEs'].update(cesDict)
 
   return S_OK(siteDict)
 
 
-def __getGlue2ShareInfo(host, shareEndpoints, shareInfoDict, cesDict):
-  """ get information from endpoints, which are the CE at a Site
-
-  :param str host: BDII host to query
-  :param list shareEndpoints: list of endpoint names
-  :param dict shareInfoDict: dictionary of GLUE2 parameters belonging to the ComputingShare
-  :param dict cesDict: dictionary with the CE information,
-                       will be modified in this function to add the information of the share
-  :returns: result structure S_OK/S_ERROR
-  """
-
-  ceInfo = {}
-  ceInfo['MaxWaitingJobs'] = shareInfoDict.get('GLUE2ComputingShareMaxWaitingJobs', '-1')  # This is not used
-  ceInfo['Queues'] = {}
-  queueInfo = {}
-  queueInfo['GlueCEStateStatus'] = shareInfoDict['GLUE2ComputingShareServingState']
-  queueInfo['GlueCEPolicyMaxCPUTime'] = str(int(shareInfoDict.get('GLUE2ComputingShareMaxCPUTime', 86400)) / 60)
-  queueInfo['GlueCEPolicyMaxWallClockTime'] = str(int(shareInfoDict.get('GLUE2ComputingShareMaxWallTime', 86400)) / 60)
-  queueInfo['GlueCEInfoTotalCPUs'] = shareInfoDict.get('GLUE2ComputingShareMaxRunningJobs', '10000')
-  queueInfo['GlueCECapability'] = []
-
-  # sometimes the time is still in minutes
-  maxCPUTime = int(queueInfo['GlueCEPolicyMaxCPUTime'])
-  if maxCPUTime in [12, 24, 36, 48, 168]:
-    queueInfo['GlueCEPolicyMaxCPUTime'] = str(maxCPUTime * 60)
-    queueInfo['GlueCEPolicyMaxWallClockTime'] = str(int(queueInfo['GlueCEPolicyMaxWallClockTime']) * 60)
-
-  exeInfo = []
-  executionEnvironments = shareInfoDict['GLUE2ComputingShareExecutionEnvironmentForeignKey']
-  if isinstance(executionEnvironments, six.string_types):
-    executionEnvironments = [executionEnvironments]
-  for executionEnvironment in executionEnvironments:
-    resExeInfo = __getGlue2ExecutionEnvironmentInfo(host, executionEnvironment)
-    if not resExeInfo['OK']:
-      gLogger.info("SCHEMA PROBLEM: Cannot get execution environment info for %r" % executionEnvironment,
-                   resExeInfo['Message'])
-      continue
-    exeInfo.append(resExeInfo['Value'])
-  if not exeInfo:
-    gLogger.warn('Did not find information for execution environment %s, using dummy values' % executionEnvironments)
-    exeInfo = [{'GlueHostMainMemoryRAMSize': '1999',  # intentionally identifiably dummy value
-                'GlueHostOperatingSystemVersion': '',
-                'GlueHostOperatingSystemName': '',
-                'GlueHostOperatingSystemRelease': '',
-                'GlueHostArchitecturePlatformType': 'x86_64',
-                'GlueHostBenchmarkSI00': '2500',  # needed for the queue to be used by the sitedirector
-                'MANAGER': 'manager:unknownBatchSystem',  # doesn't matter what this is for ARC, is eventually discarded
-                }]
-  try:
-    # take the CE with the lowest MainMemory
-    exeInfo = sorted(exeInfo, key=lambda k: int(k['GlueHostMainMemoryRAMSize']))
-  except ValueError:
-    gLogger.debug("Failed to sort the execution environments: %s" % pformat(exeInfo))
-  ceInfo.update(exeInfo[0])
-
-  if isinstance(shareEndpoints, six.string_types):
-    shareEndpoints = [shareEndpoints]
-  for endpoint in shareEndpoints:
-    ceType = endpoint.rsplit('.', 1)[1]
-    # get queue Name, in CREAM this is behind GLUE2entityOtherInfo...
-    if ceType == 'CREAM':
-      for otherInfo in shareInfoDict['GLUE2EntityOtherInfo']:
-        if otherInfo.startswith('CREAMCEId'):
-          queueName = otherInfo.split('/', 1)[1]
-
-    # cern HTCondorCE
-    elif ceType.endswith('HTCondorCE'):
-      ceType = 'HTCondorCE'
-      queueName = 'condor'
-
-    queueInfo['GlueCEImplementationName'] = ceType
-
-    ceName = endpoint.split('_', 1)[0]
-    cesDict.setdefault(ceName, {})
-    existingQueues = dict(cesDict[ceName].get('Queues', {}))
-    existingQueues[queueName] = queueInfo
-    ceInfo['Queues'] = existingQueues
-    cesDict[ceName].update(ceInfo)
-
-  # ARC CEs do not have endpoints, we have to try something else to get the information about the queue etc.
-  if not shareEndpoints and shareInfoDict['GLUE2ShareID'].startswith('urn:ogf'):
-    exeInfo = dict(exeInfo[0])  # silence pylint about tuples
-    ceType = 'ARC'
-    managerName = exeInfo.pop('MANAGER', '').split(' ', 1)[0].rsplit(':', 1)[1]
-    managerName = managerName.capitalize() if managerName == 'condor' else managerName
-    queueName = 'nordugrid-%s-%s' % (managerName, shareInfoDict['GLUE2ComputingShareMappingQueue'])
-    ceName = shareInfoDict['GLUE2ShareID'].split('ComputingShare:')[1].split(':')[0]
-    cesDict.setdefault(ceName, {})
-    existingQueues = dict(cesDict[ceName].get('Queues', {}))
-    existingQueues[queueName] = queueInfo
-    ceInfo['Queues'] = existingQueues
-    cesDict[ceName].update(ceInfo)
-
-  return S_OK()
-
-
-def __getGlue2ExecutionEnvironmentInfo(host, executionEnvironment):
+def __getGlue2ExecutionEnvironmentInfo(host, executionEnvironments):
   """ get the information about OS version, architecture, memory from GLUE2 ExecutionEnvironment
 
   :param str host: BDII host to query
-  :param str exeInfo: name of the execution environment to get some information from
+  :param list executionEnvironments: list of the execution environments to get some information from
   :returns: result structure with information in Glue1 schema to be consumed later elsewhere
   """
-  filt = "(&(objectClass=GLUE2ExecutionEnvironment)(GLUE2ResourceID=%s))" % executionEnvironment
+  exeFilter = ''
+  for execEnv in executionEnvironments:
+    exeFilter += '(GLUE2ResourceID=%s)' % execEnv
+  filt = "(&(objectClass=GLUE2ExecutionEnvironment)(|%s))" % exeFilter
   response = __ldapsearchBDII(filt=filt, attr=None, host=host, base="o=glue", selectionString="GLUE2")
   if not response['OK']:
     return response
   if not response['Value']:
-    return S_ERROR("No information found for %s" % executionEnvironment)
-  if len(response['Value']) > 1:
-    gLogger.info('SCHEMA PROBLEM: Multiple execution environments with the same ID: %s' % executionEnvironment)
-    gLogger.debug('Multiple results:\n %s' % pformat(response['Value']))
-    # only take the first one
-    response['Value'] = response['Value'][:1]
+    return S_ERROR("No information found for %s" % executionEnvironments)
+  return response
 
-  gLogger.debug("Found ExecutionEnvironment %s:\n%s" % (executionEnvironment, pformat(response)))
-  exeInfo = response['Value'][0]['attr']  # pylint: disable=unsubscriptable-object
+def __getGlue2ExecutionEnvironmentInfoForSite(sitename, foreignKeys, exeInfos):
+  """Get the information about the execution environment for a specific site or ce or something."""
+  # filter those that we want
+  exeInfos = [exeInfo for exeInfo in exeInfos if exeInfo['attr']['GLUE2ResourceID'] in foreignKeys]
+  # take the CE with the lowest MainMemory
+  exeInfo = sorted(exeInfos, key=lambda k: int(k['attr']['GLUE2ExecutionEnvironmentMainMemorySize']))
+  if not exeInfo:
+    gLogger.error('Did not find execution info for', sitename)
+    return S_OK()
+  gLogger.debug("Found ExecutionEnvironments", pformat(exeInfo[0]))
+  exeInfo = exeInfo[0]['attr']  # pylint: disable=unsubscriptable-object
   maxRam = exeInfo.get('GLUE2ExecutionEnvironmentMainMemorySize', '')
   architecture = exeInfo.get('GLUE2ExecutionEnvironmentPlatform', '')
   architecture = 'x86_64' if architecture == 'amd64' else architecture
@@ -214,13 +231,13 @@ def __getGlue2ExecutionEnvironmentInfo(host, executionEnvironment):
   osFamily = exeInfo.get('GLUE2ExecutionEnvironmentOSFamily', '')  # e.g. linux
   osName = exeInfo.get('GLUE2ExecutionEnvironmentOSName', '')
   osVersion = exeInfo.get('GLUE2ExecutionEnvironmentOSVersion', '')
-  manager = exeInfo.get('GLUE2ExecutionEnvironmentComputingManagerForeignKey', '')
+  manager = exeInfo.get('GLUE2ExecutionEnvironmentComputingManagerForeignKey', 'manager:unknownBatchSystem')
   # translate to Glue1 like keys, because that is used later on
   infoDict = {'GlueHostMainMemoryRAMSize': maxRam,
               'GlueHostOperatingSystemVersion': osName,
               'GlueHostOperatingSystemName': osFamily,
               'GlueHostOperatingSystemRelease': osVersion,
-              'GlueHostArchitecturePlatformType': architecture,
+              'GlueHostArchitecturePlatformType': architecture.lower(),
               'GlueHostBenchmarkSI00': '2500',  # needed for the queue to be used by the sitedirector
               'MANAGER': manager,  # to create the ARC QueueName mostly
               }

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -54,6 +54,7 @@ def getGlue2CEInfo(vo, host):
   listOfSitesWithPolicies = set()
   shareFilter = ''
   for policyValues in polRes:
+    # skip entries without GLUE2DomainID in the DN because we cannot associate them to a site
     if 'GLUE2DomainID' not in policyValues['attr']['dn']:
       continue
     shareID = policyValues['attr'].get('GLUE2MappingPolicyShareForeignKey', None)

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
@@ -83,25 +83,25 @@ General Parameters
 
 These parameters are valid for all types of computing elements
 
-+---------------------------------+-------------------------------------------------------+----------------------------------------------+
-| **Name**                        | **Description**                                       | **Example**                                  |
-+---------------------------------+-------------------------------------------------------+----------------------------------------------+
-| GridEnv                         | Default environment file sourced before calling       | /opt/dirac/gridenv                           |
-|                                 | grid commands, without extension '.sh'.               | (when the file is gridenv.sh)                |
-|                                 |                                                       |                                              |
-+---------------------------------+-------------------------------------------------------+----------------------------------------------+
-| SharedArea                      | Will be added to the pilot configuration              | /cvmfs/lhcb.cern.ch/lib                      |
-|                                 | as /LocalSite/SharedArea                              |                                              |
-+---------------------------------+-------------------------------------------------------+----------------------------------------------+
-| ExtraPilotOptions               | For adding some generic pilot options.                | --userEnvVariables DIRACSYSCONFIG:::pilot.cfg|
-|                                 | (only for pilots submitted by SiteDirectors)          | will add the environment variable            |
-|                                 |                                                       | DIRACSYSCONFIG                               |
-|                                 |                                                       | (see :ref:`bashrc_variables`)                |
-+---------------------------------+-------------------------------------------------------+----------------------------------------------+
-| MaxNumberOfProcessors           | The upper limit for the NumberOfProcessors queue      | 8                                            |
-|                                 | parameter set by the                                  |                                              |
-|                                 | :mod:`~DIRAC.ConfigurationSystem.Agent.Bdii2CSAgent`. |                                              |
-+---------------------------------+-------------------------------------------------------+----------------------------------------------+
++-----------------------------------------+-------------------------------------------------------+----------------------------------------------+
+| **Name**                                | **Description**                                       | **Example**                                  |
++-----------------------------------------+-------------------------------------------------------+----------------------------------------------+
+| GridEnv                                 | Default environment file sourced before calling       | /opt/dirac/gridenv                           |
+|                                         | grid commands, without extension '.sh'.               | (when the file is gridenv.sh)                |
+|                                         |                                                       |                                              |
++-----------------------------------------+-------------------------------------------------------+----------------------------------------------+
+| SharedArea                              | Will be added to the pilot configuration              | /cvmfs/lhcb.cern.ch/lib                      |
+|                                         | as /LocalSite/SharedArea                              |                                              |
++-----------------------------------------+-------------------------------------------------------+----------------------------------------------+
+| ExtraPilotOptions                       | For adding some generic pilot options.                | --userEnvVariables DIRACSYSCONFIG:::pilot.cfg|
+|                                         | (only for pilots submitted by SiteDirectors)          | will add the environment variable            |
+|                                         |                                                       | DIRACSYSCONFIG                               |
+|                                         |                                                       | (see :ref:`bashrc_variables`)                |
++-----------------------------------------+-------------------------------------------------------+----------------------------------------------+
+| GLUE2ComputingShareMaxSlotsPerJob_limit | The upper limit for the NumberOfProcessors queue      | 8                                            |
+|                                         | parameter set by the                                  |                                              |
+|                                         | :mod:`~DIRAC.ConfigurationSystem.Agent.Bdii2CSAgent`. |                                              |
++-----------------------------------------+-------------------------------------------------------+----------------------------------------------+
 
 
 ARC CE Parameters

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
@@ -83,22 +83,25 @@ General Parameters
 
 These parameters are valid for all types of computing elements
 
-+---------------------------------+-------------------------------------------------+-----------------------------------------------+
-| **Name**                        | **Description**                                 | **Example**                                   |
-+---------------------------------+-------------------------------------------------+-----------------------------------------------+
-| GridEnv                         | Default environment file sourced before calling | /opt/dirac/gridenv                            |
-|                                 | grid commands, without extension '.sh'.         | (when the file is gridenv.sh)                 |
-+---------------------------------+-------------------------------------------------+-----------------------------------------------+
-| SharedArea                      | Will be added to the pilot configuration        | /cvmfs/lhcb.cern.ch/lib                       |
-|                                 | as /LocalSite/SharedArea                        |                                               |
-+---------------------------------+-------------------------------------------------+-----------------------------------------------+
-| ExtraPilotOptions               | For adding some generic pilot options.          | --userEnvVariables DIRACSYSCONFIG:::pilot.cfg |
-|                                 | (only for pilots submitted by SiteDirectors)    | will add the environment variable             |
-|                                 |                                                 | DIRACSYSCONFIG                                |
-|                                 |                                                 | (see :ref:`bashrc_variables`)                 |
-+---------------------------------+-------------------------------------------------+-----------------------------------------------+
-
-
++---------------------------------+-------------------------------------------------------+----------------------------------------------+
+| **Name**                        | **Description**                                       | **Example**                                  |
++---------------------------------+-------------------------------------------------------+----------------------------------------------+
+| GridEnv                         | Default environment file sourced before calling       | /opt/dirac/gridenv                           |
+|                                 | grid commands, without extension '.sh'.               | (when the file is gridenv.sh)                |
+|                                 |                                                       |                                              |
++---------------------------------+-------------------------------------------------------+----------------------------------------------+
+| SharedArea                      | Will be added to the pilot configuration              | /cvmfs/lhcb.cern.ch/lib                      |
+|                                 | as /LocalSite/SharedArea                              |                                              |
++---------------------------------+-------------------------------------------------------+----------------------------------------------+
+| ExtraPilotOptions               | For adding some generic pilot options.                | --userEnvVariables DIRACSYSCONFIG:::pilot.cfg|
+|                                 | (only for pilots submitted by SiteDirectors)          | will add the environment variable            |
+|                                 |                                                       | DIRACSYSCONFIG                               |
+|                                 |                                                       | (see :ref:`bashrc_variables`)                |
++---------------------------------+-------------------------------------------------------+----------------------------------------------+
+| MaxNumberOfProcessors           | The upper limit for the NumberOfProcessors queue      | 8                                            |
+|                                 | parameter set by the                                  |                                              |
+|                                 | :mod:`~DIRAC.ConfigurationSystem.Agent.Bdii2CSAgent`. |                                              |
++---------------------------------+-------------------------------------------------------+----------------------------------------------+
 
 
 ARC CE Parameters


### PR DESCRIPTION
I would appreciate feedback on the list of functionality, still need to test this on v7r1. Started with v6r22 for iLCDirac (where it works nicely), but rebased to v7r1 because of changes in the resource information retrieval functions.

BEGINRELEASENOTES

*Core
CHANGE: Glue2: the number of ldap searches has been reduced to three making lookups much faster
CHANGE: Glue2: return also unknown sites not found in the information provider for given VO
CHANGE: Glue2: fill value for SI00 for queues as well. Value is fixed at 2500 and will overwrite any existing value. 
CHANGE: Glue2: architecture will now always be lowercase.
CHANGE: Glue2: Read the GLUE2ComputingShareMaxSlotsPerJob value and fill the NumberOfProcessors entry for the respective queue. Ignores CREAM CEs. A Ceiling for this number can be set by /Resources/Computing/CEDefaults/MaxNumberOfProcessors, defaults to 8. Solves #3926

*Configuration:
CHANGE: Bdii2CSAgent: change email subject to agent name
CHANGE: Bdii2CSAgent: Make GLUE2Only=True the default
CHANGE: Bdii2CSAgent: Email also information about CEs not found in the specified information, CEs can be ignored with ``BannedCEs`` option, solves #1034
CHANGE: dirac-admin-add-resources: printout CEs that are not known at the given information provider
CHANGE: dirac-admin-add-resources: default to Glue2, deprecate `-G` flag. Add `-g` flag to use glue1
FIX: dirac-admin-add-resources: Do not exit if no new CEs are found, still look for changes of existing CEs

ENDRELEASENOTES

During development the BDII server was terribly slow, so I changed the Glue2 code to do 3 look-ups in total, which really didn't help readability. I was worried this wouldn't work because of the shell call and the length of the command line, but this wasn't a problem when using vo=lhcb with dirac-admin-add-resources


Edit: regarding SI00=2500: (I can of course remove this, but it always takes me too long to figure out why any given queue isn't being used for submission for reasons like this value not being found. And there isn't any consistent way, if at all, to get benchmark values for sites in Glue2. There is no Benchmark published in the CERN site-bdii at all, for example.)