### PR TITLE
[v7r1] TimeLeft and JobAgent changes

### DIFF
--- a/Resources/Computing/BatchSystems/TimeLeft/HTCondorResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/HTCondorResourceUsage.py
@@ -1,0 +1,69 @@
+""" The HTCondor TimeLeft utility interrogates the HTCondor batch system for the
+    current CPU consumed, as well as its limit.
+"""
+
+__RCSID__ = "$Id$"
+
+import os
+
+from DIRAC import S_OK, S_ERROR
+from DIRAC.Resources.Computing.BatchSystems.TimeLeft.TimeLeft import runCommand
+from DIRAC.Resources.Computing.BatchSystems.TimeLeft.ResourceUsage import ResourceUsage
+
+
+class HTCondorResourceUsage(ResourceUsage):
+  """
+   This is the HTCondor plugin of the TimeLeft Utility.
+   HTCondor does not provide any way to get the wallclock/cpu limit, the batch system just provides fair-sharing to
+   users and groups: the limit depends on many parameters.
+   However, some Sites have introduced a MaxRuntime variable that sets a wallclock time limit to the allocations and
+   allow us to get an estimation of the resources usage.
+  """
+
+  def __init__(self):
+    """ Standard constructor
+    """
+    super(HTCondorResourceUsage, self).__init__('HTCondor', '_CONDOR_JOB_AD')
+
+  def getResourceUsage(self):
+    """ Returns a dictionary containing WallClockConsumed and WallClockLimit for current slot.
+        All values returned in seconds.
+    """
+    # $_CONDOR_JOB_AD corresponds to the path to the .job.ad file
+    # It contains info about the job:
+    # - MaxRuntime: wallclock time allocated to the job - not officially supported by HTCondor,
+    #   only present on some Sites
+    # - CurrentTime: current time
+    # - JobCurrentStartDate: start of the job execution
+    cmd = 'condor_status -ads $_CONDOR_JOB_AD -af MaxRuntime CurrentTime-JobCurrentStartDate'
+    result = runCommand(cmd)
+    if not result['OK']:
+      return S_ERROR('Current batch system is not supported')
+
+    output = str(result['Value']).split(' ')
+    if len(output) != 2:
+      self.log.warn("Cannot open $_CONDOR_JOB_AD: output probably empty")
+      return S_ERROR('Current batch system is not supported')
+
+    wallClockLimit = output[0]
+    wallClock = output[1]
+    if wallClockLimit == 'undefined':
+      self.log.warn("MaxRuntime attribute is not supported")
+      return S_ERROR('Current batch system is not supported')
+
+    wallClockLimit = float(wallClockLimit)
+    wallClock = float(wallClock)
+
+    consumed = {'WallClock': wallClock,
+                'WallClockLimit': wallClockLimit,
+                'Unit': 'WallClock'}
+
+    if None not in consumed.values():
+      self.log.debug("TimeLeft counters complete:", str(consumed))
+      return S_OK(consumed)
+    else:
+      missed = [key for key, val in consumed.items() if val is None]
+      msg = 'Could not determine parameter'
+      self.log.warn('Could not determine parameter', ','.join(missed))
+      self.log.debug('This is the stdout from the batch system call\n%s' % (result['Value']))
+      return S_ERROR(msg)

--- a/Resources/Computing/BatchSystems/TimeLeft/HTCondorResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/HTCondorResourceUsage.py
@@ -26,8 +26,7 @@ class HTCondorResourceUsage(ResourceUsage):
     super(HTCondorResourceUsage, self).__init__('HTCondor', '_CONDOR_JOB_AD')
 
   def getResourceUsage(self):
