### PR TITLE
[integration] update PathFinder

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -186,10 +186,14 @@ def getServiceURLs(system, service='', setup=False, randomize=False, failover=Fa
             raise Exception("No Main servers defined")
 
           for srv in mainServers:
-            urlList.append(checkServiceURL(url.replace('$MAINSERVERS$', srv), system, service))
+            url = checkServiceURL(url.replace('$MAINSERVERS$', srv), system, service)
+            if url not in urlList:
+              urlList.append(url)
           continue
-      urlList.append(checkServiceURL(url, system, service))
-    resList.extend(List.randomize(list(set(urlList))) if randomize else list(set(urlList)))
+      url = checkServiceURL(url, system, service)
+      if url not in urlList:
+        urlList.append(url)
+    resList.extend(List.randomize(urlList) if randomize else urlList)
 
   return resList
 

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -173,8 +173,8 @@ def getServiceURLs(system, service='', setup=False, randomize=False, failover=Fa
   failover = "Failover" if failover else ""
   for fURLs in ["", "Failover"] if failover else [""]:
     urls = List.fromChar(gConfigurationData.extractOptionFromCFG("%s/%sURLs/%s" % (systemSection, fURLs, service)))
-    # Be sure that url not just empty string
-    for url in [u for u in urls if u]:
+    # Be sure that url not None
+    for url in urls or []:
       # Trying if we are refering to the list of main servers
       # which would be like dips://$MAINSERVERS$:1234/System/Component
       if '$MAINSERVERS$' in url:

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -68,7 +68,6 @@ def getSystemSection(system, instance=False, setup=False):
 def getComponentSection(system, component=False, setup=False, componentCategory="Services"):
   """Function returns the path to the component.
 
-
   :param str system: system name or component name prefixed by the system in which it is placed.
                      e.g. 'WorkloadManagement/SandboxStoreHandler'
   :param str component: component name, e.g. 'SandboxStoreHandler'
@@ -89,7 +88,7 @@ def getComponentSection(system, component=False, setup=False, componentCategory=
 
 
 def getServiceSection(system, serviceName=False, setup=False):
-    """ Get service section in a system
+  """ Get service section in a system
 
       :param str system: system name
       :param str serviceName: DB name
@@ -100,7 +99,7 @@ def getServiceSection(system, serviceName=False, setup=False):
 
 
 def getAgentSection(system, agentName=False, setup=False):
-    """ Get agent section in a system
+  """ Get agent section in a system
 
       :param str system: system name
       :param str agentName: DB name

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -28,7 +28,7 @@ def divideFullName(entityName, componentName=None):
 
       :return: tuple -- contain system and component name
   """
-  entityName = strip('/')
+  entityName = entityName.strip('/')
   if entityName and '/' not in entityName and componentName:
     return (entityName, componentName)
   fields = [field.strip() for field in entityName.split("/") if field.strip()]
@@ -232,32 +232,31 @@ def getServiceURLs(system, service=None, setup=False, failover=False):
   return resList
 
 
-def getServiceURL(system, setup=False, service=None):
+def getServiceURL(system, service=None, setup=False):
   """
     Generate url.
 
     :param str system: system name or full name e.g.: Framework/ProxyManager
-    :param str setup: DIRAC setup name, can be defined in dirac.cfg
     :param str service: service name, like 'ProxyManager'.
+    :param str setup: DIRAC setup name, can be defined in dirac.cfg
 
     :return: str -- complete list of urls. e.g. dips://some-domain:3424/Framework/Service, dips://..
   """
-  system, service = serviceTuple if serviceTuple else divideFullName(system, service)
+  system, service = divideFullName(system, service)
   urls = getServiceURLs(system, service=service, setup=setup)
   return ','.join(urls) if urls else ""
 
 
-def getServiceFailoverURL(system, setup=False, service=None):
+def getServiceFailoverURL(system, service=None, setup=False):
   """ Get failover URLs for service
 
       :param str system: system name or full name, like 'Framework/Service'.
-      :param str serviceTuple: unuse!
-      :param str setup: DIRAC setup name, can be defined in dirac.cfg
       :param str service: service name, like 'ProxyManager'.
+      :param str setup: DIRAC setup name, can be defined in dirac.cfg
 
       :return: str -- complete list of urls
   """
-  system, service = serviceTuple if serviceTuple else divideFullName(system, service)
+  system, service = divideFullName(system, service)
   systemSection = getSystemSection(system, setup=setup)
   url = gConfigurationData.extractOptionFromCFG("%s/FailoverURLs/%s" % (systemSection, service))
   return checkServiceURL(url, system, service) if url else ""

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -158,12 +158,19 @@ def getServiceFailoverURL(serviceName, serviceTuple=False, setup=False):
 
 
 def getGatewayURLs(serviceName=""):
+  """ Get gateway URLs for service
+
+      :param str serviceName: service name
+
+      :return: list or False
+  """
   siteName = gConfigurationData.extractOptionFromCFG("/LocalSite/Site")
   if not siteName:
     return False
   gatewayList = gConfigurationData.extractOptionFromCFG("/DIRAC/Gateways/%s" % siteName)
   if not gatewayList:
     return False
+  gatewayList = List.fromChar(gatewayList, ",")
   if serviceName:
-    gatewayList = ["%s/%s" % ("/".join(gw.split("/")[:3]), serviceName) for gw in List.fromChar(gatewayList, ",")]
+    gatewayList = ["%s/%s" % ("/".join(gw.split("/")[:3]), serviceName) for gw in gatewayList]
   return List.randomize(gatewayList)

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -88,11 +88,8 @@ def getComponentSection(componentName, componentTuple=False, setup=False, compon
   Example:
     getComponentSection('WorkloadManagement/SandboxStoreHandler', False,False,'Services')
   """
-  system, service = componentTuple
-  if not componentTuple:
-    system, service = divideFullName(componentName)
-  systemSection = getSystemSection(system, setup=setup)
-  return "%s/%s/%s" % (systemSection, componentCategory, service)
+  system, service = componentTuple if componentTuple else divideFullName(componentName)
+  return "%s/%s/%s" % (getSystemSection(system, setup=setup), componentCategory, service)
 
 
 def getServiceSection(serviceName, serviceTuple=False, setup=False):
@@ -222,9 +219,7 @@ def getServiceFailoverURL(serviceName, serviceTuple=False, setup=False):
 
       :return: str -- complete list of urls
   """
-  system, service = serviceTuple
-  if not serviceTuple:
-    system, service = divideFullName(serviceName)
+  system, service = serviceTuple if serviceTuple else divideFullName(serviceName)
   systemSection = getSystemSection(system, setup=setup)
   url = gConfigurationData.extractOptionFromCFG("%s/FailoverURLs/%s" % (systemSection, service))
   if not url:

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -13,10 +13,20 @@ from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationDat
 
 
 def getDIRACSetup():
+  """ Get DIRAC default setup name
+
+      :return: str
+  """
   return gConfigurationData.extractOptionFromCFG("/DIRAC/Setup")
 
 
 def divideFullName(entityName):
+  """ Convert component full name to tuple
+
+      :param str entityName: component full name, e.g.: 'Framework/ProxyManager'
+
+      :return: tuple -- contain system and service name
+  """
   fields = [field.strip() for field in entityName.split("/")]
   if len(fields) < 2:
     raise RuntimeError("Service (%s) name must be with the form system/service" % entityName)
@@ -24,6 +34,13 @@ def divideFullName(entityName):
 
 
 def getSystemInstance(systemName, setup=False):
+  """ Find system instance name
+
+      :param str systemName: system name
+      :param str setup: setup name
+
+      :return: str
+  """
   if not setup:
     setup = gConfigurationData.extractOptionFromCFG("/DIRAC/Setup")
   optionPath = "/DIRAC/Setups/%s/%s" % (setup, systemName)
@@ -188,6 +205,14 @@ def getServiceURL(serviceName, serviceTuple=False, setup=False):
 
 
 def getServiceFailoverURL(serviceName, serviceTuple=False, setup=False):
+  """ Get failover URLs for service
+
+      :param str serviceName: Name of service, like 'Framework/Service'.
+      :param str serviceTuple:(optional) also name of service but look like ('Framework', 'Service').
+      :param str setup: DIRAC setup name, can be defined in dirac.cfg
+
+      :return: str -- complete list of urls
+  """
   system, service = serviceTuple
   if not serviceTuple:
     system, service = divideFullName(serviceName)

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -189,7 +189,7 @@ def getServiceURLs(system, service='', setup=False, randomize=False, failover=Fa
             urlList.append(checkServiceURL(url.replace('$MAINSERVERS$', srv), system, service))
           continue
       urlList.append(checkServiceURL(url, system, service))
-    resList.append(List.randomize(list(set(urlList))) if randomize else list(set(urlList)))
+    resList.extend(List.randomize(list(set(urlList))) if randomize else list(set(urlList)))
 
   return resList
 
@@ -214,7 +214,7 @@ def getServiceFailoverURL(serviceName, serviceTuple=False, setup=False):
   """ Get failover URLs for service
 
       :param str serviceName: Name of service, like 'Framework/Service'.
-      :param str serviceTuple:(optional) also name of service but look like ('Framework', 'Service').
+      :param str serviceTuple: (optional) also name of service but look like ('Framework', 'Service').
       :param str setup: DIRAC setup name, can be defined in dirac.cfg
 
       :return: str -- complete list of urls

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -282,4 +282,4 @@ def getGatewayURLs(system="", service=None):
   if not gateways:
     return False
   gateways = List.randomize(List.fromChar(gateways, ","))
-  return [checkServiceURL(u, system, service) for u in gateways if u] if system and service else gateways
+  return [checkComponentURL(u, system, service) for u in gateways if u] if system and service else gateways

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -34,12 +34,22 @@ def getSystemInstance(systemName, setup=False):
     raise RuntimeError("Option %s is not defined" % optionPath)
 
 
-def getSystemSection(serviceName, serviceTuple=False, instance=False, setup=False):
-  if not serviceTuple:
-    serviceTuple = divideFullName(serviceName)
+# TODO: serviceTuple here for backward compatibility and must be deleted in the next release(v7r4)
+def getSystemSection(system, serviceTuple=False, instance=False, setup=False):
+  """ Get system section
+
+      :param str system: system name or full name e.g.: Framework/ProxyManager
+      :param serviceTuple: unuse!
+      :param str instance: instance name
+      :param str setup: setup name
+
+      :return: str -- system section path
+  """
+  if '/' in system:
+    system, _ = divideFullName(system)
   if not instance:
-    instance = getSystemInstance(serviceTuple[0], setup=setup)
-  return "/Systems/%s/%s" % (serviceTuple[0], instance)
+    instance = getSystemInstance(system, setup=setup)
+  return "/Systems/%s/%s" % (system, instance)
 
 
 def getComponentSection(componentName, componentTuple=False, setup=False, componentCategory="Services"):
@@ -61,10 +71,11 @@ def getComponentSection(componentName, componentTuple=False, setup=False, compon
   Example:
     getComponentSection('WorkloadManagement/SandboxStoreHandler', False,False,'Services')
   """
+  system, service = componentTuple
   if not componentTuple:
-    componentTuple = divideFullName(componentName)
-  systemSection = getSystemSection(componentName, componentTuple, setup=setup)
-  return "%s/%s/%s" % (systemSection, componentCategory, componentTuple[1])
+    system, service = divideFullName(componentName)
+  systemSection = getSystemSection(system, setup=setup)
+  return "%s/%s/%s" % (systemSection, componentCategory, service)
 
 
 def getServiceSection(serviceName, serviceTuple=False, setup=False):
@@ -84,7 +95,7 @@ def getDatabaseSection(dbName, dbTuple=False, setup=False):
 
 
 def getSystemURLSection(serviceName, serviceTuple=False, setup=False):
-  systemSection = getSystemSection(serviceName, serviceTuple, setup=setup)
+  systemSection = getSystemSection(serviceName, setup=setup)
   return "%s/URLs" % systemSection
 
 
@@ -98,10 +109,11 @@ def getServiceURL(serviceName, serviceTuple=False, setup=False):
 
     :return: complete url. e.g. dips://some-domain:3424/Framework/Service
   """
+  system, service = serviceTuple
   if not serviceTuple:
-    serviceTuple = divideFullName(serviceName)
-  systemSection = getSystemSection(serviceName, serviceTuple, setup=setup)
-  url = gConfigurationData.extractOptionFromCFG("%s/URLs/%s" % (systemSection, serviceTuple[1]))
+    system, service = divideFullName(serviceName)
+  systemSection = getSystemSection(system, setup=setup)
+  url = gConfigurationData.extractOptionFromCFG("%s/URLs/%s" % (systemSection, service))
   if not url:
     return ""
 
@@ -133,10 +145,11 @@ def getServiceURL(serviceName, serviceTuple=False, setup=False):
 
 
 def getServiceFailoverURL(serviceName, serviceTuple=False, setup=False):
+  system, service = serviceTuple
   if not serviceTuple:
-    serviceTuple = divideFullName(serviceName)
-  systemSection = getSystemSection(serviceName, serviceTuple, setup=setup)
-  url = gConfigurationData.extractOptionFromCFG("%s/FailoverURLs/%s" % (systemSection, serviceTuple[1]))
+    system, service = divideFullName(serviceName)
+  systemSection = getSystemSection(system, setup=setup)
+  url = gConfigurationData.extractOptionFromCFG("%s/FailoverURLs/%s" % (systemSection, service))
   if not url:
     return ""
   if len(url.split("/")) < 5:

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -181,7 +181,7 @@ def getServiceURLs(system, service=None, setup=False, randomize=False, failover=
         if not mainServers:
           # Operations cannot be imported at the beginning because of a bootstrap problem
           from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
-          mainServers = Operations().getValue('MainServers', [])
+          mainServers = Operations(setup=setup).getValue('MainServers', [])
         if not mainServers:
           raise Exception("No Main servers defined")
 

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -50,14 +50,14 @@ Operations{
   }
 }
 """)
-localCFGData.localCFG=mergedCFG
-localCFGData.remoteCFG=mergedCFG
-localCFGData.mergedCFG=mergedCFG
+localCFGData.localCFG = mergedCFG
+localCFGData.remoteCFG = mergedCFG
+localCFGData.mergedCFG = mergedCFG
 localCFGData.generateNewVersion()
 
 
 @pytest.fixture
-def pathFinder(monkeypatch):  
+def pathFinder(monkeypatch):
   monkeypatch.setattr(PathFinder, "gConfigurationData", localCFGData)
   monkeypatch.setattr(Operations, "gConfigurationData", localCFGData)
   return PathFinder
@@ -144,8 +144,7 @@ def test_getSystemURLs(pathFinder, system, setup, failover, result):
     ('https://server.com/WorkloadManagement/Service1', None, None,
      'https://server.com:443/WorkloadManagement/Service1'),
     ('http://server.com/WorkloadManagement/Service1', None, None,
-     'http://server.com:80/WorkloadManagement/Service1'),
-    ])
+     'http://server.com:80/WorkloadManagement/Service1')])
 def test_checkServiceURL(pathFinder, serviceURL, system, service, result):
   """ Test checkServiceURL """
   try:

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -12,9 +12,9 @@ from DIRAC.ConfigurationSystem.private.ConfigurationClient import ConfigurationC
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 
 
