### PR TITLE
[v7r1] VOMS2CS: introduce SyncPlugins 

### DIFF
--- a/ConfigurationSystem/Agent/VOMS2CSAgent.py
+++ b/ConfigurationSystem/Agent/VOMS2CSAgent.py
@@ -56,6 +56,7 @@ class VOMS2CSAgent(AgentModule):
     self.makeFCEntry = False
     self.autoLiftSuspendedStatus = True
     self.mailFrom = 'noreply@dirac.system'
+    self.syncPluginName = None
 
   def initialize(self):
     """ Initialize the default parameters
@@ -69,6 +70,7 @@ class VOMS2CSAgent(AgentModule):
     self.autoDeleteUsers = self.am_getOption('AutoDeleteUsers', self.autoDeleteUsers)
     self.autoLiftSuspendedStatus = self.am_getOption('AutoLiftSuspendedStatus', self.autoLiftSuspendedStatus)
     self.makeFCEntry = self.am_getOption('MakeHomeDirectory', self.makeFCEntry)
+    self.syncPluginName = self.am_getOption('SyncPluginName', self.syncPluginName)
 
     self.detailedReport = self.am_getOption('DetailedReport', self.detailedReport)
     self.mailFrom = self.am_getOption('MailFrom', self.mailFrom)
@@ -101,12 +103,14 @@ class VOMS2CSAgent(AgentModule):
       autoModifyUsers = getVOOption(vo, "AutoModifyUsers", self.autoModifyUsers)
       autoDeleteUsers = getVOOption(vo, "AutoDeleteUsers", self.autoDeleteUsers)
       autoLiftSuspendedStatus = getVOOption(vo, "AutoLiftSuspendedStatus", self.autoLiftSuspendedStatus)
+      syncPluginName = getVOOption(vo, 'SyncPluginName', self.syncPluginName)
 
       vomsSync = VOMS2CSSynchronizer(vo,
                                      autoAddUsers=autoAddUsers,
                                      autoModifyUsers=autoModifyUsers,
                                      autoDeleteUsers=autoDeleteUsers,
-                                     autoLiftSuspendedStatus=autoLiftSuspendedStatus)
+                                     autoLiftSuspendedStatus=autoLiftSuspendedStatus,
+                                     syncPluginName=syncPluginName)
 
       result = self.__syncCSWithVOMS(vomsSync,  # pylint: disable=unexpected-keyword-arg
                                      proxyUserName=voAdminUser,

--- a/ConfigurationSystem/Client/SyncPlugins/DummySyncPlugin.py
+++ b/ConfigurationSystem/Client/SyncPlugins/DummySyncPlugin.py
@@ -1,0 +1,38 @@
+"""
+DummySyncPlugin
+"""
+
+
+class DummySyncPlugin(object):
+  """ Dummy Synchronization plugin that does nothing.
+      It is used to document what are the requirements for a real Sync plugin.
+
+      Such plugins are meant to validate user's information about to be added to the CS,
+      or to complete it with various sources.
+      They are called by the
+      :py:meth:`DIRAC.ConfigurationSystem.Client.VOMS2CSSynchronizer.VOMS2CSSynchronizer.syncCSWithVOMS`
+  """
+
+  def __init__(self):
+    """ The constructor does not receive any argument.
+        Note that the plugin is instanciated only once, so this is
+        a good place to do global initialization.
+    """
+    pass
+
+  def verifyAndUpdateUserInfo(self, username, userDict):
+    """
+      This method is expected to validate the user's data passed
+      as parameter, but is also allowed to extend them.
+
+      In case the validation was not to pass, this method must raise
+      ``ValueError``. The user would then not be added to the CS.
+
+    :param username: DIRAC name of the user to be added
+    :param userDict: user information collected by the VOMS2CSAgent. Typical keys include
+                     ``DN``,``CA``, ``Email``, ``Groups``
+    :returns: None
+    :raise ValueError: in case user information do not pass validation
+
+    """
+    raise NotImplementedError("Must be implemented by the plugin")

--- a/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -10,6 +10,7 @@ from DIRAC import S_OK, S_ERROR, gLogger, gConfig
 
 from DIRAC.Core.Security.VOMSService import VOMSService
 from DIRAC.Core.Utilities.List import fromChar
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.Core.Utilities.PrettyPrint import printTable
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOOption, getVOMSRoleGroupMapping, \
@@ -115,7 +116,8 @@ def _getUserNameFromSurname(name, surname):
 class VOMS2CSSynchronizer(object):
 
   def __init__(self, vo, autoModifyUsers=True, autoAddUsers=True,
-               autoDeleteUsers=False, autoLiftSuspendedStatus=False):
+               autoDeleteUsers=False, autoLiftSuspendedStatus=False,
+               syncPluginName=None):
     """ VOMS2CSSynchronizer class constructor
 
     :param str vo: VO to be synced