-    """ Returns a dictionary containing WallClockConsumed and WallClockLimit for current slot.
-        All values returned in seconds.
+    """ Returns S_OK with a dictionary containing the entries WallClock, WallClockLimit, and Unit for current slot.
     """
     # $_CONDOR_JOB_AD corresponds to the path to the .job.ad file
     # It contains info about the job:
@@ -58,12 +57,5 @@ class HTCondorResourceUsage(ResourceUsage):
                 'WallClockLimit': wallClockLimit,
                 'Unit': 'WallClock'}
 
-    if None not in consumed.values():
-      self.log.debug("TimeLeft counters complete:", str(consumed))
-      return S_OK(consumed)
-    else:
-      missed = [key for key, val in consumed.items() if val is None]
-      msg = 'Could not determine parameter'
-      self.log.warn('Could not determine parameter', ','.join(missed))
-      self.log.debug('This is the stdout from the batch system call\n%s' % (result['Value']))
-      return S_ERROR(msg)
+    self.log.debug("TimeLeft counters complete:", str(consumed))
+    return S_OK(consumed)

--- a/Resources/Computing/BatchSystems/TimeLeft/LSFResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/LSFResourceUsage.py
@@ -193,8 +193,8 @@ class LSFResourceUsage(ResourceUsage):
 
   #############################################################################
   def getResourceUsage(self):
-    """Returns a dictionary containing CPUConsumed, CPULimit, WallClockConsumed
-       and WallClockLimit for current slot.  All values returned in seconds.
+    """ Returns S_OK with a dictionary containing the entries CPU, CPULimit,
+        WallClock, WallClockLimit, and Unit for current slot.
     """
     if not self.bin:
       return S_ERROR('Could not determine bin directory for LSF')

--- a/Resources/Computing/BatchSystems/TimeLeft/MJFResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/MJFResourceUsage.py
@@ -30,8 +30,8 @@ class MJFResourceUsage(ResourceUsage):
 
   #############################################################################
   def getResourceUsage(self):
-    """Returns a dictionary containing CPUConsumed, CPULimit, WallClockConsumed
-       and WallClockLimit for current slot.  All values returned in seconds.
+    """ Returns S_OK with a dictionary containing the entries CPU, CPULimit,
+        WallClock, WallClockLimit, and Unit for current slot.
     """
 
     cpuLimit = None

--- a/Resources/Computing/BatchSystems/TimeLeft/PBSResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/PBSResourceUsage.py
@@ -33,8 +33,8 @@ class PBSResourceUsage(ResourceUsage):
 
   #############################################################################
   def getResourceUsage(self):
-    """Returns a dictionary containing CPUConsumed, CPULimit, WallClockConsumed
-       and WallClockLimit for current slot.  All values returned in seconds.
+    """ Returns S_OK with a dictionary containing the entries CPU, CPULimit,
+        WallClock, WallClockLimit, and Unit for current slot.
     """
     cmd = 'qstat -f %s' % (self.jobID)
     result = runCommand(cmd)

--- a/Resources/Computing/BatchSystems/TimeLeft/ResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/ResourceUsage.py
@@ -19,11 +19,15 @@ class ResourceUsage(object):
     self.jobID = os.environ.get(jobIdEnvVar)
 
   def getResourceUsage(self):
-    """ Returns a dictionary that can contain CPUConsumed, CPULimit, WallClockConsumed
-        and WallClockLimit for current slot.  All values returned in seconds.
-        The dictionary can also contain Unit indicating whether the Batch System allocates
-        resources with limited CPU time and or Wallclock time.
+    """ Returns S_OK with a dictionary that can contain entries:
 
