### PR TITLE
[v7r2] SSHBatch CE pilots fixes

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/Host.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Host.py
@@ -61,6 +61,7 @@ class Host(object):
     context = args.get('ExecutionContext', 'Local')
     jobidName = context.upper() + '_JOBID'
     nCores = args.get('NCores', 1)
+    nodeHost = args.get('SSHNodeHost')
 
     # Prepare the executor command
     runFileName = os.path.join(args['SharedDir'], 'run_detached.sh')
@@ -90,6 +91,8 @@ exit 0
       args['Stamp'] = stamps[_i]
       envDict = os.environ
       envDict[jobidName] = stamps[_i]
+      if nodeHost:
+        envDict['SSH_NODE_HOST'] = nodeHost
       try:
         jobDir = '%(WorkDir)s/%(Stamp)s' % args
         jobDir = os.path.expandvars(jobDir)

--- a/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
@@ -35,6 +35,7 @@ class SSHBatchComputingElement(SSHComputingElement):
 
     self.ceType = 'SSHBatch'
     self.sshHost = []
+    self.execution = 'SSHBATCH'
 
   def _reset(self):
 

--- a/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
@@ -162,7 +162,7 @@ class SSHBatchComputingElement(SSHComputingElement):
     hostDict = {}
     for job in jobIDList:
 
-      host = urlparse(job).hostname
+      host = os.path.dirname(urlparse(job).path).lstrip('/')
       hostDict.setdefault(host, [])
       hostDict[host].append(job)
 
@@ -205,7 +205,7 @@ class SSHBatchComputingElement(SSHComputingElement):
     """
     hostDict = {}
     for job in jobIDList:
-      host = urlparse(job).hostname
+      host = os.path.dirname(urlparse(job).path).lstrip('/')
       hostDict.setdefault(host, [])
       hostDict[host].append(job)
 

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -821,7 +821,7 @@ class SSHComputingElement(ComputingElement):
     # Take into account the SSHBatch possible SSHHost syntax
     host = host.split( '/' )[0]
 
-    ssh = SSH( host = host, parameters = self.ceParameters )
+    ssh = SSH(host = host, parameters = self.ceParameters)
     result = ssh.scpCall(30, localOutputFile, outputFile, upload=False)
     if not result['OK']:
       return result

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -819,9 +819,9 @@ class SSHComputingElement(ComputingElement):
       localErrorFile = 'Memory'
 
     # Take into account the SSHBatch possible SSHHost syntax
-    host = host.split( '/' )[0]
+    host = host.split('/')[0]
 
-    ssh = SSH(host = host, parameters = self.ceParameters)
+    ssh = SSH(host=host, parameters=self.ceParameters)
     result = ssh.scpCall(30, localOutputFile, outputFile, upload=False)
     if not result['OK']:
       return result

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -1,8 +1,3 @@
-########################################################################
-# File :   SSHComputingElement.py
-# Author : Dumitru Laurentiu, A.T.
-########################################################################
-
 """ SSH (Virtual) Computing Element
 
 For a given IP/host it will send jobs directly through ssh
@@ -311,7 +306,7 @@ class SSHComputingElement(ComputingElement):
     super(SSHComputingElement, self).__init__(ceUniqueID)
 
     self.ceType = 'SSH'
-    self.execution = "SSH"
+    self.execution = "SSHCE"
     self.submittedJobs = 0
     self.outputTemplate = ''
     self.errorTemplate = ''
@@ -640,6 +635,9 @@ class SSHComputingElement(ComputingElement):
         "Preamble": self.preamble,
         "NumberOfGPUs": self.numberOfGPUs,
     }
+    if host:
+      commandOptions['SSHNodeHost'] = host
+
     resultCommand = self.__executeHostCommand('submitJob', commandOptions, ssh=ssh, host=host)
     if not resultCommand['OK']:
       return resultCommand
@@ -650,11 +648,13 @@ class SSHComputingElement(ComputingElement):
     else:
       batchIDs = result['Jobs']
       if batchIDs:
-        ceHost = host
-        if host is None:
-          ceHost = self.ceName
         batchSystemName = self.batchSystem.__class__.__name__.lower()
-        jobIDs = ['%s%s://%s/%s' % (self.ceType.lower(), batchSystemName, ceHost, _id) for _id in batchIDs]
+        if host is None:
+          jobIDs = ['%s%s://%s/%s' % (self.ceType.lower(), batchSystemName, self.ceName, _id)
+                    for _id in batchIDs]
+        else:
+          jobIDs = ['%s%s://%s/%s/%s' % (self.ceType.lower(), batchSystemName, self.ceName, host, _id)
+                    for _id in batchIDs]
       else:
         return S_ERROR('No jobs IDs returned')
 
@@ -809,7 +809,7 @@ class SSHComputingElement(ComputingElement):
     if not result['OK']:
       return result
 
-    jobStamp, _host, outputFile, errorFile = result['Value']
+    jobStamp, host, outputFile, errorFile = result['Value']
 
     if localDir:
       localOutputFile = '%s/%s.out' % (localDir, jobStamp)
@@ -818,7 +818,10 @@ class SSHComputingElement(ComputingElement):
       localOutputFile = 'Memory'
       localErrorFile = 'Memory'
 
-    ssh = SSH(parameters=self.ceParameters)
+    # Take into account the SSHBatch possible SSHHost syntax
+    host = host.split( '/' )[0]
+
+    ssh = SSH( host = host, parameters = self.ceParameters )
     result = ssh.scpCall(30, localOutputFile, outputFile, upload=False)
     if not result['OK']:
       return result


### PR DESCRIPTION
The output retrieval for pilots in a SSHBatch CE was screwed due to pilot reference not reflecting the actual execution host. This also prevented proper association of pilots and jobs steered by them. 
This PR comes together with a PR in the Pilot project https://github.com/DIRACGrid/Pilot/pull/134.

BEGINRELEASENOTES

*Resources
FIX: SSHComputingElement - treat properly the case of the pilots submitted to SSHBatch CE
FIX: SSHBatchComputingElement - use special SSHBATCH execution context
FIX: Host.py - put the actual execution host name/IP into the SSH_NODE_HOST environment

ENDRELEASENOTES
