### PR TITLE
[v7r2] Remove tornado from client dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     six
     sqlalchemy
     subprocess32
-    tornado ~=5.1.1
 
 [options.packages.find]
 where=src
@@ -73,7 +72,7 @@ server =
     python-json-logger
     stomp.py
     suds-jurko
-    tornado
+    tornado ~=5.1.1
     tornado-m2crypto
 testing =
     flaky


### PR DESCRIPTION
I'm fairly sure there is no reason for it to be there and it's impossible to install outside of DIRACOS as we need the M2Crypto patches that aren't suitable for conda-forge.