### PR TITLE
[v7r2] Add callStack argument to S_ERROR to optimise CS

### DIFF
--- a/src/DIRAC/ConfigurationSystem/private/ConfigurationClient.py
+++ b/src/DIRAC/ConfigurationSystem/private/ConfigurationClient.py
@@ -145,7 +145,7 @@ class ConfigurationClient(object):
     if optionValue is None:
       return S_ERROR(
           "Path %s does not exist or it's not an option" % optionPath,
-          withStack=False,
+          callStack=["ConfigurationClient.getOption"],
       )
 
     # Value has been returned from the configuration

--- a/src/DIRAC/ConfigurationSystem/private/ConfigurationClient.py
+++ b/src/DIRAC/ConfigurationSystem/private/ConfigurationClient.py
@@ -143,7 +143,10 @@ class ConfigurationClient(object):
     optionValue = gConfigurationData.extractOptionFromCFG(optionPath)
 
     if optionValue is None:
-      return S_ERROR("Path %s does not exist or it's not an option" % optionPath)
+      return S_ERROR(
+          "Path %s does not exist or it's not an option" % optionPath,
+          withStack=False,
+      )
 
     # Value has been returned from the configuration
     if typeValue is None:

--- a/src/DIRAC/Core/Utilities/ReturnValues.py
+++ b/src/DIRAC/Core/Utilities/ReturnValues.py
@@ -21,9 +21,9 @@ def S_ERROR(*args, **kwargs):
 
   :param int errno: Error number
   :param string message: Error message
-  :param bool withStack: Set the CallStack attribute to an empty list for better performance
+  :param list callStack: Manually override the CallStack attribute better performance
   """
-  withStack = kwargs.pop("withStack", True)
+  callStack = kwargs.pop("callStack", None)
 
   result = {"OK": False, "Errno": 0, "Message": ""}
 
@@ -40,13 +40,12 @@ def S_ERROR(*args, **kwargs):
     message = "%s ( %s : %s)" % (strerror(result['Errno']), result['Errno'], message)
   result["Message"] = message
 
-  callStack = []
-  if withStack:
+  if callStack is None:
     try:
       callStack = traceback.format_stack()
       callStack.pop()
     except BaseException:
-      pass
+      callStack = []
 
   result["CallStack"] = callStack
 

--- a/src/DIRAC/Core/Utilities/ReturnValues.py
+++ b/src/DIRAC/Core/Utilities/ReturnValues.py
@@ -14,14 +14,17 @@ import traceback
 from DIRAC.Core.Utilities.DErrno import strerror
 
 
-def S_ERROR(*args):
+def S_ERROR(*args, **kwargs):
   """ return value on error condition
 
   Arguments are either Errno and ErrorMessage or just ErrorMessage fro backward compatibility
 
   :param int errno: Error number
   :param string message: Error message
+  :param bool withStack: Set the CallStack attribute to an empty list for better performance
   """
+  withStack = kwargs.pop("withStack", True)
+
   result = {"OK": False, "Errno": 0, "Message": ""}
 
   message = ''
@@ -37,11 +40,13 @@ def S_ERROR(*args):
     message = "%s ( %s : %s)" % (strerror(result['Errno']), result['Errno'], message)
   result["Message"] = message
 
-  try:
-    callStack = traceback.format_stack()
-    callStack.pop()
-  except BaseException:
-    callStack = []
+  callStack = []
+  if withStack:
+    try:
+      callStack = traceback.format_stack()
+      callStack.pop()
+    except BaseException:
+      pass
 
   result["CallStack"] = callStack
 


### PR DESCRIPTION
When profiling some agents I've noticed that most of the time is spent generating the `CallStack` field in `S_ERROR`. This is due the CS being heavily used and even default keys have to format a full traceback. This PR adds a new `callStack` keyword argument to `S_ERROR` to avoid this which makes `gConfig.getOption` ~13x faster. Benchmarked with:

```python
import DIRAC
from DIRAC.Core.Base.Script import parseCommandLine
parseCommandLine()
DIRAC.gConfig.getOption("/Systems/Transformation/Production/Agents/WorkflowTaskAgent/PollingTim", 120)
%timeit DIRAC.gConfig.getOption("/Systems/Transformation/Production/Agents/WorkflowTaskAgent/PollingTim", 120)
```

Before:
```
137 µs ± 343 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

After:
```
11.3 µs ± 35.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```


BEGINRELEASENOTES

*Core
NEW: Add callStack keyword argument to S_ERROR to allow object to be created much faster

*Configuration
CHANGE: No longer include a full CallStack in the S_ERROR object returned by ConfigurationClient.getOption

ENDRELEASENOTES
