### PR TITLE
[v7r2] Fix submitFile filepath when using a parallel library within SSHCE

### DIFF
--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -589,10 +589,11 @@ class SSHComputingElement(ComputingElement):
 
     inputs = []
     if self.parallelLibrary:
-      # In this case, the executable becomes a dependency of a parallel library script.
+      # In this case, the executable becomes an input of a parallel library script.
       # It needs to be submitted along with the submitFile, which is a parallel library wrapper.
-      inputs.append(submitFile)
-      submitFile = self.parallelLibrary.generateWrapper(submitFile)
+      inputFile = os.path.join(self.executableArea, os.path.basename(submitFile))
+      inputs.append(inputFile)
+      submitFile = self.parallelLibrary.generateWrapper(inputFile)
 
     result = self._submitJobToHost(submitFile, numberOfJobs, inputs=inputs)
     if proxy or self.parallelLibrary:


### PR DESCRIPTION
The path of `submitFile` (pilot wrapper) was related to the DIRAC server and was not changed before being wrapped in the parallel library script, which caused errors during the execution of the pilot wrapper.  

BEGINRELEASENOTES
*Resources
FIX: fix path of the executable file when using a parallel library within SSHCE
ENDRELEASENOTES
