### PR TITLE
[v7r2] DRA: fix divide by zero if we have just 1 job

### DIFF
--- a/src/DIRAC/TransformationSystem/Agent/DataRecoveryAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/DataRecoveryAgent.py
@@ -383,7 +383,7 @@ class DataRecoveryAgent(AgentModule):
     lfnCache = []
     counter = 0
     jobInfoStart = time.time()
-    for counter, job in enumerate(jobs.values()):
+    for counter, job in enumerate(jobs.values(), start=1):
       if counter % self.printEveryNJobs == 0:
         self.log.notice('Getting JobInfo: %d/%d: %3.1fs' %
                         (counter, len(jobs), float(time.time() - jobInfoStart)))


### PR DESCRIPTION

BEGINRELEASENOTES
*TS
FIX: DataRecoveryAgent: fix exception when there is exactly 1 done or failed job for a transformation

ENDRELEASENOTES