-class TestPathFinder( unittest.TestCase ):
-  def setUp( self ):
-    #Creating test configuration file
+class TestPathFinder(unittest.TestCase):
+  def setUp(self):
+    # Creating test configuration file
     self.testCfgFileName = 'test.cfg'
     cfgContent='''
     DIRAC
@@ -55,8 +55,8 @@ class TestPathFinder( unittest.TestCase ):
     '''
     with open(self.testCfgFileName, 'w') as f:
       f.write(cfgContent)
-    gConfig = ConfigurationClient(fileToLoadList = [self.testCfgFileName])  #we replace the configuration by our own one.
-    self.setup = gConfig.getValue( '/DIRAC/Setup', '' )
+    gConfig = ConfigurationClient(fileToLoadList=[self.testCfgFileName])  # we replace the configuration by our own one.
+    self.setup = gConfig.getValue('/DIRAC/Setup', '')
     self.wm = gConfig.getValue('DIRAC/Setups/' + self.setup +'/WorkloadManagement', '')
   def tearDown( self ):
     try:
@@ -70,52 +70,73 @@ class TestPathFinder( unittest.TestCase ):
     gConfigurationData.mergedCFG=CFG()
     gConfigurationData.generateNewVersion()
 
-class TestGetComponentSection( TestPathFinder ):
+class TestGetComponentSection(TestPathFinder):
 
