### PR TITLE
[v7r2] Explicitly cast some values to integers

### DIFF
--- a/Core/Utilities/Graphs/GraphUtilities.py
+++ b/Core/Utilities/Graphs/GraphUtilities.py
@@ -202,7 +202,7 @@ def comma_format(x_orig):
   x = float(x_orig)
   if x >= 1000:
     after_comma = x % 1000
-    before_comma = int(x) / 1000
+    before_comma = int(int(x) / 1000)
     return '%s,%03g' % (comma_format(before_comma), after_comma)
   else:
     return str(x_orig)

--- a/MonitoringSystem/DB/MonitoringDB.py
+++ b/MonitoringSystem/DB/MonitoringDB.py
@@ -209,13 +209,13 @@ class MonitoringDB(ElasticDB):
           if site not in result:
             result[site] = {}
           for k in j.end_data.buckets:
-            if (k.key / 1000) not in result[site]:
+            if int(k.key / 1000) not in result[site]:
               if len(selectFields) == 1:  # for backward compatibility
-                result[site][k.key / 1000] = k.avg_monthly_sales.value
+                result[site][int(k.key / 1000)] = k.avg_monthly_sales.value
               else:
-                result[site][k.key / 1000] = [k.avg_monthly_sales.value]
+                result[site][int(k.key / 1000)] = [k.avg_monthly_sales.value]
             else:
-              result[site][k.key / 1000].append(k.avg_monthly_sales.value)
+              result[site][int(k.key / 1000)].append(k.avg_monthly_sales.value)
 
     # the result format is { 'grouping':{timestamp:value, timestamp:value}:
     # value is list if more than one value exist. for example :
@@ -310,7 +310,7 @@ class MonitoringDB(ElasticDB):
     result = {}
     for bucket in retVal.aggregations['end_data'].buckets:
       # each bucket key is a time (unix epoch and usual datetime
-      bucketTime = bucket.key / 1000
+      bucketTime = int(bucket.key / 1000)
       for value in bucket['tt'].buckets:
         # each bucket contains an agregation called tt which sum/avg of the metric.
         if value.key not in result:


### PR DESCRIPTION
**I am not sure if this is correct!!!**

When adding `from __future__ import division` to LHCbDIRAC I found noticed some suspicious divisions in vanilla DIRAC. It's possible these are supposed to return floats but I suspect the integer division was intentional and was broken by #4586. Can someone who familiar with the code take a look and check?


BEGINRELEASENOTES

*Monitoring
FIX: Correct the rounding of integers when computing buckets in MonitoringDB

ENDRELEASENOTES
