### PR TITLE
[v7r1] Configuration: Updating Site Info: fix for constant update to NumberO…

### DIFF
--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -314,16 +314,22 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None, glue2=True):
 
           # tags, processors
           tag = queueDict.get('Tag', '')
-          numberOfProcessors = queueDict.get('NumberOfProcessors', '')
-          newNOP = queueInfo.get('NumberOfProcessors', 1)
+          numberOfProcessors = int(queueDict.get('NumberOfProcessors', 0))
+          newNOP = int(queueInfo.get('NumberOfProcessors', 1))
 
           # Adding queue info to the CS
           addToChangeSet((queueSection, 'maxCPUTime', maxCPUTime, newMaxCPUTime), changeSet)
           addToChangeSet((queueSection, 'SI00', si00, newSI00), changeSet)
-          if newNOP > 1:
+          if newNOP != numberOfProcessors:
             addToChangeSet((queueSection, 'NumberOfProcessors', numberOfProcessors, newNOP), changeSet)
-            newTag = ','.join(sorted(set(tag.split(',')).union({'MultiProcessor'}))).strip(',')
-            addToChangeSet((queueSection, 'Tag', tag, newTag), changeSet)
+            if newNOP > 1:
+              # if larger than one, add MultiProcessor to site tags
+              newTag = ','.join(sorted(set(tag.split(',')).union({'MultiProcessor'}))).strip(',')
+              addToChangeSet((queueSection, 'Tag', tag, newTag), changeSet)
+            else:
+              # if not larger than one, drop MultiProcessor
+              newTag = ','.join(sorted(set(tag.split(',')).difference({'MultiProcessor'}))).strip(',')
+              addToChangeSet((queueSection, 'Tag', tag, newTag), changeSet)
           if maxTotalJobs == "Unknown":
             newTotalJobs = min(1000, int(int(queueInfo.get('GlueCEInfoTotalCPUs', 0)) / 2))
             newWaitingJobs = max(2, int(newTotalJobs * 0.1))


### PR DESCRIPTION
…fProcessors

the old value was a string, the new one an int, so comparison was always false.
Also add possible removal of MultiProcessor tag of a queue goes from >1 to 1 processor

BEGINRELEASENOTES

*CS
FIX: Bdii2CSAgent: remove constant update of NumberOfProcessors parameter. Comparison between int and str lead to "new" value every run.

ENDRELEASENOTES
