### PR TITLE
[v7r1] Config.Client.Utilities: fix use of site/CE option

### DIFF
--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -219,8 +219,8 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None, glue2=True):
       addToChangeSet((siteSection, 'Mail', mail, newmail), changeSet)
       addToChangeSet((siteSection, 'Description', description, newdescription), changeSet)
 
-      ces = gConfig.getValue(cfgPath(siteSection, 'CE'), [])
-      for ce in ces:
+      ces = gConfig.getSections(cfgPath(siteSection, 'CEs'))
+      for ce in ces.get('Value', []):
         ceSection = cfgPath(siteSection, 'CEs', ce)
         ceDict = {}
         result = gConfig.getOptionsDict(ceSection)

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -169,7 +169,7 @@ def checkUnusedCEs():
         if ce in addedCEs:
           continue
         yn = raw_input("Add CE %s of type %s to %s? [default yes] [yes|no]: " % (ce, ceType, diracSite))
-        if yn == '' or yn.lower() == 'y':
+        if yn == '' or yn.lower().startswith('y'):
           newCEs.setdefault(diracSite, [])
           newCEs[diracSite].append(ce)
           addedCEs.append(ce)
@@ -179,7 +179,7 @@ def checkUnusedCEs():
         cmd = "dirac-admin-add-site %s %s %s" % (diracSite, site, ' '.join(newCEs[diracSite]))
         gLogger.notice("\nNew site/CEs will be added with command:\n%s" % cmd)
         yn = raw_input("Add it ? [default yes] [yes|no]: ")
-        if not (yn == '' or yn.lower() == 'y'):
+        if not (yn == '' or yn.lower().startswith('y')):
           continue
 
         if dry:

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -104,10 +104,9 @@ def checkUnusedCEs():
       result = getDIRACSiteName(site)
       if result['OK']:
         diracSite = ','.join(result['Value'])
-      ces = siteDict[site].keys()  # pylint: disable=no-member
-      if ces:
+      if siteDict[site]:
         gLogger.notice("  %s, DIRAC site %s" % (site, diracSite))
-        for ce in ces:
+        for ce in siteDict[site]:
           gLogger.notice(' ' * 4 + ce)
           gLogger.notice('      %s, %s' % (siteDict[site][ce]['CEType'], '%s_%s_%s' % siteDict[site][ce]['System']))
   else:
@@ -126,8 +125,7 @@ def checkUnusedCEs():
   for site in siteDict:
     # Get the country code:
     country = ''
-    ces = siteDict[site].keys()  # pylint: disable=no-member
-    for ce in ces:
+    for ce in siteDict[site]:
       country = ce.strip().split('.')[-1].lower()
       if len(country) == 2:
         break
@@ -165,7 +163,7 @@ def checkUnusedCEs():
 
     newCEs = {}
     addedCEs = []
-    for ce in ces:
+    for ce in siteDict[site]:
       ceType = siteDict[site][ce]['CEType']
       for diracSite in diracSites:
         if ce in addedCEs:

--- a/ConfigurationSystem/scripts/dirac-admin-add-resources.py
+++ b/ConfigurationSystem/scripts/dirac-admin-add-resources.py
@@ -49,7 +49,7 @@ def processScriptSwitches():
   doCEs = False
   doSEs = False
   hostURL = None
-  glue2 = False
+  glue2 = True
   for sw in Script.getUnprocessedSwitches():
     if sw[0] in ("V", "vo"):
       vo = sw[1]

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -17,6 +17,7 @@ published information, like a foreign key pointing to non-existent entry.
 from pprint import pformat
 
 from DIRAC import gLogger, gConfig
+from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getCESiteMapping, getGOCSiteName
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 
 __RCSID__ = "$Id$"
@@ -95,7 +96,20 @@ def getGlue2CEInfo(vo, host):
     sLog.error("Found some sites without any shares", pformat(sitesWithoutShares))
   else:
     sLog.notice("Found information for all known sites")
-  return S_OK(siteDict)
+
+  # remap siteDict to assign CEs to known sites, in case their names differ from the "gocdb name" in
+  # the CS.
+  newSiteDict = {}
+  ceSiteMapping = getCESiteMapping().get('Value', {})
+  # FIXME: pylint thinks siteDict is a tuple, so we cast
+  for siteName, infoDict in dict(siteDict).items():
+    for ce, ceInfo in infoDict.get('CEs', {}).items():
+      ceSiteName = ceSiteMapping.get(ce, siteName)
+      gocSiteName = getGOCSiteName(ceSiteName).get('Value', siteName)
+      newSiteDict.setdefault(gocSiteName, {}).setdefault('CEs', {})[ce] = ceInfo
+
+  return S_OK(newSiteDict)
+
 
 
 def __getGlue2ShareInfo(host, shareInfoLists):


### PR DESCRIPTION
use the list of CEs in the CEs section instead



BEGINRELEASENOTES

*Configuration
FIX: Bdii2CSAgent: Updating CE information wasn't working because the list of CEs wasn't picked up from the right place (Site/CE option, instead of `Site/CES/<CE_Sections>`)
FIX: Glue2: fix association of CEs to sites if the CE associated sitename in the BDII differs from the Name given in the CS
FIX: dirac-admin-add-resources: Fix bug preventing the use of GLUE2 mode

ENDRELEASENOTES
