### PR TITLE
[v7r2] Use DIRACOS2 for Python 3 client integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,6 +50,7 @@ jobs:
           #             CLIENT_USE_PYTHON3: No
           - TEST_NAME: "Python 3 client"
             CLIENT_USE_PYTHON3: Yes
+            CLIENT_DIRACOSVER: 2.0a8
 
     steps:
     - uses: actions/checkout@v2
@@ -74,7 +75,9 @@ jobs:
         if [[ "${{ matrix.DIRACOSVER || env.MATRIX_DEFAULT_DIRACOSVER }}" != "default" ]]; then echo -n "-e DIRACOSVER=${{ matrix.DIRACOSVER || env.MATRIX_DEFAULT_DIRACOSVER }} " >> run_in_container; fi
         echo -n "-e TEST_HTTPS=${{ matrix.TEST_HTTPS || env.MATRIX_DEFAULT_TEST_HTTPS }} " >> run_in_container
         echo -n "-e SERVER_USE_PYTHON3=${{ matrix.SERVER_USE_PYTHON3 || env.MATRIX_DEFAULT_SERVER_USE_PYTHON3 }} " >> run_in_container
+        if [[ "${{ matrix.SERVER_DIRACOSVER || env.MATRIX_DEFAULT_SERVER_DIRACOSVER }}" != "default" ]]; then echo -n "-e SERVER_DIRACOSVER=${{ matrix.SERVER_DIRACOSVER || env.MATRIX_DEFAULT_SERVER_DIRACOSVER }} " >> run_in_container; fi
         echo -n "-e CLIENT_USE_PYTHON3=${{ matrix.CLIENT_USE_PYTHON3 || env.MATRIX_DEFAULT_CLIENT_USE_PYTHON3 }} " >> run_in_container
+        if [[ "${{ matrix.CLIENT_DIRACOSVER || env.MATRIX_DEFAULT_CLIENT_DIRACOSVER }}" != "default" ]]; then echo -n "-e CLIENT_DIRACOSVER=${{ matrix.CLIENT_DIRACOSVER || env.MATRIX_DEFAULT_CLIENT_DIRACOSVER }} " >> run_in_container; fi
         # Finish wrapper script
         echo -n "dirac-testing-host \"\$@\"" >> run_in_container
         chmod +x run_in_container

--- a/docs/source/UserGuide/Tutorials/JobManagementAdvanced/index.rst
+++ b/docs/source/UserGuide/Tutorials/JobManagementAdvanced/index.rst
@@ -395,7 +395,7 @@ Let's perform this exercise in the python shell.
           $ python Test-API-JDL.py 
  
               Priority = "1";
-              Executable = "$DIRACROOT/scripts/dirac-jobexec";
+              Executable = "dirac-jobexec";
               ExecutionEnvironment = "MYVARIABLE=TEST";
               StdError = "std.err";
               LogLevel = "DEBUG";

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     botocore
     certifi
     diraccfg
-    fts3-rest
     future
     gfal2-python
     M2Crypto >=0.36

--- a/src/DIRAC/Core/scripts/dirac_platform.py
+++ b/src/DIRAC/Core/scripts/dirac_platform.py
@@ -26,22 +26,21 @@ from __future__ import division
 
 __RCSID__ = "$Id$"
 
-import sys
-import argparse
-
-parser = argparse.ArgumentParser(
-    description=__doc__,
-    formatter_class=argparse.RawDescriptionHelpFormatter)
-parser.parse_known_args()
 
 try:
   from DIRAC.Core.Utilities.Platform import getPlatformString
 except Exception:
+  import argparse
   import platform
   import os
   import sys
   import re
   import subprocess
