### PR TITLE
[v7r0] SiteDirector - use | for a union of sets

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -356,7 +356,7 @@ class SiteDirector(AgentModule):
               self.queueDict[queueName]['ParametersDict'][tagFieldName] = queueTags
             if ceTags:
               if queueTags:
-                allTags = list(set(ceTags + queueTags))
+                allTags = list(set(ceTags | queueTags))
                 self.queueDict[queueName]['ParametersDict'][tagFieldName] = allTags
               else:
                 self.queueDict[queueName]['ParametersDict'][tagFieldName] = ceTags


### PR DESCRIPTION

BEGINRELEASENOTES

*WorkloadManagement
FIX: SiteDirector - use | for the union of two sets rather than +

ENDRELEASENOTES
