### PR TITLE
[v7r0] Use GitHub Container registry due to pull limit on dockerhub

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,7 +50,7 @@ jobs:
         chmod +x run_in_container
     - name: Prepare environment
       run: |
-        docker run --name dirac-testing-host -v $PWD:/repo/DIRAC --detach --privileged -v /var/run/docker.sock:/var/run/docker.sock --rm diracgrid/docker-compose-dirac:latest bash -c 'sleep 100000000'
+        docker run --name dirac-testing-host -v $PWD:/repo/DIRAC --detach --privileged -v /var/run/docker.sock:/var/run/docker.sock --rm ghcr.io/diracgrid/management/docker-compose-dirac:latest bash -c 'sleep 100000000'
         ./run_in_container bash -c 'source DIRAC/tests/CI/run_docker_setup.sh && prepareEnvironment'
     - name: Install server
       run: ./run_in_container bash -c 'source DIRAC/tests/CI/run_docker_setup.sh && installServer'


### PR DESCRIPTION

BEGINRELEASENOTES
*tests
FIX: Use GitHub Container registry due to pull limit on dockerhub

ENDRELEASENOTES
