### PR TITLE
[v7r2] Use prompt_toolkit for reading passwords

### DIFF
--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -21,6 +21,7 @@ dependencies:
   - numpy
   - pexpect >=4.0.1
   - pillow
+  - prompt-toolkit >=3,<4
   - psutil >=4.2.0
   - pyasn1 >0.4.1
   - pyasn1-modules

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - numpy >=1.10.1,<1.16  # Limit to 1.15 as Python 2 pylint has bugs with numpy 1.16
   - pexpect >=4.0.1
   - pillow
+  - prompt_toolkit
   - psutil >=4.2.0
   - pyasn1 >0.4.1
   - pyasn1-modules

--- a/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
@@ -303,8 +303,7 @@ def generateProxy(params):
       try:
         userPasswd = prompt(u"Enter Certificate password: ", is_password=True)
       except KeyboardInterrupt:
-        gLogger.error("Caught KeyboardInterrupt, exiting...")
-        sys.exit(1)
+        return S_ERROR("Caught KeyboardInterrupt, exiting...")
     params.userPasswd = userPasswd
 
   # Find location

--- a/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import sys
-import getpass
+from prompt_toolkit import prompt
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Base import Script
 from DIRAC.Core.Utilities.NTP import getClockDeviation
@@ -297,11 +297,14 @@ def generateProxy(params):
   # First try reading the key from the file
   retVal = testChain.loadKeyFromFile(params.keyLoc, password=params.userPasswd)  # XXX why so commented?
   if not retVal['OK']:
-    passwdPrompt = "Enter Certificate password:"
     if params.stdinPasswd:
       userPasswd = sys.stdin.readline().strip("\n")
     else:
-      userPasswd = getpass.getpass(passwdPrompt)
+      try:
+        userPasswd = prompt(u"Enter Certificate password: ", is_password=True)
+      except KeyboardInterrupt:
+        gLogger.error("Caught KeyboardInterrupt, exiting...")
+        sys.exit(1)
     params.userPasswd = userPasswd
 
   # Find location

--- a/src/DIRAC/FrameworkSystem/Client/ProxyUpload.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyUpload.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 import sys
-import getpass
+from prompt_toolkit import prompt
 import DIRAC
 
 from DIRAC import gLogger
@@ -129,11 +129,14 @@ def uploadProxy(params):
     testChain = X509Chain()
     retVal = testChain.loadKeyFromFile(keyLoc, password=params.userPasswd)
     if not retVal['OK']:
-      passwdPrompt = "Enter Certificate password:"
       if params.stdinPasswd:
         userPasswd = sys.stdin.readline().strip("\n")
       else:
-        userPasswd = getpass.getpass(passwdPrompt)
+        try:
+          userPasswd = prompt(u"Enter Certificate password: ", is_password=True)
+        except KeyboardInterrupt:
+          DIRAC.gLogger.error("Caught KeyboardInterrupt, exiting...")
+          sys.exit(1)
       params.userPasswd = userPasswd
 
     DIRAC.gLogger.info("Loading cert and key")

--- a/src/DIRAC/FrameworkSystem/Client/ProxyUpload.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyUpload.py
@@ -135,8 +135,7 @@ def uploadProxy(params):
         try:
           userPasswd = prompt(u"Enter Certificate password: ", is_password=True)
         except KeyboardInterrupt:
-          DIRAC.gLogger.error("Caught KeyboardInterrupt, exiting...")
-          sys.exit(1)
+          return S_ERROR("Caught KeyboardInterrupt, exiting...")
       params.userPasswd = userPasswd
 
     DIRAC.gLogger.info("Loading cert and key")


### PR DESCRIPTION
Extracted from #4997 

BEGINRELEASENOTES

*Core
CHANGE: Use prompt-toolkit for password input when generating proxies

ENDRELEASENOTES
