### PR TITLE
[v7r2] Support datetime.date objects in JEncode

### DIFF
--- a/src/DIRAC/Core/Utilities/JEncode.py
+++ b/src/DIRAC/Core/Utilities/JEncode.py
@@ -11,6 +11,7 @@ import json
 # Describes the way date time will be transmetted
 # We do not keep miliseconds
 DATETIME_DEFAULT_FORMAT = '%Y-%m-%d %H:%M:%S'
+DATETIME_DEFAULT_DATE_FORMAT = '%Y-%m-%d'
 
 
 class JSerializable(object):
@@ -99,6 +100,8 @@ class DJSONEncoder(json.JSONEncoder):
     # If we have a datetime object, dumps its string representation
     if isinstance(obj, datetime.datetime):
       return {'__dCls': 'dt', 'obj': obj.strftime(DATETIME_DEFAULT_FORMAT)}
+    elif isinstance(obj, datetime.date):
+      return {'__dCls': 'date', 'obj': obj.strftime(DATETIME_DEFAULT_DATE_FORMAT)}
     # if the object inherits from JSJerializable, try to serialize it
     elif isinstance(obj, JSerializable):
       return obj._toJSON()  # pylint: disable=protected-access
@@ -136,6 +139,8 @@ class DJSONDecoder(json.JSONDecoder):
     # If the class is of type dt (datetime)
     if className == 'dt':
       return datetime.datetime.strptime(dataDict['obj'], DATETIME_DEFAULT_FORMAT)
+    elif className == 'date':
+      return datetime.datetime.strptime(dataDict['obj'], DATETIME_DEFAULT_DATE_FORMAT).date()
     elif className:
       import importlib
 

--- a/src/DIRAC/Core/Utilities/test/Test_Encode.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Encode.py
@@ -21,7 +21,7 @@ from DIRAC.Core.Utilities.MixedEncode import encode as mixEncode, decode as mixD
 
 from hypothesis import given, settings, HealthCheck
 from hypothesis.strategies import builds, integers, lists, recursive, floats, text,\
-    booleans, none, dictionaries, tuples, datetimes
+    booleans, none, dictionaries, tuples, dates, datetimes
 import six
 from pytest import mark, approx, raises, fixture, skip
 parametrize = mark.parametrize
@@ -55,6 +55,17 @@ enc_dec_ids_without_json = (
     'mixTuple (DIRAC_USE_JSON_DECODE=Yes)')
 
 
+def myDates():
+  """We define a custom date strategy in order
+     to pull date after 1900 (limitation of strftime)
+     and without microseconds
+  """
+  return dates(
+      min_value=datetime.datetime(1900, 1, 1, 0, 0).date(),
+      max_value=datetime.datetime.max.date(),
+  )
+
+
 def myDatetimes():
   """We define a custom datetime strategy in order
      to pull date after 1900 (limitation of strftime)
@@ -73,8 +84,8 @@ def myDatetimes():
 # are not stable, the result is approximative, and it becomes extremely difficult
 # to compare
 # Datetime also starts only at 1900 because earlier date can't be dumped with strftime
-initialStrategies = none() | booleans() | text() | integers() | myDatetimes()
-initialJsonStrategies = none() | booleans() | text() | myDatetimes()
+initialStrategies = none() | booleans() | text() | integers() | myDatetimes() | myDates()
+initialJsonStrategies = none() | booleans() | text() | myDatetimes() | myDates()
 
 
 # From a strategy (x), make a new strategy
@@ -161,10 +172,16 @@ def test_BaseType_Bool(enc_dec, data):
 
 
 @settings(suppress_health_check=function_scoped)
+@given(data=myDates())
+def test_BaseType_Dates(enc_dec, data):
+  """ Test for date"""
+  agnosticTestFunction(enc_dec, data)
+
+
+@settings(suppress_health_check=function_scoped)
 @given(data=myDatetimes())
 def test_BaseType_DateTime(enc_dec, data):
-  """ Test for data time"""
-
+  """ Test for datetime"""
   agnosticTestFunction(enc_dec, data)
 
 


### PR DESCRIPTION
In LHCbDIRAC's ProductionManagementSystem `datetime.date` objects are used quite a bit but JEncode fails to handle them.

BEGINRELEASENOTES

*Core
NEW: Support datetime.date objects in JEncode

ENDRELEASENOTES
