### PR TITLE
[v7r0] VOMS: fixes when user leaves secondary VO

### DIFF
--- a/ConfigurationSystem/Agent/VOMS2CSAgent.py
+++ b/ConfigurationSystem/Agent/VOMS2CSAgent.py
@@ -174,6 +174,7 @@ class VOMS2CSAgent(AgentModule):
             mailMsg += result['Message']
         if self.dryRun:
           self.log.info("Dry Run: mail won't be sent")
+          self.log.info(mailMsg)
         else:
           NotificationClient().sendMail(self.am_getOption('MailTo', voAdminMail),
                                         "VOMS2CSAgent run log", mailMsg,

--- a/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -348,7 +348,12 @@ class VOMS2CSSynchronizer(object):
         if groups['OK']:
           self.log.info('Found groups for user %s %s' % (diracName, groups['Value']))
           userDict['Groups'] = list(set(groups['Value'] + keepGroups))
+          addedGroups = list(set(userDict['Groups']) - set(groups['Value']))
           modified = True
+          message = "\n  Modified user %s:\n" % diracName
+          message += "    Added to group(s) %s\n" % ','.join(addedGroups)
+          self.adminMsgs['Info'].append(message)
+
 
       # Check if something changed before asking CSAPI to modify
       if diracName in diracUserDict:

--- a/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -286,9 +286,11 @@ class VOMS2CSSynchronizer(object):
       modified = False
       suspendedInVOMS = self.vomsUserDict[dn]['suspended'] or self.vomsUserDict[dn]['certSuspended']
       suspendedVOList = getUserOption(diracName, 'Suspended', [])
+      knownEmail = getUserOption(diracName, 'Email', None)
       userDict = {"DN": dn,
                   "CA": self.vomsUserDict[dn]['CA'],
-                  "Email": self.vomsUserDict[dn].get('mail', self.vomsUserDict[dn].get('emailAddress'))}
+                  "Email": self.vomsUserDict[dn].get('mail', self.vomsUserDict[dn].get('emailAddress')) or knownEmail,
+                  }
 
       # Set Suspended status for the user for this particular VO
       if suspendedInVOMS and self.vo not in suspendedVOList:
@@ -385,15 +387,37 @@ class VOMS2CSSynchronizer(object):
     for user in diracUserDict:
       dnSet = set(fromChar(diracUserDict[user]['DN']))
       if not dnSet.intersection(set(self.vomsUserDict)) and user not in nonVOUserDict:
-        for group in diracUserDict[user]['Groups']:
-          if group not in noVOMSGroups:
-            oldUsers.add(user)
+        existingGroups = diracUserDict.get(user, {}).get('Groups', [])
+        nonVOGroups = list(set(existingGroups) - set(diracVOMSMapping))
+        removedGroups = list(set(existingGroups) - set(nonVOGroups))
+        if removedGroups:
+          self.log.info("Checking user for deletion", "%s: %s" % (user, existingGroups))
+          self.log.info("User has groups in other VOs", "%s: %s" % (user, nonVOGroups))
+          userDict = diracUserDict[user]
+          userDict['Groups'] = nonVOGroups
+          if self.autoModifyUsers:
+            result = self.csapi.modifyUser(user, userDict)
+            if result['OK'] and result['Value']:
+              self.log.info("Modified user %s: %s" % (user, str(userDict)))
+              self.voChanged = True
+              message = "\n  Modified user %s:\n" % user
+              modMsg = "    Removed from group(s) %s\n" % ','.join(removedGroups)
+              self.adminMsgs['Info'].append(message + modMsg)
+              resultDict['ModifiedUsers'].append(user)
+          continue
+        if not any(group in noVOMSGroups for group in existingGroups):
+          oldUsers.add(user)
 
     # Check for obsoleted DNs
     for user in diracUserDict:
       dnSet = set(fromChar(diracUserDict[user]['DN']))
       for dn in dnSet:
         if dn in obsoletedDNs and user not in oldUsers:
+          existingGroups = diracUserDict.get(user, {}).get('Groups', [])
+          nonVOGroups = list(set(existingGroups) - set(diracVOMSMapping))
+          if nonVOGroups:
+            self.log.verbose("User has groups in other VOs", "%s: %s" % (user, nonVOGroups))
+            continue
           self.log.verbose("Modified user %s: dropped DN %s" % (user, dn))
           if self.autoModifyUsers:
             userDict = diracUserDict[user]
@@ -423,7 +447,7 @@ class VOMS2CSSynchronizer(object):
       else:
         self.adminMsgs['Info'].append('The following users to be checked for deletion:\n\t%s' %
                                       "\n\t".join(sorted(oldUsers)))
-        self.log.info('The following users to be checked for deletion: %s' % str(oldUsers))
+        self.log.info('The following users to be checked for deletion:', "\n\t".join(sorted(oldUsers)))
 
     resultDict['CSAPI'] = self.csapi
     resultDict['AdminMessages'] = self.adminMsgs


### PR DESCRIPTION
A fix for #5037, the added group wasn't part of the notification email
And the complement to #5037, this time when a user is no longer part of a second VO, but still in others, only drop from the relevant VO

BEGINRELEASENOTES

*CS
FIX: VOMS2CSSynchronizer: add email information about a user joining groups for an additional VO
FIX: VOMS2CSSynchronizer: When a user leaves a second VO, only the membership in these groups is removed
CHANGE: VOMS2CSSynchronizer: If email of user is known, do not replace it with `None`

ENDRELEASENOTES
