### PR TITLE
[v7r3] Fixes and support for CertifOauth

### DIFF
--- a/src/DIRAC/Core/Base/ExecutorReactor.py
+++ b/src/DIRAC/Core/Base/ExecutorReactor.py
@@ -80,9 +80,9 @@ class ExecutorReactor(object):
 
     def addModule(self, name, exeClass):
       self.__modules[name] = exeClass
-      self.__maxTasks = max(self.__maxTasks, exeClass.ex_getOption("MaxTasks"))
-      self.__reconnectSleep = max(self.__reconnectSleep, exeClass.ex_getOption("ReconnectSleep"))
-      self.__reconnectRetries = max(self.__reconnectRetries, exeClass.ex_getOption("ReconnectRetries"))
+      self.__maxTasks = max(self.__maxTasks, exeClass.ex_getOption("MaxTasks", 0))
+      self.__reconnectSleep = max(self.__reconnectSleep, exeClass.ex_getOption("ReconnectSleep", 0))
+      self.__reconnectRetries = max(self.__reconnectRetries, exeClass.ex_getOption("ReconnectRetries", 0))
       self.__extraArgs[name] = exeClass.ex_getExtraArguments()
 
     def connect(self):

--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -76,6 +76,7 @@ from collections import defaultdict
 import importlib_resources
 import subprocess32 as subprocess
 from diraccfg import CFG
+from prompt_toolkit import prompt
 
 import DIRAC
 from DIRAC import rootPath
@@ -1977,13 +1978,13 @@ exec dirac-webapp-run -p < /dev/null
     Get MySQL passwords from local configuration or prompt
     """
     if not self.mysqlRootPwd:
-      self.mysqlRootPwd = getpass.getpass('MySQL root password: ')
+      self.mysqlRootPwd = prompt(u"MySQL root password: ", is_password=True)
 
     if not self.mysqlPassword:
       # Take it if it is already defined
       self.mysqlPassword = self.localCfg.getOption('/Systems/Databases/Password', '')
     if not self.mysqlPassword:
-      self.mysqlPassword = getpass.getpass('MySQL Dirac password: ')
+      self.mysqlPassword = prompt(u"MySQL Dirac password: ", is_password=True)
 
     return S_OK()
 

--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -192,5 +192,6 @@ def extension_metadata():
       "priority": 0,
       "setups": {
           "DIRAC-Certification": "https://lbcertifdirac70.cern.ch:9135/Configuration/Server",
+          "DIRAC-CertifOauth": "dips://lbcertifdiracoauth.cern.ch:9135/Configuration/Server",
       },
   }


### PR DESCRIPTION
Nothing especially worthy of release notes. The issue in ExecutorReactor is that Python 3 is much less permissive about poorly defined comparisons like `5 > None` and `"Hello" > "world"`:

```python
[dirac@lbcertifdirac70 ~]$ python3
Python 3.8.10 | packaged by conda-forge | (default, May 11 2021, 07:01:05)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> max(12, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: '>' not supported between instances of 'NoneType' and 'int'
>>>
```

```python
[dirac@lbcertifdirac70 ~]$ python2
Python 2.7.5 (default, Nov 16 2020, 22:23:17)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-44)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> max(12, None)
12
```