### PR TITLE
[V7r1] MultiVO RSS

### DIFF
--- a/WorkloadManagementSystem/DB/PivotedPilotSummaryTable.py
+++ b/WorkloadManagementSystem/DB/PivotedPilotSummaryTable.py
@@ -1,0 +1,111 @@
+from DIRAC import S_OK, S_ERROR
+from DIRAC.Core.Base.DB import DB
+import DIRAC.Core.Utilities.Time as Time
+from DIRAC.Core.Utilities.MySQL import _quotedList
+
+class PivotedPilotSummaryTable:
+  """
+    SELECT Pivoted_eff.GridSite, Pivoted_eff.DestinationSite, Pivoted_eff.Done_Empties,
+           Pivoted_eff.Submitted, Pivoted_eff.Done, Pivoted_eff.Failed, Pivoted_eff.Aborted, 
+           Pivoted_eff.Running, Pivoted_eff.Waiting, Pivoted_eff.Scheduled, Pivoted_eff.Total,
+    (CASE 
+         WHEN Pivoted_eff.Done - Pivoted_eff.Done_Empties > 0 
+              THEN Pivoted_eff.Done/(Pivoted_eff.Done-Pivoted_eff.Done_Empties)
+         WHEN Pivoted_eff.Done=0 
+              THEN 0 
+         WHEN Pivoted_eff.Done=Pivoted_eff.Done_Empties 
+              THEN 99.0 ELSE 0.0 END) 
+          AS PilotsPerJob,
+          (Pivoted_eff.Total - Pivoted_eff.Aborted)/Pivoted_eff.Total*100.0 AS Eff
+    FROM (SELECT Frank.GridSite, Frank.DestinationSite, 
+                 SUM(if (Frank.Status='Done', Frank.Empties,0)) AS Done_Empties,
+                 SUM(if (Frank.Status='Submitted', Frank.qty, 0)) AS Submitted,
+                 SUM(if (Frank.Status='Done', Frank.qty, 0)) AS Done,
+                 SUM(if (Frank.Status='Failed', Frank.qty, 0)) AS Failed,
+                 SUM(if (Frank.Status='Aborted', Frank.qty, 0)) AS Aborted,
+                 SUM(if (Frank.Status='Running', Frank.qty, 0)) AS Running,
+                 SUM(if (Frank.Status='Waiting', Frank.qty, 0)) AS Waiting,
+                 SUM(if (Frank.Status='Scheduled', Frank.qty, 0)) AS Scheduled,
+                 SUM(Frank.qty) AS Total
+          FROM (SELECT GridSite, DestinationSite, Status, count(CASE WHEN CurrentJobID=0  THEN 1 END) AS Empties,
+                count(*) AS qty
+                from PilotAgents where 
+                     Status not in ('Done', 'Aborted') OR (Status in ('Done', 'Aborted')
+                     AND LastUpdateTime > '2019-12-04 10:35:00')  group by GridSite, DestinationSite, Status)
+          AS Frank
+          group by GridSite, DestinationSite)  
+    AS Pivoted_eff;
+  """
+
+  def __init__(self, columnList):
+    """
+    Initialise a table with columns to be grouped by.
+
+    :param columnList: i.e. ['GridSite', 'DestinationSite']
+    :return:
+    """
+
+    self.columnList = columnList
+    self.pstates = ['Submitted', 'Done', 'Failed', 'Aborted',
+                    'Running', 'Waiting', 'Scheduled', 'Ready']
+
+    #we want 'Site' and 'CE' in the final result
+    colMap = {'GridSite': 'Site', 'DestinationSite': 'CE'}
+    self.columns = [colMap.get(val, val) for val in columnList]
+
+    self.columns += self.pstates # MySQL._query() does not give us column names, sadly.
+
+  def buildSQL(self, selectDict = None):
+    """
+    Build an SQL query to create a table with all status counts in one row, ("pivoted")
+    grouped by columns in the column list.
+
+    :param selectDict:
+    :return: SQL query
+    """
+
+    last_update = Time.dateTime() - Time.day
+
+    pvtable = 'pivoted'
+    innerGroupBy = "(SELECT %s, Status,\n " \
+                   "count(CASE WHEN CurrentJobID=0  THEN 1 END) AS Empties," \
+                   " count(*) AS qty FROM PilotAgents\n " \
+                   "WHERE Status NOT IN ('Done', 'Aborted') OR (Status in ('Done', 'Aborted') \n" \
+                   " AND \n" \
+                   " LastUpdateTime > '%s')" \
+                   " GROUP by %s, Status)\n AS %s" % (
+                     _quotedList(self.columnList), last_update,
+                     _quotedList(self.columnList), pvtable)
+
+    # pivoted table: combine records with the same group of self.columnList into a single row.
+
+    # FIXME backqouting does not work with a prefix. Investigate.
+    pivotedQuery = "SELECT %s,\n" % ', '.join([pvtable + '.' + item for item in self.columnList])
+    line_template = " SUM(if (pivoted.Status={state!r}, pivoted.qty, 0)) AS {state}"
+    pivotedQuery += ',\n'.join(line_template.format(state=state) for state in self.pstates)
+    pivotedQuery += ",\n  SUM(if (%s.Status='Done', %s.Empties,0)) AS Done_Empty,\n" \
+                    "  SUM(%s.qty) AS Total " \
+                    "FROM\n" % (pvtable, pvtable, pvtable)
+
+    outerGroupBy = " GROUP BY %s) \nAS pivoted_eff;" % _quotedList(self.columnList)
+
+    # add efficiency columns using aliases defined in the pivoted table
+    eff_case = "(CASE\n  WHEN pivoted_eff.Done - pivoted_eff.Done_Empty > 0 \n" \
+               "  THEN pivoted_eff.Done/(pivoted_eff.Done-pivoted_eff.Done_Empty) \n" \
+               "  WHEN pivoted_eff.Done=0 THEN 0 \n" \
+               "  WHEN pivoted_eff.Done=pivoted_eff.Done_Empty \n" \
+               "  THEN 99.0 ELSE 0.0 END) AS PilotsPerJob,\n" \
+               " (pivoted_eff.Total - pivoted_eff.Aborted)/pivoted_eff.Total*100.0 AS PilotJobEff \nFROM \n("
+    eff_select_template = " CAST(pivoted_eff.{state} AS UNSIGNED) AS {state} "
+#    eff_select_template = " CAST(pivoted_eff.{state} AS UNSIGNED) AS {state} "
+    # now select the columns + the states:
+    pivoted_eff = "SELECT %s,\n" % ', '.join(['pivoted_eff' + '.' + item  for item in self.columnList]) + \
+                  ', '.join(eff_select_template.format(state=state) for state in self.pstates + ['Total']) + ", \n"
+
+    finalQuery = pivoted_eff + eff_case + pivotedQuery + innerGroupBy + outerGroupBy
+    self.columns += [' Total', 'PilotsPerJob', 'PilotJobEff']
+    return finalQuery
+
+  def getColumnList(self):
+
+    return self.columns

--- a/WorkloadManagementSystem/DB/PivotedPilotSummaryTable.py
+++ b/WorkloadManagementSystem/DB/PivotedPilotSummaryTable.py
@@ -3,21 +3,22 @@ from DIRAC.Core.Base.DB import DB
 import DIRAC.Core.Utilities.Time as Time
 from DIRAC.Core.Utilities.MySQL import _quotedList
 
