### PR TITLE
[v7r1] Add FTSOnly and ExcludeSE options to dirac-dms-protocol-matrix

### DIFF
--- a/DataManagementSystem/Client/FTS3Job.py
+++ b/DataManagementSystem/Client/FTS3Job.py
@@ -410,6 +410,7 @@ class FTS3Job(JSerializable):
                        bring_online=bring_online,
                        copy_pin_lifetime=copy_pin_lifetime,
                        retry=3,
+                       verify_checksum='target',  # Only check target vs specified, since we verify the source earlier
                        multihop=bool(allStageURLs),  # if we have stage urls, then we need multihop
                        metadata=job_metadata,
                        priority=self.priority)

--- a/RequestManagementSystem/Client/ReqClient.py
+++ b/RequestManagementSystem/Client/ReqClient.py
@@ -502,12 +502,13 @@ def printFTSJobs(request):
             for fts3Op in res['Value']:
               associatedFTS3Jobs.extend(fts3Op.ftsJobs)
         if associatedFTS3Jobs:
+          # Display the direct url and the status
           gLogger.always(
               '\n\nFTS3 jobs associated: \n%s' %
               '\n'.join(
-                  '%s@%s (%s)' %
-                  (job.ftsGUID,
-                   job.ftsServer,
+                  '%s/fts3/ftsmon/#/job/%s (%s)' %
+                  (job.ftsServer.replace(':8446', ':8449'),  # Submission port is 8446, web port is 8449
+                   job.ftsGUID,
                    job.status) for job in associatedFTS3Jobs))
         return
 


### PR DESCRIPTION
@andresailer  dc0b6d3 should please you :-D

@atsareg since this adds some script modification, it may need special attention when you propagate upstream

BEGINRELEASENOTES

*DMS
FIX: FTS3 explicitly use verify_checksum
NEW: add ``--FTSOnly`` and ``--ExcludeSE`` options to dirac-dms-protocol-matrix

*RMS
CHANGE: ReqClient prints the FTS3 job url directly

ENDRELEASENOTES


