### PR TITLE
[v7r3] Tests: remove the email address of the self generated certificates

### DIFF
--- a/container/docker_compose_setup/env_files/env_install.cfg
+++ b/container/docker_compose_setup/env_files/env_install.cfg
@@ -27,13 +27,13 @@ LocalInstallation
   # Name of the Admin user (from the user certificate we created )
   AdminUserName = ciuser
   # DN of the Admin user certificate (from the user certificate we created)
-  AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
   AdminUserEmail= adminUser@cern.ch
   # Name of the Admin group
   AdminGroupName = dirac_admin
 
   # DN of the host certificate (from the host certificate we created)
-  HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=$dirac_hostname/emailAddress=lhcb-dirac-ci@cern.ch
+  HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=$dirac_hostname
   # Define the Configuration Server as Master
   ConfigurationMaster = yes
 

--- a/container/docker_compose_setup/resources/install.cfg
+++ b/container/docker_compose_setup/resources/install.cfg
@@ -27,13 +27,13 @@ LocalInstallation
   # Name of the Admin user (from the user certificate we created )
   AdminUserName = ciuser
   # DN of the Admin user certificate (from the user certificate we created)
-  AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
   AdminUserEmail= adminUser@cern.ch
   # Name of the Admin group
   AdminGroupName = dirac_admin
 
   # DN of the host certificate (from the host certificate we created)
-  HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=dirac-dev/emailAddress=lhcb-dirac-ci@cern.ch
+  HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=dirac-dev
   # Define the Configuration Server as Master
   ConfigurationMaster = yes
 

--- a/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
+++ b/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.rst
@@ -319,7 +319,7 @@ The Configuration service will serve the content of the file ``/opt/dirac/etc/My
     {
       ciuser
       {
-        DN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+        DN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
         Email = adminUser@cern.ch
       }
     }
