### PR TITLE
[v7r1] FTS3: allow to alter TPC preference list and source SE with plugins

### DIFF
--- a/DataManagementSystem/private/FTS3Plugins/DefaultFTS3Plugin.py
+++ b/DataManagementSystem/private/FTS3Plugins/DefaultFTS3Plugin.py
@@ -1,0 +1,106 @@
+"""
+    This module implements the default behavior for the FTS3 system for TPC and source SE selection
+"""
+
+import random
+from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
+
+
+class DefaultFTS3Plugin(object):
+  """"
+      Default FTS3 plugin.
+
+      For the TPC selection, it returns the list configured in the CS.
+      For the source SE selection, it calls
+      :py:func:`DIRAC.DataManagementSystem.private.FTS3Utilities.selectUniqueRandomSource`
+
+      It is used to document what are the requirements for a real TPC plugin.
+      It is a good idea for your plugin to inherit from this one if you only want
+      to change one specific behavior.
+
+      Such plugins are meant to alter the TPC protocols list that an FTS3 job
+      will use to transfer between two SEs, and possibly make a smart selection
+      of the source SE.
+
+      They are called by :py:class:`DIRAC.DataManagementSystem.Client.FTS3Operation.FTS3Operation`
+
+      The class name must be "<PluginName>FTS3Plugin" """
+
+  def __init__(self, vo=None):
+    """ The plugin is instanciated once per ``FTS3Operation``, so it is a
+        good place to do global initialization
+
+        :param str vo: Virtual Organization
+    """
+    self.vo = vo
+    self.thirdPartyProtocols = DMSHelpers(vo=vo).getThirdPartyProtocols()
+
+  def selectTPCProtocols(self, ftsJob=None, sourceSEName=None, destSEName=None, **kwargs):
+    """
+        This method has to return an ordered list of protocols
+        that will be used by the source/dest StorageElements to agree
+        on a common TPC protocol.
+
+        There are two ways to invoke the plugin. Either with an FTS3Job instance, or
+        with specific parameters.
+
+        The FTS3Job object passed as parameter can be used to make a choice
+        based on various parameters.
+
+        Specific parameters are passed when there is access to an FTS3Job already,
+        like in the ``__needsMultiHopStaging`` function of
+        :py:mod:`~DIRAC.DataManagementSystem.Client.FTS3Operation.FTS3Operation`.
+
+        Thus, it is possible that there is not enough information to make a decision without the FTS3Job.
+        In that case, it is up to the plugin to decide whether to return the best possible answer or to raise
+        a ``ValueError`` exception
+
+
+        In this default implementation, we just return the preference list
+        that we have in the CS
+
+        :param ftsJob: :py:class:`~DIRAC.DataManagementSystem.Client.FTS3Job.FTS3Job` that will submit the transfer
+        :param sourceSEName: Name of the source StorageElement
+        :param destSEName: Name of the destination StorageElement
+
+        :returns: an ordered TPC protocols list
+        :raise ValueError: in case the plugin cannot select a protocol with the given info
+    """
+    return self.thirdPartyProtocols
+
+  def selectSourceSE(self, ftsFile, replicaDict, allowedSources):
+    """
+      For a given FTS3file object, select a source.
+
+      Note that the replicaDict may already have been filtered
+      (for example, only active replicas are taken into account),
+      so if you want to do exotic things, you may want to recheck the
+      replicas
+
+      The ``allowedSources`` is what comes from the RMS, so possibly
+      from the TS. So up to you to ignore it or not
+
+      In this default implementation, we only consider the allowed sources
+      and the active replicas, preferably on disk (already filtered in replicaDict)
+      and return a random choice
+
+      :param ftsFiles: list of FTS3File object
+      :param replicaDict: list of replicas for the file
+      :param allowedSources: list of allowed sources
+
+      :return:  one SE name
+      :raise ValueError: in case the plugin cannot select a sourceSE
+    """
+    allowedSourcesSet = set(allowedSources) if allowedSources else set()
+    # Only consider the allowed sources
+
+    # If we have a restriction, apply it, otherwise take all the replicas
+    allowedReplicaSource = (set(replicaDict) & allowedSourcesSet) if allowedSourcesSet else replicaDict
+
+    if not allowedReplicaSource:
+      raise ValueError("No valid replicas")
+
+    # pick a random source
+
+    randSource = random.choice(list(allowedReplicaSource))  # one has to convert to list
+    return randSource

--- a/DataManagementSystem/private/FTS3Plugins/__init__.py
+++ b/DataManagementSystem/private/FTS3Plugins/__init__.py
@@ -1,0 +1,3 @@
+""" DIRAC.DataManagementSystem.private.FTS3Plugins package """
+
+__RCSID__ = "$Id$"

--- a/DataManagementSystem/private/test/Test_FTS3Utilities.py
+++ b/DataManagementSystem/private/test/Test_FTS3Utilities.py
@@ -10,8 +10,9 @@ from DIRAC.DataManagementSystem.Client.FTS3File import FTS3File
 from DIRAC import S_OK, S_ERROR
 
 from DIRAC.DataManagementSystem.private.FTS3Utilities import groupFilesByTarget, \
-    selectUniqueRandomSource, \
+    selectUniqueSource, \
     FTS3ServerPolicy
+from DIRAC.DataManagementSystem.private.FTS3Plugins.DefaultFTS3Plugin import DefaultFTS3Plugin
 
 
 def mock__checkSourceReplicas(ftsFiles, preferDisk=False):
