### PR TITLE
[v7r3] Multi VO RSS

### DIFF
--- a/src/DIRAC/ResourceStatusSystem/Agent/CacheFeederAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/CacheFeederAgent.py
@@ -66,10 +66,10 @@ class CacheFeederAgent(AgentModule):
     self.commands['FreeDiskSpace'] = [{'FreeDiskSpace': {}}]
 
     # PilotsCommand
-#    self.commands[ 'Pilots' ] = [
-#                                 { 'PilotsWMS' : { 'element' : 'Site', 'siteName' : None } },
-#                                 { 'PilotsWMS' : { 'element' : 'Resource', 'siteName' : None } }
-#                                 ]
+    self.commands['Pilot'] = [
+        {'Pilot': {'element': 'Site', 'siteName': None}},
+        {'Pilot': {'element': 'Resource', 'siteName': None}}
+    ]
 
     # FIXME: do not forget about hourly vs Always ...etc
     # AccountingCacheCommand

--- a/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
@@ -183,7 +183,7 @@ class ElementInspectorAgent(AgentModule):
 
       lowerElementDict = {'element': self.elementType}
       for key, value in elemDict.items():
-        if len(key) > 2:
+        if len(key) >= 2:  # VO !
           lowerElementDict[key[0].lower() + key[1:]] = value
 
       # We add lowerElementDict to the queue
@@ -212,9 +212,10 @@ class ElementInspectorAgent(AgentModule):
       except Queue.Empty:
         return S_OK()
 
-      self.log.verbose('%s ( %s / %s ) being processed' % (element['name'],
-                                                           element['status'],
-                                                           element['statusType']))
+      self.log.verbose('%s ( VO=%s / status=%s / statusType=%s ) being processed' % (element['name'],
+                                                                                     element['vO'],
+                                                                                     element['status'],
+                                                                                     element['statusType']))
 
       try:
         resEnforce = pep.enforce(element)

--- a/src/DIRAC/ResourceStatusSystem/Agent/test/Test_Agent_ElementInspectorAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/test/Test_Agent_ElementInspectorAgent.py
@@ -25,6 +25,7 @@ queueFilled = Queue.Queue()
 queueFilled.put({'status': 'status',
                  'name': 'site',
                  'site': 'site',
+                 'vO': 'all',
                  'element': 'Site',
                  'statusType': 'all',
                  'elementType': 'Site'})

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceManagementClient.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceManagementClient.py
@@ -417,7 +417,7 @@ class ResourceManagementClient(Client):
   # PilotCache Methods .........................................................
 
   def selectPilotCache(self, site=None, cE=None, pilotsPerJob=None,
-                       pilotJobEff=None, status=None, lastCheckTime=None, meta=None):
+                       pilotJobEff=None, status=None, lastCheckTime=None, meta=None, vO=None):
     '''
     Gets from TransferCache all rows that match the parameters given.
 
@@ -437,13 +437,13 @@ class ResourceManagementClient(Client):
        For example: meta={'columns': ['Name']} will return only the 'Name' column.
     :return: S_OK() || S_ERROR()
     '''
-    columnNames = ["Site", "CE", "PilotsPerJob", "PilotJobEff", "Status", "LastCheckTime", "Meta"]
-    columnValues = [site, cE, pilotsPerJob, pilotJobEff, status, lastCheckTime, meta]
+    columnNames = ["Site", "CE", "PilotsPerJob", "PilotJobEff", "Status", "LastCheckTime", "Meta", "VO"]
+    columnValues = [site, cE, pilotsPerJob, pilotJobEff, status, lastCheckTime, meta, vO]
 
     return self._getRPC().select('PilotCache', prepareDict(columnNames, columnValues))
 
   def deletePilotCache(self, site=None, cE=None, pilotsPerJob=None,
-                       pilotJobEff=None, status=None, lastCheckTime=None):
+                       pilotJobEff=None, status=None, lastCheckTime=None, vO=None):
     '''
     Deletes from TransferCache all rows that match the parameters given.
 
@@ -461,13 +461,13 @@ class ResourceManagementClient(Client):
     :type lastCheckTime: datetime, list
     :return: S_OK() || S_ERROR()
     '''
-    columnNames = ["Site", "CE", "PilotsPerJob", "PilotJobEff", "Status", "LastCheckTime"]
-    columnValues = [site, cE, pilotsPerJob, pilotJobEff, status, lastCheckTime]
+    columnNames = ["Site", "CE", "PilotsPerJob", "PilotJobEff", "Status", "LastCheckTime", "VO"]
+    columnValues = [site, cE, pilotsPerJob, pilotJobEff, status, lastCheckTime, vO]
 
     return self._getRPC().delete('PilotCache', prepareDict(columnNames, columnValues))
 
   def addOrModifyPilotCache(self, site=None, cE=None, pilotsPerJob=None,
-                            pilotJobEff=None, status=None, lastCheckTime=None):
+                            pilotJobEff=None, status=None, lastCheckTime=None, vO=None):
     '''
     Adds or updates-if-duplicated to PilotCache. Using `site` and `cE`
     to query the database, decides whether to insert or update the table.
@@ -480,8 +480,8 @@ class ResourceManagementClient(Client):
     :param datetime lastCheckTime: measure calculated
     :return: S_OK() || S_ERROR()
     '''
-    columnNames = ["Site", "CE", "PilotsPerJob", "PilotJobEff", "Status", "LastCheckTime"]
-    columnValues = [site, cE, pilotsPerJob, pilotJobEff, status, lastCheckTime]
+    columnNames = ["Site", "CE", "PilotsPerJob", "PilotJobEff", "Status", "LastCheckTime", "VO"]
+    columnValues = [site, cE, pilotsPerJob, pilotJobEff, status, lastCheckTime, vO]
 
     return self._getRPC().addOrModify('PilotCache', prepareDict(columnNames, columnValues))
 
@@ -489,7 +489,7 @@ class ResourceManagementClient(Client):
 
   def selectPolicyResult(self, element=None, name=None, policyName=None,
                          statusType=None, status=None, reason=None,
-                         lastCheckTime=None, meta=None):
+                         lastCheckTime=None, meta=None, vO=None):
     '''
     Gets from PolicyResult all rows that match the parameters given.
 
@@ -513,14 +513,14 @@ class ResourceManagementClient(Client):
         For example: meta={'columns': ['Name']} will return only the 'Name' column.
     :return: S_OK() || S_ERROR()
     '''
-    columnNames = ["Element", "Name", "PolicyName", "StatusType", "Status", "Reason", "LastCheckTime", "Meta"]
-    columnValues = [element, name, policyName, statusType, status, reason, lastCheckTime, meta]
+    columnNames = ["Element", "Name", "PolicyName", "StatusType", "Status", "Reason", "LastCheckTime", "Meta", "VO"]
+    columnValues = [element, name, policyName, statusType, status, reason, lastCheckTime, meta, vO]
 
     return self._getRPC().select('PolicyResult', prepareDict(columnNames, columnValues))
 
   def deletePolicyResult(self, element=None, name=None, policyName=None,
                          statusType=None, status=None, reason=None,
-                         dateEffective=None, lastCheckTime=None):
+                         dateEffective=None, lastCheckTime=None, vO=None):
     '''
     Deletes from PolicyResult all rows that match the parameters given.
 
@@ -542,14 +542,15 @@ class ResourceManagementClient(Client):
     :type lastCheckTime: datetime, list
     :return: S_OK() || S_ERROR()
     '''
