### PR TITLE
[v7r1] notificationHandler avoidSpam unification

### DIFF
--- a/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -194,7 +194,7 @@ class Bdii2CSAgent(AgentModule):
         if self.addressTo and self.addressFrom:
           notification = NotificationClient()
           result = notification.sendMail(self.addressTo, self.subject, body, self.addressFrom,
-                                         localAttempt=False, avoidSpam=True)
+                                         localAttempt=False)
           if not result['OK']:
             self.log.error('Can not send new site notification mail', result['Message'])
 
@@ -312,8 +312,7 @@ class Bdii2CSAgent(AgentModule):
       body = '\n'.join(["%s/%s %s -> %s" % entry for entry in changeList])
       if body and self.addressTo and self.addressFrom:
         notification = NotificationClient()
-        result = notification.sendMail(self.addressTo, self.subject, body, self.addressFrom, localAttempt=False,
-                                       avoidSpam=True)
+        result = notification.sendMail(self.addressTo, self.subject, body, self.addressFrom, localAttempt=False)
 
       if body:
         self.log.info('The following configuration changes were detected:')

--- a/docs/source/AdministratorGuide/Systems/Framework/Notification/index.rst
+++ b/docs/source/AdministratorGuide/Systems/Framework/Notification/index.rst
@@ -7,9 +7,7 @@ The Framework/Notification service
 
 The Framework/Notification service is responsible for notification, like as send mail, sms or alarm window on DIRAC portal.
 Send an email with supplied body to the specified address using the Mail utility.
-If avoidSpam is True, then emails are first added to a set so that duplicates are removed, 
-and sent every hour.
-
+Emails with the same address, subject, and content are only sent once every 24h.
 
 Configure
 ---------


### PR DESCRIPTION
These commits were meant to be part of #4766 but apparently I forgot to push them 😭 

BEGINRELEASENOTES
*Framework
CHANGE: NotificationHandler: sendMail: the avoidSpam parameter is deprecated. All emails (same subject, address, body) are now only sent once per 24h
ENDRELEASENOTES

