### PR TITLE
Revert "[v7r1] Absolute import to avoid conflicts with system modules"

### DIFF
--- a/Core/Utilities/CFG.py
+++ b/Core/Utilities/CFG.py
@@ -1,7 +1,6 @@
 """ This is the main module that interprets DIRAC cfg format
 """
 
-from __future__ import absolute_import
 from __future__ import print_function
 
 __RCSID__ = "$Id$"

--- a/Core/Utilities/DEncode.py
+++ b/Core/Utilities/DEncode.py
@@ -11,8 +11,6 @@ Encoding and decoding for dirac, Ids:
  t -> tuple
  d -> dictionary
 """
-
-from __future__ import absolute_import
 from __future__ import print_function
 __RCSID__ = "$Id$"
 

--- a/Core/Utilities/DErrno.py
+++ b/Core/Utilities/DErrno.py
@@ -37,9 +37,6 @@
                              DErrno.ERRX : ['An error message for ERRX that is specific to LHCb']}
 
 """
-
-from __future__ import absolute_import
-
 import six
 import os
 import imp

--- a/Core/Utilities/Decorators.py
+++ b/Core/Utilities/Decorators.py
@@ -1,9 +1,7 @@
 """ Decorators for DIRAC.
 """
 
-from __future__ import absolute_import
 from __future__ import print_function
-
 import os
 import inspect
 import functools

--- a/Core/Utilities/Devloader.py
+++ b/Core/Utilities/Devloader.py
@@ -1,8 +1,6 @@
 """ Here, we need some documentation...
 """
 
-from __future__ import absolute_import
-
 import sys
 import os
 import types

--- a/Core/Utilities/ExecutorDispatcher.py
+++ b/Core/Utilities/ExecutorDispatcher.py
@@ -1,8 +1,6 @@
 """ Used by the executors for dispatching events (IIUC)
 """
 
-from __future__ import absolute_import
-
 import threading
 import time
 

--- a/Core/Utilities/ExitCallback.py
+++ b/Core/Utilities/ExitCallback.py
@@ -1,16 +1,12 @@
 # $HeadURL$
-
-
-from __future__ import absolute_import
+__RCSID__ = "$Id$"
 
 import signal
 import os
 import sys
 
-__RCSID__ = "$Id$"
-
-
 gCallbackList = []
+
 
 def registerSignals():
   """

--- a/Core/Utilities/File.py
+++ b/Core/Utilities/File.py
@@ -4,7 +4,6 @@
    By default on Error they return None.
 """
 
-from __future__ import absolute_import
 from __future__ import print_function
 __RCSID__ = "$Id$"
 

--- a/Core/Utilities/Graphs/Graph.py
+++ b/Core/Utilities/Graphs/Graph.py
@@ -5,7 +5,6 @@
     CMS/Phedex Project by ... <to be added>
 """
 
-from __future__ import absolute_import
 from __future__ import print_function
 __RCSID__ = "$Id$"
 

--- a/Core/Utilities/Graphs/GraphData.py
+++ b/Core/Utilities/Graphs/GraphData.py
@@ -5,8 +5,6 @@
 """
 
 from __future__ import print_function
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
 
 import six

--- a/Core/Utilities/Graphs/GraphUtilities.py
+++ b/Core/Utilities/Graphs/GraphUtilities.py
@@ -5,9 +5,8 @@
     CMS/Phedex Project by ... <to be added>
 """
 
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
+
 
 import six
 import os

--- a/Core/Utilities/Grid.py
+++ b/Core/Utilities/Grid.py
@@ -2,8 +2,6 @@
 The Grid module contains several utilities for grid operations
 """
 
-from __future__ import absolute_import
-
 import six
 import os
 import re

--- a/Core/Utilities/LockRing.py
+++ b/Core/Utilities/LockRing.py
@@ -1,6 +1,5 @@
-from __future__ import print_function
-from __future__ import absolute_import
 
+from __future__ import print_function
 import random
 import time
 import threading
