### PR TITLE
[v7r3] Support running dirac-configure without arguments

### DIFF
--- a/src/DIRAC/Core/Utilities/DIRACScript.py
+++ b/src/DIRAC/Core/Utilities/DIRACScript.py
@@ -106,3 +106,13 @@ def _extensionsByPriority():
     # If multiple are passed, sort the extensions so things are deterministic at least
     extensions.extend(sorted(extensionNames))
   return extensions
+
+
+def _getExtensionMetadata(extensionName):
+  """Get the metadata for a given extension name"""
+  # This is only available in Python 3.8+ so it has to be here for now
+  from importlib import metadata  # pylint: disable=no-name-in-module
+
+  for entrypoint in metadata.entry_points()['dirac']:
+    if extensionName == _entrypointToExtension(entrypoint):
+      return entrypoint.load()()

--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -84,310 +84,262 @@ from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClie
 
 __RCSID__ = "$Id$"
 
+class Params(object):
+  def __init__(self):
+    self.logLevel = None
+    self.setup = None
+    self.configurationServer = None
+    self.includeAllServers = False
+    self.gatewayServer = None
+    self.siteName = None
+    self.useServerCert = False
+    self.skipCAChecks = False
+    self.skipCADownload = False
+    self.useVersionsDir = False
+    self.architecture = None
+    self.localSE = None
+    self.ceName = None
+    self.vo = None
+    self.update = False
+    self.outputFile = ''
+    self.skipVOMSDownload = False
+    self.extensions = ''
 
-logLevel = None
-setup = None
-configurationServer = None
-includeAllServers = False
-gatewayServer = None
-siteName = None
-useServerCert = False
-skipCAChecks = False
-skipCADownload = False
-useVersionsDir = False
-architecture = None
-localSE = None
-ceName = None
-vo = None
-update = False
-outputFile = ''
-skipVOMSDownload = False
-extensions = ''
+  def setGateway(self, optionValue):
+    self.gatewayServer = optionValue
+    self.setServer(self.gatewayServer + '/Configuration/Server')
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('Gateway'), self.gatewayServer)
+    return DIRAC.S_OK()
 
+  def setOutput(self, optionValue):
+    self.outputFile = optionValue
+    return DIRAC.S_OK()
 
-def setGateway(optionValue):
-  global gatewayServer
-  gatewayServer = optionValue
-  setServer(gatewayServer + '/Configuration/Server')
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('Gateway'), gatewayServer)
-  return DIRAC.S_OK()
+  def setServer(self, optionValue):
+    self.configurationServer = optionValue
+    DIRAC.gConfig.setOptionValue('/DIRAC/Configuration/Servers', self.configurationServer)
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('ConfigurationServer'), self.configurationServer)
+    return DIRAC.S_OK()
 
+  def setAllServers(self, optionValue):
+    self.includeAllServers = True
 
-def setOutput(optionValue):
-  global outputFile
-  outputFile = optionValue
-  return DIRAC.S_OK()
+  def setSetup(self, optionValue):
+    self.setup = optionValue
+    DIRAC.gConfig.setOptionValue('/DIRAC/Setup', self.setup)
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('Setup'), self.setup)
+    return DIRAC.S_OK()
 
+  def setSiteName(self, optionValue):
+    self.siteName = optionValue
+    Script.localCfg.addDefaultEntry('/LocalSite/Site', self.siteName)
+    DIRAC.__siteName = False
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('SiteName'), self.siteName)
+    return DIRAC.S_OK()
 
-def setServer(optionValue):
-  global configurationServer
-  configurationServer = optionValue
-  DIRAC.gConfig.setOptionValue('/DIRAC/Configuration/Servers', configurationServer)
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('ConfigurationServer'), configurationServer)
-  return DIRAC.S_OK()
+  def setCEName(self, optionValue):
+    self.ceName = optionValue
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('CEName'), self.ceName)
+    return DIRAC.S_OK()
 
+  def setServerCert(self, optionValue):
+    self.useServerCert = True
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('UseServerCertificate'), self.useServerCert)
+    return DIRAC.S_OK()
 
