### PR TITLE
[v7r2] Re-runable integration tests

### DIFF
--- a/tests/CI/run_tests.sh
+++ b/tests/CI/run_tests.sh
@@ -33,9 +33,6 @@ if [[ "$INSTALLTYPE" == "server" ]]; then
     for repo_path in "${TESTREPO[@]}"; do
         # TODO: The tests should be refactored to remove the need for this
         cp -r "${repo_path}/tests" "$WORKSPACE/ServerInstallDIR/$(basename "${repo_path}")"
-        if [[ "$(basename "${repo_path}")" == "DIRAC" ]]; then
-            sed -i "s/\(elHost = \).*/\1'elasticsearch'/" "$WORKSPACE/ServerInstallDIR/DIRAC/tests/Integration/Core/Test_ElasticsearchDB.py"
-        fi
     done
     for repo_path in "${TESTREPO[@]}"; do
         source "${repo_path}/tests/Integration/all_integration_server_tests.sh"

--- a/tests/Integration/Core/Test_ElasticsearchDB.py
+++ b/tests/Integration/Core/Test_ElasticsearchDB.py
@@ -12,11 +12,12 @@ import unittest
 import sys
 import datetime
 import time
+import os
 
 from DIRAC import gLogger
 from DIRAC.Core.Utilities.ElasticSearchDB import ElasticSearchDB
 
-elHost = 'localhost'
+elHost = os.environ["NoSQLDB_HOST"]
 elPort = 9200
 
 

--- a/tests/Integration/Core/Test_ElasticsearchDB.py
+++ b/tests/Integration/Core/Test_ElasticsearchDB.py
@@ -17,7 +17,7 @@ import os
 from DIRAC import gLogger
 from DIRAC.Core.Utilities.ElasticSearchDB import ElasticSearchDB
 
-elHost = os.environ["NoSQLDB_HOST"]
+elHost = os.environ.get("NoSQLDB_HOST", 'localhost')
 elPort = 9200
 
 

--- a/tests/Integration/DataManagementSystem/Test_DataIntegrityDB.py
+++ b/tests/Integration/DataManagementSystem/Test_DataIntegrityDB.py
@@ -9,7 +9,6 @@ from __future__ import division
 from __future__ import print_function
 
 # pylint: disable=invalid-name,wrong-import-position
-import copy
 import time
 
 from DIRAC import gLogger

--- a/tests/Integration/DataManagementSystem/Test_DataIntegrityDB.py
+++ b/tests/Integration/DataManagementSystem/Test_DataIntegrityDB.py
@@ -9,6 +9,8 @@ from __future__ import division
 from __future__ import print_function
 
 # pylint: disable=invalid-name,wrong-import-position
+import copy
+import time
 
 from DIRAC import gLogger
 
@@ -21,19 +23,31 @@ from DIRAC.DataManagementSystem.DB.DataIntegrityDB import DataIntegrityDB
 def test_DataIntegrityDB():
   """ Some test cases
   """
-
-  diDB = DataIntegrityDB()
-
   source = 'Test'
   prognosis = 'TestError'
   prodID = 1234
