### PR TITLE
[v7r2] Backport: Factorise recurseImport to DIRAC.Core.Utilities.Extensions

### DIFF
--- a/src/DIRAC/Core/Utilities/ObjectLoader.py
+++ b/src/DIRAC/Core/Utilities/ObjectLoader.py
@@ -8,13 +8,13 @@ __RCSID__ = "$Id$"
 
 import six
 import re
-import imp
 import pkgutil
 import collections
 
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Utilities import List, DIRACSingleton
+from DIRAC.Core.Utilities.Extensions import recurseImport
 from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
 
 
@@ -41,7 +41,6 @@ class ObjectLoader(object):
 
   def _init(self, baseModules):
     """ Actually performs the initialization """
-
     if not baseModules:
       baseModules = ['DIRAC']
     self.__rootModules = baseModules
@@ -70,7 +69,7 @@ class ObjectLoader(object):
       if rootModule:
         impName = "%s.%s" % (rootModule, impName)
       gLogger.debug("Trying to load %s" % impName)
-      result = self.__recurseImport(impName, hideExceptions=hideExceptions)
+      result = recurseImport(impName, hideExceptions=hideExceptions)
       # Error. Something cannot be imported. Return error
       if not result['OK']:
         return result
@@ -81,42 +80,12 @@ class ObjectLoader(object):
     # Return nothing found
     return S_OK()
 
-  def __recurseImport(self, modName, parentModule=None, hideExceptions=False, fullName=False):
-    """ Internal function to load modules
-    """
-    if isinstance(modName, six.string_types):
-      modName = List.fromChar(modName, ".")
-    if not fullName:
-      fullName = ".".join(modName)
-    if fullName in self.__objs:
-      return S_OK(self.__objs[fullName])
-    try:
-      if parentModule:
-        impData = imp.find_module(modName[0], parentModule.__path__)
-      else:
-        impData = imp.find_module(modName[0])
-      impModule = imp.load_module(modName[0], *impData)
-      if impData[0]:
-        impData[0].close()
-    except Exception as excp:
-      if "No module named" in str(excp) and modName[0] in str(excp):
-        return S_OK(None)
-      errMsg = "Can't load %s in %s" % (".".join(modName), parentModule.__path__[0])
-      if not hideExceptions:
-        gLogger.exception(errMsg)
-      return S_ERROR(DErrno.EIMPERR, errMsg)
-    if len(modName) == 1:
-      self.__objs[fullName] = impModule
-      return S_OK(impModule)
-    return self.__recurseImport(modName[1:], impModule,
-                                hideExceptions=hideExceptions, fullName=fullName)
-
   def __generateRootModules(self, baseModules):
     """ Iterate over all the possible root modules
     """
     self.__rootModules = baseModules
     for rootModule in reversed(CSGlobals.getCSExtensions()):
-      if rootModule[-5:] != "DIRAC" and rootModule not in self.__rootModules:
+      if not rootModule.endswith("DIRAC") and rootModule not in self.__rootModules:
         self.__rootModules.append("%sDIRAC" % rootModule)
     self.__rootModules.append("")
 
@@ -136,18 +105,16 @@ class ObjectLoader(object):
   def loadObject(self, importString, objName=False, hideExceptions=False):
     """ Load an object from inside a module
     """
+    if not objName:
+      objName = importString.split(".")[-1]
+
     result = self.loadModule(importString, hideExceptions=hideExceptions)
     if not result['OK']:
       return result
     modObj = result['Value']
-    modFile = modObj.__file__
-
-    if not objName:
-      objName = List.fromChar(importString, ".")[-1]
-
     try:
       result = S_OK(getattr(modObj, objName))
-      result['ModuleFile'] = modFile
+      result['ModuleFile'] = modObj.__file__
       return result
     except AttributeError:
       return S_ERROR(DErrno.EIMPERR, "%s does not contain a %s object" % (importString, objName))
@@ -179,7 +146,7 @@ class ObjectLoader(object):
         impPath = modulePath
       gLogger.debug("Trying to load %s" % impPath)
 
-      result = self.__recurseImport(impPath)
+      result = recurseImport(impPath)
       if not result['OK']:
         return result
       if not result['Value']:
@@ -204,7 +171,7 @@ class ObjectLoader(object):
         if modKeyName in modules:
           continue
         fullName = "%s.%s" % (impPath, modName)
-        result = self.__recurseImport(modName, parentModule=parentModule, fullName=fullName)
+        result = recurseImport(modName, parentModule=parentModule, fullName=fullName)
         if not result['OK']:
           if continueOnError:
             gLogger.error("Error loading module but continueOnError is true", "module %s error %s" % (fullName, result))

--- a/src/DIRAC/Core/Utilities/ObjectLoader.py
+++ b/src/DIRAC/Core/Utilities/ObjectLoader.py
@@ -171,7 +171,7 @@ class ObjectLoader(object):
         if modKeyName in modules:
           continue
         fullName = "%s.%s" % (impPath, modName)
