### PR TITLE
[v7r3] Use DIRACOS_TARBALL_PATH if specified when running Python 3 integration tests

### DIFF
--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -119,13 +119,17 @@ installSite() {
   echo "==> Started installing"
 
   if [[ "${USE_PYTHON3:-}" == "Yes" ]]; then
-    if [[ -n "${DIRACOSVER:-}" ]] && [[ "${DIRACOSVER}" != "master" ]]; then
-      DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/download/${DIRACOSVER}/DIRACOS-Linux-x86_64.sh"
-    else
-      DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-x86_64.sh"
-    fi
     cd "$SERVERINSTALLDIR"
-    curl -L "${DIRACOS2_URL}" > "installer.sh"
+    if [[ -n "${DIRACOS_TARBALL_PATH:-}" ]]; then
+      cp "${DIRACOS_TARBALL_PATH}" "installer.sh"
+    else
+      if [[ -n "${DIRACOSVER:-}" ]] && [[ "${DIRACOSVER}" != "master" ]]; then
+        DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/download/${DIRACOSVER}/DIRACOS-Linux-x86_64.sh"
+      else
+        DIRACOS2_URL="https://github.com/DIRACGrid/DIRACOS2/releases/latest/download/DIRACOS-Linux-x86_64.sh"
+      fi
+      curl -L "${DIRACOS2_URL}" > "installer.sh"
+    fi
     bash "installer.sh"
     rm "installer.sh"
     echo "source \"$PWD/diracos/diracosrc\"" > "$PWD/bashrc"


### PR DESCRIPTION
Like https://github.com/DIRACGrid/DIRAC/pull/5258/files but for the server installation