+
 class PivotedPilotSummaryTable:
   """
     SELECT Pivoted_eff.GridSite, Pivoted_eff.DestinationSite, Pivoted_eff.Done_Empties,
-           Pivoted_eff.Submitted, Pivoted_eff.Done, Pivoted_eff.Failed, Pivoted_eff.Aborted, 
+           Pivoted_eff.Submitted, Pivoted_eff.Done, Pivoted_eff.Failed, Pivoted_eff.Aborted,
            Pivoted_eff.Running, Pivoted_eff.Waiting, Pivoted_eff.Scheduled, Pivoted_eff.Total,
-    (CASE 
-         WHEN Pivoted_eff.Done - Pivoted_eff.Done_Empties > 0 
+    (CASE
+         WHEN Pivoted_eff.Done - Pivoted_eff.Done_Empties > 0
               THEN Pivoted_eff.Done/(Pivoted_eff.Done-Pivoted_eff.Done_Empties)
-         WHEN Pivoted_eff.Done=0 
-              THEN 0 
-         WHEN Pivoted_eff.Done=Pivoted_eff.Done_Empties 
-              THEN 99.0 ELSE 0.0 END) 
+         WHEN Pivoted_eff.Done=0
+              THEN 0
+         WHEN Pivoted_eff.Done=Pivoted_eff.Done_Empties
+              THEN 99.0 ELSE 0.0 END)
           AS PilotsPerJob,
           (Pivoted_eff.Total - Pivoted_eff.Aborted)/Pivoted_eff.Total*100.0 AS Eff
-    FROM (SELECT Frank.GridSite, Frank.DestinationSite, 
+    FROM (SELECT Frank.GridSite, Frank.DestinationSite,
                  SUM(if (Frank.Status='Done', Frank.Empties,0)) AS Done_Empties,
                  SUM(if (Frank.Status='Submitted', Frank.qty, 0)) AS Submitted,
                  SUM(if (Frank.Status='Done', Frank.qty, 0)) AS Done,
@@ -29,11 +30,11 @@ class PivotedPilotSummaryTable:
                  SUM(Frank.qty) AS Total
           FROM (SELECT GridSite, DestinationSite, Status, count(CASE WHEN CurrentJobID=0  THEN 1 END) AS Empties,
                 count(*) AS qty
-                from PilotAgents where 
+                from PilotAgents where
                      Status not in ('Done', 'Aborted') OR (Status in ('Done', 'Aborted')
                      AND LastUpdateTime > '2019-12-04 10:35:00')  group by GridSite, DestinationSite, Status)
           AS Frank
-          group by GridSite, DestinationSite)  
+          group by GridSite, DestinationSite)
     AS Pivoted_eff;
   """
 
@@ -49,13 +50,13 @@ class PivotedPilotSummaryTable:
     self.pstates = ['Submitted', 'Done', 'Failed', 'Aborted',
                     'Running', 'Waiting', 'Scheduled', 'Ready']
 
-    #we want 'Site' and 'CE' in the final result
+    # we want 'Site' and 'CE' in the final result
     colMap = {'GridSite': 'Site', 'DestinationSite': 'CE'}
     self.columns = [colMap.get(val, val) for val in columnList]
 
-    self.columns += self.pstates # MySQL._query() does not give us column names, sadly.
+    self.columns += self.pstates  # MySQL._query() does not give us column names, sadly.
 
-  def buildSQL(self, selectDict = None):
+  def buildSQL(self, selectDict=None):
     """
     Build an SQL query to create a table with all status counts in one row, ("pivoted")
     grouped by columns in the column list.
@@ -74,8 +75,8 @@ class PivotedPilotSummaryTable:
                    " AND \n" \
                    " LastUpdateTime > '%s')" \
                    " GROUP by %s, Status)\n AS %s" % (
-                     _quotedList(self.columnList), last_update,
-                     _quotedList(self.columnList), pvtable)
+                       _quotedList(self.columnList), last_update,
+                       _quotedList(self.columnList), pvtable)
 
     # pivoted table: combine records with the same group of self.columnList into a single row.
 
@@ -99,7 +100,7 @@ class PivotedPilotSummaryTable:
     eff_select_template = " CAST(pivoted_eff.{state} AS UNSIGNED) AS {state} "
 #    eff_select_template = " CAST(pivoted_eff.{state} AS UNSIGNED) AS {state} "
     # now select the columns + the states:
-    pivoted_eff = "SELECT %s,\n" % ', '.join(['pivoted_eff' + '.' + item  for item in self.columnList]) + \
+    pivoted_eff = "SELECT %s,\n" % ', '.join(['pivoted_eff' + '.' + item for item in self.columnList]) + \
                   ', '.join(eff_select_template.format(state=state) for state in self.pstates + ['Total']) + ", \n"
 
     finalQuery = pivoted_eff + eff_case + pivotedQuery + innerGroupBy + outerGroupBy

--- a/src/DIRAC/ResourceStatusSystem/Agent/CacheFeederAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/CacheFeederAgent.py
@@ -66,10 +66,10 @@ class CacheFeederAgent(AgentModule):
     self.commands['FreeDiskSpace'] = [{'FreeDiskSpace': {}}]
 
     # PilotsCommand
-    self.commands[ 'Pilot' ] = [
-                                 { 'Pilot' : { 'element' : 'Site', 'siteName' : None } },
-                                 { 'Pilot' : { 'element' : 'Resource', 'siteName' : None } }
-                                 ]
+    self.commands['Pilot'] = [
+        {'Pilot': {'element': 'Site', 'siteName': None}},
+        {'Pilot': {'element': 'Resource', 'siteName': None}}
+    ]
 
     # FIXME: do not forget about hourly vs Always ...etc
     # AccountingCacheCommand

--- a/src/DIRAC/ResourceStatusSystem/Agent/CacheFeederAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/CacheFeederAgent.py
@@ -66,10 +66,10 @@ class CacheFeederAgent(AgentModule):
     self.commands['FreeDiskSpace'] = [{'FreeDiskSpace': {}}]
 
     # PilotsCommand
-#    self.commands[ 'Pilots' ] = [
-#                                 { 'PilotsWMS' : { 'element' : 'Site', 'siteName' : None } },
-#                                 { 'PilotsWMS' : { 'element' : 'Resource', 'siteName' : None } }
-#                                 ]
+    self.commands[ 'Pilot' ] = [
+                                 { 'Pilot' : { 'element' : 'Site', 'siteName' : None } },
+                                 { 'Pilot' : { 'element' : 'Resource', 'siteName' : None } }
+                                 ]
 
     # FIXME: do not forget about hourly vs Always ...etc
     # AccountingCacheCommand

--- a/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
@@ -212,7 +212,7 @@ class ElementInspectorAgent(AgentModule):
       except Queue.Empty:
         return S_OK()
 
-      self.log.verbose('%s ( vO=%s / status=%s / statusType=%s ) being processed' % (element['name'],
+      self.log.verbose('%s ( VO=%s / status=%s / statusType=%s ) being processed' % (element['name'],
                                                                                      element['vO'],
                                                                                      element['status'],
                                                                                      element['statusType']))

--- a/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
@@ -213,9 +213,9 @@ class ElementInspectorAgent(AgentModule):
         return S_OK()
 
       self.log.verbose('%s ( vO=%s / status=%s / statusType=%s ) being processed' % (element['name'],
-                                                           element['vO'],
-                                                           element['status'],
-                                                           element['statusType']))
+                                                                                     element['vO'],
+                                                                                     element['status'],
+                                                                                     element['statusType']))
 
       try:
         resEnforce = pep.enforce(element)

--- a/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
@@ -183,7 +183,7 @@ class ElementInspectorAgent(AgentModule):
 
       lowerElementDict = {'element': self.elementType}
       for key, value in elemDict.items():
-        if len(key) > 2:
+        if len(key) >= 2:  # VO !
           lowerElementDict[key[0].lower() + key[1:]] = value
 
       # We add lowerElementDict to the queue
@@ -212,7 +212,8 @@ class ElementInspectorAgent(AgentModule):
       except Queue.Empty:
         return S_OK()
 
-      self.log.verbose('%s ( %s / %s ) being processed' % (element['name'],
+      self.log.verbose('%s ( vO=%s / status=%s / statusType=%s ) being processed' % (element['name'],
+                                                           element['vO'],
                                                            element['status'],
                                                            element['statusType']))
 

--- a/src/DIRAC/ResourceStatusSystem/Agent/test/Test_Agent_ElementInspectorAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/test/Test_Agent_ElementInspectorAgent.py
@@ -25,6 +25,7 @@ queueFilled = Queue.Queue()
 queueFilled.put({'status': 'status',
                  'name': 'site',
                  'site': 'site',
+                 'vO': 'all',
                  'element': 'Site',
                  'statusType': 'all',
                  'elementType': 'Site'})

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceManagementClient.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceManagementClient.py
@@ -417,7 +417,7 @@ class ResourceManagementClient(Client):
   # PilotCache Methods .........................................................
 
   def selectPilotCache(self, site=None, cE=None, pilotsPerJob=None,
-                       pilotJobEff=None, status=None, lastCheckTime=None, meta=None):
+                       pilotJobEff=None, status=None, lastCheckTime=None, meta=None, vO=None):
     '''
     Gets from TransferCache all rows that match the parameters given.
 
@@ -443,7 +443,7 @@ class ResourceManagementClient(Client):
     return self._getRPC().select('PilotCache', prepareDict(columnNames, columnValues))
 
   def deletePilotCache(self, site=None, cE=None, pilotsPerJob=None,
-                       pilotJobEff=None, status=None, lastCheckTime=None):
+                       pilotJobEff=None, status=None, lastCheckTime=None, vO=None):
     '''
     Deletes from TransferCache all rows that match the parameters given.
 
@@ -467,7 +467,7 @@ class ResourceManagementClient(Client):
     return self._getRPC().delete('PilotCache', prepareDict(columnNames, columnValues))
 
   def addOrModifyPilotCache(self, site=None, cE=None, pilotsPerJob=None,
-                            pilotJobEff=None, status=None, lastCheckTime=None):
+                            pilotJobEff=None, status=None, lastCheckTime=None, vO=None):
     '''
     Adds or updates-if-duplicated to PilotCache. Using `site` and `cE`
     to query the database, decides whether to insert or update the table.
@@ -489,7 +489,7 @@ class ResourceManagementClient(Client):
 
   def selectPolicyResult(self, element=None, name=None, policyName=None,
                          statusType=None, status=None, reason=None,
-                         lastCheckTime=None, meta=None):
+                         lastCheckTime=None, meta=None, vO=None):
     '''
     Gets from PolicyResult all rows that match the parameters given.
 
@@ -520,7 +520,7 @@ class ResourceManagementClient(Client):
 
   def deletePolicyResult(self, element=None, name=None, policyName=None,
                          statusType=None, status=None, reason=None,
-                         dateEffective=None, lastCheckTime=None):
+                         dateEffective=None, lastCheckTime=None, vO=None):
     '''
     Deletes from PolicyResult all rows that match the parameters given.
 
@@ -549,7 +549,7 @@ class ResourceManagementClient(Client):
 
   def addOrModifyPolicyResult(self, element=None, name=None, policyName=None,
                               statusType=None, status=None, reason=None,
-                              dateEffective=None, lastCheckTime=None):
+                              dateEffective=None, lastCheckTime=None, vO=None):
     '''
     Adds or updates-if-duplicated to PolicyResult. Using `name`, `policyName` and
     `statusType` to query the database, decides whether to insert or update the table.

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceStatus.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceStatus.py
@@ -49,7 +49,7 @@ class ResourceStatus(object):
     # RSSCache only affects the calls directed to RSS, if using the CS it is not used.
     self.rssCache = RSSCache(cacheLifeTime, self.__updateRssCache)
 
-  def getElementStatus(self, elementName, elementType, statusType=None, default=None):
+  def getElementStatus(self, elementName, elementType, statusType=None, default=None, vO=''):
     """
     Helper function, tries to get information from the RSS for the given
     Element, otherwise, it gets it from the CS.
