### PR TITLE
[v7r2] SandboxStoreClient: fix tarfile mode

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -231,7 +231,7 @@ class SandboxStoreClient(object):
 
     try:
       sandboxSize = 0
-      with tarfile.open(name=tarFileName, mode="rb") as tf:
+      with tarfile.open(name=tarFileName, mode="r") as tf:
         for tarinfo in tf:
           tf.extract(tarinfo, path=destinationDir)
           sandboxSize += tarinfo.size


### PR DESCRIPTION
Just a small fix: `mode="rb"` is not a valid mode according to:
https://docs.python.org/2.7/library/tarfile.html

BEGINRELEASENOTES
*WorkloadManagement
FIX: SandboxStoreClient tarfile mode
ENDRELEASENOTES
