### PR TITLE
[v7r2] RMS: correct settings for RMS monitoring

### DIFF
--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -176,7 +176,8 @@ class Service(object):
       return result
     self._actions = result['Value']
 
-    gThreadScheduler.addPeriodicTask(30, self.__reportThreadPoolContents)
+    if not self.activityMonitoring:
+      gThreadScheduler.addPeriodicTask(30, self.__reportThreadPoolContents)
 
     return S_OK()
 
@@ -354,8 +355,9 @@ class Service(object):
 
       :param clientTransport: Object which describes opened connection (PlainTransport or SSLTransport)
     """
-    self._stats['connections'] += 1
-    self._monitor.setComponentExtraParam('queries', self._stats['connections'])
+    if not self.activityMonitoring:
+      self._stats['connections'] += 1
+      self._monitor.setComponentExtraParam('queries', self._stats['connections'])
     # TODO: remove later
     if useThreadPoolExecutor:
       self._threadPool.submit(self._processInThread, clientTransport)

--- a/src/DIRAC/RequestManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/RequestManagementSystem/ConfigTemplate.cfg
@@ -42,6 +42,8 @@ Agents
     ProcessPoolSleep = 5
     # If a positive integer n is given, we fetch n requests at once from the DB. Otherwise, one by one
     BulkRequest = 0
+    # If set to True, the monitoring data is sent to ES instead of the Framework/Monitoring
+    EnableRMSMonitoring = False
     OperationHandlers
     {
       ForwardDISET


### PR DESCRIPTION
The REA was using the `ActivityMonitoring` flag to enable ES monitoring, so I changed that.

BEGINRELEASENOTES
*Core
FIX: fix exception in Services when trying to use uninitialized gMonitor client while targeting ES monitoring

*RMS
CHANGE: use dedicated ES monitoring flag `RMSMonitoring`


ENDRELEASENOTES
