### PR TITLE
[v7r2] reuse Operations class for other section

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
@@ -70,9 +70,9 @@
     but this works if the object is instantiated by a proxy (and not, e.g., using a server certificate)
 
     You can also specify the main section::
-    
+
       Operations(vo=VOName, mainSection='/mainSectionName').getValue('someSection/someOption')
-    
+
     in this case, the configuration will be searched in the following sections with the name 'mainSectionName'::
 
       mainSectionName/

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
@@ -93,7 +93,7 @@ class Operations(object):
 
       You can also inherit this class to handle another section of the configuration
       by specifying the path to it in the _basePath variable, e.g.::
-      
+
         class SessionData(Operations):
 
           _basePath = '/WebApp'
@@ -102,7 +102,7 @@ class Operations(object):
           def __init__(self, credDict, setup):
             self.__credDict = credDict
             super(SessionData, self).__init__(group=credDict.get("group", ""), setup=setup)
-          
+
           def getTitle(self):
             return self.getValue('title', 'Hello world!')
   """
@@ -130,10 +130,10 @@ class Operations(object):
     # Define the configuration sections that will be merged, e.g.:
     # /Operations, /Operations/<vo>, /Operations/<setup>, /Operations/<vo>/<setup>, etc.
     self.__paths = [self._basePath] if self._useBasePathAsDefault else []
-    self.__paths.append([os.path.join(self._basePath, 'Defaults')])
+    self.__paths.append(os.path.join(self._basePath, 'Defaults'))
     if self._vo:
       self.__paths.append(os.path.join(self._basePath, self._vo))
-      self.__paths.append([os.path.join(self._basePath, self._vo, 'Defaults')])
+      self.__paths.append(os.path.join(self._basePath, self._vo, 'Defaults'))
     if self._setup:
       self.__paths.append(os.path.join(self._basePath, self._setup))
       self.__paths.append(os.path.join(self._basePath, self._vo, self._setup))
@@ -241,11 +241,11 @@ class Operations(object):
 
         :return: str
     """
-    return getOptionPath(instance) or getSectionPath(instance)
+    return self.getOptionPath(instance) or self.getSectionPath(instance)
 
   def getOptionPath(self, option):
     """ Find the CS path for an option
-    
+
         :param str option: path with respect to the WebApp standard path
 
         :return: str
@@ -258,7 +258,7 @@ class Operations(object):
 
   def getSectionPath(self, section):
     """ Find the CS path for an section
-    
+
         :param str section: path with respect to the WebApp standard path
 
         :return: str

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
@@ -71,34 +71,47 @@
 
     You can also specify the main section::
 
-      Operations(vo=VOName, mainSection='/mainSectionName').getValue('someSection/someOption')
+      Operations(vo=myVO, mainSection='/mainSection').getValue('mySection/myOption')
 
-    in this case, the configuration will be searched in the following sections with the name 'mainSectionName'::
+    in this case, the configuration will be searched in the following sections with the name 'mainSection'::
 
-      mainSectionName/
-          someOption = someValue
-          someSection/
-              aSecondOption = aSecondValue
+      DIRAC/
+          Setup = Production
+      mainSection/
+          anotherOption = anotherValue
+          mySection/
+              myOption = myValue
       Operations/
+          Defaults/                       -- this section will not be taken into account
+              ...
           Production/
-              mainSectionName/
-                  someOption = someValueInProduction
-                  someSection/
-                      aSecondOption = aSecondValueInProduction
-          aVOName/
+              mainSection/
+                  anotherOption = anotherValueInProduction
+                  mySection/
+                      myOption = myValueInProduction
+          myVO/
               Defaults/
-                  mainSectionName/
-                      someOption = someValueForVO
-                      someSection/
-                          aSecondOption = aSecondValueForVO
+                  mainSection/
+                      anotherOption = anotherValueForVO
+                      mySection/
+                          notMyOption = someValueForVO
               Production/
