### PR TITLE
[v7r1] Job Accounting: multiply wallclock per the number of processors used

### DIFF
--- a/AccountingSystem/Client/Types/DataOperation.py
+++ b/AccountingSystem/Client/Types/DataOperation.py
@@ -7,7 +7,7 @@ __RCSID__ = "$Id$"
 class DataOperation(BaseAccountingType):
 
   def __init__(self):
-    BaseAccountingType.__init__(self)
+    super(DataOperation, self).__init__()
     self.definitionKeyFields = [('OperationType', "VARCHAR(32)"),
                                 ('User', "VARCHAR(64)"),
                                 ('ExecutionSite', 'VARCHAR(256)'),

--- a/AccountingSystem/Client/Types/Job.py
+++ b/AccountingSystem/Client/Types/Job.py
@@ -3,8 +3,8 @@
     Filled by the JobWrapper (by the jobs) and by the agent "WorloadManagement/StalledJobAgent"
 """
 
-from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 import DIRAC
+from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 
 __RCSID__ = "$Id$"
 
@@ -25,7 +25,7 @@ class Job(BaseAccountingType):
                                 ]
     self.definitionAccountingFields = [('CPUTime', "INT UNSIGNED"),  # utime + stime + cutime + cstime
                                        ('NormCPUTime', "INT UNSIGNED"),  # CPUTime * CPUNormalizationFactor
-                                       ('ExecTime', "INT UNSIGNED"),  # elapsed_time (wall time)
+                                       ('ExecTime', "INT UNSIGNED"),  # elapsed_time (wall time) * numberOfProcessors
                                        ('InputDataSize', 'BIGINT UNSIGNED'),
                                        ('OutputDataSize', 'BIGINT UNSIGNED'),
                                        ('InputDataFiles', 'INT UNSIGNED'),
@@ -33,7 +33,7 @@ class Job(BaseAccountingType):
                                        ('DiskSpace', 'BIGINT UNSIGNED'),
                                        ('InputSandBoxSize', 'BIGINT UNSIGNED'),
                                        ('OutputSandBoxSize', 'BIGINT UNSIGNED'),
-                                       ('ProcessedEvents', 'INT UNSIGNED')
+                                       ('ProcessedEvents', 'INT UNSIGNED')  # unused (normally not filled)
                                        ]
     self.bucketsLength = [(86400 * 8, 3600),  # <1w+1d = 1h
                           (86400 * 35, 3600 * 4),  # <35d = 4h

--- a/AccountingSystem/Client/Types/Job.py
+++ b/AccountingSystem/Client/Types/Job.py
@@ -51,12 +51,6 @@ class Job(BaseAccountingType):
     if not result['OK']:
       return result
     execTime = result['Value']
-    result = self.getValue("CPUTime")
-    if not result['OK']:
-      return result
-    cpuTime = result['Value']
-    if cpuTime > execTime * 100:
-      return DIRAC.S_ERROR("OOps. CPUTime seems to be more than 100 times the ExecTime. Smells fishy!")
     if execTime > 33350400:  # 1 year
       return DIRAC.S_ERROR("OOps. More than 1 year of cpu time smells fishy!")
     return DIRAC.S_OK()

--- a/AccountingSystem/Client/Types/Job.py
+++ b/AccountingSystem/Client/Types/Job.py
@@ -1,3 +1,8 @@
+""" Job accounting type.
+
+    Filled by the JobWrapper (by the jobs) and by the agent "WorloadManagement/StalledJobAgent"
+"""
+
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 import DIRAC
 
@@ -7,7 +12,7 @@ __RCSID__ = "$Id$"
 class Job(BaseAccountingType):
 
   def __init__(self):
-    BaseAccountingType.__init__(self)
+    super(Job, self).__init__()
     self.definitionKeyFields = [('User', 'VARCHAR(64)'),
                                 ('UserGroup', 'VARCHAR(32)'),
                                 ('JobGroup', "VARCHAR(64)"),
@@ -18,9 +23,9 @@ class Job(BaseAccountingType):
                                 ('FinalMajorStatus', 'VARCHAR(32)'),
                                 ('FinalMinorStatus', 'VARCHAR(256)')
                                 ]
-    self.definitionAccountingFields = [('CPUTime', "INT UNSIGNED"),
-                                       ('NormCPUTime', "INT UNSIGNED"),
-                                       ('ExecTime', "INT UNSIGNED"),
+    self.definitionAccountingFields = [('CPUTime', "INT UNSIGNED"),  # utime + stime + cutime + cstime
+                                       ('NormCPUTime', "INT UNSIGNED"),  # CPUTime * CPUNormalizationFactor
+                                       ('ExecTime', "INT UNSIGNED"),  # elapsed_time (wall time)
                                        ('InputDataSize', 'BIGINT UNSIGNED'),
                                        ('OutputDataSize', 'BIGINT UNSIGNED'),
                                        ('InputDataFiles', 'INT UNSIGNED'),

--- a/AccountingSystem/Client/Types/Network.py
+++ b/AccountingSystem/Client/Types/Network.py
@@ -1,18 +1,20 @@
-'''
-Accounting class to stores network metrics gathered by perfSONARs.
-'''
+""" Accounting class to stores network metrics gathered by perfSONARs.
+
+    Filled by "Accounting/Network" agent
+"""
+
 __RCSID__ = "$Id$"
 
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 
 
 class Network(BaseAccountingType):
-  '''
+  """
   Accounting type to stores network metrics gathered by perfSONARs.
-  '''
+  """
 
   def __init__(self):
-    BaseAccountingType.__init__(self)
+    super(Network, self).__init__()
 
     # IPv6 address has up to 45 chars
     self.definitionKeyFields = [

--- a/AccountingSystem/Client/Types/Pilot.py
+++ b/AccountingSystem/Client/Types/Pilot.py
@@ -6,7 +6,7 @@ from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountin
 class Pilot(BaseAccountingType):
 
   def __init__(self):
-    BaseAccountingType.__init__(self)
+    super(Pilot, self).__init__()
     self.definitionKeyFields = [('User', 'VARCHAR(64)'),
                                 ('UserGroup', 'VARCHAR(32)'),
                                 ('Site', 'VARCHAR(64)'),

--- a/AccountingSystem/Client/Types/PilotSubmission.py
+++ b/AccountingSystem/Client/Types/PilotSubmission.py
@@ -1,5 +1,7 @@
-''' Accounting Type for Pilot Submission
-'''
+""" Accounting Type for Pilot Submission
+
+    Filled by the "WorkloadManagement/SiteDirector" agent(s)
+"""
 
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 
@@ -7,11 +9,11 @@ __RCSID__ = "$Id$"
 
 
 class PilotSubmission(BaseAccountingType):
-  ''' Accounting Type class for Pilot Submission
-  '''
+  """ Accounting Type class for Pilot Submission
+  """
 
   def __init__(self):
-    BaseAccountingType.__init__(self)
+    super(PilotSubmission, self).__init__()
 
     self.definitionKeyFields = [('HostName', 'VARCHAR(100)'),
                                 ('SiteDirector', 'VARCHAR(100)'),

--- a/AccountingSystem/Client/Types/StorageOccupancy.py
+++ b/AccountingSystem/Client/Types/StorageOccupancy.py
@@ -15,7 +15,8 @@ class StorageOccupancy(BaseAccountingType):
 
   def __init__(self):
     """constructor."""
-    BaseAccountingType.__init__(self)
+    super(StorageOccupancy, self).__init__()
+
     self.definitionKeyFields = [('Site', 'VARCHAR(64)'),
                                 ('Endpoint', 'VARCHAR(255)'),
                                 ('StorageElement', 'VARCHAR(64)'),

--- a/AccountingSystem/Client/Types/WMSHistory.py
+++ b/AccountingSystem/Client/Types/WMSHistory.py
@@ -1,3 +1,9 @@
+""" MySQL based WMSHistory accounting.
+    It's suggested to replace this with the ElasticSearch based WMSHistory monitoring.
+
+    Filled by the agent "WorkloadManagement/StatesAccountingAgent"
+"""
+
 __RCSID__ = "$Id$"
 
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
@@ -6,7 +12,7 @@ from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountin
 class WMSHistory(BaseAccountingType):
 
   def __init__(self):
-    BaseAccountingType.__init__(self)
+    super(WMSHistory, self).__init__()
     self.definitionKeyFields = [('Status', "VARCHAR(128)"),
                                 ('Site', 'VARCHAR(128)'),
                                 ('User', 'VARCHAR(128)'),

--- a/AccountingSystem/private/Plotters/JobPlotter.py
+++ b/AccountingSystem/private/Plotters/JobPlotter.py
@@ -1,3 +1,5 @@
+""" Recipes on how to create job plots
+"""
 
 from DIRAC import S_OK
 from DIRAC.AccountingSystem.Client.Types.Job import Job

--- a/MonitoringSystem/Client/Types/WMSHistory.py
+++ b/MonitoringSystem/Client/Types/WMSHistory.py
@@ -1,5 +1,7 @@
-"""
-This class is a helper to create the proper index and insert the proper values....
+""" Definition for WMSHistory Monitoring type.
+    Drop-in replacement for the Accounting/WMSHistory accounting type.
+
+    Filled by the agent "WorkloadManagement/StatesMonitoringAgent"
 """
 
 from DIRAC.MonitoringSystem.Client.Types.BaseType import BaseType

--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -179,6 +179,7 @@ class JobWrapper(object):
     self.outputSandboxSize = 0
     self.outputDataSize = 0
     self.processedEvents = 0
+    self.numberOfProcessors = 1
     self.jobAccountingSent = False
 
     self.jobArgs = {}
@@ -308,7 +309,7 @@ class JobWrapper(object):
       self.log.info('Job has no CPU time limit specified, ',
                     'applying default of %s to %s' % (self.defaultCPUTime, self.jobID))
       jobCPUTime = self.defaultCPUTime
-    processors = int(self.jobArgs.get('NumberOfProcessors', 1))
+    self.numberOfProcessors = int(self.jobArgs.get('NumberOfProcessors', 1))
 
     jobMemory = 0.
     if "Memory" in self.jobArgs:
@@ -379,7 +380,7 @@ class JobWrapper(object):
                                                      spObject=spObject,
                                                      jobCPUTime=jobCPUTime,
                                                      memoryLimit=jobMemory,
-                                                     processors=processors,
+                                                     processors=self.numberOfProcessors,
                                                      jobArgs=self.jobArgs)
 
     if not watchdogInstance['OK']:
@@ -1195,7 +1196,7 @@ class JobWrapper(object):
               'CPUTime': cpuTime,
               # Based on the factor to convert raw CPU to Normalized units (based on the CPU Model)
               'NormCPUTime': cpuTime * self.cpuNormalizationFactor,
-              'ExecTime': execTime,
+              'ExecTime': execTime * self.numberOfProcessors,
               'InputDataSize': self.inputDataSize,
               'OutputDataSize': self.outputDataSize,
               'InputDataFiles': self.inputDataFiles,

--- a/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -346,7 +346,7 @@ class Watchdog(object):
     else:
       msg += 'WallClock: %.2f s ' % (result['Value'])
       self.parameters.setdefault('WallClockTime', list()).append(result['Value'])
-      heartBeatDict['WallClockTime'] = result['Value']
+      heartBeatDict['WallClockTime'] = result['Value'] * self.processors
     self.log.info(msg)
 
     result = self._checkProgress()
@@ -865,7 +865,7 @@ class Watchdog(object):
       summary['ScaledCPUTime(s)'] = 0
     else:
       wallClock = result['Value']
-      summary['WallClockTime(s)'] = wallClock
+      summary['WallClockTime(s)'] = wallClock * self.processors
       summary['ScaledCPUTime(s)'] = wallClock * self.scaleFactor * self.processors
 
     self.__reportParameters(summary, 'UsageSummary', True)


### PR DESCRIPTION
This should solve (partially) this task: https://github.com/DIRACGrid/DIRAC/issues/1863

BEGINRELEASENOTES

*Accounting
CHANGE: multiply wallclock per the number of processors used

ENDRELEASENOTES
