### PR TITLE
[v7r1] Fix calling _monitorProxy as a periodic task

### DIFF
--- a/Resources/Computing/InProcessComputingElement.py
+++ b/Resources/Computing/InProcessComputingElement.py
@@ -57,7 +57,7 @@ class InProcessComputingElement(ComputingElement):
 
       self.log.verbose('Starting process for monitoring payload proxy')
       result = gThreadScheduler.addPeriodicTask(self.proxyCheckPeriod, self._monitorProxy,
-                                                taskArgs=(payloadProxy),
+                                                taskArgs=(payloadProxy,),
                                                 executions=0, elapsedTime=0)
       if result['OK']:
         renewTask = result['Value']

--- a/Resources/Computing/SingularityComputingElement.py
+++ b/Resources/Computing/SingularityComputingElement.py
@@ -403,7 +403,7 @@ class SingularityComputingElement(ComputingElement):
       # Now we have to set-up payload proxy renewal for the container
       # This is fairly easy as it remains visible on the host filesystem
       result = gThreadScheduler.addPeriodicTask(self.proxyCheckPeriod, self._monitorProxy,
-                                                taskArgs=(payloadProxyLoc),
+                                                taskArgs=(payloadProxyLoc,),
                                                 executions=0, elapsedTime=0)
       if result['OK']:
         renewTask = result['Value']


### PR DESCRIPTION
Fixes this issue seen in LHCb pilots:

```log
2021-01-29 03:33:39 UTC WorkloadManagement/JobAgent ERROR: Exception while executing scheduled task
Traceback (most recent call last):
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/v10r1p1/DIRAC/Core/Utilities/ThreadScheduler.py", line 188, in __executeTask
    task['func'](*task['args'])
TypeError: _monitorProxy() takes at most 2 arguments (15 given)
```


BEGINRELEASENOTES

*Resources
FIX:  Fix calling _monitorProxy as a periodic task 

ENDRELEASENOTES