-def setAllServers(optionValue):
-  global includeAllServers
-  includeAllServers = True
+  def setSkipCAChecks(self, optionValue):
+    self.skipCAChecks = True
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('SkipCAChecks'), self.skipCAChecks)
+    return DIRAC.S_OK()
 
+  def setSkipCADownload(self, optionValue):
+    self.skipCADownload = True
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('SkipCADownload'), self.skipCADownload)
+    return DIRAC.S_OK()
 
-def setSetup(optionValue):
-  global setup
-  setup = optionValue
-  DIRAC.gConfig.setOptionValue('/DIRAC/Setup', setup)
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('Setup'), setup)
-  return DIRAC.S_OK()
+  def setSkipVOMSDownload(self, optionValue):
+    self.skipVOMSDownload = True
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('SkipVOMSDownload'), self.skipVOMSDownload)
+    return DIRAC.S_OK()
 
+  def setUseVersionsDir(self, optionValue):
+    self.useVersionsDir = True
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('UseVersionsDir'), self.useVersionsDir)
+    return DIRAC.S_OK()
 
-def setSiteName(optionValue):
-  global siteName
-  siteName = optionValue
-  Script.localCfg.addDefaultEntry('/LocalSite/Site', siteName)
-  DIRAC.__siteName = False
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('SiteName'), siteName)
-  return DIRAC.S_OK()
+  def setArchitecture(self, optionValue):
+    self.architecture = optionValue
+    Script.localCfg.addDefaultEntry('/LocalSite/Architecture', self.architecture)
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('Architecture'), self.architecture)
+    return DIRAC.S_OK()
 
+  def setLocalSE(self, optionValue):
+    self.localSE = optionValue
+    Script.localCfg.addDefaultEntry('/LocalSite/LocalSE', self.localSE)
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('LocalSE'), self.localSE)
+    return DIRAC.S_OK()
 
-def setCEName(optionValue):
-  global ceName
-  ceName = optionValue
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('CEName'), ceName)
-  return DIRAC.S_OK()
+  def setVO(self, optionValue):
+    self.vo = optionValue
+    Script.localCfg.addDefaultEntry('/DIRAC/VirtualOrganization', self.vo)
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('VirtualOrganization'), self.vo)
+    return DIRAC.S_OK()
 
+  def forceUpdate(self, optionValue):
+    self.update = True
+    return DIRAC.S_OK()
 
-def setServerCert(optionValue):
-  global useServerCert
-  useServerCert = True
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('UseServerCertificate'), useServerCert)
-  return DIRAC.S_OK()
-
-
-def setSkipCAChecks(optionValue):
-  global skipCAChecks
-  skipCAChecks = True
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('SkipCAChecks'), skipCAChecks)
-  return DIRAC.S_OK()
-
-
-def setSkipCADownload(optionValue):
-  global skipCADownload
-  skipCADownload = True
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('SkipCADownload'), skipCADownload)
-  return DIRAC.S_OK()
-
-
-def setSkipVOMSDownload(optionValue):
-  global skipVOMSDownload
-  skipVOMSDownload = True
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('SkipVOMSDownload'), skipVOMSDownload)
-  return DIRAC.S_OK()
-
-
-def setUseVersionsDir(optionValue):
-  global useVersionsDir
-  useVersionsDir = True
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('UseVersionsDir'), useVersionsDir)
-  return DIRAC.S_OK()
-
-
-def setArchitecture(optionValue):
-  global architecture
-  architecture = optionValue
-  Script.localCfg.addDefaultEntry('/LocalSite/Architecture', architecture)
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('Architecture'), architecture)
-  return DIRAC.S_OK()
-
-
-def setLocalSE(optionValue):
-  global localSE
-  localSE = optionValue
-  Script.localCfg.addDefaultEntry('/LocalSite/LocalSE', localSE)
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('LocalSE'), localSE)
-  return DIRAC.S_OK()
-
-
-def setVO(optionValue):
-  global vo
-  vo = optionValue
-  Script.localCfg.addDefaultEntry('/DIRAC/VirtualOrganization', vo)
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('VirtualOrganization'), vo)
-  return DIRAC.S_OK()
-
-
-def forceUpdate(optionValue):
-  global update
-  update = True
-  return DIRAC.S_OK()
-
-
-def setExtensions(optionValue):
-  global extensions
-  extensions = optionValue
-  DIRAC.gConfig.setOptionValue('/DIRAC/Extensions', extensions)
-  DIRAC.gConfig.setOptionValue(cfgInstallPath('Extensions'), extensions)
-  return DIRAC.S_OK()
+  def setExtensions(self, optionValue):
+    self.extensions = optionValue
+    DIRAC.gConfig.setOptionValue('/DIRAC/Extensions', self.extensions)
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('Extensions'), self.extensions)
+    return DIRAC.S_OK()
 
 
 @DIRACScript()
 def main():
