### PR TITLE
[v7r1] SiteDirector: for HTCondor, write the executable in the globally defined working directory

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1075,7 +1075,17 @@ class SiteDirector(AgentModule):
       pilotsSubmitted = pilotsToSubmit
     pilotOptions = ' '.join(pilotOptions)
     self.log.verbose('pilotOptions: %s' % pilotOptions)
-    executable = self._writePilotScript(workingDirectory=self.workingDirectory,
+
+    # if a global workingDirectory is defined for the CEType (like HTCondor)
+    # use it (otherwise the __cleanup done by HTCondor will be in the wrong folder !)
+    # Note that this means that if you run multiple HTCondorCE
+    # in your machine, the executable files will be in the same place
+    # but it does not matter since they are very temporary
+
+    ce = self.queueCECache[queue]['CE']
+    workingDirectory = getattr(ce, 'workingDirectory', self.workingDirectory)
+
+    executable = self._writePilotScript(workingDirectory=workingDirectory,
                                         pilotOptions=pilotOptions,
                                         proxy=proxy,
                                         pilotExecDir=jobExecDir,

--- a/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
@@ -172,6 +172,14 @@ def test__submitPilotsToQueue(mocker):
                                                 'Setup': 'LHCb-Production',
                                                 'Site': 'LCG.CERN.cern',
                                                 'SubmitPool': ''}}}
+
+  # Create a MagicMock that does not have the workingDirectory
+  # attribute (https://cpython-test-docs.readthedocs.io/en/latest/library/unittest.mock.html#deleting-attributes)
+  # This is to use the SiteDirector's working directory, not the CE one
+  ceMock = MagicMock()
+  del ceMock.workingDirectory
+
+  sd.queueCECache = {'aQueue': {'CE': ceMock}}
   sd.queueSlots = {'aQueue': {'AvailableSlots': 10}}
   res = sd._submitPilotsToQueue(1, MagicMock(), 'aQueue')
   assert res['OK'] is True


### PR DESCRIPTION


The `SiteDirector` writes the executable in its own `self.workingDirectory` (taken from the agent config) [1] while the `HTCondorCEComputingElement` tries to clean them in its own `self.workingDirectory` (taken from `Resources`) [2]. Since they can be different, that cannot work. 
So use the CE working directory for the executables

[1] https://github.com/DIRACGrid/DIRAC/blob/95dc4b26e0c7feb89c0ad108b3ccc606075f5214/WorkloadManagementSystem/Agent/SiteDirector.py#L1078

[2] https://github.com/DIRACGrid/DIRAC/blob/95dc4b26e0c7feb89c0ad108b3ccc606075f5214/Resources/Computing/HTCondorCEComputingElement.py#L543


BEGINRELEASENOTES


*WMS
CHANGE: for HTCondor, the SiteDirectory write the executable in the globally defined working directory



ENDRELEASENOTES
