### PR TITLE
[v7r3] show extremely small values in pie plots

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/PieGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/PieGraph.py
@@ -52,7 +52,7 @@ class PieGraph(PlotBase):
     self.legendData = labels
 
     sx = float(numpy.sum(x))
-    if sx > 1:
+    if sx > 0:
       x = numpy.divide(x, sx)
 
     labels = [l[0] for l in labels]


### PR DESCRIPTION
Before:
<img width="524" alt="Знімок екрана 2021-06-17 о 23 40 22" src="https://user-images.githubusercontent.com/29888335/122475753-cbd65a00-cfcd-11eb-9403-63e2ff849902.png">
After:
<img width="841" alt="Знімок екрана 2021-06-17 о 23 43 44" src="https://user-images.githubusercontent.com/29888335/122476050-4010fd80-cfce-11eb-94aa-51e8c0b54826.png">

The question is do we need to display such small values?

BEGINRELEASENOTES
The plot does not draw a pie for very small values, this correction will display the ratio for values much smaller than one.

*Core
FIX: show extremely small values in pie plots

For examples look into release.notes

ENDRELEASENOTES
