### PR TITLE
[v7r1] Fix HeartBeatTime

### DIFF
--- a/DataManagementSystem/Agent/RequestOperations/RegisterReplica.py
+++ b/DataManagementSystem/Agent/RequestOperations/RegisterReplica.py
@@ -96,8 +96,9 @@ class RegisterReplica(DMSRequestOperationsBase):
               catMaster = catMaster and FileCatalog()._getCatalogConfigDetails(failedCatalog)\
                   .get('Value', {}).get('Master', False)
           # If one targets explicitly a catalog and it fails or if it fails on the master catalog
-          if (catalogs or catMaster) and \
-                  ('file does not exist' in opFile.Error.lower() or 'no such file' in opFile.Error.lower()):
+          if (catalogs or catMaster) \
+                  and ('file does not exist' in opFile.Error.lower()
+                       or 'no such file' in opFile.Error.lower()):
             # Check if the file really exists in SE, if not, consider this file registration as Done
             res = self.dm.getReplicaMetadata(lfn, targetSE)
             notExist = bool('No such file' in res.get('Value', {}).get('Failed', {}).get(lfn, ''))

--- a/Interfaces/scripts/dirac-wms-job-logging-info.py
+++ b/Interfaces/scripts/dirac-wms-job-logging-info.py
@@ -30,7 +30,7 @@ exitCode = 0
 errorList = []
 
 for job in parseArguments(args):
-
+  print("Job %s:" % job)
   result = dirac.getJobLoggingInfo(job, printOutput=True)
   if not result['OK']:
     errorList.append((job, result['Message']))

--- a/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -228,8 +228,8 @@ for the agent restart
     result = JobMonitoringClient().getJobParameter(jobID, 'Pilot_Reference')
     if not result['OK']:
       return result
-    pilotReference = result['Value'].get('Pilot_Reference')
-    if not pilotReference:
+    pilotReference = result['Value'].get('Pilot_Reference', 'Unknown')
+    if pilotReference == 'Unknown':
       # There is no pilot reference, hence its status is unknown
       return S_OK('NoPilot')
 

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -772,7 +772,7 @@ class JobDB(DB):
       startDate = ret['Value']
     else:
       startDate = "UTC_TIMESTAMP()"
-    # Set also the HeartBeatTime in case the job gets stucke before sending the first HeartBeat
+    # Set also the HeartBeatTime in case the job gets stuck before sending the first HeartBeat
     req = "UPDATE Jobs SET HeartBeatTime=%s WHERE JobID=%s AND HeartBeatTime IS NULL" % (startDate, jobID)
     ret = self._update(req)
     if not ret['OK']:

--- a/WorkloadManagementSystem/DB/JobDB.py
+++ b/WorkloadManagementSystem/DB/JobDB.py
@@ -750,14 +750,14 @@ class JobDB(DB):
       if not ret['OK']:
         return ret
       endDate = ret['Value']
-      req = "UPDATE Jobs SET EndExecTime=%s WHERE JobID=%s AND EndExecTime IS NULL" % (endDate, jobID)
     else:
-      req = "UPDATE Jobs SET EndExecTime=UTC_TIMESTAMP() WHERE JobID=%s AND EndExecTime IS NULL" % jobID
+      endDate = "UTC_TIMESTAMP()"
+    req = "UPDATE Jobs SET EndExecTime=%s WHERE JobID=%s AND EndExecTime IS NULL" % (endDate, jobID)
     return self._update(req)
 
 #############################################################################
   def setStartExecTime(self, jobID, startDate=None):
-    """ Set StartExecTime time stamp
+    """ Set StartExecTime time stamp and HeartBeatTime if not already set
     """
 
     ret = self._escapeString(jobID)
@@ -770,9 +770,14 @@ class JobDB(DB):
       if not ret['OK']:
         return ret
       startDate = ret['Value']
-      req = "UPDATE Jobs SET StartExecTime=%s WHERE JobID=%s AND StartExecTime IS NULL" % (startDate, jobID)
     else:
-      req = "UPDATE Jobs SET StartExecTime=UTC_TIMESTAMP() WHERE JobID=%s AND StartExecTime IS NULL" % jobID
+      startDate = "UTC_TIMESTAMP()"
+    # Set also the HeartBeatTime in case the job gets stucke before sending the first HeartBeat
+    req = "UPDATE Jobs SET HeartBeatTime=%s WHERE JobID=%s AND HeartBeatTime IS NULL" % (startDate, jobID)
+    ret = self._update(req)
+    if not ret['OK']:
+      return ret
+    req = "UPDATE Jobs SET StartExecTime=%s WHERE JobID=%s AND StartExecTime IS NULL" % (startDate, jobID)
     return self._update(req)
 
 #############################################################################


### PR DESCRIPTION
BEGINRELEASENOTES

* WMS
CHANGE: if the `HeartBeatTime` of a job is not set, it cannot be seen as `Stalled`. Hence set the `HeartBeatTime` (if not set) when setting the `StartExecTime`
CHANGE (`StalledJobAgent`): don't try and get pilot status if "Unknown"

* Interface
CHANGE: print the jobID in dirac-wms-job-logging-info 

* DMS
CHANGE: lower logging level for individual LFNs (from INFO to VERBOSE) to decrease amount of logged information. Replace with a summary

ENDRELEASENOTES
