### PR TITLE
[v7r0] load more than one DIRACSYSCONFIGFILE

### DIFF
--- a/ConfigurationSystem/Client/LocalConfiguration.py
+++ b/ConfigurationSystem/Client/LocalConfiguration.py
@@ -294,7 +294,7 @@ class LocalConfiguration(object):
     errorsList = []
     if 'DIRACSYSCONFIG' in os.environ:
       diracSysConfigFiles = os.environ['DIRACSYSCONFIG'].replace(' ', '').split(',')
-      for diracSysConfigFile in diracSysConfigFiles:
+      for diracSysConfigFile in reversed(diracSysConfigFiles):
         gConfigurationData.loadFile(diracSysConfigFile)
     gConfigurationData.loadFile(os.path.expanduser("~/.dirac.cfg"))
     for fileName in self.additionalCFGFiles:

--- a/ConfigurationSystem/Client/LocalConfiguration.py
+++ b/ConfigurationSystem/Client/LocalConfiguration.py
@@ -285,13 +285,17 @@ class LocalConfiguration(object):
 
   def __loadCFGFiles(self):
     """
-    Load ~/.dirac.cfg
-    Load cfg files specified in addCFGFile calls
-    Load cfg files with come from the command line
+    Loads possibly several cfg files, in order:
+    1. ~/.dirac.cfg
+    2. cfg files pointed by DIRACSYSCONFIG env variable (comma-separated)
+    3. cfg files specified in addCFGFile calls
+    4. cfg files that come from the command line
     """
     errorsList = []
     if 'DIRACSYSCONFIG' in os.environ:
-      gConfigurationData.loadFile(os.environ['DIRACSYSCONFIG'])
+      diracSysConfigFiles = os.environ['DIRACSYSCONFIG'].replace(' ', '').split(',')
+      for diracSysConfigFile in diracSysConfigFiles:
+        gConfigurationData.loadFile(diracSysConfigFile)
     gConfigurationData.loadFile(os.path.expanduser("~/.dirac.cfg"))
     for fileName in self.additionalCFGFiles:
       gLogger.debug("Loading file %s" % fileName)

--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2188,7 +2188,9 @@ def createBashrc():
       if cliParams.userEnvVariables:
         lines.extend(['# User-requested variables'])
         for envName, envValue in cliParams.userEnvVariables.items():
-          lines.extend(['export %s=%s' % (envName, envValue)])
+          lines.extend(['( echo $%s | grep -q $%s ) || export %s=$%s:$%s' % (
+              envName, envValue,
+              envName, envName, envValue)])
 
       lines.append('')
       f = open(bashrcFile, 'w')

--- a/docs/source/AdministratorGuide/Configuration/ConfigurationStructure/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfigurationStructure/index.rst
@@ -69,7 +69,7 @@ in the order of preference of the option resolution:
      it will be interpreted as a configuration file, if the ``DIRAC_NO_CFG`` environment variable is not set.
 
 *Value of $DIRACSYSCONFIG environment variable*
-  if the DIRACSYSCONFIG variable is set, it should point to a cfg file (written in *CFG* format)
+  if the DIRACSYSCONFIG variable is set, it should point to a list of cfg file (written in *CFG* format), comma separated
 
 *$HOME/.dirac.cfg*
   This is the file in the user's home directory with the *CFG* format

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -35,7 +35,7 @@ DIRAC_VOMSES
   Can be set to point to a folder containing VOMSES information. See :ref:`multi_vo_dirac`
 
 DIRACSYSCONFIG
-  If set, its value should be (the full location on the file system of) a DIRAC cfg file, whose content will be used for the DIRAC configuration
+  If set, its value should be (the full locations on the file system of) one of more DIRAC cfg file(s) (comma separated), whose content will be used for the DIRAC configuration
   (see :ref:`dirac-cs-structure`)
 
 DISABLE_WATCHDOG_CPU_WALLCLOCK_CHECK


### PR DESCRIPTION

BEGINRELEASENOTES

*Subsystem
CHANGE: Added possibility to load more then one cfg file from DIRACSYSCONFIGFILE env variable

ENDRELEASENOTES