-  def test_success( self ):
-    result = getComponentSection('WorkloadManagement/SandboxStoreHandler',False, False,'Services')
+  def test_success(self):
+    result = getComponentSection('WorkloadManagement/SandboxStoreHandler', False, False, 'Services')
     correctResult = '/Systems/WorkloadManagement/' + self.wm + '/Services/SandboxStoreHandler'
     self.assertEqual(result, correctResult)
 
-  def test_sucessComponentStringDoesNotExist( self ):
+  def test_sucessComponentStringDoesNotExist(self):
     """ tricky case one could expect that if entity string is wrong
         than some kind of error will be returned, but it is not the case
     """
-    result = getComponentSection('WorkloadManagement/SimpleLogConsumer',False, False,'NonRonsumersNon')
+    result = getComponentSection('WorkloadManagement/SimpleLogConsumer', False, False, 'NonRonsumersNon')
     correctResult = '/Systems/WorkloadManagement/' + self.wm + '/NonRonsumersNon/SimpleLogConsumer'
     self.assertEqual(result, correctResult)
 
-class TestURLs( TestPathFinder ):
+class TestURLs(TestPathFinder):
 
-  def test_getServiceURLSimple( self ):
+  def test_getServiceURLSimple(self):
     """Fetching a URL defined normally"""
     result = getServiceURL('WorkloadManagement/Service1')
     correctResult = 'dips://server1:1234/WorkloadManagement/Service1'
 
     self.assertEqual(result, correctResult)
 
