### PR TITLE
[v7r0] DataRecoveryAgent: skip transformations without jobs

### DIFF
--- a/TransformationSystem/Agent/DataRecoveryAgent.py
+++ b/TransformationSystem/Agent/DataRecoveryAgent.py
@@ -333,6 +333,10 @@ class DataRecoveryAgent(AgentModule):
                                self.tClient, self.fcClient, self.jobMon)
     jobs, nDone, nFailed = tInfo.getJobs(statusList=self.jobStatus)
 
+    if not jobs:
+      self.log.notice('Skipping. No jobs for transformation', str(transID))
+      return
+
     if self.jobCache[transID][0] == nDone and self.jobCache[transID][1] == nFailed:
       self.log.notice('Skipping transformation %s because nothing changed' % transID)
       return


### PR DESCRIPTION

BEGINRELEASENOTES

*TS
FIX: DataRecoveryAgent: immediately skip transformations without jobs, prevents exception later on

ENDRELEASENOTES
