### PR TITLE
[v7r1] Add better error if FC DB has a missing fields

### DIFF
--- a/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -1116,9 +1116,15 @@ class FileManagerBase(object):
       return S_OK(files)
     fileIDNames = {}
     for fileName, fileDict in res['Value'].iteritems():
-      files[fileName] = {}
-      files[fileName]['MetaData'] = fileDict
-      fileIDNames[fileDict['FileID']] = fileName
+      try:
+        files[fileName] = {}
+        files[fileName]['MetaData'] = fileDict
+        fileIDNames[fileDict['FileID']] = fileName
+      except KeyError:
+        # If we return S_ERROR here, it gets treated as an empty directory in most cases
+        # and the user isn't actually warned
+        raise Exception("File entry for '%s' is corrupt (DirID %s), please contact the catalog administrator"
+                        % (fileName, dirID))
 
     if verbose:
       result = self._getFileReplicas(fileIDNames.keys(), connection=connection)


### PR DESCRIPTION
Hi,

As discussed in the meeting this morning, we see occasional issues with files that have an FC_Files entry but no matching FC_FileInfo row. This causes the users to get "KeyError FileID" style errors when doing anything with those directories/files.

We had a look a fixing this, but there was no easy solution: Checking that all of the requested fields are there is too slow and ensuring FileID is in the dictionary gets rid of the problem in some places, but moves the crash to others keys in others.

For now we'd like to suggest this patch: It simply improves the error message that the user sees if they list a directory containing a corrupt file. It's far from perfect, but is very low risk compared to other possible fixes and still greatly improves the user experience. I'm hoping in the long run that we can pin-down the race condition in addFile to get rid of the corrupt entries in the first place :smile:.

Regards,
Simon

BEGINRELEASENOTES
*DataManagement
FIX: Improve listing error if file info is missing from DB
ENDRELEASENOTES
