### PR TITLE
[v7r2] Python 3 hackathon fixes

### DIFF
--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -235,8 +235,9 @@ class ARCComputingElement(ComputingElement):
       self.log.debug("XRSL string submitted : %s" % xrslString)
       self.log.debug("DIRAC stamp for job : %s" % diracStamp)
       # The arc bindings don't accept unicode objects in Python 2 so xrslString must be explicitly cast
-      if not arc.JobDescription_Parse(str(xrslString), jobdescs):
-        self.log.error("Invalid job description")
+      result = arc.JobDescription_Parse(str(xrslString), jobdescs)
+      if not result:
+        self.log.error("Invalid job description", "%r, message=%s" % (xrslString, result.str()))
         break
       # Submit the job
       jobs = arc.JobList()  # filled by the submit process

--- a/src/DIRAC/Resources/Computing/SingularityComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SingularityComputingElement.py
@@ -262,7 +262,7 @@ class SingularityComputingElement(ComputingElement):
     if proxy:
       proxyLoc = os.path.join(tmpDir, "proxy")
       rawfd = os.open(proxyLoc, os.O_WRONLY | os.O_CREAT, 0o600)
-      fd = os.fdopen(rawfd, "w")
+      fd = os.fdopen(rawfd, "wb")
       fd.write(proxy)
       fd.close()
     else:

--- a/src/DIRAC/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -209,7 +209,7 @@ class SandboxStoreClient(object):
 
     if inMemory:
       try:
-        with open(tarFileName, 'r') as tfile:
+        with open(tarFileName, 'rb') as tfile:
           data = tfile.read()
       except IOError as e:
         return S_ERROR('Failed to read the sandbox archive: %s' % repr(e))
@@ -231,7 +231,7 @@ class SandboxStoreClient(object):
 
     try:
       sandboxSize = 0
-      with tarfile.open(name=tarFileName, mode="r") as tf:
+      with tarfile.open(name=tarFileName, mode="rb") as tf:
         for tarinfo in tf:
           tf.extract(tarinfo, path=destinationDir)
           sandboxSize += tarinfo.size


### PR DESCRIPTION
Targetting v7r2 as I think these fixes belong there:


BEGINRELEASENOTES

*WorkloadManagement
FIX: Bytes confusion when using SandboxStoreClient with Python 3

*Resources
FIX: Bytes confusion when using SingularityComputingElement with Python 3

ENDRELEASENOTES
