### PR TITLE
[v7r2] Handlers to discover extensions of DBs

### DIFF
--- a/src/DIRAC/ProductionSystem/Service/ProductionManagerHandler.py
+++ b/src/DIRAC/ProductionSystem/Service/ProductionManagerHandler.py
@@ -8,10 +8,10 @@ __RCSID__ = "$Id$"
 
 import six
 
-from DIRAC import gLogger, S_OK
+from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
-from DIRAC.ProductionSystem.DB.ProductionDB import ProductionDB
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 
 prodTypes = [six.string_types, int]
 transTypes = [six.string_types, int, list]
@@ -24,7 +24,14 @@ class ProductionManagerHandler(RequestHandler):
     """ Initialization of DB object
     """
 
-    cls.productionDB = ProductionDB()
+    try:
+      result = ObjectLoader().loadObject("ProductionSystem.DB.ProductionDB", "ProductionDB")
+      if not result['OK']:
+        return result
+      cls.productionDB = result['Value']()
+    except RuntimeError as excp:
+      return S_ERROR("Can't connect to DB: %s" % excp)
+
     return S_OK()
 
   ####################################################################

--- a/src/DIRAC/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/src/DIRAC/TransformationSystem/Service/TransformationManagerHandler.py
@@ -9,7 +9,7 @@ import six
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
-from DIRAC.TransformationSystem.DB.TransformationDB import TransformationDB
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 
 transTypes = list(six.string_types) + list(six.integer_types)
@@ -42,7 +42,16 @@ class TransformationManagerHandler(RequestHandler):
   def initializeHandler(cls, serviceInfoDict):
     """ Initialization of DB object
     """
-    cls.transformationDB = TransformationDB()
+
+    try:
+      result = ObjectLoader().loadObject('TransformationSystem.DB.TransformationDB', 'TransformationDB')
+      if not result['OK']:
+        return result
+      cls.transformationDB = result['Value']()
+
+    except RuntimeError as excp:
+      return S_ERROR("Can't connect to TransformationDB: %s" % excp)
+
     return S_OK()
 
   types_getCounters = [six.string_types, list, dict]

