### PR TITLE
[v7r2] Fix call to JobMonitoringClient.getJobsStatus in WorkflowTasks

### DIFF
--- a/src/DIRAC/TransformationSystem/Client/TaskManager.py
+++ b/src/DIRAC/TransformationSystem/Client/TaskManager.py
@@ -1081,7 +1081,7 @@ class WorkflowTasks(TaskBase):
         if oldStatus != 'Unused':
           updateDict[lfn] = 'Unused'
 
-    res = self.jobMonitoringClient.getJobsStatus(taskNameIDs.values())
+    res = self.jobMonitoringClient.getJobsStatus(list(taskNameIDs.values()))
     if not res['OK']:
       self._logWarn("Failed to get job status from the WMS system",
                     transID=transID, method=method)


### PR DESCRIPTION
Fixes this crash when using Python 3:
```python
~/Development/DIRAC-dev/DIRAC/src/DIRAC/Core/Utilities/DEncode.py in encodeList(lValue, eList)
    437   eList.append(b"l")
    438   for uObject in lValue:
--> 439     g_dEncodeFunctions[type(uObject)](uObject, eList)
    440   eList.append(b"e")
    441

KeyError: <class 'dict_values'>
```


BEGINRELEASENOTES

*Transformation
FIX: Python 3 serialisation error when calling JobMonitoringClient.getJobsStatus in WorkflowTasks.getSubmittedFileStatus

ENDRELEASENOTES
