### PR TITLE
[v7r3] Refactor WMSUtilities and better handle logs and executables in HTCondorCE

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
@@ -122,7 +122,9 @@ class Condor(object):
         jdlFile.flush()
 
         cmd = "%s; " % preamble if preamble else ""
-        cmd += "condor_submit %s %s" % (submitOptions, jdlFile.name)
+        # we add the -spool option to spool the executable so that it can immediately deleted after the submission
+        # without it, the job will never run: missing input.
+        cmd += "condor_submit -spool %s %s" % (submitOptions, jdlFile.name)
         sp = subprocess.Popen(
             cmd,
             shell=True,

--- a/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
@@ -122,9 +122,7 @@ class Condor(object):
         jdlFile.flush()
 
         cmd = "%s; " % preamble if preamble else ""
-        # we add the -spool option to spool the executable so that it can immediately deleted after the submission
-        # without it, the job will never run: missing input.
-        cmd += "condor_submit -spool %s %s" % (submitOptions, jdlFile.name)
+        cmd += "condor_submit %s %s" % (submitOptions, jdlFile.name)
         sp = subprocess.Popen(
             cmd,
             shell=True,
@@ -160,6 +158,9 @@ class Condor(object):
             resultDict["Jobs"] = []
             for i in range(submittedJobs):
                 resultDict["Jobs"].append(".".join([cluster, str(i)]))
+            # Executable is transferred afterward
+            # Inform the caller that Condor cannot delete it before the end of the execution
+            resultDict["ExecutableToKeep"] = executable
         else:
             resultDict["Status"] = status
             resultDict["Message"] = error

--- a/src/DIRAC/Resources/Computing/CREAMComputingElement.py
+++ b/src/DIRAC/Resources/Computing/CREAMComputingElement.py
@@ -350,10 +350,10 @@ class CREAMComputingElement(ComputingElement):
         return resultDict
 
     def getJobLog(self, jobID):
-        """Get job logging info
+        """Get pilot job logging info
 
-        :param str jobID: job identifier
-        :return: string representing the logging info of a given job
+        :param str jobID: pilot job identifier
+        :return: string representing the logging info of a given pilot job
         """
         # pilotRef may integrate the pilot stamp
         # it has to be removed before being passed in parameter

--- a/src/DIRAC/Resources/Computing/CREAMComputingElement.py
+++ b/src/DIRAC/Resources/Computing/CREAMComputingElement.py
@@ -349,9 +349,28 @@ class CREAMComputingElement(ComputingElement):
 
         return resultDict
 
-    def getJobOutput(self, jobID, localDir=None):
-        """Get the specified job standard output and error files. If the localDir is provided,
-        the output is returned as file in this directory. Otherwise, the output is returned
+    def getJobLog(self, jobID):
+        """Get job logging info
+
+        :param str jobID: job identifier
+        :return: string representing the logging info of a given job
+        """
+        # pilotRef may integrate the pilot stamp
+        # it has to be removed before being passed in parameter
+        jobID = jobID.split(":::")[0]
+        cmd = ["glite-ce-job-status", "-L", "2", "%s" % jobID]
+        ret = executeGridCommand("", cmd, self.gridEnv)
+        if not ret["OK"]:
+            return ret
+
+        status, output, error = ret["Value"]
+        if status:
+            return S_ERROR(error)
+
+        return S_OK(output)
+
+    def getJobOutput(self, jobID):
+        """Get the specified job standard output and error files. The output is returned
         as strings.
         """
         if jobID.find(":::") != -1:

--- a/src/DIRAC/Resources/Computing/LocalComputingElement.py
+++ b/src/DIRAC/Resources/Computing/LocalComputingElement.py
@@ -242,6 +242,8 @@ class LocalComputingElement(ComputingElement):
             batchSystemName = self.batchSystem.__class__.__name__.lower()
             jobIDs = ["ssh" + batchSystemName + "://" + self.ceName + "/" + _id for _id in resultSubmit["Jobs"]]
             result = S_OK(jobIDs)
+            if "ExecutableToKeep" in resultSubmit:
+                result["ExecutableToKeep"] = resultSubmit["ExecutableToKeep"]
         else:
             result = S_ERROR(resultSubmit["Message"])
 

--- a/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -67,7 +67,6 @@ def test_getJobStatus(mocker):
     patchPopen = mocker.patch("DIRAC.Resources.Computing.BatchSystems.Condor.subprocess.Popen")
     patchPopen.return_value.communicate.side_effect = [("\n".join(HISTORY_LINES), "")]
     patchPopen.return_value.returncode = 0
-    mocker.patch(MODNAME + ".HTCondorCEComputingElement._HTCondorCEComputingElement__cleanup")
 
     htce = HTCE.HTCondorCEComputingElement(12345)
     ret = htce.getJobStatus(
@@ -154,7 +153,7 @@ def test_reset(setUp, localSchedd, expected):
     "localSchedd, expected",
     [
         (False, "condor_submit -terse -pool condorce.cern.ch:9619 -remote condorce.cern.ch dirac_pilot"),
-        (True, "condor_submit -terse dirac_pilot"),
+        (True, "condor_submit -terse -spool dirac_pilot"),
     ],
 )
 def test_submitJob(setUp, mocker, localSchedd, expected):

--- a/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -67,6 +67,7 @@ def test_getJobStatus(mocker):
     patchPopen = mocker.patch("DIRAC.Resources.Computing.BatchSystems.Condor.subprocess.Popen")
     patchPopen.return_value.communicate.side_effect = [("\n".join(HISTORY_LINES), "")]
     patchPopen.return_value.returncode = 0
+    mocker.patch(MODNAME + ".HTCondorCEComputingElement._HTCondorCEComputingElement__cleanup")
 
     htce = HTCE.HTCondorCEComputingElement(12345)
     ret = htce.getJobStatus(
@@ -153,7 +154,7 @@ def test_reset(setUp, localSchedd, expected):
     "localSchedd, expected",
     [
         (False, "condor_submit -terse -pool condorce.cern.ch:9619 -remote condorce.cern.ch dirac_pilot"),
-        (True, "condor_submit -terse -spool dirac_pilot"),
+        (True, "condor_submit -terse dirac_pilot"),
     ],
 )
 def test_submitJob(setUp, mocker, localSchedd, expected):

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -715,7 +715,11 @@ class SiteDirector(AgentModule):
         executable = self.getExecutable(queue, proxy=proxy, jobExecDir=jobExecDir, envVariables=envVariables)
 
         submitResult = ce.submitJob(executable, "", pilotsToSubmit)
-        os.unlink(executable)
+        # In case the CE does not need the executable after the submission, we delete it
+        # Else, we keep it, the CE will delete it after the end of the pilot execution
+        if submitResult.get("ExecutableToKeep") != executable:
+            os.unlink(executable)
+
         if not submitResult["OK"]:
             self.log.error("Failed submission to queue", "Queue %s:\n, %s" % (queue, submitResult["Message"]))
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -715,14 +715,7 @@ class SiteDirector(AgentModule):
         executable = self.getExecutable(queue, proxy=proxy, jobExecDir=jobExecDir, envVariables=envVariables)
 
         submitResult = ce.submitJob(executable, "", pilotsToSubmit)
-        # FIXME: The condor thing only transfers the file with some
-        # delay, so when we unlink here the script is gone
-        # FIXME 2: but at some time we need to clean up the pilot wrapper scripts...
-        if not (
-            self.queueDict[queue]["CEType"] == "HTCondorCE"
-            or (self.queueDict[queue]["CEType"] == "Local" and ce.batchSystem == "Condor")
-        ):
-            os.unlink(executable)
+        os.unlink(executable)
         if not submitResult["OK"]:
             self.log.error("Failed submission to queue", "Queue %s:\n, %s" % (queue, submitResult["Message"]))
 

--- a/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -216,6 +216,7 @@ class PilotManagerHandler(RequestHandler):
 
         ce = result["Value"]
         if not hasattr(ce, "getJobLog"):
+            gLogger.info("Pilot logging not available for", "%s CEs" % pilotDict["GridType"])
             return S_ERROR("Pilot logging not available for %s CEs" % pilotDict["GridType"])
 
         result = getPilotProxy(pilotDict)

--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -17,7 +17,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getSites
 from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
 
 
-
 class WMSAdministratorHandler(RequestHandler):
     @classmethod
     def initializeHandler(cls, svcInfoDict):

--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -14,7 +14,8 @@ from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getSites
-from DIRAC.WorkloadManagementSystem.Service.WMSUtilities import getGridJobOutput
+from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
+
 
 
 class WMSAdministratorHandler(RequestHandler):
@@ -41,6 +42,8 @@ class WMSAdministratorHandler(RequestHandler):
                 cls.elasticJobParametersDB = result["Value"]()
             except RuntimeError as excp:
                 return S_ERROR("Can't connect to DB: %s" % excp)
+
+        cls.pilotManager = PilotManagerClient()
 
         return S_OK()
 
@@ -214,7 +217,7 @@ class WMSAdministratorHandler(RequestHandler):
                         c = cycle
 
         if pilotReference:
-            return getGridJobOutput(pilotReference)
+            return self.pilotManager.getPilotOutput(pilotReference)
         return S_ERROR("No pilot job reference found")
 
     ##############################################################################

--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -11,13 +11,10 @@ from tempfile import mkdtemp
 import shutil
 
 from DIRAC import S_OK, S_ERROR, gLogger, gConfig
-from DIRAC.Core.Utilities.Grid import executeGridCommand
-from DIRAC.Core.Utilities.Proxy import executeWithUserProxy
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getQueue
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getGroupOption
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 from DIRAC.Resources.Computing.ComputingElementFactory import ComputingElementFactory
-from DIRAC.WorkloadManagementSystem.Client.ServerUtils import pilotAgentsDB
 
 
 # List of files to be inserted/retrieved into/from pilot Output Sandbox
@@ -40,73 +37,10 @@ def getGridEnv():
     return gridEnv
 
 
-@executeWithUserProxy
-def getPilotLoggingInfo(grid, pilotRef):
-    """
-    Get LoggingInfo of a GRID job
-    """
-    if grid == "CREAM":
-        # pilotRef may integrate the pilot stamp
-        # it has to be removed before being passed in parameter
-        pilotRef = pilotRef.split(":::")[0]
-        cmd = ["glite-ce-job-status", "-L", "2", "%s" % pilotRef]
-    elif grid == "HTCondorCE":
-        # need to import here, otherwise import errors happen
-        from DIRAC.Resources.Computing.HTCondorCEComputingElement import getCondorLogFile
-
-        resLog = getCondorLogFile(pilotRef)
-        if not resLog["OK"]:
-            return resLog
-        logFile = resLog["Value"]
-        cmd = ["cat", " ".join(logFile)]
-    else:
-        return S_ERROR("Pilot logging not available for %s CEs" % grid)
-
-    gridEnv = getGridEnv()
-    ret = executeGridCommand("", cmd, gridEnv)
-    if not ret["OK"]:
-        return ret
-
-    status, output, error = ret["Value"]
-    if status:
-        return S_ERROR(error)
-
-    return S_OK(output)
-
-
-def getGridJobOutput(pilotReference):
-    """Get the pilot job standard output and standard error files for the Grid job reference
-
-    :param str pilotReference: a grid (job) pilot reference
-    """
-
-    result = pilotAgentsDB.getPilotInfo(pilotReference)
-    if not result["OK"]:
-        gLogger.error("Failed to get info for pilot", result["Message"])
-        return S_ERROR("Failed to get info for pilot")
-    if not result["Value"]:
-        gLogger.warn("The pilot info is empty", pilotReference)
-        return S_ERROR("Pilot info is empty")
-
-    pilotDict = result["Value"][pilotReference]
+def getPilotCE(pilotDict):
+    """Instantiate and return a CE bound to a pilot"""
     owner = pilotDict["OwnerDN"]
     group = pilotDict["OwnerGroup"]
-
-    # FIXME: What if the OutputSandBox is not StdOut and StdErr, what do we do with other files?
-    result = pilotAgentsDB.getPilotOutput(pilotReference)
-    if result["OK"]:
-        stdout = result["Value"]["StdOut"]
-        error = result["Value"]["StdErr"]
-        if stdout or error:
-            resultDict = {}
-            resultDict["StdOut"] = stdout
-            resultDict["StdErr"] = error
-            resultDict["OwnerDN"] = owner
-            resultDict["OwnerGroup"] = group
-            resultDict["FileList"] = []
-            return S_OK(resultDict)
-        else:
-            gLogger.warn("Empty pilot output found", "for %s" % pilotReference)
 
     # Instantiate the appropriate CE
     ceFactory = ComputingElementFactory()
@@ -122,35 +56,30 @@ def getGridJobOutput(pilotReference):
         shutil.rmtree(queueDict["WorkingDirectory"])
         return result
     ce = result["Value"]
+    return S_OK(ce)
+
+
+def getPilotProxy(pilotDict):
+    """Get a proxy bound to a pilot"""
+    owner = pilotDict["OwnerDN"]
+    group = pilotDict["OwnerGroup"]
+
     groupVOMS = getGroupOption(group, "VOMSRole", group)
     result = gProxyManager.getPilotProxyFromVOMSGroup(owner, groupVOMS)
     if not result["OK"]:
         gLogger.error("Could not get proxy:", 'User "%s" Group "%s" : %s' % (owner, groupVOMS, result["Message"]))
         return S_ERROR("Failed to get the pilot's owner proxy")
     proxy = result["Value"]
-    ce.setProxy(proxy)
+    return S_OK(proxy)
+
+
+def getPilotRef(pilotReference, pilotDict):
+    """Get the pilot reference associated to a pilot"""
     pilotStamp = pilotDict["PilotStamp"]
     pRef = pilotReference
     if pilotStamp:
         pRef = pRef + ":::" + pilotStamp
-    result = ce.getJobOutput(pRef)
-    if not result["OK"]:
-        shutil.rmtree(queueDict["WorkingDirectory"])
-        return result
-    stdout, error = result["Value"]
-    if stdout:
-        result = pilotAgentsDB.storePilotOutput(pilotReference, stdout, error)
-        if not result["OK"]:
-            gLogger.error("Failed to store pilot output:", result["Message"])
-
-    resultDict = {}
-    resultDict["StdOut"] = stdout
-    resultDict["StdErr"] = error
-    resultDict["OwnerDN"] = owner
-    resultDict["OwnerGroup"] = group
-    resultDict["FileList"] = []
-    shutil.rmtree(queueDict["WorkingDirectory"])
-    return S_OK(resultDict)
+    return S_OK(pRef)
 
 
 def killPilotsInQueues(pilotRefDict):

--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -39,10 +39,6 @@ def getGridEnv():
 
 def getPilotCE(pilotDict):
     """Instantiate and return a CE bound to a pilot"""
-    owner = pilotDict["OwnerDN"]
-    group = pilotDict["OwnerGroup"]
-
-    # Instantiate the appropriate CE
     ceFactory = ComputingElementFactory()
     result = getQueue(pilotDict["GridSite"], pilotDict["DestinationSite"], pilotDict["Queue"])
     if not result["OK"]:
@@ -74,7 +70,9 @@ def getPilotProxy(pilotDict):
 
 
 def getPilotRef(pilotReference, pilotDict):
-    """Get the pilot reference associated to a pilot"""
+    """Add the pilotStamp to the pilotReference, if the pilotStamp is in the dictionary,
+    otherwise return unchanged pilotReference.
+    """
     pilotStamp = pilotDict["PilotStamp"]
     pRef = pilotReference
     if pilotStamp:


### PR DESCRIPTION
This PR aims to solve part of the issues that we have with the pilot wrappers: https://github.com/DIRACGrid/DIRAC/issues/5136

Currently, the `Site Director` lets HTCondor the responsibility of deleting the pilot wrappers after their execution because jobs would fail otherwise.
Thus, `HTCondorCE` needs to perform `find` calls to retrieve and delete all the old pilot wrappers that are not needed anymore.

In this PR, we add the `-spool` option to `condor_submit` that allows to immediately spool the required inputs data with the job during the submission. Thus, pilot wrappers can be modified/deleted just after the submission without impacting the jobs.

`-spool` is only used by the local condor_schedd because the `-remote` option, according to the documentation, performs `-spool` internally: https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html

I made manual tests on lxplus and with a htcondor docker container containing a local condor_schedd and it worked fine.
I don't know if we can create some tests for that.

Thanks @andresailer 

BEGINRELEASENOTES
*Resources
CHANGE: HTCondorCE submits jobs with -spool option when a local schedd is used to spool the pilot wrappers that can be deleted afterwards
*WorkloadManagementSystem
CHANGE: Add functions in WMSUtilities, move content of getPilotLoggingInfo() and getGridJobOutput() in PilotManagerHandler
ENDRELEASENOTES