-  def test_getServiceMainURL( self ):
+  def test_getServiceMainURL(self):
     """Fetching a URL referencing the MainServers"""
     result = getServiceURL('WorkloadManagement/Service2')
     correctResult = 'dips://gw1:5678/WorkloadManagement/Service2,dips://gw2:5678/WorkloadManagement/Service2'
     self.assertEqual(result, correctResult)
 
-  def test_getServiceFailoverURLNonExisting( self ):
+  def test_getServiceFailoverURLNonExisting(self):
     """Fetching a FailoverURL not defined"""
     result = getServiceFailoverURL('WorkloadManagement/Service1')
     correctResult = ''
 
     self.assertEqual(result, correctResult)
 
-  def test_getServiceFailoverURL( self ):
+  def test_getServiceFailoverURL(self):
     """Fetching a FailoverURL"""
     result = getServiceFailoverURL('WorkloadManagement/Service2')
     correctResult = 'dips://failover1:5678/WorkloadManagement/Service2'
     self.assertEqual(result, correctResult)
+  
+  def test_getServiceURLsSimple(self):
+    """Fetching a URLs defined normally"""
+    self.assertEqual(getServiceURLs('WorkloadManagement/Service1'),
+                     ['dips://server1:1234/WorkloadManagement/Service1'])
+
+  def test_getServiceMainURLs(self):
+    """Fetching a URLs referencing the MainServers"""
+    self.assertEqual(getServiceURLs('WorkloadManagement/Service2'),
+                     ['dips://gw1:5678/WorkloadManagement/Service2', 'dips://gw2:5678/WorkloadManagement/Service2'])
+
+  def test_getServiceWithFailoverURLsNonExisting(self):
+    """Fetching with FailoverURLs not defined"""
+    self.assertEqual(getServiceURLs('WorkloadManagement', 'Service1', failover=True),
+                     ['dips://server1:1234/WorkloadManagement/Service1'])
+
+  def test_getServiceWithFailoverURL(self):
+    """Fetching with FailoverURLs"""
+    self.assertEqual(getServiceURLs('WorkloadManagement', service='Service2', failover=True),
+                     ['dips://gw1:5678/WorkloadManagement/Service2', 'dips://gw2:5678/WorkloadManagement/Service2',
+                      'dips://failover1:5678/WorkloadManagement/Service2'])
 
 if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestPathFinder )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestGetComponentSection ) )
-  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestURLs ) )
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestPathFinder)
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestGetComponentSection))
+  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestURLs))
 
-  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
+  testResult = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -154,7 +154,7 @@ def test_getSystemURLs(pathFinder, system, setup, failover, result):
 def test_checkComponentURL(pathFinder, serviceURL, system, service, result):
   """ Test checkComponentURL """
   try:
-    pathFinderResult = pathFinder.checkComponentURL(serviceURL, system, service)
+    pathFinderResult = pathFinder.checkComponentURL(serviceURL, system, service, pathMandatory=True)
     assert pathFinderResult == result
   except RuntimeError as e:
     assert result.split(':')[1] in repr(e)

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -4,145 +4,152 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-import unittest
+import pytest
 from diraccfg import CFG
-from DIRAC.ConfigurationSystem.Client.PathFinder import (getComponentSection,
-                                                         getServiceFailoverURL,
-                                                         getServiceURL,
-                                                         getServiceURLs)
-from DIRAC.ConfigurationSystem.private.ConfigurationClient import ConfigurationClient
-from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 
+from DIRAC.ConfigurationSystem.Client import PathFinder
+from DIRAC.ConfigurationSystem.Client.Helpers import Operations
+from DIRAC.ConfigurationSystem.private.ConfigurationData import ConfigurationData
 
