### PR TITLE
[v7r1]  Backward compatibility fix for group less proxy

### DIFF
--- a/FrameworkSystem/DB/ProxyDB.py
+++ b/FrameworkSystem/DB/ProxyDB.py
@@ -1387,11 +1387,6 @@ Dear %s,
 
   DN:    %s
 
-  If you plan on keep using this credentials please upload a newer proxy to
-  DIRAC by executing:
-
-  $ dirac-proxy-init --upload
-
   If you have been issued different certificate, please make sure you have a
   proxy uploaded with that certificate.
 

--- a/FrameworkSystem/scripts/dirac-proxy-init.py
+++ b/FrameworkSystem/scripts/dirac-proxy-init.py
@@ -33,23 +33,32 @@ from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClie
 __RCSID__ = "$Id$"
 Script.setUsageMessage(__doc__)
 
+
 class Params(ProxyGeneration.CLIParams):
 
   addVOMSExt = False
-  uploadProxy = False
+  uploadProxy = True
   uploadPilot = False
 
   def setVOMSExt(self, _arg):
     self.addVOMSExt = True
     return S_OK()
 
-  def setUploadProxy(self, _arg):
-    self.uploadProxy = True
+  def disableProxyUpload(self, _arg):
+    self.uploadProxy = False
     return S_OK()
 
   def registerCLISwitches(self):
     ProxyGeneration.CLIParams.registerCLISwitches(self)
-    Script.registerSwitch("U", "upload", "Upload a long lived proxy to the ProxyManager", self.setUploadProxy)
+    Script.registerSwitch(
+        "U",
+        "upload",
+        "Upload a long lived proxy to the ProxyManager (deprecated, see --no-upload)")
+    Script.registerSwitch(
+        "N",
+        "no-upload",
+        "Do not upload a long lived proxy to the ProxyManager",
+        self.disableProxyUpload)
     Script.registerSwitch("M", "VOMS", "Add voms extension", self.setVOMSExt)
 
 
@@ -149,7 +158,7 @@ class ProxyInit(object):
     resultProxyUpload = ProxyUpload.uploadProxy(upParams)
     if not resultProxyUpload['OK']:
       gLogger.error(resultProxyUpload['Message'])
-      sys.exit(1)
+      return resultProxyUpload
     self.__uploadedInfo = resultProxyUpload['Value']
     gLogger.info("Proxy uploaded")
     return S_OK()

--- a/docs/source/AdministratorGuide/Tutorials/managingIdentities.rst
+++ b/docs/source/AdministratorGuide/Tutorials/managingIdentities.rst
@@ -63,7 +63,7 @@ Testing the ``ProxyManager``
 
 The simplest way to test it is to upload your user proxy::
 
-  [diracuser@dirac-tuto ~]$ dirac-proxy-init -U
+  [diracuser@dirac-tuto ~]$ dirac-proxy-init
   Generating proxy...
   Uploading proxy for dirac_user...
   Proxy generated:

--- a/tests/Integration/Framework/Test_Proxy.sh
+++ b/tests/Integration/Framework/Test_Proxy.sh
@@ -19,9 +19,9 @@ echo
 echo
 
 echo "================================"
-echo "===  dirac-proxy-init $PARAMS -U"
+echo "===  dirac-proxy-init $PARAMS"
 echo
-dirac-proxy-init $PARAMS -U
+dirac-proxy-init $PARAMS
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi
@@ -64,9 +64,9 @@ fi
 echo
 
 echo "==============================================="
-echo "===  dirac-proxy-init -g dirac_admin $PARAMS -U"
+echo "===  dirac-proxy-init -g dirac_admin $PARAMS"
 echo
-dirac-proxy-init -g dirac_admin $PARAMS -U
+dirac-proxy-init -g dirac_admin $PARAMS
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -709,12 +709,12 @@ diracUserAndGroup() {
 diracProxies() {
   echo '==> [diracProxies]'
   # User proxy, should be uploaded anyway
-  if ! dirac-proxy-init -U -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" --rfc "${DEBUG}"; then
+  if ! dirac-proxy-init -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" --rfc "${DEBUG}"; then
     echo 'ERROR: dirac-proxy-init failed' >&2
     exit 1
   fi
   # group proxy, will be uploaded explicitly
-  if ! dirac-proxy-init -U -g prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" --rfc "${DEBUG}"; then
+  if ! dirac-proxy-init -g prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" --rfc "${DEBUG}"; then
     echo 'ERROR: dirac-proxy-init failed' >&2
     exit 1
   fi


### PR DESCRIPTION
The change for `dirac-proxy-init` is needed because before, groups that would have the `AutoUploadProxy=True` set in the CS were automatically uploaded. This check is not here anymore, and do not make so much sense. The net result is that some users could 
- create a proxy
- Create jobs
- Jobs will be rescheduled because no proxy uploaded (I remind you about that, if one wants to reconsider https://github.com/DIRACGrid/DIRAC/pull/4558 )

So this PR changes the default, and always upload a proxy, unless `--no-upload` is specified

The other change is for backward compatibility purpose, as long as we are going to have proxies with groups in the DB. 

BEGINRELEASENOTES

*Framework
CHANGE: dirac-proxy-init always uploads the proxy unless --no-upload is specified
FIX: ProxyManagerClient checks for group and groupless proxies in its cache

ENDRELEASENOTES

Fixes #4963 
Fixes #4962 