@@ -73,10 +74,11 @@ class TestFileGrouping(unittest.TestCase):
   @mock.patch(
       'DIRAC.DataManagementSystem.private.FTS3Utilities._checkSourceReplicas',
       side_effect=mock__checkSourceReplicas)
-  def test_04_selectUniqueRandomSource(self, _mk_checkSourceReplicas):
+  def test_04_selectUniqueSource(self, _mk_checkSourceReplicas):
     """ Suppose they all go to the same target """
 
-    res = selectUniqueRandomSource(self.allFiles)
+    fts3Plugin = DefaultFTS3Plugin()
+    res = selectUniqueSource(self.allFiles, fts3Plugin)
 
     self.assertTrue(res['OK'])
 

--- a/dirac.cfg
+++ b/dirac.cfg
@@ -643,6 +643,8 @@ Operations
         FTS3
         {
           ServerPolicy = Random # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html#ftsserver-policy
+        # Plugin to alter default TPC selection list
+          FTS3Plugin = Default # http://dirac.readthedocs.io/en/latest/AdministratorGuide/Systems/DataManagement/fts.html#fts3-plugins
         }
       }
     }

--- a/docs/source/AdministratorGuide/Resources/storage.rst
+++ b/docs/source/AdministratorGuide/Resources/storage.rst
@@ -307,6 +307,11 @@ External services like FTS requires pair of URLs to perform third party copy.
 This is implemented using the same logic as described above. There is however an extra step: once the common protocols between 2 SEs have been filtered, an extra loop filter is done to make sure that the selected protocol can be used as read from the source and as write to the destination. Finally, the URLs which are returned are not necessarily the url of the common protocol, but are the native urls of the plugin that can accept/generate the common protocol. For example, if the common protocol is gsiftp but one of the SE has only an SRM plugin, then you will get an srm URL (which is compatible with gsiftp).
 
 
+.. versionadded:: v7r1p37
+    The FTS3Agent can now use plugins to influence the list of TPC protocols used. See :ref:`fts3`
+
+
+
 Protocol matrix
 ^^^^^^^^^^^^^^^
 

--- a/docs/source/AdministratorGuide/Systems/DataManagement/fts3.rst
+++ b/docs/source/AdministratorGuide/Systems/DataManagement/fts3.rst
@@ -50,6 +50,7 @@ Operations configuration
 
   * DataManagement/FTSVersion: FTS2/FTS3. Set it to FTS3...
   * DataManagement/FTSPlacement/FTS3/ServerPolicy: Policy to choose the FTS server see `FTSServer policy`_.
+  * DataManagement/FTSPlacement/FTS3/FTS3Plugin: Plugin to alter the behavior of the FTS3Agent
 
 
 ======================
@@ -92,11 +93,11 @@ The RMS will create one FTS3TransferOperation per RMS Operation, and one FTS3Fil
 The grouping into jobs is done following this logic:
     * Group by target SE
     * Group by source SE. If not specified, we take the active replicas as returned by the DataManager
-    * Since their might be several possible source SE, we need to pick one only. The choice is to select the SE where there is the most files of the operation present. This increases the likely hood to pick a good old Tier1
+    * Since there might be several possible source SEs, we need to pick one only. By default, the choice is random, but this can be changed (see FTS3Plugins)
     * Divide all that according to the maximum number of files we want per job
 
 Once the FTS jobs have been executed, and all the operation is completed, the callback takes place. The callback consists in fetching the RMS request which submitted the FTS3Operation, update the status of the RMS files, and insert a Registration Operation.
-Note that since the multiple targets are grouped in a single RMS operation, failing to transfer one file t one destination will result in the failure of the Operation. However, there is one Registration operation per target, and hence correctly transferred files will be registered.
+Note that since the multiple targets are grouped in a single RMS operation, failing to transfer one file to one destination will result in the failure of the Operation. However, there is one Registration operation per target, and hence correctly transferred files will be registered.
 
 ====================
 FTS3StagingOperation
@@ -170,3 +171,13 @@ States from the FTS3Job::
 The status of the FTS3Jobs and FTSFiles are updated every time we monitor the matching job.
 
 The FTS3Operation goes to Processed when all the files are in a final state, and to Finished when the callback has been called successfully
+
+
+FTS3 Plugins
+------------
+
+.. versionadded:: v7r1p37
+    The ``FTS3Plugin`` option
+
+
+The ``FTS3Plugin`` option allows one to specify a plugin to alter some default choices made by the FTS3 system. These choices concern the list of third party protocols used, as well as the selection of a source storage element. This can be useful if you want to implement a matrix-like selection of protocols, or if some links require specific protocols, etc. The plugins must be placed in :py:mod:`DIRAC.DataManagementSystem.private.FTS3Plugins`. The default behaviors, as well as the documentation on how to implement your own plugin can be found in :py:mod:`DIRAC.DataManagementSystem.private.FTS3Plugins.DefaultFTS3Plugin`


### PR DESCRIPTION
Because some links may be special or some sites shitty, this mechanism allows for more flexibility in choosing a third party protocol or a source SE when transferring with FTS.
This comes with a Default plugin which does exactly what the hardcoded behavior was doing, and serves as documentation. It is totally backward compatible.

This is currently tested in LHCb

BEGINRELEASENOTES

*Subsystem
NEW: FTS3 plugins to alter TPC and source SE preferences

ENDRELEASENOTES
