### PR TITLE
[v7r2] ComponentSupervisionAgent: look in correct CS path

### DIFF
--- a/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
@@ -93,7 +93,7 @@ class ComponentSupervisionAgent(AgentModule):
     """Initialize the agent, clients, default values."""
     AgentModule.__init__(self, *args, **kwargs)
     self.name = 'ComponentSupervisionAgent'
-    self.setup = 'Production'
+    self.setup = 'DIRAC-Production'
     self.enabled = False
     self.restartAgents = False
     self.restartExecutors = False
@@ -229,7 +229,11 @@ class ComponentSupervisionAgent(AgentModule):
   def _getComponentOption(self, instanceType, system, componentName, option, default):
     """Get component option from DIRAC CS, using components' base classes methods."""
     fullComponentName = os.path.join(system, componentName)
-    componentPath = PathFinder.getComponentSection(fullComponentName, False, self.setup, instanceType)
+    componentPath = PathFinder.getComponentSection(
+        componentName=fullComponentName,
+        setup=self.setup,
+        componentCategory=instanceType,
+    )
     if instanceType != 'Agents':
       return gConfig.getValue(os.path.join(componentPath, option), default)
     # deal with agent configuration
@@ -334,7 +338,11 @@ class ComponentSupervisionAgent(AgentModule):
 
   def checkAgent(self, agentName, options):
     """Check the age of agent's log file, if it is too old then restart the agent."""
-    pollingTime, currentLogLocation, pid = options['PollingTime'], options['LogFileLocation'], options['PID']
+    pollingTime, currentLogLocation, pid = (
+        options['PollingTime'],
+        options['LogFileLocation'],
+        options['PID']
+    )
     self.log.info('Checking Agent: %s' % agentName)
     self.log.info('Polling Time: %s' % pollingTime)
     self.log.info('Current Log File location: %s' % currentLogLocation)
@@ -344,7 +352,9 @@ class ComponentSupervisionAgent(AgentModule):
       return res
 
     age = res['Value']
-    self.log.info('Current log file for %s is %d minutes old' % (agentName, (age.seconds / MINUTES)))
+    self.log.info(
+        'Current log file for %s is %d minutes old' % (agentName, (age.seconds / MINUTES))
+    )
 
     maxLogAge = max(pollingTime + HOUR, 2 * HOUR)
     if age.seconds < maxLogAge:
@@ -521,7 +531,11 @@ class ComponentSupervisionAgent(AgentModule):
     gConfig.forceRefresh(fromMaster=True)
 
     # get port used for https based services
-    tornadoPortConfigPath = os.path.join('/Systems/Tornado', self.setup, 'Port')
+    tornadoPortConfigPath = PathFinder.getComponentSection(
+        componentName=os.path.join('/Systems/Tornado'),
+        setup=self.setup,
+        componentCategory='Port'
+    )
     self._tornadoPort = gConfig.getValue(tornadoPortConfigPath, self._tornadoPort)
     self.log.debug('Using Tornado Port:', self._tornadoPort)
 
@@ -550,7 +564,10 @@ class ComponentSupervisionAgent(AgentModule):
     system = options['System']
     module = options['Module']
     self.log.info('Checking URLs for %s/%s' % (system, module))
-    urlsConfigPath = os.path.join('/Systems', system, self.setup, 'URLs', module)
+    urlsConfigPath = PathFinder.getSystemURLSection(
+        serviceName=os.path.join(system, module),
+        setup=self.setup
+    )
     urls = gConfig.getValue(urlsConfigPath, [])
     self.log.debug('Found configured URLs for %s: %s' % (module, urls))
     self.log.debug('This URL is %s' % url)

--- a/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
@@ -4,18 +4,18 @@ from __future__ import division
 from __future__ import print_function
 
 import unittest
-import socket
 import sys
 from datetime import datetime, timedelta
 from mock import MagicMock, call, patch
 import psutil
 
+import DIRAC
+from DIRAC import gLogger
+from DIRAC import S_OK, S_ERROR
+
 import DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent as MAA
 from DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent import ComponentSupervisionAgent, NO_RESTART
 
-from DIRAC import S_OK, S_ERROR
-from DIRAC import gLogger
-import DIRAC
 
 __RCSID__ = "$Id$"
 
@@ -27,6 +27,18 @@ def clientMock(ret):
   clientClassMock.ping.return_value = ret
   clientModuleMock.return_value = clientClassMock
   return clientModuleMock
