### PR TITLE
[v7r2] Skip slow unit tests by default

### DIFF
--- a/.github/workflows/basic-python3.yml
+++ b/.github/workflows/basic-python3.yml
@@ -22,8 +22,7 @@ jobs:
           #     supported alternative: "If you want your threads to stop
           #     gracefully, make them non-daemonic and use a suitable
           #     signalling mechanism such as an Event."
-          - pytest --runslow --no-cov -k 'not test_BaseType_Unicode and not test_nestedStructure and not testLockedClass'
-          - pytest --runslow --no-cov src/DIRAC/Core/Security/test
+          - pytest --runslow -k 'not test_BaseType_Unicode and not test_nestedStructure and not testLockedClass'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/basic-python3.yml
+++ b/.github/workflows/basic-python3.yml
@@ -22,8 +22,8 @@ jobs:
           #     supported alternative: "If you want your threads to stop
           #     gracefully, make them non-daemonic and use a suitable
           #     signalling mechanism such as an Event."
-          - pytest --no-cov -k 'not test_BaseType_Unicode and not test_nestedStructure and not testLockedClass'
-          - pytest --no-cov src/DIRAC/Core/Security/test
+          - pytest --runslow --no-cov -k 'not test_BaseType_Unicode and not test_nestedStructure and not testLockedClass'
+          - pytest --runslow --no-cov src/DIRAC/Core/Security/test
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: False
       matrix:
         command:
-          - pytest --no-cov
-          - pytest --no-cov src/DIRAC/Core/Security/test
+          - pytest --runslow --no-cov
+          - pytest --runslow --no-cov src/DIRAC/Core/Security/test
           - tests/checkDocs.sh
           # TODO This should cover more than just tests/CI
           # Excluded codes related to sourcing files

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -12,8 +12,7 @@ jobs:
       fail-fast: False
       matrix:
         command:
-          - pytest --runslow --no-cov
-          - pytest --runslow --no-cov src/DIRAC/Core/Security/test
+          - pytest --runslow
           - tests/checkDocs.sh
           # TODO This should cover more than just tests/CI
           # Excluded codes related to sourcing files

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@ python_files=Test_*.py assert*.py
 # The reason here is that we do nasty things with the pythonpath
 # in order to make sure that M2Crypto and pyGSI do not step
 # on each other's feet
-addopts = -rx -v --color=yes --showlocals --tb=long --ignore=tests --ignore=src/DIRAC/Core/Security/test
+addopts = --no-cov -rx -v --color=yes --showlocals --tb=long --ignore=tests

--- a/src/DIRAC/Core/Security/m2crypto/X509Request.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Request.py
@@ -116,7 +116,7 @@ class X509Request(object):
       return S_ERROR(DErrno.EX509, "Can't serialize request: %s" % req['Message'])
     if not pkey['OK']:
       return S_ERROR(DErrno.EX509, "Can't serialize pkey: %s" % pkey['Message'])
-    return S_OK("%s%s" % (req['Value'], pkey['Value']))
+    return S_OK(b"%s%s" % (req['Value'], pkey['Value']))
 
   def loadAllFromString(self, pemData):
     """ load the Request and key argument from a PEM encoded string.
@@ -126,11 +126,11 @@ class X509Request(object):
         :returns: S_OK()
     """
     try:
-      self.__reqObj = M2Crypto.X509.load_request_string(pemData.encode())
+      self.__reqObj = M2Crypto.X509.load_request_string(pemData)
     except Exception as e:
       return S_ERROR(DErrno.ENOCERT, str(e))
     try:
-      self.__pkeyObj = M2Crypto.EVP.load_key_string(pemData.encode())
+      self.__pkeyObj = M2Crypto.EVP.load_key_string(pemData)
     except Exception as e:
       return S_ERROR(DErrno.ENOPKEY, str(e))
     self.__valid = True

--- a/src/DIRAC/Core/Security/test/Test_X509Chain.py
+++ b/src/DIRAC/Core/Security/test/Test_X509Chain.py
@@ -429,6 +429,7 @@ def test_getCertInChain(get_proxy):
   assert proxyChain.isValidProxy()['Value'] is True
 
 
+@mark.slow
 @settings(max_examples=200, suppress_health_check=function_scoped)
 @given(lifetime=integers(max_value=ONE_YEAR_IN_SECS, min_value=1))
 def test_proxyLifetime(get_proxy, lifetime):
@@ -449,6 +450,7 @@ def test_proxyLifetime(get_proxy, lifetime):
   assert (notAfterDate - expectedValidity).total_seconds() == approx(0, abs=margin)
 
 
+@mark.slow
 @settings(max_examples=200, suppress_health_check=function_scoped)
 @given(lifetime=integers(min_value=TWENTY_YEARS_IN_SEC, max_value=NO_LATER_THAN_2050_IN_SEC))
 def test_tooLong_proxyLifetime(get_proxy, lifetime):
