### PR TITLE
[v7r2] fix dirac-admin-sysadmin-cli

### DIFF
--- a/src/DIRAC/Core/DISET/private/BaseClient.py
+++ b/src/DIRAC/Core/DISET/private/BaseClient.py
@@ -70,8 +70,8 @@ class BaseClient(object):
     if not isinstance(serviceName, six.string_types):
       raise TypeError("Service name expected to be a string. Received %s type %s" %
                       (str(serviceName), type(serviceName)))
-    self._destinationSrv = serviceName
-    self._serviceName = serviceName
+    self._destinationSrv = str(serviceName)
+    self._serviceName = str(serviceName)
     self.kwargs = kwargs
     self.__useCertificates = None
     # The CS useServerCertificate option can be overridden by explicit argument

--- a/src/DIRAC/Core/DISET/private/BaseClient.py
+++ b/src/DIRAC/Core/DISET/private/BaseClient.py
@@ -70,6 +70,7 @@ class BaseClient(object):
     if not isinstance(serviceName, six.string_types):
       raise TypeError("Service name expected to be a string. Received %s type %s" %
                       (str(serviceName), type(serviceName)))
+    # Explicitly convert to a str to avoid Python 2 M2Crypto issues with unicode objects
     self._destinationSrv = str(serviceName)
     self._serviceName = str(serviceName)
     self.kwargs = kwargs

--- a/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -1253,7 +1253,7 @@ class SystemAdministratorClientCLI(CLI):
     client = SystemAdministratorIntegrator()
     silentHosts = client.getSilentHosts()
     respondingHosts = client.getRespondingHosts()
-    allHosts = len(silentHosts) + len(respondingHosts)
+    totalHosts = len(silentHosts) + len(respondingHosts)
     resultAll = client.getOverallStatus()
     resultInfo = client.getInfo()
 

--- a/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -1253,6 +1253,7 @@ class SystemAdministratorClientCLI(CLI):
     client = SystemAdministratorIntegrator()
     silentHosts = client.getSilentHosts()
     respondingHosts = client.getRespondingHosts()
+    allHosts = len(silentHosts) + len(respondingHosts)
     resultAll = client.getOverallStatus()
     resultInfo = client.getInfo()
 
@@ -1295,7 +1296,7 @@ class SystemAdministratorClientCLI(CLI):
                 records.append(record)
       printTable(fields, records, sortOption)
       if silentHosts:
-        print("\n %d out of %d hosts did not respond" % (len(silentHosts), len(respondingHosts)))
+        print("\n %d out of %d hosts did not respond" % (len(silentHosts), allHosts))
 
   def default(self, args):
 

--- a/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -1296,7 +1296,7 @@ class SystemAdministratorClientCLI(CLI):
                 records.append(record)
       printTable(fields, records, sortOption)
       if silentHosts:
-        print("\n %d out of %d hosts did not respond" % (len(silentHosts), allHosts))
+        print("\n %d out of %d hosts did not respond" % (len(silentHosts), totalHosts))
 
   def default(self, args):
 


### PR DESCRIPTION
PR fix log message and resolve problem with unicode:
```
Traceback (most recent call last):
  File "/opt/dirac/cli/DIRAC/Core/DISET/private/BaseClient.py", line 471, in _connect
    retVal = transport.initAsClient()
  File "/opt/dirac/cli/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py", line 145, in initAsClient
    self.oSocket.set_tlsext_host_name(host)
  File "/opt/dirac/cli/diracos/usr/lib64/python2.7/site-packages/M2Crypto/SSL/Connection.py", line 708, in set_tlsext_host_name
    m2.ssl_set_tlsext_host_name(self.ssl, name)
TypeError: in method 'ssl_set_tlsext_host_name', argument 2 of type 'char const *'
```

BEGINRELEASENOTES

*Core
FIX: encode serviceName

*Framework
FIX: fix log message about responded hosts in sysadmin cli

ENDRELEASENOTES
