### PR TITLE
[v7r0] RSS: catch all exception in _execute in SiteInspectorAgent

### DIFF
--- a/ResourceStatusSystem/Agent/ElementInspectorAgent.py
+++ b/ResourceStatusSystem/Agent/ElementInspectorAgent.py
@@ -212,7 +212,11 @@ class ElementInspectorAgent(AgentModule):
                                                            element['status'],
                                                            element['statusType']))
 
-      resEnforce = pep.enforce(element)
+      try:
+        resEnforce = pep.enforce(element)
+      except Exception as e:
+        self.log.exception('Exception during enforcement')
+        resEnforce = S_ERROR('Exception during enforcement')
       if not resEnforce['OK']:
         self.log.error('Failed policy enforcement', resEnforce['Message'])
         self.elementsToBeChecked.task_done()

--- a/ResourceStatusSystem/Agent/SiteInspectorAgent.py
+++ b/ResourceStatusSystem/Agent/SiteInspectorAgent.py
@@ -177,11 +177,11 @@ class SiteInspectorAgent(AgentModule):
       except Queue.Empty:
         return S_OK()
 
-      resEnforce = pep.enforce(site)
-      if not resEnforce['OK']:
-        self.log.error('Failed policy enforcement', resEnforce['Message'])
-        self.sitesToBeChecked.task_done()
-        continue
-
+      try:
+        resEnforce = pep.enforce(site)
+        if not resEnforce['OK']:
+          self.log.error('Failed policy enforcement', resEnforce['Message'])
+      except Exception as e:
+        self.log.exception('Exception during enforcement')
       # Used together with join !
       self.sitesToBeChecked.task_done()


### PR DESCRIPTION
Prevent the SIA from getting blocked

If an exception in `enforce` occurs "Task_Done()" wasn't called, which prevented `join` from continuing.

BEGINRELEASENOTES

*RSS
FIX: SiteInspectorAgent: prevent the agent from getting locked if an exception occurs during enforcement
FIX: ElementInspectorAgent: prevent the agent from getting locked if an exception occurs during enforcement

ENDRELEASENOTES
