### PR TITLE
[v7r3] Add VMDIRAC Tests

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
@@ -361,6 +361,7 @@ class VirtualMachineManagerHandler(RequestHandler):
         result = self.virtualMachineDB.declareInstanceStopping(instanceID)
         if not result['OK']:
           return result
+    return S_OK()
 
   types_declareInstanceHalting = [six.string_types, float]
 

--- a/tests/Integration/WorkloadManagementSystem/Test_VirtualMachineDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_VirtualMachineDB.py
@@ -1,0 +1,217 @@
+""" VirtualMachineDB Integration Tests
+"""
+
+import unittest
+
+from DIRAC.Core.Base.Script import parseCommandLine
+parseCommandLine()
+
+from DIRAC.WorkloadManagementSystem.DB.VirtualMachineDB import VirtualMachineDB
+
+
+class VirtualMachineDBInstanceTests(unittest.TestCase):
+  """ This tests the instance related database functions.
+      It creates two entries, one is used for the tests and the second
+      is checked after each test to check it hasn't changed.
+  """
+
+  INST_UUID = "1111-2222-3333"
+  INST_NAME = "TestInst"
+  INST_IMAGE = "TestImage"
+  INST_EP = "MyCloud::mycloud.domain"
+  INST_POD = "testvo"  # pod is generally just set to VO name and not really used
+
+  def setUp(self):
+    """ Adds an instance which we can then check the properties of """
+    self.__db = VirtualMachineDB()
+    # Start by clearing the database so we don't get any surprises
+    for vmTable in VirtualMachineDB.tablesDesc:
+      res = self.__db._query("DELETE FROM `%s`" % vmTable)
+      self.assertTrue(res['OK'])
+    # Now create our test instances
+    res = self.__db.insertInstance(self.INST_UUID, self.INST_IMAGE, self.INST_NAME, self.INST_EP, self.INST_POD)
+    self.assertTrue(res['OK'])
+    # Most functions will need the internal DB instance ID
+    res = self.__db.getInstanceID(self.INST_UUID)
+    self.assertTrue(res['OK'])
+    self.__id = res['Value']
+    # Create the second "canary" instance entry that should always be unchanged
+    res = self.__db.insertInstance(self.INST_UUID + '2', self.INST_IMAGE + '2', self.INST_NAME + '2',
+                                   self.INST_EP + '2', self.INST_POD + '2')
+    self.assertTrue(res['OK'])
+
+  def tearDown(self):
+    """ Checks that the second instance is unchanged and then clears the DB tables
+        so that any changes the test made aren't retained for future tests """
+    test_id = self.__db.getInstanceID(self.INST_UUID + '2')['Value']
+    for paramName, paramValue in [('UniqueID', self.INST_UUID + '2'),
+                                  ('InstanceID', test_id),
+                                  ('Name', self.INST_NAME + '2'),
+                                  ('Endpoint', self.INST_EP + '2'),
+                                  ('RunningPod', self.INST_POD + '2'),
+                                  ('Status', 'Submitted')
+                                  ]:
+      res = self.__db.getInstanceParameter(paramName, test_id)
+      self.assertTrue(res['OK'])
+      self.assertEqual(res['Value'], paramValue)
+    res = self.__db.checkImageStatus(self.INST_IMAGE + '2')
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], 'New')
+
+  def test_imageStatus(self):
+    """ Adding an instance should automatically add its image in the "New" state """
+    res = self.__db.checkImageStatus(self.INST_IMAGE)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], 'New')
+    # An image is considered validated when an instance using it starts running
+    # returning at least one heartbeat
+    self.assertTrue(self.__db.declareInstanceRunning(self.INST_UUID, "127.0.0.1")['OK'])
+    self.assertTrue(self.__db.instanceIDHeartBeat(self.INST_UUID, 0.0, 0, 0, 0, 60)['OK'])
+    res = self.__db.checkImageStatus(self.INST_IMAGE)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], 'Validated')
+
+  def test_instanceParam(self):
+    """ Check we can get all of the instance parameters and that unknown properties fail  """
+    for paramName, paramValue in [('UniqueID', self.INST_UUID),
+                                  ('InstanceID', self.__id),
+                                  ('Name', self.INST_NAME),
+                                  ('Endpoint', self.INST_EP),
+                                  ('RunningPod', self.INST_POD),
+                                  ('Status', 'Submitted')
+                                  ]:
+      res = self.__db.getInstanceParameter(paramName, self.__id)
+      self.assertTrue(res['OK'])
+      self.assertEqual(res['Value'], paramValue)
+    res = self.__db.getInstanceParameter("BadParam", self.__id)
+    self.assertFalse(res['OK'])
+    # Some parameters have dedicated access functions too
+    res = self.__db.getEndpointFromInstance(self.INST_UUID)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], self.INST_EP)
+    res = self.__db.getInstanceStatus(self.__id)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], "Submitted")
+    # A running instance with a heartbeat has a few of extra parameters
+    # Bytes and files are stored in the history table and not tested here
+    INST_LOAD = 4.0
+    INST_JOBS = 5
+    INST_FILES = 6
+    INST_BYTES = 7
+    INST_UPTIME = 8
+    self.assertTrue(self.__db.declareInstanceRunning(self.INST_UUID, "127.0.0.1")['OK'])
+    res = self.__db.instanceIDHeartBeat(self.INST_UUID, INST_LOAD, INST_JOBS,
+                                        INST_FILES, INST_BYTES, INST_UPTIME)
+    self.assertTrue(res['OK'])
+    for paramName, paramValue in [('Load', INST_LOAD),
+                                  ('Jobs', INST_JOBS),
+                                  ('Uptime', INST_UPTIME)
+                                  ]:
+      res = self.__db.getInstanceParameter(paramName, self.__id)
+      self.assertTrue(res['OK'])
+      self.assertEqual(res['Value'], paramValue)
+    # There is also a function to get all fields in one go
+    # Check a small selection of the fields in that
+    res = self.__db.getAllInfoForUniqueID(self.INST_UUID)
+    self.assertTrue(res['OK'])
+    inst = res['Value']['Instance']
+    self.assertEqual(inst['Name'], self.INST_NAME)
+    self.assertEqual(inst['Endpoint'], self.INST_EP)
+    self.assertEqual(inst['RunningPod'], self.INST_POD)
+    self.assertEqual(inst['Status'], "Running")
+
+  def test_changeInstanceID(self):
+    """ Check we can update an instance's ID. """
+    NEW_ID = "4444-5555-6666"
+    res = self.__db.setInstanceUniqueID(self.__id, NEW_ID)
+    self.assertTrue(res['OK'])
+    # Check it changed and that we can get it by the new ID
+    res = self.__db.getUniqueID(self.__id)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], NEW_ID)
+    res = self.__db.getInstanceID(NEW_ID)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], self.__id)
+
+  def test_getByName(self):
+    """ Check we can get an instance by name. """
+    res = self.__db.getUniqueIDByName(self.INST_NAME)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], self.INST_UUID)
+
+  def test_instanceStates(self):
+    """ Swap the instance through all of the states and check it updates. """
+    self.assertTrue(self.__db.declareInstanceRunning(self.INST_UUID, "127.0.0.1")['OK'])
+    self.assertEqual(self.__db.getInstanceStatus(self.__id)['Value'], "Running")
+    self.assertTrue(self.__db.declareInstanceStopping(self.__id)['OK'])
+    self.assertEqual(self.__db.getInstanceStatus(self.__id)['Value'], "Stopping")
+    self.assertTrue(self.__db.declareInstanceHalting(self.INST_UUID, 0.0)['OK'])
+    self.assertEqual(self.__db.getInstanceStatus(self.__id)['Value'], "Halted")
+    # We don't test all invalid transitions, but an instance cannot go from halted
+    # back to running, so this should not update the state
+    self.__db.declareInstanceRunning(self.INST_UUID, "127.0.0.1")
+    self.assertEqual(self.__db.getInstanceStatus(self.__id)['Value'], "Halted")
+
+  def test_recordDBHalt(self):
+    """ This function lets an admin declare an instance in the halting state,
+        test that it does update the DB. This only works on a running instance.
+    """
+    # We should get an error as we can't halt a submitted instnace
+    self.assertFalse(self.__db.recordDBHalt(self.__id, 0.0)['OK'])
+    # Put it into the running state and try again
+    self.assertTrue(self.__db.declareInstanceRunning(self.INST_UUID, "127.0.0.1")['OK'])
+    self.assertTrue(self.__db.recordDBHalt(self.__id, 0.0)['OK'])
+    self.assertEqual(self.__db.getInstanceStatus(self.__id)['Value'], "Halted")
+
+  def test_instanceIPs(self):
+    """ Check instance IP assignment functions. """
+    PUBLIC_IP = "123.123.123.123"
+    PRIVATE_IP = "127.123.123.123"
+    # This function should strip an IPv6 mapping from the public IP
+    # Test this at the same time
+    res = self.__db.declareInstanceRunning(self.INST_UUID, "::ffff:" + PUBLIC_IP, PRIVATE_IP)
+    self.assertTrue(res['OK'])
+    res = self.__db.getInstanceParameter('PrivateIP', self.__id)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], PRIVATE_IP)
+    res = self.__db.getInstanceParameter('PublicIP', self.__id)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], PUBLIC_IP)
+
+  def test_heartbeats(self):
+    """ Test that the heartbeat mechanism works as expected. """
+    # Put the instance into the running state and check that it doesn't get pruned
+    self.assertTrue(self.__db.declareInstanceRunning(self.INST_UUID, "127.0.0.1")['OK'])
+    self.assertTrue(self.__db.instanceIDHeartBeat(self.INST_UUID, 0.0, 0, 0, 0, 60)['OK'])
+    self.assertTrue(self.__db.declareStalledInstances()['OK'])
+    self.assertEqual(self.__db.getInstanceStatus(self.__id)['Value'], "Running")
+    # We now manually patch the heartbeat we added so that it's further in the past
+    # Far enough back that the instance appears stuck to check it gets marked as stalled
+    exp_time = self.__db.stallingInterval * 2  # Use twice the interval for safety
+    sql = "UPDATE vm_Instances SET LastUpdate = LastUpdate - INTERVAL %u SECOND WHERE InstanceID = %s" \
+          % (exp_time, self.__id)
+    self.assertTrue(self.__db._query(sql)['OK'])
+    res = self.__db.getAllInfoForUniqueID(self.INST_UUID)
+    self.assertTrue(self.__db.declareStalledInstances()['OK'])
+    self.assertEqual(self.__db.getInstanceStatus(self.__id)['Value'], "Stalled")
+
+  def test_getByState(self):
+    """ Tests the getInstancesByStatus function. """
+    # First check that a bad status isn't accepted by the function
+    self.assertFalse(self.__db.getInstancesByStatus("BadState")['OK'])
+    # Now do the tests with valid inputs
+    res = self.__db.getInstancesByStatus("Submitted")
+    self.assertTrue(res['OK'])
+    images = res['Value']
+    # We should have two instances
+    # Check that the structure looks correct {image: [instnaces]}
+    self.assertEqual(len(images), 2)
+    self.assertIn(self.INST_IMAGE, images)
+    self.assertIn(self.INST_UUID, images[self.INST_IMAGE])
+    # Mark the test instance as running and check it doesn't appear in the output
+    self.assertTrue(self.__db.declareInstanceRunning(self.INST_UUID, "127.0.0.1")['OK'])
+    res = self.__db.getInstancesByStatus("Submitted")
+    self.assertTrue(res['OK'])
+    images = res['Value']
+    self.assertEqual(len(images), 1)
+    self.assertNotIn(self.INST_IMAGE, images)

