### PR TITLE
[v7r1] FTS3: submit FTS3Job with lowercase checksum

### DIFF
--- a/DataManagementSystem/Client/FTS3Job.py
+++ b/DataManagementSystem/Client/FTS3Job.py
@@ -380,9 +380,15 @@ class FTS3Job(JSerializable):
         transfers.append(stageTrans)
 
       trans_metadata = {'desc': 'Transfer %s' % ftsFileID, 'fileID': ftsFileID}
+
+      # because of an xroot bug (https://github.com/xrootd/xrootd/issues/1433)
+      # the checksum needs to be lowercase. It does not impact the other
+      # protocol, so it's fine to put it here.
+      # I only add it in this transfer and not the "staging" one above because it
+      # impacts only root -> root transfers
       trans = fts3.new_transfer(sourceSURL,
                                 targetSURL,
-                                checksum='ADLER32:%s' % ftsFile.checksum,
+                                checksum='ADLER32:%s' % ftsFile.checksum.lower(),
                                 filesize=ftsFile.size,
                                 metadata=trans_metadata,
                                 activity=self.activity)


### PR DESCRIPTION
A bug in xrootd https://github.com/xrootd/xrootd/issues/1433 requires that we submit transfers with lower case checksum 

This was found in this ticket https://ggus.eu/index.php?mode=ticket_info&ticket_id=151081

it is currently being tested in LHCb, so far so good


BEGINRELEASENOTES
*DMS
FIX: Submit FTS3 jobs with lowercase checksum
ENDRELEASENOTES
