### PR TITLE
[v7r0] Add extraOptions only when the executable is a DIRAC script

### DIFF
--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -215,7 +215,7 @@ class JobWrapper(object):
       os.mkdir(str(self.jobID))
       os.chdir(str(self.jobID))
       extraOpts = self.jobArgs.get('ExtraOptions', '')
-      if extraOpts:
+      if extraOpts and '$DIRACROOT' in self.jobArgs.get('Executable', '').strip():
         if os.path.exists('%s/%s' % (self.root, extraOpts)):
           shutil.copyfile('%s/%s' % (self.root, extraOpts), extraOpts)
         self.__loadLocalCFGFiles(self.localSiteRoot)

--- a/WorkloadManagementSystem/Utilities/Utils.py
+++ b/WorkloadManagementSystem/Utilities/Utils.py
@@ -5,6 +5,7 @@ import io
 import os
 import sys
 import json
+import six
 
 from DIRAC import gConfig, gLogger, S_OK
 from DIRAC.Core.Utilities.File import mkDir
@@ -17,6 +18,8 @@ def createJobWrapper(jobID, jobParams, resourceParams, optimizerParams,
   """ This method creates a job wrapper filled with the CE and Job parameters to execute the job.
       Main user is the JobAgent
   """
+  if isinstance(extraOptions, six.string_types) and extraOptions.endswith('.cfg'):
+    extraOptions = '--cfg %s' % extraOptions
 
   arguments = {'Job': jobParams,
                'CE': resourceParams,
@@ -78,6 +81,8 @@ def createRelocatedJobWrapper(wrapperPath, rootLocation,
   """ This method creates a job wrapper for a specific job in wrapperPath,
       but assumes this has been reloated to rootLocation before running it.
   """
+  if isinstance(extraOptions, six.string_types) and extraOptions.endswith('.cfg'):
+    extraOptions = '--cfg %s' % extraOptions
 
   arguments = {'Job': jobParams,
                'CE': resourceParams,


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
CHANGE: JobWrapper: Add extraOptions only when the executable is a DIRAC script


ENDRELEASENOTES