@@ -106,7 +106,7 @@ class ResourceStatus(object):
         statusType = ['all']
 
     if self.rssFlag:
-      return self.__getRSSElementStatus(elementName, elementType, statusType)
+      return self.__getRSSElementStatus(elementName, elementType, statusType, vO)
     else:
       return self.__getCSElementStatus(elementName, elementType, statusType, default)
 
@@ -147,7 +147,7 @@ class ResourceStatus(object):
         It will try 5 times to contact the RSS before giving up
     """
 
-    meta = {'columns': ['Name', 'ElementType', 'StatusType', 'Status']}
+    meta = {'columns': ['Name', 'ElementType', 'StatusType', 'Status', 'VO']}
 
     for ti in range(5):
       rawCache = self.rssClient.selectStatusElement('Resource', 'Status', meta=meta)
@@ -163,7 +163,7 @@ class ResourceStatus(object):
 
 ################################################################################
 
-  def __getRSSElementStatus(self, elementName, elementType, statusType):
+  def __getRSSElementStatus(self, elementName, elementType, statusType, vO):
     """ Gets from the cache or the RSS the Elements status. The cache is a
         copy of the DB table. If it is not on the cache, most likely is not going
         to be on the DB.
@@ -182,7 +182,7 @@ class ResourceStatus(object):
     :type statusType: str, list
     """
 
-    cacheMatch = self.rssCache.match(elementName, elementType, statusType)
+    cacheMatch = self.rssCache.match(elementName, elementType, statusType, vO)
 
     self.log.debug('__getRSSElementStatus')
     self.log.debug(cacheMatch)
@@ -350,26 +350,27 @@ def getDictFromList(fromList):
 
 def getCacheDictFromRawData(rawList):
   """
-  Formats the raw data list, which we know it must have tuples of four elements.
-  ( element1, element2, element3, elementt4 ) into a dictionary of tuples with the format
-  { ( element1, element2, element3 ): element4 )}.
+  Formats the raw data list, which we know it must have tuples of five elements.
+  ( element1, element2, element3, elementt4, element5 ) into a dictionary of tuples with the format
+  { ( element1, element2, element3, element5 ): element4 )}.
   The resulting dictionary will be the new Cache.
 
   It happens that element1 is elementName,
                   element2 is elementType,
                   element3 is statusType,
                   element4 is status.
+                  element5 is vO
 
   :Parameters:
     **rawList** - `list`
-      list of three element tuples [( element1, element2, element3, element4 ),... ]
+      list of three element tuples [( element1, element2, element3, element4, element5 ),... ]
 
-  :return: dict of the form { ( elementName, elementType, statusType ) : status, ... }
+  :return: dict of the form { ( elementName, elementType, statusType, vO ) : status, ... }
   """
 
   res = {}
   for entry in rawList:
-    res.update({(entry[0], entry[1], entry[2]): entry[3]})
+    res.update({(entry[0], entry[1], entry[2], entry[4]): entry[3]})
 
   return res
 

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceStatus.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceStatus.py
@@ -49,7 +49,7 @@ class ResourceStatus(object):
     # RSSCache only affects the calls directed to RSS, if using the CS it is not used.
     self.rssCache = RSSCache(cacheLifeTime, self.__updateRssCache)
 
-  def getElementStatus(self, elementName, elementType, statusType=None, default=None, vO=''):
+  def getElementStatus(self, elementName, elementType, statusType=None, default=None, vO=None):
     """
     Helper function, tries to get information from the RSS for the given
     Element, otherwise, it gets it from the CS.

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceStatusClient.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceStatusClient.py
@@ -166,7 +166,7 @@ class ResourceStatusClient(Client):
   def deleteStatusElement(self, element, tableType, name=None, statusType=None,
                           status=None, elementType=None, reason=None,
                           dateEffective=None, lastCheckTime=None,
-                          tokenOwner=None, tokenExpiration=None, meta=None, vo='all'):
+                          tokenOwner=None, tokenExpiration=None, meta=None, vO='all'):
     """
     Deletes from <element><tableType> all rows that match the parameters given.
 
@@ -212,7 +212,7 @@ class ResourceStatusClient(Client):
                                statusType=None, status=None,
                                elementType=None, reason=None,
                                dateEffective=None, lastCheckTime=None,
-                               tokenOwner=None, tokenExpiration=None, vo='all'):
+                               tokenOwner=None, tokenExpiration=None, vO='all'):
     """
     Adds or updates-if-duplicated from <element><tableType> and also adds a log
     if flag is active.
