### PR TITLE
[v7r2] Add pr-sweep action for PR cherry-picking

### DIFF
--- a/.github/workflows/pr-sweep.yml
+++ b/.github/workflows/pr-sweep.yml
@@ -1,0 +1,16 @@
+name: PR sweep
+
+on: [push]
+
+jobs:
+  pr-sweep:
+    runs-on: ubuntu-latest
+    if: github.repository == 'DIRACGrid/DIRAC'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.PAT }}
+    - uses: aidasoft/pr-sweeper@v1
+      with:
+        github-pat: ${{ secrets.PAT }}

--- a/.github/workflows/pr-sweep.yml
+++ b/.github/workflows/pr-sweep.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   pr-sweep:
     runs-on: ubuntu-latest
+    concurrency: pr-sweep
     if: github.repository == 'DIRACGrid/DIRAC'
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I have finished `pr-sweep` details about the action can be found https://github.com/marketplace/actions/pr-sweeper

I advice it's used from `v7r2` as there are many renames between `v7r1` and `v7r2` which complicates the cherry-pick also the relocation of files can cause problems....

What needs to be done before this can go into production

 - [ ] create a Personal Access Token with write privileges to DIRACGrid/DIRAC and add it as secret `PAT`
 - [ ] Create labels `alsoTargeting:xyz`, `sweep:done`, `sweep:failed`, `sweep from:xyz`

I have tested the system with the some `v7r2` currently open in this repo and the results of merging  them can be found here https://github.com/DIRACGrid-test/DIRAC/pulls 

~~There might however be a problem it several of think king of jobs `pr-sweep` run in parallel~~

BEGINRELEASENOTES
*operations
NEW: add pr-sweep action to cheery-pick PRs to other branches
ENDRELEASENOTES
