### PR TITLE
[v7r1] Avoid pointless sleeping during server tests

### DIFF
--- a/Core/Utilities/MySQL.py
+++ b/Core/Utilities/MySQL.py
@@ -170,6 +170,7 @@ gInstancesCount = 0
 __RCSID__ = "$Id$"
 
 MAXCONNECTRETRY = 10
+RETRY_SLEEP_DURATION = 5
 
 
 def _checkFields(inFields, inValues):
@@ -257,7 +258,7 @@ class MySQL(object):
       return self.__getWithRetry(dbName, retries, retries)
 
     def __getWithRetry(self, dbName, totalRetries, retriesLeft):
-      sleepTime = 5 * (totalRetries - retriesLeft)
+      sleepTime = RETRY_SLEEP_DURATION * (totalRetries - retriesLeft)
       if sleepTime > 0:
         time.sleep(sleepTime)
       try:

--- a/tests/Integration/Core/Test_MySQLDB.py
+++ b/tests/Integration/Core/Test_MySQLDB.py
@@ -7,6 +7,7 @@ import sys
 import time
 import pytest
 
+import DIRAC
 from DIRAC import gLogger, gConfig
 from DIRAC.Core.Utilities import Time
 from DIRAC.Core.Utilities.MySQL import MySQL
@@ -105,9 +106,13 @@ def genVal2():
     ('mysql', 'Dirac', 'Dirac', 'AccountingDB', 3306, True),
     ('fake', 'fake', 'fake', 'FakeDB', 0000, False),
 ])
-def test_connection(host, user, password, dbName, port, expected):
+def test_connection(host, user, password, dbName, port, expected, monkeypatch):
   """ Try to connect to a DB
   """
+  # Avoid having many retries which sleep for long durations
+  monkeypatch.setattr(DIRAC.Core.Utilities.MySQL, "MAXCONNECTRETRY", 1)
+  monkeypatch.setattr(DIRAC.Core.Utilities.MySQL, "RETRY_SLEEP_DURATION", 0.5)
+
   mysqlDB = getDB(host, user, password, dbName, port)
   result = mysqlDB._connect()
   assert result['OK'] is expected


### PR DESCRIPTION
Reduces the time taken to run the server integration tests from ~14 minutes to ~4 minutes by avoiding pointless sleeps and retries.