-    columnNames = ["Element", "Name", "PolicyName", "StatusType", "Status", "Reason", "DateEffective", "LastCheckTime"]
-    columnValues = [element, name, policyName, statusType, status, reason, dateEffective, lastCheckTime]
+    columnNames = ["Element", "Name", "PolicyName", "StatusType", "Status", "Reason", "DateEffective",
+                   "LastCheckTime", "VO"]
+    columnValues = [element, name, policyName, statusType, status, reason, dateEffective, lastCheckTime, vO]
 
     return self._getRPC().delete('PolicyResult', prepareDict(columnNames, columnValues))
 
   def addOrModifyPolicyResult(self, element=None, name=None, policyName=None,
                               statusType=None, status=None, reason=None,
-                              dateEffective=None, lastCheckTime=None):
+                              dateEffective=None, lastCheckTime=None, vO=None):
     '''
     Adds or updates-if-duplicated to PolicyResult. Using `name`, `policyName` and
     `statusType` to query the database, decides whether to insert or update the table.
@@ -566,8 +567,9 @@ class ResourceManagementClient(Client):
     :param datetime lastCheckTime: time-stamp setting last time the policy result was checked
     :return: S_OK() || S_ERROR()
     '''
-    columnNames = ["Element", "Name", "PolicyName", "StatusType", "Status", "Reason", "DateEffective", "LastCheckTime"]
-    columnValues = [element, name, policyName, statusType, status, reason, dateEffective, lastCheckTime]
+    columnNames = ["Element", "Name", "PolicyName", "StatusType", "Status", "Reason", "DateEffective",
+                   "LastCheckTime", "VO"]
+    columnValues = [element, name, policyName, statusType, status, reason, dateEffective, lastCheckTime, vO]
 
     return self._getRPC().addOrModify('PolicyResult', prepareDict(columnNames, columnValues))
 

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceStatus.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceStatus.py
@@ -49,7 +49,7 @@ class ResourceStatus(object):
     # RSSCache only affects the calls directed to RSS, if using the CS it is not used.
     self.rssCache = RSSCache(cacheLifeTime, self.__updateRssCache)
 
-  def getElementStatus(self, elementName, elementType, statusType=None, default=None):
+  def getElementStatus(self, elementName, elementType, statusType=None, default=None, vO=None):
     """
     Helper function, tries to get information from the RSS for the given
     Element, otherwise, it gets it from the CS.
@@ -106,7 +106,7 @@ class ResourceStatus(object):
         statusType = ['all']
 
     if self.rssFlag:
-      return self.__getRSSElementStatus(elementName, elementType, statusType)
+      return self.__getRSSElementStatus(elementName, elementType, statusType, vO)
     else:
       return self.__getCSElementStatus(elementName, elementType, statusType, default)
 
@@ -147,7 +147,7 @@ class ResourceStatus(object):
         It will try 5 times to contact the RSS before giving up
     """
 
-    meta = {'columns': ['Name', 'ElementType', 'StatusType', 'Status']}
+    meta = {'columns': ['Name', 'ElementType', 'StatusType', 'Status', 'VO']}
 
     for ti in range(5):
       rawCache = self.rssClient.selectStatusElement('Resource', 'Status', meta=meta)
@@ -163,7 +163,7 @@ class ResourceStatus(object):
 
 ################################################################################
 
-  def __getRSSElementStatus(self, elementName, elementType, statusType):
+  def __getRSSElementStatus(self, elementName, elementType, statusType, vO):
     """ Gets from the cache or the RSS the Elements status. The cache is a
         copy of the DB table. If it is not on the cache, most likely is not going
         to be on the DB.
@@ -182,7 +182,7 @@ class ResourceStatus(object):
     :type statusType: str, list
     """
 
-    cacheMatch = self.rssCache.match(elementName, elementType, statusType)
+    cacheMatch = self.rssCache.match(elementName, elementType, statusType, vO)
 
     self.log.debug('__getRSSElementStatus')
     self.log.debug(cacheMatch)
@@ -350,26 +350,27 @@ def getDictFromList(fromList):
 
 def getCacheDictFromRawData(rawList):
   """
-  Formats the raw data list, which we know it must have tuples of four elements.
-  ( element1, element2, element3, elementt4 ) into a dictionary of tuples with the format
-  { ( element1, element2, element3 ): element4 )}.
+  Formats the raw data list, which we know it must have tuples of five elements.
+  ( element1, element2, element3, elementt4, element5 ) into a dictionary of tuples with the format
+  { ( element1, element2, element3, element5 ): element4 )}.
   The resulting dictionary will be the new Cache.
 
   It happens that element1 is elementName,
                   element2 is elementType,
                   element3 is statusType,
                   element4 is status.
+                  element5 is vO
 
   :Parameters:
     **rawList** - `list`
-      list of three element tuples [( element1, element2, element3, element4 ),... ]
+      list of three element tuples [( element1, element2, element3, element4, element5 ),... ]
 
-  :return: dict of the form { ( elementName, elementType, statusType ) : status, ... }
+  :return: dict of the form { ( elementName, elementType, statusType, vO ) : status, ... }
   """
 
   res = {}
   for entry in rawList:
-    res.update({(entry[0], entry[1], entry[2]): entry[3]})
+    res.update({(entry[0], entry[1], entry[2], entry[4]): entry[3]})
 
   return res
 

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceStatusClient.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceStatusClient.py
@@ -77,7 +77,7 @@ class ResourceStatusClient(Client):
 
   def insertStatusElement(self, element, tableType, name, statusType, status,
                           elementType, reason, dateEffective, lastCheckTime,
-                          tokenOwner, tokenExpiration=None, vo='all'):
+                          tokenOwner, tokenExpiration=None, vO='all'):
     """
     Inserts on <element><tableType> a new row with the arguments given.
 
@@ -113,14 +113,14 @@ class ResourceStatusClient(Client):
     columnNames = ["Name", "StatusType", "Status", "ElementType", "Reason",
                    "DateEffective", "LastCheckTime", "TokenOwner", "TokenExpiration", "VO"]
     columnValues = [name, statusType, status, elementType, reason, dateEffective,
-                    lastCheckTime, tokenOwner, tokenExpiration, vo]
+                    lastCheckTime, tokenOwner, tokenExpiration, vO]
 
     return self._getRPC().insert(element + tableType, prepareDict(columnNames, columnValues))
 
   def selectStatusElement(self, element, tableType, name=None, statusType=None,
                           status=None, elementType=None, reason=None,
                           dateEffective=None, lastCheckTime=None,
-                          tokenOwner=None, tokenExpiration=None, meta=None, vo='all'):
+                          tokenOwner=None, tokenExpiration=None, meta=None, vO='all'):
     """
     Gets from <element><tableType> all rows that match the parameters given.
 
@@ -159,14 +159,14 @@ class ResourceStatusClient(Client):
     columnNames = ["Name", "StatusType", "Status", "ElementType", "Reason",
                    "DateEffective", "LastCheckTime", "TokenOwner", "TokenExpiration", "Meta", "VO"]
     columnValues = [name, statusType, status, elementType, reason, dateEffective,
-                    lastCheckTime, tokenOwner, tokenExpiration, meta, vo]
+                    lastCheckTime, tokenOwner, tokenExpiration, meta, vO]
 
     return self._getRPC().select(element + tableType, prepareDict(columnNames, columnValues))
 
   def deleteStatusElement(self, element, tableType, name=None, statusType=None,
                           status=None, elementType=None, reason=None,
                           dateEffective=None, lastCheckTime=None,
-                          tokenOwner=None, tokenExpiration=None, meta=None, vo='all'):
+                          tokenOwner=None, tokenExpiration=None, meta=None, vO='all'):
     """
     Deletes from <element><tableType> all rows that match the parameters given.
 
@@ -204,7 +204,7 @@ class ResourceStatusClient(Client):
     columnNames = ["Name", "StatusType", "Status", "ElementType", "Reason",
                    "DateEffective", "LastCheckTime", "TokenOwner", "TokenExpiration", "Meta", "VO"]
     columnValues = [name, statusType, status, elementType, reason, dateEffective,
-                    lastCheckTime, tokenOwner, tokenExpiration, meta, vo]
+                    lastCheckTime, tokenOwner, tokenExpiration, meta, vO]
 
     return self._getRPC().delete(element + tableType, prepareDict(columnNames, columnValues))
 
@@ -212,7 +212,7 @@ class ResourceStatusClient(Client):
                                statusType=None, status=None,
                                elementType=None, reason=None,
                                dateEffective=None, lastCheckTime=None,
-                               tokenOwner=None, tokenExpiration=None, vo='all'):
+                               tokenOwner=None, tokenExpiration=None, vO='all'):
     """
     Adds or updates-if-duplicated from <element><tableType> and also adds a log
     if flag is active.
