### PR TITLE
[v7r2] Python 3 fixes in UserProfileClient and deprecations

### DIFF
--- a/src/DIRAC/FrameworkSystem/Client/UserProfileClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/UserProfileClient.py
@@ -59,7 +59,7 @@ class UserProfileClient(object):
 
   def __decodeVar(self, data, dataTypeRE):
     try:
-      dataObj, lenData = DEncode.decode(data)
+      dataObj, lenData = DEncode.decode(data.encode())
     except Exception as e:
       return S_ERROR("Cannot decode data: %s" % str(e))
     if dataTypeRE:
@@ -89,10 +89,10 @@ class UserProfileClient(object):
       return result
     try:
       encodedData = result['Value']
-      dataObj = {}
-      for k in encodedData:
-        v, lenData = DEncode.decode(encodedData[k])
-        dataObj[k] = v
+      dataObj = {
+          key: DEncode.decode(value.encode())[0]
+          for key, value in encodedData.items()
+      }
     except Exception as e:
       return S_ERROR("Cannot decode data: %s" % str(e))
     return S_OK(dataObj)

--- a/src/DIRAC/FrameworkSystem/Client/UserProfileClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/UserProfileClient.py
@@ -7,6 +7,7 @@ import re
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.DISET.RPCClient import RPCClient
 from DIRAC.Core.Utilities import DEncode, Time
+from DIRAC.Core.Utilities.Decorators import deprecated
 
 
 class UserProfileClient(object):
@@ -40,6 +41,7 @@ class UserProfileClient(object):
                                          self.__generateTypeDest(dataObj[k])) for k in dataObj])
     return ""
 
+  @deprecated("Unused, will be removed in v7r3")
   def checkTypeRe(self, dataObj, typeRE):
     if typeRE[0] != "^":
       typeRE = "^%s" % typeRE
@@ -119,12 +121,15 @@ class UserProfileClient(object):
   def deleteProfiles(self, userList):
     return self.__getRPCClient().deleteProfiles(userList)
 
+  @deprecated("Unused, will be removed in v7r3")
   def storeHashTag(self, tagName):
     return self.__getRPCClient().storeHashTag(tagName)
 
+  @deprecated("Unused, will be removed in v7r3")
   def retrieveHashTag(self, hashTag):
     return self.__getRPCClient().retrieveHashTag(hashTag)
 
+  @deprecated("Unused, will be removed in v7r3")
   def retrieveAllHashTags(self):
     return self.__getRPCClient().retrieveAllHashTags()
 

--- a/src/DIRAC/FrameworkSystem/DB/UserProfileDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/UserProfileDB.py
@@ -659,7 +659,7 @@ class UserProfileDB(DB):
 
     permissions = self.__parsePerms(permission, False)
     if not permissions:
-      return S_OK()
+      return S_OK([])
 
     condition = ",".join(["%s='%s'" % (k, permissions[k]) for k in permissions])
 


### PR DESCRIPTION

BEGINRELEASENOTES

*Framework
CHANGE: Deprecate checkTypeRe and HashTags in UserProfileClient
FIX: Python 3 compatibility in UserProfileClient

ENDRELEASENOTES
