### PR TITLE
[v7r1] CS.Client.Utilities: change exception caught to IndexError

### DIFF
--- a/ConfigurationSystem/Client/Utilities.py
+++ b/ConfigurationSystem/Client/Utilities.py
@@ -319,7 +319,7 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None, glue2=True):
           localCEType = queueDict.get('LocalCEType', 'InProcess')
           try:
             localCEType_inner = localCEType.split('/')[1]
-          except ValueError:
+          except IndexError:
             localCEType_inner = ''
 
           numberOfProcessors = int(queueDict.get('NumberOfProcessors', 0))


### PR DESCRIPTION
If there is no `/` in the string then an IndexError exeption comes up. @fstagni can there be a ValueError here as well?

BEGINRELEASENOTES

*CS
FIX:  CS.Client.Utilities: change exception caught to IndexError

ENDRELEASENOTES
