### PR TITLE
[v7r2] hackathon fixes

### DIFF
--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -386,8 +386,6 @@ class ComponentInstaller(object):
 
     # DIRAC/Extensions
     extensions = self.localCfg.getOption(cfgInstallPath('Extensions'), [])
-    while 'Web' in list(extensions):
-      extensions.remove('Web')
     centralCfg.createNewSection('DIRAC', '')
     if extensions:
       centralCfg['DIRAC'].addKey('Extensions', ','.join(extensions), '')  # pylint: disable=no-member
@@ -396,9 +394,11 @@ class ComponentInstaller(object):
     if vo:
       centralCfg['DIRAC'].addKey('VirtualOrganization', vo, '')  # pylint: disable=no-member
 
-    for section in ['Systems', 'Resources',
-                    'Resources/Sites', 'Resources/Sites/DIRAC',
-                    'Resources/Sites/LCG', 'Operations', 'Registry']:
+    for section in ['Systems',
+                    'Resources',
+                    'Resources/Sites',
+                    'Operations',
+                    'Registry']:
       if installCfg.isSection(section):
         centralCfg.createNewSection(section, contents=installCfg[section])
 

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobReport.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobReport.py
@@ -26,7 +26,7 @@ class JobReport(object):
     """
     self.jobStatusInfo = []  # where job status updates are cumulated
     self.appStatusInfo = []  # where application status updates are cumulated
-    self.jobParameters = {}
+    self.jobParameters = []  # where job parameters are cumulated
     self.jobID = int(jobid)
     self.source = source
     if not source:
@@ -75,11 +75,9 @@ class JobReport(object):
     return S_OK()
 
   def setJobParameter(self, par_name, par_value, sendFlag=True):
-    """ Send job parameter for jobID
+    """ Set job parameter for jobID
     """
-    timeStamp = Time.toString()
-    # add job parameter record
-    self.jobParameters[par_name] = (par_value, timeStamp)
+    self.jobParameters.append((par_name, par_value))
     if sendFlag and self.jobID:
       # and send
       return self.sendStoredJobParameters()
@@ -87,12 +85,10 @@ class JobReport(object):
     return S_OK()
 
   def setJobParameters(self, parameters, sendFlag=True):
-    """ Send job parameters for jobID
+    """ Set job parameters for jobID
     """
-    timeStamp = Time.toString()
-    # add job parameter record
     for pname, pvalue in parameters:
-      self.jobParameters[pname] = (pvalue, timeStamp)
+      self.jobParameters.append((pname, pvalue))
 
     if sendFlag and self.jobID:
       # and send
@@ -131,12 +127,11 @@ class JobReport(object):
     """ Send the job parameters stored in the internal cache
     """
 
-    parameters = [[pname, value[0]] for pname, value in self.jobParameters.items()]
-    if parameters:
-      result = JobStateUpdateClient().setJobParameters(self.jobID, parameters)
+    if self.jobParameters:
+      result = JobStateUpdateClient().setJobParameters(self.jobID, self.jobParametersparameters)
       if result['OK']:
         # Empty the internal parameter container
-        self.jobParameters = {}
+        self.jobParameters = []
       return result
     else:
       return S_OK('Empty')
@@ -168,9 +163,8 @@ class JobReport(object):
       print(status.ljust(20), timeStamp)
 
     print("Job parameters:")
-    for pname, value in self.jobParameters.items():
-      pvalue, timeStamp = value
-      print(pname.ljust(20), pvalue.ljust(30), timeStamp)
+    for pname, pvalue in self.jobParameters:
+      print(pname.ljust(20), pvalue.ljust(30))
 
   def generateForwardDISET(self):
     """ Generate and return failover requests for the operations in the internal cache

--- a/src/DIRAC/WorkloadManagementSystem/Client/test/Test_Client_DownloadInputData.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/test/Test_Client_DownloadInputData.py
@@ -1,7 +1,10 @@
 """Test for WMS clients."""
-# pylint: disable=protected-access, missing-docstring, invalid-name, line-too-long
+# pylint: disable=protected-access, missing-docstring, invalid-name
 
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
 import pytest
 
 from mock import MagicMock

--- a/src/DIRAC/WorkloadManagementSystem/Client/test/Test_JobReport.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/test/Test_JobReport.py
@@ -1,0 +1,35 @@
+"""Test for JobReport"""
+# pylint: disable=protected-access, missing-docstring, invalid-name
+
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import pytest
+
+from mock import MagicMock
+
+from DIRAC import S_OK, S_ERROR
+
+# sut
+from DIRAC.WorkloadManagementSystem.Client.JobReport import JobReport
+
+
+def test_jobReport(mocker):
+  mocker.patch('DIRAC.WorkloadManagementSystem.Client.JobStateUpdateClient', side_effect=MagicMock())
+
+  jr = JobReport(123)
+  res = jr.setJobStatus('Matched', 'minor_matched', 'app_matched', sendFlag=False)
+  assert res['OK']
+  res = jr.setJobStatus('Running', 'minor_running', 'app_running', sendFlag=False)
+  assert res['OK']
+  res = jr.setJobParameter('par_1', 'value_1', sendFlag=False)
+  assert res['OK']
+  res = jr.setJobParameter('par_2', 'value_2', sendFlag=False)
+  assert res['OK']
+  res = jr.setJobParameters([
+      ('par_3', 'value_3'),
+      ('par_4', 'value_4')],
+      sendFlag=False)
+  print(jr.jobParameters)
+  jr.dump()

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -249,10 +249,9 @@ class JobWrapper(object):
     """Sets some initial job parameters
     """
     parameters = []
+    parameters.append(('Pilot_Reference', self.ceArgs.get('PilotReference', self.pilotRef)))
     if 'LocalSE' in self.ceArgs:
       parameters.append(('AgentLocalSE', ','.join(self.ceArgs['LocalSE'])))
-    if 'PilotReference' in self.ceArgs:
-      parameters.append(('Pilot_Reference', self.ceArgs['PilotReference']))
     if 'CPUScalingFactor' in self.ceArgs:
       parameters.append(('CPUScalingFactor', self.ceArgs['CPUScalingFactor']))
     if 'CPUNormalizationFactor' in self.ceArgs:

--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -199,14 +199,13 @@ class WMSAdministratorHandler(RequestHandler):
     if not pilotReference:
       # Failed to get the pilot reference, try to look in the attic parameters
       res = self.jobDB.getAtticJobParameters(int(jobID), ['Pilot_Reference'])
-      if not res['OK']:
-        return res
-      c = -1
-      # Get the pilot reference for the last rescheduling cycle
-      for cycle in res['Value']:
-        if cycle > c:
-          pilotReference = res['Value'][cycle]['Pilot_Reference']
-          c = cycle
+      if res['OK']:
+        c = -1
+        # Get the pilot reference for the last rescheduling cycle
+        for cycle in res['Value']:
+          if cycle > c:
+            pilotReference = res['Value'][cycle]['Pilot_Reference']
+            c = cycle
 
     if pilotReference:
       return getGridJobOutput(pilotReference)

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/Utils.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/Utils.py
@@ -10,8 +10,6 @@ import sys
 import json
 import six
 
-import six
-
 from DIRAC import gConfig, gLogger, S_OK
 from DIRAC.Core.Utilities.File import mkDir
 


### PR DESCRIPTION
I noticed that not all the JobParameters were found (at least, less than those in v7r1). This is because the content of JobReport was not always committed by the JobAgent. This should fix it.

BEGINRELEASENOTES

*WMS
FIX: Committing the JobReport just before evaluating the result of job submission

ENDRELEASENOTES
