### PR TITLE
[v7r1] SiteDirector: fix wrong return type in function

### DIFF
--- a/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -823,7 +823,7 @@ class SiteDirector(AgentModule):
     result = self.matcherClient.getMatchingTaskQueues(ceDict)
     if not result['OK']:
       self.log.error('Could not retrieve TaskQueues from TaskQueueDB', result['Message'])
-      return result
+      return 0, {}
     taskQueueDict = result['Value']
     if not taskQueueDict:
       self.log.verbose('No matching TQs found',


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: SiteDirector._getPilotsWeMayWantToSubmit: fix return type in case of error

ENDRELEASENOTES
