### PR TITLE
[v7r1] HTCondorResourceUsage: fix the access to $_CONDOR_JOB_AD

### DIFF
--- a/Resources/Computing/BatchSystems/TimeLeft/HTCondorResourceUsage.py
+++ b/Resources/Computing/BatchSystems/TimeLeft/HTCondorResourceUsage.py
@@ -34,7 +34,8 @@ class HTCondorResourceUsage(ResourceUsage):
     #   only present on some Sites
     # - CurrentTime: current time
     # - JobCurrentStartDate: start of the job execution
-    cmd = 'condor_status -ads $_CONDOR_JOB_AD -af MaxRuntime CurrentTime-JobCurrentStartDate'
+    jobDescription = os.environ.get('_CONDOR_JOB_AD')
+    cmd = 'condor_status -ads %s -af MaxRuntime CurrentTime-JobCurrentStartDate' % jobDescription
     result = runCommand(cmd)
     if not result['OK']:
       return S_ERROR('Current batch system is not supported')


### PR DESCRIPTION
Just a small fix to the `HTCondorResourceUsage` module that we've just introduced.
The module is not able to get `$_CONDOR_JOB_AD` and is, thus, inefficient.

BEGINRELEASENOTES
*Resources
FIX: Getting access to $_CONDOR_JOB_AD in HTCondorResourceUsage
ENDRELEASENOTES