-class TestPathFinder(unittest.TestCase):
-  def setUp(self):
-    # Creating test configuration file
-    self.testCfgFileName = 'test.cfg'
-    cfgContent='''
-    DIRAC
+localCFGData = ConfigurationData(False)
+mergedCFG = CFG()
+mergedCFG.loadFromBuffer("""
+DIRAC
+{
+  Setup=TestSetup
+  Setups
+  {
+    TestSetup
     {
-      Setup=TestSetup
-      Setups
-      {
-        TestSetup
-        {
-          WorkloadManagement=MyWM
-        }
-      }
+      WorkloadManagement=MyWM
     }
-    Systems
+  }
+}
+Systems
+{
+  WorkloadManagement
+  {
+    MyWM
     {
-      WorkloadManagement
+      URLs
       {
-        MyWM
-        {
-          URLs
-          {
-            Service1 = dips://server1:1234/WorkloadManagement/Service1
-            Service2 = dips://$MAINSERVERS$:5678/WorkloadManagement/Service2
-          }
-          FailoverURLs
-          {
-            Service2 = dips://failover1:5678/WorkloadManagement/Service2
-          }
-        }
+        Service1 = dips://server1:1234/WorkloadManagement/Service1
+        Service2 = dips://$MAINSERVERS$:5678/WorkloadManagement/Service2
+      }
+      FailoverURLs
+      {
+        Service2 = dips://failover1:5678/WorkloadManagement/Service2
       }
     }
-    Operations{
-      Defaults
-      {
-        MainServers = gw1, gw2
-      }
-    }
-    '''
-    with open(self.testCfgFileName, 'w') as f:
-      f.write(cfgContent)
-    gConfig = ConfigurationClient(fileToLoadList=[self.testCfgFileName])  # we replace the configuration by our own one.
-    self.setup = gConfig.getValue('/DIRAC/Setup', '')
-    self.wm = gConfig.getValue('DIRAC/Setups/' + self.setup +'/WorkloadManagement', '')
-  def tearDown( self ):
-    try:
-      os.remove(self.testCfgFileName)
-    except OSError:
-      pass
-    # SUPER UGLY: one must recreate the CFG objects of gConfigurationData
-    # not to conflict with other tests that might be using a local dirac.cfg
-    gConfigurationData.localCFG=CFG()
-    gConfigurationData.remoteCFG=CFG()
-    gConfigurationData.mergedCFG=CFG()
-    gConfigurationData.generateNewVersion()
+  }
+}
+Operations{
+  Defaults
+  {
+    MainServers = gw1, gw2
+  }
+}
+""")
+localCFGData.localCFG=mergedCFG
+localCFGData.remoteCFG=mergedCFG
+localCFGData.mergedCFG=mergedCFG
+localCFGData.generateNewVersion()
 
 
-class TestGetComponentSection(TestPathFinder):
-
-  def test_success(self):
-    result = getComponentSection('WorkloadManagement/SandboxStoreHandler', False, False, 'Services')
-    correctResult = '/Systems/WorkloadManagement/' + self.wm + '/Services/SandboxStoreHandler'
-    self.assertEqual(result, correctResult)
-
-  def test_sucessComponentStringDoesNotExist(self):
-    """ tricky case one could expect that if entity string is wrong
-        than some kind of error will be returned, but it is not the case
-    """
-    result = getComponentSection('WorkloadManagement/SimpleLogConsumer', False, False, 'NonRonsumersNon')
-    correctResult = '/Systems/WorkloadManagement/' + self.wm + '/NonRonsumersNon/SimpleLogConsumer'
-    self.assertEqual(result, correctResult)
+@pytest.fixture
+def pathFinder(monkeypatch):  
+  monkeypatch.setattr(PathFinder, "gConfigurationData", localCFGData)
+  monkeypatch.setattr(Operations, "gConfigurationData", localCFGData)
+  return PathFinder
 
 
-class TestURLs(TestPathFinder):
-
-  def test_getServiceURLSimple(self):
-    """Fetching a URL defined normally"""
-    result = getServiceURL('WorkloadManagement/Service1')
-    correctResult = 'dips://server1:1234/WorkloadManagement/Service1'
-
-    self.assertEqual(result, correctResult)
-
-  def test_getServiceMainURL(self):
-    """Fetching a URL referencing the MainServers"""
-    result = getServiceURL('WorkloadManagement/Service2')
-    correctResult = 'dips://gw1:5678/WorkloadManagement/Service2,dips://gw2:5678/WorkloadManagement/Service2'
-    self.assertEqual(result, correctResult)
-
-  def test_getServiceFailoverURLNonExisting(self):
-    """Fetching a FailoverURL not defined"""
-    result = getServiceFailoverURL('WorkloadManagement/Service1')
-    correctResult = ''
-
-    self.assertEqual(result, correctResult)
-
-  def test_getServiceFailoverURL(self):
-    """Fetching a FailoverURL"""
-    result = getServiceFailoverURL('WorkloadManagement/Service2')
-    correctResult = 'dips://failover1:5678/WorkloadManagement/Service2'
-    self.assertEqual(result, correctResult)
-
-  def test_getServiceURLsSimple(self):
-    """Fetching a URLs defined normally"""
-    self.assertEqual(getServiceURLs('WorkloadManagement/Service1'),
-                     ['dips://server1:1234/WorkloadManagement/Service1'])
-
-  def test_getServiceMainURLs(self):
-    """Fetching a URLs referencing the MainServers"""
-    self.assertEqual(getServiceURLs('WorkloadManagement/Service2'),
-                     ['dips://gw1:5678/WorkloadManagement/Service2', 'dips://gw2:5678/WorkloadManagement/Service2'])
-
-  def test_getServiceWithFailoverURLsNonExisting(self):
-    """Fetching with FailoverURLs not defined"""
-    self.assertEqual(getServiceURLs('WorkloadManagement', 'Service1', failover=True),
-                     ['dips://server1:1234/WorkloadManagement/Service1'])
-
-  def test_getServiceWithFailoverURL(self):
-    """Fetching with FailoverURLs"""
-    self.assertEqual(getServiceURLs('WorkloadManagement', service='Service2', failover=True),
-                     ['dips://gw1:5678/WorkloadManagement/Service2', 'dips://gw2:5678/WorkloadManagement/Service2',
-                      'dips://failover1:5678/WorkloadManagement/Service2'])
+def test_getDIRACSetup(pathFinder):
+  """ Test getDIRACSetup """
+  assert pathFinder.getDIRACSetup() == 'TestSetup'
 
 
-if __name__ == '__main__':
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestPathFinder)
-  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestGetComponentSection))
-  suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestURLs))
+@pytest.mark.parametrize("componentName, componentTuple, setup, componentType, result", [
+    ('WorkloadManagement/SandboxStoreHandler', False, False, 'Services',
+     '/Systems/WorkloadManagement/MyWM/Services/SandboxStoreHandler'),
+    # tricky case one could expect that if entity string is wrong
+    # than some kind of error will be returned, but it is not the case
+    ('WorkloadManagement/SimpleLogConsumer', False, False, 'NonRonsumersNon',
+     '/Systems/WorkloadManagement/MyWM/NonRonsumersNon/SimpleLogConsumer')])
+def test_getComponentSection(pathFinder, componentName, componentTuple, setup, componentType, result):
+  """ Test getComponentSection """
+  assert pathFinder.getComponentSection(componentName, componentTuple, setup, componentType) == result
 
-  testResult = unittest.TextTestRunner(verbosity=2).run(suite)
+
+@pytest.mark.parametrize("serviceName, service, result", [
+    ('WorkloadManagement/Service1', None,
+     'dips://server1:1234/WorkloadManagement/Service1'),
+    ('WorkloadManagement', 'Service1',
+     'dips://server1:1234/WorkloadManagement/Service1'),
+    ('WorkloadManagement', 'Service2',
+     'dips://gw1:5678/WorkloadManagement/Service2,dips://gw2:5678/WorkloadManagement/Service2')])
+def test_getServiceURL(pathFinder, serviceName, service, result):
+  """ Test getServiceURL """
+  assert pathFinder.getServiceURL(serviceName, service=service) == result
+
+
+@pytest.mark.parametrize("serviceName, service, result", [
+    ('WorkloadManagement/Service1', None, ''),
+    ('WorkloadManagement', 'Service1', ''),
+    ('WorkloadManagement', 'Service2', 'dips://failover1:5678/WorkloadManagement/Service2')])
+def test_getServiceFailoverURL(pathFinder, serviceName, service, result):
+  """ Test getServiceFailoverURL """
+  assert pathFinder.getServiceFailoverURL(serviceName, service=service) == result
+
+
+@pytest.mark.parametrize("serviceName, service, failover, result", [
+    ('WorkloadManagement/Service1', None, False, ['dips://server1:1234/WorkloadManagement/Service1']),
+    ('WorkloadManagement', 'Service1', False, ['dips://server1:1234/WorkloadManagement/Service1']),
+    ('WorkloadManagement', 'Service2', False, ['dips://gw1:5678/WorkloadManagement/Service2',
+                                               'dips://gw2:5678/WorkloadManagement/Service2']),
+    ('WorkloadManagement', 'Service1', True, ['dips://server1:1234/WorkloadManagement/Service1']),
+    ('WorkloadManagement', 'Service2', True, ['dips://gw1:5678/WorkloadManagement/Service2',
+                                              'dips://gw2:5678/WorkloadManagement/Service2',
+                                              'dips://failover1:5678/WorkloadManagement/Service2'])])
+def test_getServiceURLs(pathFinder, serviceName, service, failover, result):
+  """ Test getServiceURLs """
+  assert pathFinder.getServiceURLs(serviceName, service=service, failover=failover) == result
+
+
+@pytest.mark.parametrize("system, setup, failover, result", [
+    ('WorkloadManagement', None, False, {
+        'Service1': ['dips://server1:1234/WorkloadManagement/Service1'],
+        'Service2': ['dips://gw1:5678/WorkloadManagement/Service2',
+                     'dips://gw2:5678/WorkloadManagement/Service2']}),
+    ('WorkloadManagement', None, True, {
+        'Service1': ['dips://server1:1234/WorkloadManagement/Service1'],
+        'Service2': ['dips://gw1:5678/WorkloadManagement/Service2',
+                     'dips://gw2:5678/WorkloadManagement/Service2',
+                     'dips://failover1:5678/WorkloadManagement/Service2']})])
+def test_getSystemURLs(pathFinder, system, setup, failover, result):
+  """ Test getSystemURLs """
+  assert pathFinder.getSystemURLs(system, setup=setup, failover=failover) == result
+
+
+@pytest.mark.parametrize("serviceURL, system, service, result", [
+    ('dips://server.com:1234/WorkloadManagement/Service1', None, None,
+     'dips://server.com:1234/WorkloadManagement/Service1'),
+    ('dips://server.com:1234/', 'WorkloadManagement', 'Service1',
+     'dips://server.com:1234/WorkloadManagement/Service1'),
+    ('dips://server.com:1234', 'WorkloadManagement', 'Service1',
+     'dips://server.com:1234/WorkloadManagement/Service1'),
+    ('dips://server.com:1234/', 'WorkloadManagement', None,
+     'raise:path'),
+    ('dips://server.com/WorkloadManagement/Service1', None, None,
+     'raise:port'),
+    ('https://server.com/WorkloadManagement/Service1', None, None,
+     'https://server.com:443/WorkloadManagement/Service1'),
+    ('http://server.com/WorkloadManagement/Service1', None, None,
+     'http://server.com:80/WorkloadManagement/Service1'),
+    ])
+def test_checkServiceURL(pathFinder, serviceURL, system, service, result):
+  """ Test checkServiceURL """
+  try:
+    pathFinderResult = pathFinder.checkServiceURL(serviceURL, system, service)
+    assert pathFinderResult == result
+  except RuntimeError as e:
+    assert result.split(':')[1] in repr(e)

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -151,10 +151,10 @@ def test_getSystemURLs(pathFinder, system, setup, failover, result):
      'https://server.com:443/WorkloadManagement/Service1'),
     ('http://server.com/WorkloadManagement/Service1', None, None,
      'http://server.com:80/WorkloadManagement/Service1')])
-def test_checkServiceURL(pathFinder, serviceURL, system, service, result):
-  """ Test checkServiceURL """
+def test_checkComponentURL(pathFinder, serviceURL, system, service, result):
+  """ Test checkComponentURL """
   try:
-    pathFinderResult = pathFinder.checkServiceURL(serviceURL, system, service)
+    pathFinderResult = pathFinder.checkComponentURL(serviceURL, system, service)
     assert pathFinderResult == result
   except RuntimeError as e:
     assert result.split(':')[1] in repr(e)

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -7,7 +7,10 @@ from __future__ import print_function
 import os
 import unittest
 from diraccfg import CFG
-from DIRAC.ConfigurationSystem.Client.PathFinder import getComponentSection, getServiceFailoverURL, getServiceURL
+from DIRAC.ConfigurationSystem.Client.PathFinder import (getComponentSection,
+                                                         getServiceFailoverURL,
+                                                         getServiceURL,
+                                                         getServiceURLs)
 from DIRAC.ConfigurationSystem.private.ConfigurationClient import ConfigurationClient
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 
@@ -70,6 +73,7 @@ class TestPathFinder(unittest.TestCase):
     gConfigurationData.mergedCFG=CFG()
     gConfigurationData.generateNewVersion()
 
+
 class TestGetComponentSection(TestPathFinder):
 
   def test_success(self):
@@ -84,6 +88,7 @@ class TestGetComponentSection(TestPathFinder):
     result = getComponentSection('WorkloadManagement/SimpleLogConsumer', False, False, 'NonRonsumersNon')
     correctResult = '/Systems/WorkloadManagement/' + self.wm + '/NonRonsumersNon/SimpleLogConsumer'
     self.assertEqual(result, correctResult)
+
 
 class TestURLs(TestPathFinder):
 
@@ -112,7 +117,7 @@ class TestURLs(TestPathFinder):
     result = getServiceFailoverURL('WorkloadManagement/Service2')
     correctResult = 'dips://failover1:5678/WorkloadManagement/Service2'
     self.assertEqual(result, correctResult)
-  
+
   def test_getServiceURLsSimple(self):
     """Fetching a URLs defined normally"""
     self.assertEqual(getServiceURLs('WorkloadManagement/Service1'),
@@ -133,6 +138,7 @@ class TestURLs(TestPathFinder):
     self.assertEqual(getServiceURLs('WorkloadManagement', service='Service2', failover=True),
                      ['dips://gw1:5678/WorkloadManagement/Service2', 'dips://gw2:5678/WorkloadManagement/Service2',
                       'dips://failover1:5678/WorkloadManagement/Service2'])
+
 
 if __name__ == '__main__':
   suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestPathFinder)

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -68,16 +68,18 @@ def test_getDIRACSetup(pathFinder):
   assert pathFinder.getDIRACSetup() == 'TestSetup'
 
 
-@pytest.mark.parametrize("componentName, componentTuple, setup, componentType, result", [
+@pytest.mark.parametrize("system, componentName, setup, componentType, result", [
     ('WorkloadManagement/SandboxStoreHandler', False, False, 'Services',
+     '/Systems/WorkloadManagement/MyWM/Services/SandboxStoreHandler'),
+    ('WorkloadManagement', 'SandboxStoreHandler', False, 'Services',
      '/Systems/WorkloadManagement/MyWM/Services/SandboxStoreHandler'),
     # tricky case one could expect that if entity string is wrong
     # than some kind of error will be returned, but it is not the case
     ('WorkloadManagement/SimpleLogConsumer', False, False, 'NonRonsumersNon',
      '/Systems/WorkloadManagement/MyWM/NonRonsumersNon/SimpleLogConsumer')])
-def test_getComponentSection(pathFinder, componentName, componentTuple, setup, componentType, result):
+def test_getComponentSection(pathFinder, system, componentName, setup, componentType, result):
   """ Test getComponentSection """
-  assert pathFinder.getComponentSection(componentName, componentTuple, setup, componentType) == result
+  assert pathFinder.getComponentSection(system, componentName, setup, componentType) == result
 
 
 @pytest.mark.parametrize("serviceName, service, result", [

--- a/src/DIRAC/Core/Base/private/ModuleLoader.py
+++ b/src/DIRAC/Core/Base/private/ModuleLoader.py
@@ -50,7 +50,7 @@ class ModuleLoader(object):
       # Look in the CS
       system = modName
       # Can this be generated with sectionFinder?
-      csPath = "%s/Executors" % PathFinder.getSystemSection(system, (system, ))
+      csPath = "%s/Executors" % PathFinder.getSystemSection(system)
       gLogger.verbose("Exploring %s to discover modules" % csPath)
       result = gConfig.getSections(csPath)
       if result['OK']:

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -44,7 +44,7 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import skipCACheck
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import findDefaultGroupForDN
-from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURL, getServiceURLs, getGatewayURLs
+from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURLs, getGatewayURLs
 
 from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
 from DIRAC.Core.Security import Locations
@@ -428,7 +428,8 @@ class TornadoBaseClient(object):
     """
       Returns the url the service.
     """
-    return getServiceURL(self._serviceName)
+    urls = getServiceURLs(self._serviceName, randomize=True)
+    return urls[0] if urls else ""
 
   def _getBaseStub(self):
     """ Returns a tuple with (self._destinationSrv, newKwargs)

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -44,7 +44,7 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import skipCACheck
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import findDefaultGroupForDN
-from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURLs, getGatewayURLs
+from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURL, getServiceURLs, getGatewayURLs
 
 from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
 from DIRAC.Core.Security import Locations

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -347,7 +347,7 @@ class TornadoBaseClient(object):
 
     # If nor url is given as constructor, we extract the list of URLs from the CS (System/URLs/Component)
     try:
