### PR TITLE
[v7r1] Improve backwards compatibility for running jobs submitted with v7r2

### DIFF
--- a/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -225,7 +225,7 @@ class JobWrapper(object):
       os.mkdir(str(self.jobID))
       os.chdir(str(self.jobID))
       extraOpts = self.jobArgs.get('ExtraOptions', '')
-      if extraOpts and '$DIRACROOT' in self.jobArgs.get('Executable', '').strip():
+      if extraOpts and 'dirac-jobexec' in self.jobArgs.get('Executable', '').strip():
         if os.path.exists('%s/%s' % (self.root, extraOpts)):
           shutil.copyfile('%s/%s' % (self.root, extraOpts), extraOpts)
         self.__loadLocalCFGFiles(self.localSiteRoot)
@@ -330,6 +330,14 @@ class JobWrapper(object):
     # In case the executable is dirac-jobexec,
     # the argument should include the jobDescription.xml file
     jobArguments = self.jobArgs.get('Arguments', '')
+
+    # This is a workaround for Python 2 style installations
+    if six.PY3 and executable == "$DIRACROOT/scripts/dirac-jobexec":
+      self.log.warn(
+          'Replaced job executable "$DIRACROOT/scripts/dirac-jobexec" with '
+          '"dirac-jobexec". Please fix your submission script!'
+      )
+      executable = "dirac-jobexec"
 
     executable = os.path.expandvars(executable)
     exeThread = None


### PR DESCRIPTION
As part of the upgrade to v7r2 in LHCb we found jobs started crashing with:

```python
2021-06-03 06:53:27 UTC dirac-jobexec/GaudiApplication ERROR: Failure in GaudiApplication execute module
Traceback (most recent call last):
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/v10r1p13/LHCbDIRAC/Workflow/Modules/GaudiApplication.py", line 164, in execute
    prodConfFileName = self.createProdConfFile(stepOutputTypes, histogram, runNumberGauss, firstEventNumberGauss)
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/v10r1p13/LHCbDIRAC/Workflow/Modules/ModuleBase.py", line 1108, in createProdConfFile
    jobMaxCPUTime=86400)
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/v10r1p13/LHCbDIRAC/Workflow/Modules/ModulesUtilities.py", line 132, in getEventsToProduce
    CPUTime = getCPUTime(CPUNormalizationFactor)
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/v10r1p13/DIRAC/WorkloadManagementSystem/Client/CPUNormalization.py", line 219, in getCPUTime
    queueSection = '/Resources/Sites/%s/%s/CEs/%s/Queues' % (siteName.split('.')[0], siteName, gridCE)
AttributeError: 'NoneType' object has no attribute 'split'
```

The problem is that the LocalSite part of the CS not being filled as the `pilot.cfg` file is missing.

The cause is that the Executable in the job wrapper is now `dirac-jobexec` instead of `$DIRACROOT/scripts/dirac-jobexec`. DIRAC v7r1 only copies the pilot.cfg if `$DIRACROOT` is found in the `Executable` name so existing pilots running v7r1 with filling mode fail to execute jobs that were submitted with v7r2.

Nothing can be done to fix the pilots in LHCb but this should make upgrading smoother for other installations.

BEGINRELEASENOTES

*WorkloadManagement
FIX: Look for `dirac-jobexec` instead of `$DIRACROOT` to decide when to copy the `pilot.cfg` to improve compatibility with v7r2

ENDRELEASENOTES
