### PR TITLE
[v7r2] MySQLdb.thread_safe() does not exist in mysqlclient, use MySQLdb.threadsafety instead

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -392,7 +392,7 @@ class MySQL(object):
     self.logger = self.log
 
     # let the derived class decide what to do with if is not 1
-    self._threadsafe = MySQLdb.thread_safe()
+    self._threadsafe = MySQLdb.threadsafety
     # self.log.debug('thread_safe = %s' % self._threadsafe)
 
     self.__hostName = str(hostName)


### PR DESCRIPTION
I don't think this warrants release notes.