-      urls = getServiceURL(self._destinationSrv, setup=self.setup)
+      urls = getServiceURLs(self._destinationSrv, setup=self.setup)
     except Exception as e:
       return S_ERROR("Cannot get URL for %s in setup %s: %s" % (self._destinationSrv, self.setup, repr(e)))
     if not urls:
@@ -363,7 +363,7 @@ class TornadoBaseClient(object):
       pass
 
     # We randomize the list, and add at the end the failover URLs (System/FailoverURLs/Component)
-    urlsList = List.randomize(List.fromChar(urls, ",")) + failoverUrls
+    urlsList = List.randomize(urls) + failoverUrls
     self.__nbOfUrls = len(urlsList)
     # __nbOfRetry removed in HTTPS (managed by requests)
     if self.__nbOfUrls == len(self.__bannedUrls):

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -44,7 +44,7 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import skipCACheck
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import findDefaultGroupForDN
-from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURL, getGatewayURLs
+from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURLs, getGatewayURLs
 
 from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
 from DIRAC.Core.Security import Locations

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -347,7 +347,7 @@ class TornadoBaseClient(object):
     # If nor url is given as constructor, we extract the list of URLs from the CS (System/URLs/Component)
     try:
       # We randomize the list, and add at the end the failover URLs (System/FailoverURLs/Component)
