### PR TITLE
[v7r2] Prevent setuptools_scm from trying to use old style version tags

### DIFF
--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -45,6 +45,7 @@ dependencies:
   - coverage
   - hypothesis
   - ipython
+  - make
   - mock
   - parameterized
   - pylint >=1.6.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,5 @@ build-backend = "setuptools.build_meta"
 # Enable setuptools_scm to compute the version number from the most recent tag
 # https://github.com/pypa/setuptools_scm/#pyprojecttoml-usage
 [tool.setuptools_scm]
+# Avoid letting setuptools_scm use old style tags (i.e. vXrYpZ)
+git_describe_command = "git describe --dirty --tags --long --match *[0-9]* --exclude v[0-9]r* --exclude v[0-9][0-9]r*"


### PR DESCRIPTION
Also adds `make` to the Python 3 environment.yaml file to avoid issues building the docs in very lightweight docker containers.