--- a/src/DIRAC/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/src/DIRAC/TransformationSystem/Service/TransformationManagerHandler.py
@@ -44,7 +44,7 @@ class TransformationManagerHandler(RequestHandler):
     """
 
     try:
-      result = ObjectLoader().loadObject('TransformationSystem.DB.TransformationDB', 'TransformationDB')
+      result = ObjectLoader().loadObject("TransformationSystem.DB.TransformationDB", "TransformationDB")
       if not result['OK']:
         return result
       cls.transformationDB = result['Value']()

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -18,13 +18,10 @@ from DIRAC.Core.DISET.RequestHandler import RequestHandler
 import DIRAC.Core.Utilities.Time as Time
 from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
 from DIRAC.Core.Utilities.JEncode import strToIntDict
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
 
-from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
-from DIRAC.WorkloadManagementSystem.DB.ElasticJobParametersDB import ElasticJobParametersDB
-from DIRAC.WorkloadManagementSystem.DB.TaskQueueDB import TaskQueueDB
-from DIRAC.WorkloadManagementSystem.DB.JobLoggingDB import JobLoggingDB
 from DIRAC.WorkloadManagementSystem.Service.JobPolicy import JobPolicy, RIGHT_GET_INFO
 
 SUMMARY = []
@@ -38,15 +35,40 @@ class JobMonitoringHandler(RequestHandler):
   def initializeHandler(cls, svcInfoDict):
     """ initialize DBs
     """
-    cls.jobDB = JobDB()
-    cls.jobLoggingDB = JobLoggingDB()
-    cls.taskQueueDB = TaskQueueDB()
+    try:
+      result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
+      if not result['OK']:
+        return result
+      cls.jobDB = result['Value']()
+
+      result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobLoggingDB", "JobLoggingDB")
+      if not result['OK']:
+        return result
+      cls.jobLoggingDB = result['Value']()
+
+      result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.TaskQueueDB", "TaskQueueDB")
+      if not result['OK']:
+        return result
+      cls.taskQueueDB = result['Value']()
+
+    except RuntimeError as excp:
+      return S_ERROR("Can't connect to DB: %s" % excp)
 
     cls.elasticJobParametersDB = None
     useESForJobParametersFlag = Operations().getValue(
-        '/Services/JobMonitoring/useESForJobParametersFlag', False)
+        "/Services/JobMonitoring/useESForJobParametersFlag", False)
     if useESForJobParametersFlag:
-      cls.elasticJobParametersDB = ElasticJobParametersDB()
+
+      try:
+        result = ObjectLoader().loadObject(
+            "WorkloadManagementSystem.DB.ElasticJobParametersDB", "ElasticJobParametersDB"
+        )
+        if not result['OK']:
+          return result
+        cls.elasticJobParametersDB = result['Value']()
+      except RuntimeError as excp:
+        return S_ERROR("Can't connect to DB: %s" % excp)
+
     return S_OK()
 
   def initialize(self):

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -21,10 +21,8 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.Utilities import Time
 from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
-from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
-from DIRAC.WorkloadManagementSystem.DB.ElasticJobParametersDB import ElasticJobParametersDB
-from DIRAC.WorkloadManagementSystem.DB.JobLoggingDB import JobLoggingDB
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
 from DIRAC.Core.Utilities.Decorators import deprecated
 
@@ -36,14 +34,33 @@ class JobStateUpdateHandler(RequestHandler):
     """
     Determines the switching of ElasticSearch and MySQL backends
     """
-    cls.jobDB = JobDB()
-    cls.jobLoggingDB = JobLoggingDB()
+    try:
+      result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
+      if not result['OK']:
+        return result
+      cls.jobDB = result['Value']()
+
+      result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobLoggingDB", "JobLoggingDB")
+      if not result['OK']:
+        return result
+      cls.jobLoggingDB = result['Value']()
+
+    except RuntimeError as excp:
+      return S_ERROR("Can't connect to DB: %s" % excp)
 
     cls.elasticJobParametersDB = None
     useESForJobParametersFlag = Operations().getValue(
         '/Services/JobMonitoring/useESForJobParametersFlag', False)
     if useESForJobParametersFlag:
-      cls.elasticJobParametersDB = ElasticJobParametersDB()
+      try:
+        result = ObjectLoader().loadObject(
+            "WorkloadManagementSystem.DB.ElasticJobParametersDB", "ElasticJobParametersDB"
+        )
+        if not result['OK']:
+          return result
+        cls.elasticJobParametersDB = result['Value']()
+      except RuntimeError as excp:
+        return S_ERROR("Can't connect to DB: %s" % excp)
     return S_OK()
 
   ###########################################################################

--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -11,10 +11,9 @@ import six
 from DIRAC import S_OK, S_ERROR
 
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getSites
-from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
-from DIRAC.WorkloadManagementSystem.DB.ElasticJobParametersDB import ElasticJobParametersDB
 from DIRAC.WorkloadManagementSystem.Service.WMSUtilities import getGridJobOutput
 
 FINAL_STATES = ['Done', 'Aborted', 'Cleared', 'Deleted', 'Stalled']
@@ -26,13 +25,27 @@ class WMSAdministratorHandler(RequestHandler):
   def initializeHandler(cls, svcInfoDict):
     """ WMS AdministratorService initialization
     """
-    cls.jobDB = JobDB()
+    try:
+      result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
+      if not result['OK']:
+        return result
+      cls.jobDB = result['Value']()
+    except RuntimeError as excp:
+      return S_ERROR("Can't connect to DB: %s" % excp)
 
     cls.elasticJobParametersDB = None
     useESForJobParametersFlag = Operations().getValue(
         '/Services/JobMonitoring/useESForJobParametersFlag', False)
     if useESForJobParametersFlag:
-      cls.elasticJobParametersDB = ElasticJobParametersDB()
+      try:
+        result = ObjectLoader().loadObject(
+            "WorkloadManagementSystem.DB.ElasticJobParametersDB", "ElasticJobParametersDB"
+        )
+        if not result['OK']:
+          return result
+        cls.elasticJobParametersDB = result['Value']()
+      except RuntimeError as excp:
+        return S_ERROR("Can't connect to DB: %s" % excp)
 
     return S_OK()
 


### PR DESCRIPTION
This is solution for https://github.com/DIRACGrid/DIRAC/issues/3848 and of real issue that we are facing now in LHCb. I don't love it but I can't find quickly a better solution.

As an explanation of why this is needed: in the process of moving, one day, to tornado-based https services, the global objects (in this case the `TransformationDB` objects) used in the TransformationManagerHandler (DIRAC, and e.g. for LHCb also LHCbDIRAC) were replaced, in v7r2, by class members (see https://github.com/DIRACGrid/DIRAC/issues/4825). This would work normally fine (as python inheritance works...) but services, as coded in DISET, somehow manage to override some of the inheritance rules.

So, what's coded here should possibly be used "everywhere" (but SQLAlchemyDB-based DB modules already have a built-in inheritance).

BEGINRELEASENOTES

*TS
CHANGE: TransformatioManagerHandler discovers extensions of DBs

ENDRELEASENOTES