-  global logLevel
-  global setup
-  global configurationServer
-  global includeAllServers
-  global gatewayServer
-  global siteName
-  global useServerCert
-  global skipCAChecks
-  global skipCADownload
-  global useVersionsDir
-  global architecture
-  global localSE
-  global ceName
-  global vo
-  global update
-  global outputFile
-  global skipVOMSDownload
-  global extensions
+  params = Params()
 
   Script.disableCS()
 
-  Script.registerSwitch("S:", "Setup=", "Set <setup> as DIRAC setup", setSetup)
-  Script.registerSwitch("e:", "Extensions=", "Set <extensions> as DIRAC extensions", setExtensions)
-  Script.registerSwitch("C:", "ConfigurationServer=", "Set <server> as DIRAC configuration server", setServer)
-  Script.registerSwitch("I", "IncludeAllServers", "include all Configuration Servers", setAllServers)
-  Script.registerSwitch("n:", "SiteName=", "Set <sitename> as DIRAC Site Name", setSiteName)
-  Script.registerSwitch("N:", "CEName=", "Determiner <sitename> from <cename>", setCEName)
-  Script.registerSwitch("V:", "VO=", "Set the VO name", setVO)
+  Script.registerSwitch("S:", "Setup=", "Set <setup> as DIRAC setup", params.setSetup)
+  Script.registerSwitch("e:", "Extensions=", "Set <extensions> as DIRAC extensions", params.setExtensions)
+  Script.registerSwitch("C:", "ConfigurationServer=", "Set <server> as DIRAC configuration server", params.setServer)
+  Script.registerSwitch("I", "IncludeAllServers", "include all Configuration Servers", params.setAllServers)
+  Script.registerSwitch("n:", "SiteName=", "Set <sitename> as DIRAC Site Name", params.setSiteName)
+  Script.registerSwitch("N:", "CEName=", "Determiner <sitename> from <cename>", params.setCEName)
+  Script.registerSwitch("V:", "VO=", "Set the VO name", params.setVO)
 
-  Script.registerSwitch("W:", "gateway=", "Configure <gateway> as DIRAC Gateway for the site", setGateway)
+  Script.registerSwitch("W:", "gateway=", "Configure <gateway> as DIRAC Gateway for the site", params.setGateway)
 
-  Script.registerSwitch("U", "UseServerCertificate", "Configure to use Server Certificate", setServerCert)
-  Script.registerSwitch("H", "SkipCAChecks", "Configure to skip check of CAs", setSkipCAChecks)
-  Script.registerSwitch("D", "SkipCADownload", "Configure to skip download of CAs", setSkipCADownload)
-  Script.registerSwitch("M", "SkipVOMSDownload", "Configure to skip download of VOMS info", setSkipVOMSDownload)
+  Script.registerSwitch("U", "UseServerCertificate", "Configure to use Server Certificate", params.setServerCert)
+  Script.registerSwitch("H", "SkipCAChecks", "Configure to skip check of CAs", params.setSkipCAChecks)
+  Script.registerSwitch("D", "SkipCADownload", "Configure to skip download of CAs", params.setSkipCADownload)
+  Script.registerSwitch("M", "SkipVOMSDownload", "Configure to skip download of VOMS info", params.setSkipVOMSDownload)
 
-  Script.registerSwitch("v", "UseVersionsDir", "Use versions directory", setUseVersionsDir)
+  Script.registerSwitch("v", "UseVersionsDir", "Use versions directory", params.setUseVersionsDir)
 
