### PR TITLE
[v7r0] Allow to change SSL methods and ciphers with M2Crypto

### DIFF
--- a/Core/DISET/__init__.py
+++ b/Core/DISET/__init__.py
@@ -7,6 +7,18 @@ __RCSID__ = "$Id$"
 DEFAULT_RPC_TIMEOUT = 600
 #: Default timeout to establish a connection
 DEFAULT_CONNECTION_TIMEOUT = 10
+
+#: Default SSL Ciher accepted. Current default is for pyGSI/M2crypto compatibility
+#: Can be changed with DIRAC_M2CRYPTO_SSL_CIPHERS
+#: Recommandation (incompatible with pyGSI)
+# pylint: disable=line-too-long
+#: AES256-GCM-SHA384:AES256-SHA256:AES128-GCM-SHA256:AES128-SHA256:HIGH:MEDIUM:RSA:!3DES:!RC4:!aNULL:!eNULL:!MD5:!SEED:!IDEA:!SHA # noqa
+# Cipher line should be as readable as possible, sorry pylint
+# pylint: disable=line-too-long
+DEFAULT_SSL_CIPHERS = 'AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:CAMELLIA256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:HIGH:MEDIUM:RSA:!3DES:!RC4:!aNULL:!eNULL:!MD5:!SEED:!IDEA'  # noqa
+
 #: Default SSL methods accepted. Current default accepts TLSv1 for pyGSI/M2crypto compatibility
 #: Can be changed with DIRAC_M2CRYPTO_SSL_METHODS
+#: Recommandation (incompatible with pyGSI)
+# TLSv2:TLSv3
 DEFAULT_SSL_METHODS = 'TLSv1:TLSv2:TLSv3'

--- a/Core/DISET/__init__.py
+++ b/Core/DISET/__init__.py
@@ -7,3 +7,6 @@ __RCSID__ = "$Id$"
 DEFAULT_RPC_TIMEOUT = 600
 #: Default timeout to establish a connection
 DEFAULT_CONNECTION_TIMEOUT = 10
+#: Default SSL methods accepted. Current default accepts TLSv1 for pyGSI/M2crypto compatibility
+#: Can be changed with DIRAC_M2CRYPTO_SSL_METHODS
+DEFAULT_SSL_METHODS = 'TLSv1:TLSv2:TLSv3'

--- a/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/Core/DISET/private/Transports/M2SSLTransport.py
@@ -79,9 +79,12 @@ class SSLTransport(BaseTransport):
 
     # If not specified in the arguments (never is in DIRAC code...)
     # and we are setting up a server listing connection, set the accepted
-    # ssl methods
-    if kwargs.get('bServerMode') and 'sslMethods' not in kwargs:
-      kwargs['sslMethods'] = os.environ.get('DIRAC_M2CRYPTO_SSL_METHODS')
+    # ssl methods and ciphers
+    if kwargs.get('bServerMode'):
+      if 'sslMethods' not in kwargs:
+        kwargs['sslMethods'] = os.environ.get('DIRAC_M2CRYPTO_SSL_METHODS')
+      if 'sslCiphers' not in kwargs:
+        kwargs['sslCiphers'] = os.environ.get('DIRAC_M2CRYPTO_SSL_CIPHERS')
 
     self.__ctx = kwargs.pop('ctx', None)
     if not self.__ctx:

--- a/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/Core/DISET/private/Transports/M2SSLTransport.py
@@ -77,6 +77,12 @@ class SSLTransport(BaseTransport):
 
     self.__locked = False  # We don't support locking, so this is always false.
 
+    # If not specified in the arguments (never is in DIRAC code...)
+    # and we are setting up a server listing connection, set the accepted
+    # ssl methods
+    if kwargs.get('bServerMode') and 'sslMethods' not in kwargs:
+      kwargs['sslMethods'] = os.environ.get('DIRAC_M2CRYPTO_SSL_METHODS')
+
     self.__ctx = kwargs.pop('ctx', None)
     if not self.__ctx:
       self.__ctx = getM2SSLContext(**kwargs)

--- a/Core/DISET/private/Transports/SSL/M2Utils.py
+++ b/Core/DISET/private/Transports/SSL/M2Utils.py
@@ -6,6 +6,7 @@ Utilities for using M2Crypto SSL with DIRAC.
 import os
 from M2Crypto import SSL, m2
 