--- a/tests/Integration/WorkloadManagementSystem/Test_VirtualMachineManagerClient.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_VirtualMachineManagerClient.py
@@ -1,0 +1,101 @@
+""" VirtualMachineManager Service Integration Tests
+"""
+
+import uuid
+import unittest
+
+from DIRAC.Core.Base.Script import parseCommandLine
+parseCommandLine()
+
+from DIRAC.Core.DISET.RPCClient import RPCClient
+
+
+class VirtualMachineManagerTests(unittest.TestCase):
+  """ These tests check the VirtualMachineManager functions.
+   """
+
+  def _assertState(self, uniqueID, state):
+    """ Asserts the given instance (UUID) is in the the given state.
+        Returns the full instance info dict for further inspection if needed.
+    """
+    res = self.__client.getAllInfoForUniqueID(uniqueID)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value']['Instance']['Status'], state)
+    return res['Value']
+
+  def setUp(self):
+    self.__client = RPCClient("WorkloadManagement/VirtualMachineManager")
+    res = self.__client.checkVmWebOperation('Any')
+    self.assertTrue(res['OK'])
+    if res['Value'] != 'Auth':
+      self.fail("Client has insufficient privs to test VM calls")
+    # Create a test instance
+    self.__inst_uuid = str(uuid.uuid4())
+    self.__inst_image = 'ClientImage'
+    self.__inst_name = 'ClientInst-%s' % self.__inst_uuid
+    self.__inst_ep = 'UKI-CLOUD::testcloud.cloud'
+    self.__inst_pod = 'clientvo'
+    res = self.__client.insertInstance(self.__inst_uuid,
+                                       self.__inst_image,
+                                       self.__inst_name,
+                                       self.__inst_ep,
+                                       self.__inst_pod)
+    self.assertTrue(res['OK'])
+    self.__id = res['Value']
+
+  def test_instanceBasics(self):
+    """ Check that we can add an instance and then get the details back.
+    """
+    # Create instance
+    # Check get functions
+    res = self.__client.getUniqueID(str(self.__id))
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], self.__inst_uuid)
+    res = self.__client.getUniqueIDByName(self.__inst_name)
+    self.assertTrue(res['OK'])
+    self.assertEqual(res['Value'], self.__inst_uuid)
+    # Check set functions
+    INST_ALT_UUID = str(uuid.uuid4())
+    self.assertTrue(self.__client.setInstanceUniqueID(self.__id, INST_ALT_UUID)['OK'])
+    res = self.__client.getAllInfoForUniqueID(INST_ALT_UUID)  # Use new UUID to fetch VM
+    self.assertTrue(res['OK'])
+    # Check get by state
+    res = self.__client.getInstancesByStatus('Submitted')
+    self.assertTrue(res['OK'])
+    self.assertIn(INST_ALT_UUID, res['Value'][self.__inst_image])
+
+  def test_instanceStates(self):
+    """ Create an instance entry and check we can set its state. """
+    self._assertState(self.__inst_uuid, 'Submitted')
+    self.assertTrue(self.__client.declareInstanceRunning(self.__inst_uuid, "127.127.127.1")['OK'])
+    self._assertState(self.__inst_uuid, 'Running')
+    self.assertTrue(self.__client.declareInstancesStopping([self.__id])['OK'])
+    self._assertState(self.__inst_uuid, 'Stopping')
+    self.assertTrue(self.__client.declareInstanceHalting(self.__inst_uuid, 0.0)['OK'])
+    self._assertState(self.__inst_uuid, 'Halted')
+
+  def test_instanceProps(self):
+    """ Check that instance properties get set correctly.
+    """
+    INST_LOAD = 1.2
+    INST_JOBS = 3
+    INST_FILES = 4
+    INST_BYTES = 5
+    INST_UPTIME = 67
+    INST_IP = "127.127.127.1"
+    self.assertTrue(self.__client.declareInstanceRunning(self.__inst_uuid, INST_IP)['OK'])
+    res = self.__client.instanceIDHeartBeat(self.__inst_uuid, INST_LOAD, INST_JOBS,
+                                            INST_FILES, INST_BYTES, INST_UPTIME)
+    self.assertTrue(res['OK'])
+    res = self._assertState(self.__inst_uuid, 'Running')
+    inst = res['Instance']
+    self.assertEqual(inst['Name'], self.__inst_name)
+    self.assertEqual(inst['Endpoint'], self.__inst_ep)
+    self.assertEqual(inst['RunningPod'], self.__inst_pod)
+    self.assertEqual(inst['PrivateIP'], INST_IP)
+    self.assertEqual(inst['Load'], INST_LOAD)
+    self.assertEqual(inst['Jobs'], INST_JOBS)
+    self.assertEqual(inst['Uptime'], INST_UPTIME)
+    img = res['Image']
+    self.assertEqual(img['Name'], self.__inst_image)
+    self.assertEqual(img['Status'], 'Validated')

