### PR TITLE
[v7r2] Fix using DIRAC v7r2 with Ganga

### DIFF
--- a/src/DIRAC/Core/Base/Script.py
+++ b/src/DIRAC/Core/Base/Script.py
@@ -60,7 +60,10 @@ def parseCommandLine(script=False, ignoreErrors=False, initializeMonitor=False):
 
   # Read and parse the script __doc__ to create a draft help message
   if not gIsAlreadySetUsageMsg:
-    localCfg.setUsageMessage(inspect.currentframe().f_back.f_globals['__doc__'])
+    try:
+      localCfg.setUsageMessage(inspect.currentframe().f_back.f_globals['__doc__'])
+    except KeyError:
+      pass
     gIsAlreadySetUsageMsg = True
 
   if gIsAlreadyInitialized:
@@ -134,7 +137,10 @@ def addDefaultOptionValue(option, value):
 def setUsageMessage(usageMessage):
   global gIsAlreadySetUsageMsg
   gIsAlreadySetUsageMsg = True
-  localCfg.setUsageMessage(inspect.currentframe().f_back.f_globals['__doc__'])
+  try:
+    localCfg.setUsageMessage(inspect.currentframe().f_back.f_globals['__doc__'])
+  except KeyError:
+    pass
   localCfg.setUsageMessage(usageMessage)
 
 


### PR DESCRIPTION
Fixes the following error when using Ganga:

```python
ERROR    Error submitting job to Dirac: GangaDiracError: Traceback (most recent call last):
  File "<stdin>", line 697, in <module>
  File "<string>", line 11, in <module>
  File "/cvmfs/lhcbdev.cern.ch/lhcbdirac/v10r2-pre5/DIRAC/Core/Base/Script.py", line 63, in parseCommandLine
    localCfg.setUsageMessage(inspect.currentframe().f_back.f_globals['__doc__'])
KeyError: '__doc__'

ERROR

===
/afs/cern.ch/user/c/cburr/gangadir/workspace/cburr/LocalXML/0/input/dirac-script-0.py
===

ERROR

====

ERROR    resultdict = {}

# dirac job created by ganga
from DIRAC.Core.Base.Script import parseCommandLine
parseCommandLine()
from LHCbDIRAC.Interfaces.API.DiracLHCb import DiracLHCb
from LHCbDIRAC.Interfaces.API.LHCbJob import LHCbJob
dirac = DiracLHCb()
sjNo='0'

j = LHCbJob()

# default commands added by ganga
j.setName('{Ganga_Executable_(0)}')


j.setExecutable('exe-script.py','','Ganga_Executable.log', systemConfig='x86_64-centos7-gcc8-opt')
j.setInputSandbox(['/afs/cern.ch/user/c/cburr/gangadir/workspace/cburr/LocalXML/0/input/_input_sandbox_0.tgz', ])



# <-- user settings
j.setCPUTime(1000000)

# user settings -->

# diracOpts added by user


# submit the job to dirac
j.setDIRACPlatform()

try:
	j.setNumberOfProcessors(minNumberOfProcessors=1, maxNumberOfProcessors=1)
except (AttributeError, TypeError):
	pass

j._addParameter(j.workflow, 'GangaVersion', 'JDL', '8.4.8', 'The version of ganga used to submit this job')

result = dirac.submitJob(j)
if isinstance(result, dict) and 'Value' in result:
	resultdict.update({sjNo : result['Value']})
else:
	resultdict.update({sjNo : result['Message']})
output(resultdict)

ERROR
====

ERROR    BackendError: Error submitting job to Dirac: GangaDiracError: Traceback (most recent call last):
  File "<stdin>", line 697, in <module>
  File "<string>", line 11, in <module>
  File "/cvmfs/lhcbdev.cern.ch/lhcbdirac/v10r2-pre5/DIRAC/Core/Base/Script.py", line 63, in parseCommandLine
    localCfg.setUsageMessage(inspect.currentframe().f_back.f_globals['__doc__'])
KeyError: '__doc__'
 (Dirac backend)
```

BEGINRELEASENOTES

*Core
FIX: Avoid KeyError when calling parseCommandLine

ENDRELEASENOTES