### PR TITLE
[v7r1] M2Crypto: add a DIRAC_M2CRYPTO_DEBUG env variable for SSL debuging

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -11,6 +11,9 @@ when desired.
 DIRAC_DEBUG_DENCODE_CALLSTACK
   If set, debug information for the encoding and decoding will be printed out
 
+DIRAC_DEBUG_M2CRYPTO
+  If ``true`` or ``yes``, print a lot of SSL debug output
+
 DIRAC_DEBUG_STOMP
   If set, the stomp library will print out debug information
 
@@ -28,9 +31,6 @@ DIRAC_USE_JSON_DECODE
 DIRAC_USE_JSON_ENCODE
   Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page
 
-DIRAC_USE_M2CRYPTO
-  If anything else than ``true`` or ``yes`` (default) DIRAC will revert back to using pyGSI instead of m2crypto for handling certificates, proxies, etc.
-
 DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
   If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
 
@@ -47,7 +47,7 @@ DIRAC_USE_NEWTHREADPOOL
   If this environment is set to ``true`` or ``yes``, the concurrent.futures.ThreadPoolExecutor will be used.
 
 DIRAC_USE_M2CRYPTO
-  If ``true`` or ``yes`` DIRAC uses m2crypto instead of pyGSI for handling certificates, proxies, etc.
+  If anything else than ``true`` or ``yes`` (default) DIRAC will revert back to using pyGSI instead of m2crypto for handling certificates, proxies, etc.
 
 DIRACSYSCONFIG
   If set, its value should be (the full locations on the file system of) one of more DIRAC cfg file(s) (comma separated), whose content will be used for the DIRAC configuration


### PR DESCRIPTION
Add an environment variable that allows for in depth SSL debugging

BEGINRELEASENOTES
*Core
NEW: DIRAC_M2CRYPTO_DEBUG env variable for SSL debugging

ENDRELEASENOTES
