### PR TITLE
[v7r1] Fix for the case where no subprocess32 module found

### DIFF
--- a/Resources/Computing/BatchSystems/Host.py
+++ b/Resources/Computing/BatchSystems/Host.py
@@ -16,7 +16,7 @@ import shutil
 import signal
 try:
   import subprocess32 as subprocess
-except:
+except ImportError:
   import subprocess
 import stat
 import json

--- a/Resources/Computing/BatchSystems/Host.py
+++ b/Resources/Computing/BatchSystems/Host.py
@@ -14,7 +14,10 @@ import os
 import glob
 import shutil
 import signal
-import subprocess32 as subprocess
+try:
+  import subprocess32 as subprocess
+except:
+  import subprocess
 import stat
 import json
 import multiprocessing


### PR DESCRIPTION
 For SSH hosts as CEs with old versions python interpreters subprocess32 module does not exist,  in this case subprocess module is as good

BEGINRELEASENOTES

*Resources
FIX: Host.py - Fix for the case where no subprocess32 module found

ENDRELEASENOTES
