### PR TITLE
[v7r1] Add listStatesForWeb endpoint to make Public State Manager faster

### DIFF
--- a/FrameworkSystem/Client/UserProfileClient.py
+++ b/FrameworkSystem/Client/UserProfileClient.py
@@ -130,3 +130,7 @@ class UserProfileClient(object):
     it returns the available profile names by not taking account the permission: ReadAccess and PublishAccess
     """
     return self.__getRPCClient().getUserProfileNames(permission)
+
+  def listStatesForWeb(self, permission={}):
+    rpcClient = self.__getRPCClient()
+    return rpcClient.listStatesForWeb(permission)

--- a/FrameworkSystem/Client/UserProfileClient.py
+++ b/FrameworkSystem/Client/UserProfileClient.py
@@ -132,5 +132,4 @@ class UserProfileClient(object):
     return self.__getRPCClient().getUserProfileNames(permission)
 
   def listStatesForWeb(self, permission={}):
-    rpcClient = self.__getRPCClient()
-    return rpcClient.listStatesForWeb(permission)
+    return self.__getRPCClient().listStatesForWeb(permission)

--- a/FrameworkSystem/DB/UserProfileDB.py
+++ b/FrameworkSystem/DB/UserProfileDB.py
@@ -9,6 +9,8 @@ import os
 import sys
 import hashlib
 
+import cachetools
+
 from DIRAC import S_OK, S_ERROR, gLogger, gConfig
 from DIRAC.Core.Utilities import Time
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
@@ -76,6 +78,7 @@ class UserProfileDB(DB):
     """
     self.__permValues = ['USER', 'GROUP', 'VO', 'ALL']
     self.__permAttrs = ['ReadAccess', 'PublishAccess']
+    self.__cache = cachetools.TTLCache(1024, 15)
     DB.__init__(self, 'UserProfileDB', 'Framework/UserProfileDB')
     retVal = self.__initializeDB()
     if not retVal['OK']:
@@ -123,14 +126,32 @@ class UserProfileDB(DB):
   def __getVOId(self, voName, insertIfMissing=True):
     return self.__getObjId(voName, 'VO', 'up_VOs', insertIfMissing)
 
+  def __getFieldsCached(self, tableName, outFields, condDict):
+    """Call getFields with a TTL cache
+
+    The UserProfileDB is written in such a way that repeatedly makes the same
+    DB queries thousands of times. To workaround this, use a simple short-lived
+    TTL cache to dramatically improve performance.
+    """
+    key = (tableName, tuple(outFields), tuple(sorted(condDict.items())))
+    if key not in self.__cache:
+      result = self.getFields(tableName, outFields, condDict)
+      if not result['OK']:
+        return result
+      data = result['Value']
+      if len(data) > 0:
+        objId = data[0][0]
+        self.updateFields(tableName, ['LastAccess'], ['UTC_TIMESTAMP()'], {'Id': objId})
+      self.__cache[key] = result
+    return self.__cache[key]
+
   def __getObjId(self, objValue, varName, tableName, insertIfMissing=True):
-    result = self.getFields(tableName, ['Id'], {varName: objValue})
+    result = self.__getFieldsCached(tableName, ['Id'], {varName: objValue})
     if not result['OK']:
       return result
     data = result['Value']
     if len(data) > 0:
       objId = data[0][0]
-      self.updateFields(tableName, ['LastAccess'], ['UTC_TIMESTAMP()'], {'Id': objId})
       return S_OK(objId)
     if not insertIfMissing:
       return S_ERROR("No entry %s for %s defined in the DB" % (objValue, varName))

--- a/FrameworkSystem/Service/UserProfileManagerHandler.py
+++ b/FrameworkSystem/Service/UserProfileManagerHandler.py
@@ -79,6 +79,32 @@ class UserProfileManagerHandler(RequestHandler):
     userGroup = credDict['group']
     return gUPDB.deleteVar(userName, userGroup, profileName, varName)
 
+  types_listStatesForWeb = [dict]
+
+  def export_listStatesForWeb(self, permission):
+    retVal = self.export_getUserProfileNames(permission)
+    if not retVal["OK"]:
+      return retVal
+    data = retVal['Value']
+
+    records = []
+    for i in data:
+      application = i.replace('Web/application/', '')
+      retVal = self.export_listAvailableProfileVars(i)
+      if not retVal['OK']:
+        return retVal
+      states = retVal['Value']
+      for state in states:
+        record = dict(zip(['user', 'group', 'vo', 'name'], state))
+        record['app'] = application
+        retVal = self.export_getProfileVarPermissions(i, record['name'])
+        if not retVal['OK']:
+          return retVal
+        record['permissions'] = retVal['Value']
+        records += [record]
+
+    return S_OK(records)
+
   types_listAvailableProfileVars = [types.StringTypes]
 
   def export_listAvailableProfileVars(self, profileName, filterDict={}):

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,7 @@ M2Crypto>=0.36
 Sphinx>=1.8.0
 docutils>=0.15
 boto3
+cachetools<4
 elasticsearch_dsl
 future
 futures

--- a/docs/requirements_py3.txt
+++ b/docs/requirements_py3.txt
@@ -5,6 +5,7 @@ M2Crypto==0.32
 Sphinx>=1.8.0
 boto3
 elasticsearch_dsl
+cachetools
 future
 futures
 matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - boto3
   - certifi
   - cmreshandler >1.0.0b4
+  - cachetools <4
   - docutils
   - elasticsearch-dsl ~=6.3.1
   - fts-rest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ boto3
 #asn1
 M2Crypto>=0.36
 autopep8==1.3.3
+cachetools<4
 certifi
 coverage
 docutils


### PR DESCRIPTION
This PR fixes an issue in the web app which cases the Public State Manager to almost never load for some users due to the response being too slow. There are two main optimisations:

1. Add a bulk endpoint to avoid the request scaling with `latency * number of shared states`
2. Add a cache in `UserProfileDB` to avoid making the same few read/timestamp updates being made hundreds/thousands of times.

Note for 2. it uses cache tools which would need to be added in DIRACOS. Any objections?

I'll follow up with a WebApp PR which makes use of this.

BEGINRELEASENOTES

*Framework
NEW: Add UserProfileClient.listStatesForWeb endpoint to make the Public State Manager faster

ENDRELEASENOTES
