### PR TITLE
[v7r1] bdii2csagent purgeSites fix

### DIFF
--- a/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -247,6 +247,8 @@ class Bdii2CSAgent(AgentModule):
       totalResult = S_ERROR(message)
     else:
       self.voBdiiCEDict[vo] = totalResult['Value']
+      self.__purgeSites(totalResult['Value'])
+
     return totalResult
 
   def __getBdiiSEInfo(self, vo):
@@ -282,7 +284,6 @@ class Bdii2CSAgent(AgentModule):
       if not result['OK']:
         continue
       ceBdiiDict = result['Value']
-      self.__purgeSites(ceBdiiDict)
       result = getSiteUpdates(vo, bdiiInfo=ceBdiiDict, log=self.log)
       if not result['OK']:
         continue

--- a/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -304,11 +304,16 @@ class Bdii2CSAgent(AgentModule):
       if not ces:
         self.log.error("No CE information for site:", site)
         continue
-      res = getCESiteMapping(ces[0])
-      if not res['OK']:
-        self.log.error("Failed to get DIRAC site name for ce", "%s: %s" % (ces[0], res['Message']))
-        continue
-      siteInCS = res['Value'][ces[0]]
+      siteInCS = 'Not_In_CS'
+      for ce in ces:
+        res = getCESiteMapping(ce)
+        if not res['OK']:
+          self.log.error("Failed to get DIRAC site name for ce", "%s: %s" % (ce, res['Message']))
+          continue
+        # if the ce is not in the CS the returned value will be empty
+        if ce in res['Value']:
+          siteInCS = res['Value'][ce]
+          break
       self.log.debug("Checking site %s (%s), aka %s" % (site, ces, siteInCS))
       if siteInCS in self.selectedSites:
         continue

--- a/FrameworkSystem/Service/NotificationHandler.py
+++ b/FrameworkSystem/Service/NotificationHandler.py
@@ -89,9 +89,8 @@ class NotificationHandler(RequestHandler):
     if not fromAddress == 'None':
       eMail._fromAddress = fromAddress
     eMail._fromAddress = gConfig.getValue('%s/FromAddress' % csSection) or eMail._fromAddress
-    if avoidSpam:
-      gMailSet.add(eMail)
-      return S_OK("Mail added to gMailSet")
+    if avoidSpam and eMail in gMailSet:
+      return S_OK("Mail already sent")
     else:
       result = eMail._send()
       if not result['OK']:


### PR DESCRIPTION
@fstagni this is currently the hotfix on lbcertifdirac, so the last email you received should only contain "new" cern CEs.

Did you also want to receive notification that there are sites ignored? Because that could result in emails being sent every time.

BEGINRELEASENOTES

*CS
FIX: Bdii2CSAgent: Fix exception if selectedSites was set, but some unknown Sites were found by the agent
CHANGE: Bdii2CSAgent: if selectedSites is configured, also remove all CEs from unknown sites from the results

*Framework
CHANGE: NotificationHandler: sendMail: the `avoidSpam` parameter is deprecated. All emails (same subject, address, body) are now only sent once per 24h

ENDRELEASENOTES
