### PR TITLE
[v7r0] HTCondorCE: Limit cleanup to a single run per minute per SiteDirector

### DIFF
--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -526,7 +526,7 @@ Queue %(nJobs)s
       return
 
     now = datetime.datetime.utcnow()
-    if (self._lastCleanupTime - now).total_seconds < 60:
+    if (now - self._lastCleanupTime).total_seconds() < 60:
       self._cleanupLock.release()
       return
 

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -45,7 +45,9 @@ When using a local condor_schedd look at the HTCondor documenation for enabling 
 import os
 import tempfile
 import commands
+import datetime
 import errno
+import threading
 
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement
@@ -159,6 +161,10 @@ class HTCondorCEComputingElement(ComputingElement):
   """ HTCondorCE computing element class
       implementing the functions jobSubmit, getJobOutput
   """
+
+  # static variables to ensure single cleanup every minute
+  _lastCleanupTime = datetime.datetime.utcnow()
+  _cleanupLock = threading.Lock()
 
   #############################################################################
   def __init__(self, ceUniqueID):
@@ -516,6 +522,16 @@ Queue %(nJobs)s
     # FIXME: again some issue with the working directory...
     # workingDirectory = self.ceParameters.get( 'WorkingDirectory', DEFAULT_WORKINGDIRECTORY )
 
+    if not self._cleanupLock.acquire(False):
+      return
+
+    now = datetime.datetime.utcnow()
+    if (self._lastCleanupTime - now).total_seconds < 60:
+      self._cleanupLock.release()
+      return
+
+    self._lastCleanupTime = now
+
     self.log.debug("Cleaning working directory: %s" % self.workingDirectory)
 
     # remove all files older than 120 minutes starting with DIRAC_ Condor will
@@ -534,3 +550,4 @@ Queue %(nJobs)s
         findPars)
     if status:
       self.log.error("Failure during HTCondorCE __cleanup", stdout)
+    self._cleanupLock.release()

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -537,7 +537,8 @@ Queue %(nJobs)s
     # remove all files older than 120 minutes starting with DIRAC_ Condor will
     # push files on submission, but it takes at least a few seconds until this
     # happens so we can't directly unlink after condor_submit
-    status, stdout = commands.getstatusoutput('find %s -mmin +120 -name "DIRAC_*" -delete ' % self.workingDirectory)
+    status, stdout = commands.getstatusoutput('find -O3 %s -maxdepth 1 -mmin +120 -name "DIRAC_*" -delete ' %
+                                              self.workingDirectory)
     if status:
       self.log.error("Failure during HTCondorCE __cleanup", stdout)
 

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -522,15 +522,15 @@ Queue %(nJobs)s
     # FIXME: again some issue with the working directory...
     # workingDirectory = self.ceParameters.get( 'WorkingDirectory', DEFAULT_WORKINGDIRECTORY )
 
-    if not self._cleanupLock.acquire(False):
+    if not HTCondorCEComputingElement._cleanupLock.acquire(False):
       return
 
     now = datetime.datetime.utcnow()
-    if (now - self._lastCleanupTime).total_seconds() < 60:
-      self._cleanupLock.release()
+    if (now - HTCondorCEComputingElement._lastCleanupTime).total_seconds() < 60:
+      HTCondorCEComputingElement._cleanupLock.release()
       return
 
-    self._lastCleanupTime = now
+    HTCondorCEComputingElement._lastCleanupTime = now
 
     self.log.debug("Cleaning working directory: %s" % self.workingDirectory)
 

--- a/Resources/Computing/HTCondorCEComputingElement.py
+++ b/Resources/Computing/HTCondorCEComputingElement.py
@@ -542,9 +542,9 @@ Queue %(nJobs)s
     if status:
       self.log.error("Failure during HTCondorCE __cleanup", stdout)
 
-    # remove all out/err/log files older than "DaysToKeepLogs" days in the CE part of the working Directory
-    workDir = os.path.join(self.workingDirectory, self.ceName)
-    findPars = dict(workDir=workDir, days=self.daysToKeepLogs)
+    # remove all out/err/log files older than "DaysToKeepLogs" days in the working directory
+    # not running this for each CE so we do global cleanup
+    findPars = dict(workDir=self.workingDirectory, days=self.daysToKeepLogs)
     # remove all out/err/log files older than "DaysToKeepLogs" days
     status, stdout = commands.getstatusoutput(
         r'find %(workDir)s -mtime +%(days)s -type f \( -name "*.out" -o -name "*.err" -o -name "*.log" \) -delete ' %


### PR DESCRIPTION
- [ ] Please check my locking logic thoroughly
- [x] please indicate if 60 seconds is OK, or should be made variable or longer
- [ ] This doesn't limit two sitedirectors on the same machine from running the find+delete in parallel

BEGINRELEASENOTES

*Resources
FIX: HTCondorCE: Limit calls to actual cleanup (find and delete files on disk) to once per minute per SiteDirector, fixes #5118 
CHANGE: HTCondorCE cleanup: Run the DIRAC_  executable purge with `-O3` and `-maxdepth 1` to speed up the find

ENDRELEASENOTES
