### PR TITLE
[v7r1] Modifications to manage certificates to access the Elias (Elaasticsea…

### DIFF
--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -530,6 +530,62 @@ def getElasticDBParameters(fullname):
     ssl = False if result['Value'].lower() in ('false', 'no', 'n') else True
   parameters['SSL'] = ssl
 
+  # Elasticsearch use certs
+  result = gConfig.getOption(cs_path + '/CRT')
+  if not result['OK']:
+    # No host name found, try at the common place
+    result = gConfig.getOption('/Systems/NoSQLDatabases/CRT')
+    if not result['OK']:
+      gLogger.warn("Failed to get the configuration parameter: certs. Using False")
+      certs = False
+    else:
+      certs = result['Value']
+  else:
+    certs = result['Value']
+  parameters['CRT'] = certs
+
+  # Elasticsearch ca_certs
+  result = gConfig.getOption(cs_path + '/ca_certs')
+  if not result['OK']:
+    # No host name found, try at the common place
+    result = gConfig.getOption('/Systems/NoSQLDatabases/ca_certs')
+    if not result['OK']:
+      gLogger.warn("Failed to get the configuration parameter: ca_certs. Using None")
+      ca_certs = None
+    else:
+      ca_certs = result['Value']
+  else:
+    ca_certs = result['Value']
+  parameters['ca_certs'] = ca_certs
+
+  # Elasticsearch client_key
+  result = gConfig.getOption(cs_path + '/client_key')
+  if not result['OK']:
+    # No host name found, try at the common place
+    result = gConfig.getOption('/Systems/NoSQLDatabases/client_key')
+    if not result['OK']:
+      gLogger.warn("Failed to get the configuration parameter: client_key. Using None")
+      client_key = None
+    else:
+      client_key = result['Value']
+  else:
+    client_key = result['Value']
+  parameters['client_key'] = client_key
+
+  # Elasticsearch client_cert
+  result = gConfig.getOption(cs_path + '/client_cert')
+  if not result['OK']:
+    # No host name found, try at the common place
+    result = gConfig.getOption('/Systems/NoSQLDatabases/client_cert')
+    if not result['OK']:
+      gLogger.warn("Failed to get the configuration parameter: client_cert. Using None")
+      client_cert = None
+    else:
+      client_cert = result['Value']
+  else:
+    client_cert = result['Value']
+  parameters['client_cert'] = client_cert
+
   return S_OK(parameters)
 
 

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -536,7 +536,7 @@ def getElasticDBParameters(fullname):
     # No host name found, try at the common place
     result = gConfig.getOption('/Systems/NoSQLDatabases/CRT')
     if not result['OK']:
-      gLogger.warn("Failed to get the configuration parameter: certs. Using False")
+      gLogger.warn("Failed to get the configuration parameter: CRT. Using False")
       certs = False
     else:
       certs = result['Value']

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -533,7 +533,7 @@ def getElasticDBParameters(fullname):
   # Elasticsearch use certs
   result = gConfig.getOption(cs_path + '/CRT')
   if not result['OK']:
-    # No host name found, try at the common place
+    # No CRT option found, try at the common place
     result = gConfig.getOption('/Systems/NoSQLDatabases/CRT')
     if not result['OK']:
       gLogger.warn("Failed to get the configuration parameter: CRT. Using False")
@@ -547,7 +547,7 @@ def getElasticDBParameters(fullname):
   # Elasticsearch ca_certs
   result = gConfig.getOption(cs_path + '/ca_certs')
   if not result['OK']:
-    # No host name found, try at the common place
+    # No CA certificate found, try at the common place
     result = gConfig.getOption('/Systems/NoSQLDatabases/ca_certs')
     if not result['OK']:
       gLogger.warn("Failed to get the configuration parameter: ca_certs. Using None")
@@ -561,7 +561,7 @@ def getElasticDBParameters(fullname):
   # Elasticsearch client_key
   result = gConfig.getOption(cs_path + '/client_key')
   if not result['OK']:
-    # No host name found, try at the common place
+    # No client private key found, try at the common place
     result = gConfig.getOption('/Systems/NoSQLDatabases/client_key')
     if not result['OK']:
       gLogger.warn("Failed to get the configuration parameter: client_key. Using None")
@@ -575,7 +575,7 @@ def getElasticDBParameters(fullname):
   # Elasticsearch client_cert
   result = gConfig.getOption(cs_path + '/client_cert')
   if not result['OK']:
-    # No host name found, try at the common place
+    # No cient certificate found, try at the common place
     result = gConfig.getOption('/Systems/NoSQLDatabases/client_cert')
     if not result['OK']:
       gLogger.warn("Failed to get the configuration parameter: client_cert. Using None")

--- a/Core/Base/ElasticDB.py
+++ b/Core/Base/ElasticDB.py
@@ -36,13 +36,22 @@ class ElasticDB(ElasticSearchDB):
     self.__user = dbParameters.get('User', '')
     self.__dbPassword = dbParameters.get('Password', '')
     self.__useSSL = dbParameters.get('SSL', True)
+    self.__useCRT = dbParameters.get('CRT', True)
+    self.__ca_certs = dbParameters.get('ca_certs', None)
+    self.__client_key = dbParameters.get('client_key', None)
+    self.__client_cert = dbParameters.get('client_cert', None)
 
     super(ElasticDB, self).__init__(self._dbHost,
                                     self._dbPort,
                                     self.__user,
                                     self.__dbPassword,
                                     indexPrefix,
-                                    useSSL=self.__useSSL)
+                                    useSSL=self.__useSSL,
+                                    useCRT=self.__useCRT,
+                                    ca_certs=self.__ca_certs,
+                                    client_key=self.__client_key,
+                                    client_cert=self.__client_cert)
+
     if not self._connected:
       raise RuntimeError('Can not connect to ES cluster %s, exiting...' % self.clusterName)
 

