### PR TITLE
[v7r3] SiteDirector: do not send dirac-install if it's py3 pilot

### DIFF
--- a/.github/workflows/pilotWrapper.yml
+++ b/.github/workflows/pilotWrapper.yml
@@ -11,10 +11,10 @@ jobs:
       fail-fast: False
       matrix:
         python:
-          - 2.6.9
           - 2.7.5
           - 2.7.13
           - 3.6.8
+          - 3.9.4
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -20,20 +20,20 @@ DIRAC is written in python 2.7.13 and transitioning to python 3.
 
 Status master branch (stable):
 
-.. image:: https://github.com/DIRACGrid/DIRAC/workflows/Basic%20tests/badge.svg?branch=rel-v7r1
-   :target: https://github.com/DIRACGrid/DIRAC/actions?query=workflow%3A%22Basic+tests%22+branch%3Arel-v7r1
+.. image:: https://github.com/DIRACGrid/DIRAC/workflows/Basic%20tests/badge.svg?branch=rel-v7r2
+   :target: https://github.com/DIRACGrid/DIRAC/actions?query=workflow%3A%22Basic+tests%22+branch%3Arel-v7r2
    :alt: Basic Tests Status
 
-.. image:: https://github.com/DIRACGrid/DIRAC/workflows/dirac-install/badge.svg?branch=rel-v7r1
-   :target: https://github.com/DIRACGrid/DIRAC/actions?query=workflow%3A%22dirac-install%22+branch%3Arel-v7r1
+.. image:: https://github.com/DIRACGrid/DIRAC/workflows/dirac-install/badge.svg?branch=rel-v7r2
+   :target: https://github.com/DIRACGrid/DIRAC/actions?query=workflow%3A%22dirac-install%22+branch%3Arel-v7r2
    :alt: Dirac Install Status
 
-.. image:: https://github.com/DIRACGrid/DIRAC/workflows/pilot%20wrapper/badge.svg?branch=rel-v7r1
-   :target: https://github.com/DIRACGrid/DIRAC/actions?query=workflow%3A%22pilot+wrapper%22+branch%3Arel-v7r1
+.. image:: https://github.com/DIRACGrid/DIRAC/workflows/pilot%20wrapper/badge.svg?branch=rel-v7r2
+   :target: https://github.com/DIRACGrid/DIRAC/actions?query=workflow%3A%22pilot+wrapper%22+branch%3Arel-v7r2
    :alt: Pilot Wrapper Status
 
-.. image:: https://github.com/DIRACGrid/DIRAC/workflows/Integration%20tests/badge.svg?branch=rel-v7r1
-   :target: https://github.com/DIRACGrid/DIRAC/actions?query=workflow%3A%22Integration+tests%22+branch%3Arel-v7r1
+.. image:: https://github.com/DIRACGrid/DIRAC/workflows/Integration%20tests/badge.svg?branch=rel-v7r2
+   :target: https://github.com/DIRACGrid/DIRAC/actions?query=workflow%3A%22Integration+tests%22+branch%3Arel-v7r2
    :alt: Integration Tests Status
 
 .. image:: https://readthedocs.org/projects/dirac/badge/?version=latest

--- a/docs/docs.conf
+++ b/docs/docs.conf
@@ -42,10 +42,6 @@ target_file = source/AdministratorGuide/Configuration/ExampleConfig.rst
 # list of commands which are not executed to get doc files, rst files have to be
 # created by hand
 ignore_commands=
