### PR TITLE
[v7r2] Fix TypeError in ColorGenerator

### DIFF
--- a/src/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py
@@ -6,9 +6,6 @@ __RCSID__ = "$Id$"
 
 
 class ColorGenerator:
-
-  sHexDigits = "0123456789ABCDEF"
-
   def __init__(self):
     self.lUsedColors = []
 
@@ -19,9 +16,7 @@ class ColorGenerator:
     return any(self.__equalColors(c1, c2) for c2 in cl2)
 
   def __toHex(self, n):
-    d1 = int(n / 16)
-    d2 = int(n - d1 * 16)
-    return "%s%s" % (self.sHexDigits[d1], self.sHexDigits[d2])
+    return hex(int(n))[2:].upper().rjust(2, "0")
 
   def reset(self):
     self.lUsedColors = []

--- a/src/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py
@@ -16,10 +16,7 @@ class ColorGenerator:
     return c1[0] == c2[0] and c1[1] == c2[1] and c1[2] == c2[2]
 
   def __equalColorInList(self, c1, cl2):
-    for c2 in cl2:
-      if self.__equalColors(c1, c2):
-        return True
-    return False
+    return any(self.__equalColors(c1, c2) for c2 in cl2)
 
   def __toHex(self, n):
     d1 = int(n / 16)
@@ -43,7 +40,9 @@ class ColorGenerator:
       self.lUsedColors.append((255, 0, 255))
     elif iNumColorsUsed == 5:
       self.lUsedColors.append((255, 255, 0))
-    else:
+    elif len(self.lUsedColors) < 128:
+      # This has terrible performance is the number of used colours gets too high
+      # At that point the color stops making much sense so allow it to loop
       im = 0
       iM = 1
       rC = self.lUsedColors[0]
@@ -57,8 +56,7 @@ class ColorGenerator:
             iM += 1
             im = 0
       self.lUsedColors.append(rC)
-    fC = self.lUsedColors[iNumColorsUsed]
-    return fC
+    return self.lUsedColors[iNumColorsUsed % 128]
 
   def getFloatColor(self):
     fC = self.__generateColor()

--- a/src/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py
@@ -23,7 +23,7 @@ class ColorGenerator:
 
   def __toHex(self, n):
     d1 = int(n / 16)
-    d2 = (n - d1 * 16)
+    d2 = int(n - d1 * 16)
     return "%s%s" % (self.sHexDigits[d1], self.sHexDigits[d2])
 
   def reset(self):

--- a/src/DIRAC/FrameworkSystem/private/monitoring/test/Test_ColorGenerator.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/test/Test_ColorGenerator.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from DIRAC.FrameworkSystem.private.monitoring.ColorGenerator import ColorGenerator
+
+
+def test_getHexColor():
+  cg = ColorGenerator()
+  for i in range(2):
+    assert cg.getHexColor() == "0000FF"
+    assert cg.getHexColor() == "00FF00"
+    assert cg.getHexColor() == "FF0000"
+    assert cg.getHexColor() == "00FFFF"
+    assert cg.getHexColor() == "FF00FF"
+    assert cg.getHexColor() == "FFFF00"
+    assert cg.getHexColor() == "007F7F"
+    assert cg.getHexColor() == "7F007F"
+    assert cg.getHexColor() == "7F7F00"
+    assert cg.getHexColor() == "007FFF"
+    assert cg.getHexColor() == "00FF7F"
+    assert cg.getHexColor() == "7F7F7F"
+    assert cg.getHexColor() == "7F00FF"
+    assert cg.getHexColor() == "FF007F"
+    assert cg.getHexColor() == "7F7FFF"
+    for j in range(1000):
+      assert len(cg.getHexColor()) == 6
+    cg.reset()
+
+
+def test_getFloatColor():
+  cg = ColorGenerator()
+  cg.reset()
+  for i in range(2):
+    assert cg.getFloatColor() == (0.0, 0.0, 1.0)
+    assert cg.getFloatColor() == (0.0, 1.0, 0.0)
+    assert cg.getFloatColor() == (1.0, 0.0, 0.0)
+    assert cg.getFloatColor() == (0.0, 1.0, 1.0)
+    assert cg.getFloatColor() == (1.0, 0.0, 1.0)
+    assert cg.getFloatColor() == (1.0, 1.0, 0.0)
+    assert cg.getFloatColor() == (0.0, 0.5, 0.5)
+    assert cg.getFloatColor() == (0.5, 0.0, 0.5)
+    assert cg.getFloatColor() == (0.5, 0.5, 0.0)
+    assert cg.getFloatColor() == (0.0, 0.5, 1.0)
+    assert cg.getFloatColor() == (0.0, 1.0, 0.5)
+    assert cg.getFloatColor() == (0.5, 0.5, 0.5)
+    assert cg.getFloatColor() == (0.5, 0.0, 1.0)
+    assert cg.getFloatColor() == (1.0, 0.0, 0.5)
+    assert cg.getFloatColor() == (0.5, 0.5, 1.0)
+    for j in range(1000):
+      result = cg.getFloatColor()
+      assert len(result) == 3
+      assert all(isinstance(x, float) for x in result)
+    cg.reset()


### PR DESCRIPTION
Fixes this error seen in LHCb:

```python
2021-06-14 14:06:29 UTC Framework/Monitoring ERROR: Uncaught exception when serving RPC Function plotView
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/DISET/RequestHandler.py", line 289, in __RPCCallFunction
    uReturnValue = oMethod(*args)
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Service/MonitoringHandler.py", line 170, in export_plotView
    return gServiceInterface.plotView(viewRequest)
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/private/monitoring/ServiceInterface.py", line 408, in plotView
    return self.generatePlots(viewRequest['fromSecs'], viewRequest['toSecs'], viewDefinition, viewRequest['size'])
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/private/monitoring/ServiceInterface.py", line 330, in generatePlots
    return self.__generateGroupPlots(fromSecs, toSecs, viewDescription, size)
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/private/monitoring/ServiceInterface.py", line 263, in __generateGroupPlots
    retVal = self.plotCache.groupPlot(fromSecs, toSecs, groupPlot, viewDescription['stacked'], size)
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/private/monitoring/PlotCache.py", line 99, in groupPlot
    return self.__getGraph(getattr(self.rrdManager, "groupPlot"), args)
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/private/monitoring/PlotCache.py", line 123, in __getGraph
    return plotFunc(graphFilename=graphFile, *args)
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/private/monitoring/RRDManager.py", line 277, in groupPlot
    rrdCmd += " 'AREA:%s#%s:%s:STACK'" % (idActivity, colorGen.getHexColor(),
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py", line 69, in getHexColor
    return "%s%s%s" % (self.__toHex(fC[0]), self.__toHex(fC[1]), self.__toHex(fC[2]))
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py", line 27, in __toHex
    return "%s%s" % (self.sHexDigits[d1], self.sHexDigits[d2])
TypeError: string indices must be integers, not float
2021-06-14 14:06:29 UTC Framework/Monitoring NOTICE: Returning response ([2001:1458:201:e4::100:378]:35058)[lhcb_admin:roma] (0.23 secs) ERROR: Server error while serving plotView: string indices must be
integers, not float
```

Also adds unit tests and avoids pathological behaviour when a large number of colours are generated and the runtime becomes exponential before eventually looping forever.

BEGINRELEASENOTES

*Framework
FIX: Avoid TypeError in ColorGenerator

ENDRELEASENOTES
