### PR TITLE
[v7r1] Fix type checking in FTS3ManagerHandler.getActiveJobs

### DIFF
--- a/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -127,7 +127,7 @@ class FTS3ManagerHandler(RequestHandler):
     opJSON = encode(getOperation)
     return S_OK(opJSON)
 
-  types_getActiveJobs = [six.integer_types, [None] + [basestring], basestring]
+  types_getActiveJobs = [six.integer_types, [type(None)] + [basestring], basestring]
 
   @classmethod
   def export_getActiveJobs(cls, limit, lastMonitor, jobAssignmentTag):


### PR DESCRIPTION
Fixes this error:

```
2021-07-27 13:19:23 UTC DataManagement/FTS3Manager ERROR: Error in parameter check: isinstance() arg 2 must be a class, type, or tuple of classes and types
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/DISET/RequestHandler.py", line 325, in __checkExpectedArgumentTypes
    if not isinstance(args[iIndex], tuple(oTypesList[iIndex])):
TypeError: isinstance() arg 2 must be a class, type, or tuple of classes and types
```

BEGINRELEASENOTES

*Data Management
FIX: Type error when calling FTS3ManagerHandler.getActiveJobs

ENDRELEASENOTES