+
+
+def mockComponentSection(*_args, **kwargs):
+  """Mock the PathFinder.getComponentSection to return individual componentSections."""
+  fullComponentName = kwargs.get('componentName')
+  return "/Systems/Sys/Production/Services/" + fullComponentName.split('/', 1)[1]
+
+
+def mockURLSection(*_args, **kwargs):
+  """Mock the PathFinder.getComponentSection to return individual componentSections."""
+  fullComponentName = kwargs['serviceName']
+  return "/Systems/Sys/Production/URLs/" + fullComponentName.split('/', 1)[1]
 
 
 class TestComponentSupervisionAgent(unittest.TestCase):
@@ -573,11 +585,6 @@ class TestComponentSupervisionAgent(unittest.TestCase):
     for i in [1, 3]:
       newurls.append('%(prot)s://%(host)s:%(port)s/Sys/Serv%(i)s' % dict(i=i, host=host, port=port[i], prot=prot[i]))
 
-    def mockComponentSection(*args, **_kwargs):
-      """Mock the PathFinder.getComponentSection to return individual componentSections."""
-      fullComponentName = args[0]
-      return "/Systems/Sys/Production/Services/" + fullComponentName
-
     def gVal(*args, **_kwargs):
       """Mock getValue."""
       if 'Tornado' in args[0]:
@@ -591,7 +598,7 @@ class TestComponentSupervisionAgent(unittest.TestCase):
       if 'Protocol' in args[0]:
         return 'https' if 'Serv3' in args[0] else args[1]
       else:
-        assert False, 'Unknown config option requested'
+        assert False, 'Unknown config option requested %s' % args[0]
     gConfigMock = MagicMock()
     gConfigMock.getValue.side_effect = gVal
     services = {'Services': {'Sys': {'Serv1': {'Setup': True, 'PID': '18128', 'Port': '1001', 'RunitStatus': 'Run',
@@ -603,12 +610,15 @@ class TestComponentSupervisionAgent(unittest.TestCase):
                                      'SystemAdministrator': {'Setup': True, 'PID': '18128', 'Port': '1003',
                                                              'RunitStatus': 'Run', 'Module': 'Serv', 'Installed': True},
                                      }}}
+
     self.restartAgent.sysAdminClient.getOverallStatus.return_value = S_OK(services)
 
     with patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig', new=gConfigMock), \
             patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.socket.gethostname', return_value=host), \
             patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getComponentSection',
-                  side_effect=mockComponentSection):
+                  side_effect=mockComponentSection), \
+            patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getSystemURLSection',
+                  side_effect=mockURLSection):
       res = self.restartAgent.checkURLs()
     self.assertTrue(res['OK'])
     self.restartAgent.csAPI.modifyValue.assert_has_calls([call('/Systems/Sys/Production/URLs/Serv', ','.join(tempurls)),
@@ -625,14 +635,19 @@ class TestComponentSupervisionAgent(unittest.TestCase):
     self.restartAgent.sysAdminClient.getOverallStatus.return_value = S_OK(dict(Services={}))
 
     self.restartAgent.csAPI.commit = MagicMock(return_value=S_ERROR('Nope'))
-    with patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig', new=MagicMock()):
+    with patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig', new=MagicMock()), \
+         patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getComponentSection',
+               side_effect=mockComponentSection):
       res = self.restartAgent.checkURLs()
     self.assertFalse(res['OK'])
     self.assertIn('Failed to commit', res['Message'])
     self.assertIn('Commit to CS failed', self.restartAgent.errors[0])
 
     self.restartAgent.csAPI.commit = MagicMock(return_value=S_OK())
-    with patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig', new=MagicMock()):
+    with patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig', new=MagicMock()), \
+         patch('DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getComponentSection',
+               side_effect=mockComponentSection):
+
       res = self.restartAgent.checkURLs()
     self.assertTrue(res['OK'])
 

--- a/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
@@ -195,7 +195,7 @@ Agents
     # Overall enable or disable
     EnableFlag = False
     # Which setup to monitor
-    Setup = Production
+    Setup = DIRAC-Production
     # Email addresses receiving notifications
     MailTo =
     # Sender email address


### PR DESCRIPTION
BEGINRELEASENOTES

*Framework
FIX: ComponentSupervisionAgent: consistently use the actual "Setup", and not the "instance" to look up options. Note: you might need to change your config from "Production" to "DIRAC-Production" depending on you config.

ENDRELEASENOTES

- [x]  change configTemplate Setup option to "DIRAC-Production"
- [x] Fix tests