@@ -256,7 +256,7 @@ class ResourceStatusClient(Client):
   def modifyStatusElement(self, element, tableType, name=None, statusType=None,
                           status=None, elementType=None, reason=None,
                           dateEffective=None, lastCheckTime=None, tokenOwner=None,
-                          tokenExpiration=None, vo='all'):
+                          tokenExpiration=None, vO='all'):
     """
     Updates from <element><tableType> and also adds a log if flag is active.
 
@@ -300,7 +300,7 @@ class ResourceStatusClient(Client):
                                  statusType=None, status=None,
                                  elementType=None, reason=None,
                                  dateEffective=None, lastCheckTime=None,
-                                 tokenOwner=None, tokenExpiration=None, vo='all'):
+                                 tokenOwner=None, tokenExpiration=None, vO='all'):
     """
     Adds if-not-duplicated from <element><tableType> and also adds a log if flag
     is active.

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceStatusClient.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceStatusClient.py
@@ -77,7 +77,7 @@ class ResourceStatusClient(Client):
 
   def insertStatusElement(self, element, tableType, name, statusType, status,
                           elementType, reason, dateEffective, lastCheckTime,
-                          tokenOwner, tokenExpiration=None, vo='all'):
+                          tokenOwner, tokenExpiration=None, vO='all'):
     """
     Inserts on <element><tableType> a new row with the arguments given.
 
@@ -120,7 +120,7 @@ class ResourceStatusClient(Client):
   def selectStatusElement(self, element, tableType, name=None, statusType=None,
                           status=None, elementType=None, reason=None,
                           dateEffective=None, lastCheckTime=None,
-                          tokenOwner=None, tokenExpiration=None, meta=None, vo='all'):
+                          tokenOwner=None, tokenExpiration=None, meta=None, vO='all'):
     """
     Gets from <element><tableType> all rows that match the parameters given.
 

--- a/src/DIRAC/ResourceStatusSystem/Client/SiteStatus.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/SiteStatus.py
@@ -63,7 +63,7 @@ class SiteStatus(object):
         It will try 5 times to contact the RSS before giving up
     """
 
-    meta = {'columns': ['Name', 'Status']}
+    meta = {'columns': ['Name', 'Status', 'VO']}
 
     for ti in range(5):
       rawCache = self.rsClient.selectStatusElement('Site', 'Status', meta=meta)
@@ -147,7 +147,7 @@ class SiteStatus(object):
     :return: dict
     """
 
-    cacheMatch = self.rssCache.match(siteName, '', '')
+    cacheMatch = self.rssCache.match(siteName, '', '', 'all')  # sites have VO="all".
 
     self.log.debug('__getRSSSiteStatus')
     self.log.debug(cacheMatch)

--- a/src/DIRAC/ResourceStatusSystem/Command/PilotCommand.py
+++ b/src/DIRAC/ResourceStatusSystem/Command/PilotCommand.py
@@ -99,7 +99,7 @@ class PilotCommand(Command):
       # You should never see this error
       return S_ERROR('"%s" is not  Site nor Resource' % element)
 
-    pilotsResults = self.pilots.getPilotSummaryWeb(wmsDict, [], 0, 0)
+    #pilotsResults = self.pilots.getPilotSummaryWeb(wmsDict, [], 0, 0)
 
     if element == 'Resource':
       pilotsResultPivot = self.pilots.getGroupedPilotSummary({}, ['GridSite', 'DestinationSite', 'OwnerGroup'])
@@ -109,17 +109,8 @@ class PilotCommand(Command):
       # You should never see this error
       return S_ERROR('"%s" is not  Site nor Resource' % element)
 
-    import pprint
-    print "PilotCommand -> Pilots results: "
-    pp = pprint.PrettyPrinter(indent=4)
-    pp.pprint(pilotsResults)
-
-    print('---------------- from pivoted table ---------------')
-    pp.pprint(pilotsResultPivot)
-
     if not pilotsResults['OK']:
       return pilotsResults
-    pilotsResults = pilotsResults['Value']
     pilotsResults = pilotsResultPivot['Value']
 
     if 'ParameterNames' not in pilotsResults:

--- a/src/DIRAC/ResourceStatusSystem/Command/PilotCommand.py
+++ b/src/DIRAC/ResourceStatusSystem/Command/PilotCommand.py
@@ -43,11 +43,12 @@ class PilotCommand(Command):
 
     for pilotDict in result:
 
-      resQuery = self.rmClient.addOrModifyPilotCache(pilotDict['Site'],
-                                                     pilotDict['CE'],
-                                                     pilotDict['PilotsPerJob'],
-                                                     pilotDict['PilotJobEff'],
-                                                     pilotDict['Status'])
+      resQuery = self.rmClient.addOrModifyPilotCache(site=pilotDict['Site'],
+                                                     cE=pilotDict['CE'],
+                                                     vO=pilotDict.get('OwnerGroup', None),
+                                                     pilotsPerJob=pilotDict['PilotsPerJob'],
+                                                     pilotJobEff=pilotDict['PilotJobEff'],
+                                                     status=pilotDict['Status'])
       if not resQuery['OK']:
         return resQuery
 
@@ -59,6 +60,7 @@ class PilotCommand(Command):
       - name : <str>
     """
 
+    self.log.debug("_prepareCommand: args:", self.args)
     if 'name' not in self.args:
       return S_ERROR('"name" not found in self.args')
     name = self.args['name']
@@ -67,13 +69,18 @@ class PilotCommand(Command):
       return S_ERROR('element is missing')
     element = self.args['element']
 
+    if 'vO' not in self.args:
+      return S_ERROR('_prepareCommand: "vO" not found in self.args')
+    vo = self.args['vO']
+
     if element not in ['Site', 'Resource']:
       return S_ERROR('"%s" is not Site nor Resource' % element)
 
-    return S_OK((element, name))
+    return S_OK((element, name, vo))
 
   def doNew(self, masterParams=None):
 
+    self.log.debug('PilotCommand doNew')
     if masterParams is not None:
       element, name = masterParams
     else:
@@ -94,9 +101,26 @@ class PilotCommand(Command):
 
     pilotsResults = self.pilots.getPilotSummaryWeb(wmsDict, [], 0, 0)
 
+    if element == 'Resource':
+      pilotsResultPivot = self.pilots.getGroupedPilotSummary({}, ['GridSite', 'DestinationSite', 'OwnerGroup'])
+    elif element == 'Site':
+      pilotsResultPivot = self.pilots.getGroupedPilotSummary({}, ['GridSite', 'OwnerGroup'])
+    else:
+      # You should never see this error
+      return S_ERROR('"%s" is not  Site nor Resource' % element)
+
+    import pprint
+    print "PilotCommand -> Pilots results: "
+    pp = pprint.PrettyPrinter(indent=4)
+    pp.pprint(pilotsResults)
+
+    print('---------------- from pivoted table ---------------')
+    pp.pprint(pilotsResultPivot)
+
     if not pilotsResults['OK']:
       return pilotsResults
     pilotsResults = pilotsResults['Value']
+    pilotsResults = pilotsResultPivot['Value']
 
     if 'ParameterNames' not in pilotsResults:
       return S_ERROR('Wrong result dictionary, missing "ParameterNames"')
@@ -129,10 +153,11 @@ class PilotCommand(Command):
 
   def doCache(self):
 
+    self.log.debug('PilotCommand doCache')
     params = self._prepareCommand()
     if not params['OK']:
       return params
-    element, name = params['Value']
+    element, name, vo = params['Value']
 
     if element == 'Site':
       # WMS returns Site entries with CE = 'Multiple'
@@ -143,14 +168,15 @@ class PilotCommand(Command):
       # You should never see this error
       return S_ERROR('"%s" is not  Site nor Resource' % element)
 
-    result = self.rmClient.selectPilotCache(site, ce)
+    result = self.rmClient.selectPilotCache(site=site, cE=ce)
     if result['OK']:
       result = S_OK([dict(zip(result['Columns'], res)) for res in result['Value']])
-
+    self.log.debug("PilotCommand doCache result: ", result)
     return result
 
   def doMaster(self):
 
+    self.log.debug('PilotCommand doMaster')
     siteNames = getSites()
     if not siteNames['OK']:
       return siteNames

--- a/src/DIRAC/ResourceStatusSystem/Command/PilotCommand.py
+++ b/src/DIRAC/ResourceStatusSystem/Command/PilotCommand.py
@@ -99,8 +99,6 @@ class PilotCommand(Command):
       # You should never see this error
       return S_ERROR('"%s" is not  Site nor Resource' % element)
 
-    #pilotsResults = self.pilots.getPilotSummaryWeb(wmsDict, [], 0, 0)
-
     if element == 'Resource':
       pilotsResultPivot = self.pilots.getGroupedPilotSummary({}, ['GridSite', 'DestinationSite', 'OwnerGroup'])
     elif element == 'Site':
@@ -109,8 +107,8 @@ class PilotCommand(Command):
       # You should never see this error
       return S_ERROR('"%s" is not  Site nor Resource' % element)
 
-    if not pilotsResults['OK']:
-      return pilotsResults
+    if not pilotsResultPivot['OK']:
+      return pilotsResultPivot
     pilotsResults = pilotsResultPivot['Value']
 
     if 'ParameterNames' not in pilotsResults:

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -389,6 +389,7 @@ class ResourceManagementDB(SQLAlchemyDB):
 
     # Create required tables
     self._createTablesIfNotThere(self.tablesList)
+  ## Extended SQL methods ######################################################
 
   def addOrModify(self, table, params):
     """

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -215,11 +215,11 @@ class PilotCache(rmsBase):
 
   site = Column('Site', String(64), nullable=False, primary_key=True)
   ce = Column('CE', String(64), nullable=False, primary_key=True)
