### PR TITLE
[v7r1] bdii fix

### DIFF
--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -19,6 +19,7 @@ from pprint import pformat
 from DIRAC import gLogger, gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getCESiteMapping, getGOCSiteName
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
+from DIRAC.Core.Utilities.List import breakListIntoChunks
 
 __RCSID__ = "$Id$"
 
@@ -251,16 +252,23 @@ def __getGlue2ExecutionEnvironmentInfo(host, executionEnvironments):
   :param list executionEnvironments: list of the execution environments to get some information from
   :returns: result of the ldapsearch for all executionEnvironments, Glue2 schema
   """
-  exeFilter = ''
-  for execEnv in executionEnvironments:
-    exeFilter += '(GLUE2ResourceID=%s)' % execEnv
-  filt = "(&(objectClass=GLUE2ExecutionEnvironment)(|%s))" % exeFilter
-  response = __ldapsearchBDII(filt=filt, attr=None, host=host, base="o=glue", selectionString="GLUE2")
-  if not response['OK']:
-    return response
-  if not response['Value']:
-    return S_ERROR("No information found for %s" % executionEnvironments)
-  return response
+  listOfValues = []
+  # break up to avoid argument list too long, it started failing at about 1900 entries
+  for exeEnvs in breakListIntoChunks(executionEnvironments, 1000):
+    exeFilter = ''
+    for execEnv in exeEnvs:
+      exeFilter += '(GLUE2ResourceID=%s)' % execEnv
+    filt = "(&(objectClass=GLUE2ExecutionEnvironment)(|%s))" % exeFilter
+    response = __ldapsearchBDII(filt=filt, attr=None, host=host, base="o=glue", selectionString="GLUE2")
+    if not response['OK']:
+      return response
+    if not response['Value']:
+      sLog.error("No information found for %s" % executionEnvironments)
+      continue
+    listOfValues += response['Value']
+  if not listOfValues:
+    return S_ERROR("No information found for executionEnvironments")
+  return S_OK(listOfValues)
 
 
 def __getGlue2ExecutionEnvironmentInfoForSite(sitename, foreignKeys, exeInfos):

--- a/Core/Utilities/Glue2.py
+++ b/Core/Utilities/Glue2.py
@@ -87,7 +87,7 @@ def getGlue2CEInfo(vo, host):
 
   siteInfo = __getGlue2ShareInfo(host, shareInfoLists)
   if not siteInfo['OK']:
-    sLog.error("Could not get CE info for", shareID + "  " + siteInfo['Message'])
+    sLog.error("Could not get CE info for", "%s: %s" % (shareID, siteInfo['Message']))
     return siteInfo
   siteDict = siteInfo['Value']
   sLog.debug("Found Sites:\n%s" % pformat(siteDict))

--- a/Core/Utilities/Subprocess.py
+++ b/Core/Utilities/Subprocess.py
@@ -438,7 +438,7 @@ class Subprocess(object):
                                     universal_newlines=True)
       self.childPID = self.child.pid
     except OSError as v:
-      retDict = S_ERROR(v)
+      retDict = S_ERROR(repr(v))
       retDict['Value'] = (-1, '', str(v))
       return retDict
     except Exception as x:
@@ -447,7 +447,7 @@ class Subprocess(object):
         self.child.stderr.close()
       except Exception:
         pass
-      retDict = S_ERROR(x)
+      retDict = S_ERROR(repr(x))
       retDict['Value'] = (-1, '', str(x))
       return retDict
 


### PR DESCRIPTION

BEGINRELEASENOTES
*Core
FIX: Glue2: fix error when too many execution environments were looked for
FIX: Subprocess: when the systemCall failed, S_ERROR now contains a string in 'Message' instead of an exception object

ENDRELEASENOTES
