### PR TITLE
[v7r2] Tornado: export DIRAC_USE_TORNADO_IOLOOP=Yes in the runsv file

### DIFF
--- a/docs/source/DeveloperGuide/TornadoServices/index.rst
+++ b/docs/source/DeveloperGuide/TornadoServices/index.rst
@@ -167,6 +167,7 @@ Finally, there is no automatic installations script. So just install a CS as you
     #
     #
   -  exec python $DIRAC/DIRAC/Core/scripts/dirac-service.py Configuration/Server --cfg /opt/dirac/pro/etc/Configuration_Server.cfg < /dev/null
+  +  export DIRAC_USE_TORNADO_IOLOOP=Yes
   +  exec tornado-start-CS -ddd
 
 

--- a/src/DIRAC/Core/Tornado/scripts/tornado_start_CS.py
+++ b/src/DIRAC/Core/Tornado/scripts/tornado_start_CS.py
@@ -19,8 +19,13 @@ from DIRAC.Core.Utilities.DIRACScript import DIRACScript
 
 @DIRACScript()
 def main():
-  # Must be defined BEFORE any dirac import
-  os.environ['DIRAC_USE_TORNADO_IOLOOP'] = "True"
+
+  if os.environ.get('DIRAC_USE_TORNADO_IOLOOP', 'false').lower() not in ('yes', 'true'):
+    raise RuntimeError(
+        "DIRAC_USE_TORNADO_IOLOOP is not defined in the environment." + "\n" +
+        "It is necessary to run with Tornado." + "\n" +
+        "https://dirac.readthedocs.io/en/latest/DeveloperGuide/TornadoServices/index.html"
+    )
 
   from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceSection
   from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData

--- a/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
+++ b/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
@@ -19,8 +19,13 @@ from DIRAC.Core.Utilities.DIRACScript import DIRACScript
 
 @DIRACScript()
 def main():
-  # Must be defined BEFORE any dirac import
-  os.environ['DIRAC_USE_TORNADO_IOLOOP'] = "True"
+
+  if os.environ.get('DIRAC_USE_TORNADO_IOLOOP', 'false').lower() not in ('yes', 'true'):
+    raise RuntimeError(
+        "DIRAC_USE_TORNADO_IOLOOP is not defined in the environment." + "\n" +
+        "It is necessary to run with Tornado." + "\n" +
+        "https://dirac.readthedocs.io/en/latest/DeveloperGuide/TornadoServices/index.html"
+    )
 
   from DIRAC import gConfig
   from DIRAC.ConfigurationSystem.Client import PathFinder

--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -2541,6 +2541,7 @@ exec dirac-webapp-run -p < /dev/null
   rcfile=%(bashrc)s
   [ -e $rcfile ] && source $rcfile
   #
+  export DIRAC_USE_TORNADO_IOLOOP=Yes
   exec 2>&1
   #
   #


### PR DESCRIPTION
Addresses https://github.com/DIRACGrid/DIRAC/issues/5223

BEGINRELEASENOTES

*Core
FIX: DIRAC_USE_TORNADO_IOLOOP is set in the runsv file rather than the python starting script (#5223 )

ENDRELEASENOTES
