### PR TITLE
[v7r2] Install rucio from PyPI again

### DIFF
--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -91,7 +91,5 @@ dependencies:
     # fts-rest doesn't support Python 3, this branch changed has just enough to
     # make it importing possible
     - git+https://gitlab.cern.ch/cburr/fts-rest.git@python3
-    # Doesn't support Python 3.9
-    # - rucio-clients >=1.25.6
-    - git+https://github.com/rucio/rucio.git@eafde85bfbfe51fb22c7774e2af8deda3fb05e81
+    - rucio-clients >=1.26.0rc1
     - -e .


### PR DESCRIPTION
It turns out installing from their git repo was an even worse idea than expected as it installs the full server package instead of the client causing https://github.com/DIRACGrid/DIRAC/issues/5250.

Luckily they now have a pre-release so we can make this slightly less hacky.