+  vo = Column('VO', String(64), nullable=False, primary_key=True, server_default='all')
   status = Column('Status', String(16), nullable=False)
   pilotjobeff = Column('PilotJobEff', Float(asdecimal=False), nullable=False, server_default='0')
   pilotsperjob = Column('PilotsPerJob', Float(asdecimal=False), nullable=False, server_default='0')
   lastchecktime = Column('LastCheckTime', DateTime, nullable=False)
-  vo = Column('VO', String(64), nullable=False, primary_key=True, server_default='all')
 
   def fromDict(self, dictionary):
     """

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -215,11 +215,11 @@ class PilotCache(rmsBase):
 
   site = Column('Site', String(64), nullable=False, primary_key=True)
   ce = Column('CE', String(64), nullable=False, primary_key=True)
-  vo = Column('VO', String(64), nullable=False, primary_key=True, server_default='all')
   status = Column('Status', String(16), nullable=False)
   pilotjobeff = Column('PilotJobEff', Float(asdecimal=False), nullable=False, server_default='0')
   pilotsperjob = Column('PilotsPerJob', Float(asdecimal=False), nullable=False, server_default='0')
   lastchecktime = Column('LastCheckTime', DateTime, nullable=False)
+  vo = Column('VO', String(64), nullable=False, primary_key=True, server_default='all')
 
   def fromDict(self, dictionary):
     """

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -221,6 +221,8 @@ class PilotCache(rmsBase):
   pilotsperjob = Column('PilotsPerJob', Float(asdecimal=False), nullable=False, server_default='0')
   lastchecktime = Column('LastCheckTime', DateTime, nullable=False)
 
