### PR TITLE
[7r2] Add prompt-toolkit to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     gfal2-python
     M2Crypto >=0.36
     pexpect
+    prompt-toolkit >=3
     psutil
     pyasn1
     pyasn1-modules


### PR DESCRIPTION
Was missed when extracting #5004 from #4997.

BEGINRELEASENOTES

*Python 3
FIX: Add prompt-toolkit to setuptools metadata.

ENDRELEASENOTES
