### PR TITLE
[v7r1] Move cpu work left computation at the beginning of the jobagent execution

### DIFF
--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -159,6 +159,7 @@ class JobAgent(AgentModule):
       # Only call timeLeft utility after a job has been picked up
       self.log.info('Attempting to check CPU time left for filling mode')
       if self.fillingMode:
+        self.timeLeft = self.computeCPUWorkLeft()
         self.log.info('normalized CPU units remaining in slot', self.timeLeft)
         if self.timeLeft <= self.minimumTimeLeft:
           return self.__finish('No more time left')
@@ -366,8 +367,6 @@ class JobAgent(AgentModule):
       self.log.exception("Exception in submission", "", lException=subExcept, lExcInfo=True)
       return self._rescheduleFailedJob(jobID, 'Job processing failed with exception', self.stopOnApplicationFailure)
 
-    self.timeLeft = self.computeCPUWorkLeft(processors)
-
     return S_OK('Job Agent cycle complete')
 
   #############################################################################
@@ -383,7 +382,7 @@ class JobAgent(AgentModule):
     jdlFile.close()
 
   #############################################################################
-  def computeCPUWorkLeft(self, processors):
+  def computeCPUWorkLeft(self, processors=1):
     """
     Compute CPU Work Left in hepspec06 seconds
 


### PR DESCRIPTION
The CPU work left computation was performed at the end of cycle *N* and the value was used in cycle *N+1*. 
If no slot is available or no job is matched for a while, the `timeleft` value is not updated and wrong.

BEGINRELEASENOTES
*WorkloadManagement
FIX: Move the CPU work left computation at the beginning of the JobAgent execution

ENDRELEASENOTES
