### PR TITLE
[v7r1] fixes for MultiProcessor queues

### DIFF
--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -312,8 +312,16 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None, glue2=True):
             if 'CPUScalingReferenceSI00' in cap:
               newSI00 = cap.split('=')[-1]
 
-          # tags, processors
+          # tags, processors, localCEType
           tag = queueDict.get('Tag', '')
+          # LocalCEType can be empty (equivalent to "InProcess")
+          # or "Pool", "Singularity", but also "Pool/Singularity"
+          localCEType = queueDict.get('LocalCEType', 'InProcess')
+          try:
+            localCEType_inner = localCEType.split('/')[1]
+          except ValueError:
+            localCEType_inner = ''
+
           numberOfProcessors = int(queueDict.get('NumberOfProcessors', 0))
           newNOP = int(queueInfo.get('NumberOfProcessors', 1))
 
@@ -323,11 +331,17 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None, glue2=True):
           if newNOP != numberOfProcessors:
             addToChangeSet((queueSection, 'NumberOfProcessors', numberOfProcessors, newNOP), changeSet)
             if newNOP > 1:
-              # if larger than one, add MultiProcessor to site tags
+              # if larger than one, add MultiProcessor to site tags, and LocalCEType=Pool
               newTag = ','.join(sorted(set(tag.split(',')).union({'MultiProcessor'}))).strip(',')
               addToChangeSet((queueSection, 'Tag', tag, newTag), changeSet)
+              if localCEType_inner:
+                newLocalCEType = 'Pool/' + localCEType_inner
+              else:
+                newLocalCEType = 'Pool'
+              addToChangeSet((queueSection, 'LocalCEType', localCEType, newLocalCEType), changeSet)
             else:
-              # if not larger than one, drop MultiProcessor
+              # if not larger than one, drop MultiProcessor Tag.
+              # Here we do not change the LocalCEType as Pool CE would still be perfectly valid.
               newTag = ','.join(sorted(set(tag.split(',')).difference({'MultiProcessor'}))).strip(',')
               addToChangeSet((queueSection, 'Tag', tag, newTag), changeSet)
           if maxTotalJobs == "Unknown":

--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -343,7 +343,7 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None, glue2=True):
               # if not larger than one, drop MultiProcessor Tag.
               # Here we do not change the LocalCEType as Pool CE would still be perfectly valid.
               newTag = ','.join(sorted(set(tag.split(',')).difference({'MultiProcessor'}))).strip(',')
-              addToChangeSet((queueSection, 'Tag', tag, newTag), changeSet)
+              changeSet.add(queueSection, 'Tag', tag, newTag)
           if maxTotalJobs == "Unknown":
             newTotalJobs = min(1000, int(int(queueInfo.get('GlueCEInfoTotalCPUs', 0)) / 2))
             newWaitingJobs = max(2, int(newTotalJobs * 0.1))

