### PR TITLE
Make make_release.py re-usable for WebAppDIRAC

### DIFF
--- a/.github/workflows/make_release.py
+++ b/.github/workflows/make_release.py
@@ -66,8 +66,4 @@ if __name__ == "__main__":
     if not args.version.startswith("v"):
         raise ValueError('For consistency versions must start with "v"')
 
-    v = Version(args.version)
-    if (v.major, v.minor) < (7, 2):
-        raise NotImplementedError("Only supported for DIRAC 7.2 or later")
-
     make_release(args.version, args.rev, release_notes="")

--- a/.github/workflows/make_release.py
+++ b/.github/workflows/make_release.py
@@ -3,7 +3,6 @@ import argparse
 
 from packaging.version import Version
 import requests
-from uritemplate import expand as uri_expand
 
 
 def make_release(version, commit_hash, release_notes=""):


### PR DESCRIPTION
There is no need for this check as the code doesn't exist in branches prior to v7r2 and without it the same code can be used to automatically deploy the WebAppDIRAC releases to PyPI.