### PR TITLE
 [integration] fix to allow options from Operations to be used by file catalog clients.

### DIFF
--- a/src/DIRAC/Resources/Catalog/FileCatalog.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalog.py
@@ -427,7 +427,7 @@ class FileCatalog(object):
         return res
       catalogConfig = res['Value']
       if catalogConfig['Status'] == 'Active':
-        res = self._generateCatalogObject(catalogName)
+        res = self._generateCatalogObject(catalogName, **catalogConfig)
         if not res['OK']:
           return res
         oCatalog = res['Value']
@@ -473,10 +473,10 @@ class FileCatalog(object):
     catalogConfig['Master'] = (catalogConfig.setdefault('Master', False) == 'True')
     return S_OK(catalogConfig)
 
-  def _generateCatalogObject(self, catalogName):
+  def _generateCatalogObject(self, catalogName, **options):
     """ Create a file catalog object from its name and CS description
     """
     useProxy = gConfig.getValue('/LocalSite/Catalogs/%s/UseProxy' % catalogName, False)
     if not useProxy:
       useProxy = self.opHelper.getValue('/Services/Catalogs/%s/UseProxy' % catalogName, False)
-    return FileCatalogFactory().createCatalog(catalogName, useProxy)
+    return FileCatalogFactory().createCatalog(catalogName, useProxy, **options)

--- a/src/DIRAC/Resources/Catalog/FileCatalogFactory.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalogFactory.py
@@ -21,7 +21,7 @@ class FileCatalogFactory(object):
     self.log = gLogger.getSubLogger('FileCatalogFactory')
     self.catalogPath = ''
 
-  def createCatalog(self, catalogName, useProxy=False):
+  def createCatalog(self, catalogName, useProxy=False, **options):
     """ Create a file catalog object from its name and CS description
     """
     catalogPath = getCatalogPath(catalogName)
@@ -31,6 +31,8 @@ class FileCatalogFactory(object):
     result = gConfig.getOptionsDict(catalogPath)
     if result['OK']:
       optionsDict = result['Value']
+
+    optionsDict.update(options)
 
     if useProxy:
       result = self.__getCatalogClass(catalogType)


### PR DESCRIPTION
BEGINRELEASENOTES

The `FileCatalog.py` obtains options both from Resources and Operations but they are not passed in to `FileCatalogfFctory` and consequently are not available to file catalog clients. This PR updates the options from Resources with the options from Operations and passes them to a the factory, so they are all available to a client.

ENDRELEASENOTES
