### PR TITLE
[targetReleaseBranch] fix python3 incompatibility in InputDataByProtocol

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/InputDataByProtocol.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/InputDataByProtocol.py
@@ -251,7 +251,7 @@ class InputDataByProtocol(object):
 
     # Check if the files were actually resolved (i.e. have a TURL)
     # If so, remove them from failed list
-    for lfn, mdataList in trackLFNs.items():  # There is a pop below, can't use iteritems()
+    for lfn, mdataList in list(trackLFNs.items()):  # There is a pop below, can't iterate trackLFNs
       for mdata in list(mdataList):
         if 'turl' not in mdata:
           mdataList.remove(mdata)


### PR DESCRIPTION
since items() returns an iterator in python3, it must first be converted to a list to enable pop to work

BEGINRELEASENOTES
*WMS
FIX: fix python3 incompatibility in InputDataByProtocol
ENDRELEASENOTES