@@ -249,14 +249,14 @@ class ResourceStatusClient(Client):
     columnNames = ["Name", "StatusType", "Status", "ElementType", "Reason",
                    "DateEffective", "LastCheckTime", "TokenOwner", "TokenExpiration", "VO"]
     columnValues = [name, statusType, status, elementType, reason, dateEffective,
-                    lastCheckTime, tokenOwner, tokenExpiration, vo]
+                    lastCheckTime, tokenOwner, tokenExpiration, vO]
 
     return self._getRPC().addOrModify(element + tableType, prepareDict(columnNames, columnValues))
 
   def modifyStatusElement(self, element, tableType, name=None, statusType=None,
                           status=None, elementType=None, reason=None,
                           dateEffective=None, lastCheckTime=None, tokenOwner=None,
-                          tokenExpiration=None, vo='all'):
+                          tokenExpiration=None, vO='all'):
     """
     Updates from <element><tableType> and also adds a log if flag is active.
 
@@ -292,7 +292,7 @@ class ResourceStatusClient(Client):
     columnNames = ["Name", "StatusType", "Status", "ElementType", "Reason",
                    "DateEffective", "LastCheckTime", "TokenOwner", "TokenExpiration", "VO"]
     columnValues = [name, statusType, status, elementType, reason, dateEffective,
-                    lastCheckTime, tokenOwner, tokenExpiration, vo]
+                    lastCheckTime, tokenOwner, tokenExpiration, vO]
 
     return self._getRPC().addOrModify(element + tableType, prepareDict(columnNames, columnValues))
 
@@ -300,7 +300,7 @@ class ResourceStatusClient(Client):
                                  statusType=None, status=None,
                                  elementType=None, reason=None,
                                  dateEffective=None, lastCheckTime=None,
-                                 tokenOwner=None, tokenExpiration=None, vo='all'):
+                                 tokenOwner=None, tokenExpiration=None, vO='all'):
     """
     Adds if-not-duplicated from <element><tableType> and also adds a log if flag
     is active.
@@ -337,7 +337,7 @@ class ResourceStatusClient(Client):
     columnNames = ["Name", "StatusType", "Status", "ElementType", "Reason",
                    "DateEffective", "LastCheckTime", "TokenOwner", "TokenExpiration", "VO"]
     columnValues = [name, statusType, status, elementType, reason, dateEffective,
-                    lastCheckTime, tokenOwner, tokenExpiration, vo]
+                    lastCheckTime, tokenOwner, tokenExpiration, vO]
 
     return self._getRPC().addIfNotThere(element + tableType, prepareDict(columnNames, columnValues))
 

--- a/src/DIRAC/ResourceStatusSystem/Client/SiteStatus.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/SiteStatus.py
@@ -63,7 +63,7 @@ class SiteStatus(object):
         It will try 5 times to contact the RSS before giving up
     """
 
-    meta = {'columns': ['Name', 'Status']}
+    meta = {'columns': ['Name', 'Status', 'VO']}
 
     for ti in range(5):
       rawCache = self.rsClient.selectStatusElement('Site', 'Status', meta=meta)
@@ -147,7 +147,7 @@ class SiteStatus(object):
     :return: dict
     """
 
-    cacheMatch = self.rssCache.match(siteName, '', '')
+    cacheMatch = self.rssCache.match(siteName, '', '', 'all')  # sites have VO="all".
 
     self.log.debug('__getRSSSiteStatus')
     self.log.debug(cacheMatch)

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -221,6 +221,8 @@ class PilotCache(rmsBase):
   pilotsperjob = Column('PilotsPerJob', Float(asdecimal=False), nullable=False, server_default='0')
   lastchecktime = Column('LastCheckTime', DateTime, nullable=False)
 
+  columnsOrder = ['Site', 'CE', 'Status', 'PilotJobEff', 'PilotsPerJob', 'LastCheckTime', 'VO']
+
   def fromDict(self, dictionary):
     """
     Fill the fields of the PilotCache object from a dictionary
@@ -387,6 +389,7 @@ class ResourceManagementDB(SQLAlchemyDB):
 
     # Create required tables
     self._createTablesIfNotThere(self.tablesList)
+  # Extended SQL methods ######################################################
 
   def addOrModify(self, table, params):
     """

--- a/src/DIRAC/ResourceStatusSystem/Policy/PilotEfficiencyPolicy.py
+++ b/src/DIRAC/ResourceStatusSystem/Policy/PilotEfficiencyPolicy.py
@@ -1,10 +1,8 @@
 """ PilotEfficiencyPolicy
 
-  Policy that calculates the efficiency following the formula::
+  Policy that gets efficiency from the PilotCommand result and
+  sets the resource status. Efficiency is given in percent.
 
-    done / ( failed + aborted + done )
-
-  if the denominator is smaller than 10, it does not take any decision.
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -24,10 +22,13 @@ class PilotEfficiencyPolicy(PolicyBase):
   def _evaluate(commandResult):
     """ _evaluate
 
