### PR TITLE
[v7r2] Allow groupadd to fail when running integration tests

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -221,7 +221,9 @@ def prepare_environment(
         cmd = _build_docker_cmd(container_name, use_root=True, cwd="/")
         gid = str(os.getgid())
         uid = str(os.getuid())
-        subprocess.run(cmd + ["groupadd", "--gid", gid, "dirac"], check=True)
+        ret = subprocess.run(cmd + ["groupadd", "--gid", gid, "dirac"], check=False)
+        if ret.returncode != 0:
+            typer.secho(f"Failed to add add group dirac with id={gid}", fg=c.YELLOW)
         subprocess.run(
             cmd
             + [


### PR DESCRIPTION
Not worthy of release notes but makes the integration tests script slightly more robust.