### PR TITLE
[v7r1] Fix SingularityComputingElement.__findInstallBaseDir

### DIFF
--- a/Resources/Computing/SingularityComputingElement.py
+++ b/Resources/Computing/SingularityComputingElement.py
@@ -144,7 +144,7 @@ class SingularityComputingElement(ComputingElement):
     for searchPath in searchPaths:
       binPath = os.path.join(searchPath, 'singularity')
       if os.path.isfile(binPath):
-        # File found, check it's exectuable to be certain:
+        # File found, check it's executable to be certain:
         if os.access(binPath, os.X_OK):
           self.log.debug('Found singularity at "%s"' % binPath)
           self.__singularityBin = binPath
@@ -154,7 +154,11 @@ class SingularityComputingElement(ComputingElement):
 
   @staticmethod
   def __findInstallBaseDir():
-    return os.readlink(os.path.join(DIRAC.rootPath, "bashrc"))
+    """Find the path to root of the current DIRAC installation"""
+    candidate = os.path.join(DIRAC.rootPath, "bashrc")
+    if not os.path.exists(candidate):
+      raise NotImplementedError("Failed to find a candidate bashrc")
+    return os.path.dirname(os.readlink(candidate))
 
   def __getInstallFlags(self, infoDict=None):
     """ Get the flags to pass to dirac-install.py inside the container.

--- a/Resources/Computing/SingularityComputingElement.py
+++ b/Resources/Computing/SingularityComputingElement.py
@@ -156,8 +156,6 @@ class SingularityComputingElement(ComputingElement):
   def __findInstallBaseDir():
     """Find the path to root of the current DIRAC installation"""
     candidate = os.path.join(DIRAC.rootPath, "bashrc")
-    if not os.path.exists(candidate):
-      raise NotImplementedError("Failed to find a candidate bashrc")
     return os.path.dirname(os.readlink(candidate))
 
   def __getInstallFlags(self, infoDict=None):


### PR DESCRIPTION
`SingularityComputingElement.__findInstallBaseDir` was missing a `os.path.dirname` causing it to try to source `/path/to/bashrc/bashrc`.

@fstagni This fixes the issue seen in the last LHCbDIRAC hackathon. I've already applied it on CVMFS to test that it now works properly (at least for a basic job).

BEGINRELEASENOTES

*Resources
FIX: Fix using SingularityComputingElement with the host's DIRAC installation

ENDRELEASENOTES