-# does not have --help, starts compiling externals
-  dirac-compile-externals,
-# does not have --help
-  dirac-install-client,
 # does not have --help
   dirac-framework-self-ping
 

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
@@ -237,7 +237,6 @@ A simpler example using the LHCbPilot extension follows::
   rm -rf /tmp/area/*
 
   # URLs where to get scripts, that for Pilot3 are copied over to your WebPortal, e.g. like:
-  DIRAC_INSTALL='https://lhcb-portal-dirac.cern.ch/pilot/dirac-install.py'
   DIRAC_PILOT='https://lhcb-portal-dirac.cern.ch/pilot/dirac-pilot.py'
   DIRAC_PILOT_TOOLS='https://lhcb-portal-dirac.cern.ch/pilot/pilotTools.py'
   DIRAC_PILOT_COMMANDS='https://lhcb-portal-dirac.cern.ch/pilot/pilotCommands.py'
@@ -248,7 +247,6 @@ A simpler example using the LHCbPilot extension follows::
 
   #
   ##get the necessary scripts
-  wget --no-check-certificate -O dirac-install.py $DIRAC_INSTALL
   wget --no-check-certificate -O dirac-pilot.py $DIRAC_PILOT
   wget --no-check-certificate -O pilotTools.py $DIRAC_PILOT_TOOLS
   wget --no-check-certificate -O pilotCommands.py $DIRAC_PILOT_COMMANDS

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1143,7 +1143,12 @@ class SiteDirector(AgentModule):
     """
 
     try:
-      pilotFilesCompressedEncodedDict = getPilotFilesCompressedEncodedDict([DIRAC_INSTALL],
+      if self.python3Pilots:
+        pilotFiles = []
+      else:
+        pilotFiles = [DIRAC_INSTALL]
+
+      pilotFilesCompressedEncodedDict = getPilotFilesCompressedEncodedDict(pilotFiles,
                                                                            proxy)
     except Exception as be:
       self.log.exception("Exception during pilot modules files compression", lException=be)

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
@@ -27,21 +27,17 @@ def test_scriptoptions():
   """
 
   res = pilotWrapperScript(
-      pilotFilesCompressedEncodedDict={'dirac-install.py': 'someContentOfDiracInstall',
+      pilotFilesCompressedEncodedDict={'dirac_boh.py': 'someContentOfDiracInstall',
                                        'someOther.py': 'someOtherContent'},
       pilotOptions="-c 123 --foo bar")
 
-  assert "with open('dirac-install.py', 'wb') as fd:" in res
+  assert "with open('dirac_boh.py', 'wb') as fd:" in res
   assert 'os.environ["someName"]="someValue"' not in res
 
 
 def test_scriptReal():
   """ test script creation
   """
-  diracInstall = os.path.join(os.getcwd(), 'src/DIRAC/Core/scripts/dirac-install.py')
-  with open(diracInstall, "rb") as fd:
-    diracInstall = fd.read()
-  diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9))
 
   diracPilot = os.path.join(os.getcwd(), 'src/DIRAC/Core/Base/API.py')  # just some random file
   with open(diracPilot, "rb") as fd:
@@ -59,14 +55,12 @@ def test_scriptReal():
   diracPilotCommandsEncoded = base64.b64encode(bz2.compress(diracPilotCommands, 9))
 
   res = pilotWrapperScript(
-      pilotFilesCompressedEncodedDict={'dirac-install.py': diracInstallEncoded,
-                                       'dirac-pilot.py': diracPilotEncoded,
+      pilotFilesCompressedEncodedDict={'dirac-pilot.py': diracPilotEncoded,
                                        'pilotTools.py': diracPilotToolsEncoded,
                                        'pilotCommands.py': diracPilotCommandsEncoded},
       pilotOptions="-c 123 --foo bar")
 
   assert "with open('dirac-pilot.py', 'wb') as fd:" in res
-  assert "with open('dirac-install.py', 'wb') as fd:" in res
   assert 'os.environ["someName"]="someValue"' not in res
 
 
@@ -74,7 +68,7 @@ def test_scriptWithEnvVars():
   """ test script creation
   """
   res = pilotWrapperScript(
-      pilotFilesCompressedEncodedDict={'dirac-install.py': 'someContentOfDiracInstall',
+      pilotFilesCompressedEncodedDict={'dirac_boh.py': 'someContentOfDiracInstall',
                                        'someOther.py': 'someOtherContent'},
       pilotOptions="-c 123 --foo bar",
       envVariables={'someName': 'someValue',

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -6,10 +6,10 @@
 # - starts it
 #
 # It should be executed for different versions of python, e.g.:
-# - 2.6.x
 # - 2.7.x (x < 9)
 # - 2.7.x (x >= 9)
 # - 3.6.x
+# - 3.9.x
 #
 #
 # Invoke this with:
@@ -80,7 +80,7 @@ diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9)).decode()
 
 res = pilotWrapperScript(
     pilotFilesCompressedEncodedDict={'dirac-install.py': diracInstallEncoded},
-    pilotOptions="--setup=CI -N ce.dirac.org -Q DIRACQUEUE -n DIRAC.CI.ORG --debug",
+    pilotOptions="--setup=CI -N ce.dirac.org -Q DIRACQUEUE -n DIRAC.CI.ORG --pythonVersion=3 --debug",
     location='diracproject.web.cern.ch/diracproject/tars/Pilot/DIRAC/master/,wrong.cern.ch')
 
 with open('pilot-wrapper.sh', 'wb') as pj:

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -28,8 +28,6 @@ from __future__ import division
 import sys
 import os
 import time
-import base64
-import bz2
 
 # 1) gets the (DIRAC-free) PilotWrapper.py, and dirac-install.py
 
@@ -45,27 +43,11 @@ if sys.version_info >= (2, 7, 9):
   context = ssl._create_unverified_context()
   rf = url_library_urlopen(sys.argv[1],
                            context=context)
-  try:  # dirac-install.py location from the args, if provided
-    di = url_library_urlopen(sys.argv[2],
-                             context=context)
-  except IndexError:
-    di_loc = 'https://raw.githubusercontent.com/DIRACGrid/management/master/dirac-install.py'
-    di = url_library_urlopen(di_loc,
-                             context=context)
 else:
   rf = url_library_urlopen(sys.argv[1])
-  try:  # dirac-install.py location from the args, if provided
-    di = url_library_urlopen(sys.argv[2])
-  except IndexError:
-    di_loc = 'https://raw.githubusercontent.com/DIRACGrid/management/master/dirac-install.py'
-    di = url_library_urlopen(di_loc)
 
 with open('PilotWrapper.py', 'wb') as pj:
   pj.write(rf.read())
-  pj.close()  # for python 2.6
-with open('dirac-install.py', 'wb') as pj:
-  pj.write(di.read())
-  pj.close()  # for python 2.6
 
 
 # 2)  use its functions to generate a pilot wrapper
@@ -73,13 +55,7 @@ time.sleep(1)
 # by now this will be in the local dir
 from PilotWrapper import pilotWrapperScript  # pylint: disable=import-error
 
-diracInstall = os.path.join(os.getcwd(), 'dirac-install.py')
-with open(diracInstall, "rb") as fd:
-  diracInstall = fd.read()
-diracInstallEncoded = base64.b64encode(bz2.compress(diracInstall, 9)).decode()
-
 res = pilotWrapperScript(
-    pilotFilesCompressedEncodedDict={'dirac-install.py': diracInstallEncoded},
     pilotOptions="--setup=CI -N ce.dirac.org -Q DIRACQUEUE -n DIRAC.CI.ORG --pythonVersion=3 --debug",
     location='diracproject.web.cern.ch/diracproject/tars/Pilot/DIRAC/master/,wrong.cern.ch')
 


### PR DESCRIPTION
This waits for `Pilot/devel` branch to merge to `Pilot/master` branch (after https://github.com/DIRACGrid/Pilot/pull/133)

BEGINRELEASENOTES

*WMS
CHANGE: SiteDirector: do not send dirac-install if it's py3 pilot

ENDRELEASENOTES