--- a/tests/Integration/all_integration_client_tests.sh
+++ b/tests/Integration/all_integration_client_tests.sh
@@ -55,6 +55,9 @@ echo -e "*** $(date -u)  **** WMS TESTS ****\n"
 python "${THIS_DIR}/WorkloadManagementSystem/Test_SandboxStoreClient.py" --cfg "$WORKSPACE/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_JobWrapper.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_PilotsClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+# Make sure we have the prod role for these tests to get the VmRpcOperator permission
+dirac-proxy-init -g prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_VirtualMachineManagerClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 ## no real tests
 python "${THIS_DIR}/WorkloadManagementSystem/createJobXMLDescriptions.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -46,8 +46,8 @@ pytest "${THIS_DIR}/WorkloadManagementSystem/Test_TaskQueueDB.py" |& tee -a "${S
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_ElasticJobParametersDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_PilotAgentsDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
+pytest "${THIS_DIR}/WorkloadManagementSystem/Test_VirtualMachineDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 python "${THIS_DIR}/WorkloadManagementSystem/Test_Client_WMS.py" --cfg "${WORKSPACE}/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/sb.cfg" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
-
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u)  **** DMS TESTS ****\n"
 pytest "${THIS_DIR}/DataManagementSystem/Test_DataIntegrityDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -695,7 +695,7 @@ diracUserAndGroup() {
     exit 1
   fi
 
