### PR TITLE
[v7r2] TS: add a status check before updating it

### DIFF
--- a/src/DIRAC/TransformationSystem/Client/TransformationClient.py
+++ b/src/DIRAC/TransformationSystem/Client/TransformationClient.py
@@ -7,7 +7,7 @@ __RCSID__ = "$Id$"
 
 import six
 
-from DIRAC import S_OK, gLogger
+from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
@@ -457,8 +457,10 @@ class TransformationClient(Client):
 
     return newStatuses
 
-  def setTransformationParameter(self, transID, paramName, paramValue, force=False):
+  def setTransformationParameter(self, transID, paramName, paramValue, force=False, currentStatus=None):
     """ Sets a transformation parameter. There's a special case when coming to setting the status of a transformation.
+
+        :param currentStatus: if set, make sure the status did not change in the DB before setting it
     """
     rpcClient = self._getRPC()
 
@@ -474,6 +476,9 @@ class TransformationClient(Client):
       if not originalStatus['OK']:
         return originalStatus
       originalStatus = originalStatus['Value']
+
+      if currentStatus and currentStatus != originalStatus:
+        return S_ERROR("Status changed in the DB: %s" % originalStatus)
 
       transIDAsDict = {transID: [originalStatus, transformationType]}
       dictOfProposedstatus = {transID: paramValue}

--- a/tests/Integration/TransformationSystem/Test_Client_Transformation.py
+++ b/tests/Integration/TransformationSystem/Test_Client_Transformation.py
@@ -281,6 +281,12 @@ class TransformationClientChain(TestClientTransformationTestCase):
     self.assertTrue(res['OK'])
     self.assertAlmostEqual(len(res['Value']), 4)
 
+    # Prevent race condition
+    res = self.transClient.setTransformationParameter(transID, 'Status', 'Idle', currentStatus='NotWhatItShouldBe')
+    self.assertFalse(res['OK'])
+    res = self.transClient.setTransformationParameter(transID, 'Status', 'Idle', currentStatus='Active')
+    self.assertTrue(res['OK'])
+
     # delete it in the end
     self.transClient.cleanTransformation(transID)
     self.transClient.deleteTransformation(transID)


### PR DESCRIPTION
This prevents a race condition when the status known to an agent is not what is in the DB anymore.
Unfortunately, this only decreases the likelihood of the race condition. A real fix would be to change this whole method at the DB level and add the known status as a selection criteria. But that's a lot more work 



BEGINRELEASENOTES

*TS
NEW: add currentStatus parameter to TransformationClient.setTransformationParameter


ENDRELEASENOTES
