### PR TITLE
[v7r3] Use HTTPS URL for DIRAC-Certification setup

### DIFF
--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -215,6 +215,6 @@ def extension_metadata():
   return {
       "priority": 0,
       "setups": {
-          "DIRAC-Certification": "dips://lbcertifdirac70.cern.ch:9135/Configuration/Server",
+          "DIRAC-Certification": "https://lbcertifdirac70.cern.ch:9135/Configuration/Server",
       },
   }


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
CHANGE: Update URL for DIRAC-Certification setup

ENDRELEASENOTES
