### PR TITLE
[v7r1] arc.Endpoint doesn't accept unicode in ARCComputingElement

### DIFF
--- a/Resources/Computing/ARCComputingElement.py
+++ b/Resources/Computing/ARCComputingElement.py
@@ -218,7 +218,7 @@ class ARCComputingElement(ComputingElement):
     batchIDList = []
     stampDict = {}
 
-    endpoint = arc.Endpoint(self.ceHost + ":2811/jobs", arc.Endpoint.JOBSUBMIT,
+    endpoint = arc.Endpoint(str(self.ceHost + ":2811/jobs"), arc.Endpoint.JOBSUBMIT,
                             "org.nordugrid.gridftpjob")
 
     # Submit jobs iteratively for now. Tentatively easier than mucking around with the JobSupervisor class
@@ -326,7 +326,7 @@ class ARCComputingElement(ComputingElement):
     if not vo:
       # Presumably the really proper way forward once the infosys-discuss WG comes up with a solution
       # and it is implemented. Needed for DIRAC instances which use robot certificates for pilots.
-      endpoints = [arc.Endpoint("ldap://" + self.ceHost + "/MDS-Vo-name=local,o=grid",
+      endpoints = [arc.Endpoint(str("ldap://" + self.ceHost + "/MDS-Vo-name=local,o=grid"),
                                 arc.Endpoint.COMPUTINGINFO, 'org.nordugrid.ldapng')]
       retriever = arc.ComputingServiceRetriever(self.usercfg, endpoints)
       retriever.wait()  # Takes a bit of time to get and parse the ldap information


### PR DESCRIPTION
BEGINRELEASENOTES

*Resources
FIX: Initialisation of arc.Endpoint in ARCComputingElement

ENDRELEASENOTES

Fixes the error seen in the hackathon but I think there is no reason not to backport to v7r0:

```
2020-10-29 10:10:12 UTC WorkloadManagement/SiteDirector ERROR: Agent exception while calling method <bound method SiteDirector.execute of <SiteDirector.SiteDirector object at 0x7f243c394e50>>
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/Base/AgentModule.py", line 344, in am_secureCall
    result = functor(*args)
  File "/opt/dirac/pro/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 459, in execute
    result = self.submitPilots()
  File "/opt/dirac/pro/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 579, in submitPilots
    res = self._submitPilotsToQueue(pilotsToSubmit, ce, queueName)
  File "/opt/dirac/pro/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 856, in _submitPilotsToQueue
    submitResult = ce.submitJob(executable, '', pilotSubmissionChunk)
  File "/opt/dirac/pro/DIRAC/Resources/Computing/ARCComputingElement.py", line 225, in submitJob
    "org.nordugrid.gridftpjob")
  File "/opt/dirac/pro/diracos/usr/lib64/python2.7/site-packages/arc/compute.py", line 376, in __init__
    this = _compute.new_Endpoint(*args)
NotImplementedError: Wrong number of arguments for overloaded function 'new_Endpoint'.
  Possible C/C++ prototypes are:
    Arc::Endpoint(std::string const &,std::set< std::string,std::less< std::string >,std::allocator< std::string > > const &,std::string const &)
    Arc::Endpoint(std::string const &,std::set< std::string,std::less< std::string >,std::allocator< std::string > > const &)
    Arc::Endpoint(std::string const &)
    Arc::Endpoint()
    Arc::Endpoint(std::string const &,Arc::Endpoint::CapabilityEnum const,std::string const &)
    Arc::Endpoint(std::string const &,Arc::Endpoint::CapabilityEnum const)
    Arc::Endpoint(Arc::ExecutionTarget const &,std::string const &)
    Arc::Endpoint(Arc::ExecutionTarget const &)
    Arc::Endpoint(Arc::ComputingEndpointAttributes const &,std::string const &)
    Arc::Endpoint(Arc::ComputingEndpointAttributes const &)
    Arc::Endpoint(Arc::ConfigEndpoint const &)
```
