### PR TITLE
[v7r1] Remove backward compatibility hack of baseSE 

### DIFF
--- a/Resources/Storage/StorageBase.py
+++ b/Resources/Storage/StorageBase.py
@@ -364,8 +364,7 @@ class StorageBase(object):
     # TODO comparison to Sandbox below is for backward compatibility, should
     # be removed in the next release
     if voLFN != self.se.vo and voLFN != "SandBox" and voLFN != "Sandbox":
-
-      return S_ERROR('LFN does not follow the DIRAC naming convention %s' % lfn)
+      return S_ERROR('LFN (%s) path must start with VO name (%s)' % (lfn, self.se.vo))
 
     urlDict = dict(self.protocolParameters)
     urlDict['Options'] = '&'.join("%s=%s" % (optionName, urlDict[paramName])

--- a/Resources/Storage/StorageFactory.py
+++ b/Resources/Storage/StorageFactory.py
@@ -121,15 +121,7 @@ class StorageFactory(object):
     res = self._getConfigStorageOptions(storageName, derivedStorageName=derivedStorageName,
                                         seConfigPath=seConfigPath)
     if not res['OK']:
-      # This is for the backward compatibility and to invite developer to move their BaseSE in the correct section
-      gLogger.warn("Deprecated configuration, you can ignore the error message above."
-                   " Please move the baseSE in the correct section: ", SE_BASE_CONFIG_PATH)
-      # We change the value of seConfigPath to avoid other errors due to the bad SE_BASE_CONFIG_PATH
-      seConfigPath = SE_CONFIG_PATH
-      res = self._getConfigStorageOptions(storageName, derivedStorageName=derivedStorageName,
-                                          seConfigPath=seConfigPath)
-      if not res['OK']:
-        return res
+      return res
     self.options = res['Value']
 
     # Get the protocol specific details
@@ -205,11 +197,12 @@ class StorageFactory(object):
     if referenceType in res['Value']:
       configPath = cfgPath(seConfigPath, storageName, referenceType)
       referenceName = gConfig.getValue(configPath)
+      # We first look into the BaseStorageElements section.
+      # If not, we look into the StorageElements section
+      # (contrary to BaseSE, it's OK for an Alias to be in the StorageElements section)
       result = self._getConfigStorageName(referenceName, 'Alias', seConfigPath=SE_BASE_CONFIG_PATH)
       if not result['OK']:
-        # This is for the backward compatibility and to invite developer to move their BaseSE in the correct section
-        gLogger.warn("Deprecated configuration, you can ignore the error message above."
-                     " Please move the baseSE in the correct section: ", SE_BASE_CONFIG_PATH)
+        # Since it is not in the StorageElementBases section, check in the StorageElements section
         result = self._getConfigStorageName(referenceName, 'Alias', seConfigPath=SE_CONFIG_PATH)
         if not result['OK']:
           return result

--- a/Resources/Storage/test/Test_StorageFactory.py
+++ b/Resources/Storage/test/Test_StorageFactory.py
@@ -51,10 +51,6 @@ dict_cs = {
                     "Access": "remote",
                 }
             },
-        },
-        "StorageElements": {
-            # This SE must be in the section above but we put it here to test
-            # backward compatibility
             "CERN-BASE": {
                 "BackendType": "Eos",
                 "SEType": "T0D1",
@@ -68,6 +64,37 @@ dict_cs = {
                     "SpaceToken": "LHCb-EOS",
                     "WSUrl": "/srm/v2/server?SFN:",
                 }
+            },
+        },
+        "StorageElements": {
+            # This SE must be in the section above. We kept the backward
+            # compatibility for a while, but now it is time to remove it
+            "CERN-BASE-WRONGLOCATION": {
+                "BackendType": "Eos",
+                "SEType": "T0D1",
+                "AccessProtocol.1": {
+                    "Host": "srm-eoslhcb.cern.ch",
+                    "Port": 8443,
+                    "PluginName": "GFAL2_SRM2",
+                    "Protocol": "srm",
+                    "Path": "/eos/lhcb/grid/prod",
+                    "Access": "remote",
+                    "SpaceToken": "LHCb-EOS",
+                    "WSUrl": "/srm/v2/server?SFN:",
+                }
+            },
+            # This should not work anymore because
+            # CERN-BASE-WRONGLOCATION is in StorageElements
+            "CERN-WRONGLOCATION": {
+                "BaseSE": "CERN-BASE-WRONGLOCATION",
+                "AccessProtocol.1": {
+                    "PluginName": "GFAL2_SRM2",
+                    "Path": "/eos/lhcb/grid/prod",
+                }
+            },
+            # Alias in StorageElements location should still work
+            "CERN-WRONGLOCATION-ALIAS": {
+                "Alias": "CERN-BASE-WRONGLOCATION"
             },
             "CERN-SIMPLE": {
                 "BackendType": "Eos",
@@ -665,6 +692,27 @@ class StorageFactoryWeirdDefinition(unittest.TestCase):
     }]
 
     self.assertListEqual(storages['ProtocolOptions'], expectedProtocols)
+
+  def test_baseSE_in_SEDefinition(self, _sf_generateStorageObject, _rss_getSEStatus):
+    """ In this test, a storage inherits from a baseSE which is declared in the
+        StorageElements section instead of the BaseStorageElements section.
+        It used to be possible, but we remove this compatibility layer.
+    """
+
+    sf = StorageFactory(vo='lhcb')
+    storages = sf.getStorages('CERN-WRONGLOCATION')
+
+    self.assertFalse(storages['OK'], storages)
+
+  def test_aliasSE_in_SEDefinition(self, _sf_generateStorageObject, _rss_getSEStatus):
+    """ In this test, a storage aliases a baseSE which is declared in the
+        StorageElements section. That should remain possible
+    """
+
+    sf = StorageFactory(vo='lhcb')
+    storages = sf.getStorages('CERN-WRONGLOCATION-ALIAS')
+
+    self.assertTrue(storages['OK'], storages)
 
 
 @mock.patch('DIRAC.Resources.Storage.StorageFactory.gConfig', new=sf_gConfig)


### PR DESCRIPTION
Implements https://github.com/DIRACGrid/DIRAC/issues/3516
Also contains https://github.com/DIRACGrid/DIRAC/issues/2790

BEGINRELEASENOTES
*Resources

CHANGE: remove backward compatibility for BaseSE defined in StorageElements section (issue 3516)
CHANGE: Clearer error message related to LFN convention (issue #2790)

ENDRELEASENOTES
