### PR TITLE
[v7r1] Fix jobStatusBulk

### DIFF
--- a/WorkloadManagementSystem/Client/JobReport.py
+++ b/WorkloadManagementSystem/Client/JobReport.py
@@ -137,20 +137,12 @@ class JobReport(object):
     """ Send the job parameters stored in the internal cache
     """
 
-    parameters = []
-    for pname, value in self.jobParameters.items():
-      pvalue, _timeStamp = value
-      parameters.append([pname, pvalue])
-
+    parameters = [[pname, value[0]] for pname, value in self.jobParameters.items()]
     if parameters:
       result = JobStateUpdateClient().setJobParameters(self.jobID, parameters)
-      if not result['OK']:
-        return result
-
       if result['OK']:
         # Empty the internal parameter container
         self.jobParameters = {}
-
       return result
     else:
       return S_OK('Empty')
@@ -161,11 +153,9 @@ class JobReport(object):
 
     success = True
     result = self.sendStoredStatusInfo()
-    if not result['OK']:
-      success = False
+    success &= result['OK']
     result = self.sendStoredJobParameters()
-    if not result['OK']:
-      success = False
+    success &= result['OK']
 
     if success:
       return S_OK()

--- a/WorkloadManagementSystem/Client/JobReport.py
+++ b/WorkloadManagementSystem/Client/JobReport.py
@@ -107,15 +107,20 @@ class JobReport(object):
 
     statusDict = {}
     for status, minor, dtime in self.jobStatusInfo:
-      statusDict[dtime] = {'Status': status,
-                           'MinorStatus': minor,
-                           'ApplicationStatus': '',
-                           'Source': self.source}
+      # No need to send empty items in dictionary
+      sDict = {}
+      if status:
+        sDict['Status'] = status
+      if minor:
+        sDict['MinorStatus'] = minor
+      if sDict:
+        sDict['Source'] = self.source
+        statusDict[dtime] = sDict
     for appStatus, dtime in self.appStatusInfo:
-      statusDict[dtime] = {'Status': '',
-                           'MinorStatus': '',
-                           'ApplicationStatus': appStatus,
-                           'Source': self.source}
+      # No need to send empty items in dictionary
+      if appStatus:
+        statusDict[dtime] = {'ApplicationStatus': appStatus,
+                             'Source': self.source}
 
     if statusDict:
       result = JobStateUpdateClient().setJobStatusBulk(self.jobID, statusDict)

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -393,8 +393,12 @@ class JobDB(DB):
       return ret
     jobID = ret['Value']
 
+    # If no list is given, return all attributes
+    if not attrList:
+      attrList = self.jobAttributeNames
+
     attrNameList = []
-    for x in attrList if attrList else self.jobAttributeNames:
+    for x in attrList:
       ret = self._escapeString(x)
       if not ret['OK']:
         return ret
@@ -414,7 +418,7 @@ class JobDB(DB):
     values = res['Value'][0]
 
     attributes = {}
-    for name, value in zip(attrList if attrList else self.jobAttributeNames, values):
+    for name, value in zip(attrList, values):
       attributes[name] = str(value)
 
     return S_OK(attributes)

--- a/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -62,7 +62,7 @@ class JobLoggingDB(DB):
       else:
         self.log.error('Incorrect date for the logging record')
         _date = Time.dateTime()
-    except BaseException:
+    except Exception:
       self.log.exception('Exception while date evaluation')
       _date = Time.dateTime()
     epoc = time.mktime(_date.timetuple()) + _date.microsecond / 1000000. - MAGIC_EPOC_NUMBER

--- a/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -556,7 +556,7 @@ class JobMonitoringHandler(RequestHandler):
   def export_getJobParameters(cls, jobIDs, parName=None):
     """
     :param str/int/long/list jobIDs: one single job ID or a list of them
-    :param str parName: one single parameter name, or None (meaning all of them)
+    :param str parName: one single parameter name, a list or None (meaning all of them)
     """
     if cls.gElasticJobParametersDB:
       if not isinstance(jobIDs, list):
