### PR TITLE
[v7r2] newer versions of setuptools_scm do not support py2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,5 @@ caniusepython3
 subprocess32
 flaky
 ldap3
+# setuptools_scm comes via tornado. newer versions of setuptools_scm do not support py2
+setuptools_scm<6.0


### PR DESCRIPTION

BEGINRELEASENOTES
*tests
CHANGE: fix version, newer versions of setuptools_scm do not support py2

ENDRELEASENOTES