-    efficiency < 0.5 :: Banned
-    efficiency < 0.9 :: Degraded
+    efficiency < 50.0 :: Banned
+    efficiency < 90.0 :: Degraded
 
     """
+    # ideally,  this should be obtained from config.
+    bannedLimit = 50.0
+    degradedLimit = 90.0
 
     result = {
         'Status': None,
@@ -53,25 +54,19 @@ class PilotEfficiencyPolicy(PolicyBase):
       result['Reason'] = 'No values to take a decision'
       return S_OK(result)
 
-    aborted = commandResult['Aborted']
-    # deleted = float( commandResult[ 'Deleted' ] )
-    done = commandResult['Done']
-    failed = commandResult['Failed']
+    # Pilot efficiency is now available directly from the command result, in percent:
+    efficiency = commandResult.get('PilotJobEff', None)
+    # get the VO from the result, if present
+    result['VO'] = commandResult.get('VO', None)
 
-    # total     = aborted + deleted + done + failed
-    total = aborted + done + failed
-
-    # we want a minimum amount of pilots to take a decision ( at least 10 pilots )
-    if total < 10:
+    if efficiency is None:
       result['Status'] = 'Unknown'
       result['Reason'] = 'Not enough pilots to take a decision'
       return S_OK(result)
 
-    efficiency = done / total
-
-    if efficiency <= 0.5:
+    if efficiency <= bannedLimit:
       result['Status'] = 'Banned'
-    elif efficiency <= 0.9:
+    elif efficiency <= degradedLimit:
       result['Status'] = 'Degraded'
     else:
       result['Status'] = 'Active'

--- a/src/DIRAC/ResourceStatusSystem/Policy/test/Test_RSS_Policy_PilotEfficiencyPolicy.py
+++ b/src/DIRAC/ResourceStatusSystem/Policy/test/Test_RSS_Policy_PilotEfficiencyPolicy.py
@@ -5,96 +5,115 @@ from __future__ import division
 from __future__ import print_function
 
 import unittest
-
 import DIRAC.ResourceStatusSystem.Policy.PilotEfficiencyPolicy as moduleTested
 
 ################################################################################
 
-class PilotEfficiencyPolicy_TestCase( unittest.TestCase ):
- 
-  def setUp( self ):
+
+class PilotEfficiencyPolicy_TestCase(unittest.TestCase):
+
+  def setUp(self):
     '''
     Setup
     '''
-                 
-    self.moduleTested = moduleTested
-    self.testClass    = self.moduleTested.PilotEfficiencyPolicy
 
-  def tearDown( self ):
+    self.moduleTested = moduleTested
+    self.testClass = self.moduleTested.PilotEfficiencyPolicy
+
+  def tearDown(self):
     '''
     Tear down
     '''
 
     del self.moduleTested
     del self.testClass
- 
+
 
 ################################################################################
 
-class PilotEfficiencyPolicy_Success( PilotEfficiencyPolicy_TestCase ):
- 
-  def test_instantiate( self ):
+class PilotEfficiencyPolicy_Success(PilotEfficiencyPolicy_TestCase):
+
+  def test_instantiate(self):
     ''' tests that we can instantiate one object of the tested class
     '''
 
     module = self.testClass()
-    self.assertEqual( 'PilotEfficiencyPolicy', module.__class__.__name__ )
+    self.assertEqual('PilotEfficiencyPolicy', module.__class__.__name__)
 
-  def test_evaluate( self ):
+  def test_evaluate(self):
     ''' tests the method _evaluate
     '''
 
     module = self.testClass()
 
-    res = module._evaluate( { 'OK' : False, 'Message' : 'Bo!' } )
+    res = module._evaluate({'OK': False, 'Message': 'Bo!'})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Error', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Bo!', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Error', res['Value']['Status'])
+    self.assertEqual('Bo!', res['Value']['Reason'])
 
-    res = module._evaluate( { 'OK' : True, 'Value' : None } )
+    res = module._evaluate({'OK': True, 'Value': None})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Unknown', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'No values to take a decision', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Unknown', res['Value']['Status'])
+    self.assertEqual('No values to take a decision', res['Value']['Reason'])
 
-    res = module._evaluate( { 'OK' : True, 'Value' : [] } )
+    res = module._evaluate({'OK': True, 'Value': []})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Unknown', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'No values to take a decision', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Unknown', res['Value']['Status'])
+    self.assertEqual('No values to take a decision', res['Value']['Reason'])
 
-    res = module._evaluate( { 'OK' : True, 'Value' : [{}] } )
+    res = module._evaluate({'OK': True, 'Value': [{}]})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Unknown', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'No values to take a decision', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Unknown', res['Value']['Status'])
+    self.assertEqual('No values to take a decision', res['Value']['Reason'])
 
-    res  = module._evaluate( { 'OK' : True, 'Value' : [{ 'Aborted' : 0, 'Deleted' : 0,
-                                                        'Done' : 0, 'Failed' : 0 }] } )
+    res = module._evaluate({'OK': True, 'Value': [{'Aborted': 0, 'Deleted': 0,
+                                                   'Done': 0, 'Failed': 0}]})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Unknown', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Not enough pilots to take a decision', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Unknown', res['Value']['Status'])
+    self.assertEqual('Not enough pilots to take a decision', res['Value']['Reason'])
 
-    res  = module._evaluate( { 'OK' : True, 'Value' : [{'Aborted' : 10, 'Deleted' : 0,
-                                                        'Done' : 10, 'Failed' : 0 }] } )
-    self.assertTrue(res['OK'])
-    self.assertEqual( 'Banned', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Pilots Efficiency of 0.50', res[ 'Value' ][ 'Reason' ] )
+    # Pilot efficiency is now available directly from the command result, in percent.
+    # The key is 'PilotJobEff'  It is calculated as (total - aborted-failed)/total * 100
 
-    res  = module._evaluate( { 'OK' : True, 'Value' : [{'Aborted' : 0, 'Deleted' : 0,
-                                                        'Done' : 30, 'Failed' : 10 }] } )
-    self.assertTrue(res['OK'])
-    self.assertEqual( 'Degraded', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Pilots Efficiency of 0.75', res[ 'Value' ][ 'Reason' ] )
+    result = {'Aborted': 10, 'Deleted': 0, 'Done': 10, 'Failed': 0}
+    result['PilotJobEff'] = self._pilotEff(result)
 
-    res  = module._evaluate( { 'OK' : True, 'Value' : [{'Aborted' : 0, 'Deleted' : 0,
-                                                        'Done' : 19, 'Failed' : 1 }] } )
+    res = module._evaluate({'OK': True, 'Value': [result]})
     self.assertTrue(res['OK'])
-    self.assertEqual( 'Active', res[ 'Value' ][ 'Status' ] )
-    self.assertEqual( 'Pilots Efficiency of 0.95', res[ 'Value' ][ 'Reason' ] )
+    self.assertEqual('Banned', res['Value']['Status'])
+    self.assertEqual('Pilots Efficiency of 50.00', res['Value']['Reason'])
+
+    result = {'Aborted': 0, 'Deleted': 0, 'Done': 30, 'Failed': 10}
+    result['PilotJobEff'] = self._pilotEff(result)
+
+    res = module._evaluate({'OK': True, 'Value': [result]})
+    self.assertTrue(res['OK'])
+    self.assertEqual('Degraded', res['Value']['Status'])
+    self.assertEqual('Pilots Efficiency of 75.00', res['Value']['Reason'])
+
+    result = {'Aborted': 0, 'Deleted': 0, 'Done': 19, 'Failed': 1}
+    result['PilotJobEff'] = self._pilotEff(result)
+
+    res = module._evaluate({'OK': True, 'Value': [result]})
+    self.assertTrue(res['OK'])
+    self.assertEqual('Active', res['Value']['Status'])
+    self.assertEqual('Pilots Efficiency of 95.00', res['Value']['Reason'])
+
+  def _pilotEff(self, result):
+    """
+    Calculate pilot efficiency.
+
+    :param result: the original dictionary of the form {status: count, status: count...}
+    :return: pilot success rate in percent
+    """
+    return (sum(result.values()) - result['Aborted'] - result['Failed']) / sum(result.values()) * 100
 
 ################################################################################
 
-if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( PilotEfficiencyPolicy_TestCase )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( PilotEfficiencyPolicy_Success ) )
-  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
 
-#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF
+if __name__ == '__main__':
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(PilotEfficiencyPolicy_TestCase)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(PilotEfficiencyPolicy_Success))
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)
+
+# EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogPolicyResultAction.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/LogPolicyResultAction.py
@@ -64,11 +64,13 @@ class LogPolicyResultAction(BaseAction):
       if policyName is None:
         return S_ERROR('policyName should not be None')
 
+      vo = singlePolicyResult.get('VO')
       # Truncate reason to fit in database column
       reason = (reason[:508] + '..') if len(reason) > 508 else reason
 
       polUpdateRes = self.rmClient.addOrModifyPolicyResult(element=element,
                                                            name=name,
+                                                           vO=vo,
                                                            policyName=policyName,
                                                            statusType=statusType,
                                                            status=status,

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/PDP.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/PDP.py
@@ -299,6 +299,8 @@ class PDP(object):
     if not nextState['OK']:
       return nextState
     nextState = nextState['Value']
+    # most restrictive status defines the VO affected. VO='all' will affect all VOs
+    policyCombined['VO'] = policiesToCombine[0].get('VO', 'all')
 
     # If the RssMachine does not accept the candidate, return forcing message
     if candidateState != nextState:

--- a/src/DIRAC/ResourceStatusSystem/Utilities/InfoGetter.py
+++ b/src/DIRAC/ResourceStatusSystem/Utilities/InfoGetter.py
@@ -178,7 +178,7 @@ def _sanitizedecisionParams(decisionParams):
   """
 
   # active is a hook to disable the policy / action if needed
-  params = ('element', 'name', 'elementType', 'statusType', 'status', 'reason', 'tokenOwner', 'active')
+  params = ('element', 'name', 'vO', 'elementType', 'statusType', 'status', 'reason', 'tokenOwner', 'active')
 
   sanitizedParams = {}
 

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_list_status.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_list_status.py
@@ -39,6 +39,7 @@ def registerSwitches():
       ('tokenOwner=', 'Owner of the token; None if default'),
       ('statusType=', 'StatusType; None if default'),
       ('status=', 'Status; None if default'),
