### PR TITLE
[v7r2] Remove fts3-rest from the setuptools configuration for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     botocore
     certifi
     diraccfg
-    fts3-rest
     future
     gfal2-python
     M2Crypto >=0.36


### PR DESCRIPTION
As it's causing a nuisance and the client mostly works without it I propose removing it from the setuptools metadata for now.

Should be reverted once https://github.com/DIRACGrid/DIRACOS2/issues/10 is resolved.