-  Script.registerSwitch("A:", "Architecture=", "Configure /Architecture=<architecture>", setArchitecture)
-  Script.registerSwitch("L:", "LocalSE=", "Configure LocalSite/LocalSE=<localse>", setLocalSE)
+  Script.registerSwitch("A:", "Architecture=", "Configure /Architecture=<architecture>", params.setArchitecture)
+  Script.registerSwitch("L:", "LocalSE=", "Configure LocalSite/LocalSE=<localse>", params.setLocalSE)
 
   Script.registerSwitch(
       "F",
       "ForceUpdate",
       "Force Update of cfg file (i.e. dirac.cfg) (otherwise nothing happens if dirac.cfg already exists)",
-      forceUpdate)
+      params.forceUpdate)
 
-  Script.registerSwitch("O:", "output=", "output configuration file", setOutput)
+  Script.registerSwitch("O:", "output=", "output configuration file", params.setOutput)
 
-  Script.setUsageMessage('\n'.join([__doc__.split('\n')[1],
-                                    '\nUsage:',
-                                    '  %s [options] ...\n' % Script.scriptName]))
+  Script.setUsageMessage('\n'.join([
+      __doc__.split('\n')[1],
+      '\nUsage:',
+      '  %s [options] ...\n' % Script.scriptName
+  ]))
 
   Script.parseCommandLine(ignoreErrors=True)
   args = Script.getExtraCLICFGFiles()
 
-  if not logLevel:
-    logLevel = DIRAC.gConfig.getValue(cfgInstallPath('LogLevel'), '')
-    if logLevel:
-      DIRAC.gLogger.setLevel(logLevel)
+  if not params.logLevel:
+    params.logLevel = DIRAC.gConfig.getValue(cfgInstallPath('LogLevel'), '')
+    if params.logLevel:
+      DIRAC.gLogger.setLevel(params.logLevel)
   else:
-    DIRAC.gConfig.setOptionValue(cfgInstallPath('LogLevel'), logLevel)
+    DIRAC.gConfig.setOptionValue(cfgInstallPath('LogLevel'), params.logLevel)
 
-  if not gatewayServer:
+  if not params.gatewayServer:
     newGatewayServer = DIRAC.gConfig.getValue(cfgInstallPath('Gateway'), '')
     if newGatewayServer:
-      setGateway(newGatewayServer)
+      params.setGateway(newGatewayServer)
 
-  if not configurationServer:
+  if not params.configurationServer:
     newConfigurationServer = DIRAC.gConfig.getValue(cfgInstallPath('ConfigurationServer'), '')
     if newConfigurationServer:
-      setServer(newConfigurationServer)
+      params.setServer(newConfigurationServer)
 
-  if not includeAllServers:
+  if not params.includeAllServers:
     newIncludeAllServer = DIRAC.gConfig.getValue(cfgInstallPath('IncludeAllServers'), False)
     if newIncludeAllServer:
-      setAllServers(True)
+      params.setAllServers(True)
 
-  if not setup:
+  if not params.setup:
     newSetup = DIRAC.gConfig.getValue(cfgInstallPath('Setup'), '')
     if newSetup:
-      setSetup(newSetup)
+      params.setSetup(newSetup)
 
-  if not siteName:
+  if not params.siteName:
     newSiteName = DIRAC.gConfig.getValue(cfgInstallPath('SiteName'), '')
     if newSiteName:
-      setSiteName(newSiteName)
+      params.setSiteName(newSiteName)
 
-  if not ceName:
+  if not params.ceName:
     newCEName = DIRAC.gConfig.getValue(cfgInstallPath('CEName'), '')
     if newCEName:
-      setCEName(newCEName)
+      params.setCEName(newCEName)
 
-  if not useServerCert:
+  if not params.useServerCert:
     newUserServerCert = DIRAC.gConfig.getValue(cfgInstallPath('UseServerCertificate'), False)
     if newUserServerCert:
-      setServerCert(newUserServerCert)
+      params.setServerCert(newUserServerCert)
 
-  if not skipCAChecks:
+  if not params.skipCAChecks:
     newSkipCAChecks = DIRAC.gConfig.getValue(cfgInstallPath('SkipCAChecks'), False)
     if newSkipCAChecks:
-      setSkipCAChecks(newSkipCAChecks)
+      params.setSkipCAChecks(newSkipCAChecks)
 
