### PR TITLE
[v7r0] Squash sitedirector platform list

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -411,7 +411,7 @@ class SiteDirector(AgentModule):
               architecture = ceDict.get('architecture', 'x86_64')
               platform = '_'.join([architecture, ceDict['OS']])
             if platform:
-              # Upadte self.platforms, keeping entries unique and squashing lists
+              # Update self.platforms, keeping entries unique and squashing lists
               oldPlatforms = set(self.platforms)
               if isinstance(platform, list):
                 oldPlatforms.update(set(platform))

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -410,8 +410,14 @@ class SiteDirector(AgentModule):
             elif "OS" in ceDict:
               architecture = ceDict.get('architecture', 'x86_64')
               platform = '_'.join([architecture, ceDict['OS']])
-            if platform and platform not in self.platforms:
-              self.platforms.append(platform)
+            if platform:
+              # Upadte self.platforms, keeping entries unique and squashing lists
+              oldPlatforms = set(self.platforms)
+              if isinstance(platform, list):
+                oldPlatforms.update(set(platform))
+              else:
+                oldPlatforms.add(platform)
+              self.platforms = list(oldPlatforms)
 
             if "Platform" not in self.queueDict[queueName]['ParametersDict'] and platform:
               result = self.resourcesModule.getDIRACPlatform(platform)


### PR DESCRIPTION
This squashes/flattens the platform list in the SiteDirector, fixing a crash if CheckPlatform=True on v7 instances. Fixes  #4835.

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: Flatten platform list avoid crash if CheckPlatform=True
ENDRELEASENOTES