+      ('VO=', 'Virtual organisation; None if default')
   )
 
   for switch in switches:
@@ -74,6 +75,7 @@ def parseSwitches():
   switches.setdefault('tokenOwner', None)
   switches.setdefault('statusType', None)
   switches.setdefault('status', None)
+  switches.setdefault('VO', None)
 
   if 'element' not in switches:
     subLogger.error("element Switch missing")

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_query_db.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_query_db.py
@@ -51,6 +51,7 @@ def registerSwitches():
       ('reason=', 'Decision that triggered the assigned status'),
       ('lastCheckTime=', 'Time-stamp setting last time the status & status were checked'),
       ('tokenOwner=', 'Owner of the token ( to specify only with select/delete queries'),
+      ('VO=', 'Virtual organisation; None if default')
   )
 
   for switch in switches:
@@ -96,6 +97,7 @@ def parseSwitches():
   switches.setdefault('reason', None)
   switches.setdefault('lastCheckTime', None)
   switches.setdefault('tokenOwner', None)
+  switches.setdefault('VO', None)
 
   if 'status' in switches and switches['status'] is not None:
     switches['status'] = switches['status'].title()
@@ -281,7 +283,7 @@ def select(args, switchDict):
   rssClient = ResourceStatusClient.ResourceStatusClient()
 
   meta = {'columns': ['name', 'statusType', 'status', 'elementType', 'reason',
-                      'dateEffective', 'lastCheckTime', 'tokenOwner', 'tokenExpiration']}
+                      'dateEffective', 'lastCheckTime', 'tokenOwner', 'tokenExpiration', 'vO']}
 
   result = {'output': None, 'successful': None, 'message': None, 'match': None}
   output = rssClient.selectStatusElement(element=args[1].title(),
@@ -292,6 +294,7 @@ def select(args, switchDict):
                                          elementType=switchDict['elementType'],
                                          lastCheckTime=switchDict['lastCheckTime'],
                                          tokenOwner=switchDict['tokenOwner'],
+                                         vO=switchDict['VO'],
                                          meta=meta)
   result['output'] = [dict(zip(output['Columns'], e)) for e in output['Value']]
   result['output'] = filterReason(result['output'], switchDict['reason'])
@@ -320,7 +323,8 @@ def add(args, switchDict):
                                               elementType=switchDict['elementType'],
                                               reason=switchDict['reason'],
                                               tokenOwner=getToken('owner'),
-                                              tokenExpiration=getToken('expiration'))
+                                              tokenExpiration=getToken('expiration'),
+                                              vO=switchDict['VO'])
 
   if output.get('Value'):
     result['match'] = int(output['Value'] if output['Value'] else 0)
@@ -347,7 +351,8 @@ def modify(args, switchDict):
                                          elementType=switchDict['elementType'],
                                          reason=switchDict['reason'],
                                          tokenOwner=getToken('owner'),
-                                         tokenExpiration=getToken('expiration')
+                                         tokenExpiration=getToken('expiration'),
+                                         vO=switchDict['VO']
                                          )
 
   if output.get('Value'):
@@ -374,7 +379,8 @@ def delete(args, switchDict):
                                          status=switchDict['status'],
                                          elementType=switchDict['elementType'],
                                          reason=switchDict['reason'],
-                                         tokenOwner=switchDict['tokenOwner'])
+                                         tokenOwner=switchDict['tokenOwner'],
+                                         vO=switchDict['VO'])
 
   if 'Value' in output:
     result['match'] = int(output['Value'] if output['Value'] else 0)

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_status.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_status.py
@@ -36,7 +36,7 @@ def registerSwitches():
       ('statusType=', 'StatusType (or comma-separeted list of names), if none applies to all possible statusTypes'),
       ('status=', 'Status to be changed'),
       ('reason=', 'Reason to set the Status'),
-      ('VO=', 'VO to change a status for. Deafault: all '
+      ('VO=', 'VO to change a status for. Default: "all" '
               'VO=all sets the status for all VOs not explicitly listed in the RSS'),
   )
 

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_token.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_token.py
@@ -43,6 +43,7 @@ def registerSwitches():
       ('reason=', 'Reason to set the Status'),
       ('days=', 'Number of days the token is acquired'),
       ('releaseToken', 'Release the token and let the RSS take control'),
+      ('VO=', 'VO to set a token for (obligatory)')
   )
 
   for switch in switches:
@@ -80,7 +81,7 @@ def parseSwitches():
   else:
     switches['releaseToken'] = False
 
-  for key in ('element', 'name', 'reason'):
+  for key in ('element', 'name', 'reason', 'VO'):
 
     if key not in switches:
       subLogger.error("%s Switch missing" % key)
@@ -126,6 +127,7 @@ def setToken(user):
   elements = rssClient.selectStatusElement(switchDict['element'], 'Status',
                                            name=switchDict['name'],
                                            statusType=switchDict['statusType'],
+                                           vO=switchDict['VO'],
                                            meta={'columns': ['StatusType', 'TokenOwner']})
 
   if not elements['OK']:
@@ -134,9 +136,9 @@ def setToken(user):
 
   # If there list is empty they do not exist on the DB !
   if not elements:
-    subLogger.warn('Nothing found for %s, %s, %s' % (switchDict['element'],
-                                                     switchDict['name'],
-                                                     switchDict['statusType']))
+    subLogger.warn('Nothing found for %s, %s, %s %s' % (switchDict['element'],
+                                                        switchDict['name'], switchDict['VO'],
+                                                        switchDict['statusType']))
     return S_OK()
 
   # If we want to release the token
@@ -161,6 +163,7 @@ def setToken(user):
                                            statusType=statusType,
                                            reason=switchDict['reason'],
                                            tokenOwner=newTokenOwner,
+                                           vO=switchDict['VO'],
                                            tokenExpiration=tokenExpiration)
     if not result['OK']:
       return result
@@ -172,7 +175,7 @@ def setToken(user):
     else:
       msg = '(aquired from %s)' % tokenOwner
 
-    subLogger.info('%s:%s %s' % (switchDict['name'], statusType, msg))
+    subLogger.info('name:%s, VO:%s statusType:%s %s' % (switchDict['name'], switchDict['VO'], statusType, msg))
   return S_OK()
 
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -438,13 +438,15 @@ class SiteDirector(AgentModule):
 
     if self.rssFlag:
       ceNamesList = [queue['CEName'] for queue in self.queueDict.values()]
-      result = self.rssClient.getElementStatus(ceNamesList, "ComputingElement")
+      result = self.rssClient.getElementStatus(ceNamesList, "ComputingElement", vO=self.vo)
       if not result['OK']:
         self.log.error("Can not get the status of computing elements",
                        " %s" % result['Message'])
         return result
+      # Try to get CEs which have been probed and those unprobed (vO='all').
       self.ceMaskList = [ceName for ceName in result['Value'] if result['Value'][ceName]
                          ['all'] in ('Active', 'Degraded')]
+      self.log.debug("CE list with status Active or Degraded: ", self.ceMaskList)
 
     result = self.submitPilots()
     if not result['OK']:

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -637,9 +637,9 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
     based on the same algorithm as in the Web version, basically takes into account Done and
     Aborted pilots only from the last day. The selection is done entirely in SQL.
 
