### PR TITLE
[v7r2] X509Request: correct comparison of public keys

### DIFF
--- a/.github/workflows/basic-python3.yml
+++ b/.github/workflows/basic-python3.yml
@@ -23,7 +23,7 @@ jobs:
           #     gracefully, make them non-daemonic and use a suitable
           #     signalling mechanism such as an Event."
           - pytest --no-cov -k 'not test_BaseType_Unicode and not test_nestedStructure and not testLockedClass'
-          # - pytest --no-cov src/DIRAC/Core/Security/test
+          - pytest --no-cov src/DIRAC/Core/Security/test
 
     steps:
     - uses: actions/checkout@v2

--- a/src/DIRAC/Core/Security/m2crypto/X509Request.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Request.py
@@ -88,7 +88,7 @@ class X509Request(object):
 
   def dumpPKey(self):
     """
-    Get the pkey as a string
+    Get the private as a string
 
     :returns: S_OK(PEM encoded PKey)
     """
@@ -168,6 +168,7 @@ class X509Request(object):
 
     :param chain: :py:class:`X509Chain` object
     """
+
     if not self.__valid:
       return S_ERROR(DErrno.ENOCERT)
     retVal = chain.getCertInChain()
@@ -177,8 +178,11 @@ class X509Request(object):
     chainPubKey = lastCert.getPublicKey()
     if not chainPubKey['OK']:
       return chainPubKey
-    chainPubKey = chainPubKey['Value'].as_pem(cipher=None, callback=M2Crypto.util.no_passphrase_callback)
-    reqPubKey = self.__reqObj.get_pubkey().as_pem(cipher=None, callback=M2Crypto.util.no_passphrase_callback)
+
+    # as_der will dump public key info, while as_pem
+    # dumps private key.
+    chainPubKey = chainPubKey['Value'].as_der()
+    reqPubKey = self.__reqObj.get_pubkey().as_der()
     if not chainPubKey == reqPubKey:
       return S_ERROR(DErrno.EX509, "Public keys do not match")
 


### PR DESCRIPTION
Renable the test disabled here https://github.com/DIRACGrid/DIRAC/pull/4858
The real problem was a incorrect test in the code, exposed by a change of behaviour of openssl. 


BEGINRELEASENOTES

*Core
FIX: Correct comparison of public key for X509Request

ENDRELEASENOTES

For the curious (and my memory in the future), details here

```python
import M2Crypto
import six

# Dirty hack... in fact, it's just that our python2 environments
# uses openssl 1.0.2u and the python 3 openssl 1.1.1h
# and that's the real difference.
IS_OPENSSL_1_1_1 = six.PY3

# Generate a pair of keys and assign it to a Request
rsa = M2Crypto.RSA.gen_key(1024, 65537, callback=M2Crypto.util.quiet_genparam_callback)
pkeyObj = M2Crypto.EVP.PKey()
pkeyObj.assign_rsa(rsa)
reqObj = M2Crypto.X509.Request()
reqObj.set_pubkey(pkeyObj) 

reqObj.sign(pkeyObj, "sha256")

assert reqObj.verify(pkeyObj)

# Dump the request as PEM
reqStr = reqObj.as_pem()

# Reload the request as a new object

reqObj2 = M2Crypto.X509.load_request_string(reqStr, format=M2Crypto.X509.FORMAT_PEM)

print("pkeyObj.as_pem")
print(pkeyObj.as_pem(cipher=None).decode())

print()

print("reqObj.get_pubkey().as_pem")
print(reqObj.get_pubkey().as_pem(cipher=None).decode())

print()

print("reqObj2.get_pubkey().as_pem")
print(reqObj2.get_pubkey().as_pem(cipher=None).decode())

# Compare the PEM dump of the Request objects
assert reqObj.as_pem() == reqObj2.as_pem()

# get the public key of the RSA key
bio = M2Crypto.BIO.MemoryBuffer()
rsa.save_pub_key_bio(bio)
rsa_pub= bio.read()         


# get_rsa returns the public RSA key
# so we are comparing the public key of
# the RSA key 
# the EVP
# the first request object
# the second request object
assert reqObj.get_pubkey().get_rsa().as_pem(cipher=None) \
       == reqObj2.get_pubkey().get_rsa().as_pem(cipher=None) \
       == rsa_pub \
       == pkeyObj.get_rsa().as_pem(cipher=None)


# Here we compare a der dump of the public key of the request
# and the EVP object. As the DER dump dumps only the public
# part, they should be the same
assert reqObj.get_pubkey().as_der() == pkeyObj.as_der() == reqObj2.get_pubkey().as_der()

# That should NOT be the same, since 
# the pem dump dumps private keys info. 
# in the case of the request, there are no private keys
# BUT it seems like with openssl 1.1.1, the private key comes along
# It seems to be due to that: https://github.com/openssl/openssl/commit/fa0a9d715e7e35d4f597683c16b643343245fa26#diff-7ccb70ea343c7e0cdcb92d9171980816e5a4d19f56e6d4e707bc396c581e8868R135
if IS_OPENSSL_1_1_1:
  assert reqObj.get_pubkey().as_pem(cipher=None) == pkeyObj.as_pem(cipher=None)
else:
  assert reqObj.get_pubkey().as_pem(cipher=None) != pkeyObj.as_pem(cipher=None)

# Compare the PEM dump of their keys
# as_pem dumps private info.
# the EVP of the public key should contain rubish
# so they SHOULD be different. But they are not with old version
# Doing some more tests, I have the feeling that the private part is initialized
# with something related to the RSA private key, but it is not the key itself.
# Anyway, this comparison DOES NOT MAKE SENSE, and this is what was done in DIRAC
if IS_OPENSSL_1_1_1:
  assert reqObj.get_pubkey().as_pem(cipher=None) != reqObj2.get_pubkey().as_pem(cipher=None)
else:
  assert reqObj.get_pubkey().as_pem(cipher=None) == reqObj2.get_pubkey().as_pem(cipher=None)
```