-                  mainSectionName/
-                      someOption = someValueInProduction
-                      someSection/
-                          aSecondOption = aSecondValueInProduction
-              Certification/
-                  mainSectionName/
-                      someOption = someValueInCertification
+                  mainSection/
+                      anotherOption = anotherValueInProductionForVO
+                      mySection/
+                          myOption = myValueInProductionForVO
+              Certification/              -- this section will not be considered because Production setup is specified
+                  mainSection/
+                      anotherOption = anotherValueInCertificationForVO
+
+    section option will be merged in the following order::
+
+      /mainSection/mySection/myOption -- set a "myValue" for a myOption
+      /Operations/Production/mainSection/mySection/myOption -- set a "myValueInProduction" for a myOption
+      /Operations/myVO/Defaults/mainSection/mySection/myOption -- myOption is missing here, let's move on
+      /Operations/myVO/Production/mainSection/mySection/myOption -- set a "myValueInProductionForVO" for a myOption
+
+    So the method will return "myValueInProductionForVO".
 
 """
 from __future__ import absolute_import

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
@@ -127,16 +127,25 @@ class Operations(object):
     self._setup = setup or getSetup()
     self._group = group
 
-    # Define the configuration sections that will be merged, e.g.:
-    # /Operations, /Operations/<vo>, /Operations/<setup>, /Operations/<vo>/<setup>, etc.
-    self.__paths = [self._basePath] if self._useBasePathAsDefault else []
+    self.__paths = []
+    # Define the configuration sections that will be merged in the following order:
+    # -> /<base path>/                          (need to set _useBasePathAsDefault)
+    # -> /<base path>/Defaults/
+    # -> /<base path>/<setup>/
+    # -> /<base path>/<vo>/                     (need to set _useBasePathAsDefault)
+    # -> /<base path>/<vo>/Defaults/
+    # -> /<base path>/<vo>/<setup>/
+    if self._useBasePathAsDefault:
+      self.__paths.append(self._basePath)
     self.__paths.append(os.path.join(self._basePath, 'Defaults'))
-    if self._vo:
-      self.__paths.append(os.path.join(self._basePath, self._vo))
-      self.__paths.append(os.path.join(self._basePath, self._vo, 'Defaults'))
     if self._setup:
       self.__paths.append(os.path.join(self._basePath, self._setup))
-      self.__paths.append(os.path.join(self._basePath, self._vo, self._setup))
+    if self._vo:
+      if self._useBasePathAsDefault:
+        self.__paths.append(os.path.join(self._basePath, self._vo))
+      self.__paths.append(os.path.join(self._basePath, self._vo, 'Defaults'))
+      if self._setup:
+        self.__paths.append(os.path.join(self._basePath, self._vo, self._setup))
 
   def _cacheExpired(self):
     """ Cache expired or not

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
@@ -184,23 +184,23 @@ class Operations(object):
 
         :return: bool
     """
-    return self.__cacheVersion != gConfigurationData.getVersion()
+    return Operations.__cacheVersion != gConfigurationData.getVersion()
 
   def __getCFGCache(self):
     """ Get cached CFG
 
         :return: CFG
     """
-    self.__cacheLock.acquire()
+    Operations.__cacheLock.acquire()
     try:
       currentVersion = gConfigurationData.getVersion()
-      if currentVersion != self.__cacheVersion:
-        self.__cache = {}
-        self.__cacheVersion = currentVersion
+      if currentVersion != Operations.__cacheVersion:
+        Operations.__cache = {}
+        Operations.__cacheVersion = currentVersion
 
       cacheKey = (self._vo, self._setup)
-      if cacheKey in self.__cache:
-        return self.__cache[cacheKey]
+      if cacheKey in Operations.__cache:
+        return Operations.__cache[cacheKey]
 
       mergedCFG = CFG()
 
@@ -209,12 +209,12 @@ class Operations(object):
         if pathCFG:
           mergedCFG = mergedCFG.mergeWith(pathCFG)
 
-      self.__cache[cacheKey] = mergedCFG
+      Operations.__cache[cacheKey] = mergedCFG
 
-      return self.__cache[cacheKey]
+      return Operations.__cache[cacheKey]
     finally:
       try:
-        self.__cacheLock.release()
+        Operations.__cacheLock.release()
       except thread.error:
         pass
 

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/test/Test_Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/test/Test_Operations.py
@@ -192,7 +192,7 @@ Operations
         btestOpt = btestOptVal
       }
       specSection
-      { 
+      {
         option = btestVal
         section
         {
@@ -236,7 +236,7 @@ Operations
                                                           'defOpt': 'defOptVal',
                                                           'secOptA': 'defSecOptA',
                                                           'secOptB': 'bproSecOptB'},
-                                              'specSection': {'option': 'bproVal', 
+                                              'specSection': {'option': 'bproVal',
                                                               'section': {'bproOpt': 'bproOptVal',
                                                                           'bdefOpt': 'bdefOptVal',
                                                                           'proOpt': 'proOptVal',
@@ -415,14 +415,11 @@ def test_Operations(mocker, vo, setup, mainSection, cfg, optionPath, sectionPath
 
   mocker.patch('DIRAC.ConfigurationSystem.Client.Helpers.Operations.gConfigurationData.sync', mockSync)
   mocker.patch('DIRAC.ConfigurationSystem.Client.Helpers.Operations.gConfigurationData.mergedCFG', mergedCFG)
-  mocker.patch('DIRAC.ConfigurationSystem.Client.Helpers.Operations.getVOfromProxyGroup', side_effect=mockGetVOfromProxyGroup)
+  mocker.patch('DIRAC.ConfigurationSystem.Client.Helpers.Operations.getVOfromProxyGroup',
+               side_effect=mockGetVOfromProxyGroup)
   mocker.patch('DIRAC.ConfigurationSystem.Client.Helpers.Operations.getSetup', side_effect=mockGetSetup)
 
   oper = Operations(vo=vo, setup=setup, mainSection=mainSection)
-
-  # Print origin result
-  print("(%s, %s, %s, %s," % (("'%s'" % vo) if vo else None, ("'%s'" % setup) if setup else None, ("'%s'" % mainSection) if mainSection else None, oper._getCFG()['Value'].getAsDict()))
-  print("     '%s', '%s')," % (oper.getOptionPath('option'), oper.getSectionPath('section')))
 
   def checkValue(data, path=''):
     # Test getSections

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/test/Test_Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/test/Test_Operations.py
@@ -461,6 +461,6 @@ def test_Operations(ops, vo, setup, mainSection, cfg, optionPath, sectionPath):
 
 def test_expiresCache(ops):
   """ Test cache version """
-  oldVertion = ops.gConfigurationData.getVersion()
+  old = ops.gConfigurationData.getVersion()
   ops.gConfigurationData.generateNewVersion()
-  assert ops.Operations()._cacheExpired(), 'oldVersion(%s), newVersion(%s)' % (oldVertion, ops.gConfigurationData.getVersion())
+  assert ops.Operations()._cacheExpired(), 'old(%s), new(%s)' % (old, ops.gConfigurationData.getVersion())

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/test/Test_Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/test/Test_Operations.py
@@ -1,0 +1,470 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import pytest
+from mock import MagicMock
+
+from diraccfg import CFG
+
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
+
+mockSync = MagicMock()
+mockSync.return_value = 'sync'
+mockGetSetup = MagicMock()
+mockGetSetup.return_value = 'proSetup'
+mockGetVOForGroup = MagicMock()
+mockGetVOForGroup.return_value = 'proSetup'
+mockGetVOfromProxyGroup = MagicMock()
+mockGetVOfromProxyGroup.return_value = {}
+
+mergedCFG = CFG()
+mergedCFG.loadFromBuffer("""
+specSection
+{
+  option = specVal
+  section
+  {
+    secOptA = specSecOptA
+    secOptB = specSecOptB
+  }
+}
+Operations
+{
+  Defaults
+  {
+    option = defVal
+    section
+    {
+      secOptA = defSecOptA
+      secOptB = defSecOptB
+      defOpt = defOptVal
+    }
+    specSection
+    {
+      option = defVal
+      section
+      {
+        secOptB = defSecOptB
+        defOpt = defOptVal
+      }
+    }
+  }
+  proSetup
+  {
+    option = proVal
+    section
+    {
+      secOptB = proSecOptB
+      proOpt = proOptVal
+    }
+    specSection
+    {
+      option = proVal
+      section
+      {
+        secOptB = proSecOptB
+        proOpt = proOptVal
+      }
+    }
+  }
+  testSetup
+  {
+    option = testVal
+    section
+    {
+      secOptB = testSecOptB
+      testOpt = testOptVal
+    }
+    specSection
+    {
+      option = testVal
+      section
+      {
+        secOptB = testSecOptB
+        testOpt = testOptVal
+      }
+    }
+  }
+  aVO
+  {
+    Defaults
+    {
+      option = adefVal
+      section
+      {
+        secOptB = adefSecOptB
+        adefOpt = adefOptVal
+      }
+      specSection
+      {
+        option = adefVal
+        section
+        {
+          secOptB = adefSecOptB
+          adefOpt = adefOptVal
+        }
+      }
+    }
+    proSetup
+    {
+      option = aproVal
+      section
+      {
+        secOptB = aproSecOptB
+        aproOpt = aproOptVal
+      }
+      specSection
+      {
+        option = aproVal
+        section
+        {
+          secOptB = aproSecOptB
+          aproOpt = aproOptVal
+        }
+      }
+    }
+    testSetup
+    {
+      option = atestVal
+      section
+      {
+        secOptB = atestSecOptB
+        atestOpt = atestOptVal
+      }
+      specSection
+      {
+        option = atestVal
+        section
+        {
+          secOptB = atestSecOptB
+          atestOpt = atestOptVal
+        }
+      }
+    }
+  }
+  bVO
+  {
+    Defaults
+    {
+      option = bdefVal
+      section
+      {
+        secOptB = bdefSecOptB
+        bdefOpt = bdefOptVal
+      }
+      specSection
+      {
+        option = bdefVal
+        section
+        {
+          secOptB = bdefSecOptB
+          bdefOpt = bdefOptVal
+        }
+      }
+    }
+    proSetup
+    {
+      option = bproVal
+      section
+      {
+        secOptB = bproSecOptB
+        bproOpt = bproOptVal
+      }
+      specSection
+      {
+        option = bproVal
+        section
+        {
+          secOptB = bproSecOptB
+          bproOpt = bproOptVal
+        }
+      }
+    }
+    testSetup
+    {
+      option = btestVal
+      section
+      {
+        secOptB = btestSecOptB
+        btestOpt = btestOptVal
+      }
+      specSection
+      { 
+        option = btestVal
+        section
+        {
+          secOptB = btestSecOptB
+          btestOpt = btestOptVal
+        }
+      }
+    }
+  }
+}
+""")
+
+
+@pytest.mark.parametrize("vo, setup, mainSection, cfg, optionPath, sectionPath", [
+    (None, None, None, {'option': 'proVal', 'section': {'secOptA': 'defSecOptA',
+                                                        'secOptB': 'proSecOptB',
+                                                        'proOpt': 'proOptVal',
+                                                        'defOpt': 'defOptVal'},
+                                            'specSection': {'option': 'proVal',
+                                                            'section': {'secOptB': 'proSecOptB',
+                                                                        'proOpt': 'proOptVal',
+                                                                        'defOpt': 'defOptVal'}}},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    ('aVO', None, None, {'option': 'aproVal', 'section': {'proOpt': 'proOptVal',
+                                                          'aproOpt': 'aproOptVal',
+                                                          'adefOpt': 'adefOptVal',
+                                                          'defOpt': 'defOptVal',
+                                                          'secOptA': 'defSecOptA',
+                                                          'secOptB': 'aproSecOptB'},
+                                              'specSection': {'option': 'aproVal',
+                                                              'section': {'proOpt': 'proOptVal',
+                                                                          'secOptB': 'aproSecOptB',
+                                                                          'proOpt': 'proOptVal',
+                                                                          'aproOpt': 'aproOptVal',
+                                                                          'adefOpt': 'adefOptVal',
+                                                                          'defOpt': 'defOptVal'}}},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    ('bVO', None, None, {'option': 'bproVal', 'section': {'bproOpt': 'bproOptVal',
+                                                          'bdefOpt': 'bdefOptVal',
+                                                          'proOpt': 'proOptVal',
+                                                          'defOpt': 'defOptVal',
+                                                          'secOptA': 'defSecOptA',
+                                                          'secOptB': 'bproSecOptB'},
+                                              'specSection': {'option': 'bproVal', 
+                                                              'section': {'bproOpt': 'bproOptVal',
+                                                                          'bdefOpt': 'bdefOptVal',
+                                                                          'proOpt': 'proOptVal',
+                                                                          'defOpt': 'defOptVal',
+                                                                          'secOptB': 'bproSecOptB'}}},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    ('aVO', 'proSetup', None, {'option': 'aproVal', 'section': {'proOpt': 'proOptVal',
+                                                                'aproOpt': 'aproOptVal',
+                                                                'adefOpt': 'adefOptVal',
+                                                                'defOpt': 'defOptVal',
+                                                                'secOptA': 'defSecOptA',
+                                                                'secOptB': 'aproSecOptB'},
+                                                    'specSection': {'option': 'aproVal',
+                                                                    'section': {'proOpt': 'proOptVal',
+                                                                                'aproOpt': 'aproOptVal',
+                                                                                'adefOpt': 'adefOptVal',
+                                                                                'defOpt': 'defOptVal',
+                                                                                'secOptB': 'aproSecOptB'}}},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    ('aVO', 'testSetup', None, {'option': 'atestVal', 'section': {'atestOpt': 'atestOptVal',
+                                                                  'testOpt': 'testOptVal',
+                                                                  'adefOpt': 'adefOptVal',
+                                                                  'defOpt': 'defOptVal',
+                                                                  'secOptA': 'defSecOptA',
+                                                                  'secOptB': 'atestSecOptB'},
+                                                      'specSection': {'option': 'atestVal',
+                                                                      'section': {'atestOpt': 'atestOptVal',
+                                                                                  'testOpt': 'testOptVal',
+                                                                                  'adefOpt': 'adefOptVal',
+                                                                                  'defOpt': 'defOptVal',
+                                                                                  'secOptB': 'atestSecOptB'}}},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    ('bVO', 'proSetup', None, {'option': 'bproVal', 'section': {'bproOpt': 'bproOptVal',
+                                                                'bdefOpt': 'bdefOptVal',
+                                                                'proOpt': 'proOptVal',
+                                                                'defOpt': 'defOptVal',
+                                                                'secOptA': 'defSecOptA',
+                                                                'secOptB': 'bproSecOptB'},
+                                                    'specSection': {'option': 'bproVal',
+                                                                    'section': {'bproOpt': 'bproOptVal',
+                                                                                'bdefOpt': 'bdefOptVal',
+                                                                                'proOpt': 'proOptVal',
+                                                                                'defOpt': 'defOptVal',
+                                                                                'secOptB': 'bproSecOptB'}}},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    ('bVO', 'testSetup', None, {'option': 'btestVal', 'section': {'testOpt': 'testOptVal',
+                                                                  'bdefOpt': 'bdefOptVal',
+                                                                  'btestOpt': 'btestOptVal',
+                                                                  'defOpt': 'defOptVal',
+                                                                  'secOptA': 'defSecOptA',
+                                                                  'secOptB': 'btestSecOptB'},
+                                                      'specSection': {'option': 'btestVal',
+                                                                      'section': {'testOpt': 'testOptVal',
+                                                                                  'bdefOpt': 'bdefOptVal',
+                                                                                  'btestOpt': 'btestOptVal',
+                                                                                  'defOpt': 'defOptVal',
+                                                                                  'secOptB': 'btestSecOptB'}}},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    (None, 'proSetup', None, {'option': 'proVal', 'section': {'defOpt': 'defOptVal',
+                                                              'secOptA': 'defSecOptA',
+                                                              'proOpt': 'proOptVal',
+                                                              'secOptB': 'proSecOptB'},
+                                                  'specSection': {'option': 'proVal',
+                                                                  'section': {'defOpt': 'defOptVal',
+                                                                              'proOpt': 'proOptVal',
+                                                                              'secOptB': 'proSecOptB'}}},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    (None, 'testSetup', None, {'option': 'testVal', 'section': {'testOpt': 'testOptVal',
+                                                                'defOpt': 'defOptVal',
+                                                                'secOptA': 'defSecOptA',
+                                                                'secOptB': 'testSecOptB'},
+                                                    'specSection': {'option': 'testVal',
+                                                                    'section': {'testOpt': 'testOptVal',
+                                                                                'defOpt': 'defOptVal',
+                                                                                'secOptB': 'testSecOptB'}}},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+
+    # Test specSection
+    ('notExist', None, None, {'specSection': {'section': {'defOpt': 'defOptVal',
+                                                          'proOpt': 'proOptVal',
+                                                          'secOptB': 'proSecOptB'},
+                                              'option': 'proVal'},
+                              'section': {'defOpt': 'defOptVal',
+                                          'secOptA': 'defSecOptA',
+                                          'proOpt': 'proOptVal',
+                                          'secOptB': 'proSecOptB'},
+                              'option': 'proVal'},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    (None, 'notExist', None, {'specSection': {'section': {'defOpt': 'defOptVal',
+                                                          'secOptB': 'defSecOptB'},
+                                              'option': 'defVal'},
+                              'section': {'defOpt': 'defOptVal',
+                                          'secOptA': 'defSecOptA',
+                                          'secOptB': 'defSecOptB'},
+                              'option': 'defVal'},
+     '/Operations/Defaults/option', '/Operations/Defaults/section'),
+    (None, None, 'specSection', {'section': {'secOptA': 'specSecOptA',
+                                             'proOpt': 'proOptVal',
+                                             'secOptB': 'proSecOptB'},
+                                 'option': 'proVal'},
+     '/specSection/option', '/specSection/section'),
+    ('aVO', None, 'specSection', {'section': {'aproOpt': 'aproOptVal',
+                                              'secOptA': 'specSecOptA',
+                                              'adefOpt': 'adefOptVal',
+                                              'proOpt': 'proOptVal',
+                                              'secOptB': 'aproSecOptB'},
+                                  'option': 'aproVal'},
+     '/specSection/option', '/specSection/section'),
+    ('aVO', 'proSetup', 'specSection', {'section': {'aproOpt': 'aproOptVal',
+                                                    'secOptA': 'specSecOptA',
+                                                    'adefOpt': 'adefOptVal',
+                                                    'proOpt': 'proOptVal',
+                                                    'secOptB': 'aproSecOptB'},
+                                        'option': 'aproVal'},
+     '/specSection/option', '/specSection/section'),
+    ('aVO', 'testSetup', 'specSection', {'section': {'testOpt': 'testOptVal',
+                                                     'atestOpt': 'atestOptVal',
+                                                     'secOptA': 'specSecOptA',
+                                                     'adefOpt': 'adefOptVal',
+                                                     'secOptB': 'atestSecOptB'},
+                                         'option': 'atestVal'},
+     '/specSection/option', '/specSection/section'),
+    ('aVO', 'notExist', 'specSection', {'section': {'secOptA': 'specSecOptA',
+                                                    'adefOpt': 'adefOptVal',
+                                                    'secOptB': 'adefSecOptB'},
+                                        'option': 'adefVal'},
+     '/specSection/option', '/specSection/section'),
+    ('bVO', None, 'specSection', {'section': {'bdefOpt': 'bdefOptVal',
+                                              'bproOpt': 'bproOptVal',
+                                              'secOptA': 'specSecOptA',
+                                              'proOpt': 'proOptVal',
+                                              'secOptB': 'bproSecOptB'},
+                                  'option': 'bproVal'},
+     '/specSection/option', '/specSection/section'),
+    ('bVO', 'proSetup', 'specSection', {'section': {'bdefOpt': 'bdefOptVal',
+                                                    'bproOpt': 'bproOptVal',
+                                                    'secOptA': 'specSecOptA',
+                                                    'proOpt': 'proOptVal',
+                                                    'secOptB': 'bproSecOptB'},
+                                        'option': 'bproVal'},
+     '/specSection/option', '/specSection/section'),
+    ('bVO', 'testSetup', 'specSection', {'section': {'testOpt': 'testOptVal',
+                                                     'bdefOpt': 'bdefOptVal',
+                                                     'secOptA': 'specSecOptA',
+                                                     'btestOpt': 'btestOptVal',
+                                                     'secOptB': 'btestSecOptB'},
+                                         'option': 'btestVal'},
+     '/specSection/option', '/specSection/section'),
+    ('bVO', 'notExist', 'specSection', {'section': {'bdefOpt': 'bdefOptVal',
+                                                    'secOptA': 'specSecOptA',
+                                                    'secOptB': 'bdefSecOptB'},
+                                        'option': 'bdefVal'},
+     '/specSection/option', '/specSection/section'),
+    (None, 'proSetup', 'specSection', {'section': {'secOptA': 'specSecOptA',
+                                                   'proOpt': 'proOptVal',
+                                                   'secOptB': 'proSecOptB'},
+                                       'option': 'proVal'},
+     '/specSection/option', '/specSection/section'),
+    (None, 'testSetup', 'specSection', {'section': {'testOpt': 'testOptVal',
+                                                    'secOptA': 'specSecOptA',
+                                                    'secOptB': 'testSecOptB'},
+                                        'option': 'testVal'},
+     '/specSection/option', '/specSection/section'),
+    (None, 'notExist', 'specSection', {'section': {'secOptA': 'specSecOptA',
+                                                   'secOptB': 'specSecOptB'},
+                                       'option': 'specVal'},
+     '/specSection/option', '/specSection/section'),
+    ('notExist', 'notExist', 'specSection', {'section': {'secOptA': 'specSecOptA',
+                                                         'secOptB': 'specSecOptB'},
+                                             'option': 'specVal'},
+     '/specSection/option', '/specSection/section'),
+    (None, None, 'notExist', {}, '', ''),
+
+])
+def test_Operations(mocker, vo, setup, mainSection, cfg, optionPath, sectionPath):
+
+  mocker.patch('DIRAC.ConfigurationSystem.Client.Helpers.Operations.gConfigurationData.sync', mockSync)
+  mocker.patch('DIRAC.ConfigurationSystem.Client.Helpers.Operations.gConfigurationData.mergedCFG', mergedCFG)
+  mocker.patch('DIRAC.ConfigurationSystem.Client.Helpers.Operations.getVOfromProxyGroup', side_effect=mockGetVOfromProxyGroup)
+  mocker.patch('DIRAC.ConfigurationSystem.Client.Helpers.Operations.getSetup', side_effect=mockGetSetup)
+
+  oper = Operations(vo=vo, setup=setup, mainSection=mainSection)
+
+  # Print origin result
+  print("(%s, %s, %s, %s," % (("'%s'" % vo) if vo else None, ("'%s'" % setup) if setup else None, ("'%s'" % mainSection) if mainSection else None, oper._getCFG()['Value'].getAsDict()))
+  print("     '%s', '%s')," % (oper.getOptionPath('option'), oper.getSectionPath('section')))
+
+  def checkValue(data, path=''):
+    # Test getSections
+    result = oper.getSections(path)
+    assert result['OK'], result['Message']
+    assert set(result['Value']) == set([k for k in data if isinstance(data[k], dict)])
+
+    # Test getOptions
+    result = oper.getOptions(path)
+    assert result['OK'], result['Message']
+    assert set(result['Value']) == set([k for k in data if not isinstance(data[k], dict)])
+
+    # Test getOptionsDict
+    result = oper.getOptionsDict(path)
+    assert result['OK'], result['Message']
+    assert result['Value'] == {k: data[k] for k in data if not isinstance(data[k], dict)}
+
+    for key in data:
+
+      if isinstance(data[key], dict):
+        # Check next section
+        checkValue(data[key], os.path.join(path, key))
+
+      else:
+        # Test getValue
+        assert oper.getValue(os.path.join(path, key)) == data[key]
+
+  checkValue(cfg)
+
+  # getPath
+  assert oper.getPath('option') == optionPath
+  assert oper.getPath('section') == sectionPath
+
+  # getOptionPath
+  assert oper.getOptionPath('option') == optionPath
+
+  # getSectionPath
+  assert oper.getSectionPath('section') == sectionPath
+
+
+def test_expiresCache():
+
+  oldVertion = gConfigurationData.getVersion()
+  gConfigurationData.generateNewVersion()
+  assert Operations()._cacheExpired(), 'oldVersion(%s), newVersion(%s)' % (oldVertion, gConfigurationData.getVersion())

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -16,6 +16,7 @@ pytest "${THIS_DIR}/AccountingSystem/Test_Plots.py" |& tee -a "${SERVER_TEST_OUT
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Configuration TESTS ****\n"
 pytest "${THIS_DIR}/ConfigurationSystem/Test_Helpers.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/ConfigurationSystem/Test_Operations.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Core TESTS ****\n"

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -16,7 +16,6 @@ pytest "${THIS_DIR}/AccountingSystem/Test_Plots.py" |& tee -a "${SERVER_TEST_OUT
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Configuration TESTS ****\n"
 pytest "${THIS_DIR}/ConfigurationSystem/Test_Helpers.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-pytest "${THIS_DIR}/ConfigurationSystem/Test_Operations.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Core TESTS ****\n"


### PR DESCRIPTION
BEGINRELEASENOTES
This small modification makes it possible to use the search logic in setups and VO paths that realised in the `Operations` for helper classes of other sections.

*Configuration
CHANGE: add possibility to reuse Operations class for other section

ENDRELEASENOTES