-  if not skipCADownload:
+  if not params.skipCADownload:
     newSkipCADownload = DIRAC.gConfig.getValue(cfgInstallPath('SkipCADownload'), False)
     if newSkipCADownload:
-      setSkipCADownload(newSkipCADownload)
+      params.setSkipCADownload(newSkipCADownload)
 
-  if not useVersionsDir:
+  if not params.useVersionsDir:
     newUseVersionsDir = DIRAC.gConfig.getValue(cfgInstallPath('UseVersionsDir'), False)
     if newUseVersionsDir:
-      setUseVersionsDir(newUseVersionsDir)
+      params.setUseVersionsDir(newUseVersionsDir)
       # Set proper Defaults in configuration (even if they will be properly overwrite by gComponentInstaller
       instancePath = os.path.dirname(os.path.dirname(DIRAC.rootPath))
       rootPath = os.path.join(instancePath, 'pro')
       DIRAC.gConfig.setOptionValue(cfgInstallPath('InstancePath'), instancePath)
       DIRAC.gConfig.setOptionValue(cfgInstallPath('RootPath'), rootPath)
 
-  if not architecture:
+  if not params.architecture:
     newArchitecture = DIRAC.gConfig.getValue(cfgInstallPath('Architecture'), '')
     if newArchitecture:
-      setArchitecture(newArchitecture)
+      params.setArchitecture(newArchitecture)
 
-  if not vo:
+  if not params.vo:
     newVO = DIRAC.gConfig.getValue(cfgInstallPath('VirtualOrganization'), '')
     if newVO:
-      setVO(newVO)
+      params.setVO(newVO)
 
-  if not extensions:
+  if not params.extensions:
     newExtensions = DIRAC.gConfig.getValue(cfgInstallPath('Extensions'), '')
     if newExtensions:
-      setExtensions(newExtensions)
+      params.setExtensions(newExtensions)
 
   DIRAC.gLogger.notice('Executing: %s ' % (' '.join(sys.argv)))
   DIRAC.gLogger.notice('Checking DIRAC installation at "%s"' % DIRAC.rootPath)
 
-  if update:
-    if outputFile:
-      DIRAC.gLogger.notice('Will update the output file %s' % outputFile)
+  if params.update:
+    if params.outputFile:
+      DIRAC.gLogger.notice('Will update the output file %s' % params.outputFile)
     else:
       DIRAC.gLogger.notice('Will update %s' % DIRAC.gConfig.diracConfigFilePath)
 
-  if setup:
-    DIRAC.gLogger.verbose('/DIRAC/Setup =', setup)
-  if vo:
-    DIRAC.gLogger.verbose('/DIRAC/VirtualOrganization =', vo)
-  if configurationServer:
-    DIRAC.gLogger.verbose('/DIRAC/Configuration/Servers =', configurationServer)
+  if params.setup:
+    DIRAC.gLogger.verbose('/DIRAC/Setup =', params.setup)
+  if params.vo:
+    DIRAC.gLogger.verbose('/DIRAC/VirtualOrganization =', params.vo)
+  if params.configurationServer:
+    DIRAC.gLogger.verbose('/DIRAC/Configuration/Servers =', params.configurationServer)
 
-  if siteName:
-    DIRAC.gLogger.verbose('/LocalSite/Site =', siteName)
-  if architecture:
-    DIRAC.gLogger.verbose('/LocalSite/Architecture =', architecture)
-  if localSE:
-    DIRAC.gLogger.verbose('/LocalSite/localSE =', localSE)
+  if params.siteName:
+    DIRAC.gLogger.verbose('/LocalSite/Site =', params.siteName)
+  if params.architecture:
+    DIRAC.gLogger.verbose('/LocalSite/Architecture =', params.architecture)
+  if params.localSE:
+    DIRAC.gLogger.verbose('/LocalSite/localSE =', params.localSE)
 
-  if not useServerCert:
+  if not params.useServerCert:
     DIRAC.gLogger.verbose('/DIRAC/Security/UseServerCertificate =', 'no')
     # Being sure it was not there before
     Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
@@ -402,21 +354,21 @@ def main():
   if host:
     DIRAC.gConfig.setOptionValue(cfgPath("DIRAC", "Hostname"), host)
 
