### PR TITLE
[v7r1] resorting to calculate time left with info in possession

### DIFF
--- a/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
@@ -4,8 +4,6 @@
 
 __RCSID__ = "$Id$"
 
-import os
-
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Resources.Computing.BatchSystems.TimeLeft.TimeLeft import runCommand
 from DIRAC.Resources.Computing.BatchSystems.TimeLeft.ResourceUsage import ResourceUsage
@@ -53,7 +51,7 @@ class SLURMResourceUsage(ResourceUsage):
       cpu = float(cpu)
 
     consumed = {'CPU': wallClock,
-                'CPULimit': wallClockLimit,
+                'CPULimit': cpuLimit,
                 'WallClock': wallClock,
                 'WallClockLimit': wallClockLimit}
 


### PR DESCRIPTION
This PR pushes the "filling mode" (more than 1 job/pilot) by always resorting to calculate the time left with the info in our possession. Basically, if we can't get such info from the batch system, we use just `os.times()` and what we know. This should improve the situation for the case of e.g. Condor.

BEGINRELEASENOTES

*WMS
CHANGE: resorting to calculate time left with info in possession

ENDRELEASENOTES