-        :return: dict such as {cpuConsumed, cpuLimit, wallClockConsumed, wallClockLimit, unit}
+        - CPU: the CPU time consumed since the beginning of the execution for current slot (seconds)
+        - CPULimit: the CPU time limit for current slot (seconds)
+        - WallClock: the wall clock time consumed since the beginning of the execution for current slot (seconds)
+        - WallClockLimit: the wall clock time limit for current slot (seconds)
+        - Unit: indicates whether the Batch System allocates resources with limited CPU time and/or wallclock time
+          Unit can take the following values: 'CPU', 'WallClock' or 'Both'.
+
+        :return: dict such as {CPU, CPULimit, WallClock, WallClockLimit, Unit}
     """
     raise NotImplementedError("getResourceUsage not implemented")

--- a/Resources/Computing/BatchSystems/TimeLeft/ResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/ResourceUsage.py
@@ -19,9 +19,11 @@ class ResourceUsage(object):
     self.jobID = os.environ.get(jobIdEnvVar)
 
   def getResourceUsage(self):
-    """ Returns a dictionary containing CPUConsumed, CPULimit, WallClockConsumed
+    """ Returns a dictionary that can contain CPUConsumed, CPULimit, WallClockConsumed
         and WallClockLimit for current slot.  All values returned in seconds.
+        The dictionary can also contain Unit indicating whether the Batch System allocates
+        resources with limited CPU time and or Wallclock time.
 
-        :return: dict such as {cpuConsumed, cpuLimit, wallClockConsumed, wallClockLimit}
+        :return: dict such as {cpuConsumed, cpuLimit, wallClockConsumed, wallClockLimit, unit}
     """
     raise NotImplementedError("getResourceUsage not implemented")

--- a/Resources/Computing/BatchSystems/TimeLeft/SGEResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/SGEResourceUsage.py
@@ -35,8 +35,8 @@ class SGEResourceUsage(ResourceUsage):
 
   #############################################################################
   def getResourceUsage(self):
-    """Returns a dictionary containing CPUConsumed, CPULimit, WallClockConsumed
-       and WallClockLimit for current slot.  All values returned in seconds.
+    """ Returns S_OK with a dictionary containing the entries CPU, CPULimit,
+        WallClock, WallClockLimit, and Unit for current slot.
     """
     cmd = 'qstat -f -j %s' % (self.jobID)
     result = runCommand(cmd)

--- a/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
@@ -22,8 +22,8 @@ class SLURMResourceUsage(ResourceUsage):
     self.log.verbose('JOB_ID=%s' % self.jobID)
 
   def getResourceUsage(self):
-    """Returns a dictionary containing CPUConsumed, CPULimit, WallClockConsumed
-       and WallClockLimit for current slot.  All values returned in seconds.
+    """ Returns S_OK with a dictionary containing the entries CPU, CPULimit,
+        WallClock, WallClockLimit, and Unit for current slot.
     """
     # sacct displays accounting data for all jobs and job steps
     # -j is the given job, -o the information of interest, -X to get rid of intermediate steps
@@ -58,16 +58,15 @@ class SLURMResourceUsage(ResourceUsage):
                 'WallClockLimit': wallClockLimit,
                 'Unit': 'WallClock'}
 
-    if None not in consumed.values():
-      # This cannot happen as we can't get wallClock from anywhere
-      self.log.debug("TimeLeft counters complete:", str(consumed))
-      return S_OK(consumed)
-    else:
+    if None in consumed.values():
       missed = [key for key, val in consumed.items() if val is None]
       msg = 'Could not determine parameter'
       self.log.warn('Could not determine parameter', ','.join(missed))
       self.log.debug('This is the stdout from the batch system call\n%s' % (result['Value']))
       return S_ERROR(msg)
