### PR TITLE
[v7r2] Fix TypeError in dirac-wms-pilot-job-info

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_pilot_job_info.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_pilot_job_info.py
@@ -73,7 +73,7 @@ def main():
               totCPU += float(params['TotalCPUTime(s)'])
               totWall += float(params['WallClockTime(s)'])
               params['CPUEfficiency'] = '%s %%' % (
-                  100. * params['TotalCPUTime(s)'] / params['WallClockTime(s)'])
+                  100. * float(params['TotalCPUTime(s)']) / float(params['WallClockTime(s)']))
             for i, par in parameters:
               for param in [p for p in _stringInList(str(par), str(params))
                             if not _stringInList(str(p), str(result[jobID]))]:


### PR DESCRIPTION
```python
bash-4.2$ dirac-wms-pilot-job-info gsiftp://calc2.t1.grid.kiae.ru:2811/jobs/2v4MDmcf3LzngXGZXoMFMvcqYUz0ymWKy3zmSlHKDmABFKDmF1GXIo
Traceback (most recent call last):
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v10.2.3-x86_64-1623745062/bin/dirac-wms-pilot-job-info", line 8, in <module>
    sys.exit(main())
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v10.2.3-x86_64-1623745062/lib/python3.9/site-packages/DIRAC/Core/Utilities/DIRACScript.py", line 77, in __call__
    return entrypoint.load()._func()
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v10.2.3-x86_64-1623745062/lib/python3.9/site-packages/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_pilot_job_info.py", line 76, in main
    100. * params['TotalCPUTime(s)'] / params['WallClockTime(s)'])
TypeError: can't multiply sequence by non-int of type 'float'
```

BEGINRELEASENOTES

*WorkloadManagement
FIX: TypeError when running dirac-wms-pilot-job-info

ENDRELEASENOTES
