### PR TITLE
[v7r1] Glue2: fix problem for sites with multiple queues

### DIFF
--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -139,6 +139,7 @@ def __getGlue2ShareInfo(host, shareInfoLists):
   siteDict = {}
   for siteName, shareInfoDicts in shareInfoLists.items():
     siteDict[siteName] = {'CEs': {}}
+    cesDict = siteDict[siteName]['CEs']
     for shareInfoDict in shareInfoDicts:
       ceInfo = {}
       ceInfo['MaxWaitingJobs'] = shareInfoDict.get('GLUE2ComputingShareMaxWaitingJobs', '-1')  # This is not used
@@ -195,7 +196,6 @@ def __getGlue2ShareInfo(host, shareInfoLists):
       shareEndpoints = shareInfoDict.get('GLUE2ShareEndpointForeignKey', [])
       if isinstance(shareEndpoints, basestring):
         shareEndpoints = [shareEndpoints]
-      cesDict = {}
       for endpoint in shareEndpoints:
         ceType = endpoint.rsplit('.', 1)[1]
         # get queue Name, in CREAM this is behind GLUE2entityOtherInfo...
@@ -240,7 +240,6 @@ def __getGlue2ShareInfo(host, shareInfoLists):
           cesDict[ceName].update(ceInfo)
       except Exception:
         sLog.error('Exception in ARC part for site:', siteName)
-      siteDict[siteName]['CEs'].update(cesDict)
 
   return S_OK(siteDict)
 


### PR DESCRIPTION
cesDict content was overwritten, and not deepmerged

BEGINRELEASENOTES
*Core
FIX:  Glue2: fix problem for CEs with multiple Queues, only one queue was discovered

ENDRELEASENOTES
