### PR TITLE
[v7r1] Fix WebApp/PilotMonitor/showJobs

### DIFF
--- a/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -16,6 +16,7 @@ import DIRAC.Core.Utilities.Time as Time
 from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
 from DIRAC.Core.Utilities.JEncode import strToIntDict
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
 
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 from DIRAC.WorkloadManagementSystem.DB.ElasticJobParametersDB import ElasticJobParametersDB
@@ -371,6 +372,21 @@ class JobMonitoringHandler(RequestHandler):
     endDate = selectDict.get('ToDate', None)
     if endDate:
       del selectDict['ToDate']
+
+    # Provide JobID bound to a specific PilotJobReference
+    # There is no reason to have both PilotJobReference and JobID in selectDict
+    # If that occurs, use the JobID instead of the PilotJobReference
+    pilotJobRefs = selectDict.get('PilotJobReference')
+    if pilotJobRefs:
+      del selectDict['PilotJobReference']
+      if 'JobID' not in selectDict or not selectDict['JobID']:
+        if not isinstance(pilotJobRefs, list):
+          pilotJobRefs = [pilotJobRefs]
+        selectDict['JobID'] = []
+        for pilotJobRef in pilotJobRefs:
+          res = PilotManagerClient().getPilotInfo(pilotJobRef)
+          if res['OK'] and 'Jobs' in res['Value'][pilotJobRef]:
+            selectDict['JobID'].extend(res['Value'][pilotJobRef]['Jobs'])
 
     result = self.jobPolicy.getControlledUsers(RIGHT_GET_INFO)
     if not result['OK']:


### PR DESCRIPTION
The `PilotMonitor/showJobs` feature opens a `JobMonitor` window to see the `CurrentJobID` only.
DIRAC Pilot-Jobs are able to handle multiple jobs: on HPCs, Pilot-Jobs can handle tens of jobs at the same time.
It would be easier to debug issues in the Pilot-Jobs if we would have access to all the jobs bound to a specific Pilot-Job instead of the current one.

This PR includes Pilot-Job references in the `JobMonitoring` web summary.
Change made in the WebApp are available here: https://github.com/DIRACGrid/WebAppDIRAC/pull/405

BEGINRELEASENOTES
*WorkloadManagement
CHANGE: JobMonitoring.getJobPageSummaryWeb can provide jobIDs according to the pilotJobReferences
ENDRELEASENOTES