+
+    self.log.debug("TimeLeft counters complete:", str(consumed))
+    return S_OK(consumed)
 
   def _getFormattedTimeInSeconds(self, slurmTime):
     """ Convert SLURM time format into seconds

--- a/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
@@ -50,10 +50,13 @@ class SLURMResourceUsage(ResourceUsage):
         cpuLimit = wallClockLimit * int(allocCPUs)
       cpu = float(cpu)
 
-    consumed = {'CPU': wallClock,
+    # Slurm allocations are based on wallclock time, not cpu time.
+    # We precise it in the 'Unit' field
+    consumed = {'CPU': cpu,
                 'CPULimit': cpuLimit,
                 'WallClock': wallClock,
-                'WallClockLimit': wallClockLimit}
+                'WallClockLimit': wallClockLimit,
+                'Unit': 'WallClock'}
 
     if None not in consumed.values():
       # This cannot happen as we can't get wallClock from anywhere

--- a/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
@@ -64,9 +64,9 @@ class TimeLeft(object):
     resourceDict = self.batchPlugin.getResourceUsage()
 
     if 'Value' in resourceDict:
-      if resourceDict['Value']['CPU']:
+      if resourceDict['Value'].get('CPU'):
         return resourceDict['Value']['CPU'] * self.scaleFactor
-      elif resourceDict['Value']['WallClock']:
+      elif resourceDict['Value'].get('WallClock'):
         # When CPU value missing, guess from WallClock and number of processors
         return resourceDict['Value']['WallClock'] * self.scaleFactor * processors
 
@@ -90,20 +90,20 @@ class TimeLeft(object):
 
     resources = resourceDict['Value']
     self.log.debug("self.batchPlugin.getResourceUsage(): %s" % str(resources))
-    if not resources['CPULimit'] and not resources['WallClockLimit']:
+    if not resources.get('CPULimit') and not resources.get('WallClockLimit'):
       # This should never happen
       return S_ERROR('No CPU or WallClock limit obtained')
 
     # if one of CPULimit or WallClockLimit is missing, compute a reasonable value
-    if not resources['CPULimit']:
+    if not resources.get('CPULimit'):
       resources['CPULimit'] = resources['WallClockLimit'] * processors
-    elif not resources['WallClockLimit']:
+    elif not resources.get('WallClockLimit'):
       resources['WallClockLimit'] = resources['CPULimit'] / processors
 
     # if one of CPU or WallClock is missing, compute a reasonable value
-    if not resources['CPU']:
+    if not resources.get('CPU'):
       resources['CPU'] = resources['WallClock'] * processors
-    elif not resources['WallClock']:
+    elif not resources.get('WallClock'):
       resources['WallClock'] = resources['CPU'] / processors
 
     timeLeft = 0.
@@ -156,7 +156,8 @@ class TimeLeft(object):
         'PBS': 'PBS_JOBID',
         'BQS': 'QSUB_REQNAME',
         'SGE': 'SGE_TASK_ID',
-        'SLURM': 'SLURM_JOB_ID'}  # more to be added later
+        'SLURM': 'SLURM_JOB_ID',
+        'HTCondor': '_CONDOR_JOB_AD'}  # more to be added later
     name = None
     for batchSystem, envVar in batchSystems.items():
       if envVar in os.environ:

--- a/Resources/Computing/BatchSystems/TimeLeft/test/Test_TimeLeft.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/test/Test_TimeLeft.py
@@ -78,11 +78,11 @@ def test_enoughTimeLeft(cpu, cpuLimit, wallClock, wallClockLimit, cpuMargin, wal
     ('LSF', {'bin': '/usr/bin', 'hostNorm': 10.0}, LSF_OUT, 0.0),
     ('MJF', {}, MJF_OUT, 0.0),
     ('SGE', {}, SGE_OUT, 300.0),
-    # ('SLURM', {}, SLURM_OUT_0, 432000.0),
-    # ('SLURM', {}, SLURM_OUT_1, 432000.0),
-    # ('SLURM', {}, SLURM_OUT_2, 108000.0),
-    # ('SLURM', {}, SLURM_OUT_3, 216000.0),
-    # ('SLURM', {}, SLURM_OUT_4, 0.0),
+    ('SLURM', {}, SLURM_OUT_0, 432000.0),
+    ('SLURM', {}, SLURM_OUT_1, 432000.0),
+    ('SLURM', {}, SLURM_OUT_2, 108000.0),
+    ('SLURM', {}, SLURM_OUT_3, 216000.0),
+    ('SLURM', {}, SLURM_OUT_4, 0.0),
 ])
 def test_getScaledCPU(mocker, batch, requiredVariables, returnValue, expected):
   """ Test getScaledCPU()
