### PR TITLE
[Integration] Use GitHub Container registry due to pull limit on dockerhub

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,12 +28,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: login
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
       - name: create
         run: |
-          docker pull docker.pkg.github.com/diracgrid/management/dirac-distribution:latest
-          docker run docker.pkg.github.com/diracgrid/management/dirac-distribution:latest bash -c \
+          docker pull ghcr.io/diracgrid/management/dirac-distribution:latest
+          docker run ghcr.io/diracgrid/management/dirac-distribution:latest bash -c \
           "python3 dirac-distribution.py -r ${{ matrix.branch }} | tail -n 1  > /tmp/deploy.sh && "\
           "sed -i 's/lhcbprod/${{ secrets.KRB_USERNAME }}/g' /tmp/deploy.sh && "\
           "cat /tmp/deploy.sh && "\


### PR DESCRIPTION
BEGINRELEASENOTES
*tests
FIX: Use GitHub Container registry due to pull limit on dockerhub

ENDRELEASENOTES