-  if skipCAChecks:
+  if params.skipCAChecks:
     DIRAC.gLogger.verbose('/DIRAC/Security/SkipCAChecks =', 'yes')
     # Being sure it was not there before
     Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
     Script.localCfg.addDefaultEntry('/DIRAC/Security/SkipCAChecks', 'yes')
   else:
     # Necessary to allow initial download of CA's
-    if not skipCADownload:
+    if not params.skipCADownload:
       DIRAC.gConfig.setOptionValue('/DIRAC/Security/SkipCAChecks', 'yes')
-  if not skipCADownload:
+  if not params.skipCADownload:
     Script.enableCS()
     try:
       dirName = os.path.join(DIRAC.rootPath, 'etc', 'grid-security', 'certificates')
       mkDir(dirName)
-    except BaseException:
+    except Exception:
       DIRAC.gLogger.exception()
       DIRAC.gLogger.fatal('Fail to create directory:', dirName)
       DIRAC.exit(-1)
@@ -428,12 +380,12 @@ def main():
     except Exception as e:
       DIRAC.gLogger.error('Failed to sync CAs and CRLs: %s' % str(e))
 
-    if not skipCAChecks:
+    if not params.skipCAChecks:
       Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
 
-  if ceName or siteName:
+  if params.ceName or params.siteName:
     # This is used in the pilot context, we should have a proxy, or a certificate, and access to CS
-    if useServerCert:
+    if params.useServerCert:
       # Being sure it was not there before
       Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
       Script.localCfg.addDefaultEntry('/DIRAC/Security/UseServerCertificate', 'yes')
@@ -454,48 +406,48 @@ def main():
       else:
         sites = siteSections['Value']
 
-      if not siteName:
-        if ceName:
+      if not params.siteName:
+        if params.ceName:
           for site in sites:
             res = DIRAC.gConfig.getSections('/Resources/Sites/%s/%s/CEs/' % (grid, site), [])
             if not res['OK']:
               DIRAC.gLogger.warn('Could not get %s CEs list' % site)
-            if ceName in res['Value']:
-              siteName = site
+            if params.ceName in res['Value']:
+              params.siteName = site
               break
-      if siteName:
-        DIRAC.gLogger.notice('Setting /LocalSite/Site = %s' % siteName)
-        Script.localCfg.addDefaultEntry('/LocalSite/Site', siteName)
+      if params.siteName:
+        DIRAC.gLogger.notice('Setting /LocalSite/Site = %s' % params.siteName)
+        Script.localCfg.addDefaultEntry('/LocalSite/Site', params.siteName)
         DIRAC.__siteName = False
-        if ceName:
-          DIRAC.gLogger.notice('Setting /LocalSite/GridCE = %s' % ceName)
-          Script.localCfg.addDefaultEntry('/LocalSite/GridCE', ceName)
+        if params.ceName:
+          DIRAC.gLogger.notice('Setting /LocalSite/GridCE = %s' % params.ceName)
+          Script.localCfg.addDefaultEntry('/LocalSite/GridCE', params.ceName)
 
-        if not localSE and siteName in sites:
-          localSE = getSEsForSite(siteName)
-          if localSE['OK'] and localSE['Value']:
-            localSE = ','.join(localSE['Value'])
-            DIRAC.gLogger.notice('Setting /LocalSite/LocalSE =', localSE)
-            Script.localCfg.addDefaultEntry('/LocalSite/LocalSE', localSE)
+        if not params.localSE and params.siteName in sites:
+          params.localSE = getSEsForSite(params.siteName)
+          if params.localSE['OK'] and params.localSE['Value']:
+            params.localSE = ','.join(params.localSE['Value'])
+            DIRAC.gLogger.notice('Setting /LocalSite/LocalSE =', params.localSE)
+            Script.localCfg.addDefaultEntry('/LocalSite/LocalSE', params.localSE)
           break
 
-  if gatewayServer:
-    DIRAC.gLogger.verbose('/DIRAC/Gateways/%s =' % DIRAC.siteName(), gatewayServer)
-    Script.localCfg.addDefaultEntry('/DIRAC/Gateways/%s' % DIRAC.siteName(), gatewayServer)
+  if params.gatewayServer:
+    DIRAC.gLogger.verbose('/DIRAC/Gateways/%s =' % DIRAC.siteName(), params.gatewayServer)
+    Script.localCfg.addDefaultEntry('/DIRAC/Gateways/%s' % DIRAC.siteName(), params.gatewayServer)
 
   # Create the local cfg if it is not yet there
