### PR TITLE
[v7r3] encode stub in FileCoding

### DIFF
--- a/src/DIRAC/Core/Utilities/Plotting/FileCoding.py
+++ b/src/DIRAC/Core/Utilities/Plotting/FileCoding.py
@@ -46,7 +46,7 @@ def extractRequestFromFileId(fileId):
   if compressType == 'Z':
     gLogger.info("Compressed request, uncompressing")
     try:
-      # Encoding is only required for Python 2 and can be removed for WebAppDIRAC v5
+      # Encoding is only required for Python 2 and can be removed when Python 2 support is no longer needed
       stub = base64.urlsafe_b64decode(stub.encode())
     except Exception as e:
       gLogger.error("Oops! Plot request is not properly encoded!", str(e))

--- a/src/DIRAC/Core/Utilities/Plotting/FileCoding.py
+++ b/src/DIRAC/Core/Utilities/Plotting/FileCoding.py
@@ -46,7 +46,7 @@ def extractRequestFromFileId(fileId):
   if compressType == 'Z':
     gLogger.info("Compressed request, uncompressing")
     try:
-      stub = base64.urlsafe_b64decode(stub)
+      stub = base64.urlsafe_b64decode(stub.encode())
     except Exception as e:
       gLogger.error("Oops! Plot request is not properly encoded!", str(e))
       return S_ERROR("Oops! Plot request is not properly encoded!: %s" % str(e))

--- a/src/DIRAC/Core/Utilities/Plotting/FileCoding.py
+++ b/src/DIRAC/Core/Utilities/Plotting/FileCoding.py
@@ -46,6 +46,7 @@ def extractRequestFromFileId(fileId):
   if compressType == 'Z':
     gLogger.info("Compressed request, uncompressing")
     try:
+      # Encoding is only required for Python 2 and can be removed for WebAppDIRAC v5
       stub = base64.urlsafe_b64decode(stub.encode())
     except Exception as e:
       gLogger.error("Oops! Plot request is not properly encoded!", str(e))


### PR DESCRIPTION
Encoding stub must fix base64 decoding error:
```
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/Utilities/Plotting/FileCoding.py", line 49, in extractRequestFromFileId
    stub = base64.urlsafe_b64decode(stub)
  File "/opt/dirac/versions/v7r3-pre15_1626334216/diracos/usr/lib64/python2.7/base64.py", line 119, in urlsafe_b64decode
    return b64decode(s.translate(_urlsafe_decode_translation))
TypeError: character mapping must return integer, None or unicode
```

BEGINRELEASENOTES

*Core
FIX: encode stub before base64

ENDRELEASENOTES