@@ -472,11 +474,12 @@ def test_tooLong_proxyLifetime(get_proxy, lifetime):
 
 # def generateProxyToString(self, lifeTime, diracGroup=False, strength=1024, limited=False, proxyKey=False, rfc = True):
 
-# hypthesis successfuly prove that m2crypto implementation does not work
+# hypthesis successfully prove that m2crypto implementation does not work
 # for an empty group name, or 0, or whatever can be evaluated to False . Fine...
 # Let's just focus on letters and '-'
 
 
+@mark.slow
 @settings(max_examples=200, suppress_health_check=function_scoped)
 @given(diracGroup=text(ascii_letters + '-_' + digits, min_size=1))
 def test_diracGroup(get_proxy, diracGroup):
@@ -516,11 +519,12 @@ def test_getIssuerCert(get_proxy):
 # From now on, test proxy coming from Requests
 ################################################################
 
-  #
-  # retVal = chain.generateChainFromRequestString(reqDict['request'],
-  #                                               lifetime=chainLifeTime,
-  #                                               diracGroup=diracGroup,
-  #                                               rfc = rfcIfPossible)
+#
+# retVal = chain.generateChainFromRequestString(reqDict['request'],
+#                                               lifetime=chainLifeTime,
+#                                               diracGroup=diracGroup,
+#                                               rfc = rfcIfPossible)
+@mark.slow
 @settings(max_examples=200, suppress_health_check=function_scoped)
 @given(diracGroup=text(ascii_letters + '-', min_size=1), lifetime=integers(min_value=1, max_value=TWENTY_YEARS_IN_SEC))
 def test_delegation(get_X509Request, get_proxy, diracGroup, lifetime):

--- a/src/DIRAC/Core/Security/test/Test_X509Request.py
+++ b/src/DIRAC/Core/Security/test/Test_X509Request.py
@@ -53,7 +53,7 @@ def test_dumpRequest(get_X509Request):
   res = x509Req.dumpRequest()
 
   assert res['OK']
-  assert 'CERTIFICATE REQUEST' in res['Value']
+  assert b'CERTIFICATE REQUEST' in res['Value']
 
 
 def test_loadAllFromString_fromDumpRequest(get_X509Request):

