### PR TITLE
[v7r2] Use String(64) for DIRACVersion column

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/InstalledComponentsDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/InstalledComponentsDB.py
@@ -245,7 +245,7 @@ class HostLogging(componentsBase):
 
   hostName = Column('HostName', String(32), nullable=False, primary_key=True)
   # status
-  DIRAC = Column('DIRACVersion', String(32))
+  DIRAC = Column('DIRACVersion', String(64))
   Extension = Column('Extension', String(64))
   Load1 = Column('Load1', String(32))  # float
   Load5 = Column('Load5', String(32))  # float


### PR DESCRIPTION
When running the integration tests locally I noticed:
```
2021-04-07 13:54:48 UTC Framework/SystemAdministrator ERROR: Could not commit changes: (MySQLdb._exceptions.DataError) (1406, "Data too long for column 'DIRACVersion' at row 1")
[SQL: INSERT INTO `HostLogging` (`HostName`, `DIRACVersion`, `Extension`, `Load1`, `Load5`, `Load15`, `Memory`, `DiskOccupancy`, `Swap`, `CPUClock`, `CPUModel`, `CertificateDN`, `CertificateIssuer`, `CertificateValidity`, `Cores`, `PhysicalCores`, `OpenFiles`, `OpenPipes`, `OpenSockets`, `Setup`, `Uptime`, `Timestamp`) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)]
[parameters: ('server', '7.3.0a4.dev23+g30c910240.d20210407', 'LHCb:10.2.0a3.dev154+g0601f588e.d20210407', '0.75', '0.5', '0.4', '98.5%/15950.1MB', '/etc/hosts:91%', '0.0%/0.0MB', '800.000', 'Intel(R) Core(TM) i5-4670K CPU @ 3.40GHz', '/C=ch/O=DIRAC/OU=DIRAC CI/CN=server', '/O=DIRAC CI/CN=DIRAC CI Signing Certification Authority', '6 days, 20:56:03', 4, 1, 0, 0, 0, 'dirac-JenkinsSetup', '1 day, 1:01:45.161602', datetime.datetime(2021, 4, 7, 13, 54, 48, 161723))]
(Background on this error at: http://sqlalche.me/e/13/9h9h)
```

This is because the locally installed version was `'LHCb:10.2.0a3.dev154+g0601f588e.d20210407'`.


BEGINRELEASENOTES

*Framework
CHANGE: Use String(64) for DIRACVersion column in InstalledComponentsDB.HostLogging

ENDRELEASENOTES