+from DIRAC.Core.DISET import DEFAULT_SSL_METHODS
 from DIRAC.Core.Security import Locations
 from DIRAC.Core.Security.m2crypto.X509Chain import X509Chain
 
@@ -63,7 +64,7 @@ def getM2SSLContext(ctx=None, **kwargs):
         - proxyLocation: String, Path to file to use as proxy, defaults to
                                  usual location(s) if not set.
         - skipCACheck: Boolean, if True, don't verify peer certificates.
-        - sslMethod: String, List of SSL algorithms to enable in OpenSSL style
+        - sslMethods: String, List of SSL algorithms to enable in OpenSSL style
                               cipher format, e.g. "SSLv3:TLSv1".
         - sslCiphers: String, OpenSSL style cipher string of ciphers to allow
                               on this connection.
@@ -120,15 +121,15 @@ def getM2SSLContext(ctx=None, **kwargs):
     ctx.get_cert_store().set_flags(SSL.verify_allow_proxy_certs)  # pylint: disable=no-member
 
   # Other parameters
-  sslMethod = kwargs.get('sslMethod', None)
-  if sslMethod:
+  sslMethods = kwargs.get('sslMethods', DEFAULT_SSL_METHODS)
+  if sslMethods:
     # Pylint can't see the m2 constants due to the way the library is loaded
     # We just have to disable that warning for the next bit...
     # pylint: disable=no-member
     methods = [('SSLv2', m2.SSL_OP_NO_SSLv2),
                ('SSLv3', m2.SSL_OP_NO_SSLv3),
                ('TLSv1', m2.SSL_OP_NO_TLSv1)]
-    allowed_methods = sslMethod.split(':')
+    allowed_methods = sslMethods.split(':')
     # If a method isn't explicitly allowed, set the flag to disable it...
     for method, method_flag in methods:
       if method not in allowed_methods:

--- a/Core/DISET/private/Transports/SSL/M2Utils.py
+++ b/Core/DISET/private/Transports/SSL/M2Utils.py
@@ -6,14 +6,10 @@ Utilities for using M2Crypto SSL with DIRAC.
 import os
 from M2Crypto import SSL, m2
 
-from DIRAC.Core.DISET import DEFAULT_SSL_METHODS
+from DIRAC.Core.DISET import DEFAULT_SSL_CIPHERS, DEFAULT_SSL_METHODS
 from DIRAC.Core.Security import Locations
 from DIRAC.Core.Security.m2crypto.X509Chain import X509Chain
 
-# Default ciphers to use if unspecified
-# Cipher line should be as readable as possible, sorry pylint
-# pylint: disable=line-too-long
-DEFAULT_SSL_CIPHERS = "AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:CAMELLIA256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:HIGH:MEDIUM:RSA:!3DES:!RC4:!aNULL:!eNULL:!MD5:!SEED:!IDEA"  # noqa
 # Verify depth of peer certs
 VERIFY_DEPTH = 50
 

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -25,6 +25,9 @@ DIRAC_GFAL_GRIDFTP_SESSION_REUSE
 DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
   If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
 
+DIRAC_M2CRYPTO_SSL_CIPHERS
+  If set, overwrites the default SSL ciphers accepted. It should be a column separated list. See :py:mod:`DIRAC.Core.DISET`
+
 DIRAC_M2CRYPTO_SSL_METHODS
   If set, overwrites the default SSL methods accepted. It should be a column separated list. See :py:mod:`DIRAC.Core.DISET`
 

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -25,6 +25,9 @@ DIRAC_GFAL_GRIDFTP_SESSION_REUSE
 DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
   If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
 
+DIRAC_M2CRYPTO_SSL_METHODS
+  If set, overwrites the default SSL methods accepted. It should be a column separated list. See :py:mod:`DIRAC.Core.DISET`
+
 DIRAC_NO_CFG
   If set to anything, cfg files on the command line must be passed to the command using the --cfg option.
 


### PR DESCRIPTION
BEGINRELEASENOTES
*Core
NEW: introduce DIRAC_M2CRYPTO_SSL_METHODS to configure accepted protocols
NEW: introduce DIRAC_M2CRYPTO_SSL_CIPHERS to configure accepted ciphers

ENDRELEASENOTES