--- a/src/DIRAC/Core/Security/test/x509TestUtilities.py
+++ b/src/DIRAC/Core/Security/test/x509TestUtilities.py
@@ -272,10 +272,16 @@ def deimportDIRAC():
       This method is extremely fragile, but hopefully, we can get ride of all these
       messy tests soon, when PyGSI has gone.
   """
-  for mod in list(sys.modules):
-    # You should be careful with what you remove....
-    if (mod == 'DIRAC' or mod.startswith('DIRAC.')) and not mod.startswith('DIRAC.Core.Security.test'):
-      sys.modules.pop(mod)
+  if len(X509CHAINTYPES) != 1 or len(X509REQUESTTYPES) != 1:
+    raise NotImplementedError(
+        "This no longer de-imports DIRAC, if we want to test another SSL wrapper "
+        "we will have to find another way of doing this or run a separate pytest "
+        "process again"
+    )
+  # for mod in list(sys.modules):
+  #   # You should be careful with what you remove....
+  #   if (mod == 'DIRAC' or mod.startswith('DIRAC.')) and not mod.startswith('DIRAC.Core.Security.test'):
+  #     sys.modules.pop(mod)
 
 
 X509CHAINTYPES = ('M2_X509Chain',)

--- a/src/DIRAC/Core/Utilities/test/Test_Encode.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Encode.py
@@ -15,7 +15,6 @@ from string import printable
 import datetime
 import sys
 
-
 from DIRAC.Core.Utilities.DEncode import encode as disetEncode, decode as disetDecode, g_dEncodeFunctions
 from DIRAC.Core.Utilities.JEncode import encode as jsonEncode, decode as jsonDecode, JSerializable
 from DIRAC.Core.Utilities.MixedEncode import encode as mixEncode, decode as mixDecode
@@ -240,6 +239,7 @@ def test_BaseType_Unicode(enc_dec, data):
 
 
 # Json will not pass this because of tuples and integers as dict keys
+@mark.slow
 @settings(suppress_health_check=function_scoped)
 @given(data=nestedStrategy)
 def test_nestedStructure(enc_dec_without_json, data):
@@ -276,6 +276,7 @@ class Serializable(JSerializable):
     return all([getattr(self, attr) == getattr(other, attr) for attr in self._attrToSerialize])
 
 
+@mark.slow
 @settings(suppress_health_check=(HealthCheck.too_slow,) + function_scoped)
 @given(data=nestedStrategyJson)
 def test_Serializable(data):
@@ -318,6 +319,7 @@ def test_missingAttrToSerialize():
     agnosticTestFunction(jsonTuple, objData)
 
 
+@mark.slow
 @settings(suppress_health_check=function_scoped)
 @given(data=nestedStrategyJson)
 def test_nestedSerializable(data):

--- a/src/DIRAC/Core/Utilities/test/Test_ProcessPool.py
+++ b/src/DIRAC/Core/Utilities/test/Test_ProcessPool.py
@@ -39,6 +39,9 @@ from DIRAC import gLogger
 ## SUT
 from DIRAC.Core.Utilities.ProcessPool import ProcessPool
 
+# Mark this entire module as slow
+pytestmark = pytest.mark.slow
+
 
 @pytest.fixture(autouse=True)
 def capture_wrap():

--- a/src/DIRAC/Core/Utilities/test/Test_Profiler.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Profiler.py
@@ -9,10 +9,14 @@ import time
 from os.path import dirname, join
 from subprocess import Popen
 
+import pytest
 from flaky import flaky
 
 import DIRAC
 from DIRAC.Core.Utilities.Profiler import Profiler
+
+# Mark this entire module as slow
+pytestmark = pytest.mark.slow
 
 
 def test_base():

--- a/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
@@ -29,7 +29,8 @@ from subprocess import Popen
 # SUT
 from DIRAC.Core.Utilities.Subprocess import systemCall, shellCall, pythonCall, getChildrenPIDs
 
-########################################################################
+# Mark this entire module as slow
+pytestmark = pytest.mark.slow
 
 cmd = ["sleep", "2"]
 

--- a/src/DIRAC/Resources/Computing/test/Test_InProcessComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_InProcessComputingElement.py
@@ -6,6 +6,8 @@ tests for InProcessComputingElement module
 import os
 import shutil
 
+import pytest
+
 from DIRAC.Resources.Computing.test.Test_PoolComputingElement import jobScript, _stopJob
 from DIRAC.WorkloadManagementSystem.Utilities.Utils import createJobWrapper
 
@@ -13,6 +15,7 @@ from DIRAC.WorkloadManagementSystem.Utilities.Utils import createJobWrapper
 from DIRAC.Resources.Computing.InProcessComputingElement import InProcessComputingElement
 
 
+@pytest.mark.slow
 def test_submitJob():
   with open('testJob.py', 'w') as execFile:
     execFile.write(jobScript % '1')

--- a/src/DIRAC/Resources/Computing/test/Test_PoolComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_PoolComputingElement.py
@@ -45,6 +45,7 @@ def _stopJob(nJob):
     os.remove('stop_job_%s' % nJob)
 
 
+@pytest.mark.slow
 def test_executeJob():
 
   ceParameters = {'WholeNode': True,

--- a/src/DIRAC/Resources/ProxyProvider/test/Test_DIRACCAProxyProvider.py
+++ b/src/DIRAC/Resources/ProxyProvider/test/Test_DIRACCAProxyProvider.py
@@ -18,6 +18,8 @@ except ImportError:
 import unittest
 import tempfile
 
+import pytest
+
 from DIRAC import gLogger, rootPath
 from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-error
 from DIRAC.Resources.ProxyProvider.DIRACCAProxyProvider import DIRACCAProxyProvider
@@ -88,6 +90,7 @@ class DIRACCAProviderTestCase(unittest.TestCase):
 
 class testDIRACCAProvider(DIRACCAProviderTestCase):
 
+  @pytest.mark.slow
   def test_getProxy(self):
     """ Test 'getProxy' - try to get proxies for different users and check it
     """

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -67,6 +67,7 @@ def test_performChecks():
   assert res['OK']
 
 
+@pytest.mark.slow
 def test_execute(mocker):
 
   mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+# Adds the --runslow command line arg based on the example in the docs
+# https://docs.pytest.org/en/stable/example/simple.html
+# #control-skipping-of-tests-according-to-command-line-option
+def pytest_addoption(parser):
+  parser.addoption(
+      "--runslow", action="store_true", default=False, help="run slow tests"
+  )
+
+
+def pytest_configure(config):
+  config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+  if config.getoption("--runslow"):
+    # --runslow given in cli: do not skip slow tests
+    return
+  skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+  for item in items:
+    if "slow" in item.keywords:
+      item.add_marker(skip_slow)


### PR DESCRIPTION
See https://docs.pytest.org/en/stable/example/simple.html#control-skipping-of-tests-according-to-command-line-option for details about what is being done. The `--runslow` flag is passed in the CI so we still ensure that the tests are passing without being burdened by them locally.

I merge all the unit tests together in to a single job now that they can be. Also enables the `Test_X509Request.py` which was accidentally misnamed (and fixed a couple of associated Python 3 incompatibilities. cc @chaen for review

BEGINRELEASENOTES

*Testing
NEW: --runslow option on unit tests to allow faster local tests

ENDRELEASENOTES