--- a/ConfigurationSystem/test/Test_agentOptions.py
+++ b/ConfigurationSystem/test/Test_agentOptions.py
@@ -59,7 +59,7 @@ AGENTS = [('DIRAC.AccountingSystem.Agent.NetworkAgent', {'IgnoreOptions': ['Mess
                                                                                           'TransfIDMeta']}),
           # ('DIRAC.TransformationSystem.Agent.RequestTaskAgent', {}),  # not inheriting from AgentModule
           # ('DIRAC.TransformationSystem.Agent.WorkflowTaskAgent', {}),  # not inheriting from AgentModule
-          ('DIRAC.WorkloadManagementSystem.Agent.JobAgent', {'IgnoreOptions': ['FillingModeFlag', 'JobWrapperTemplate',
+          ('DIRAC.WorkloadManagementSystem.Agent.JobAgent', {'IgnoreOptions': ['JobWrapperTemplate',
                                                                                'MinimumTimeLeft']}),
           ('DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent', {}),
           ('DIRAC.WorkloadManagementSystem.Agent.PilotStatusAgent', {'IgnoreOptions': ['PilotAccountingEnabled',

--- a/Core/Utilities/ElasticSearchDB.py
+++ b/Core/Utilities/ElasticSearchDB.py
@@ -244,7 +244,13 @@ class ElasticSearchDB(object):
 
     :param str indexName: the name of the index
     """
-    return self.client.indices.exists(indexName)
+    # if the index does not exist at all, we might get an obscure authorization exception.
+    sLog.debug("Checking existance of index %s" % indexName)
+    try:
+      return self.client.indices.exists(indexName)
+    except TransportError:
+      sLog.exception()
+      return False
 
   ########################################################################
 

--- a/Core/scripts/dirac-cert-convert.sh
+++ b/Core/scripts/dirac-cert-convert.sh
@@ -28,7 +28,7 @@ USERCERT_P12_ORIG=$1
 USERCERT_P12="${GLOBUS}"/$(basename "${USERCERT_P12_ORIG}")
 USERCERT_PEM="${GLOBUS}"/usercert.pem
 USERKEY_PEM="${GLOBUS}"/userkey.pem
-OPENSSL=$(which openssl)
+OPENSSL=$(command -v openssl)
 DATE=$(/bin/date +%F-%H:%M)
 
 if [[ ! -f "${USERCERT_P12_ORIG}" ]]; then

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -443,7 +443,7 @@ class JobAgent(AgentModule):
     self.log.info("Requesting proxy', 'for %s@%s" % (ownerDN, ownerGroup))
     token = gConfig.getValue("/Security/ProxyToken", "")
     if not token:
-      self.log.info("No token defined. Trying to download proxy without token")
+      self.log.verbose("No token defined. Trying to download proxy without token")
       token = False
     retVal = gProxyManager.getPayloadProxyFromDIRACGroup(ownerDN, ownerGroup,
                                                          self.defaultProxyLength, token)

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -61,7 +61,7 @@ class JobAgent(AgentModule):
     # This is the factor to convert raw CPU to Normalized units (based on the CPU Model)
     self.cpuFactor = 0.0
     self.jobSubmissionDelay = 10
-    self.fillingMode = False
+    self.fillingMode = True
     self.minimumTimeLeft = 1000
     self.stopOnApplicationFailure = True
     self.stopAfterFailedMatches = 10
@@ -132,10 +132,12 @@ class JobAgent(AgentModule):
   def execute(self):
     """The JobAgent execution method.
     """
+
+    # Temporary mechanism to pass a shutdown message to the agent
+    if os.path.exists('/var/lib/dirac_drain'):
+      return self.__finish('Node is being drained by an operator')
+
     if self.jobCount:
-      # Temporary mechanism to pass a shutdown message to the agent
-      if os.path.exists('/var/lib/dirac_drain'):
-        return self.__finish('Node is being drained by an operator')
       # Only call timeLeft utility after a job has been picked up
       self.log.info('Attempting to check CPU time left for filling mode')
       if self.fillingMode:

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -62,7 +62,7 @@ class JobAgent(AgentModule):
     self.cpuFactor = 0.0
     self.jobSubmissionDelay = 10
     self.fillingMode = True
-    self.minimumTimeLeft = 1000
+    self.minimumTimeLeft = 5000
     self.stopOnApplicationFailure = True
     self.stopAfterFailedMatches = 10
     self.jobCount = 0
@@ -77,16 +77,15 @@ class JobAgent(AgentModule):
     self.pilotInfoReportedFlag = False
 
   #############################################################################
-  def initialize(self, loops=0):
+  def initialize(self):
     """Sets default parameters and creates CE instance
     """
-    # Disable monitoring, logLevel INFO, limited cycles
+    # Disable monitoring
     self.am_setOption('MonitoringEnabled', False)
-    self.am_setOption('MaxCycles', loops)
 
     localCE = gConfig.getValue('/LocalSite/LocalCE', self.ceName)
     if localCE != self.ceName:
-      self.log.info('Defining CE from local configuration', '= %s' % localCE)
+      self.log.info('Defining Inner CE from local configuration', '= %s' % localCE)
 
     # Create backend Computing Element
     ceFactory = ComputingElementFactory()

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1142,17 +1142,6 @@ class SiteDirector(AgentModule):
             "(version in CS: %s)" % lcgBundleVersion)
         pilotOptions.append('-g %s' % lcgBundleVersion)
 
-    ownerDN = self.pilotDN
-    ownerGroup = self.pilotGroup
-    # Request token for maximum pilot efficiency
-    numberOfProcessors = int(queueDict.get('NumberOfProcessors', 1))
-    result = gProxyManager.requestToken(ownerDN, ownerGroup, pilotsToSubmit * numberOfProcessors)
-    if not result['OK']:
-      self.log.error('Invalid proxy token request', result['Message'])
-      return [None, None]
-    (token, _) = result['Value']
-    pilotOptions.append('-o /Security/ProxyToken=%s' % token)
-
     # Debug
     if self.pilotLogLevel.lower() == 'debug':
       pilotOptions.append('-ddd')

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1145,7 +1145,7 @@ class SiteDirector(AgentModule):
     ownerDN = self.pilotDN
     ownerGroup = self.pilotGroup
     # Request token for maximum pilot efficiency
-    numberOfProcessors = queueDict.get('NumberOfProcessors', 1)
+    numberOfProcessors = int(queueDict.get('NumberOfProcessors', 1))
     result = gProxyManager.requestToken(ownerDN, ownerGroup, pilotsToSubmit * numberOfProcessors)
     if not result['OK']:
       self.log.error('Invalid proxy token request', result['Message'])

--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -62,7 +62,6 @@ WAITING_PILOT_STATUS = ['Submitted', 'Waiting', 'Scheduled', 'Ready']
 FINAL_PILOT_STATUS = ['Aborted', 'Failed', 'Done']
 
 MAX_PILOTS_TO_SUBMIT = 100
-MAX_JOBS_IN_FILLMODE = 5
 
 
 def getSubmitPools(group=None, vo=None):
@@ -101,7 +100,6 @@ class SiteDirector(AgentModule):
     # failedPilotOutput stores the number of times the Site Director failed to get a given pilot output
     self.failedPilotOutput = defaultdict(int)
     self.firstPass = True
-    self.maxJobsInFillMode = MAX_JOBS_IN_FILLMODE
     self.maxPilotsToSubmit = MAX_PILOTS_TO_SUBMIT
 
     self.gridEnv = ''
@@ -217,7 +215,6 @@ class SiteDirector(AgentModule):
     self.workingDirectory = self.am_getOption('WorkDirectory')
     self.maxQueueLength = self.am_getOption('MaxQueueLength', self.maxQueueLength)
     self.pilotLogLevel = self.am_getOption('PilotLogLevel', self.pilotLogLevel)
-    self.maxJobsInFillMode = self.am_getOption('MaxJobsInFillMode', self.maxJobsInFillMode)
     self.maxPilotsToSubmit = self.am_getOption('MaxPilotsToSubmit', self.maxPilotsToSubmit)
     self.pilotWaitingFlag = self.am_getOption('PilotWaitingFlag', self.pilotWaitingFlag)
     self.failedQueueCycleFactor = self.am_getOption('FailedQueueCycleFactor', self.failedQueueCycleFactor)
@@ -281,7 +278,6 @@ class SiteDirector(AgentModule):
       self.log.always('Pilot submission accounting sending requested')
 
     self.log.always('MaxPilotsToSubmit:', self.maxPilotsToSubmit)
-    self.log.always('MaxJobsInFillMode:', self.maxJobsInFillMode)
 
     if self.firstPass:
       if self.queueDict:
@@ -1149,24 +1145,14 @@ class SiteDirector(AgentModule):
     ownerDN = self.pilotDN
     ownerGroup = self.pilotGroup
     # Request token for maximum pilot efficiency
-    result = gProxyManager.requestToken(ownerDN, ownerGroup, pilotsToSubmit * self.maxJobsInFillMode)
+    numberOfProcessors = queueDict.get('NumberOfProcessors', 1)
+    result = gProxyManager.requestToken(ownerDN, ownerGroup, pilotsToSubmit * numberOfProcessors)
     if not result['OK']:
       self.log.error('Invalid proxy token request', result['Message'])
       return [None, None]
-    (token, numberOfUses) = result['Value']
+    (token, _) = result['Value']
     pilotOptions.append('-o /Security/ProxyToken=%s' % token)
-    # Use Filling mode
-    pilotOptions.append('-M %s' % min(numberOfUses, self.maxJobsInFillMode))
 
-    # Since each pilot will execute min( numberOfUses, self.maxJobsInFillMode )
-    # with numberOfUses tokens we can submit at most:
-    #    numberOfUses / min( numberOfUses, self.maxJobsInFillMode )
-    # pilots
-    newPilotsToSubmit = numberOfUses / min(numberOfUses, self.maxJobsInFillMode)
-    if newPilotsToSubmit != pilotsToSubmit:
-      self.log.info("Number of pilots to submit is changed",
-                    "to %d after getting the proxy token" % newPilotsToSubmit)
-      pilotsToSubmit = newPilotsToSubmit
     # Debug
     if self.pilotLogLevel.lower() == 'debug':
       pilotOptions.append('-ddd')

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
@@ -62,9 +62,9 @@ def test__getPilotOptions(mocker):
                                                 'SubmitPool': ''}}}
   res = sd._getPilotOptions('aQueue', 10)
   assert res[0] == ['-S TestSetup', '-V 123', '-l 123',
-                    '-o /Security/ProxyToken=token', '-M 1', '-C T,e,s,t,S,e,t,u,p',
+                    '-o /Security/ProxyToken=token', '-C T,e,s,t,S,e,t,u,p',
                     '-e 1,2,3', '-N aCE', '-Q aQueue', '-n LCG.CERN.cern']
-  assert res[1] == 1
+  assert res[1] == 10
 
 
 @pytest.mark.parametrize("mockMatcherReturnValue, expected, anyExpected, sitesExpected", [

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
@@ -61,8 +61,7 @@ def test__getPilotOptions(mocker):
                                                 'Site': 'LCG.CERN.cern',
                                                 'SubmitPool': ''}}}
   res = sd._getPilotOptions('aQueue', 10)
-  assert res[0] == ['-S TestSetup', '-V 123', '-l 123',
-                    '-o /Security/ProxyToken=token', '-C T,e,s,t,S,e,t,u,p',
+  assert res[0] == ['-S TestSetup', '-V 123', '-l 123', '-C T,e,s,t,S,e,t,u,p',
                     '-e 1,2,3', '-N aCE', '-Q aQueue', '-n LCG.CERN.cern']
   assert res[1] == 10
 

--- a/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -201,8 +201,6 @@ Agents
 
     # The maximum length of a queue (in seconds). Default: 3 days
     MaxQueueLength = 259200
-    # The maximum number of jobs in filling mode
-    MaxJobsInFillMode = 5
     # Log level of the pilots
     PilotLogLevel = INFO
     # Max number of pilots to submit per cycle
@@ -236,7 +234,6 @@ Agents
     PollingTime = 120
     CETypes = CREAM
     Site = Any
-    MaxJobsInFillMode = 5
     PilotLogLevel = INFO
     GetPilotOutput = False
     UpdatePilotStatus = True

--- a/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -122,7 +122,6 @@ Agents
     StopOnApplicationFailure = true
     StopAfterFailedMatches = 10
     SubmissionDelay = 10
-    CEType = InProcess
     JobWrapperTemplate = DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapperTemplate.py
   }
   StalledJobAgent

--- a/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -102,7 +102,7 @@ class Watchdog(object):
     self.processors = processors
 
   #############################################################################
-  def initialize(self, loops=0):
+  def initialize(self):
     """ Watchdog initialization.
     """
     if self.initialized:
@@ -119,7 +119,6 @@ class Watchdog(object):
       return S_ERROR('Can not get the WorkloadManagement system instance')
     self.section = '/Systems/WorkloadManagement/%s/JobWrapper' % wms_instance
 
-    self.maxcount = loops
     self.log.verbose('Watchdog initialization')
     self.log.info('Attempting to Initialize Watchdog for: %s' % (self.systemFlag))
     # Test control flags

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -183,9 +183,8 @@ class PilotCStoJSONSynchronizer(object):
           continue
 
         for ce in ceList['Value']:
+          # This CEType is like 'HTCondor' or 'ARC' etc.
           ceType = gConfig.getValue('/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/CEType')
-          localCEType = gConfig.getValue('/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/LocalCEType')
-
           if ceType is None:
             # Skip but log it
             self.log.error('CE has no option CEType!', ce + ' at ' + site)
@@ -193,8 +192,19 @@ class PilotCStoJSONSynchronizer(object):
           else:
             pilotDict['CEs'][ce] = {'Site': site, 'GridCEType': ceType}
 
+          # This LocalCEType is like 'InProcess' or 'Pool' or 'Pool/Singularity' etc.
+          # It can be in the queue and/or the CE level
+          localCEType = gConfig.getValue(
+              '/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/LocalCEType')
           if localCEType is not None:
             pilotDict['CEs'][ce].setdefault('LocalCEType', localCEType)
+
+          queueList = gConfig.getSections('/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/Queues/')
+          for queue in queueList:
+            localCEType = gConfig.getValue(
+                '/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/' + queue + '/LocalCEType')
+            if localCEType is not None:
+              pilotDict['CEs'][ce][queue].setdefault('LocalCEType', localCEType)
 
     defaultSetup = gConfig.getValue('/DIRAC/DefaultSetup')
     if defaultSetup:

--- a/WorkloadManagementSystem/Utilities/QueueUtilities.py
+++ b/WorkloadManagementSystem/Utilities/QueueUtilities.py
@@ -64,7 +64,7 @@ def getQueuesResolved(siteDict):
             queueDict[parameter] = queueParameter
 
         # If we have a multi-core queue add MultiProcessor tag
-        if queueDict.get('NumberOfProcessors', 1) > 1:
+        if int(queueDict.get('NumberOfProcessors', 1)) > 1:
           queueDict.setdefault('Tag', []).append('MultiProcessor')
 
         queueDict['CEName'] = ce

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
@@ -38,7 +38,7 @@ The three strings are concatenated with "." to produce the name of the sites.
 CEs  sub-subsection
 -------------------
 
-This sub-subsection specify the attributes of each particular CE of the site. Must be noticed than in eachDRAC site can be more than one CE.
+This sub-subsection specifies the attributes of each particular CE of the site. For each DIRAC site there can be more than one CE.
 
 +------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 | **Name**                                       | **Description**                                             | **Example**                    |

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
@@ -50,10 +50,11 @@ This sub-subsection specify the attributes of each particular CE of the site. Mu
 | *<CE_NAME>/CEType*                             | Type of CE, can take values as LCG or CREAM                  | CEType = ARC                   |
 +------------------------------------------------+------------------------------------------------------------- +--------------------------------+
 | *<CE_NAME>/LocalCEType*                        | Type of 'Inner' CE, normally empty. Default = "InProcess".   | LocalCEType = Pool             |
-|                                                | Possibilities: potentially all CEs type, but in practice     |                                |
+|                                                | Possibilities: potentially all CE types, but in practice     |                                |
 |                                                | the most valid would be: InProcess, Sudo, Singularity, Pool. |                                |
 |                                                | Pool CE in turn uses InProcess (Default)                     |                                |
 |                                                | or Sudo or Singularity. To specify, use Pool/ce_type.        | LocalCEType = Pool/Singularity |
+|                                                | This option can also go at the Queue level.                  |                                |
 +------------------------------------------------+------------------------------------------------------------- +--------------------------------+
 | *<CE_NAME>/OS*                                 | CE operating system in a DIRAC format                        | OS = ScientificLinux_Boron_5.3 |
 +------------------------------------------------+------------------------------------------------------------- +--------------------------------+
@@ -97,7 +98,9 @@ This sub-subsection specify the attributes of each particular CE of the site. Mu
 | *<CE_NAME>/Queues/<QUEUE_NAME>/Tag*            | List of tags specific for the Queue                          | Tag = GPU,96RAM                |
 +------------------------------------------------+------------------------------------------------------------- +--------------------------------+
 | *<CE_NAME>/Queues/<QUEUE_NAME>/RequiredTag*    | List of required tags that a job to be eligible must have    | RequiredTag = GPU,96RAM        |
-+------------------------------------------------+-------------------------------------------------------------+--------------------------------+
++------------------------------------------------+--------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/LocalCEType*    | Same as *<CE_NAME>/LocalCEType* (see above) but per queue.   | LocalCEType = Pool/Singularity |
++------------------------------------------------+--------------------------------------------------------------+--------------------------------+
 
 
 An example for this session follows::
@@ -139,6 +142,8 @@ An example for this session follows::
                 MaxTotalJobs = 5000
                 MaxWaitingJobs = 200
                 maxCPUTime = 7776
+                LocalCEType = Pool/Singularity
+                Tag = MultiProcessor
               }
             }
             VO = lhcb

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Sites/index.rst
@@ -38,69 +38,69 @@ The three strings are concatenated with "." to produce the name of the sites.
 CEs  sub-subsection
 -------------------
 
-This sub-subsection specify the attributes of each particular CE of the site. Must be noticed than in each DIRAC site can be more than one CE.
+This sub-subsection specify the attributes of each particular CE of the site. Must be noticed than in eachDRAC site can be more than one CE.
 
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| **Name**                                       | **Description**                                              | **Example**                    |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>*                                    | Subsection named as the CE fully qualified name              | ce01.in2p3.fr                  |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/architecture*                       | CE architecture                                              | architecture = x86_64          |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/CEType*                             | Type of CE, can take values as LCG or CREAM                  | CEType = ARC                   |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/LocalCEType*                        | Type of 'Inner' CE, normally empty. Default = "InProcess".   | LocalCEType = Pool             |
-|                                                | Possibilities: potentially all CE types, but in practice     |                                |
-|                                                | the most valid would be: InProcess, Sudo, Singularity, Pool. |                                |
-|                                                | Pool CE in turn uses InProcess (Default)                     |                                |
-|                                                | or Sudo or Singularity. To specify, use Pool/ce_type.        | LocalCEType = Pool/Singularity |
-|                                                | This option can also go at the Queue level.                  |                                |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/OS*                                 | CE operating system in a DIRAC format                        | OS = ScientificLinux_Boron_5.3 |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Pilot*                              | Boolean attributes than indicates if the site accept pilots  | Pilot = True                   |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/SubmissionMode*                     | If the CE is a cream CE the mode of submission               | SubmissionMode = Direct        |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/wnTmpDir*                           | Worker node temporal directory                               | wnTmpDir = /tmp                |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/MaxProcessors*                      | Maximum number of available processors on worker nodes       | MaxProcessors = 12             |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/WholeNode*                          | CE allows *whole node* jobs                                  | WholeNode = True               |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Tag*                                | List of tags specific for the CE                             | Tag = GPU,96RAM                |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/RequiredTag*                        | List of required tags that a job to be eligible must have    | RequiredTag = GPU,96RAM        |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues*                             | Subsection. Queues available for this VO in the CE           | Queues                         |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>*                | Name of the queue exactly how is published                   | jobmanager-pbs-formation       |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/CEQueueName*    | Name of the queue in the corresponding CE if not the same    |                                |
-|                                                | as the name of the queue section                             | CEQueueName = pbs-grid         |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/maxCPUTime*     | Maximum time allowed to jobs to run in the queue             | maxCPUTime = 1440              |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/MaxTotalJobs*   | If the CE is a CREAM CE the maximum number of jobs in all    | MaxTotalJobs =200              |
-|                                                | the status                                                   |                                |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/MaxWaitingJobs* | If the CE is a CREAM CE the maximum number of jobs in        | MaxWaitingJobs = 70            |
-|                                                | waiting status                                               |                                |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/OutputURL*      | If the CE is a CREAM CE the URL where to find the outputs    | OutputURL = gsiftp://localhost |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/SI00*           | CE CPU Scaling Reference                                     | SI00 = 2130                    |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/MaxProcessors*  | overrides *<CE_NAME>/MaxProcessors* at queue level           | MaxProcessors = 12             |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/WholeNode*      | overrides *<CE_NAME>/WholeNode* at queue level               | WholeNode = True               |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/Tag*            | List of tags specific for the Queue                          | Tag = GPU,96RAM                |
-+------------------------------------------------+------------------------------------------------------------- +--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/RequiredTag*    | List of required tags that a job to be eligible must have    | RequiredTag = GPU,96RAM        |
-+------------------------------------------------+--------------------------------------------------------------+--------------------------------+
-| *<CE_NAME>/Queues/<QUEUE_NAME>/LocalCEType*    | Same as *<CE_NAME>/LocalCEType* (see above) but per queue.   | LocalCEType = Pool/Singularity |
-+------------------------------------------------+--------------------------------------------------------------+--------------------------------+
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| **Name**                                       | **Description**                                             | **Example**                    |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>*                                    | Subsection named as the CE fully qualified name             | ce01.in2p3.fr                  |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/architecture*                       | CE architecture                                             | architecture = x86_64          |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/CEType*                             | Type of CE, can take values as LCG or CREAM                 | CEType = ARC                   |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/LocalCEType*                        | Type of 'Inner' CE, normally empty. Default = "InProcess".  | LocalCEType = Pool             |
+|                                                | Possibilities: potentially all CE types, but in practice    |                                |
+|                                                | the most valid would be: InProcess, Sudo, Singularity, Pool.|                                |
+|                                                | Pool CE in turn uses InProcess (Default)                    |                                |
+|                                                | or Sudo or Singularity. To specify, use Pool/ce_type.       | LocalCEType = Pool/Singularity |
+|                                                | This option can also go at the Queue level.                 |                                |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/OS*                                 | CE operating system in a DIRAC format                       | OS = ScientificLinux_Boron_5.3 |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Pilot*                              | Boolean attributes than indicates if the site accept pilots | Pilot = True                   |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/SubmissionMode*                     | If the CE is a cream CE the mode of submission              | SubmissionMode = Direct        |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/wnTmpDir*                           | Worker node temporal directory                              | wnTmpDir = /tmp                |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/MaxProcessors*                      | Maximum number of available processors on worker nodes      | MaxProcessors = 12             |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/WholeNode*                          | CE allows *whole node* jobs                                 | WholeNode = True               |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Tag*                                | List of tags specific for the CE                            | Tag = GPU,96RAM                |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/RequiredTag*                        | List of required tags that a job to be eligible must have   | RequiredTag = GPU,96RAM        |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues*                             | Subsection. Queues available for this VO in the CE          | Queues                         |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>*                | Name of the queue exactly how is published                  | jobmanager-pbs-formation       |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/CEQueueName*    | Name of the queue in the corresponding CE if not the same   |                                |
+|                                                | as the name of the queue section                            | CEQueueName = pbs-grid         |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/maxCPUTime*     | Maximum time allowed to jobs to run in the queue            | maxCPUTime = 1440              |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/MaxTotalJobs*   | If the CE is a CREAM CE the maximum number of jobs in all   | MaxTotalJobs =200              |
+|                                                | the status                                                  |                                |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/MaxWaitingJobs* | If the CE is a CREAM CE the maximum number of jobs in       | MaxWaitingJobs = 70            |
+|                                                | waiting status                                              |                                |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/OutputURL*      | If the CE is a CREAM CE the URL where to find the outputs   | OutputURL = gsiftp://localhost |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/SI00*           | CE CPU Scaling Reference                                    | SI00 = 2130                    |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/MaxProcessors*  | overrides *<CE_NAME>/MaxProcessors* at queue level          | MaxProcessors = 12             |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/WholeNode*      | overrides *<CE_NAME>/WholeNode* at queue level              | WholeNode = True               |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/Tag*            | List of tags specific for the Queue                         | Tag = GPU,96RAM                |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/RequiredTag*    | List of required tags that a job to be eligible must have   | RequiredTag = GPU,96RAM        |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
+| *<CE_NAME>/Queues/<QUEUE_NAME>/LocalCEType*    | Same as *<CE_NAME>/LocalCEType* (see above) but per queue.  | LocalCEType = Pool/Singularity |
++------------------------------------------------+-------------------------------------------------------------+--------------------------------+
 
 
 An example for this session follows::


### PR DESCRIPTION
BEGINRELEASENOTES

*Configuration
CHANGE: Adding Pool as LocalCEType for MultiProcessor queues (invoked by BDII2CSAgent)

*WMS
CHANGE: JobAgent: getting CEType only from LocalSite/LocalCE config
CHANGE: JobAgent: flipped the default for fillingMode
CHANGE: SiteDirector: The max number of jobs in filling mode is not set anymore by the SD. The option MaxJobsInFillMode  was removed

*Core
FIX: ElasticSearchDB: fix exception handling when checking existence of indices

ENDRELEASENOTES
