### PR TITLE
[v7r0] exclude fuse from df (watchdog checks)

### DIFF
--- a/Core/Utilities/Os.py
+++ b/Core/Utilities/Os.py
@@ -32,7 +32,7 @@ def uniquePath(path=None):
     return None
 
 
-def getDiskSpace(path='.'):
+def getDiskSpace(path='.', exclude=None):
   """ Get the free disk space in the partition containing the path.
       The disk space is reported in MBytes. Returned 0 in case of any
       error, e.g. path does not exist
@@ -40,7 +40,10 @@ def getDiskSpace(path='.'):
 
   if not os.path.exists(path):
     return -1
-  comm = 'df -P -m %s | tail -1' % path
+  comm = 'df -P -m %s ' % path
+  if exclude:
+    comm += '-x %s ' % exclude
+  comm += '| tail -1'
   resultDF = shellCall(10, comm)
   if resultDF['OK'] and not resultDF['Value'][0]:
     output = resultDF['Value'][1]

--- a/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -315,7 +315,7 @@ class Watchdog(object):
     if 'DiskSpace' not in self.parameters:
       self.parameters['DiskSpace'] = []
 
-    result = self.getDiskSpace()
+    result = self.getDiskSpace(exclude='fuse')
     if not result['OK']:
       self.log.warn("Could not establish DiskSpace", result['Message'])
     else:


### PR DESCRIPTION
So that mountpoints can be cleaned up by automount after a period unused (specific request from CERN batch service).

BEGINRELEASENOTES

*WMS
FIX: exclude fuse from df (watchdog checks)

ENDRELEASENOTES