-    :param selectDict: A dictionary to pass additional conditions to select statements, i.e.
-                       it allows to define start time for Done and Aborted Pilots.
-    :param columnList: A list of column to consider when grouping to calculate efficiencies.
+    :param dict selectDict: A dictionary to pass additional conditions to select statements, i.e.
+                            it allows to define start time for Done and Aborted Pilots.
+    :param list columnList: A list of column to consider when grouping to calculate efficiencies.
                        e.g. ['GridSite', 'DestinationSite'] is used to calculate efficiencies
                        for sites and  CEs. If we want to add an OwnerGroup it would be:
                        ['GridSite', 'DestinationSite', 'OwnerGroup'].

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -1166,9 +1166,9 @@ class PivotedPilotSummaryTable:
 
     # we want 'Site' and 'CE' in the final result
     colMap = {'GridSite': 'Site', 'DestinationSite': 'CE'}
-    self.columns = [colMap.get(val, val) for val in columnList]
+    self._columns = [colMap.get(val, val) for val in columnList]
 
-    self.columns += self.pstates  # MySQL._query() does not give us column names, sadly.
+    self._columns += self.pstates  # MySQL._query() does not give us column names, sadly.
 
   def buildSQL(self, selectDict=None):
     """
@@ -1204,21 +1204,21 @@ class PivotedPilotSummaryTable:
     outerGroupBy = " GROUP BY %s) \nAS pivotedEff;" % _quotedList(self.columnList)
 
     # add efficiency columns using aliases defined in the pivoted table
-    eff_case = "(CASE\n  WHEN pivotedEff.Done - pivotedEff.Done_Empty > 0 \n" \
+    effCase = "(CASE\n  WHEN pivotedEff.Done - pivotedEff.Done_Empty > 0 \n" \
                "  THEN pivotedEff.Done/(pivotedEff.Done-pivotedEff.Done_Empty) \n" \
                "  WHEN pivotedEff.Done=0 THEN 0 \n" \
                "  WHEN pivotedEff.Done=pivotedEff.Done_Empty \n" \
                "  THEN 99.0 ELSE 0.0 END) AS PilotsPerJob,\n" \
                " (pivotedEff.Total - pivotedEff.Aborted)/pivotedEff.Total*100.0 AS PilotJobEff \nFROM \n("
-    eff_select_template = " CAST(pivotedEff.{state} AS UNSIGNED) AS {state} "
+    effSelectTemplate = " CAST(pivotedEff.{state} AS UNSIGNED) AS {state} "
     # now select the columns + states:
     pivotedEff = "SELECT %s,\n" % ', '.join(['pivotedEff' + '.' + item for item in self.columnList]) + \
-        ', '.join(eff_select_template.format(state=state) for state in self.pstates + ['Total']) + ", \n"
+        ', '.join(effSelectTemplate.format(state=state) for state in self.pstates + ['Total']) + ", \n"
 
-    finalQuery = pivotedEff + eff_case + pivotedQuery + innerGroupBy + outerGroupBy
-    self.columns += ['Total', 'PilotsPerJob', 'PilotJobEff']
+    finalQuery = pivotedEff + effCase + pivotedQuery + innerGroupBy + outerGroupBy
+    self._columns += ['Total', 'PilotsPerJob', 'PilotJobEff']
     return finalQuery
 
   def getColumnList(self):
 
-    return self.columns
+    return self._columns

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -1146,7 +1146,7 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
 
 class PivotedPilotSummaryTable:
   """
-  The class creates a 'pivoted' table by combining records with with the same group
+  The class creates a 'pivoted' table by combining records with the same group
   of self.columnList into a single row. It allows an easy calculateion of pilot efficiencies.
   """
 

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -1173,7 +1173,7 @@ class PivotedPilotSummaryTable:
     Build an SQL query to create a table with all status counts in one row, ("pivoted")
     grouped by columns in the column list.
 
-    :param selectDict:
+    :param dict selectDict:
     :return: SQL query
     """
 

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -1147,7 +1147,7 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
 class PivotedPilotSummaryTable:
   """
   The class creates a 'pivoted' table by combining records with the same group
-  of self.columnList into a single row. It allows an easy calculateion of pilot efficiencies.
+  of self.columnList into a single row. It allows an easy calculation of pilot efficiencies.
   """
 
   def __init__(self, columnList):

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -24,14 +24,16 @@ __RCSID__ = "$Id$"
 
 import six
 import threading
+import decimal
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Base.DB import DB
 import DIRAC.Core.Utilities.Time as Time
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getCESiteMapping
-from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getUsernameForDN, getDNForUsername
+from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getUsernameForDN, getDNForUsername, getVOForGroup
 from DIRAC.ResourceStatusSystem.Client.SiteStatus import SiteStatus
+from DIRAC.Core.Utilities.MySQL import _quotedList
 
 
 class PilotAgentsDB(DB):
@@ -629,6 +631,96 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
 #     return S_OK( result )
 
 ##########################################################################################
+  def getGroupedPilotSummary(self, selectDict, columnList):
+    """
+    The simplified pilot summary based on getPilotSummaryWeb method. It calculates pilot efficiency
+    based on the same algorithm as in the Web version, basically takes into account Done and
+    Aborted pilots only from the last day. The selection is done entirely in SQL.
+
+    :param selectDict: A dictionary to pass additional conditions to select statements, i.e.
+                       it allows to define start time for Done and Aborted Pilots.
+    :param columnList: A list of column to consider when grouping to calculate efficiencies.
+                       e.g. ['GridSite', 'DestinationSite'] is used to calculate efficiencies
+                       for sites and  CEs. If we want to add an OwnerGroup it would be:
+                       ['GridSite', 'DestinationSite', 'OwnerGroup'].
+    :return: a dict containing the ParameterNames and Records lists.
+    """
+
+    table = PivotedPilotSummaryTable(columnList)
+    sqlQuery = table.buildSQL()
+
+    self.logger.info("SQL query : ")
+    self.logger.info("\n" + sqlQuery)
+
+    res = self._query(sqlQuery)
+    if not res['OK']:
+      return res
+
+    self.logger.info(res)
+    # TODO add site or CE status, while looping
+    rows = []
+    columns = table.getColumnList()
+    try:
+      groupIndex = columns.index('OwnerGroup')
+      # should probably change a column name to VO here as well to avoid confusion
+    except ValueError:
+      groupIndex = None
+    result = {'ParameterNames': columns}
+    multiple = False
+    # If not grouped by CE:
+    if 'CE' not in columns:
+      multiple = True
+
+    for row in res['Value']:
+      lrow = list(row)
+      if groupIndex:
+        lrow[groupIndex] = getVOForGroup(row[groupIndex])
+      if multiple:
+        lrow.append('Multiple')
+      for index, value in enumerate(row):
+        if isinstance(value, decimal.Decimal):
+          lrow[index] = float(value)
+      # get the value of the Total column
+      if 'Total' in columnList:
+        total = lrow[columnList.index('Total')]
+      else:
+        total = 0
+      if 'PilotJobEff' in columnList:
+        eff = lrow[columnList.index('PilotJobEff')]
+      else:
+        eff = 0.
+      lrow.append(self._getElementStatus(total, eff))
+      rows.append(tuple(lrow))
+# If not grouped by CE and more then 1 CE in the result:
+    if multiple:
+      columns.append('CE')  # 'DestinationSite' re-mapped to 'CE' already
+    columns.append('Status')
+    result['Records'] = rows
+
+    return S_OK(result)
+
+  def _getElementStatus(self, total, eff):
+    """
+    Assign status to a site or resource based on pilot efficiency.
+    :param total: number of pilots to assign the status, otherwise 'Idle'
+    :param eff:  efficiency in %
+
+    :return: status string
+    """
+
+    # Evaluate the quality status of the Site/CE
+    if total > 10:
+      if eff < 25.:
+        return 'Bad'
+      elif eff < 60.:
+        return 'Poor'
+      elif eff < 85.:
+        return 'Fair'
+      else:
+        return 'Good'
+    else:
+      return 'Idle'
+
   def getPilotSummaryWeb(self, selectDict, sortList, startItem, maxItems):
     """ Get summary of the pilot jobs status by CE/site in a standard structure
     """
