### PR TITLE
[v7r0] Disable dirac install and pilot wrapper CI on forks

### DIFF
--- a/.github/workflows/diracinstall.yml
+++ b/.github/workflows/diracinstall.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   diracInstall:
     runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
 
     strategy:
       fail-fast: False

--- a/.github/workflows/pilotWrapper.yml
+++ b/.github/workflows/pilotWrapper.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   PilotWrapper:
     runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
 
     strategy:
       fail-fast: False


### PR DESCRIPTION
Currently the "dirac install" and "pilot wrapper" pipelines run on both the DIRACGrid and fork's CI. This PR copies the line used by the other pipelines for avoiding this.