-  if not outputFile:
-    outputFile = DIRAC.gConfig.diracConfigFilePath
-  outputFile = os.path.abspath(outputFile)
-  if not os.path.exists(outputFile):
-    configDir = os.path.dirname(outputFile)
+  if not params.outputFile:
+    params.outputFile = DIRAC.gConfig.diracConfigFilePath
+  params.outputFile = os.path.abspath(params.outputFile)
+  if not os.path.exists(params.outputFile):
+    configDir = os.path.dirname(params.outputFile)
     mkDir(configDir)
-    update = True
-    DIRAC.gConfig.dumpLocalCFGToFile(outputFile)
+    params.update = True
+    DIRAC.gConfig.dumpLocalCFGToFile(params.outputFile)
 
-  if includeAllServers:
+  if params.includeAllServers:
     # We need user proxy or server certificate to continue in order to get all the CS URLs
-    if not useServerCert:
+    if not params.useServerCert:
       Script.enableCS()
       result = getProxyInfo()
       if not result['OK']:
@@ -512,20 +464,20 @@ def main():
     DIRAC.gConfig.setOptionValue('/DIRAC/Configuration/Servers', ','.join(DIRAC.gConfig.getServersList()))
     DIRAC.gLogger.verbose('/DIRAC/Configuration/Servers =', ','.join(DIRAC.gConfig.getServersList()))
 
-  if useServerCert:
+  if params.useServerCert:
     # always removing before dumping
     Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
     Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
     Script.localCfg.deleteOption('/DIRAC/Security/SkipVOMSDownload')
 
-  if update:
-    DIRAC.gConfig.dumpLocalCFGToFile(outputFile)
+  if params.update:
+    DIRAC.gConfig.dumpLocalCFGToFile(params.outputFile)
 
   # ## LAST PART: do the vomsdir/vomses magic
 
   # This has to be done for all VOs in the installation
 
-  if skipVOMSDownload:
+  if params.skipVOMSDownload:
     # We stop here
     sys.exit(0)
 
@@ -570,7 +522,7 @@ def main():
       DIRAC.gLogger.exception("Could not generate vomses file")
       error = "Could not generate vomses file for VO %s" % voName
 
-  if useServerCert:
+  if params.useServerCert:
     Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
     # When using Server Certs CA's will be checked, the flag only disables initial download
     # this will be replaced by the use of SkipCADownload

--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -213,4 +213,7 @@ def abort(exitCode, *args, **kwargs):
 def extension_metadata():
   return {
       "priority": 0,
+      "setups": {
+          "DIRAC-Certification": "dips://lbcertifdirac70.cern.ch:9135/Configuration/Server",
+      },
   }


### PR DESCRIPTION
This PR uses `prompt-toolkit` (a dependency of IPython) to improve the CLI interactions. As this inherently interactive I've included videos of how it looks. If this is accepted I'll add `prompt-toolkit` to DIRACOS (it's already there, but I'll make it an explicit dependency).

* 803e53b: Gets rid of the globals used by `dirac-configure`. I could easily rebase this commit out of this PR if desired.

* c12c515: Use `prompt-toolkit` to read the certificate password instead of plain `getpass`. This fixes the long standing bug that pressing `Control + C` while typing your password breaks the prompt. (moved to #5004)

https://user-images.githubusercontent.com/5220533/109291419-40bc3300-7829-11eb-9501-fbbd52175273.mov

* 5687a7a: If `dirac-configure` is ran without any arguments with a Python 3 installation it will suggest setups and CS URLs using the `extension_metadata`. Python 2 based installations are unaffected.

https://user-images.githubusercontent.com/5220533/109291407-3d28ac00-7829-11eb-94aa-da24274708ec.mov

BEGINRELEASENOTES

*Core
FIX: Handle SIGINT correctly when reading certificate passwords
NEW: dirac-configure can now be ran without arguments when using Python 3

ENDRELEASENOTES
