### PR TITLE
[v7r1] Fix group by syntax in ReqSummaryWeb

### DIFF
--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -575,7 +575,10 @@ class RequestDB(object):
 
           if key == 'Type':
             summaryQuery = summaryQuery.join(Request.__operations__)\
-                                       .group_by(Request.RequestID, Operation.Type)
+                                       .group_by(Request.RequestID, Request.RequestName,
+                                                 Request.JobID, Request.OwnerDN, Request.OwnerGroup,
+                                                 Request._Status, Request.Error,
+                                                 Request._CreationTime, Request._LastUpdate)
             tableName = 'Operation'
           elif key == 'Status':
             key = '_Status'

--- a/RequestManagementSystem/DB/RequestDB.py
+++ b/RequestManagementSystem/DB/RequestDB.py
@@ -578,7 +578,7 @@ class RequestDB(object):
                                        .group_by(Request.RequestID, Request.RequestName,
                                                  Request.JobID, Request.OwnerDN, Request.OwnerGroup,
                                                  Request._Status, Request.Error,
-                                                 Request._CreationTime, Request._LastUpdate)
+                                                 Request._CreationTime, Request._LastUpdate, Operation.Type)
             tableName = 'Operation'
           elif key == 'Status':
             key = '_Status'


### PR DESCRIPTION
*RequestManagement
FIX: Fix the GROUP BY syntax in the RequestSummaryWeb to be compliant with MariaDB 10.5. The fix is backward compatible with MySQL 5.7