@@ -114,11 +114,11 @@ def test_getScaledCPU(mocker, batch, requiredVariables, returnValue, expected):
 @pytest.mark.parametrize("batch, requiredVariables, returnValue, expected_1, expected_2", [
     ('LSF', {'bin': '/usr/bin', 'hostNorm': 10.0, 'cpuLimit': 1000, 'wallClockLimit': 1000}, LSF_OUT, True, 9400.0),
     ('SGE', {}, SGE_OUT, True, 9400.0),
-    # ('SLURM', {}, SLURM_OUT_0, True, 1728000.0),
-    # ('SLURM', {}, SLURM_OUT_1, True, 84672000.0),
-    # ('SLURM', {}, SLURM_OUT_2, True, 216000.0),
-    # ('SLURM', {}, SLURM_OUT_3, False, 0.0),
-    # ('SLURM', {}, SLURM_OUT_4, False, 0.0),
+    ('SLURM', {}, SLURM_OUT_0, True, 72000.0),
+    ('SLURM', {}, SLURM_OUT_1, True, 3528000.0),
+    ('SLURM', {}, SLURM_OUT_2, True, 9000.0),
+    ('SLURM', {}, SLURM_OUT_3, False, 18000.0),
+    ('SLURM', {}, SLURM_OUT_4, False, 0.0),
 ])
 def test_getTimeLeft(mocker, batch, requiredVariables, returnValue, expected_1, expected_2):
   """ Test getTimeLeft()

--- a/Resources/Computing/BatchSystems/TimeLeft/test/Test_TimeLeft.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/test/Test_TimeLeft.py
@@ -58,6 +58,10 @@ SLURM_OUT_2 = "12345,21600,24,900,30:00"
 SLURM_OUT_3 = "12345,43200,24,1800,30:00"
 SLURM_OUT_4 = ""
 
+HTCONDOR_OUT_0 = "86400 3600"
+HTCONDOR_OUT_1 = "undefined 3600"
+HTCONDOR_OUT_2 = ""
+
 
 @pytest.mark.parametrize("cpu, cpuLimit, wallClock, wallClockLimit, cpuMargin, wallClockMargin, expected", [
     (100., 1000., 50., 80., 3, 10, True),
@@ -83,6 +87,9 @@ def test_enoughTimeLeft(cpu, cpuLimit, wallClock, wallClockLimit, cpuMargin, wal
     ('SLURM', {}, SLURM_OUT_2, 108000.0),
     ('SLURM', {}, SLURM_OUT_3, 216000.0),
     ('SLURM', {}, SLURM_OUT_4, 0.0),
+    ('HTCondor', {}, HTCONDOR_OUT_0, 18000.0),
+    ('HTCondor', {}, HTCONDOR_OUT_1, 0.0),
+    ('HTCondor', {}, HTCONDOR_OUT_2, 0.0)
 ])
 def test_getScaledCPU(mocker, batch, requiredVariables, returnValue, expected):
   """ Test getScaledCPU()
@@ -119,6 +126,9 @@ def test_getScaledCPU(mocker, batch, requiredVariables, returnValue, expected):
     ('SLURM', {}, SLURM_OUT_2, True, 9000.0),
     ('SLURM', {}, SLURM_OUT_3, False, 18000.0),
     ('SLURM', {}, SLURM_OUT_4, False, 0.0),