-      urlsList = getServiceURLs(self._destinationSrv, setup=self.setup, randomize=True, failover=True)
+      urlsList = getServiceURLs(self._destinationSrv, setup=self.setup, failover=True)
     except Exception as e:
       return S_ERROR("Cannot get URL for %s in setup %s: %s" % (self._destinationSrv, self.setup, repr(e)))
     if not urlsList:
@@ -428,7 +428,7 @@ class TornadoBaseClient(object):
     """
       Returns the url the service.
     """
-    urls = getServiceURLs(self._serviceName, randomize=True)
+    urls = getServiceURLs(self._serviceName)
     return urls[0] if urls else ""
 
   def _getBaseStub(self):

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -44,11 +44,11 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import skipCACheck
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import findDefaultGroupForDN
-from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURL, getServiceFailoverURL
+from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURL, getGatewayURLs
 
 from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
 from DIRAC.Core.Security import Locations
-from DIRAC.Core.Utilities import List, Network
+from DIRAC.Core.Utilities import Network
 from DIRAC.Core.Utilities.JEncode import decode, encode
 
 
@@ -323,10 +323,9 @@ class TornadoBaseClient(object):
     # Load the Gateways URLs for the current site Name
     gatewayURL = False
     if not self.kwargs.get(self.KW_IGNORE_GATEWAYS):