@@ -123,6 +125,8 @@ class VOMS2CSSynchronizer(object):
     :param autoAddUsers: flag to automatically add new users to CS
     :param autoDeleteUsers: flag to automatically delete users from CS if no more in VOMS
     :param autoLiftSuspendedStatus: flag to automatically remove Suspended status in CS
+    :param syncPluginName: name of the plugin to validate or extend users' info
+
     :return: None
     """
 
@@ -139,13 +143,26 @@ class VOMS2CSSynchronizer(object):
     self.autoDeleteUsers = autoDeleteUsers
     self.autoLiftSuspendedStatus = autoLiftSuspendedStatus
     self.voChanged = False
+    self.syncPlugin = None
+
+    if syncPluginName:
+      objLoader = ObjectLoader()
+      _class = objLoader.loadObject(
+          'ConfigurationSystem.Client.SyncPlugins.%sSyncPlugin' %
+          syncPluginName, '%sSyncPlugin' % syncPluginName)
+
+      if not _class['OK']:
+        raise Exception(_class['Message'])
+
+      self.syncPlugin = _class['Value']()
 
   def syncCSWithVOMS(self):
     """ Performs the synchronization of the DIRAC registry with the VOMS data. The resulting
         CSAPI object containing modifications is returned as part of the output dictionary.
         Those changes can be applied by the caller depending on the mode (dry or a real run)
 
-    :return: S_OK with a dictionary containing the results of the synchronization operation
+
+      :return: S_OK with a dictionary containing the results of the synchronization operation
     """
     resultDict = defaultdict(list)
 
@@ -268,6 +285,16 @@ class VOMS2CSSynchronizer(object):
               if group not in noSyncVOMSGroups:
                 groupsWithRole.append(group)
           userDict['Groups'] = list(set(groupsWithRole + [defaultVOGroup]))
+
+          # Run the sync plugins for extra info and/or validations
+          if self.syncPlugin:
+            try:
+              self.syncPlugin.verifyAndUpdateUserInfo(newDiracName, userDict)
+            except ValueError as e:
+              self.log.error("Error validating new user", "nickname %s\n error %s" % (newDiracName, e))
+              self.adminMsgs['Errors'].append('Error validating new user %s: %s\n  %s' % (newDiracName, userDict, e))
+              continue
+
           message = "\n  Added new user %s:\n" % newDiracName
           for key in userDict:
             message += "    %s: %s\n" % (key, str(userDict[key]))

--- a/ConfigurationSystem/ConfigTemplate.cfg
+++ b/ConfigurationSystem/ConfigTemplate.cfg
@@ -73,6 +73,8 @@ Agents
     VO = Any
     # Flag to turn to False if you want this agent to write in the CS (more granularity within other options)
     DryRun = True
+    # Name of the plugin to validate or expand user's info. See :py:mod:`DIRAC.ConfigurationSystem.Client.SyncPlugins.DummySyncPlugin`
+    SyncPluginName =
   }
   ##END
   ##BEGIN GOCDB2CSAgent

--- a/tests/Utilities/assertingUtils.py
+++ b/tests/Utilities/assertingUtils.py
@@ -167,7 +167,7 @@ def checkAgentOptions(getOptionMock, systemName, agentName,
       continue
     LOG.info("Looking for call to option %r with value %r, (%s)", option, value, type(value))
     if not isinstance(value, bool) and not value:  # empty string, list, dict ...
-      assert any(call(option, null) in getOptionMock.call_args_list for null in ({}, set(), [], '', 0))
+      assert any(call(option, null) in getOptionMock.call_args_list for null in ({}, set(), [], '', 0, None))
     else:
       assert call(option, value) in getOptionMock.call_args_list or \
           call(option, [value]) in getOptionMock.call_args_list


### PR DESCRIPTION
LHCb use case is to add a CERN primary username into the CS. It will also prevent against typo in nicknames when creating new users in VOMS

I'd have been happy to add even more docs than what is already here, but there does not seem to be a VOMS2CS dedicated part (though it would surely deserve it :-) )

BEGINRELEASENOTES

*Configuration
NEW: VOMS2CSAgent introduce SyncPlugins to add extra or validate user information information

ENDRELEASENOTES
