### PR TITLE
[v7r1] Fix a problem with vo being returned in a middle to a list in toList.…

### DIFF
--- a/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -241,7 +241,7 @@ class PilotCache(rmsBase):
   def toList(self):
     """ Simply returns a list of column values
     """
-    return [self.site, self.ce, self.vo, self.status, self.pilotjobeff, self.pilotsperjob, self.lastchecktime]
+    return [self.site, self.ce, self.status, self.pilotjobeff, self.pilotsperjob, self.lastchecktime, self.vo]
 
 
 class PolicyResult(rmsBase):
@@ -288,7 +288,7 @@ class PolicyResult(rmsBase):
     """ Simply returns a list of column values
     """
     return [self.policyname, self.statustype, self.element, self.name,
-            self.vo, self.status, self.reason, self.dateeffective, self.lastchecktime]
+            self.status, self.reason, self.dateeffective, self.lastchecktime, self.vo]
 
 
 class SpaceTokenOccupancyCache(rmsBase):

--- a/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -101,9 +101,9 @@ class ElementStatusBase(object):
   def toList(self):
     """ Simply returns a list of column values
     """
-    return [self.name, self.statustype, self.vo, self.status, self.reason,
+    return [self.name, self.statustype, self.status, self.reason,
             self.dateeffective, self.tokenexpiration, self.elementtype,
-            self.lastchecktime, self.tokenowner]
+            self.lastchecktime, self.tokenowner, self.vo]
 
 
 class ElementStatusBaseWithID(ElementStatusBase):
@@ -140,9 +140,9 @@ class ElementStatusBaseWithID(ElementStatusBase):
   def toList(self):
     """ Simply returns a list of column values
     """
-    return [self.id, self.name, self.statustype, self.vo, self.status, self.reason,
+    return [self.id, self.name, self.statustype, self.status, self.reason,
             self.dateeffective, self.tokenexpiration, self.elementtype,
-            self.lastchecktime, self.tokenowner]
+            self.lastchecktime, self.tokenowner, self.vo]
 
 
 # tables with schema defined in ElementStatusBase

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
@@ -188,6 +188,7 @@ class ResourceManagementClientChain(TestClientResourceManagementTestCase):
     self.assertTrue(res['OK'])
     # check if the name that we got is equal to the previously added 'TestName12345'
     self.assertEqual(res['Value'][0][0], 'TestName12345')
+    self.assertEqual(res['Value'][0][6], 'all')  # default value for vo, as the last element
 
     res = self.rmClient.addOrModifyPilotCache('TestName12345', status='newStatus')
     self.assertTrue(res['OK'])
@@ -224,6 +225,7 @@ class ResourceManagementClientChain(TestClientResourceManagementTestCase):
     self.assertTrue(res['OK'])
     # check if the name that we got is equal to the previously added 'TestName12345'
     self.assertEqual(res['Value'][0][1], 'statusType')
+    self.assertEqual(res['Value'][0][8], 'all')  # default value for vo, as the last element
 
     res = self.rmClient.addOrModifyPolicyResult('element', 'TestName12345', 'policyName', 'statusType',
                                                 status='newStatus')

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
@@ -193,8 +193,8 @@ class ResourceManagementClientChain(TestClientResourceManagementTestCase):
     self.assertTrue(res['OK'])
 
     res = self.rmClient.selectPilotCache('TestName12345')
-    # check if the result has changed. New schema, vo column added, hence pos 3.
-    self.assertEqual(res['Value'][0][3], 'newStatus')
+    # check if the result has changed.
+    self.assertEqual(res['Value'][0][2], 'newStatus')
 
     # TEST deletePilotCache
     # ...............................................................................
@@ -231,7 +231,7 @@ class ResourceManagementClientChain(TestClientResourceManagementTestCase):
 
     res = self.rmClient.selectPolicyResult('element', 'TestName12345', 'policyName', 'statusType')
     # check if the result has changed.
-    self.assertEqual(res['Value'][0][5], 'newStatus')
+    self.assertEqual(res['Value'][0][4], 'newStatus')
 
     # TEST deletePolicyResult
     # ...............................................................................

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
@@ -64,6 +64,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
     self.assertEqual(res['Value'][0][2], 'Active')
+    self.assertEqual(res['Value'][0][9], 'all')  # vo value at the end of the list
 
     # try to select the previously entered element from the Log table (it should NOT be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py
@@ -63,8 +63,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][2], 'all')
-    self.assertEqual(res['Value'][0][3], 'Active')
+    self.assertEqual(res['Value'][0][2], 'Active')
 
     # try to select the previously entered element from the Log table (it should NOT be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')
@@ -96,8 +95,8 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestSite1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Active')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
+    self.assertEqual(res['Value'][0][2], 'Active')
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
 
     # try to select the previously entered element from the Log table (it should NOT be there)
     res = rssClient.selectStatusElement('Site', 'Log', 'TestSite1234')
