### PR TITLE
[v7r2] fix RefresherBase log

### DIFF
--- a/src/DIRAC/ConfigurationSystem/private/RefresherBase.py
+++ b/src/DIRAC/ConfigurationSystem/private/RefresherBase.py
@@ -20,7 +20,7 @@ def _updateFromRemoteLocation(serviceClient):
   """
     Refresh the configuration
   """
-  gLogger.debug("", "Trying to refresh from %s" % serviceClient.serviceURL)
+  gLogger.debug("", "Trying to refresh from %s" % serviceClient.serverURL)
   localVersion = gConfigurationData.getVersion()
   retVal = serviceClient.getCompressedDataIfNewer(localVersion)
   if retVal['OK']:


### PR DESCRIPTION

BEGINRELEASENOTES
`DIRAC.Core.Base.Client.Client` has no ``serviceURL`` attribute, so log print:
```
Trying to refresh from functools.partial(<bound method Client.executeRPC of <DIRAC.ConfigurationSystem.Client.ConfigurationClient.ConfigurationClient object at 0x7f9b7f147d00>>, call='serviceURL')
```

*Configuration
FIX: fix RefresherBase log

ENDRELEASENOTES
