### PR TITLE
[v7r2] Add cachetools to dependency files

### DIFF
--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -12,6 +12,7 @@ dependencies:
   - python =3.9
   - pip
   - boto3
+  - cachetools
   - certifi
   - cmreshandler >1.0.0b4
   - docutils

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ scripts =
 install_requires =
     boto3
     botocore
+    cachetools
     certifi
     diraccfg
     future


### PR DESCRIPTION
Part of https://github.com/DIRACGrid/DIRAC/pull/5159 but these files only exist in v7.2+.