+  columnsOrder = ['Site', 'CE', 'Status', 'PilotJobEff', 'PilotsPerJob', 'LastCheckTime', 'VO']
+
   def fromDict(self, dictionary):
     """
     Fill the fields of the PilotCache object from a dictionary

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -188,7 +188,7 @@ class ElementStatusBaseWithID(ElementStatusBase):
   def toList(self):
     """ Simply returns a list of column values
     """
-    return [self.id, self.name, self.statustype, self.status, self.reason,
+    return [self.id, self.name, self.statustype,  self.status, self.reason,
             self.dateeffective, self.tokenexpiration, self.elementtype,
             self.lastchecktime, self.tokenowner, self.vo]
 

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -188,7 +188,7 @@ class ElementStatusBaseWithID(ElementStatusBase):
   def toList(self):
     """ Simply returns a list of column values
     """
-    return [self.id, self.name, self.statustype,  self.status, self.reason,
+    return [self.id, self.name, self.statustype, self.status, self.reason,
             self.dateeffective, self.tokenexpiration, self.elementtype,
             self.lastchecktime, self.tokenowner, self.vo]
 

--- a/src/DIRAC/ResourceStatusSystem/Policy/PilotEfficiencyPolicy.py
+++ b/src/DIRAC/ResourceStatusSystem/Policy/PilotEfficiencyPolicy.py
@@ -60,14 +60,14 @@ class PilotEfficiencyPolicy(PolicyBase):
     result['VO'] = commandResult.get('VO', None)
 
     if efficiency is None:
-      result[ 'Status' ] = 'Unknown'
-      result[ 'Reason' ] = 'Pilot efficiency value is not present in the result obtained'
+      result['Status'] = 'Unknown'
+      result['Reason'] = 'Pilot efficiency value is not present in the result obtained'
       return S_OK(result)
 
     if efficiency <= bannedLimit:
-      result[ 'Status' ] = 'Banned'
+      result['Status'] = 'Banned'
     elif efficiency <= degradedLimit:
-      result[ 'Status' ] = 'Degraded'
+      result['Status'] = 'Degraded'
     else:
       result['Status'] = 'Active'
 

--- a/src/DIRAC/ResourceStatusSystem/Policy/PilotEfficiencyPolicy.py
+++ b/src/DIRAC/ResourceStatusSystem/Policy/PilotEfficiencyPolicy.py
@@ -61,7 +61,7 @@ class PilotEfficiencyPolicy(PolicyBase):
 
     if efficiency is None:
       result['Status'] = 'Unknown'
-      result['Reason'] = 'Pilot efficiency value is not present in the result obtained'
+      result['Reason'] = 'Not enough pilots to take a decision'
       return S_OK(result)
 
     if efficiency <= bannedLimit:

--- a/src/DIRAC/ResourceStatusSystem/Policy/test/Test_RSS_Policy_PilotEfficiencyPolicy.py
+++ b/src/DIRAC/ResourceStatusSystem/Policy/test/Test_RSS_Policy_PilotEfficiencyPolicy.py
@@ -4,97 +4,117 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from __future__ import division
 import unittest
-
 import DIRAC.ResourceStatusSystem.Policy.PilotEfficiencyPolicy as moduleTested
 
 ################################################################################
 
-class PilotEfficiencyPolicy_TestCase( unittest.TestCase ):
- 
-  def setUp( self ):
+
+class PilotEfficiencyPolicy_TestCase(unittest.TestCase):
+
+  def setUp(self):
     '''
     Setup
     '''
-                 
-    self.moduleTested = moduleTested
-    self.testClass    = self.moduleTested.PilotEfficiencyPolicy
 
-  def tearDown( self ):
+    self.moduleTested = moduleTested
+    self.testClass = self.moduleTested.PilotEfficiencyPolicy
+
+  def tearDown(self):
     '''
     Tear down
     '''
 
     del self.moduleTested
     del self.testClass
- 
+
 
 ################################################################################
 
-class PilotEfficiencyPolicy_Success( PilotEfficiencyPolicy_TestCase ):
- 
-  def test_instantiate( self ):
+class PilotEfficiencyPolicy_Success(PilotEfficiencyPolicy_TestCase):
+
+  def test_instantiate(self):
     ''' tests that we can instantiate one object of the tested class
     '''
 
     module = self.testClass()
-    self.assertEqual( 'PilotEfficiencyPolicy', module.__class__.__name__ )
+    self.assertEqual('PilotEfficiencyPolicy', module.__class__.__name__)
 
-  def test_evaluate( self ):
+  def test_evaluate(self):
     ''' tests the method _evaluate
     '''
 
     module = self.testClass()
 
-    res = module._evaluate( { 'OK' : False, 'Message' : 'Bo!' } )
+    res = module._evaluate({'OK': False, 'Message': 'Bo!'})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Error', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Bo!', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Error', res['Value']['Status'])
+    self.assertEqual('Bo!', res['Value']['Reason'])
 
-    res = module._evaluate( { 'OK' : True, 'Value' : None } )
+    res = module._evaluate({'OK': True, 'Value': None})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Unknown', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'No values to take a decision', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Unknown', res['Value']['Status'])
+    self.assertEqual('No values to take a decision', res['Value']['Reason'])
 
-    res = module._evaluate( { 'OK' : True, 'Value' : [] } )
+    res = module._evaluate({'OK': True, 'Value': []})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Unknown', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'No values to take a decision', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Unknown', res['Value']['Status'])
+    self.assertEqual('No values to take a decision', res['Value']['Reason'])
 
-    res = module._evaluate( { 'OK' : True, 'Value' : [{}] } )
+    res = module._evaluate({'OK': True, 'Value': [{}]})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Unknown', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'No values to take a decision', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Unknown', res['Value']['Status'])
+    self.assertEqual('No values to take a decision', res['Value']['Reason'])
 
-    res  = module._evaluate( { 'OK' : True, 'Value' : [{ 'Aborted' : 0, 'Deleted' : 0,
-                                                        'Done' : 0, 'Failed' : 0 }] } )
+    res = module._evaluate({'OK': True, 'Value': [{'Aborted': 0, 'Deleted': 0,
+                                                   'Done': 0, 'Failed': 0}]})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Unknown', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Not enough pilots to take a decision', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Unknown', res['Value']['Status'])
+    self.assertEqual('Not enough pilots to take a decision', res['Value']['Reason'])
 
-    res  = module._evaluate( { 'OK' : True, 'Value' : [{'Aborted' : 10, 'Deleted' : 0,
-                                                        'Done' : 10, 'Failed' : 0 }] } )
-    self.assertTrue(res['OK'])
-    self.assertEqual( 'Banned', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Pilots Efficiency of 0.50', res[ 'Value' ][ 'Reason' ] )
+    # Pilot efficiency is now available directly from the command result, in percent.
+    # The key is 'PilotJobEff'  It is calculated as (total - aborted-failed)/total * 100
 
-    res  = module._evaluate( { 'OK' : True, 'Value' : [{'Aborted' : 0, 'Deleted' : 0,
-                                                        'Done' : 30, 'Failed' : 10 }] } )
-    self.assertTrue(res['OK'])
-    self.assertEqual( 'Degraded', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Pilots Efficiency of 0.75', res[ 'Value' ][ 'Reason' ] )
+    result = {'Aborted': 10, 'Deleted': 0, 'Done': 10, 'Failed': 0}
+    result['PilotJobEff'] = self._pilotEff(result)
 
-    res  = module._evaluate( { 'OK' : True, 'Value' : [{'Aborted' : 0, 'Deleted' : 0,
-                                                        'Done' : 19, 'Failed' : 1 }] } )
+    res = module._evaluate({'OK': True, 'Value': [result]})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Active', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Pilots Efficiency of 0.95', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Banned', res['Value']['Status'])
+    self.assertEqual('Pilots Efficiency of 50.00', res['Value']['Reason'])
+
+    result = {'Aborted': 0, 'Deleted': 0, 'Done': 30, 'Failed': 10}
+    result['PilotJobEff'] = self._pilotEff(result)
+
+    res = module._evaluate({'OK': True, 'Value': [result]})
+    self.assertTrue(res['OK'])
+    self.assertEqual('Degraded', res['Value']['Status'])
+    self.assertEqual('Pilots Efficiency of 75.00', res['Value']['Reason'])
+
+    result = {'Aborted': 0, 'Deleted': 0, 'Done': 19, 'Failed': 1}
+    result['PilotJobEff'] = self._pilotEff(result)
+
+    res = module._evaluate({'OK': True, 'Value': [result]})
+    self.assertTrue(res['OK'])
+    self.assertEqual('Active', res['Value']['Status'])
+    self.assertEqual('Pilots Efficiency of 95.00', res['Value']['Reason'])
+
+  def _pilotEff(self, result):
+    """
+    Calculate pilot efficiency.
+
+    :param result: the original dictionary of the form {status: count, status: count...}
+    :return: pilot success rate in percent
+    """
+    return (sum(result.itervalues()) - result['Aborted'] - result['Failed']) / sum(result.itervalues()) * 100
 
 ################################################################################
 
-if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( PilotEfficiencyPolicy_TestCase )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( PilotEfficiencyPolicy_Success ) )
-  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
 
-#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF
+if __name__ == '__main__':
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(PilotEfficiencyPolicy_TestCase)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(PilotEfficiencyPolicy_Success))
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)
+
+# EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogPolicyResultAction.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogPolicyResultAction.py
@@ -49,7 +49,6 @@ class LogPolicyResultAction(BaseAction):
     statusType = self.decisionParams['statusType']
     if statusType is None:
       return S_ERROR('statusType should not be None')
-    #vo =self.decisionParams['vO']
 
     for singlePolicyResult in self.singlePolicyResults:
 

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogPolicyResultAction.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogPolicyResultAction.py
@@ -49,6 +49,7 @@ class LogPolicyResultAction(BaseAction):
     statusType = self.decisionParams['statusType']
     if statusType is None:
       return S_ERROR('statusType should not be None')
+    #vo =self.decisionParams['vO']
 
     for singlePolicyResult in self.singlePolicyResults:
 
@@ -64,11 +65,13 @@ class LogPolicyResultAction(BaseAction):
       if policyName is None:
         return S_ERROR('policyName should not be None')
 
+      vo = singlePolicyResult.get('VO')
       # Truncate reason to fit in database column
       reason = (reason[:508] + '..') if len(reason) > 508 else reason
 
       polUpdateRes = self.rmClient.addOrModifyPolicyResult(element=element,
                                                            name=name,
+                                                           vO=vo,
                                                            policyName=policyName,
                                                            statusType=statusType,
                                                            status=status,

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogStatusAction.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogStatusAction.py
@@ -60,11 +60,31 @@ class LogStatusAction(BaseAction):
     if reason is None:
       return S_ERROR('reason should not be None')
 
+    vo = self.enforcementResult.get('VO')
     # Truncate reason to fit in database column
     reason = (reason[:508] + '..') if len(reason) > 508 else reason
+    # VO = 'all' (non-VO aware policy) for a combined policy affects all VOs for a given site or resource,
+    if vo == 'all':
+      resSelect = self.rsClient.selectStatusElement(element, 'Status', name=name, statusType=None, vO=None,
+                                      status=None, elementType=None, reason=None,
+                                      dateEffective=None, lastCheckTime=None,
+                                      tokenOwner='rs_svc', tokenExpiration=None, meta=None)
+      if not resSelect['OK']:
+        self.log.error("Could not obtain all VO rows for element: %s" % element)
+        return resSelect
+      voColumnIndex = resSelect['Columns'].index('VO')
+      for row in resSelect['Value']:
+        vo = row[voColumnIndex]
+        resLogUpdate = self.rsClient.addOrModifyStatusElement(element, 'Status',
+                                                              name=name, statusType=statusType, vO=vo,
+                                                              status=status, elementType=elementType,
+                                                              reason=reason
+                                                              )
+        self.log.debug("Update result", resLogUpdate)
 
-    resLogUpdate = self.rsClient.addOrModifyStatusElement(element, 'Status',
-                                                          name=name, statusType=statusType,
+    else:
+      resLogUpdate = self.rsClient.addOrModifyStatusElement(element, 'Status',
+                                                          name=name, statusType=statusType, vO=vo,
                                                           status=status, elementType=elementType,
                                                           reason=reason
                                                           )

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogStatusAction.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogStatusAction.py
@@ -66,9 +66,9 @@ class LogStatusAction(BaseAction):
     # VO = 'all' (non-VO aware policy) for a combined policy affects all VOs for a given site or resource,
     if vo == 'all':
       resSelect = self.rsClient.selectStatusElement(element, 'Status', name=name, statusType=None, vO=None,
-                                      status=None, elementType=None, reason=None,
-                                      dateEffective=None, lastCheckTime=None,
-                                      tokenOwner='rs_svc', tokenExpiration=None, meta=None)
+                                                    status=None, elementType=None, reason=None,
+                                                    dateEffective=None, lastCheckTime=None,
+                                                    tokenOwner='rs_svc', tokenExpiration=None, meta=None)
       if not resSelect['OK']:
         self.log.error("Could not obtain all VO rows for element: %s" % element)
         return resSelect
@@ -84,10 +84,10 @@ class LogStatusAction(BaseAction):
 
     else:
       resLogUpdate = self.rsClient.addOrModifyStatusElement(element, 'Status',
-                                                          name=name, statusType=statusType, vO=vo,
-                                                          status=status, elementType=elementType,
-                                                          reason=reason
-                                                          )
+                                                            name=name, statusType=statusType, vO=vo,
+                                                            status=status, elementType=elementType,
+                                                            reason=reason
+                                                            )
 
     return resLogUpdate
 

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/PDP.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/PDP.py
@@ -300,7 +300,7 @@ class PDP(object):
       return nextState
     nextState = nextState['Value']
     # most restrictive status defines the VO affected. VO='all' will affect all VOs
-    policyCombined['VO'] =  policiesToCombine[0].get('VO', 'all')
+    policyCombined['VO'] = policiesToCombine[0].get('VO', 'all')
 
     # If the RssMachine does not accept the candidate, return forcing message
     if candidateState != nextState:

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/PDP.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/PDP.py
@@ -299,6 +299,8 @@ class PDP(object):
     if not nextState['OK']:
       return nextState
     nextState = nextState['Value']
+    # most restrictive status defines the VO affected. VO='all' will affect all VOs
+    policyCombined['VO'] =  policiesToCombine[0].get('VO', 'all')
 
     # If the RssMachine does not accept the candidate, return forcing message
     if candidateState != nextState:

--- a/src/DIRAC/ResourceStatusSystem/Utilities/InfoGetter.py
+++ b/src/DIRAC/ResourceStatusSystem/Utilities/InfoGetter.py
@@ -178,7 +178,7 @@ def _sanitizedecisionParams(decisionParams):
   """
 
   # active is a hook to disable the policy / action if needed