@@ -346,7 +346,7 @@ The Configuration service will serve the content of the file ``/opt/dirac/etc/My
     {
       dirac-tuto
       {
-        DN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=dirac-tuto/emailAddress=lhcb-dirac-ci@cern.ch
+        DN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=dirac-tuto
         Properties = TrustedHost
         Properties += CSAdministrator
         Properties += JobAdministrator
@@ -524,9 +524,9 @@ You should now be able to get a proxy::
   [diracuser@dirac-tuto DIRAC]$ dirac-proxy-init
   Generating proxy...
   Proxy generated:
-  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=460648814
-  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
-  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/CN=460648814
+  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
+  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
   timeleft     : 23:59:59
   DIRAC group  : dirac_user
   rfc          : True

--- a/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.sh
+++ b/docs/source/AdministratorGuide/Tutorials/basicTutoSetup.sh
@@ -130,13 +130,13 @@ LocalInstallation
   # Name of the Admin user (from the user certificate we created )
   AdminUserName = ciuser
   # DN of the Admin user certificate (from the user certificate we created)
-  AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
   AdminUserEmail= adminUser@cern.ch
   # Name of the Admin group
   AdminGroupName = dirac_admin
 
   # DN of the host certificate (from the host certificate we created)
-  HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=dirac-tuto/emailAddress=lhcb-dirac-ci@cern.ch
+  HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=dirac-tuto
   # Define the Configuration Server as Master
   ConfigurationMaster = yes
 

--- a/docs/source/AdministratorGuide/Tutorials/installRMS.rst
+++ b/docs/source/AdministratorGuide/Tutorials/installRMS.rst
@@ -101,7 +101,7 @@ The Request has a name (``myFirstRequest``) that we chose, but also an ID, retur
   [diracuser@dirac-tuto ~]$ dirac-rms-request myFirstRequest
   Request name='myFirstRequest' ID=8 Status='Waiting'
   Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:05, NotBefore 2019-04-23 14:37:05
-  Owner: '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch', Group: dirac_data
+  Owner: '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser', Group: dirac_data
     [0] Operation Type='ReplicateAndRegister' ID=8 Order=0 Status='Waiting'
         TargetSE: StorageElementTwo - Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:05
       [01] ID=2 LFN='/tutoVO/user/c/ciuser/myTestFile.txt' Status='Waiting' Checksum='1e750431'
@@ -109,7 +109,7 @@ The Request has a name (``myFirstRequest``) that we chose, but also an ID, retur
   [diracuser@dirac-tuto ~]$ dirac-rms-request 8
   Request name='myFirstRequest' ID=8 Status='Waiting'
   Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:05, NotBefore 2019-04-23 14:37:05
-  Owner: '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch', Group: dirac_data
+  Owner: '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser', Group: dirac_data
     [0] Operation Type='ReplicateAndRegister' ID=8 Order=0 Status='Waiting'
         TargetSE: StorageElementTwo - Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:05
       [01] ID=2 LFN='/tutoVO/user/c/ciuser/myTestFile.txt' Status='Waiting' Checksum='1e750431'
@@ -120,7 +120,7 @@ You can here clearly see that the Request consists of one ``ReplicateAndRegister
   [diracuser@dirac-tuto ~]$ dirac-rms-request 8
   Request name='myFirstRequest' ID=8 Status='Done'
   Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:29, NotBefore 2019-04-23 14:37:05
-  Owner: '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch', Group: dirac_data
+  Owner: '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser', Group: dirac_data
     [0] Operation Type='ReplicateAndRegister' ID=8 Order=0 Status='Done'
         TargetSE: StorageElementTwo - Created 2019-04-23 14:37:05, Updated 2019-04-23 14:37:29
       [01] ID=2 LFN='/tutoVO/user/c/ciuser/myTestFile.txt' Status='Done' Checksum='1e750431'

--- a/docs/source/AdministratorGuide/Tutorials/managingIdentities.rst
+++ b/docs/source/AdministratorGuide/Tutorials/managingIdentities.rst
@@ -67,9 +67,9 @@ The simplest way to test it is to upload your user proxy::
   Generating proxy...
   Uploading proxy for dirac_user...
   Proxy generated:
-  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=6045995638
-  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
-  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/CN=6045995638
+  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
+  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
   timeleft     : 23:59:59
   DIRAC group  : dirac_user
   rfc          : True
@@ -79,7 +79,7 @@ The simplest way to test it is to upload your user proxy::
 
   Proxies uploaded:
   DN                                                                     | Group      | Until (GMT)
-  /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch | dirac_user | 2020/04/09 14:43
+  /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser | dirac_user | 2020/04/09 14:43
 
 As you can see, the ProxyDB now contains a delegated proxy for the ``ciuser`` with the group ``dirac_user``.
 
@@ -88,9 +88,9 @@ If you use a proxy with the ``ProxyManagement`` permission, like the ``dirac_adm
   [diracuser@dirac-tuto ~]$ dirac-proxy-init -g dirac_admin
   Generating proxy...
   Proxy generated:
-  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=5472309786
-  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
-  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/CN=5472309786
+  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
+  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
   timeleft     : 23:59:59
   DIRAC group  : dirac_admin
   rfc          : True
@@ -118,9 +118,9 @@ You should now be able to get a proxy belonging to the `dirac_data` group that w
   Generating proxy...
   Uploading proxy for dirac_data...
   Proxy generated:
-  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=6009266000
-  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
-  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  subject      : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/CN=6009266000
+  issuer       : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
+  identity     : /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
   timeleft     : 23:59:59
   DIRAC group  : dirac_data
   rfc          : True
@@ -130,8 +130,8 @@ You should now be able to get a proxy belonging to the `dirac_data` group that w
 
   Proxies uploaded:
   DN                                                                     | Group      | Until (GMT)
-  /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch | dirac_data | 2020/04/09 14:43
-  /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch | dirac_user | 2020/04/09 14:43
+  /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser | dirac_data | 2020/04/09 14:43
+  /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser | dirac_user | 2020/04/09 14:43
 
 
 .. note:: if you get ``Unauthorized query ( 1111 : Unauthorized query)``, it means the ProxyManager has not yet updated its internal configuration. Just restart it to save time, or wait.

--- a/docs/source/DeveloperGuide/TornadoServices/index.rst
+++ b/docs/source/DeveloperGuide/TornadoServices/index.rst
@@ -272,15 +272,15 @@ Contacting the service using ``DIRAC``::
     ...: 
   Out[7]: 
   {u'OK': True,
-  u'Value': {u'DN': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch',
+  u'Value': {u'DN': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser',
     u'group': u'dirac_user',
-    u'identity': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch',
+    u'identity': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser',
     u'isLimitedProxy': False,
     u'isProxy': True,
-    u'issuer': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch',
+    u'issuer': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser',
     u'properties': [u'NormalUser'],
     u'secondsLeft': 86141,
-    u'subject': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=2409820262',
+    u'subject': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/CN=2409820262',
     u'username': u'adminusername',
     u'validDN': False,
     u'validGroup': False},
@@ -301,7 +301,7 @@ Contacting the service using ``requests``::
       ...: with requests.post(url, data=kwargs, cert=cert, verify=caPath) as r:
       ...:     print r.json()
       ...:     
-  {u'OK': True, u'Value': {u'DN': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch', u'username': u'adminusername', u'secondsLeft': 85846, u'group': u'dirac_user', u'isProxy': True, u'validGroup': False, u'validDN': False, u'issuer': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch', u'isLimitedProxy': False, u'properties': [u'NormalUser'], u'identity': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch', u'subject': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=2409820262'}}
+  {u'OK': True, u'Value': {u'DN': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser', u'username': u'adminusername', u'secondsLeft': 85846, u'group': u'dirac_user', u'isProxy': True, u'validGroup': False, u'validDN': False, u'issuer': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser', u'isLimitedProxy': False, u'properties': [u'NormalUser'], u'identity': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser', u'subject': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/CN=2409820262'}}
 
 
 

--- a/src/DIRAC/Core/DISET/private/Transports/BaseTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/BaseTransport.py
@@ -110,7 +110,7 @@ class BaseTransport(object):
 
       In SSLTransport it contains (after the handshake):
 
-       - 'DN' : All identity name, e.g. ```/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch```
+       - 'DN' : All identity name, e.g. ```/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser```
        - 'CN' : Only the user name e.g. ciuser
        - 'x509Chain' : List of all certificates in the chain
        - 'isProxy' : True if the client use proxy certificate

--- a/src/DIRAC/Core/Tornado/Server/TornadoService.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoService.py
@@ -338,15 +338,15 @@ class TornadoService(RequestHandler):  # pylint: disable=abstract-method
           ...:     print r.json()
           ...:
         {u'OK': True,
-            u'Value': {u'DN': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch',
+            u'Value': {u'DN': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser',
             u'group': u'dirac_user',
-            u'identity': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch',
+            u'identity': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser',
             u'isLimitedProxy': False,
             u'isProxy': True,
-            u'issuer': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch',
+            u'issuer': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser',
             u'properties': [u'NormalUser'],
             u'secondsLeft': 85441,
-            u'subject': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch/CN=2409820262',
+            u'subject': u'/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/CN=2409820262',
             u'username': u'adminusername',
             u'validDN': False,
             u'validGroup': False}}

--- a/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py
@@ -473,7 +473,7 @@ class Matcher (TestWMSTestCase):
     # insert a proper DN to run the test
     resourceDescription = {
         'OwnerGroup': 'prod',
-        'OwnerDN': '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch',
+        'OwnerDN': '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser',
         'DIRACVersion': 'pippo',
         'ReleaseVersion': 'blabla',
         'VirtualOrganization': 'LHCb',
@@ -497,7 +497,7 @@ class Matcher (TestWMSTestCase):
     self.assertTrue(res['OK'], res.get('Message'))
 
     tqDB = TaskQueueDB()
-    tqDefDict = {'OwnerDN': '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch',
+    tqDefDict = {'OwnerDN': '/C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser',
                  'OwnerGroup': 'prod', 'Setup': 'dirac-JenkinsSetup', 'CPUTime': 86400}
     res = tqDB.insertJob(jobID, tqDefDict, 10)
     self.assertTrue(res['OK'], res.get('Message'))

--- a/tests/Jenkins/config/ci/openssl_config_host.cnf
+++ b/tests/Jenkins/config/ci/openssl_config_host.cnf
@@ -22,8 +22,6 @@ C                   = ch
 O                   = DIRAC
 OU                  = DIRAC CI
 CN                  = #hostname#
-emailAddress        = lhcb-dirac-ci@cern.ch
-
 
 
 [ v3_req ]

--- a/tests/Jenkins/config/ci/openssl_config_user.cnf
+++ b/tests/Jenkins/config/ci/openssl_config_user.cnf
@@ -12,7 +12,6 @@ C                      = ch
 O                      = DIRAC
 OU                     = DIRAC CI
 CN                     = ciuser
-emailAddress           = lhcb-dirac-ci@cern.ch
 
 [ v3_req ]
 # Extensions for client certificates (`man x509v3_config`).

--- a/tests/Jenkins/install.cfg
+++ b/tests/Jenkins/install.cfg
@@ -22,11 +22,11 @@ LocalInstallation
   #
   #          openssl x509 -noout -subject -enddate -in <certfile.pem>
   #
-  AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch
+  AdminUserDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=ciuser
   AdminUserEmail = lhcb-dirac-ci@cern.ch
   AdminGroupName = dirac_admin
   #  DN of the host certificate (*) (default: None )
-  HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=VAR_HostDN/emailAddress=lhcb-dirac-ci@cern.ch
+  HostDN = /C=ch/O=DIRAC/OU=DIRAC CI/CN=VAR_HostDN
   ConfigurationMaster = yes
   Host = localhost
   # List of Systems to be installed - by default all services are added

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -669,12 +669,12 @@ diracCredentials() {
 diracUserAndGroup() {
   echo '==> [diracUserAndGroup]'
 
-  if ! dirac-admin-add-user -N ciuser -D /C=ch/O=DIRAC/OU=DIRAC\ CI/CN=ciuser/emailAddress=lhcb-dirac-ci@cern.ch -M lhcb-dirac-ci@cern.ch -G dirac_user "${DEBUG}"; then
+  if ! dirac-admin-add-user -N ciuser -D /C=ch/O=DIRAC/OU=DIRAC\ CI/CN=ciuser -M lhcb-dirac-ci@cern.ch -G dirac_user "${DEBUG}"; then
     echo 'ERROR: dirac-admin-add-user failed' >&2
     exit 1
   fi
 
-  if ! dirac-admin-add-user -N trialUser -D /C=ch/O=DIRAC/OU=DIRAC\ CI/CN=trialUser/emailAddress=lhcb-dirac-ci@cern.ch -M lhcb-dirac-ci@cern.ch -G dirac_user "${DEBUG}"; then
+  if ! dirac-admin-add-user -N trialUser -D /C=ch/O=DIRAC/OU=DIRAC\ CI/CN=trialUser -M lhcb-dirac-ci@cern.ch -G dirac_user "${DEBUG}"; then
     echo 'ERROR: dirac-admin-add-user failed' >&2
     exit 1
   fi


### PR DESCRIPTION
The proxies generated with the self signed test users were not following the RFC3820 (see details bellow). This went unnoticed because this specific part of the RFC is only enforced since openssl 1.1 series (https://github.com/openssl/openssl/commit/c8223538cb05e5aac6418a5ba6dc4775b7ab486b.

The specific part we are not respecting is section `3.4`

```
   The subject field of a Proxy Certificate MUST be the issuer field
   (that is the subject of the Proxy Issuer) appended with a single
   Common Name component.
```

This is the certificate we were generating:

```
[dirac@server user]$ openssl x509 -in /home/dirac/ServerInstallDIR/user/client.pem -noout -subject -issuer
subject=C = ch, O = DIRAC, OU = DIRAC CI, CN = ciuser, emailAddress = lhcb-dirac-ci@cern.ch
issuer=O = DIRAC CI, CN = DIRAC CI Signing Certification Authority
```


And this is the proxy that comes out of it

```
[dirac@server user]$ openssl x509 -in /tmp/x509up_u1000 -noout -subject -issuer
subject=C = ch, O = DIRAC, OU = DIRAC CI, CN = ciuser/emailAddress=lhcb-dirac-ci@cern.ch, CN = 4091627920
issuer=C = ch, O = DIRAC, OU = DIRAC CI, CN = ciuser, emailAddress = lhcb-dirac-ci@cern.ch
```

As you can see, it does not follow the description above. 

So to fix this, I just removed the email bit from the test config. 

it should fix https://github.com/DIRACGrid/DIRAC/issues/5003

BEGINRELEASENOTES
*Test
CHANGE: don't use mail in the self generated certificates

ENDRELEASENOTES
