### PR TITLE
[v7r2] Workaround for OSError when copying vomses directory with too many extended attributes

### DIFF
--- a/src/DIRAC/Core/Security/VOMS.py
+++ b/src/DIRAC/Core/Security/VOMS.py
@@ -11,6 +11,8 @@ import stat
 import tempfile
 import shutil
 
+import six
+
 from DIRAC import S_OK, S_ERROR, gConfig, rootPath, gLogger
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Security.ProxyFile import multiProxyArgument, deleteMultiProxy
@@ -243,7 +245,11 @@ class VOMS(BaseSecurity):
           return vomsesPath
         tmpDir = tempfile.mkdtemp()
         tmpDir = os.path.join(tmpDir, "vomses")
-        shutil.copytree(vomsesPath, tmpDir)
+        if six.PY2:
+          shutil.copytree(vomsesPath, tmpDir)
+        else:
+          # https://bugs.python.org/issue44205
+          shutil.copytree(vomsesPath, tmpDir, copy_function=shutil.copy)
         os.chmod(tmpDir, requiredDirPerms)
         for fP in os.listdir(tmpDir):
           os.chmod(os.path.join(tmpDir, fP), requiredFilePerms)

--- a/src/DIRAC/Core/Security/VOMS.py
+++ b/src/DIRAC/Core/Security/VOMS.py
@@ -249,7 +249,7 @@ class VOMS(BaseSecurity):
           shutil.copytree(vomsesPath, tmpDir)
         else:
           # https://bugs.python.org/issue44205
-          shutil.copytree(vomsesPath, tmpDir, copy_function=shutil.copy)
+          shutil.copytree(vomsesPath, tmpDir, copy_function=shutil.copy)  # pylint: disable=unexpected-keyword-arg
         os.chmod(tmpDir, requiredDirPerms)
         for fP in os.listdir(tmpDir):
           os.chmod(os.path.join(tmpDir, fP), requiredFilePerms)


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: Workaround for OSError when copying vomses directory with too many extended attributes

ENDRELEASENOTES
