### PR TITLE
[v7r2] Get dirac-jobexec from PATH by default

### DIFF
--- a/docs/source/UserGuide/Tutorials/JobManagementAdvanced/index.rst
+++ b/docs/source/UserGuide/Tutorials/JobManagementAdvanced/index.rst
@@ -395,7 +395,7 @@ Let's perform this exercise in the python shell.
           $ python Test-API-JDL.py 
  
               Priority = "1";
-              Executable = "$DIRACROOT/scripts/dirac-jobexec";
+              Executable = "dirac-jobexec";
               ExecutionEnvironment = "MYVARIABLE=TEST";
               StdError = "std.err";
               LogLevel = "DEBUG";

--- a/src/DIRAC/Interfaces/API/Job.py
+++ b/src/DIRAC/Interfaces/API/Job.py
@@ -83,7 +83,7 @@ class Job(API):
     self.stdout = stdout
     self.stderr = stderr
     self.logLevel = 'info'
-    self.executable = '$DIRACROOT/scripts/dirac-jobexec'  # to be clarified
+    self.executable = 'dirac-jobexec'  # to be clarified
     # $DIRACROOT is set by the JobWrapper at execution time
     self.addToInputSandbox = []
     self.addToOutputSandbox = []

--- a/src/DIRAC/Interfaces/API/test/testWF.jdl
+++ b/src/DIRAC/Interfaces/API/test/testWF.jdl
@@ -1,6 +1,6 @@
  
     Arguments = "jobDescription.xml -o LogLevel=DEBUG  -p JOB_ID=%(JOB_ID)s  -p InputData=%(InputData)s";
-    Executable = "$DIRACROOT/scripts/dirac-jobexec";
+    Executable = "dirac-jobexec";
     InputData = %(InputData)s;
     InputSandbox = jobDescription.xml;
     JOB_ID = %(JOB_ID)s;

--- a/src/DIRAC/Interfaces/API/test/testWFSIO.jdl
+++ b/src/DIRAC/Interfaces/API/test/testWFSIO.jdl
@@ -1,6 +1,6 @@
  
     Arguments = "jobDescription.xml -o LogLevel=info";
-    Executable = "$DIRACROOT/scripts/dirac-jobexec";
+    Executable = "dirac-jobexec";
     JobGroup = jobGroup;
     JobName = jobName;
     JobType = jobType;

--- a/src/DIRAC/TransformationSystem/test/Test_JobInfo.py
+++ b/src/DIRAC/TransformationSystem/test/Test_JobInfo.py
@@ -39,7 +39,7 @@ class TestJI(unittest.TestCase):
 
     self.jdl2 = {
         'LogTargetPath': "/ilc/prod/clic/500gev/yyveyx_o/ILD/REC/00006326/LOG/00006326_015.tar",
-        'Executable': "$DIRACROOT/scripts/dirac-jobexec",
+        'Executable': "dirac-jobexec",
         'TaskID': 15,
         'SoftwareDistModule': "ILCDIRAC.Core.Utilities.CombinedSoftwareInstallation",
         'JobName': "00006326_00000015",
@@ -109,7 +109,7 @@ class TestJI(unittest.TestCase):
 
     self.jdlBrokenContent = {
         'LogTargetPath': "/ilc/prod/clic/500gev/yyveyx_o/ILD/REC/00006326/LOG/00006326_015.tar",
-        'Executable': "$DIRACROOT/scripts/dirac-jobexec",
+        'Executable': "dirac-jobexec",
         'TaskID': 'muahahaha',
         'SoftwareDistModule': "ILCDIRAC.Core.Utilities.CombinedSoftwareInstallation",
         'JobName': "00006326_00000015",
@@ -180,7 +180,7 @@ class TestJI(unittest.TestCase):
     # jdl with single outputdata,
     self.jdl1 = {
         'LogTargetPath': "/ilc/prod/clic/3tev/e1e1_o/SID/SIM/00006301/LOG/00006301_10256.tar",
-        'Executable': "$DIRACROOT/scripts/dirac-jobexec",
+        'Executable': "dirac-jobexec",
         'TaskID': 10256,
         'SoftwareDistModule': "ILCDIRAC.Core.Utilities.CombinedSoftwareInstallation",
         'JobName': "00006301_00010256",
@@ -250,7 +250,7 @@ class TestJI(unittest.TestCase):
 
     self.jdlNoInput = {
         'LogTargetPath': "/ilc/prod/clic/1.4tev/ea_qqqqnu/gen/00006498/LOG/00006498_1307.tar",
-        'Executable': "$DIRACROOT/scripts/dirac-jobexec",
+        'Executable': "dirac-jobexec",
         'TaskID': 1307,
         'SoftwareDistModule': "ILCDIRAC.Core.Utilities.CombinedSoftwareInstallation",
         'JobName': "00006498_00001307",

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
@@ -35,7 +35,7 @@ def test__getJDLParameters(mocker):
 
   jdl = """
         [
-            Executable = "$DIRACROOT/scripts/dirac-jobexec";
+            Executable = "dirac-jobexec";
             StdError = "std.err";
             LogLevel = "info";
             Site = "ANY";

--- a/tests/Integration/WorkloadManagementSystem/Test_JobDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_JobDB.py
@@ -20,7 +20,7 @@ from DIRAC import gLogger
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 
 jdl = """[
-    Executable = "$DIRACROOT/scripts/dirac-jobexec";
+    Executable = "dirac-jobexec";
     StdError = "std.err";
     LogLevel = "info";
     Site = "ANY";

--- a/tests/Integration/WorkloadManagementSystem/Test_JobWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_JobWrapper.py
@@ -42,7 +42,7 @@ class JobWrapperSubmissionCase(JobWrapperTestCase):
     jobParams = {'JobID': '1',
                  'JobType': 'Merge',
                  'CPUTime': '1000000',
-                 'Executable': '$DIRACROOT/scripts/dirac-jobexec',
+                 'Executable': 'dirac-jobexec',
                  'Arguments': "helloWorld.xml -o LogLevel=DEBUG --cfg pilot.cfg",
                  'InputSandbox': ['helloWorld.xml', 'exe-script.py']}
     resourceParams = {}


### PR DESCRIPTION
The use of `$DIRACROOT/scripts/` doesn't really make sense with a Python 3 + pip installation. I think it should be safe to take it from `$PATH` in all situations?

BEGINRELEASENOTES

*WorkloadManagement
CHANGE: Take dirac-jobexec from PATH by default

ENDRELEASENOTES