@@ -9,8 +8,6 @@ from hashlib import md5
 
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK
 from DIRAC.Core.Utilities.DIRACSingleton import DIRACSingleton
-
-__RCSID__ = "$Id$"
 
 
 class LockRing(object):

--- a/Core/Utilities/MJF.py
+++ b/Core/Utilities/MJF.py
@@ -7,8 +7,6 @@
     information.
 """
 
-from __future__ import absolute_import
-
 import os
 import ssl
 import time

--- a/Core/Utilities/Mail.py
+++ b/Core/Utilities/Mail.py
@@ -2,8 +2,6 @@
     Extremely simple utility class to send mails
 """
 
-from __future__ import absolute_import
-
 import six
 import os
 import socket

--- a/Core/Utilities/MemStat.py
+++ b/Core/Utilities/MemStat.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import
-
 import os
+
 
 def VmB(vmKey):
   __memScale = {'kB': 1024.0, 'mB': 1024.0 * 1024.0, 'KB': 1024.0, 'MB': 1024.0 * 1024.0}

--- a/Core/Utilities/MixedEncode.py
+++ b/Core/Utilities/MixedEncode.py
@@ -1,9 +1,6 @@
 """ Transition methods to allow to move from DEncode to JEncode
 
 """
-
-from __future__ import absolute_import
-
 import os
 from DIRAC.Core.Utilities import DEncode, JEncode
 

--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -148,8 +148,6 @@
 """
 
 from __future__ import print_function
-from __future__ import absolute_import
-
 import six
 import collections
 import time

--- a/Core/Utilities/NTP.py
+++ b/Core/Utilities/NTP.py
@@ -1,7 +1,4 @@
 # $HeadURL$
-
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
 
 from socket import socket, AF_INET, SOCK_DGRAM

--- a/Core/Utilities/Network.py
+++ b/Core/Utilities/Network.py
@@ -2,8 +2,7 @@
    Collection of DIRAC useful network related modules
    by default on Error they return None
 """
-
-from __future__ import absolute_import
+__RCSID__ = "$Id$"
 
 import socket
 import urlparse
@@ -14,8 +13,6 @@ import fcntl
 import platform
 
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
-
-__RCSID__ = "$Id$"
 
 
 def discoverInterfaces():

--- a/Core/Utilities/Os.py
+++ b/Core/Utilities/Os.py
@@ -3,7 +3,6 @@
    by default on Error they return None
 """
 
-from __future__ import absolute_import
 from __future__ import print_function
 from past.builtins import long
 import six

--- a/Core/Utilities/Pfn.py
+++ b/Core/Utilities/Pfn.py
@@ -9,8 +9,6 @@
 
 """
 
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
 
 # # imports

--- a/Core/Utilities/Platform.py
+++ b/Core/Utilities/Platform.py
@@ -2,10 +2,7 @@
 Compile the externals
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import unicode_literals, absolute_import, division, print_function
 
 import platform
 import sys

--- a/Core/Utilities/Plotting/DataCache.py
+++ b/Core/Utilities/Plotting/DataCache.py
@@ -1,8 +1,6 @@
 """ Accounting Cache
 """
 
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
 
 import os.path

--- a/Core/Utilities/ProcessPool.py
+++ b/Core/Utilities/ProcessPool.py
@@ -97,8 +97,6 @@ executing same type of callables in subprocesses and  hence you are expecting th
 everywhere.
 """
 
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
 
 import multiprocessing

--- a/Core/Utilities/Proxy.py
+++ b/Core/Utilities/Proxy.py
@@ -35,8 +35,6 @@ Utilities to execute one or more functions with a given proxy.
 
 """
 
-from __future__ import absolute_import
-
 import os
 
 from DIRAC import gConfig, gLogger, S_ERROR, S_OK

--- a/Core/Utilities/Subprocess.py
+++ b/Core/Utilities/Subprocess.py
@@ -27,7 +27,6 @@ set a timeout.
 
 """
 from __future__ import division
-from __future__ import absolute_import
 
 from multiprocessing import Process, Manager
 import threading

--- a/Core/Utilities/ThreadPool.py
+++ b/Core/Utilities/ThreadPool.py
@@ -69,8 +69,6 @@ soon as the requests have finished. To enable this mode call::
 
 """
 from __future__ import print_function
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
 
 import time

