### PR TITLE
[v7r1] Fix in loop of SiteCEMapping CS helper

### DIFF
--- a/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/ConfigurationSystem/Client/Helpers/Resources.py
@@ -8,7 +8,7 @@ from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,
 
 import six
 
-from DIRAC import S_OK, S_ERROR, gConfig
+from DIRAC import S_OK, S_ERROR, gConfig, gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
 from DIRAC.Core.Utilities.List import uniqueElements, fromChar
 
@@ -46,7 +46,8 @@ def getSiteCEMapping():
                                                               site.split('.')[0], site, 'CEs'),
                                                       [])
     if not res['OK']:
-      return res
+      gLogger.error('Wrong configuration of CE for site:', site)
+      continue
     sitesCEsMapping[site] = res['Value']
   return S_OK(sitesCEsMapping)
 


### PR DESCRIPTION
*CS
FIX: The loop in the siteCE mapping was exiting as soon as a mis-configured site was found. This for instance had some dide effect, like preventing the SiteDirector for ARC sites to read the configuration of correctly configured CEs. Fixed to continue the loop, while adding an error message.