+    ('HTCondor', {}, HTCONDOR_OUT_0, True, 828000),
+    ('HTCondor', {}, HTCONDOR_OUT_1, False, 0.0),
+    ('HTCondor', {}, HTCONDOR_OUT_2, False, 0.0)
 ])
 def test_getTimeLeft(mocker, batch, requiredVariables, returnValue, expected_1, expected_2):
   """ Test getTimeLeft()

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -25,6 +25,11 @@ ExtraSubmitString:
 
      request_cpus = 8 \\n periodic_remove = ...
 
+   CERN proposes additional features to the standard HTCondor implementation. Among these features, one can find
+   an option to limit the allocation runtime (`+MaxRuntime`), that does not exist in the standard HTCondor version:
+   no explicit way to define a runtime limit (`maxCPUTime` would act as the limit). On CERN-HTCondor CEs, one can use
+   CERN-specific features via the `ExtraSubmitString` configuration parameter.
+
 UseLocalSchedd:
    If False, directly submit to a remote condor schedule daemon,
    then one does not need to run condor daemons on the submit machine.

--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -71,7 +71,8 @@ class JobAgent(AgentModule):
 
     # Timeleft
     self.initTimes = os.times()
-    self.timeLeft = 0.0
+    self.initTimeLeft = 0.0
+    self.timeLeft = self.initTimeLeft
     self.timeLeftUtil = None
     self.pilotInfoReportedFlag = False
 
@@ -105,8 +106,9 @@ class JobAgent(AgentModule):
       ceDict = result['Value'][0]
     else:
       ceDict = result['Value']
-    self.timeLeft = ceDict.get('CPUTime', self.timeLeft)
-    self.timeLeft = gConfig.getValue('/Resources/Computing/CEDefaults/MaxCPUTime', self.timeLeft)
+    self.initTimeLeft = ceDict.get('CPUTime', self.initTimeLeft)
+    self.initTimeLeft = gConfig.getValue('/Resources/Computing/CEDefaults/MaxCPUTime', self.initTimeLeft)
+    self.timeLeft = self.initTimeLeft
 
     self.initTimes = os.times()
     # Localsite options
@@ -357,18 +359,7 @@ class JobAgent(AgentModule):
       self.log.exception("Exception in submission", "", lException=subExcept, lExcInfo=True)
       return self._rescheduleFailedJob(jobID, 'Job processing failed with exception', self.stopOnApplicationFailure)
 
-    # Sum all times but the last one (elapsed_time) and remove times at init (is this correct?)
-    cpuTime = sum(os.times()[:-1]) - sum(self.initTimes[:-1])
-
-    result = self.timeLeftUtil.getTimeLeft(cpuTime, processors)
-    if result['OK']:
-      self.timeLeft = result['Value']
-    else:
-      self.log.warn(
-          "There were errors calculating time left using the Timeleft utility",
-          result['Message'])
-      self.log.warn("The time left will be calculated using os.times() and the info in our possession")
-      self.timeLeft = self._getCPUTimeLeft()
+    self.timeLeft = self.computeCPUWorkLeft(processors)
 
     return S_OK('Job Agent cycle complete')
 
@@ -385,17 +376,39 @@ class JobAgent(AgentModule):
     jdlFile.close()
 
   #############################################################################
-  def _getCPUTimeLeft(self):
+  def computeCPUWorkLeft(self, processors):
     """
