### PR TITLE
[v7r2] dirac-admin-update-instance: fix use of --excludeHosts

### DIFF
--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_instance.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_instance.py
@@ -68,7 +68,7 @@ def main():
     pass
 
   if not isinstance(excludeHosts, list):
-    excludeHosts = hosts.split(',')
+    excludeHosts = excludeHosts.split(',')
 
 
   from concurrent.futures import ThreadPoolExecutor, as_completed


### PR DESCRIPTION

BEGINRELEASENOTES
*Framework
FIX: fix use of --excludeHosts in dirac-admin-update-instance

ENDRELEASENOTES