-        result = recurseImport(modName, parentModule=parentModule, fullName=fullName)
+        result = recurseImport(fullName)
         if not result['OK']:
           if continueOnError:
             gLogger.error("Error loading module but continueOnError is true", "module %s error %s" % (fullName, result))

--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -152,32 +152,6 @@ else:
 __siteName = False
 
 
-# # Update DErrno with the extensions errors
-# from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
-# from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
-# allExtensions = CSGlobals.getCSExtensions()
-#
-# # Update for each extension. Careful to conflict :-)
-# for extension in allExtensions:
-#   ol = ObjectLoader( baseModules = ["%sDIRAC" % extension] )
-#   extraErrorModule = ol.loadModule( 'Core.Utilities.DErrno' )
-#   if extraErrorModule['OK']:
-#     extraErrorModule = extraErrorModule['Value']
-#
-#     # The next 3 dictionary MUST be present for consistency
-#
-#     # Global name of errors
-#     DErrno.__dict__.update( extraErrorModule.extra_dErrName )
-#     # Dictionary with the error codes
-#     DErrno.dErrorCode.update( extraErrorModule.extra_dErrorCode )
-#     # Error description string
-#     DErrno.dStrError.update( extraErrorModule.extra_dStrError )
-#
-#     # extra_compatErrorString is optional
-#     for err in getattr( extraErrorModule, 'extra_compatErrorString', [] ) :
-#       DErrno.compatErrorString.setdefault( err, [] ).extend( extraErrorModule.extra_compatErrorString[err] )
-
-
 def siteName():
   """
   Determine and return DIRAC name for current site


### PR DESCRIPTION
Operations using the ObjectLoader machinery in threads can fail with traces like:
```python
  File "/miniconda/envs/analysis-productions/lib/python3.8/site-packages/dirac_prod/classes/input_dataset.py", line 32, in replicas
    for se, pfn in dw(Dirac().getReplicas([str(self)], active=True))[str(self)].items():
  File "/miniconda/envs/analysis-productions/lib/python3.8/site-packages/DIRAC/Interfaces/API/Dirac.py", line 858, in getReplicas
    repsResult = dm.getReplicas(lfns, active=active, preferDisk=preferDisk, diskOnly=diskOnly)
  File "/miniconda/envs/analysis-productions/lib/python3.8/site-packages/DIRAC/DataManagementSystem/Client/DataManager.py", line 1742, in getReplicas
    succPfn = seObj.getURL(se_lfn[se],
  File "/miniconda/envs/analysis-productions/lib/python3.8/site-packages/DIRAC/Resources/Storage/StorageElement.py", line 969, in getURL
    result = self.__executeMethod(lfn, protocols=protocols)
  File "/miniconda/envs/analysis-productions/lib/python3.8/site-packages/DIRAC/Resources/Storage/StorageElement.py", line 1240, in __executeMethod
    storageParameters = storage.getParameters()
  File "/miniconda/envs/analysis-productions/lib/python3.8/site-packages/DIRAC/Resources/Storage/StorageBase.py", line 119, in getParameters
    parameterDict['URLBase'] = self.getURLBase().get('Value', '')
  File "/miniconda/envs/analysis-productions/lib/python3.8/site-packages/DIRAC/Resources/Storage/GFAL2_XROOTStorage.py", line 109, in getURLBase
    return self.__addDoubleSlash(super(GFAL2_XROOTStorage, self).getURLBase(withWSUrl=withWSUrl))
TypeError: super(type, obj): obj must be an instance or subtype of type
```

It turns out this is due to DIRAC importing the storage class twice. To reproduce it more simply, create a file named `reproducer.py` containing:

```python
class A:
    def example(self):
        pass

class B(A):
    def example(self):
        super(B, self).example()
```

Then run

```python
import imp
import reproducer

obj1 = reproducer.B()
obj1.example()

reproducer = imp.load_module("reproducer", *imp.find_module("reproducer"))
obj2 = reproducer.B()

obj2.example()
obj1.example()
```

This results in:

```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-c14935bd165d> in <module>
      9
     10 obj2.example()
---> 11 obj1.example()

~/Development/DPA/LbAnalysisProductions/reproducer.py in example(self)
      5 class B(A):
      6     def example(self):
----> 7         super(B, self).example()

TypeError: super(type, obj): obj must be an instance or subtype of type
```

While I noticed it while using Python 3, it's a long standing bug that just went unnoticed and this "feature" of the `imp` module is documented in https://docs.python.org/3/library/imp.html#imp.load_module It turns out I already fixed as part of #5000 so I propose to backport this commit.

> This function does more than importing the module: if the module was already imported, it will reload the module!


BEGINRELEASENOTES

*Core
FIX: Avoid race when importing modules which can cause classes to be redefined

ENDRELEASENOTES
