### PR TITLE
[v7r2] Remove CPUScalingFactor from DIRAC

### DIFF
--- a/docs/source/DeveloperGuide/CodeTesting/index.rst
+++ b/docs/source/DeveloperGuide/CodeTesting/index.rst
@@ -441,7 +441,6 @@ To run this test, you'll have to add few lines to your local dirac.cfg::
    LocalSite
    {
      Site = DIRAC.mySite.local
-     CPUScalingFactor = 0.0
      #SharedArea = /cvmfs/lhcb.cern.ch/lib
      #LocalArea =/home/some/local/LocalArea
      GridCE = my.CE.local

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_parameters.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_parameters.py
@@ -16,7 +16,6 @@ Example:
   $ dirac-wms-job-parameters 1
   {'CPU(MHz)': '1596.479',
    'CPUNormalizationFactor': '6.8',
-   'CPUScalingFactor': '6.8',
    'CacheSize(kB)': '4096KB',
    'GridCEQueue': 'ce.labmc.inf.utfsm.cl:2119/jobmanager-lcgpbs-prod',
    'HostName': 'wn05.labmc',

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/test/Test_TimeLeft.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/test/Test_TimeLeft.py
@@ -88,8 +88,7 @@ def test_getScaledCPU(mocker, batch, requiredVariables, returnValue, expected):
   res = tl.getScaledCPU()
   assert res == 0
 
-  tl.scaleFactor = 5.0
-  tl.normFactor = 5.0
+  tl.cpuPower = 5.0
 
   batchSystemName = '%sResourceUsage' % batch
   batchSystemPath = 'DIRAC.Resources.Computing.BatchSystems.TimeLeft.%s' % batchSystemName
@@ -133,8 +132,7 @@ def test_getTimeLeft(mocker, batch, requiredVariables, returnValue, expected_1, 
 
   batchStr = 'batchPlugin.%s()' % (batchSystemName)
   tl.batchPlugin = eval(batchStr)
-  tl.scaleFactor = 10.0
-  tl.normFactor = 10.0
+  tl.cpuPower = 10.0
 
   # Update attributes of the batch systems to get scaled CPU
   tl.batchPlugin.__dict__.update(requiredVariables)

--- a/src/DIRAC/Resources/Computing/PoolComputingElement.py
+++ b/src/DIRAC/Resources/Computing/PoolComputingElement.py
@@ -255,5 +255,6 @@ class PoolComputingElement(ComputingElement):
   def shutdown(self):
     """ Wait for all futures (jobs) to complete
     """
-    self.pPool.shutdown()  # blocking
+    if self.pPool:
+      self.pPool.shutdown()  # blocking
     return S_OK(self.taskResults)

--- a/src/DIRAC/WorkloadManagementSystem/Client/test/Test_Client_WorkloadManagementSystem.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/test/Test_Client_WorkloadManagementSystem.py
@@ -54,7 +54,6 @@ class MatcherTestCase(ClientsTestCase):
     resourceDescription = {'Architecture': 'x86_64-slc6',
                            'CEQueue': 'jenkins-queue_not_important',
                            'CPUNormalizationFactor': '9.5',
-                           'CPUScalingFactor': '9.5',
                            'CPUTime': 1080000,
                            'CPUTimeLeft': 5000,
                            'DIRACVersion': 'v8r0p1',

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -252,8 +252,6 @@ class JobWrapper(object):
     parameters.append(('Pilot_Reference', self.ceArgs.get('PilotReference', self.pilotRef)))
     if 'LocalSE' in self.ceArgs:
       parameters.append(('AgentLocalSE', ','.join(self.ceArgs['LocalSE'])))
-    if 'CPUScalingFactor' in self.ceArgs:
-      parameters.append(('CPUScalingFactor', self.ceArgs['CPUScalingFactor']))
     if 'CPUNormalizationFactor' in self.ceArgs:
       parameters.append(('CPUNormalizationFactor', self.ceArgs['CPUNormalizationFactor']))
     if self.boincUserID:

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -104,7 +104,7 @@ class Watchdog(object):
     self.timeLeftUtil = TimeLeft()
     self.timeLeft = 0
     self.littleTimeLeft = False
-    self.scaleFactor = 1.0
+    self.cpuPower = 1.0
     self.processors = processors
 
   #############################################################################
@@ -157,7 +157,7 @@ class Watchdog(object):
     # the self.checkingTime and self.pollingTime are in seconds,
     # thus they need to be multiplied by a large enough factor
     self.fineTimeLeftLimit = gConfig.getValue(self.section + '/TimeLeftLimit', 150 * self.pollingTime)
-    self.scaleFactor = gConfig.getValue('/LocalSite/CPUScalingFactor', 1.0)
+    self.cpuPower = gConfig.getValue('/LocalSite/CPUNormalizationFactor', 1.0)
 
     return S_OK()
 
@@ -866,7 +866,7 @@ class Watchdog(object):
     else:
       wallClock = result['Value']
       summary['WallClockTime(s)'] = wallClock * self.processors
-      summary['ScaledCPUTime(s)'] = wallClock * self.scaleFactor * self.processors
+      summary['ScaledCPUTime(s)'] = wallClock * self.cpuPower * self.processors
 
     self.__reportParameters(summary, 'UsageSummary', True)
     self.currentStats = summary

--- a/tests/Integration/WorkloadManagementSystem/pilot.cfg
+++ b/tests/Integration/WorkloadManagementSystem/pilot.cfg
@@ -11,6 +11,5 @@ LocalSite
   GridCE = jenkins.cern.ch
   CEQueue = jenkins-queue_not_important
   Architecture = x86_64-slc6
-  CPUScalingFactor = 10.0
   CPUNormalizationFactor = 10.0
 }


### PR DESCRIPTION
This PR removes all the calls to `/LocalSite/CPUScalingFactor`, which was related to the deprecated `MJF` system removed in this commit:
https://github.com/DIRACGrid/DIRAC/commit/1d734d7b04c41bcb1fd2d9b1c80531fe1a1c269e

`TimeLeft` was still trying to use `CPUScalingFactor` and was failing because the option does not exist anymore, and thus was not able to provide a right value of the CPU work left.

BEGINRELEASENOTES
*Resources 
FIX: remove CPUScalingFactor calls
*WorkloadManagementSystem
FIX: remove CPUScalingFactor calls

ENDRELEASENOTES