+
+  parser = argparse.ArgumentParser(
+      description=__doc__,
+      formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.parse_known_args()
 
   # We need to patch python platform module. It does a string comparison for the libc versions.
   # it fails when going from 2.9 to 2.10,

--- a/src/DIRAC/Core/scripts/dirac_version.py
+++ b/src/DIRAC/Core/scripts/dirac_version.py
@@ -21,17 +21,18 @@ __RCSID__ = "$Id$"
 
 import argparse
 
-parser = argparse.ArgumentParser(
-    description=__doc__,
-    formatter_class=argparse.RawDescriptionHelpFormatter)
-parser.parse_known_args()
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript
 
 
 @DIRACScript()
 def main():
+  parser = argparse.ArgumentParser(
+      description=__doc__,
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+  )
+  parser.parse_known_args()
+
   print(DIRAC.version)
 
 

--- a/src/DIRAC/Interfaces/API/Job.py
+++ b/src/DIRAC/Interfaces/API/Job.py
@@ -83,7 +83,7 @@ class Job(API):
     self.stdout = stdout
     self.stderr = stderr
     self.logLevel = 'info'
-    self.executable = '$DIRACROOT/scripts/dirac-jobexec'  # to be clarified
+    self.executable = 'dirac-jobexec'  # to be clarified
     # $DIRACROOT is set by the JobWrapper at execution time
     self.addToInputSandbox = []
     self.addToOutputSandbox = []

--- a/src/DIRAC/Interfaces/API/test/Test_DIRAC.py
+++ b/src/DIRAC/Interfaces/API/test/Test_DIRAC.py
@@ -127,8 +127,14 @@ def test_runLocal(dirac, job, mocker, osmock, confMock):
   ret = dirac.runLocal(job)
   LOG.info("dirac log calls: %s", dirac.log.call_args_list)
   LOG.info("CallStack: %s", pformat(ret.get('CallStack', {})))
-  assert sysMock.call_args_list[0][1]['cmdSeq'] == ['/root/dirac/scripts/dirac-jobexec',
-                                                    'jobDescription.xml', '-o', 'LogLevel=DEBUG']
+  try:
+    assert sysMock.call_args_list[0][1]['cmdSeq'] == [
+        'dirac-jobexec', 'jobDescription.xml', '-o', 'LogLevel=DEBUG'
+    ]
+  except AssertionError:
+    assert sysMock.call_args_list[0][1]['cmdSeq'] == [
+        '/root/dirac/scripts/dirac-jobexec', 'jobDescription.xml', '-o', 'LogLevel=DEBUG'
+    ]
   assert ret.get('Message', None) is None
   assert ret['OK']
   assert call('/abspath/absfile.xml', '/pwd/tempFolder/') in shMock.copy.call_args_list

--- a/src/DIRAC/Interfaces/API/test/testWF.jdl
+++ b/src/DIRAC/Interfaces/API/test/testWF.jdl
@@ -1,6 +1,6 @@
  
     Arguments = "jobDescription.xml -o LogLevel=DEBUG  -p JOB_ID=%(JOB_ID)s  -p InputData=%(InputData)s";
-    Executable = "$DIRACROOT/scripts/dirac-jobexec";
+    Executable = "dirac-jobexec";
     InputData = %(InputData)s;
     InputSandbox = jobDescription.xml;
     JOB_ID = %(JOB_ID)s;

--- a/src/DIRAC/Interfaces/API/test/testWFSIO.jdl
+++ b/src/DIRAC/Interfaces/API/test/testWFSIO.jdl
@@ -1,6 +1,6 @@
  
     Arguments = "jobDescription.xml -o LogLevel=info";
-    Executable = "$DIRACROOT/scripts/dirac-jobexec";
+    Executable = "dirac-jobexec";
     JobGroup = jobGroup;
     JobName = jobName;
     JobType = jobType;

--- a/src/DIRAC/TransformationSystem/test/Test_JobInfo.py
+++ b/src/DIRAC/TransformationSystem/test/Test_JobInfo.py
@@ -39,7 +39,7 @@ class TestJI(unittest.TestCase):
 
     self.jdl2 = {
         'LogTargetPath': "/ilc/prod/clic/500gev/yyveyx_o/ILD/REC/00006326/LOG/00006326_015.tar",
-        'Executable': "$DIRACROOT/scripts/dirac-jobexec",
+        'Executable': "dirac-jobexec",
         'TaskID': 15,
         'SoftwareDistModule': "ILCDIRAC.Core.Utilities.CombinedSoftwareInstallation",
         'JobName': "00006326_00000015",
@@ -109,7 +109,7 @@ class TestJI(unittest.TestCase):
 
     self.jdlBrokenContent = {
         'LogTargetPath': "/ilc/prod/clic/500gev/yyveyx_o/ILD/REC/00006326/LOG/00006326_015.tar",
-        'Executable': "$DIRACROOT/scripts/dirac-jobexec",
+        'Executable': "dirac-jobexec",
         'TaskID': 'muahahaha',
         'SoftwareDistModule': "ILCDIRAC.Core.Utilities.CombinedSoftwareInstallation",
         'JobName': "00006326_00000015",
@@ -180,7 +180,7 @@ class TestJI(unittest.TestCase):
     # jdl with single outputdata,
     self.jdl1 = {
         'LogTargetPath': "/ilc/prod/clic/3tev/e1e1_o/SID/SIM/00006301/LOG/00006301_10256.tar",
-        'Executable': "$DIRACROOT/scripts/dirac-jobexec",
+        'Executable': "dirac-jobexec",
         'TaskID': 10256,
         'SoftwareDistModule': "ILCDIRAC.Core.Utilities.CombinedSoftwareInstallation",
         'JobName': "00006301_00010256",
@@ -250,7 +250,7 @@ class TestJI(unittest.TestCase):
 
     self.jdlNoInput = {
         'LogTargetPath': "/ilc/prod/clic/1.4tev/ea_qqqqnu/gen/00006498/LOG/00006498_1307.tar",
-        'Executable': "$DIRACROOT/scripts/dirac-jobexec",
+        'Executable': "dirac-jobexec",
         'TaskID': 1307,
         'SoftwareDistModule': "ILCDIRAC.Core.Utilities.CombinedSoftwareInstallation",
         'JobName': "00006498_00001307",

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
@@ -35,7 +35,7 @@ def test__getJDLParameters(mocker):
 
   jdl = """
         [
-            Executable = "$DIRACROOT/scripts/dirac-jobexec";
+            Executable = "dirac-jobexec";
             StdError = "std.err";
             LogLevel = "info";
             Site = "ANY";

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -28,6 +28,7 @@ import tarfile
 import glob
 import json
 import six
+import distutils.spawn
 
 from six.moves.urllib.parse import unquote as urlunquote
 
@@ -231,6 +232,7 @@ class JobWrapper(object):
         if os.path.exists('%s/%s' % (self.root, extraOpts)):
           shutil.copyfile('%s/%s' % (self.root, extraOpts), extraOpts)
         self.__loadLocalCFGFiles(self.localSiteRoot)
+
     else:
       self.log.info('JobID is not defined, running in current directory')
 
@@ -333,6 +335,14 @@ class JobWrapper(object):
     # the argument should include the jobDescription.xml file
     jobArguments = self.jobArgs.get('Arguments', '')
 
+    # This is a workaround for Python 2 style installations
+    if six.PY3 and executable == "$DIRACROOT/scripts/dirac-jobexec":
+      self.log.warn(
+          'Replaced job executable "$DIRACROOT/scripts/dirac-jobexec" with '
+          '"dirac-jobexec". Please fix your submission script!'
+      )
+      executable = "dirac-jobexec"
+
     executable = os.path.expandvars(executable)
     exeThread = None
     spObject = None
@@ -340,6 +350,11 @@ class JobWrapper(object):
     if re.search('DIRACROOT', executable):
       executable = executable.replace('$DIRACROOT', self.localSiteRoot)
       self.log.verbose('Replaced $DIRACROOT for executable as %s' % (self.localSiteRoot))
+
+    # Try to find the executable on PATH
+    if "/" not in executable:
+      # Returns None if the executable is not found so use "or" to leave it unchanged
+      executable = distutils.spawn.find_executable(executable) or executable
 
     # Make the full path since . is not always in the PATH
     executable = os.path.abspath(executable)

--- a/tests/CI/run_docker_setup.sh
+++ b/tests/CI/run_docker_setup.sh
@@ -111,13 +111,6 @@ prepareEnvironment() {
     fi
 
     echo "declare -a ALTERNATIVE_MODULES"
-    if [[ -n "${ALTERNATIVE_MODULES+x}" ]]; then
-      for module_path in "${ALTERNATIVE_MODULES[@]}"; do
-        echo "ALTERNATIVE_MODULES+=(\"${module_path}\")"
-      done
-    else
-      echo "ALTERNATIVE_MODULES+=(\"${DIRAC_BASE_DIR}/src/DIRAC\")"
-    fi
 
     echo "declare -a INSTALLOPTIONS"
     if [[ -n "${INSTALLOPTIONS+x}" ]]; then
@@ -154,12 +147,37 @@ prepareEnvironment() {
   cp "${SERVERCONFIG}" "${CLIENTCONFIG}"
 
   if [[ "${SERVER_USE_PYTHON3:-}" == "Yes" ]]; then
-    echo "INSTALLOPTIONS+=(\"--pythonVersion=3\")" >> "${SERVERCONFIG}"
+    echo "export SERVER_USE_PYTHON3=${SERVER_USE_PYTHON3}" >> "${SERVERCONFIG}"
+    echo "ALTERNATIVE_MODULES+=(\"${DIRAC_BASE_DIR}/\")" >> "${SERVERCONFIG}"
+  else
+    if [[ -n "${ALTERNATIVE_MODULES+x}" ]]; then
+      for module_path in "${ALTERNATIVE_MODULES[@]}"; do
+        echo "ALTERNATIVE_MODULES+=(\"${module_path}\")" >> "${SERVERCONFIG}"
+      done
+    else
+      echo "ALTERNATIVE_MODULES+=(\"${DIRAC_BASE_DIR}/src/DIRAC\")" >> "${SERVERCONFIG}"
+    fi
   fi
 
-  echo "${CLIENT_USE_PYTHON3}"
+  if [[ -n "${SERVER_DIRACOSVER+x}" ]]; then
+    echo "export DIRACOSVER=${SERVER_DIRACOSVER}" >> "${SERVERCONFIG}"
+  fi
+
   if [[ "${CLIENT_USE_PYTHON3:-}" == "Yes" ]]; then
-    echo "INSTALLOPTIONS+=(\"--pythonVersion=3\")" >> "${CLIENTCONFIG}"
+    echo "export CLIENT_USE_PYTHON3=${CLIENT_USE_PYTHON3}" >> "${CLIENTCONFIG}"
+    echo "ALTERNATIVE_MODULES+=(\"${DIRAC_BASE_DIR}/\")" >> "${CLIENTCONFIG}"
+  else
+    if [[ -n "${ALTERNATIVE_MODULES+x}" ]]; then
+      for module_path in "${ALTERNATIVE_MODULES[@]}"; do
+        echo "ALTERNATIVE_MODULES+=(\"${module_path}\")" >> "${CLIENTCONFIG}"
+      done
+    else
+      echo "ALTERNATIVE_MODULES+=(\"${DIRAC_BASE_DIR}/src/DIRAC\")" >> "${CLIENTCONFIG}"
+    fi
+  fi
+
+  if [[ -n "${CLIENT_DIRACOSVER+x}" ]]; then
+    echo "export DIRACOSVER=${CLIENT_DIRACOSVER}" >> "${CLIENTCONFIG}"
   fi
 
   echo "Generated server config file is:"

--- a/tests/CI/run_tests.sh
+++ b/tests/CI/run_tests.sh
@@ -45,12 +45,8 @@ elif [[ "$INSTALLTYPE" == "client" ]]; then
     source "$WORKSPACE/ClientInstallDIR/bashrc"
     set -o pipefail
     ERR=0
-    # TODO: The tests should be refactored to remove the need for this
     for repo_path in "${TESTREPO[@]}"; do
-        cp -r "${repo_path}/tests" "$WORKSPACE/ClientInstallDIR/$(basename "${repo_path}")"
-    done
-    for repo_path in "${TESTREPO[@]}"; do
-        source "$WORKSPACE/ClientInstallDIR/$(basename "${repo_path}")/tests/Integration/all_integration_client_tests.sh"
+        source "${repo_path}/tests/Integration/all_integration_client_tests.sh"
     done
 fi
 

--- a/tests/Integration/WorkloadManagementSystem/Test_JobDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_JobDB.py
@@ -20,7 +20,7 @@ from DIRAC import gLogger
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 
 jdl = """[
-    Executable = "$DIRACROOT/scripts/dirac-jobexec";
+    Executable = "dirac-jobexec";
     StdError = "std.err";
     LogLevel = "info";
     Site = "ANY";

--- a/tests/Integration/WorkloadManagementSystem/Test_JobWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_JobWrapper.py
@@ -42,7 +42,7 @@ class JobWrapperSubmissionCase(JobWrapperTestCase):
     jobParams = {'JobID': '1',
                  'JobType': 'Merge',
                  'CPUTime': '1000000',
-                 'Executable': '$DIRACROOT/scripts/dirac-jobexec',
+                 'Executable': 'dirac-jobexec',
                  'Arguments': "helloWorld.xml -o LogLevel=DEBUG --cfg pilot.cfg",
                  'InputSandbox': ['helloWorld.xml', 'exe-script.py']}
     resourceParams = {}

--- a/tests/Integration/WorkloadManagementSystem/Test_TimeLeft.sh
+++ b/tests/Integration/WorkloadManagementSystem/Test_TimeLeft.sh
@@ -19,7 +19,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ###############################################################################
 # Can't find anywhere a batch plugin, not even MJF
 
-$DIRACSCRIPTS/dirac-wms-get-queue-cpu-time --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
+dirac-wms-get-queue-cpu-time --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
 
 if [[ "${?}" -eq 0 ]]; then
   echo -e "\nSuccess\n\n"
@@ -35,7 +35,7 @@ fi
 export MACHINEFEATURES="${SCRIPT_DIR}/sb.cfg"
 export JOBFEATURES="${SCRIPT_DIR}/sb.cfg"
 
-$DIRACSCRIPTS/dirac-wms-get-queue-cpu-time --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
+dirac-wms-get-queue-cpu-time --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
 
 if [[ "${?}" -eq 0 ]]; then
   echo -e "\nSuccess\n\n"
@@ -51,7 +51,7 @@ fi
 export MACHINEFEATURES=${SCRIPT_DIR}/MJF/
 export JOBFEATURES=${SCRIPT_DIR}/MJF/
 
-$DIRACSCRIPTS/dirac-wms-get-queue-cpu-time --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
+dirac-wms-get-queue-cpu-time --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
 
 if [[ "${?}" -eq 0 ]]; then
   echo -e "\nSuccess\n\n"

--- a/tests/Integration/WorkloadManagementSystem/Test_dirac-jobexec.sh
+++ b/tests/Integration/WorkloadManagementSystem/Test_dirac-jobexec.sh
@@ -23,7 +23,7 @@ python "${SCRIPT_DIR}/createJobXMLDescriptions.py" $DEBUG
 # Running the real tests
 
 # OK
-$DIRACSCRIPTS/dirac-jobexec jobDescription-OK.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
+dirac-jobexec jobDescription-OK.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
 if [[ "${?}" -eq 0 ]]; then
   echo -e "\nSuccess\n\n"
 else
@@ -32,7 +32,7 @@ else
 fi
 
 # OK2
-$DIRACSCRIPTS/dirac-jobexec jobDescription-OK-multiSteps.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
+dirac-jobexec jobDescription-OK-multiSteps.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
 if [[ "${?}" -eq 0 ]]; then
   echo -e "\nSuccess\n\n"
 else
@@ -42,7 +42,7 @@ fi
 
 
 # FAIL
-$DIRACSCRIPTS/dirac-jobexec jobDescription-FAIL.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
+dirac-jobexec jobDescription-FAIL.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
 if [[ "${?}" -eq 111 ]]; then
   echo -e "\nSuccess\n\n"
 else
@@ -51,7 +51,7 @@ else
 fi
 
 # FAIL2
-$DIRACSCRIPTS/dirac-jobexec jobDescription-FAIL-multiSteps.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
+dirac-jobexec jobDescription-FAIL-multiSteps.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
 if [[ "${?}" -eq 111 ]]; then
   echo -e "\nSuccess\n\n"
 else
@@ -61,7 +61,7 @@ fi
 
 
 # FAIL with exit code > 255
-$DIRACSCRIPTS/dirac-jobexec jobDescription-FAIL1502.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
+dirac-jobexec jobDescription-FAIL1502.xml --cfg "${SCRIPT_DIR}/pilot.cfg" $DEBUG
 if [[ "${?}" -eq 222 ]]; then # This is 1502 & 255 (0xDE)
   echo -e "\nSuccess\n\n"
 else

--- a/tests/Integration/all_integration_client_tests.sh
+++ b/tests/Integration/all_integration_client_tests.sh
@@ -9,13 +9,16 @@
 echo -e '****************************************'
 echo -e '********' "client -> server tests" '********\n'
 
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo -e "THIS_DIR=${THIS_DIR}" |& tee -a clientTestOutputs.txt
+
 echo -e "*** $(date -u)  Getting a non privileged user\n" |& tee -a clientTestOutputs.txt
 dirac-proxy-init -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Accounting TESTS ****\n"
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/AccountingSystem/Test_DataStoreClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/AccountingSystem/Test_ReportsClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/AccountingSystem/Test_DataStoreClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/AccountingSystem/Test_ReportsClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 
 #-------------------------------------------------------------------------------#
@@ -25,50 +28,49 @@ echo -e "*** $(date -u)  Getting a non privileged user\n" |& tee -a clientTestOu
 dirac-proxy-init -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 
 echo -e "*** $(date -u)  Starting RMS Client test as a non privileged user\n" |& tee -a clientTestOutputs.txt
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/RequestManagementSystem/Test_Client_Req.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 echo -e "*** $(date -u)  getting the prod role again\n" |& tee -a clientTestOutputs.txt
 dirac-proxy-init -g prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 echo -e "*** $(date -u)  Starting RMS Client test as an admin user\n" |& tee -a clientTestOutputs.txt
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/RequestManagementSystem/Test_Client_Req.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/RequestManagementSystem/Test_Client_Req.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RSS TESTS ****\n"
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/ResourceStatusSystem/Test_ResourceStatus.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/ResourceStatusSystem/Test_SiteStatus.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/ResourceStatusSystem/Test_Publisher.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/ResourceStatusSystem/Test_EmailActionAgent.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ResourceStatusSystem/Test_ResourceManagement.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ResourceStatusSystem/Test_ResourceStatus.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ResourceStatusSystem/Test_SiteStatus.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ResourceStatusSystem/Test_Publisher.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ResourceStatusSystem/Test_EmailActionAgent.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** WMS TESTS ****\n"
 # pytest "${CLIENTINSTALLDIR}"/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsLoggingClient.py |& tee -a clientTestOutputs.txt
-python "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_SandboxStoreClient.py" --cfg "$WORKSPACE/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobWrapper.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_PilotsClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+python "${THIS_DIR}/WorkloadManagementSystem/Test_SandboxStoreClient.py" --cfg "$WORKSPACE/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_JobWrapper.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_PilotsClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 ## no real tests
-python "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/createJobXMLDescriptions.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-"${CLIENTINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_dirac-jobexec.sh" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-"${CLIENTINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_TimeLeft.sh" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+python "${THIS_DIR}/WorkloadManagementSystem/createJobXMLDescriptions.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+"${THIS_DIR}/WorkloadManagementSystem/Test_dirac-jobexec.sh" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+"${THIS_DIR}/WorkloadManagementSystem/Test_TimeLeft.sh" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** MONITORING TESTS ****\n"
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/Monitoring/Test_MonitoringSystem.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/Monitoring/Test_MonitoringSystem.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** TS TESTS ****\n"
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/TransformationSystem/Test_Client_Transformation.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-# pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/TransformationSystem/Test_TS_DFC_Catalog.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-
+pytest "${THIS_DIR}/TransformationSystem/Test_Client_Transformation.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+# pytest "${THIS_DIR}/TransformationSystem/Test_TS_DFC_Catalog.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** PS TESTS ****\n"
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/ProductionSystem/Test_Client_Production.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/ProductionSystem/Test_Client_TS_Prod.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ProductionSystem/Test_Client_Production.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ProductionSystem/Test_Client_TS_Prod.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** DataManager TESTS ****\n"
@@ -77,7 +79,7 @@ echo -e "*** $(date -u) **** DataManager TESTS ****\n"
 echo -e "*** $(date -u)  Getting a non privileged user to find its VO dynamically\n" |& tee -a clientTestOutputs.txt
 dirac-proxy-init -g jenkins_user -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG |& tee -a clientTestOutputs.txt
 
-userVO=$(python -c "from DIRAC.Core.Base.Script import parseCommandLine; parseCommandLine(); from DIRAC.Core.Security.ProxyInfo import getVOfromProxyGroup; print getVOfromProxyGroup().get('Value','')")
+userVO=$(python -c "from DIRAC.Core.Base.Script import parseCommandLine; parseCommandLine(); from DIRAC.Core.Security.ProxyInfo import getVOfromProxyGroup; print(getVOfromProxyGroup().get('Value',''))")
 userVO="${userVO:-Jenkins}"
 echo -e "*** $(date -u) VO is "${userVO}"\n" |& tee -a clientTestOutputs.txt
 
@@ -100,7 +102,7 @@ dirac-dms-filecatalog-cli -f FileCatalog < dataManager_create_folders
 echo -e "*** $(date -u)  Getting a non privileged user\n" |& tee -a clientTestOutputs.txt
 dirac-proxy-init -g jenkins_user -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_DataManager.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/DataManagementSystem/Test_DataManager.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 # MultiVO File Catalog tests are configured to use MultiVOFileCatalog module with a separate DB.
@@ -110,7 +112,7 @@ pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_Da
 # normal user proxy
 dirac-proxy-init -g jenkins_user -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 echo -e "*** $(date -u) **** MultiVO User Metadata TESTS ****\n"
-python -m pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_UserMetadata.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+python -m pytest "${THIS_DIR}/DataManagementSystem/Test_UserMetadata.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 echo -e "*** $(date -u) **** S3 TESTS ****\n"
-pytest "${CLIENTINSTALLDIR}/DIRAC/tests/Integration/Resources/Storage/Test_Resources_S3.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/Resources/Storage/Test_Resources_S3.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))


### PR DESCRIPTION
Includes the two already approved PRs as it will be broken without them: #4980 #4975

The main change here is to use DIRACOS2 and `pip install` when running the Python 3 client integration tests (up until now the version from `chrisburr/DIRACOS2` was being used with `dirac-install`).

The only notable change is that use of `$DIRACROOT/scripts/` doesn't really make sense with a Python 3 + pip installation but I think it should be safe to take it from `$PATH` in all situations. Any thoughts?

BEGINRELEASENOTES

*WorkloadManagement
CHANGE: Take dirac-jobexec from PATH by default

*Python 3
NEW: Run Python 3 integration tests with DIRACOS2 and pip install

ENDRELEASENOTES
