### PR TITLE
[v7r2] Optimisation for Transformation system queries

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -456,17 +456,17 @@ class MySQL(object):
     except Exception:
       return False
 
-  def __escapeString(self, myString):
+  def __escapeString(self, myString, connection=None):
     """
     To be used for escaping any MySQL string before passing it to the DB
     this should prevent passing non-MySQL accepted characters to the DB
     It also includes quotation marks " around the given string
     """
-
-    retDict = self._getConnection()
-    if not retDict['OK']:
-      return retDict
-    connection = retDict['Value']
+    if connection is None:
+      retDict = self._getConnection()
+      if not retDict['OK']:
+        return retDict
+      connection = retDict['Value']
 
     try:
       myString = str(myString)
@@ -538,6 +538,10 @@ class MySQL(object):
     Escapes all strings in the list of values provided
     """
     # self.log.debug('_escapeValues:', inValues)
+    retDict = self._getConnection()
+    if not retDict['OK']:
+      return retDict
+    connection = retDict['Value']
 
     inEscapeValues = []
 
@@ -546,14 +550,14 @@ class MySQL(object):
 
     for value in inValues:
       if isinstance(value, six.string_types):
-        retDict = self.__escapeString(value)
+        retDict = self.__escapeString(value, connection=connection)
         if not retDict['OK']:
           return retDict
         inEscapeValues.append(retDict['Value'])
       elif isinstance(value, (tuple, list)):
         tupleValues = []
         for val in value:
-          retDict = self.__escapeString(val)
+          retDict = self.__escapeString(val, connection=connection)
           if not retDict['OK']:
             return retDict
           tupleValues.append(retDict['Value'])
@@ -561,7 +565,7 @@ class MySQL(object):
       elif isinstance(value, bool):
         inEscapeValues = [str(value)]
       else:
-        retDict = self.__escapeString(str(value))
+        retDict = self.__escapeString(str(value), connection=connection)
         if not retDict['OK']:
           return retDict
         inEscapeValues.append(retDict['Value'])

--- a/src/DIRAC/TransformationSystem/Client/TransformationClient.py
+++ b/src/DIRAC/TransformationSystem/Client/TransformationClient.py
@@ -96,7 +96,7 @@ class TransformationClient(Client):
                                        body, maxTasks, eventsPerTask, addFiles, inputMetaQuery, outputMetaQuery)
 
   def getTransformations(self, condDict=None, older=None, newer=None, timeStamp=None,
-                         orderAttribute=None, limit=100, extraParams=False):
+                         orderAttribute=None, limit=100, extraParams=False, columns=None):
     """ gets all the transformations in the system, incrementally. "limit" here is just used to determine the offset.
     """
     rpcClient = self._getRPC()
@@ -110,7 +110,7 @@ class TransformationClient(Client):
     offsetToApply = 0
     while True:
       res = rpcClient.getTransformations(condDict, older, newer, timeStamp, orderAttribute, limit,
-                                         extraParams, offsetToApply)
+                                         extraParams, offsetToApply, columns)
       if not res['OK']:
         return res
       else:

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.sql
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.sql
@@ -43,7 +43,8 @@ CREATE TABLE Transformations(
     MaxNumberOfTasks INT NOT NULL DEFAULT 0,
     EventsPerTask INT NOT NULL DEFAULT 0,
     PRIMARY KEY(TransformationID),
-    INDEX(TransformationName)
+    INDEX(TransformationName),
+    INDEX(TransformationFamily)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
 -- -------------------------------------------------------------------------------
@@ -94,6 +95,7 @@ CREATE TABLE TransformationTasks(
     LastUpdateTime DATETIME NOT NULL,
     PRIMARY KEY(TransformationID, TaskID),
     INDEX(ExternalStatus),
+    INDEX(TransformationID,ExternalStatus),
     FOREIGN KEY(TransformationID) REFERENCES Transformations(TransformationID)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
@@ -117,6 +119,7 @@ CREATE TABLE TransformationFiles(
     INDEX(TransformationID),
     INDEX(Status),
     INDEX(FileID),
+    INDEX(TransformationID,Status),
     FOREIGN KEY(TransformationID) REFERENCES Transformations(TransformationID),
     FOREIGN KEY(FileID) REFERENCES DataFiles(FileID)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;

--- a/src/DIRAC/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/src/DIRAC/TransformationSystem/Service/TransformationManagerHandler.py
@@ -141,7 +141,8 @@ class TransformationManagerHandler(RequestHandler):
 
   @classmethod
   def export_getTransformations(cls, condDict=None, older=None, newer=None, timeStamp='CreationDate',
-                                orderAttribute=None, limit=None, extraParams=False, offset=None):
+                                orderAttribute=None, limit=None, extraParams=False, offset=None,
+                                columns=None):
     if not condDict:
       condDict = {}
     return cls.transformationDB.getTransformations(
@@ -152,7 +153,9 @@ class TransformationManagerHandler(RequestHandler):
         orderAttribute=orderAttribute,
         limit=limit,
         extraParams=extraParams,
-        offset=offset)
+        offset=offset,
+        columns=columns,
+    )
 
   types_getTransformation = [transTypes]
 


### PR DESCRIPTION
The three commits are worth viewing separately as they're three separate improvements:
* 48bdcf3: Add indices which make several queries considerably faster
* bba7880: When escaping a long list of values the database is pinged for every element by `MySQL._getConnection` making queries like `TransformationID is in (1,2,3,4,5,6,7,8,9,10)` unnecessarily slow from all the round trips to the database
* af2560a: Add `columns` argument to `TransformationClient.getTransformations` which is primarily useful for avoiding the download of hundred of megabytes of XML in the `Body` column when getting lots of transformations.


BEGINRELEASENOTES

*Core
FIX: Avoid pinging the database every time MySQL.__escapeString is called

*Transformation
NEW: Add columns keyword argument to TransformationClient.getTransformations
NEW: Add index on (TransformationID,Status) in TransformationFiles table
NEW: Add index on (TransformationID,ExternalStatus) in TransformationTasks table
NEW: Add index on (TransformationFamily) in Transformations table

ENDRELEASENOTES