@@ -1050,3 +1142,81 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)" %
     resultDict['Records'] = records
 
     return S_OK(resultDict)
+
+
+class PivotedPilotSummaryTable:
+  """
+  The class creates a 'pivoted' table by combining records with with the same group
+  of self.columnList into a single row. It allows an easy calculateion of pilot efficiencies.
+  """
+
+  def __init__(self, columnList):
+    """
+    Initialise a table with columns to be grouped by.
+
+    :param columnList: i.e. ['GridSite', 'DestinationSite']
+    :return:
+    """
+
+    self.columnList = columnList
+    self.pstates = ['Submitted', 'Done', 'Failed', 'Aborted',
+                    'Running', 'Waiting', 'Scheduled', 'Ready']
+
+    # we want 'Site' and 'CE' in the final result
+    colMap = {'GridSite': 'Site', 'DestinationSite': 'CE'}
+    self.columns = [colMap.get(val, val) for val in columnList]
+
+    self.columns += self.pstates  # MySQL._query() does not give us column names, sadly.
+
+  def buildSQL(self, selectDict=None):
+    """
+    Build an SQL query to create a table with all status counts in one row, ("pivoted")
+    grouped by columns in the column list.
+
+    :param selectDict:
+    :return: SQL query
+    """
+
+    last_update = Time.dateTime() - Time.day
+
+    pvtable = 'pivoted'
+    innerGroupBy = "(SELECT %s, Status,\n " \
+                   "count(CASE WHEN CurrentJobID=0  THEN 1 END) AS Empties," \
+                   " count(*) AS qty FROM PilotAgents\n " \
+                   "WHERE Status NOT IN ('Done', 'Aborted') OR (Status in ('Done', 'Aborted') \n" \
+                   " AND \n" \
+                   " LastUpdateTime > '%s')" \
+                   " GROUP by %s, Status)\n AS %s" % (
+                       _quotedList(self.columnList), last_update,
+                       _quotedList(self.columnList), pvtable)
+
+    # pivoted table: combine records with the same group of self.columnList into a single row.
+
+    pivotedQuery = "SELECT %s,\n" % ', '.join([pvtable + '.' + item for item in self.columnList])
+    line_template = " SUM(if (pivoted.Status={state!r}, pivoted.qty, 0)) AS {state}"
+    pivotedQuery += ',\n'.join(line_template.format(state=state) for state in self.pstates)
+    pivotedQuery += ",\n  SUM(if (%s.Status='Done', %s.Empties,0)) AS Done_Empty,\n" \
+                    "  SUM(%s.qty) AS Total " \
+                    "FROM\n" % (pvtable, pvtable, pvtable)
+
+    outerGroupBy = " GROUP BY %s) \nAS pivoted_eff;" % _quotedList(self.columnList)
+
+    # add efficiency columns using aliases defined in the pivoted table
+    eff_case = "(CASE\n  WHEN pivoted_eff.Done - pivoted_eff.Done_Empty > 0 \n" \
+               "  THEN pivoted_eff.Done/(pivoted_eff.Done-pivoted_eff.Done_Empty) \n" \
+               "  WHEN pivoted_eff.Done=0 THEN 0 \n" \
+               "  WHEN pivoted_eff.Done=pivoted_eff.Done_Empty \n" \
+               "  THEN 99.0 ELSE 0.0 END) AS PilotsPerJob,\n" \
+               " (pivoted_eff.Total - pivoted_eff.Aborted)/pivoted_eff.Total*100.0 AS PilotJobEff \nFROM \n("
+    eff_select_template = " CAST(pivoted_eff.{state} AS UNSIGNED) AS {state} "
+    # now select the columns + states:
+    pivoted_eff = "SELECT %s,\n" % ', '.join(['pivoted_eff' + '.' + item for item in self.columnList]) + \
+                  ', '.join(eff_select_template.format(state=state) for state in self.pstates + ['Total']) + ", \n"
+
+    finalQuery = pivoted_eff + eff_case + pivotedQuery + innerGroupBy + outerGroupBy
+    self.columns += [' Total', 'PilotsPerJob', 'PilotJobEff']
+    return finalQuery
+
+  def getColumnList(self):
+
+    return self.columns

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -1205,11 +1205,11 @@ class PivotedPilotSummaryTable:
 
     # add efficiency columns using aliases defined in the pivoted table
     effCase = "(CASE\n  WHEN pivotedEff.Done - pivotedEff.Done_Empty > 0 \n" \
-               "  THEN pivotedEff.Done/(pivotedEff.Done-pivotedEff.Done_Empty) \n" \
-               "  WHEN pivotedEff.Done=0 THEN 0 \n" \
-               "  WHEN pivotedEff.Done=pivotedEff.Done_Empty \n" \
-               "  THEN 99.0 ELSE 0.0 END) AS PilotsPerJob,\n" \
-               " (pivotedEff.Total - pivotedEff.Aborted)/pivotedEff.Total*100.0 AS PilotJobEff \nFROM \n("
+        "  THEN pivotedEff.Done/(pivotedEff.Done-pivotedEff.Done_Empty) \n" \
+        "  WHEN pivotedEff.Done=0 THEN 0 \n" \
+        "  WHEN pivotedEff.Done=pivotedEff.Done_Empty \n" \
+        "  THEN 99.0 ELSE 0.0 END) AS PilotsPerJob,\n" \
+        " (pivotedEff.Total - pivotedEff.Aborted)/pivotedEff.Total*100.0 AS PilotJobEff \nFROM \n("
     effSelectTemplate = " CAST(pivotedEff.{state} AS UNSIGNED) AS {state} "
     # now select the columns + states:
     pivotedEff = "SELECT %s,\n" % ', '.join(['pivotedEff' + '.' + item for item in self.columnList]) + \

--- a/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -190,6 +190,21 @@ class PilotManagerHandler(RequestHandler):
     return cls.pilotAgentsDB.getPilotSummaryWeb(selectDict, sortList, startItem, maxItems)
 
   ##############################################################################
+  types_getGroupedPilotSummary = [dict, list]
+
+  @classmethod
+  def export_getGroupedPilotSummary(cls, selectDict, columnList):
+    """
+    Get pilot summary showing grouped by columns in columnList, all pilot states
+    and pilot efficiencies in a single row.
+
+    :param selectDict: additional arguments to SELECT clause
+    :param columnList: a list of columns to GROUP BY (less status column)
+    :return: a dictionary containing column names and data records
+    """
+    return cls.pilotAgentsDB.getGroupedPilotSummary(selectDict, columnList)
+
+  ##############################################################################
   types_getPilots = [six.string_types + six.integer_types]
 
   @classmethod

--- a/tests/Integration/WorkloadManagementSystem/Test_PilotAgentsDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_PilotAgentsDB.py
@@ -12,12 +12,60 @@ from __future__ import print_function
 from DIRAC.Core.Base.Script import parseCommandLine
 parseCommandLine()
 
+from mock import patch
 from DIRAC import gLogger
 from DIRAC.WorkloadManagementSystem.DB.PilotAgentsDB import PilotAgentsDB
+from DIRAC.WorkloadManagementSystem.DB.PilotAgentsDB import PivotedPilotSummaryTable
 
 gLogger.setLevel('DEBUG')
 
 paDB = PilotAgentsDB()