--- a/Core/Utilities/ThreadScheduler.py
+++ b/Core/Utilities/ThreadScheduler.py
@@ -1,6 +1,7 @@
 """ a scheduler of threads, of course!
 """
-from __future__ import absolute_import
+
+__RCSID__ = "$Id$"
 
 from past.builtins import long
 import hashlib
@@ -9,8 +10,6 @@ import time
 
 from DIRAC import S_ERROR, S_OK, gLogger
 from DIRAC.Core.Utilities.ThreadSafe import Synchronizer
-
-__RCSID__ = "$Id$"
 
 gSchedulerLock = Synchronizer()
 

--- a/FrameworkSystem/private/standardLogging/LogLevels.py
+++ b/FrameworkSystem/private/standardLogging/LogLevels.py
@@ -2,11 +2,9 @@
 LogLevels wrapper
 """
 
-from __future__ import absolute_import
+__RCSID__ = "$Id$"
 
 import logging
-
-__RCSID__ = "$Id$"
 
 
 class LogLevels(object):

--- a/FrameworkSystem/private/standardLogging/Logging.py
+++ b/FrameworkSystem/private/standardLogging/Logging.py
@@ -2,7 +2,7 @@
 Logging
 """
 
-from __future__ import absolute_import
+__RCSID__ = "$Id$"
 
 import logging
 import os
@@ -12,8 +12,6 @@ from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
 from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Core.Utilities.LockRing import LockRing
 from DIRAC.Resources.LogBackends.AbstractBackend import AbstractBackend
-
-__RCSID__ = "$Id$"
 
 
 class Logging(object):

--- a/FrameworkSystem/private/standardLogging/LoggingRoot.py
+++ b/FrameworkSystem/private/standardLogging/LoggingRoot.py
@@ -2,7 +2,6 @@
 Logging Root
 """
 
-from __future__ import absolute_import
 from __future__ import print_function
 __RCSID__ = "$Id$"
 

--- a/Interfaces/API/Dirac.py
+++ b/Interfaces/API/Dirac.py
@@ -15,7 +15,6 @@
 """
 
 from __future__ import print_function
-from __future__ import absolute_import
 __RCSID__ = "$Id$"
 
 from past.builtins import long

--- a/Interfaces/API/DiracAdmin.py
+++ b/Interfaces/API/DiracAdmin.py
@@ -6,8 +6,6 @@ site banning and unbanning, WMS proxy uploading etc.
 """
 
 from __future__ import print_function
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
 
 import six

--- a/Interfaces/API/Job.py
+++ b/Interfaces/API/Job.py
@@ -23,8 +23,6 @@
    Note that several executables can be provided and wil be executed sequentially.
 """
 
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
 
 import six

--- a/Interfaces/API/JobRepository.py
+++ b/Interfaces/API/JobRepository.py
@@ -1,7 +1,5 @@
 """ This is the Job Repository which stores and manipulates DIRAC job metadata in CFG format """
 
-from __future__ import absolute_import
-
 __RCSID__ = "$Id$"
 
 from DIRAC import gLogger, S_OK, S_ERROR


### PR DESCRIPTION
Reverts DIRACGrid/DIRAC#4919

These changes have nasty side effects wherever dynamic loading is done. It broke the LHCbDIRAC CI.  Example of such places is https://github.com/DIRACGrid/DIRAC/blob/b47d9319debd0c0464660aa1ce3a15fe47a51043/Core/Utilities/Graphs/Graph.py#L280
Instead of trying to hunt down every little corner like that one (which is anyway impossible), I'd rather just revert and wait for v7r2 to be out, with its proper implementation of absolute import. 
We have lived like this for many years, so it shouldn't be a problem.

Please merge asap, we are blocked in our releases because broken CI