### PR TITLE
[v7r0] bashrc: X509 variables are left untouched if already set

### DIFF
--- a/Core/scripts/dirac-install.py
+++ b/Core/scripts/dirac-install.py
@@ -2102,11 +2102,11 @@ def createBashrc():
           # But this will have to be created at some point (dirac-configure)
           certDir = '%s/etc/grid-security/certificates' % proPath
       lines.extend(['# CAs path for SSL verification',
-                    'export X509_CERT_DIR=%s' % certDir,
-                    'export SSL_CERT_DIR=%s' % certDir])
+                    'export X509_CERT_DIR=${X509_CERT_DIR:-%s}' % certDir,
+                    'export SSL_CERT_DIR=${SSL_CERT_DIR:-%s}' % certDir])
 
       lines.append(
-          'export X509_VOMS_DIR=%s' %
+          'export X509_VOMS_DIR=${X509_VOMS_DIR:-%s}' %
           os.path.join(
               proPath,
               'etc',
@@ -2406,11 +2406,11 @@ def createBashrcForDiracOS():
           # But this will have to be created at some point (dirac-configure)
           certDir = '%s/etc/grid-security/certificates' % proPath
       lines.extend(['# CAs path for SSL verification',
-                    'export X509_CERT_DIR=%s' % certDir,
-                    'export SSL_CERT_DIR=%s' % certDir])
+                    'export X509_CERT_DIR=${X509_CERT_DIR:-%s}' % certDir,
+                    'export SSL_CERT_DIR=${SSL_CERT_DIR:-%s}' % certDir])
 
       lines.append(
-          'export X509_VOMS_DIR=%s' %
+          'export X509_VOMS_DIR=${X509_VOMS_DIR:-%s}' %
           os.path.join(
               proPath,
               'etc',

--- a/DataManagementSystem/Client/FTS3Job.py
+++ b/DataManagementSystem/Client/FTS3Job.py
@@ -9,6 +9,8 @@ import errno
 # Requires at least version 3.3.3
 import fts3.rest.client.easy as fts3
 from fts3.rest.client.exceptions import FTS3ClientException, NotFound
+# We specifically use Request in the FTS client because of a leak in the
+# default pycurl. See https://its.cern.ch/jira/browse/FTS-261
 from fts3.rest.client.request import Request as ftsSSLRequest
 
 from DIRAC.Resources.Storage.StorageElement import StorageElement

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -40,3 +40,9 @@ DIRACSYSCONFIG
 
 DISABLE_WATCHDOG_CPU_WALLCLOCK_CHECK
   This variable only makes sense for DIRAC pilots. When set, the wallclock check done within the watchdog is disabled.
+
+DIRAC_X509_HOST_CERT
+  Defines the location of the host certificate, and takes precedence over CS options. This option is not meant to be used in the ``bashrc`` of DIRAC, but rather by external tools starting DIRAC (read orchestrators).
+
+DIRAC_X509_HOST_KEY
+  Defines the location of the host key, and takes precedence over CS options. This option is not meant to be used in the ``bashrc`` of DIRAC, but rather by external tools starting DIRAC (read orchestrators).


### PR DESCRIPTION
@petricm this is what you should do for `X509_VOMSES` too

The 2 new environment variables allow to specify a location for the host certificate and key, that takes precedence over the CS locations. This is in line with what is done for the other `X509_*` variables

BEGINRELEASENOTES
*Core
CHANGE: default generated bashrc does not overwrite `X509*` variables if already set
NEW: Add ``DIRAC_X509_HOST_CERT`` and ``DIRAC_X509_HOST_KEY`` environment variables

ENDRELEASENOTES
