### PR TITLE
[v7r1] Docs: add enum34 needed by rucio clients

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,7 @@ docutils>=0.15
 boto3
 cachetools<4
 elasticsearch_dsl
+enum34
 future
 futures
 ldap3


### PR DESCRIPTION
Just adding a package to build the docs on RTD.
