### PR TITLE
[v7r2] Add environment variable to speed up the CS

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,9 @@ jobs:
           ###### Thread pool
           - TEST_NAME: "New thread pool"
             ARGS: DIRAC_USE_NEWTHREADPOOL=No
+          ###### Thread pool
+          - TEST_NAME: "Fewer cfg locks"
+            ARGS: DIRAC_FEWER_CFG_LOCKS=Yes
           ###### HTTPS tests
           - TEST_NAME: "HTTPS"
             ARGS: TEST_HTTPS=Yes

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -22,7 +22,7 @@ DIRAC_DEPRECATED_FAIL
   integration tests against future versions of DIRAC
 
 DIRAC_FEWER_CFG_LOCKS
-  If ``true`` or ``yes`` or ``on`` or ``1`` or ``y`` or ``t``, DIRAC will reduce the number of of locks used when accessing the CS for better performance (default, ``no``).
+  If ``true`` or ``yes`` or ``on`` or ``1`` or ``y`` or ``t``, DIRAC will reduce the number of locks used when accessing the CS for better performance (default, ``no``).
 
 DIRAC_GFAL_GRIDFTP_SESSION_REUSE
   If set to ``true`` or ``yes`` the GRIDFT SESSION RESUSE option will be set to True, should be set on server

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -21,6 +21,9 @@ DIRAC_DEPRECATED_FAIL
   If set, the use of functions or objects that are marked ``@deprecated`` will fail. Useful for example in continuous
   integration tests against future versions of DIRAC
 
+DIRAC_FEWER_CFG_LOCKS
+  If ``true`` or ``yes`` or ``on`` or ``1`` or ``y`` or ``t``, DIRAC will reduce the number of of locks used when accessing the CS for better performance (default, ``no``).
+
 DIRAC_GFAL_GRIDFTP_SESSION_REUSE
   If set to ``true`` or ``yes`` the GRIDFT SESSION RESUSE option will be set to True, should be set on server
   installations. See the information in the :ref:`resourcesStorageElement` page.
@@ -49,9 +52,6 @@ DIRAC_NO_CFG
 
 DIRAC_USE_NEWTHREADPOOL
   If this environment is set to ``true`` or ``yes``, the concurrent.futures.ThreadPoolExecutor will be used (default=Yes)
-
-DIRAC_FEWER_CFG_LOCKS
-  If anything else than ``true`` or ``yes`` DIRAC will reduce the number of of locks used when accessing the CS for better performance (default, ``false``).
 
 DIRACSYSCONFIG
   If set, its value should be (the full locations on the file system of) one of more DIRAC cfg file(s) (comma separated), whose content will be used for the DIRAC configuration

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -50,8 +50,8 @@ DIRAC_NO_CFG
 DIRAC_USE_NEWTHREADPOOL
   If this environment is set to ``true`` or ``yes``, the concurrent.futures.ThreadPoolExecutor will be used (default=Yes)
 
-DIRAC_USE_M2CRYPTO
-  If anything else than ``true`` or ``yes`` (default) DIRAC will revert back to using pyGSI instead of m2crypto for handling certificates, proxies, etc.
+DIRAC_FEWER_CFG_LOCKS
+  If anything else than ``true`` or ``yes`` DIRAC will reduce the number of of locks used when accessing the CS for better performance (default, ``false``).
 
 DIRACSYSCONFIG
   If set, its value should be (the full locations on the file system of) one of more DIRAC cfg file(s) (comma separated), whose content will be used for the DIRAC configuration

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -28,6 +28,7 @@ FEATURE_VARIABLES = {
     "DIRACOSVER": "master",
     "DIRACOS_TARBALL_PATH": None,
     "TEST_HTTPS": "No",
+    "DIRAC_FEWER_CFG_LOCKS": None,
     "DIRAC_USE_NEWTHREADPOOL": None,
     "USE_PYTHON3": None,
 }

--- a/src/DIRAC/ConfigurationSystem/private/Refresher.py
+++ b/src/DIRAC/ConfigurationSystem/private/Refresher.py
@@ -50,6 +50,9 @@ class Refresher(RefresherBase, threading.Thread):
     """
     if not self._refreshEnabled or self._automaticUpdate or not gConfigurationData.getServers():
       return
+    # To improve performance, skip acquiring the lock if possible
+    if not self._lastRefreshExpired():
+      return
     self._triggeredRefreshLock.acquire()
     try:
       if not self._lastRefreshExpired():
@@ -60,7 +63,7 @@ class Refresher(RefresherBase, threading.Thread):
         self._triggeredRefreshLock.release()
       except thread.error:
         pass
-    # Launch the refreshf
+    # Launch the refresh
     thd = threading.Thread(target=self._refreshInThread)
     thd.setDaemon(1)
     thd.start()

--- a/src/DIRAC/ConfigurationSystem/private/RefresherBase.py
+++ b/src/DIRAC/ConfigurationSystem/private/RefresherBase.py
@@ -43,6 +43,7 @@ class RefresherBase(object):
   def __init__(self):
     self._automaticUpdate = False
     self._lastUpdateTime = 0
+    self._refreshTime = gConfigurationData.getRefreshTime()
     self._url = False
     self._refreshEnabled = True
     self._timeout = 60
@@ -80,7 +81,7 @@ class RefresherBase(object):
     """
       Just returns if last refresh must be considered as expired or not
     """
-    return time.time() - self._lastUpdateTime >= gConfigurationData.getRefreshTime()
+    return time.time() - self._lastUpdateTime >= self._refreshTime
 
   def forceRefresh(self, fromMaster=False):
     """
@@ -150,6 +151,7 @@ class RefresherBase(object):
                                     skipCACheck=gConfigurationData.skipCACheck())
       dRetVal = _updateFromRemoteLocation(oClient)
       if dRetVal['OK']:
+        self._refreshTime = gConfigurationData.getRefreshTime()
         return dRetVal
       else:
         updatingErrorsList.append(dRetVal['Message'])


### PR DESCRIPTION
When profiling the production agents/services in LHCb I've notice that a significant amount of time is spent waiting for one of the three locks in the CS. This change can make both single and multithreaded code that heavily uses the CS significantly faster (hard to measure/define but I've seen 2x in single threaded and 4x in multithreaded when testing).

While I can see why the locks are put in place in the CS I think they're actually implemented in such a way that they're not that useful while having a big impact on the overall CS performance.

Additionally, the "dangerZone" locks have been broken for the last 12 years as the `disableDangerZones` option still decrements the thread count causing the thread count to go negative and never be respected properly (potentially fixed by https://github.com/DIRACGrid/DIRAC/pull/5183 but I think it's better just to get rid of the locks):

```
In [1]: from DIRAC.Core.Base.Script import parseCommandLine
   ...: parseCommandLine()
   ...: from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
   ...: gConfigurationData.runningThreadsNumber
   ...:
Out[1]: -4
```

As this change obviously has the potential to cause problems, @chaen suggested using an environment variable to allow this to be quickly enabled/disabled in v7r2.

I also add a cache on the value of `gConfigurationData.getRefreshTime()` as it's accessed at least once for every CS operation.

See also: https://github.com/DIRACGrid/diraccfg/pull/5/

BEGINRELEASENOTES

*Configuration
NEW: Add DIRAC_FEWER_CFG_LOCKS environment variable to significantly improve multithreading performance in CS heavy workloads

ENDRELEASENOTES
