### PR TITLE
[v6r22] exclude fuse from df (watchdog checks)

### DIFF
--- a/Core/Utilities/Os.py
+++ b/Core/Utilities/Os.py
@@ -30,7 +30,8 @@ def uniquePath( path = None ):
   except Exception:
     return None
 
-def getDiskSpace( path = '.' ):
+
+def getDiskSpace(path='.', exclude=None):
   """ Get the free disk space in the partition containing the path.
       The disk space is reported in MBytes. Returned 0 in case of any
       error, e.g. path does not exist
@@ -38,7 +39,10 @@ def getDiskSpace( path = '.' ):
 
   if not os.path.exists( path ):
     return -1
-  comm = 'df -P -m %s | tail -1' % path
+  comm = 'df -P -m %s ' % path
+  if exclude:
+    comm += '-x %s ' % exclude
+  comm += '| tail -1'
   resultDF = shellCall( 10, comm )
   if resultDF['OK'] and not resultDF['Value'][0]:
     output = resultDF['Value'][1]

--- a/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -309,7 +309,9 @@ class Watchdog(object):
       self.parameters['RSS'].append(rss)
       msg += "Job Vsize: %.1f kb " % vsize
       msg += "Job RSS: %.1f kb " % rss
-    result = self.getDiskSpace()
+    # We exclude fuse so that mountpoints can be cleaned up by automount after a period unused
+    # (specific request from CERN batch service).
+    result = self.getDiskSpace(exclude='fuse')
     if not result['OK']:
       self.log.warn("Could not establish DiskSpace", result['Message'])
     else:
@@ -749,7 +751,9 @@ class Watchdog(object):
     self.parameters['Vsize'] = []
     self.parameters['RSS'] = []
 
-    result = self.getDiskSpace()
+    # We exclude fuse so that mountpoints can be cleaned up by automount after a period unused
+    # (specific request from CERN batch service).
+    result = self.getDiskSpace(exclude='fuse')
     self.log.verbose('DiskSpace: %s' % (result))
     if not result['OK']:
       self.log.warn("Could not establish DiskSpace")
@@ -961,7 +965,7 @@ class Watchdog(object):
     return S_ERROR('Watchdog: ' + methodName + ' method should be implemented in a subclass')
 
   #############################################################################
-  def getDiskSpace(self):
+  def getDiskSpace(self, exclude=None):
     """ Attempts to get the available disk space, should be overridden in a subclass"""
     methodName = 'getDiskSpace'
     self.log.warn('Watchdog: ' + methodName + ' method should be implemented in a subclass')

--- a/WorkloadManagementSystem/JobWrapper/WatchdogLinux.py
+++ b/WorkloadManagementSystem/JobWrapper/WatchdogLinux.py
@@ -80,11 +80,11 @@ class WatchdogLinux(Watchdog):
     return S_OK(float(mem))
 
   #############################################################################
-  def getDiskSpace(self):
+  def getDiskSpace(self, exclude=None):
     """Obtains the disk space used.
     """
     result = S_OK()
-    diskSpace = getDiskSpace()
+    diskSpace = getDiskSpace(exclude=exclude)
 
     if diskSpace == -1:
       result = S_ERROR('Could not obtain disk usage')


### PR DESCRIPTION
So that mountpoints can be cleaned up by automount after a period unused (specific request from CERN batch service).

BEGINRELEASENOTES

*WMS
FIX: exclude fuse from df (watchdog checks)

ENDRELEASENOTES