-  lfn = '/Test/%08d/File1' % prodID
-  fileMetadata1 = {lfn: {'Prognosis': prognosis, 'PFN': 'File1', 'SE': 'Test-SE'}}
-  fileOut1 = {'FileID': 1, 'LFN': lfn, 'PFN': 'File1', 'Prognosis': prognosis,
+  timestamp = int(time.time())
+  lfn = '/Test/%08d/File1/%d' % (prodID, timestamp)
+  pfn = 'File1/%d' % (timestamp)
+  fileMetadata1 = {lfn: {'Prognosis': prognosis, 'PFN': pfn, 'SE': 'Test-SE'}}
+  fileOut1 = {'LFN': lfn, 'PFN': pfn, 'Prognosis': prognosis,
               'GUID': None, 'SE': 'Test-SE', 'Size': None}
   newStatus = 'Solved'
   newPrognosis = 'AnotherError'
 
+  diDB = DataIntegrityDB()
+
+  # Clean up the database if required
+  result = diDB.getTransformationProblematics(1234)
+  assert result['OK']
+  for fileID in result['Value'].values():
+    result = diDB.removeProblematic(fileID)
+    assert result['OK']
+  result = diDB.getProblematicsSummary()
+  assert result['OK']
+  assert result['Value'] == {}
+
+  # Run the actual test
   result = diDB.insertProblematic(source, fileMetadata1)
   assert result['OK']
   assert result['Value'] == {'Successful': {lfn: True}, 'Failed': {}}
@@ -52,6 +66,7 @@ def test_DataIntegrityDB():
 
   result = diDB.getProblematic()
   assert result['OK']
+  fileOut1["FileID"] = result["Value"]["FileID"]
   assert result['Value'] == fileOut1
 
   result = diDB.incrementProblematicRetry(result['Value']['FileID'])
@@ -68,13 +83,13 @@ def test_DataIntegrityDB():
 
   result = diDB.getTransformationProblematics(prodID)
   assert result['OK']
-  assert result['Value'][lfn] == 1
+  assert result['Value'][lfn] == fileOut1["FileID"]
 
-  result = diDB.setProblematicStatus(1, newStatus)
+  result = diDB.setProblematicStatus(fileOut1["FileID"], newStatus)
   assert result['OK']
   assert result['Value'] == 1
 
-  result = diDB.changeProblematicPrognosis(1, newPrognosis)
+  result = diDB.changeProblematicPrognosis(fileOut1["FileID"], newPrognosis)
   assert result['OK']
   assert result['Value'] == 1
 
@@ -82,7 +97,7 @@ def test_DataIntegrityDB():
   assert result['OK']
   assert result['Value'] == []
 
-  result = diDB.removeProblematic(1)
+  result = diDB.removeProblematic(fileOut1["FileID"])
   assert result['OK']
   assert result['Value'] == 1
 

--- a/tests/Integration/RequestManagementSystem/Test_Client_Req.py
+++ b/tests/Integration/RequestManagementSystem/Test_Client_Req.py
@@ -80,6 +80,13 @@ class ReqClientTestCase(unittest.TestCase):
 
 class ReqClientMix(ReqClientTestCase):
   def _checkSummary(self, initial, changes):
+    """Check if getDBSummary has be updated as expected
+
+    :param initial: Return value from ``self.requestClient.getDBSummary()``
+                    before the test was started.
+    :param changes: The expected changes to the database summary. Tuple
+                    consisting of ``(parentKey, key, state, delta)``.
+    """
     expected = copy.deepcopy(initial)
     for parent, key, state, delta in changes:
       if parent is None:

--- a/tests/Integration/RequestManagementSystem/Test_Client_Req.py
+++ b/tests/Integration/RequestManagementSystem/Test_Client_Req.py
@@ -80,7 +80,7 @@ class ReqClientTestCase(unittest.TestCase):
 
 class ReqClientMix(ReqClientTestCase):
   def _checkSummary(self, initial, changes):
-    """Check if getDBSummary has be updated as expected
+    """Check if getDBSummary has been updated as expected
 
     :param initial: Return value from ``self.requestClient.getDBSummary()``
                     before the test was started.

--- a/tests/Integration/RequestManagementSystem/Test_Client_Req.py
+++ b/tests/Integration/RequestManagementSystem/Test_Client_Req.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
+import copy
 import unittest
 import sys
 import six
@@ -78,32 +79,50 @@ class ReqClientTestCase(unittest.TestCase):
 
 
 class ReqClientMix(ReqClientTestCase):
+  def _checkSummary(self, initial, changes):
+    expected = copy.deepcopy(initial)
+    for parent, key, state, delta in changes:
+      if parent is None:
+        d = expected
+      else:
+        d = expected.setdefault(parent, {})
+      d.setdefault(key, {})
+      d[key].setdefault(state, 0)
+      d[key][state] += delta
+
+    res = self.requestClient.getDBSummary()
+    self.assertTrue(res['OK'])
+    self.assertEqual(res["Value"], expected)
 
   def test01fullChain(self):
+    ret = self.requestClient.getDBSummary()
+    self.assertTrue(ret['OK'])
+    initialSummary = ret["Value"]
+
     put = self.requestClient.putRequest(self.request)
     self.assertTrue(put['OK'], put)
 
     self.assertTrue(isinstance(put['Value'], six.integer_types))
     reqID = put['Value']
 
-    # # summary
+    # summary
     ret = self.requestClient.getDBSummary()
     self.assertTrue(ret['OK'])
-    self.assertEqual(ret['Value'],
-                     {'Operation': {'ReplicateAndRegister': {'Waiting': 1}},
-                      'Request': {'Waiting': 1},
-                      'File': {'Waiting': 2}})
+    self._checkSummary(initialSummary, [
+        ("Operation", "ReplicateAndRegister", "Waiting", 1),
+        (None, "Request", "Waiting", 1),
+        (None, "File", "Waiting", 2),
+    ])
 
     get = self.requestClient.getRequest(reqID)
     self.assertTrue(get['OK'])
     self.assertEqual(isinstance(get['Value'], Request), True)
     # # summary - the request became "Assigned"
-    res = self.requestClient.getDBSummary()
-    self.assertTrue(res['OK'])
-    self.assertEqual(res['Value'],
-                     {'Operation': {'ReplicateAndRegister': {'Waiting': 1}},
-                      'Request': {'Assigned': 1},
-                      'File': {'Waiting': 2}})
+    self._checkSummary(initialSummary, [
+        ("Operation", "ReplicateAndRegister", "Waiting", 1),
+        (None, "Request", "Assigned", 1),
+        (None, "File", "Waiting", 2),
+    ])
 
     res = self.requestClient.getRequestInfo(reqID)
     self.assertEqual(res['OK'], True, res['Message'] if 'Message' in res else 'OK')
@@ -138,10 +157,12 @@ class ReqClientMix(ReqClientTestCase):
     # # get summary again
     ret = self.requestClient.getDBSummary()
     self.assertTrue(ret['OK'])
-    self.assertEqual(ret['Value'],
-                     {'Operation': {'ReplicateAndRegister': {'Waiting': 2}},
-                      'Request': {'Waiting': 1, 'Assigned': 1},
-                      'File': {'Waiting': 4}})
+    self._checkSummary(initialSummary, [
+        ("Operation", "ReplicateAndRegister", "Waiting", 2),
+        (None, "Request", "Waiting", 1),
+        (None, "Request", "Assigned", 1),
+        (None, "File", "Waiting", 4),
+    ])
 
     delete = self.requestClient.deleteRequest(reqID)
     self.assertEqual(delete['OK'], True, delete['Message'] if 'Message' in delete else 'OK')
@@ -151,7 +172,7 @@ class ReqClientMix(ReqClientTestCase):
     # # should be empty now
     ret = self.requestClient.getDBSummary()
     self.assertTrue(ret['OK'])
-    self.assertEqual(ret['Value'], {'Operation': {}, 'Request': {}, 'File': {}})
+    self.assertEqual(ret['Value'], initialSummary)
 
   def test02Authorization(self):
     """ Test whether request sets on behalf of others are rejected, unless done with Delegation properties

--- a/tests/Integration/RequestManagementSystem/Test_ReqDB.py
+++ b/tests/Integration/RequestManagementSystem/Test_ReqDB.py
@@ -41,17 +41,6 @@ class ReqDBTestCase(unittest.TestCase):
     self.bulkRequest = 1000
 
 
-class ReqDB(ReqDBTestCase):
-
-  def test_db(self):
-
-    # # empty DB at that stage
-    ret = RequestDB().getDBSummary()
-    self.assertEqual(ret,
-                     {'OK': True,
-                      'Value': {'Operation': {}, 'Request': {}, 'File': {}}})
-
-
 class ReqDBMix(ReqDBTestCase):
 
   def test01Stress(self):
@@ -224,7 +213,6 @@ class ReqDBMix(ReqDBTestCase):
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase(ReqDBTestCase)
-  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ReqDB))
   suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ReqDBMix))
   testResult = unittest.TextTestRunner(verbosity=2).run(suite)
   sys.exit(not testResult.wasSuccessful())

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -1,58 +1,59 @@
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------
 # A convenient way to run all the integration tests for servers
-#
-# It supposes that DIRAC is installed in ${SERVERINSTALLDIR}
 #-------------------------------------------------------------------------------
 
 echo -e '****************************************'
 echo -e '*******' "integration server tests" '*******\n'
 
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo -e "THIS_DIR=${THIS_DIR}" |& tee -a "${SERVER_TEST_OUTPUT}"
+
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Accounting TESTS ****\n"
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/AccountingSystem/Test_Plots.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/AccountingSystem/Test_Plots.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Configuration TESTS ****\n"
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/ConfigurationSystem/Test_Helpers.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ConfigurationSystem/Test_Helpers.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Core TESTS ****\n"
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Core/Test_ElasticsearchDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Core/Test_MySQLDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/Core/Test_ElasticsearchDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/Core/Test_MySQLDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** FRAMEWORK TESTS (partially skipped) ****\n"
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Framework/Test_InstalledComponentsDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-python "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Framework/Test_ProxyDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-#pytest ${SERVERINSTALLDIR}/DIRAC/tests/Integration/Framework/Test_LoggingDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/Framework/Test_InstalledComponentsDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+python "${THIS_DIR}/Framework/Test_ProxyDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+#pytest ${THIS_DIR}/Framework/Test_LoggingDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** MONITORING TESTS ****\n"
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Monitoring/Test_MonitoringReporter.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Monitoring/Test_Plotter.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Monitoring/Test_MonitoringDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/Monitoring/Test_MonitoringReporter.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/Monitoring/Test_Plotter.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/Monitoring/Test_MonitoringDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RSS TESTS ****\n"
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/ResourceStatusSystem/Test_FullChain.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ResourceStatusSystem/Test_FullChain.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** WMS TESTS ****\n"
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobLoggingDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_TaskQueueDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_ElasticJobParametersDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-python "${SERVERINSTALLDIR}/DIRAC/tests/Integration/WorkloadManagementSystem/Test_Client_WMS.py" --cfg "${WORKSPACE}/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_JobDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_JobLoggingDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_TaskQueueDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_ElasticJobParametersDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+python "${THIS_DIR}/WorkloadManagementSystem/Test_Client_WMS.py" --cfg "${WORKSPACE}/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** DMS TESTS ****\n"
 ## DFC
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_DataIntegrityDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/DataManagementSystem/Test_DataIntegrityDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 echo "Test DFC DB" |& tee -a "${SERVER_TEST_OUTPUT}"
-python "${SERVERINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+python "${THIS_DIR}/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 echo -e "*** $(date -u)  Reinitialize the DFC DB\n" |& tee -a "${SERVER_TEST_OUTPUT}"
 diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
@@ -60,9 +61,9 @@ diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
 echo -e "*** $(date -u)  Run the DFC client tests as user without admin privileges" |& tee -a "${SERVER_TEST_OUTPUT}"
 echo -e "*** $(date -u)  Getting a non privileged user\n" |& tee -a "${SERVER_TEST_OUTPUT}"
 dirac-proxy-init -C "${WORKSPACE}/ServerInstallDIR/user/client.pem" -K "${WORKSPACE}/ServerInstallDIR/user/client.key" "${DEBUG}"
-python "${SERVERINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_Client_DFC.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+python "${THIS_DIR}/DataManagementSystem/Test_Client_DFC.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
-python "${SERVERINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+python "${THIS_DIR}/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 echo 'Reinitialize the DFC DB' |& tee -a "${SERVER_TEST_OUTPUT}"
 diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
@@ -74,27 +75,27 @@ dirac-restart-component Tornado Tornado "${DEBUG}" |& tee -a "${SERVER_TEST_OUTP
 echo -e "*** $(date -u)  Run it with the admin privileges" |& tee -a "${SERVER_TEST_OUTPUT}"
 echo -e "*** $(date -u)  getting the prod role again\n" |& tee -a "${SERVER_TEST_OUTPUT}"
 dirac-proxy-init -g prod -C "${WORKSPACE}/ServerInstallDIR/user/client.pem" -K "${WORKSPACE}/ServerInstallDIR/user/client.key" "${DEBUG}" |& tee -a "${SERVER_TEST_OUTPUT}"
-python "${SERVERINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_Client_DFC.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+python "${THIS_DIR}/DataManagementSystem/Test_Client_DFC.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
-python "${SERVERINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+python "${THIS_DIR}/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** FTS TESTS ****\n"
 # I know, it says Client, but it also instaciates a DB, so it needs to be here
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/DataManagementSystem/Test_Client_FTS3.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/DataManagementSystem/Test_Client_FTS3.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** RMS TESTS ****\n"
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/RequestManagementSystem/Test_ReqDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/RequestManagementSystem/Test_ReqDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** Resources TESTS ****\n"
 
-python "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Resources/Storage/Test_Resources_GFAL2StorageBase.py" ProductionSandboxSE |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Resources/Computing/Test_SingularityCE.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-python "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Resources/ProxyProvider/Test_DIRACCAProxyProvider.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+python "${THIS_DIR}/Resources/Storage/Test_Resources_GFAL2StorageBase.py" ProductionSandboxSE |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/Resources/Computing/Test_SingularityCE.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+python "${THIS_DIR}/Resources/ProxyProvider/Test_DIRACCAProxyProvider.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 # Can only run if there's a Stomp MQ local...
 # TODO Enable
-# pytest "${SERVERINSTALLDIR}/DIRAC/tests/Integration/Resources/MessageQueue/Test_ActiveClose.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+# pytest "${THIS_DIR}/Resources/MessageQueue/Test_ActiveClose.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -49,14 +49,19 @@ python "${THIS_DIR}/WorkloadManagementSystem/Test_Client_WMS.py" --cfg "${WORKSP
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** DMS TESTS ****\n"
-## DFC
 pytest "${THIS_DIR}/DataManagementSystem/Test_DataIntegrityDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
+echo 'Reinitialize the DFC DB' |& tee -a "${SERVER_TEST_OUTPUT}"
+diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
 echo "Test DFC DB" |& tee -a "${SERVER_TEST_OUTPUT}"
 python "${THIS_DIR}/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 echo -e "*** $(date -u)  Reinitialize the DFC DB\n" |& tee -a "${SERVER_TEST_OUTPUT}"
 diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
+
+echo -e "*** $(date -u)  Restart the DFC service (required for Test_Client_DFC)\n" |& tee -a "${SERVER_TEST_OUTPUT}"
+dirac-restart-component DataManagement FileCatalog "${DEBUG}" |& tee -a "${SERVER_TEST_OUTPUT}"
+dirac-restart-component Tornado Tornado "${DEBUG}" |& tee -a "${SERVER_TEST_OUTPUT}"
 
 echo -e "*** $(date -u)  Run the DFC client tests as user without admin privileges" |& tee -a "${SERVER_TEST_OUTPUT}"
 echo -e "*** $(date -u)  Getting a non privileged user\n" |& tee -a "${SERVER_TEST_OUTPUT}"
@@ -68,7 +73,7 @@ python "${THIS_DIR}/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SER
 echo 'Reinitialize the DFC DB' |& tee -a "${SERVER_TEST_OUTPUT}"
 diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
 
-echo -e "*** $(date -u)  Restart the DFC service\n" |& tee -a "${SERVER_TEST_OUTPUT}"
+echo -e "*** $(date -u)  Restart the DFC service (required for Test_Client_DFC)\n" |& tee -a "${SERVER_TEST_OUTPUT}"
 dirac-restart-component DataManagement FileCatalog "${DEBUG}" |& tee -a "${SERVER_TEST_OUTPUT}"
 dirac-restart-component Tornado Tornado "${DEBUG}" |& tee -a "${SERVER_TEST_OUTPUT}"
 
@@ -82,7 +87,7 @@ python "${THIS_DIR}/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SER
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** FTS TESTS ****\n"
-# I know, it says Client, but it also instaciates a DB, so it needs to be here
+# I know, it says Client, but it also instantiates a DB, so it needs to be here
 pytest "${THIS_DIR}/DataManagementSystem/Test_Client_FTS3.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#


### PR DESCRIPTION
This PR makes it possible to re-run the integration tests when running them against a local installation without recreating the entire server.

BEGINRELEASENOTES

*Tests
NEW: Integration tests can be re-ran locally without re-installing the entire setup

ENDRELEASENOTES