-  params = ('element', 'name', 'elementType', 'statusType', 'status', 'reason', 'tokenOwner', 'active')
+  params = ('element', 'name', 'vO', 'elementType', 'statusType', 'status', 'reason', 'tokenOwner', 'active')
 
   sanitizedParams = {}
 

--- a/src/DIRAC/ResourceStatusSystem/Utilities/RSSCacheNoThread.py
+++ b/src/DIRAC/ResourceStatusSystem/Utilities/RSSCacheNoThread.py
@@ -133,19 +133,14 @@ class Cache(object):
     result = {}
 
     for cacheKey in cacheKeys:
-      cacheKey = list(cacheKey)
-      cacheKey.append('all')
-      cacheKey1 = tuple(cacheKey)
-      cacheRow = self.__cache.get(cacheKey1, validSeconds=self.__validSeconds)
-
+      longCacheKey = cacheKey + ('all',)
+      cacheRow = self.__cache.get(longCacheKey, validSeconds=self.__validSeconds)
       if not cacheRow:
-        cacheKey = list(cacheKey)
-        cacheKey.append(vO)
-        cacheKey1 = tuple(cacheKey)
-        cacheRow = self.__cache.get(cacheKey1, validSeconds=self.__validSeconds)
+        longCacheKey = cacheKey + (vO,)
+        cacheRow = self.__cache.get(longCacheKey, validSeconds=self.__validSeconds)
         if not cacheRow:
           return S_ERROR('Cannot get extended %s (neither for VO = %s nor for "all" Vos)' % (str(cacheKey), vO))
-      result.update({cacheKey1: cacheRow})
+      result.update({longCacheKey: cacheRow})
 
     return S_OK(result)
 
@@ -296,7 +291,7 @@ class RSSCache(Cache):
     # has expired in between. It has 30 valid seconds, which means something was
     # extremely slow above.
     if matchKeys['CheckVO']:
-      cacheMatches = self.check(matchKeys['Value'], vO) # add an appropriate VO to the keys
+      cacheMatches = self.check(matchKeys['Value'], vO)  # add an appropriate VO to the keys
     else:
       cacheMatches = self.get(matchKeys['Value'])
     if not cacheMatches['OK']:
@@ -371,7 +366,7 @@ class RSSCache(Cache):
       flattenedCache.update({(key[0], key[1], key[2]): value
                             for key, value in validCache.items() if key[3] == vO})
       validCache = flattenedCache
-    else: # site, not VO specific in SiteStatus, eventually to be upgraded there to include the VO
+    else:  # site, not VO specific in SiteStatus, eventually to be upgraded there to include the VO
       pass
 
     if isinstance(elementNames, six.string_types):

--- a/src/DIRAC/ResourceStatusSystem/Utilities/RSSCacheNoThread.py
+++ b/src/DIRAC/ResourceStatusSystem/Utilities/RSSCacheNoThread.py
@@ -115,6 +115,40 @@ class Cache(object):
 
     return S_OK(result)
 
+  def check(self, cacheKeys, vO):
+    """
+    Modified get() method. Attempts to find keys with a vO value appended or 'all'
+    value appended. The cacheKeys passed in are 'flattened' cache keys (no vO)
+    Gets values for cacheKeys given, if all are found ( present on the cache and
+    valid ), returns S_OK with the results. If any is not neither present not
+    valid, returns S_ERROR.
+
+    :Parameters:
+      **cacheKeys** - `list`
+        list of keys to be extracted from the cache
+
+    :return: S_OK | S_ERROR
+    """
+
+    result = {}
+
+    for cacheKey in cacheKeys:
+      cacheKey = list(cacheKey)
+      cacheKey.append('all')
+      cacheKey1 = tuple(cacheKey)
+      cacheRow = self.__cache.get(cacheKey1, validSeconds=self.__validSeconds)
+
+      if not cacheRow:
+        cacheKey = list(cacheKey)
+        cacheKey.append(vO)
+        cacheKey1 = tuple(cacheKey)
+        cacheRow = self.__cache.get(cacheKey1, validSeconds=self.__validSeconds)
+        if not cacheRow:
+          return S_ERROR('Cannot get extended %s (neither for VO = %s nor for "all" Vos)' % (str(cacheKey), vO))
+      result.update({cacheKey1: cacheRow})
+
+    return S_OK(result)
+
   # Cache refreshers
 
   def refreshCache(self):
@@ -195,7 +229,7 @@ class RSSCache(Cache):
 
     self.allStatusTypes = RssConfiguration().getConfigStatusType()
 
-  def match(self, elementNames, elementType, statusTypes):
+  def match(self, elementNames, elementType, statusTypes, vO):
     """
     In first instance, if the cache is invalid, it will request a new one from
     the server.
@@ -220,14 +254,14 @@ class RSSCache(Cache):
 
     self.acquireLock()
     try:
-      return self._match(elementNames, elementType, statusTypes)
+      return self._match(elementNames, elementType, statusTypes, vO)
     finally:
       # Release lock, no matter what !
       self.releaseLock()
 
   # Private methods: NOT THREAD SAFE !!
 
-  def _match(self, elementNames, elementType, statusTypes):
+  def _match(self, elementNames, elementType, statusTypes, vO):
     """
     Method doing the actual work. It must be wrapped around locks to ensure no
     disaster happens.
@@ -251,18 +285,20 @@ class RSSCache(Cache):
 
     # Gets matched keys
     try:
-      matchKeys = self.__match(validCache, elementNames, elementType, statusTypes)
+      matchKeys = self.__match(validCache, elementNames, elementType, statusTypes, vO)
     except IndexError:
       return S_ERROR("RSS cache empty?")
 
     if not matchKeys['OK']:
       return matchKeys
-    matchKeys = matchKeys['Value']
 
     # Gets objects for matched keys. It will return S_ERROR if the cache value
     # has expired in between. It has 30 valid seconds, which means something was
     # extremely slow above.
-    cacheMatches = self.get(matchKeys)
+    if matchKeys['CheckVO']:
+      cacheMatches = self.check(matchKeys['Value'], vO) # add an appropriate VO to the keys
+    else:
+      cacheMatches = self.get(matchKeys['Value'])
     if not cacheMatches['OK']:
       return cacheMatches
 
@@ -284,7 +320,7 @@ class RSSCache(Cache):
     valid dictionary. If the list is empty, we assume the cache is invalid or
     not filled, so we issue a cache refresh and return its data.
 
-    :return: { ( elementName, statusType ) : status, ... }
+    :return: { ( elementName, statusType, vO ) : status, ... }
     """
 
     cacheKeys = self.cacheKeys()
@@ -296,7 +332,7 @@ class RSSCache(Cache):
 
     return cache
 
-  def __match(self, validCache, elementNames, elementType, statusTypes):
+  def __match(self, validCache, elementNames, elementType, statusTypes, vO):
     """
     Obtains all keys on the cache ( should not be empty ! ).
 
@@ -319,10 +355,24 @@ class RSSCache(Cache):
       **statusTypes** - [ None, `string`, `list` ]
         name(s) of the statusTypes to be matched
 
