### PR TITLE
[v7r2] Add importlib_resources to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ GitPython>=2.1.0
 matplotlib>=2.1.0,<3.0
 mock>=1.0.1
 MySQL-python>=1.2.5
+importlib_resources
 jinja2
 ipython==5.3.0
 numpy>=1.10.1


### PR DESCRIPTION
This isn't actually used by the DIRAC CI anymore but the LHCbDIRAC CI still depends on it. Once DIRAC is Python 3 only we can get rid of all this duplication.