### PR TITLE
[v7r2] Pin astroid to avoid linter false positives

### DIFF
--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -7,7 +7,7 @@ channels:
 
 dependencies:
   # Temporary workarounds
-  - astroid !=2.5  # https://github.com/PyCQA/astroid/issues/903
+  - astroid 2.5.6  # https://github.com/PyCQA/astroid/issues/1006 and https://github.com/PyCQA/astroid/issues/1007
   # runtime
   - python =3.9
   - pip


### PR DESCRIPTION
I've opened issues upstream so hopefully these can be fixed rather than littering the code with disabled checks.

This is another case where `pre-commit` would be nice as it automatically pins versions of packages like `astroid`/`pylint` so we can bump the versions when it suits us rather than being randomly hit by regressions (or previously unknown bugs). Example: https://github.com/scikit-hep/uproot4/pull/373