### PR TITLE
[v7r1] ReqDB and FTS3DB compatible with SqlAlchemy 1.4

### DIFF
--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -201,7 +201,8 @@ class RequestDB(object):
                                   .where(Request.RequestID == requestID)
                                   .values({Request._Status: 'Canceled',
                                            Request._LastUpdate: datetime.datetime.utcnow()
-                                           .strftime(Request._datetimeFormat)}))
+                                           .strftime(Request._datetimeFormat)})
+                                  .execution_options(synchronize_session=False))  # See FTS3DB for synchronize_session
       session.commit()
 
       # No row was changed


### PR DESCRIPTION
Fixes https://github.com/DIRACGrid/DIRAC/issues/5071

1.4 is a major release, opening way for 2.0. More details in the discussion linked in the issue.

BEGINRELEASENOTES

*DMS
FIX: SQLAlchemy 1.4 support for FTS3DB

*RMS
FIX: SQLAlchemy 1.4 support for ReqDB

ENDRELEASENOTES