-  if ! dirac-admin-add-group -G prod -U adminusername,ciuser,trialUser -P Operator,FullDelegation,ProxyManagement,ServiceAdministrator,JobAdministrator,CSAdministrator,AlarmsManagement,FileCatalogManagement,SiteManager,NormalUser "${DEBUG}"; then
+  if ! dirac-admin-add-group -G prod -U adminusername,ciuser,trialUser -P Operator,FullDelegation,ProxyManagement,ServiceAdministrator,JobAdministrator,CSAdministrator,AlarmsManagement,FileCatalogManagement,SiteManager,NormalUser,VmRpcOperation "${DEBUG}"; then
     echo 'ERROR: dirac-admin-add-group failed' >&2
     exit 1
   fi


### PR DESCRIPTION
Hi,

Here are some tests of the basic functionality of the VMDIRAC DB + Service. It also removes a bunch of unused functions (all of the pod stuff) and fixes up a few bugs that got introduced during the merge (found thanks to the new tests :-)

The tests only really focus on the core functions, but it's a start. The main things not tested are the history functions used by the web interface: I'm not really sure if they've worked in recent times, so they probably need additional attention in conjunction with the webapp code first anyway.

(Probably) closes #5283 .

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Fix-up minor errors introduced during VMDIRAC merge
NEW: Tests for VirtualMachine DB & Service
ENDRELEASENOTES
