### PR TITLE
[v7r1] Added docs for connection to ES

### DIFF
--- a/docs/source/AdministratorGuide/ExternalsSupport/index.rst
+++ b/docs/source/AdministratorGuide/ExternalsSupport/index.rst
@@ -36,6 +36,22 @@ MySQL is a hard dependency for all DIRAC servers installations. Supported versio
 - 5.7
 - 8.0
 
+MySQL server is not shipped with DIRAC. You are responsible of its administration.
+
+While specific configurations may be applied for each MySQL Database connection,
+generic connection details can be applied in CS location below (the shown values are the defaults)::
+
+   Systems
+   {
+     Databases
+     {
+       User = Dirac
+       Password = Dirac
+       Host = localhost
+       Port = 3306
+     }
+   }
+
 
 ElasticSearch versions:
 -----------------------
@@ -44,3 +60,31 @@ ElasticSearch is an optional dependency for DIRAC servers installations. Support
 
 - 6.x
 - 7.x
+
+ElasticSearch server is not shipped with DIRAC. You are responsible of its administration.
+
+You can run your ES cluster without authentication, or using User name and password, or using certificates. You may add the following parameters:
+
+  - ``User`` (default:'')
+  - ``Password`` (default:'')
+  - ``Host`` (default:localhost)
+  - ``Port`` (default:9201)
+  - ``SSL`` (default:True)
+  - ``CRT`` (default:True)
+  - ``ca_certs`` (default:None)
+  - ``client_key`` (default:None)
+  - ``client_cert`` (default:None)
+
+
+to the location::
+
+   Systems
+   {
+     NoSQLDatabases
+     {
+       User = ...
+       Password = ...
+       ...
+     }
+   }
+

--- a/docs/source/AdministratorGuide/ServerInstallations/InstallingDiracServer.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/InstallingDiracServer.rst
@@ -30,6 +30,15 @@ distributed among a number of servers installed using the procedure for addition
 
 For all DIRAC installations any number of client installations is possible.
 
+
+Using Puppet
+------------
+
+The procedure outlined below is a manual procedure for installing DIRAC.
+Some installations have been done using `puppet <https://puppet.com/>`_.
+Find puppet modules used at CERN in https://gitlab.cern.ch/ai/it-puppet-module-dirac.
+
+
 .. _server_requirements:
 
 

--- a/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
+++ b/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
@@ -13,42 +13,10 @@ Overview
 The Monitoring system is used to monitor various components of DIRAC. Currently, we have two monitoring types:
 
   - WMSHistory: for monitoring the DIRAC WMS
-  - Component Monitoring: for monitoring  DIRAC components such as services, agents, etc.
+  - Component Monitoring: for monitoring  DIRAC components such as services, agents, etc (in preview mode, it will be fully working starting from DIRAC v7r2).
 
 It is based on Elasticsearch distributed search and analytics NoSQL database. If you want to use it, you have to install the Monitoring service and
 elasticsearch db. You can use a single node, if you do not have to store lot of data, otherwise you need a cluster (more than one node).
-
-Install Elasticsearch
-======================
-
-You can found in https://www.elastic.co official web site. I propose to use standard tools to install for example: yum, rpm, etc. otherwise
-you encounter some problems. If you are not familiar with managing linux packages, you have to ask your college or read some relevant documents.
-
-Configure the MonitoringSystem
-===============================
-
-You can run your El cluster without authentication or using User name and password. You have to add the following parameters:
-
-  - User
-  - Password
-  - Host
-  - Port
-
-The User name and Password must be added to the local cfg file while the other can be added to the CS using the Configuration web application.
-You have to handle the EL secret information in a similar way to what is done for the other supported SQL databases, e.g. MySQL
-
-
-For example::
-
-   Systems
-   {
-     NoSQLDatabases
-     {
-       User = test
-       Password = password
-     }
-
-   }
 
 
 Enable WMSHistory monitoring

--- a/docs/source/AdministratorGuide/index.rst
+++ b/docs/source/AdministratorGuide/index.rst
@@ -14,9 +14,9 @@ This administration documentation refers to the "Core" DIRAC project.
    :maxdepth: 2
 
    Introduction/index
-   UserManagement/index
    ExternalsSupport/index
    ServerInstallations/index
+   UserManagement/index
    HowTo/index
    Configuration/index
    Resources/index


### PR DESCRIPTION
closes #4940 

I also added a note with a link to the DIRAC puppet modules that are used at CERN by LHCb and CLIC. Honestly those info should be expanded but I don't have enough knowledge for doing it @andresailer @chaen 

BEGINRELEASENOTES

*Docs
FIX: added explanation on connecting to ES using certificates

ENDRELEASENOTES