-      dRetVal = gConfig.getOption("/DIRAC/Gateways/%s" % DIRAC.siteName())
-      if dRetVal['OK']:
-        rawGatewayURL = List.randomize(List.fromChar(dRetVal['Value'], ","))[0]
-        gatewayURL = "/".join(rawGatewayURL.split("/")[:3])
+      gatewayURLs = getGatewayURLs()
+      if gatewayURLs:
+        gatewayURL = "/".join(gatewayURLs[0].split("/")[:3])
 
     # If what was given as constructor attribute is a properly formed URL,
     # we just return this one.
@@ -347,23 +346,13 @@ class TornadoBaseClient(object):
 
     # If nor url is given as constructor, we extract the list of URLs from the CS (System/URLs/Component)
     try:
-      urls = getServiceURLs(self._destinationSrv, setup=self.setup)
+      # We randomize the list, and add at the end the failover URLs (System/FailoverURLs/Component)
+      urlsList = getServiceURLs(self._destinationSrv, setup=self.setup, randomize=True, failover=True)
     except Exception as e:
       return S_ERROR("Cannot get URL for %s in setup %s: %s" % (self._destinationSrv, self.setup, repr(e)))
-    if not urls:
+    if not urlsList:
       return S_ERROR("URL for service %s not found" % self._destinationSrv)
 
-    failoverUrls = []
-    # Try if there are some failover URLs to use as last resort
-    try:
-      failoverUrlsStr = getServiceFailoverURL(self._destinationSrv, setup=self.setup)
-      if failoverUrlsStr:
-        failoverUrls = failoverUrlsStr.split(',')
-    except Exception as e:
-      pass
-
-    # We randomize the list, and add at the end the failover URLs (System/FailoverURLs/Component)
-    urlsList = List.randomize(urls) + failoverUrls
     self.__nbOfUrls = len(urlsList)
     # __nbOfRetry removed in HTTPS (managed by requests)
     if self.__nbOfUrls == len(self.__bannedUrls):
@@ -376,9 +365,6 @@ class TornadoBaseClient(object):
       for i in self.__bannedUrls:
         gLogger.debug("Removing banned URL", "%s" % i)
         urlsList.remove(i)
-
-    # Take the first URL from the list
-    # randUrls = List.randomize( urlsList ) + failoverUrls
 
     sURL = urlsList[0]
 

--- a/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
@@ -534,7 +534,7 @@ class ComponentSupervisionAgent(AgentModule):
       # ignore SystemAdministrator, does not have URLs
       if 'SystemAdministrator' in service:
         continue
-      self._checkServiceURL(service, options)
+      self._checkComponentURL(service, options)
 
     if self.csAPI.csModified and self.commitURLs:
       self.log.info('Commiting changes to the CS')
@@ -544,7 +544,7 @@ class ComponentSupervisionAgent(AgentModule):
         return S_ERROR('Failed to commit to CS')
     return S_OK()
 
-  def _checkServiceURL(self, serviceName, options):
+  def _checkComponentURL(self, serviceName, options):
     """Ensure service URL is properly configured in the CS."""
     url = self._getURL(serviceName, options)
     system = options['System']

--- a/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
@@ -534,7 +534,7 @@ class ComponentSupervisionAgent(AgentModule):
       # ignore SystemAdministrator, does not have URLs
       if 'SystemAdministrator' in service:
         continue
-      self._checkComponentURL(service, options)
+      self._checkServiceURL(service, options)
 
     if self.csAPI.csModified and self.commitURLs:
       self.log.info('Commiting changes to the CS')
@@ -544,7 +544,7 @@ class ComponentSupervisionAgent(AgentModule):
         return S_ERROR('Failed to commit to CS')
     return S_OK()
 
-  def _checkComponentURL(self, serviceName, options):
+  def _checkServiceURL(self, serviceName, options):
     """Ensure service URL is properly configured in the CS."""
     url = self._getURL(serviceName, options)
     system = options['System']

--- a/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
@@ -229,7 +229,7 @@ class ComponentSupervisionAgent(AgentModule):
   def _getComponentOption(self, instanceType, system, componentName, option, default):
     """Get component option from DIRAC CS, using components' base classes methods."""
     fullComponentName = os.path.join(system, componentName)
-    componentPath = PathFinder.getComponentSection(fullComponentName, False, self.setup, instanceType)
+    componentPath = PathFinder.getComponentSection(fullComponentName, setup=self.setup, componentCategory=instanceType)
     if instanceType != 'Agents':
       return gConfig.getValue(os.path.join(componentPath, option), default)
     # deal with agent configuration


### PR DESCRIPTION


BEGINRELEASENOTES
This PR adds some convenience in getting service URLs as a list. As well as the ability to obtain URLs of all services in the context of the system. Port and path validation has also been added.

Currently, mostly getServiceURL is used, which returns a list of URLs as a string, which is then converted to a list type, or processed as a single URL. Therefore, for better clarity, getServiceURLs returns a list of URLs and can randomize the list and add failover URLs.

*ConfigurationSystem
NEW: test new PathFinder methods
NEW: add checkServiceURL that check URL port and path
NEW: add getServiceURLs that return list type result
NEW: add getSystemURLs that return all services URLs for system
FIX: getGatewayURLs pass list to randomize when serviceName is empty
CHANGE: getSystemSection do not use serviceTuple, add docs, use system and service instead of componentTuple

*FrameworkSystem
CHANGE: ComponentMonitoringDB use getSystemURLs

*Core
CHANGE: TornadoBaseClient use getServiceURLs

ENDRELEASENOTES