@@ -576,8 +576,10 @@ class JobMonitoringHandler(RequestHandler):
 
       # and now combine
       final = dict(parametersM)
-      for jobID in parametersM:
+      # if job in JobDB, update with parameters from ES if any
+      for jobID in final:
         final[jobID].update(parameters.get(jobID, {}))
+      # if job in ES and not in JobDB, take ES
       for jobID in parameters:
         if jobID not in final:
           final[jobID] = parameters[jobID]

--- a/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -616,12 +616,13 @@ class JobMonitoringHandler(RequestHandler):
   types_getJobAttributes = [int]
 
   @classmethod
-  def export_getJobAttributes(cls, jobID):
+  def export_getJobAttributes(cls, jobID, attrList=None):
     """
     :param int jobID: one single Job ID
+    :param list attrList: optional list of attributes
     """
 
-    return cls.gJobDB.getJobAttributes(jobID)
+    return cls.gJobDB.getJobAttributes(jobID, attrList=attrList)
 
 ##############################################################################
   types_getJobAttribute = [int, basestring]

--- a/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -8,12 +8,12 @@
 """
 
 from __future__ import absolute_import
+import time
 import six
 from six.moves import range
 
 __RCSID__ = "$Id$"
 
-import time
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler

--- a/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -251,13 +251,20 @@ class JobStateUpdateHandler(RequestHandler):
     return S_OK()
 
   ###########################################################################
+  types_setJobAttribute = [[six.string_types, int], six.string_types, six.string_types]
+
+  def export_setJobAttribute(self, jobID, attribute, value):
+    """Set a job attribute
+    """
+    return jobDB.setJobAttribute(int(jobID), attribute, value)
+
+  ###########################################################################
   types_setJobSite = [[six.string_types, int], six.string_types]
 
   def export_setJobSite(self, jobID, site):
     """Allows the site attribute to be set for a job specified by its jobID.
     """
-    result = jobDB.setJobAttribute(int(jobID), 'Site', site)
-    return result
+    return jobDB.setJobAttribute(int(jobID), 'Site', site)
 
   ###########################################################################
   types_setJobFlag = [[six.string_types, int], six.string_types]
@@ -265,8 +272,7 @@ class JobStateUpdateHandler(RequestHandler):
   def export_setJobFlag(self, jobID, flag):
     """ Set job flag for job with jobID
     """
-    result = jobDB.setJobAttribute(int(jobID), flag, 'True')
-    return result
+    return jobDB.setJobAttribute(int(jobID), flag, 'True')
 
   ###########################################################################
   types_unsetJobFlag = [[six.string_types, int], six.string_types]
@@ -274,8 +280,7 @@ class JobStateUpdateHandler(RequestHandler):
   def export_unsetJobFlag(self, jobID, flag):
     """ Unset job flag for job with jobID
     """
-    result = jobDB.setJobAttribute(int(jobID), flag, 'False')
-    return result
+    return jobDB.setJobAttribute(int(jobID), flag, 'False')
 
   ###########################################################################
   types_setJobApplicationStatus = [[six.string_types, int], six.string_types, six.string_types]

--- a/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -184,7 +184,7 @@ class JobStateUpdateHandler(RequestHandler):
 
     dates = sorted(statusDict)
     log = self.log.getSubLogger('JobStatusBulk/Job-%s' % jobID)
-    log.verbose("*** New call *** Last update time %s - Sorted new times %s" % (lastTime, dates))
+    log.debug("*** New call ***", "Last update time %s - Sorted new times %s" % (lastTime, dates))
     # Remove useless items in order to make it simpler later
     for sDict in statusDict.values():
       for item in ('Status', 'MinorStatus', 'ApplicationStatus', 'ApplicationCounter'):
@@ -206,15 +206,14 @@ class JobStateUpdateHandler(RequestHandler):
       # Get the last status values
       for date in [dt for dt in dates if dt >= lastTime]:
         sDict = statusDict[date]
-        log.verbose("\tTime %s - Statuses %s" % (date, str(sDict)))
+        log.debug("\t", "Time %s - Statuses %s" % (date, str(sDict)))
         status = sDict.get('Status', status)
         minor = sDict.get('MinorStatus', minor)
         application = sDict.get('ApplicationStatus', application)
         appCounter = sDict.get('ApplicationCounter', appCounter)
 
-      log.verbose(
-          "Final statuses: status '%s', minor '%s', application '%s', appCounter '%s'" %
-          (status, minor, application, appCounter))
+      log.debug("Final statuses:", "status '%s', minor '%s', application '%s', appCounter '%s'" %
+                (status, minor, application, appCounter))
       attrNames = []
       attrValues = []
       if status:

--- a/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -244,7 +244,12 @@ class JobStateUpdateHandler(RequestHandler):
       minor = sDict.get('MinorStatus', 'idem')
       application = sDict.get('ApplicationStatus', 'idem')
       source = sDict.get('Source', 'Unknown')
-      result = logDB.addLoggingRecord(jobID, status, minor, application, date, source)
+      result = logDB.addLoggingRecord(jobID,
+                                      status=status,
+                                      minor=minor,
+                                      application=application,
+                                      date=date,
+                                      source=source)
       if not result['OK']:
         return result
 
@@ -387,8 +392,8 @@ class JobStateUpdateHandler(RequestHandler):
       return S_ERROR('Job %d not found' % jobID)
 
     status = result['Value']['Status']
-    if status == "Stalled" or status == "Matched":
-      result = jobDB.setJobAttribute(jobID, 'Status', 'Running', True)
+    if status in (JobStatus.STALLED, JobStatus.MATCHED):
+      result = jobDB.setJobAttribute(jobID, 'Status', JobStatus.RUNNING, True)
       if not result['OK']:
         self.log.warn('Failed to restore the job status to Running')
 

--- a/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -159,7 +159,6 @@ class JobStateUpdateHandler(RequestHandler):
     status = ''
     minor = ''
     application = ''
-    appCounter = ''
     jobID = int(jobID)
 
     result = jobDB.getJobAttributes(jobID, ['Status', 'StartExecTime', 'EndExecTime'])
@@ -185,9 +184,9 @@ class JobStateUpdateHandler(RequestHandler):
     dates = sorted(statusDict)
     log = self.log.getSubLogger('JobStatusBulk/Job-%s' % jobID)
     log.debug("*** New call ***", "Last update time %s - Sorted new times %s" % (lastTime, dates))
-    # Remove useless items in order to make it simpler later
+    # Remove useless items in order to make it simpler later, although should not be there
     for sDict in statusDict.values():
-      for item in ('Status', 'MinorStatus', 'ApplicationStatus', 'ApplicationCounter'):
+      for item in ('Status', 'MinorStatus', 'ApplicationStatus'):
         if not sDict.get(item):
           sDict.pop(item, None)
     # Pick up start and end times from all updates, if they don't exist
@@ -210,10 +209,9 @@ class JobStateUpdateHandler(RequestHandler):
         status = sDict.get('Status', status)
         minor = sDict.get('MinorStatus', minor)
         application = sDict.get('ApplicationStatus', application)
-        appCounter = sDict.get('ApplicationCounter', appCounter)
 
-      log.debug("Final statuses:", "status '%s', minor '%s', application '%s', appCounter '%s'" %
-                (status, minor, application, appCounter))
+      log.debug("Final statuses:", "status '%s', minor '%s', application '%s'" %
+                (status, minor, application))
       attrNames = []
       attrValues = []
       if status:
@@ -225,9 +223,6 @@ class JobStateUpdateHandler(RequestHandler):
       if application:
         attrNames.append('ApplicationStatus')
         attrValues.append(application)
-      if appCounter:
-        attrNames.append('ApplicationCounter')
-        attrValues.append(appCounter)
       result = jobDB.setJobAttributes(jobID, attrNames, attrValues, update=True)
       if not result['OK']:
         return result

--- a/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -183,7 +183,7 @@ class JobStateUpdateHandler(RequestHandler):
     lastTime = Time.toString(Time.fromEpoch(lastTime))
 
     dates = sorted(statusDict)
-    log = self.log.getSubLogger('JobStatusBulk/PhC/Job-%s' % jobID)
+    log = self.log.getSubLogger('JobStatusBulk/Job-%s' % jobID)
     log.verbose("*** New call *** Last update time %s - Sorted new times %s" % (lastTime, dates))
     # Remove useless items in order to make it simpler later
     for sDict in statusDict.values():

--- a/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -173,6 +173,11 @@ class JobStateUpdateHandler(RequestHandler):
       status = JobStatus.RUNNING
     startTime = result['Value'].get('StartExecTime', '')
     endTime = result['Value'].get('EndExecTime', '')
+    # getJobAttributes only returns strings :(
+    if startTime == 'None':
+      startTime = None
+    if endTime == 'None':
+      endTime = None
 
     # Get the latest WN time stamps of status updates
     result = logDB.getWMSTimeStamps(int(jobID))

--- a/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
@@ -292,8 +292,6 @@ class JobMonitoring(TestWMSTestCase):
     self.assertTrue(res['OK'], res.get('Message'))
     res = jobMonitor.getAtticJobParameters(jobID)
     self.assertTrue(res['OK'], res.get('Message'))
-    res = jobStateUpdate.setJobsStatus([jobID], 'Done', 'MinorStatus', 'Unknown')
-    self.assertTrue(res['OK'], res.get('Message'))
     res = jobMonitor.getJobSummary(jobID)
     self.assertTrue(res['OK'], res.get('Message'))
     self.assertEqual(res['Value']['Status'], 'Done', msg="Got %s" % str(res['Value']['Status']))

--- a/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
@@ -351,7 +351,7 @@ class JobMonitoringMore(TestWMSTestCase):
     res = jobMonitor.getSites()
     print(res)
     self.assertTrue(res['OK'], res.get('Message'))
-    self.assertTrue(set(res['Value']) <= {'ANY', 'DIRAC.Jenkins.ch'}, msg="Got %s" % res['Value'])
+    self.assertTrue(set(res['Value']) <= {'ANY', 'DIRAC.Jenkins.ch', 'Site'}, msg="Got %s" % res['Value'])
     res = jobMonitor.getJobTypes()
     self.assertTrue(res['OK'], res.get('Message'))
     self.assertEqual(sorted(res['Value']), sorted(types), msg="Got %s" % str(sorted(res['Value'])))

--- a/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
@@ -292,6 +292,8 @@ class JobMonitoring(TestWMSTestCase):
     self.assertTrue(res['OK'], res.get('Message'))
     res = jobMonitor.getAtticJobParameters(jobID)
     self.assertTrue(res['OK'], res.get('Message'))
+    res = jobStateUpdate.setJobStatus(jobID, 'Done', 'MinorStatus', 'Unknown')
+    self.assertTrue(res['OK'], res.get('Message'))
     res = jobMonitor.getJobSummary(jobID)
     self.assertTrue(res['OK'], res.get('Message'))
     self.assertEqual(res['Value']['Status'], 'Done', msg="Got %s" % str(res['Value']['Status']))


### PR DESCRIPTION
BEGINRELEASENOTES
*WorkloadManagement
FIX: There was a bug handling the bulk status updates that was not updating correctly the job status although the job logging information was correct). This PR fixes this bug. It was tested in certification as a hotfix
CHANGE: internally always call the `setJobStatusBulk()` method in order to be consistent
CHANGE: in `JobReport`, only send statuses that are not empty, and remove handling of `ApplicationCounter` that is never sent nor used anywhere

ENDRELEASENOTES
