### PR TITLE
[v7r1] registerFile takes 6 arguments

### DIFF
--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -576,6 +576,7 @@ class FileCatalogClientCLI(CLI):
 
     if len(args) != 6:
       print("Command takes 6 arguments, %d given" % len(args))
+      print(self.do_register.__doc__)
       return
 
     path = args[0]

--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -569,9 +569,9 @@ class FileCatalogClientCLI(CLI):
 
         usage: add <lfn> <pfn> <size> <SE> <guid> <Checksum>
 
-        If pfn value is None, it will be assigned en empty string
-        If guid value is None, it will be generated
-        If Checksum value is None, it will be assigned en empty string
+        * If pfn value is None, it will be assigned en empty string
+        * If guid value is None, it will be generated
+        * If Checksum value is None, it will be assigned en empty string
     """
 
     if len(args) != 6:
@@ -590,7 +590,7 @@ class FileCatalogClientCLI(CLI):
     else:
       guid = args[4]
     infoDict['GUID'] = guid
-    infoDict['Checksum'] = args[4] if args[4] != "None" else ""
+    infoDict['Checksum'] = args[5] if args[5] != "None" else ""
 
     fileDict = {}
     fileDict[lfn] = infoDict

--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -71,7 +71,7 @@ class FileCatalogClientCLI(CLI):
     """ Register a record to the File Catalog
 
         usage:
-          register file <lfn> <pfn> <size> <SE> [<guid>]  - register new file record in the catalog
+          register file <lfn> <pfn> <size> <SE> <guid> <Checksum>  - register new file record in the catalog
           register replica <lfn> <pfn> <SE>   - register new replica in the catalog
     """
 

--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -569,9 +569,9 @@ class FileCatalogClientCLI(CLI):
 
         usage: add <lfn> <pfn> <size> <SE> <guid> <Checksum>
 
-        * If pfn value is None, it will be assigned en empty string
+        * If pfn value is None, it will be assigned an empty string
         * If guid value is None, it will be generated
-        * If Checksum value is None, it will be assigned en empty string
+        * If Checksum value is None, it will be assigned an empty string
     """
 
     if len(args) != 6:

--- a/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -565,23 +565,31 @@ class FileCatalogClientCLI(CLI):
     return result
 
   def registerFile(self, args):
-    """ Add a file to the catatlog
+    """ Add a file to the catalog
 
-        usage: add <lfn> <pfn> <size> <SE> [<guid>]
+        usage: add <lfn> <pfn> <size> <SE> <guid> <Checksum>
+
+        If pfn value is None, it will be assigned en empty string
+        If guid value is None, it will be generated
+        If Checksum value is None, it will be assigned en empty string
     """
+
+    if len(args) != 6:
+      print("Command takes 6 arguments, %d given" % len(args))
+      return
 
     path = args[0]
     infoDict = {}
     lfn = self.getPath(path)
-    infoDict['PFN'] = args[1]
+    infoDict['PFN'] = args[1] if args[1] != "None" else ""
     infoDict['Size'] = int(args[2])
     infoDict['SE'] = args[3]
-    if len(args) == 5:
-      guid = args[4]
-    else:
+    if args[4] == "None":
       _status, guid = commands.getstatusoutput('uuidgen')
+    else:
+      guid = args[4]
     infoDict['GUID'] = guid
-    infoDict['Checksum'] = ''
+    infoDict['Checksum'] = args[4] if args[4] != "None" else ""
 
     fileDict = {}
     fileDict[lfn] = infoDict


### PR DESCRIPTION
  Allow register file CLI command to register also Checksum. Addresses #5203  

BEGINRELEASENOTES

*DataManagement
CHANGE: FileCatalogClientCLI register File now takes a fixed number of arguments (6) including Checksum

ENDRELEASENOTES