--- a/Core/Utilities/ElasticSearchDB.py
+++ b/Core/Utilities/ElasticSearchDB.py
@@ -58,7 +58,8 @@ class ElasticSearchDB(object):
   RESULT_SIZE = 10000
 
   ########################################################################
-  def __init__(self, host, port, user=None, password=None, indexPrefix='', useSSL=True):
+  def __init__(self, host, port, user=None, password=None, indexPrefix='', useSSL=True,
+                useCRT=False, ca_certs=None, client_key=None, client_cert=None):
     """ c'tor
 
     :param self: self reference
@@ -68,6 +69,10 @@ class ElasticSearchDB(object):
     :param str password: if the db is password protected we need to provide a password
     :param str indexPrefix: it is the indexPrefix used to get all indexes
     :param bool useSSL: We can disable using secure connection. By default we use secure connection.
+    :param bool useCRT: Use certificates.
+    :param str ca_certs: Server certificate.
+    :param str client_key: Client key.
+    :param str client_cert: Client certificate.
     """
 
     self.__indexPrefix = indexPrefix
@@ -105,6 +110,14 @@ class ElasticSearchDB(object):
                                   use_ssl=True,
                                   verify_certs=True,
                                   ca_certs=casFile)
+    elif useCRT:
+        self.client = Elasticsearch(self.__url,
+                                  timeout=self.__timeout,
+                                  use_ssl=True,
+                                  verify_certs=True,
+                                  ca_certs=ca_certs,
+                                  client_cert=client_cert,
+                                  client_key=client_key)
     else:
       self.client = Elasticsearch(self.__url, timeout=self.__timeout)
 

--- a/Core/Utilities/ElasticSearchDB.py
+++ b/Core/Utilities/ElasticSearchDB.py
@@ -59,7 +59,7 @@ class ElasticSearchDB(object):
 
   ########################################################################
   def __init__(self, host, port, user=None, password=None, indexPrefix='', useSSL=True,
-                useCRT=False, ca_certs=None, client_key=None, client_cert=None):
+               useCRT=False, ca_certs=None, client_key=None, client_cert=None):
     """ c'tor
 
     :param self: self reference
@@ -112,12 +112,12 @@ class ElasticSearchDB(object):
                                   ca_certs=casFile)
     elif useCRT:
         self.client = Elasticsearch(self.__url,
-                                  timeout=self.__timeout,
-                                  use_ssl=True,
-                                  verify_certs=True,
-                                  ca_certs=ca_certs,
-                                  client_cert=client_cert,
-                                  client_key=client_key)
+                                    timeout=self.__timeout,
+                                    use_ssl=True,
+                                    verify_certs=True,
+                                    ca_certs=ca_certs,
+                                    client_cert=client_cert,
+                                    client_key=client_key)
     else:
       self.client = Elasticsearch(self.__url, timeout=self.__timeout)
 


### PR DESCRIPTION
Configuration we used in /opt/dirac/etc/dirac.cfg to access the ELIAS database hosted at CC-IN2P3
-----------------------------
/DIRAC/Setups/CTA-cert/Monitoring = Certification

/Systems/Monitoring/Certification/Databases/MonitoringDB
          {
          Host = elias-beta.cc.in2p3.fr
          Port = 9200
          SSL = False
          IndexPrefix = cta-
          CRT = True
          ca_certs = /opt/dirac/etc/grid-security/ES/ca.crt
          client_key = /opt/dirac/etc/grid-security/ES/ctacertbot.key
          client_cert = /opt/dirac/etc/grid-security//ES/ctacertbot.crt
        }


BEGINRELEASENOTES

*Monitoring
NEW: added possibility to login to ES via certificates.

ENDRELEASENOTES
