### PR TITLE
[v7r2] Fix handling Subprocess calls which produce invalid output

### DIFF
--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -93,5 +93,5 @@ dependencies:
     - git+https://gitlab.cern.ch/cburr/fts-rest.git@python3
     # Doesn't support Python 3.9
     # - rucio-clients >=1.25.6
-    - git+https://github.com/rucio/rucio.git@master
+    - git+https://github.com/rucio/rucio.git@eafde85bfbfe51fb22c7774e2af8deda3fb05e81
     - -e .

--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -19,7 +19,7 @@ dependencies:
   - elasticsearch-dsl
   - future
   - gitpython >=2.1.0
-  - m2crypto >=0.36
+  - m2crypto >=0.36,!=0.38.0
   - matplotlib
   - numpy
   - pexpect >=4.0.1

--- a/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
@@ -78,10 +78,6 @@ def test_decodingCommandOutput():
   assert retVal["Value"] == (0, u"\ufffd\n", "")
 
   sp = Subprocess()
-  retVal = sp.systemCall(r"echo -e -n '\xdf' >&2", shell=True)
+  retVal = sp.systemCall(r"""python -c 'import os; os.fdopen(2, "wb").write(b"\xdf")'""", shell=True)
   assert retVal["OK"]
   assert retVal["Value"] == (0, "", u"\ufffd")
-
-  retVal = sp.systemCall(r"echo -e '\xdf' >&2", shell=True)
-  assert retVal["OK"]
-  assert retVal["Value"] == (0, "", u"\ufffd\n")

--- a/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
@@ -27,7 +27,7 @@ import pytest
 from subprocess import Popen
 
 # SUT
-from DIRAC.Core.Utilities.Subprocess import systemCall, shellCall, pythonCall, getChildrenPIDs
+from DIRAC.Core.Utilities.Subprocess import systemCall, shellCall, pythonCall, getChildrenPIDs, Subprocess
 
 # Mark this entire module as slow
 pytestmark = pytest.mark.slow
@@ -66,3 +66,22 @@ def test_getChildrenPIDs():
     assert isinstance(p, int)
 
   mainProcess.wait()
+
+
+def test_decodingCommandOutput():
+  retVal = systemCall(10, ["echo", "-e", "-n", r"\xdf"])
+  assert retVal["OK"]
+  assert retVal["Value"] == (0, u"\ufffd", "")
+
+  retVal = systemCall(10, ["echo", "-e", r"\xdf"])
+  assert retVal["OK"]
+  assert retVal["Value"] == (0, u"\ufffd\n", "")
+
+  sp = Subprocess()
+  retVal = sp.systemCall(r"echo -e -n '\xdf' >&2", shell=True)
+  assert retVal["OK"]
+  assert retVal["Value"] == (0, "", u"\ufffd")
+
+  retVal = sp.systemCall(r"echo -e '\xdf' >&2", shell=True)
+  assert retVal["OK"]
+  assert retVal["Value"] == (0, "", u"\ufffd\n")


### PR DESCRIPTION
Should fix this error seen in some LHCb jobs by explicitly replacing the bad sequences with the [unicode replacement character](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character). The alternatives would be to:

* explicitly treat this as `bytes` but that will make all calls to subprocess harder
* add a new `text=True` keyword argument is needed like the standard library has but that's going to be quite invasive and that time is probably better spent deprecating DIRAC's `Subprocess` class in favour of the standard library.


```python
2021-06-15 10:54:27 UTC Test_UserJobs/Subprocess [22371007629120] ERROR: SUBPROCESS: readFromFile exception
Traceback (most recent call last):
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/v10r2p3/DIRAC/Core/Utilities/Subprocess.py", line 382, in __readFromFile
    dataString += nB.decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd6 in position 1938: ordinal not in range(128)
2021-06-15 10:54:27 UTC Test_UserJobs/Subprocess [22371007629120] ERROR: Error reading type(nB) =<type 'str'>
2021-06-15 10:54:27 UTC Test_UserJobs/Subprocess [22371007629120] ERROR: Error reading nB =2021-06-15 10:54:27 UTC dirac_jobexec/Subprocess ERROR: SUBPROCESS: readFromFile exception
Traceback (most recent call last):
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/v10r2p3/DIRAC/Core/Utilities/Subprocess.py", line 382, in __readFromFile
    dataString += nB.decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd6 in position 1403: ordinal not in range(128)
2021-06-15 10:54:27 UTC dirac_jobexec/Subprocess ERROR: Error reading type(nB) =<type 'str'>
2021-06-15 10:54:27 UTC dirac_jobexec/Subprocess ERROR: Error reading nB ========================================================================
======       Pre-compound/De-excitation Physics Parameters     ========
=======================================================================
Type of pre-compound inverse x-section              3
Pre-compound model active                           1
Pre-compound excitation low energy (MeV)            0.1
Pre-compound excitation high energy (MeV)           30
Type of de-excitation inverse x-section             3
Type of de-excitation factory                       Evaporation+GEM
Number of de-excitation channels                    68
Min excitation energy (keV)                         0.01
Min energy per nucleon for multifragmentation (MeV) 2e+05
Limit excitation energy for Fermi BreakUp (MeV)     20
Level density (1/MeV)                               0.075
Use simple level density model                      1
Use discrete excitation energy of the residual      0
Time limit for long lived isomeres (ns)             1000
Internal e- conversion flag                         1
Store e- internal conversion data                   0
Electron internal conversion ID                     2
Correlated gamma emission flag                      0
Max 2J for sampling of angular correlations         10
Upload data before 1st event for                Z < 9
=======================================================================
6�x

FAIL

```

BEGINRELEASENOTES

*Core
FIX: Fix handling Subprocess calls which produce invalid output

ENDRELEASENOTES
