### PR TITLE
[v7r1] Some fixes for scripts

### DIFF
--- a/Core/scripts/dirac-install-extension.py
+++ b/Core/scripts/dirac-install-extension.py
@@ -10,12 +10,13 @@ Usage::
 
 """
 
-from __future__ import unicode_literals, absolute_import, division, print_function
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
 
 import os
 import sys
 import six
-import time
 import getopt
 import importlib
 

--- a/Core/scripts/dirac-platform.py
+++ b/Core/scripts/dirac-platform.py
@@ -29,7 +29,9 @@ __RCSID__ = "$Id$"
 import sys
 import argparse
 
-parser = argparse.ArgumentParser(usage=__doc__)
+parser = argparse.ArgumentParser(
+    description=__doc__,
+    formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.parse_known_args()
 
 try:

--- a/Core/scripts/dirac-platform.py
+++ b/Core/scripts/dirac-platform.py
@@ -27,17 +27,10 @@ from __future__ import print_function
 __RCSID__ = "$Id$"
 
 import sys
-import getopt
+import argparse
 
-cmdOpt = ('h', 'help', 'help doc string')
-
-optList, args = getopt.getopt(sys.argv[1:], cmdOpt[0], cmdOpt[1])
-for opt, value in optList:
-  if opt in ('-h', '--help'):
-    print(__doc__)
-    print('Options::\n\n')
-    print("  %s %s : %s" % (cmdOpt[0].ljust(3), cmdOpt[1].ljust(20), cmdOpt[2]))
-    sys.exit(0)
+parser = argparse.ArgumentParser(usage=__doc__)
+parser.parse_known_args()
 
 try:
   from DIRAC.Core.Utilities.Platform import getPlatformString

--- a/Core/scripts/dirac-version.py
+++ b/Core/scripts/dirac-version.py
@@ -19,18 +19,10 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
-import sys
-import getopt
+import argparse
 
-cmdOpt = ('h', 'help', 'help doc string')
-
-optList, args = getopt.getopt(sys.argv[1:], cmdOpt[0], cmdOpt[1])
-for opt, value in optList:
-  if opt in ('-h', '--help'):
-    print(__doc__)
-    print('Options::\n\n')
-    print("  %s %s : %s" % (cmdOpt[0].ljust(3), cmdOpt[1].ljust(20), cmdOpt[2]))
-    sys.exit(0)
+parser = argparse.ArgumentParser(usage=__doc__)
+parser.parse_known_args()
 
 import DIRAC
 print(DIRAC.version)

--- a/Core/scripts/dirac-version.py
+++ b/Core/scripts/dirac-version.py
@@ -21,7 +21,9 @@ __RCSID__ = "$Id$"
 
 import argparse
 
-parser = argparse.ArgumentParser(usage=__doc__)
+parser = argparse.ArgumentParser(
+    description=__doc__,
+    formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.parse_known_args()
 
 import DIRAC

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -180,9 +180,8 @@ class JobAgent(AgentModule):
       if runningJobs:
         self.log.info('No available slots', '%d running jobs' % runningJobs)
         return S_OK('Job Agent cycle complete with %d running jobs' % runningJobs)
-      else:
-        self.log.info('CE is not available')
-        return self.__finish('CE Not Available')
+      self.log.info('CE is not available (and there are no running jobs)')
+      return self.__finish('CE Not Available')
 
     result = self.computingElement.getDescription()
     if not result['OK']:
@@ -613,8 +612,8 @@ class JobAgent(AgentModule):
                     'with message "%s", execution complete.' % message)
       self.am_stopExecution()
       return S_ERROR(message)
-    else:
-      return S_OK(message)
+
+    return S_OK(message)
 
   #############################################################################
   def _rescheduleFailedJob(self, jobID, message, stop=True):

--- a/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
+++ b/WorkloadManagementSystem/Utilities/PilotCStoJSONSynchronizer.py
@@ -199,12 +199,17 @@ class PilotCStoJSONSynchronizer(object):
           if localCEType is not None:
             pilotDict['CEs'][ce].setdefault('LocalCEType', localCEType)
 
-          queueList = gConfig.getSections('/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/Queues/')
+          res = gConfig.getSections('/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/Queues/')
+          if not res['OK']:
+            # Skip but log it
+            self.log.error("No queues found for CE", ce + ': ' + res['Message'])
+            continue
+          queueList = res['Value']
           for queue in queueList:
             localCEType = gConfig.getValue(
-                '/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/' + queue + '/LocalCEType')
+                '/Resources/Sites/' + grid + '/' + site + '/CEs/' + ce + '/Queues/' + queue + '/LocalCEType')
             if localCEType is not None:
-              pilotDict['CEs'][ce][queue].setdefault('LocalCEType', localCEType)
+              pilotDict['CEs'][ce].setdefault(queue, {'LocalCEType': localCEType})
 
     defaultSetup = gConfig.getValue('/DIRAC/DefaultSetup')
     if defaultSetup:


### PR DESCRIPTION
This fixes a minor compatibility issue with the way the DIRAC pilot invokes the dirac-platform script (seen in https://jenkins-dirac.web.cern.ch/view/DIRAC/job/Pilot3_CVM4_pipeline/106/console which might be a problem for VMDIRAC)


BEGINRELEASENOTES

*Core
CHANGE: using argparse for a few scripts instead of getopt

ENDRELEASENOTES
