### PR TITLE
[v7r1] SiteDirector - use | operand for the union of tests

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -353,7 +353,7 @@ class SiteDirector(AgentModule):
               self.queueDict[queueName]['ParametersDict'][tagFieldName] = queueTags
             if ceTags:
               if queueTags:
-                allTags = list(set(ceTags) + set(queueTags))
+                allTags = list(set(ceTags) | set(queueTags))
                 self.queueDict[queueName]['ParametersDict'][tagFieldName] = allTags
               else:
                 self.queueDict[queueName]['ParametersDict'][tagFieldName] = ceTags


### PR DESCRIPTION

BEGINRELEASENOTES

*WorkloadManagement
FIX: SiteDirector - use | operand for the union of tests

ENDRELEASENOTES
