### PR TITLE
[v7r2] Use ConfigurationClient in CSCLI and CSShellCLI to fix more HTTPS issues

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/CSCLI.py
+++ b/src/DIRAC/ConfigurationSystem/Client/CSCLI.py
@@ -18,7 +18,7 @@ from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.Core.Base.CLI import CLI, colorize
 from DIRAC.ConfigurationSystem.private.Modificator import Modificator
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
-from DIRAC.Core.DISET.RPCClient import RPCClient
+from DIRAC.ConfigurationSystem.Client.ConfigurationClient import ConfigurationClient
 
 __RCSID__ = "$Id$"
 
@@ -127,7 +127,7 @@ class CSCLI(CLI):
   def _tryConnection(self):
     print("Trying connection to %s" % self.masterURL)
     try:
-      self.rpcClient = RPCClient(self.masterURL)
+      self.rpcClient = ConfigurationClient(url=self.masterURL)
       self._setStatus()
     except Exception as x:
       gLogger.error("Couldn't connect to master CS server", "%s (%s)" % (self.masterURL, str(x)))

--- a/src/DIRAC/ConfigurationSystem/Client/CSShellCLI.py
+++ b/src/DIRAC/ConfigurationSystem/Client/CSShellCLI.py
@@ -14,7 +14,7 @@ import six
 from DIRAC.Core.Base.CLI import CLI, colorize
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 from DIRAC.ConfigurationSystem.private.Modificator import Modificator
-from DIRAC.Core.DISET.RPCClient import RPCClient
+from DIRAC.ConfigurationSystem.Client.ConfigurationClient import ConfigurationClient
 
 
 class CSShellCLI(CLI):
@@ -54,7 +54,7 @@ class CSShellCLI(CLI):
 
     print("Trying to connect to " + self.serverURL + "...", end=' ')
 
-    self.modificator = Modificator(RPCClient(self.serverURL))
+    self.modificator = Modificator(ConfigurationClient(url=self.serverURL))
     rv = self.modificator.loadFromRemote()
     rv2 = self.modificator.loadCredentials()
 


### PR DESCRIPTION
No idea if this is correct but I noticed while preparing https://github.com/DIRACGrid/WebAppDIRAC/pull/439

BEGINRELEASENOTES

*Configuration
CHANGE: Use ConfigurationClient in CSCLI and CSShellCLI

ENDRELEASENOTES
