### PR TITLE
[v7r2] Fix incorrect call for new Monitoring in ExecutorDispatcher

### DIFF
--- a/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
+++ b/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
@@ -10,6 +10,8 @@ import time
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities.ReturnValues import isReturnStructure
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
+from DIRAC.FrameworkSystem.Client.MonitoringClient import MonitoringClient
+from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
 
 
 class ExecutorState(object):
@@ -294,6 +296,11 @@ class ExecutorDispatcher(object):
       return rS
 
   def __init__(self, monitor=None):
+    """
+      :param monitor: good question.... what's meant to be used for monitoring.
+          Either a :py:class`DIRAC.FrameworkSystem.Client.MonitoringClient.MonitoringClient` or a
+          :py:class`DIRAC.MonitoringSystem.Client.MonitoringReporter.MonitoringReporter`
+    """
     self.__idMap = {}
     self.__execTypes = {}
     self.__executorsLock = threading.Lock()
@@ -305,7 +312,11 @@ class ExecutorDispatcher(object):
     self.__queues = ExecutorQueues(self.__log)
     self.__states = ExecutorState(self.__log)
     self.__cbHolder = ExecutorDispatcherCallbacks()
-    self.__monitor = monitor
+    self.__monitor = None
+    if isinstance(monitor, MonitoringClient):
+      self.__monitor = monitor
+    elif isinstance(monitor, MonitoringReporter):
+      self.__monitoringReporter = monitor
     gThreadScheduler.addPeriodicTask(60, self.__doPeriodicStuff)
     # If a task is frozen too many times, send error or forget task?
     self.__failedOnTooFrozen = True


### PR DESCRIPTION
Fixes this exception
```
2021-01-20 15:52:11 UTC WorkloadManagement/OptimizationMind ERROR: Exception while calling initialization function
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/DISET/private/Service.py", line 159, in initialize
    result = initFunc(dict(self._serviceInfoDict))
  File "/opt/dirac/pro/DIRAC/Core/Base/ExecutorMindHandler.py", line 71, in initializeHandler
    cls.__eDispatch = ExecutorDispatcher(cls.srv_getMonitor())
  File "/opt/dirac/pro/DIRAC/Core/Utilities/ExecutorDispatcher.py", line 317, in __init__
    self.__monitor.registerActivity("executors", "Executor reactors connected",
AttributeError: 'MonitoringReporter' object has no attribute 'registerActivity'
```

This PR just disable the monitoring for the new ES based system, but it should be implemented (https://github.com/DIRACGrid/DIRAC/issues/4912)



BEGINRELEASENOTES
*Core
FIX: ExecutorDispatcher does not use the new ES based monitoring

ENDRELEASENOTES
