### PR TITLE
[v7r2] Improve git describe command used by setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,4 @@ build-backend = "setuptools.build_meta"
 # https://github.com/pypa/setuptools_scm/#pyprojecttoml-usage
 [tool.setuptools_scm]
 # Avoid letting setuptools_scm use old style tags (i.e. vXrYpZ)
-git_describe_command = "git describe --dirty --tags --long --match *[0-9]* --exclude v[0-9]r* --exclude v[0-9][0-9]r*"
+git_describe_command = "git describe --dirty --tags --long --match *[0-9].[0-9]* --exclude v[0-9]r* --exclude v[0-9][0-9]r*"


### PR DESCRIPTION
There is an invalid tag in the history which cases the issue reported by @TaykYoku on slack when pip installing directly from a fork which pre-dates the new style versioning. This change makes the `git describe` command more robust (causing the version to default to something like `0.1.dev33206+g68d885b.d20210602` instead of erroring).


BEGINRELEASENOTES

*Python 3
FIX: Improve "git describe" command used by setuptools-scm to ignore v6e7p27

ENDRELEASENOTES
