### PR TITLE
[v7r2] fix CI params

### DIFF
--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 5s
       timeout: 2s
-      retries: 10
+      retries: 15
 
   # Mock of an S3 storage
   s3-direct:

--- a/tests/CI/run_docker_setup.sh
+++ b/tests/CI/run_docker_setup.sh
@@ -217,6 +217,10 @@ prepareEnvironment() {
     docker cp "${DIRACOS_TARBALL_PATH}" server:"${DIRACOS_TARBALL_PATH}"
     docker cp "${DIRACOS_TARBALL_PATH}" client:"${DIRACOS_TARBALL_PATH}"
   fi
+
+  # Open permissions for the dirac user after the above operations
+  docker exec server bash -c "chown -R dirac:dirac /home/dirac"
+  docker exec client bash -c "chown -R dirac:dirac /home/dirac"
 }
 
 installServer() {
@@ -230,7 +234,7 @@ installServer() {
   docker exec client bash -c "cp $WORKSPACE/ServerInstallDIR/user/client.* $USER_HOME/.globus/"
   server_uid=$(docker exec -u dirac server bash -c 'echo $UID')
   client_uid=$(docker exec -u dirac client bash -c 'echo $UID')
-  docker cp "server:/tmp/x509up_u${server_uid}" - | docker cp - client:/tmp/
+  docker cp server:"/tmp/x509up_u${server_uid}" - | docker cp - client:/tmp/
   docker exec client bash -c "chown -R dirac:dirac /home/dirac"
   docker exec client bash -c "chown -R dirac:dirac /tmp/x509up_u${client_uid}"
 }


### PR DESCRIPTION
For me, CI tests(running locally with docker) fall for two reasons:

```
+ cp -r /home/dirac/LocalRepo/TestCode/DIRAC DIRAC
cp: cannot open '/home/dirac/LocalRepo/TestCode/DIRAC/tests/__pycache__/conftest.cpython-27-PYTEST.pyc' for reading: Permission denied
cp: cannot open '/home/dirac/LocalRepo/TestCode/DIRAC/src/DIRAC/ConfigurationSystem/Client/test/__pycache__/Test_LocalConfiguration.cpython-27-PYTEST.pyc' for reading: Permission denied
```
and
```
+ docker-compose -f ./docker-compose.yml up -d
Creating elasticsearch ... done
Creating s3-direct     ... done
Creating mysql         ... done

ERROR: for dirac-server  Container "ae9b230765db" is unhealthy.
ERROR: Encountered errors while bringing up the project.
```

BEGINRELEASENOTES

*tests
FIX: give permissions for the dirac user before server installation
FIX:  wait a little longer elasticsearch server

ENDRELEASENOTES
