### PR TITLE
[v7r2] ObjectLoader: protect against all exceptions instead of just ImportError

### DIFF
--- a/src/DIRAC/Core/Utilities/ObjectLoader.py
+++ b/src/DIRAC/Core/Utilities/ObjectLoader.py
@@ -98,7 +98,7 @@ class ObjectLoader(object):
       impModule = imp.load_module(modName[0], *impData)
       if impData[0]:
         impData[0].close()
-    except ImportError as excp:
+    except Exception as excp:
       if "No module named" in str(excp) and modName[0] in str(excp):
         return S_OK(None)
       errMsg = "Can't load %s in %s" % (".".join(modName), parentModule.__path__[0])


### PR DESCRIPTION
This is following https://github.com/DIRACGrid/DIRAC/pull/4957

BEGINRELEASENOTES
*Core
CHANGE: protect ObjectLoader against all exceptions 
ENDRELEASENOTES