+
+
+def preparePilots(stateCount, testSite, testCE, testGroup):
+  """
+  Set up a bunch of pilots in different states.
+
+  :param list stateCount:
+  :param str testSite: Site name
+  :param str testCE: CE name
+  :param str testGroup: group name
+  :return list pilot reference list:
+  """
+  pilotRef = []
+  nPilots = sum(stateCount)
+
+  for i in range(nPilots):
+    pilotRef.append('pilotRef_' + str(i))
+
+  res = paDB.addPilotTQReference(pilotRef, 123, 'ownerDN', testGroup, )
+  assert res['OK'] is True, res['Message']
+
+  index = 0
+  for j, num in enumerate(stateCount):
+    for i in range(num):
+      pNum = i + index
+      res = paDB.setPilotStatus('pilotRef_' + str(pNum), PivotedPilotSummaryTable.pstates[j], destination=testCE,
+                                statusReason='Test States', gridSite=testSite, queue=None,
+                                benchmark=None, currentJob=num,
+                                updateTime=None, conn=False)
+      assert res['OK'] is True, res['Message']
+
+    index += num
+  return pilotRef
+
+
+def cleanUpPilots(pilotRef):
+  """
+  Delete all pilots pointed to by pilotRef
+
+  :param  lipilotRef:
+  :return:
+  """
+
+  for elem in pilotRef:
+    res = paDB.deletePilot(elem)
+    assert res['OK'] is True, res['Message']
 
 
 def test_basic():
@@ -29,3 +77,110 @@ def test_basic():
   res = paDB.deletePilot('pilotRef')
 
   # FIXME: to expand...
+
+
+@patch('DIRAC.WorkloadManagementSystem.DB.PilotAgentsDB.getVOForGroup')
+def test_getGroupedPilotSummary(mocked_fcn):
+  """
+  Test 'pivoted' pilot summary method.
+
+  :return: None
+  """
+  stateCount = [10, 50, 7, 3, 12, 8, 6, 4]
+  testGroup = 'ownerGroup'
+  testGroupVO = 'ownerGroupVO'
+  testCE = 'TestCE'
+  testSite = 'TestSite'
+
+  mocked_fcn.return_value = 'ownerGroupVO'
+
+  pilotRef = preparePilots(stateCount, testSite, testCE, testGroup)
+  selectDict = {}
+  columnList = ['GridSite', 'DestinationSite', 'OwnerGroup']
+  res = paDB.getGroupedPilotSummary(selectDict, columnList)
+
+  cleanUpPilots(pilotRef)
+  expectedParameterList = ['Site', 'CE', 'OwnerGroup', 'Submitted', 'Done', 'Failed',
+                           'Aborted', 'Running', 'Waiting', 'Scheduled', 'Ready',
+                           'Total', 'PilotsPerJob', 'PilotJobEff', 'Status']
+
+  assert res['OK'] is True, res['Message']
+  values = res['Value']
+  assert 'ParameterNames' in values, "ParameterNames key missing in result"
+  assert values['ParameterNames'] == expectedParameterList, "Expected and obtained ParameterNames differ"
+
+  assert 'Records' in values, "Records key missing in result"
+  # in the setup with one Site/CE/OwnerGroup there will be only one record:
+  assert len(values['Records']) == 1
+  record = values['Records'][0]
+  assert len(record) == len(expectedParameterList)
+  assert record[0] == testSite
+  assert record[1] == testCE
+  assert record[2] == testGroupVO
+
+  # pilot state counts:
+  for i, entry in enumerate(record[3:10]):
+    assert entry == stateCount[i], " found entry: %s, expected stateCount: %d " % (str(entry), stateCount[i])
+  # Total
+  total = record[expectedParameterList.index('Total')]
+  assert total == sum(stateCount)
+  # pilot efficiency
+  delta = 0.01
+  accuracy = record[expectedParameterList.index('PilotJobEff')] - 100.0 * \
+      (total - record[expectedParameterList.index('Aborted')]) / total
+  assert accuracy <= delta, " Pilot eff accuracy %d should be < %d " % (accuracy, delta)
+  # there aren't any jobs, so:
+  assert record[expectedParameterList.index('Status')] == 'Idle'
+
+
+def test_PivotedPilotSummaryTable():
+  """
+  Test the 'pivoted' query only. Check whether the number of pilots in different states returned by
+  the query is correct.
+
+  :return: None
+  """
+
+  # PivotedPilotSummaryTable pstates gives pilot possible states (table.pstates)
+  # pstates = ['Submitted', 'Done', 'Failed', 'Aborted', 'Running', 'Waiting', 'Scheduled', 'Ready']
+
+  stateCount = [10, 50, 7, 3, 12, 8, 6, 4]
+  testGroup = 'ownerGroup'
+  testCE = 'TestCE'
+  testSite = 'TestSite'
+
+  pilotRef = preparePilots(stateCount, testSite, testCE, testGroup)
+
+  table = PivotedPilotSummaryTable(['GridSite', 'DestinationSite', 'OwnerGroup'])
+
+  sqlQuery = table.buildSQL()
+  res = paDB._query(sqlQuery)
+  assert res['OK'] is True, res['Message']
+
+  columns = table.getColumnList()
+  # first 3 columns are: Site, CE and a group (VO mapping comes later, not in the SQL above)
+  assert 'Site' in columns
+  assert columns.index('Site') == 0
+  assert 'CE' in columns
+  assert columns.index('CE') == 1
+  assert 'OwnerGroup' in columns
+  assert columns.index('OwnerGroup') == 2
+
+  # pilot numbers by states:
+  assert 'Total' in columns
+
+  # with the setup above there will be only one row, first 3 elements must match the columns.
+  row = res['Value'][0]
+  assert row[0] == testSite
+  assert row[1] == testCE
+  assert row[2] == testGroup
+
+  total = row[columns.index('Total')]
+
+  assert total == sum(stateCount), res['Value']
+
+  for i, state in enumerate(table.pstates):
+    assert state in columns
+    assert row[columns.index(state)] == stateCount[i], " state: %s, stateCount: %d " % (state, stateCount[i])
+
+  cleanUpPilots(pilotRef)

--- a/tests/Integration/WorkloadManagementSystem/Test_PilotAgentsDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_PilotAgentsDB.py
@@ -26,7 +26,8 @@ def preparePilots(stateCount, testSite, testCE, testGroup):
   """
   Set up a bunch of pilots in different states.
 
-  :param list stateCount:
+  :param list stateCount: number of pilots per state. States are:'Submitted', 'Done', 'Failed',
+  'Aborted', 'Running', 'Waiting', 'Scheduled', 'Ready'
   :param str testSite: Site name
   :param str testCE: CE name
   :param str testGroup: group name

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -45,6 +45,7 @@ pytest "${THIS_DIR}/WorkloadManagementSystem/Test_JobLoggingDB.py" |& tee -a "${
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_TaskQueueDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_ElasticJobParametersDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_PilotAgentsDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 python "${THIS_DIR}/WorkloadManagementSystem/Test_Client_WMS.py" --cfg "${WORKSPACE}/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#


### PR DESCRIPTION
**Multi VO Resource Status and Resource Management implementation.**

This PR is done against the integration branch and it supersedes https://github.com/DIRACGrid/DIRAC/pull/5006

The base for the dynamic, VO-based resource management is the ResourceStatus
table. This table would	normally have some Active resources:

```
 Name                         | VO          | Status   | Reason
ceprod03.grid.hep.ph.ic.ac.uk | all         | Active   | whatever reason
```

For the purpose of this	demonstration we	activate the _DowntimePolicy_
and the _PilotEfficiencyPolicy_. After the first one is run, we have:

`ceprod03.grid.hep.ph.ic.ac.uk | all    | Active   | No DownTime announced ###`

The _DowntimePolicy_ is not _VO_-aware, so its result is valid for all _VOs_.

Now, when we try to submit some _gridpp_ jobs to	`ceprod03`, and the pilot policy is run, the
result will come back to our table and we would get an additional line:

```
ceprod03.grid.hep.ph.ic.ac.uk | all    | Active   | No DownTime announced ###
ceprod03.grid.hep.ph.ic.ac.uk | gridpp | Active   | Pilots Efficiency of 100.00 ###No DownTime announced ###
```

The meaning of the first line is: valid for all VOs but ones explicitly listed.

At this point all is in the hands of a _SiteDirector._ If	it is a _GridPP SiteDirector_,
it will obey a status listed for its own _VO,_ other site directors will use the
first line to select available resources.

