### PR TITLE
[v7r2] Fix global state issues setuptools scripts

### DIFF
--- a/src/DIRAC/FrameworkSystem/scripts/dirac_install_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_install_component.py
@@ -13,23 +13,18 @@ from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 from DIRAC.Core.Base import Script
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript
 from DIRAC import exit as DIRACexit
-from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
 
 __RCSID__ = "$Id$"
 
-gComponentInstaller.exitOnError = True
-
 overwrite = False
+module = ''
+specialOptions = {}
 
 
 def setOverwrite(opVal):
   global overwrite
   overwrite = True
   return S_OK()
-
-
-module = ''
-specialOptions = {}
 
 
 def setModule(optVal):
@@ -52,6 +47,9 @@ def main():
   global specialOptions
   global module
   global specialOptions
+
+  from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
+  gComponentInstaller.exitOnError = True
 
   Script.registerSwitch("w", "overwrite", "Overwrite the configuration in the global CS", setOverwrite)
   Script.registerSwitch("m:", "module=", "Python module name for the component code", setModule)

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_install_tornado_service.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_install_tornado_service.py
@@ -15,11 +15,9 @@ from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 from DIRAC.Core.Base import Script
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript
 from DIRAC import exit as DIRACexit
-from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
 
 __RCSID__ = "$Id$"
 
-gComponentInstaller.exitOnError = True
 
 overwrite = False
 
@@ -54,6 +52,10 @@ def main():
   global specialOptions
   global module
   global specialOptions
+
+  from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
+  gComponentInstaller.exitOnError = True
+
   Script.registerSwitch("w", "overwrite", "Overwrite the configuration in the global CS", setOverwrite)
   Script.registerSwitch("m:", "module=", "Python module name for the component code", setModule)
   Script.registerSwitch("p:", "parameter=", "Special component option ", setSpecialOption)

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_uninstall_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_uninstall_component.py
@@ -15,11 +15,8 @@ from DIRAC.Core.Base import Script
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript
 from DIRAC.Core.Utilities.PromptUser import promptUser
 from DIRAC import exit as DIRACexit
-from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
 
 __RCSID__ = "$Id$"
-
-gComponentInstaller.exitOnError = True
 
 force = False
 
@@ -33,6 +30,10 @@ def setForce(opVal):
 @DIRACScript()
 def main():
   global force
+
+  from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
+  gComponentInstaller.exitOnError = True
+
   Script.registerSwitch("f", "force", "Forces the removal of the logs", setForce)
   Script.setUsageMessage('\n'.join([__doc__.split('\n')[1],
                                     'Usage:',


### PR DESCRIPTION
When refactoring the scripts for setuptools I made a few mistakes which cause the global DIRAC state to be broken slightly for the scripts. This doesn't affect installations using the current `dirac-install.py` script (hence why it was missed). This just fixes it in a similar way to the other refactoring in #4774.

Also picks up #4913 as the CI is broken without it.