-    Return the TimeLeft as estimated by DIRAC using the process time
-    and the CPU normalization defined locally in the Local Config.
+    Compute CPU Work Left in hepspec06 seconds
+
+    :param int processors: number of processors available
+    :return: cpu work left (cpu time left * cpu power of the cpus)
     """
-    cpuTime = sum(os.times()[:-1])
-    self.log.info('Current raw CPU time consumed is %s' % cpuTime)
-    timeleft = self.timeLeft
+    # Sum all times but the last one (elapsed_time) and remove times at init (is this correct?)
+    cpuTime = sum(os.times()[:-1]) - sum(self.initTimes[:-1])
+    result = self.timeLeftUtil.getTimeLeft(cpuTime, processors)
+    if result['OK']:
+      cpuWorkLeft = result['Value']
+    else:
+      self.log.warn(
+          "There were errors calculating time left using the Timeleft utility",
+          result['Message'])
+      self.log.warn("The time left will be calculated using os.times() and the info in our possession")
+      cpuWorkLeft = self._getCPUWorkLeft(cpuTime)
+    return cpuWorkLeft
+
+  def _getCPUWorkLeft(self, cpuConsumed):
+    """
+    Compute the CPU Work Left as estimated by DIRAC using the process time
+    and the CPU Power defined locally in the Local Config.
+
+    :param int cpuConsumed: cpu time already consumed since the beginning of the execution
+    :return: cpu work left (cpu time left * cpu power of the cpus)
+    """
+    self.log.info('Current raw CPU time consumed is %s' % cpuConsumed)
+    cpuWorkleft = self.timeLeft
     if self.cpuFactor:
-      timeleft -= cpuTime * self.cpuFactor
-    return timeleft
+      cpuWorkleft = self.initTimeLeft - cpuConsumed * self.cpuFactor
+    return cpuWorkleft
 
   #############################################################################
   def _setupProxy(self, ownerDN, ownerGroup):

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
@@ -142,8 +142,8 @@ def test__setupProxy(mocker, mockGCReplyInput, mockPMReplyInput, expected):
     assert result['Message'] == expected['Message']
 
 
-def test__getCPUTimeLeft(mocker):
-  """ Testing JobAgent()._getCPUTimeLeft()
+def test__getCPUWorkLeft(mocker):
+  """ Testing JobAgent()._getCPUWorkLeft()
   """
 
   mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.AgentModule.__init__")
@@ -153,7 +153,7 @@ def test__getCPUTimeLeft(mocker):
   jobAgent.log = gLogger
   jobAgent.log.setLevel('DEBUG')
 
-  result = jobAgent._getCPUTimeLeft()
+  result = jobAgent._getCPUWorkLeft(0)
 
   assert 0 == result
 

--- a/docs/source/AdministratorGuide/Resources/computingelements.rst
+++ b/docs/source/AdministratorGuide/Resources/computingelements.rst
@@ -128,7 +128,7 @@ A commented example follows::
        long
        {
          # Max CPU time in HEP'06 unit secs
-         CPUTime = 10000
+         maxCPUTime = 10000
          # Max total number of jobs in the queue
          MaxTotalJobs = 5
          # Max number of waiting jobs in the queue
@@ -176,7 +176,7 @@ configuration follows ::
        long
        {
          # Max CPU time in HEP'06 unit secs
-         CPUTime = 10000
+         maxCPUTime = 10000
          # Max total number of jobs in the queue
          MaxTotalJobs = 5
          # Max number of waitin jobs in the queue


### PR DESCRIPTION
closes https://github.com/DIRACGrid/DIRAC/issues/4788

- Add a condition in `TimeLeft.getTimeLeft()` to know whether a Batch System relies on wallclock time and/or cpu time for allocated resources (e.g. Slurm and CERN-HTCondor only rely on wallclock time). This also reverts the change made on the `SlurmResourceUsage` plugin introduced in https://github.com/DIRACGrid/DIRAC/pull/4965#pullrequestreview-591048491
- Modify the cpu work left computation in `JobAgent` when the batch system cannot provide (relevant) information: `timeLeft` decreases linearly instead of decreasing exponentially.
- Add a `HTCondorResourceUsage` plugin: which is actually a CERN-specific HTCondor Resource Usage module to get the time left in CERN-HTCondor resources. To modify the wallclock time limit of the allocations, one can set `ExtraSubmitString = +MaxRuntime=<seconds>` in the configuration of CERN-specific HTCondor CEs. For other HTCondor resources, setting `MaxCPUTime` in the configuration of the queues should be sufficient.


BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: fix the cpu work left computation in JobAgent when batch system information cannot be processed

*Resources
CHANGE: add a condition in TimeLeft module to know whether the batch system relies on wallclock and/or cpu time
ADD: HTCondorResourceUsage module to get the time left in CERN-specific HTCondor resources.
ENDRELEASENOTES
