### PR TITLE
[v7r0] Ignore LCG tiers when looking for sites with storage

### DIFF
--- a/Interfaces/scripts/dirac-wms-job-parameters.py
+++ b/Interfaces/scripts/dirac-wms-job-parameters.py
@@ -37,8 +37,6 @@ for job in parseArguments(args):
   if not result['OK']:
     errorList.append((job, result['Message']))
     exitCode = 2
-  else:
-    gLogger.notice(result['Value'])
 
 for error in errorList:
   print("ERROR %s: %s" % error)

--- a/TransformationSystem/Client/TaskManagerPlugin.py
+++ b/TransformationSystem/Client/TaskManagerPlugin.py
@@ -119,7 +119,7 @@ class TaskManagerPlugin(PluginBase):
     if 'WithStorage' in autoAddedSites:
       # Add all sites with storage, such that jobs can run wherever data is
       autoAddedSites.remove('WithStorage')
-      autoAddedSites += DMSHelpers().getTiers(withStorage=True, tier=(0, 1, 2))
+      autoAddedSites += DMSHelpers().getTiers(withStorage=True)
 
     # 3. removing sites in Exclude
     if not excludedSites:


### PR DESCRIPTION
BEGINRELEASENOTES
*TS
CHANGE: consider all sites when getting sites with storage (not only LCG sites with Tier0, 1 or 2

*WMS
FIX: dirac-wms-job-parameters: output was printed twice

ENDRELEASENOTES
