### PR TITLE
[v7r2] fix ProxyManagerClient docs (from #4853)

### DIFF
--- a/src/DIRAC/FrameworkSystem/Client/ProxyManagerClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyManagerClient.py
@@ -1,4 +1,7 @@
-""" ProxyManagemerClient has the function to "talk" to the ProxyManager service
+""" ProxyManagerClient has the function to "talk" to the ProxyManager service
+    (:mod:`~DIRAC.FrameworkSystem.Service.ProxyManagerHandler`).
+    This inherits the DIRAC base Client for direct execution of server functionality.
+    Client also contain caching of the requested proxy information.
 """
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION

BEGINRELEASENOTES
For some reason, this fix was not merged from v7r1 #4853 

*Framework
FIX: fix ProxyManagerClient docs

ENDRELEASENOTES
