### PR TITLE
[v7r1] Clarify tarfile error message in pilot logs

### DIFF
--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -210,8 +210,8 @@ for loc in locations:
     # if we get here we break out of the loop of locations
     break
   except (url_library_URLError, Exception) as e:
-    print('%%s unreacheable' %% loc, file=sys.stderr)
-    logger.error('%%s unreacheable' %% loc)
+    print('%%s unreacheable (this is normal!)' %% loc, file=sys.stderr)
+    logger.error('%%s unreacheable (this is normal!)' %% loc)
     logger.exception(e)
 
 else:

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -199,8 +199,8 @@ for loc in locations:
         pt.extractall()
         pt.close()
       except Exception as x:
-        print("tarfile failed with message %%s" %% repr(x), file=sys.stderr)
-        logger.error("tarfile failed with message %%s" %% repr(x))
+        print("tarfile failed with message (this is normal!) %%s" %% repr(x), file=sys.stderr)
+        logger.error("tarfile failed with message (this is normal!) %%s" %% repr(x))
         logger.warn("Trying tar command (tar -xvf pilot.tar)")
         res = os.system("tar -xvf pilot.tar")
         if res:

--- a/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -204,8 +204,8 @@ for loc in locations:
         logger.warn("Trying tar command (tar -xvf pilot.tar)")
         res = os.system("tar -xvf pilot.tar")
         if res:
-          logger.error("tar failed with exit code %%d, giving up" %% int(res))
-          print("tar failed with exit code %%d, giving up" %% int(res), file=sys.stderr)
+          logger.error("tar failed with exit code %%d, giving up (this is normal!)" %% int(res))
+          print("tar failed with exit code %%d, giving up (this is normal!)" %% int(res), file=sys.stderr)
           raise
     # if we get here we break out of the loop of locations
     break


### PR DESCRIPTION
This message is a constant source of confusion for people in the pilot logs so I propose we put at least something to help people realise this isn't actually the problem. I've gone for the concise option but an alternative would be to actually check if there are locations remaining in the list.

BEGINRELEASENOTES

*WorkloadManagement
CHANGE: Clarify that "tarfile failed with message" can be normal

ENDRELEASENOTES
