### PR TITLE
[v7r1] fix syntax query

### DIFF
--- a/AccountingSystem/DB/AccountingDB.py
+++ b/AccountingSystem/DB/AccountingDB.py
@@ -1145,7 +1145,13 @@ class AccountingDB(DB):
     if sqlLinkList:
       cmd += " AND %s" % " AND ".join(sqlLinkList)
     if groupFields:
-      cmd += " GROUP BY %s" % (groupFields[0] % tuple(groupFields[1]))
+      testGroupFields = " %s" % selectFields[0] % tuple(realFieldList)
+      testGroupFieldsList = testGroupFields.split(",")
+      realGroupFields = ()
+      for testGroupFields in testGroupFieldsList:
+        if "sum" not in testGroupFields.lower():
+          realGroupFields += (testGroupFields.strip(),)
+      cmd += " GROUP BY " + ','.join(realGroupFields)
     if orderFields:
       cmd += " ORDER BY %s" % (orderFields[0] % tuple(orderFields[1]))
     self.log.verbose(cmd)

--- a/AccountingSystem/DB/AccountingDB.py
+++ b/AccountingSystem/DB/AccountingDB.py
@@ -1145,13 +1145,16 @@ class AccountingDB(DB):
     if sqlLinkList:
       cmd += " AND %s" % " AND ".join(sqlLinkList)
     if groupFields:
-      testGroupFields = " %s" % selectFields[0] % tuple(realFieldList)
-      testGroupFieldsList = testGroupFields.split(",")
-      realGroupFields = ()
-      for testGroupFields in testGroupFieldsList:
-        if "sum" not in testGroupFields.lower():
-          realGroupFields += (testGroupFields.strip(),)
-      cmd += " GROUP BY " + ','.join(realGroupFields)
+      if len(groupFields[1]) == 1:
+        testGroupFields = " %s" % selectFields[0] % tuple(realFieldList)
+        testGroupFieldsList = testGroupFields.split(",")
+        realGroupFields = ()
+        for testGroupFields in testGroupFieldsList:
+          if "sum" not in testGroupFields.lower():
+            realGroupFields += (testGroupFields.strip(),)
+        cmd += " GROUP BY " + ','.join(realGroupFields)
+      else:
+        cmd += " GROUP BY %s" % (groupFields[0] % tuple(groupFields[1]))
     if orderFields:
       cmd += " ORDER BY %s" % (orderFields[0] % tuple(orderFields[1]))
     self.log.verbose(cmd)


### PR DESCRIPTION
*Accounting
FIX: GROUP BY statement syntax to be compatible with more recent SQL reference (e.g. as used in MariaDB 10.5). This fix is backward compatible.

