### PR TITLE
[v7r1] Fix typo in CERNLDAPSyncPlugin

### DIFF
--- a/ConfigurationSystem/Client/SyncPlugins/CERNLDAPSyncPlugin.py
+++ b/ConfigurationSystem/Client/SyncPlugins/CERNLDAPSyncPlugin.py
@@ -31,7 +31,7 @@ class CERNLDAPSyncPlugin(object):
     """
     attributes = self._getUserInfo(username)
     cernAccountType = attributes["cernAccountType"]
-    userDict["CERNAccountType"] = cernAccountType
+    userDict["CERNAccountType"] = cernAccountType[0]
     if cernAccountType == ["Primary"]:
       userDict["PrimaryCERNAccount"] = username
     else:


### PR DESCRIPTION
This field is a list of 1 item so it should be stored as a string rather than a list.