@@ -129,8 +128,8 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Banned')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
+    self.assertEqual(res['Value'][0][2], 'Banned')
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
 
     # try to select the previously entered element from the Log table (now it should be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')
@@ -138,7 +137,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][1], 'TestName1234')
     self.assertEqual(res['Value'][0][2], 'statusType')
-    self.assertEqual(res['Value'][0][4], 'Banned')
+    self.assertEqual(res['Value'][0][3], 'Banned')
 
     # try to select the previously entered element from the Log table
     # with a reduced list of columns
@@ -174,8 +173,8 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Active')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
+    self.assertEqual(res['Value'][0][2], 'Active')
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
 
     # try to select the previously entered element from the Log table (now it should be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')
@@ -183,8 +182,8 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][1], 'TestName1234')
     self.assertEqual(res['Value'][0][2], 'statusType')
-    self.assertEqual(res['Value'][0][4], 'Banned')
-    self.assertEqual(res['Value'][1][4], 'Active')  # this is the last one
+    self.assertEqual(res['Value'][0][3], 'Banned')
+    self.assertEqual(res['Value'][1][3], 'Active')  # this is the last one
 
     print("modifing once more the previously entered element")
     res = rssClient.modifyStatusElement('Resource', 'Status', 'TestName1234', 'statusType',
@@ -198,8 +197,8 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Probing')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
+    self.assertEqual(res['Value'][0][2], 'Probing')
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
 
     # try to select the previously entered element from the Log table (now it should be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')
@@ -207,9 +206,9 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][1], 'TestName1234')
     self.assertEqual(res['Value'][0][2], 'statusType')
-    self.assertEqual(res['Value'][0][4], 'Banned')
-    self.assertEqual(res['Value'][1][4], 'Active')
-    self.assertEqual(res['Value'][2][4], 'Probing')  # this is the last one
+    self.assertEqual(res['Value'][0][3], 'Banned')
+    self.assertEqual(res['Value'][1][3], 'Active')
+    self.assertEqual(res['Value'][2][3], 'Probing')  # this is the last one
 
     # try to select the previously entered element from the Log table (now it should be there)
     # with a reduced list of columns
@@ -235,10 +234,10 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][0], 'TestName1234')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Probing')
-    self.assertEqual(res['Value'][0][4], 'a new reason')
-    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][8], res['Value'][0][5]))
-    self.assertNotEqual(res['Value'][0][8], res['Value'][0][5])
+    self.assertEqual(res['Value'][0][2], 'Probing')
+    self.assertEqual(res['Value'][0][3], 'a new reason')
+    print("inserted lastCheckTime and DateEffective: %s, %s" % (res['Value'][0][7], res['Value'][0][4]))
+    self.assertNotEqual(res['Value'][0][7], res['Value'][0][4])
 
     # try to select the previously entered element from the Log table (now it should be there)
     res = rssClient.selectStatusElement('Resource', 'Log', 'TestName1234')
@@ -246,10 +245,10 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     self.assertTrue(res['OK'])
     self.assertEqual(res['Value'][0][1], 'TestName1234')
     self.assertEqual(res['Value'][0][2], 'statusType')
-    self.assertEqual(res['Value'][0][4], 'Banned')
-    self.assertEqual(res['Value'][1][4], 'Active')
-    self.assertEqual(res['Value'][2][4], 'Probing')
-    self.assertEqual(res['Value'][3][4], 'Probing')  # this is the last one
+    self.assertEqual(res['Value'][0][3], 'Banned')
+    self.assertEqual(res['Value'][1][3], 'Active')
+    self.assertEqual(res['Value'][2][3], 'Probing')
+    self.assertEqual(res['Value'][3][3], 'Probing')  # this is the last one
 
     # try to select the previously entered element from the Log table (now it should be there)
     # Using also Meta
@@ -345,7 +344,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     # check if the name that we got is equal to the previously added 'TestName123456789'
     self.assertEqual(res['Value'][0][0], 'TestName123456789')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Active')
+    self.assertEqual(res['Value'][0][2], 'Active')
 
     # try to re-add the same element but with different value
     res = rssClient.addIfNotThereStatusElement('Resource', 'Status', 'TestName123456789', 'statusType',
@@ -359,7 +358,7 @@ class ResourceStatusClientChain(TestClientResourceStatusTestCase):
     # check if the name that we got is equal to the previously added 'TestName123456789'
     self.assertEqual(res['Value'][0][0], 'TestName123456789')
     self.assertEqual(res['Value'][0][1], 'statusType')
-    self.assertEqual(res['Value'][0][3], 'Active')  # NOT Banned
+    self.assertEqual(res['Value'][0][2], 'Active')  # NOT Banned
 
     # delete it
     res = rssClient.deleteStatusElement('Resource', 'Status', 'TestName123456789')


### PR DESCRIPTION
Adresses #4789 .
Changed the order of column values returned by relevant `toList` methods by putting the `vo` element at the end of a list. Reversed all tests to what they were before adding the `vo` column. All client and server tests pass.



