### PR TITLE
[v7r0] SSHCE: get SSH host from the CE config instead of the jobID to get job output

### DIFF
--- a/Resources/Computing/SSHComputingElement.py
+++ b/Resources/Computing/SSHComputingElement.py
@@ -709,8 +709,7 @@ class SSHComputingElement(ComputingElement):
       localOutputFile = 'Memory'
       localErrorFile = 'Memory'
 
-    host = urlparse(jobID).hostname
-    ssh = SSH(parameters=self.ceParameters, host=host)
+    ssh = SSH(parameters=self.ceParameters)
     result = ssh.scpCall(30, localOutputFile, outputFile, upload=False)
     if not result['OK']:
       return result


### PR DESCRIPTION
The job ID contains the name of the CE which can be different from the `SSHHost` parameter. For example we may have the following CE configuration:
```
aldbr.github.fr
{
  SSHHost = aldbr32.github.fr
  ...
}
```

The job ID will contain `aldbr.github.fr`.
Currently, the `SSHComputingElement` extracts the hostname from the job ID to get the job output: `aldbr.github.fr`.
Thus, in some cases, the `SSHComputingElement` is not able to access the remote node to get the job output.

Either we make sure that the name of the CE correspond to `SSHHost`, or we extract the hostname from `SSHHost`.
The second solution is chosen in this PR.

BEGINRELEASENOTES
*Resources
FIX: get SSH hostname from the CE config instead of the job ID to get the job output
ENDRELEASENOTES
