### PR TITLE
[v7r1] Add pilot.cfg fix for SingularityCE in install mode

### DIFF
--- a/Resources/Computing/SingularityComputingElement.py
+++ b/Resources/Computing/SingularityComputingElement.py
@@ -57,6 +57,8 @@ unset DIRACOS
 ./dirac-install.py %(install_args)s
 source bashrc
 dirac-configure -F %(config_args)s -I
+# Add compatibility with pilot3 where config is in pilot.cfg
+ln -s etc/dirac.cfg pilot.cfg
 # Run next wrapper (to start actual job)
 bash %(next_wrapper)s
 # Write the payload errorcode to a file for the outer scripts


### PR DESCRIPTION
Hi,

This fix re-adds a line of code in SingularityCE to create a symlink for pilot.cfg (if installDIRAC mode is used) to fix a bug with dirac-jobexec jobs (they won't run if pilot.cfg is missing). We're not sure why this line was removed in the first place, we couldn't find any issues or e-mails explaining why it was removed, so we think it may just have been an accident (but if anyone does find an issue with it, let me know and I'll investigate further).

Regards,
Simon


BEGINRELEASENOTES
*Resources
FIX: SingularityCE: Create pilot.cfg as part of the inner DIRAC install.
ENDRELEASENOTES