-    :return: S_OK() || S_ERROR()
+    :return: S_OK() with a Vo check marker || S_ERROR()
     """
 
     cacheKeys = list(validCache)
+    # flatten the cache. From our VO perspective we are only want to keep:
+    # 1) keys with vO tuple element equal to our vO,
+    # 2) keys with vO tuple element equal to 'all', but only if no element described in 1) exists.
+    # a resource key is set to have 3 elements to allow a comparison with a cartesian product.
+    checkVo = False
+    if len(cacheKeys[0]) == 4:  # resource
+      checkVo = True
+      flattenedCache = {(key[0], key[1], key[2]):
+                        value for key, value in validCache.items() if key[3] =="all"}
+      flattenedCache.update({(key[0], key[1], key[2]): value
+                            for key, value in validCache.items() if key[3] == vO})
+      validCache = flattenedCache
+    else: # site, not VO specific in SiteStatus, eventually to be upgraded there to include the VO
+      pass
 
     if isinstance(elementNames, six.string_types):
       elementNames = [elementNames]
@@ -366,12 +416,14 @@ class RSSCache(Cache):
       self.log.warn('Empty cartesian product')
       return S_ERROR('Empty cartesian product')
 
-    notInCache = list(cartesianProduct.difference(set(cacheKeys)))
+    notInCache = list(cartesianProduct.difference(set(validCache)))
     if notInCache:
       self.log.warn('Cache misses: %s' % notInCache)
       return S_ERROR('Cache misses: %s' % notInCache)
 
-    return S_OK(cartesianProduct)
+    result = S_OK(cartesianProduct)
+    result['CheckVO'] = checkVo
+    return result
 
   @staticmethod
   def __getDictFromCacheMatches(cacheMatches):
@@ -380,7 +432,7 @@ class RSSCache(Cache):
 
     :Parameters:
       **cacheMatches** - `dict`
-        cache dictionary of the form { ( elementName, elementType, statusType ) : status, ... }
+        cache dictionary of the form { ( elementName, elementType, statusType, vO ) : status, ... }
 
 
     :return: dict of the form { elementName : { statusType: status, ... }, ... }
@@ -389,7 +441,7 @@ class RSSCache(Cache):
     result = {}
 
     for cacheKey, cacheValue in cacheMatches.items():
-      elementName, _elementType, statusType = cacheKey
+      elementName, _elementType, statusType, vO = cacheKey
       result.setdefault(elementName, {})[statusType] = cacheValue
 
     return result

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -438,13 +438,15 @@ class SiteDirector(AgentModule):
 
     if self.rssFlag:
       ceNamesList = [queue['CEName'] for queue in self.queueDict.values()]
-      result = self.rssClient.getElementStatus(ceNamesList, "ComputingElement")
+      result = self.rssClient.getElementStatus(ceNamesList, "ComputingElement", vO=self.vo)
       if not result['OK']:
         self.log.error("Can not get the status of computing elements",
                        " %s" % result['Message'])
         return result
+      # Try to get CEs which have been probed and those unprobed (vO='all').
       self.ceMaskList = [ceName for ceName in result['Value'] if result['Value'][ceName]
                          ['all'] in ('Active', 'Degraded')]
+      self.log.debug("CE list with status Active or Degraded: ", self.ceMaskList)
 
     result = self.submitPilots()
     if not result['OK']:

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -639,8 +639,8 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
 
     :param selectDict: A dictionary to pass additional conditions to select statements, i.e.
                        it allows to define start time for Done and Aborted Pilots.
-    :param columnList  a list of column to consider when grouping to calculate efficiencies.
-                       e.g. ['GridSite', 'DestinationSite'] is used to calculate efficiences
+    :param columnList: A list of column to consider when grouping to calculate efficiencies.
+                       e.g. ['GridSite', 'DestinationSite'] is used to calculate efficiencies
                        for sites and  CEs. If we want to add an OwnerGroup it would be:
                        ['GridSite', 'DestinationSite', 'OwnerGroup'].
     :return: a dict containing the ParameterNames and Records lists.

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -650,12 +650,12 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
     sqlQuery = table.buildSQL()
 
     self.logger.info("SQL query : ")
-    self.logger.info("\n"+sqlQuery)
+    self.logger.info("\n" + sqlQuery)
 
     res = self._query(sqlQuery)
     if not res['OK']:
       return res
-    
+
     self.logger.info(res)
     # TODO add site or CE status, while looping
     rows = []
@@ -672,14 +672,14 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
       multiple = True
 
     for row in res['Value']:
-      lrow =list(row)
+      lrow = list(row)
       if groupIndex:
         lrow[groupIndex] = getVOForGroup(row[groupIndex])
       if multiple:
         lrow.append('Multiple')
       for index, value in enumerate(row):
-        if type(value) == decimal.Decimal:
-          lrow[index]  = float(value)
+        if isinstance(value, decimal.Decimal):
+          lrow[index] = float(value)
       # get the value of the Total column
       if 'Total' in columnList:
         total = lrow[columnList.index('Total')]
@@ -693,7 +693,7 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
       rows.append(tuple(lrow))
 # If not grouped by CE and more then 1 CE in the result:
     if multiple:
-      columns.append('CE') # 'DestinationSite' re-mapped to 'CE' already
+      columns.append('CE')  # 'DestinationSite' re-mapped to 'CE' already
     columns.append('Status')
     result['Records'] = rows
 

--- a/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -202,8 +202,7 @@ class PilotManagerHandler(RequestHandler):
     :param columnList: a list of columns to GROUP BY (less status column)
     :return: a dictionary containing column names and data records
     """
-    result = pilotDB.getGroupedPilotSummary(selectDict, columnList)
-    return result
+    return pilotDB.getGroupedPilotSummary(selectDict, columnList)
 
   ##############################################################################
   types_getPilots = [six.string_types + six.integer_types]

--- a/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -190,6 +190,22 @@ class PilotManagerHandler(RequestHandler):
     return cls.pilotAgentsDB.getPilotSummaryWeb(selectDict, sortList, startItem, maxItems)
 
   ##############################################################################
+  types_getGroupedPilotSummary = [dict, list]
+
+  @classmethod
+  def export_getGroupedPilotSummary(cls, selectDict, columnList):
+    """
+    Get pilot summary showing grouped by columns in columnList, all pilot states
+    and pilot efficincies in a single row.
+
+    :param selectDict: additional arguments to SELECT clause
+    :param columnList: a list of columns to GROUP BY (less status column)
+    :return: a dictionary containing column names and data records
+    """
+    result = pilotDB.getGroupedPilotSummary(selectDict, columnList)
+    return result
+
+  ##############################################################################
   types_getPilots = [six.string_types + six.integer_types]
 
   @classmethod


### PR DESCRIPTION

**Multi VO Resource Status and Resource Management implementation.**

This PR is done against `v7r1 `because it has been tested with this version. It would eventually
have to be rebased on top of `v7r3`

The base for the dynamic, VO-based resource management is the ResourceStatus
table. This table would	normally have some Active resources:

```
 Name                         | VO          | Status   | Reason
ceprod03.grid.hep.ph.ic.ac.uk | all         | Active   | whatever reason
```

For the purpose of this	demonstration we	activate the _DowntimePolicy_
and the _PilotEfficiencyPolicy_. After the first one is run, we have:

`ceprod03.grid.hep.ph.ic.ac.uk | all    | Active   | No DownTime announced ###`

The _DowntimePolicy_ is not _VO_-aware, so its result is valid for all _VOs_.

Now, when we try to submit some _gridpp_ jobs to	`ceprod03`, and the pilot policy is run, the
result will come back to our table and we would get an additional line:

```
ceprod03.grid.hep.ph.ic.ac.uk | all    | Active   | No DownTime announced ###
ceprod03.grid.hep.ph.ic.ac.uk | gridpp | Active   | Pilots Efficiency of 100.00 ###No DownTime announced ###
```

The meaning of the first line is: valid for all VOs but ones explicitly listed.

At this point all is in the hands of a _SiteDirector._ If	it is a _GridPP SiteDirector_,
it will obey a status listed for its own _VO,_ other site directors will use the
first line to select available resources.

