### PR TITLE
[v7r2] Make DIRAC.Core.Base.Client.Client threadsafe

### DIFF
--- a/src/DIRAC/Core/Base/Client.py
+++ b/src/DIRAC/Core/Base/Client.py
@@ -34,6 +34,14 @@ from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Core.DISET import DEFAULT_RPC_TIMEOUT
 
 
+class partialmethodWithDoc(partialmethod):
+  """Extension of meth:`functools.partialmethod` that preserves docstrings"""
+  def __get__(self, instance, owner):
+    func = super(partialmethodWithDoc, self).__get__(instance, owner)
+    func.__doc__ = self.__doc__
+    return func
+
+
 class Client(object):
   """ Simple class to redirect unknown actions directly to the server. Arguments
       to the constructor are passed to the RPCClient constructor as they are.
@@ -142,7 +150,7 @@ def createClient(serviceName):
       arguments = arguments[1:]
 
     # Create the actual functions, with or without arguments, **kwargs can be: rpc, timeout, url
-    func = partialmethod(Client.executeRPC, call=funcName)
+    func = partialmethodWithDoc(Client.executeRPC, call=funcName)
     func.__doc__ = funcDocString + doc
     func.__doc__ += "\n\nAutomatically created for the service function "
     func.__doc__ += ":func:`~%s.export_%s`" % (handlerClassPath, funcName)

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
@@ -84,7 +84,14 @@ def test__rescheduleFailedJob(mocker, mockJMInput, expected):
   mockJM.return_value = mockJMInput
 
   mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.AgentModule.__init__")
-  mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.JobManagerClient.executeRPC", side_effect=mockJM)
+  mocker.patch(
+      "DIRAC.WorkloadManagementSystem.Client.JobStateUpdateClient.JobStateUpdateClient.setJobStatusBulk",
+      side_effect=mockJM,
+  )
+  mocker.patch(
+      "DIRAC.WorkloadManagementSystem.Client.JobManagerClient.JobManagerClient.rescheduleJob",
+      side_effect=mockJM,
+  )
 
   jobAgent = JobAgent('Test', 'Test1')
 


### PR DESCRIPTION
BEGINRELEASENOTES

*Core
FIX: The RPC Client class should now be threadsafe
FIX: Correctly add RPC attributes to client objects in Python 3 

ENDRELEASENOTES
