### PR TITLE
[v7r2] Fix bug where transformation system sandboxes are kept forever

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
@@ -164,6 +164,12 @@ class JobCleaningAgent(AgentModule):
       self.log.info("No jobs to remove")
       return S_OK()
 
+    self.log.info("Unassigning sandboxes from soon to be deleted jobs", "(%d)" % len(jobList))
+    result = SandboxStoreClient(useCertificates=True).unassignJobs(jobList)
+    if not result['OK']:
+      self.log.error("Cannot unassign jobs to sandboxes", result['Message'])
+      return result
+
     self.log.info("Attempting to remove deleted jobs", "(%d)" % len(jobList))
 
     # remove from jobList those that have still Operations to do in RMS
@@ -230,10 +236,6 @@ class JobCleaningAgent(AgentModule):
 
     self.log.notice("Attempting to delete jobs", "(%d for %s)" % (len(jobList), condDict))
 
-    result = SandboxStoreClient(useCertificates=True).unassignJobs(jobList)
-    if not result['OK']:
-      self.log.error("Cannot unassign jobs to sandboxes", result['Message'])
-      return result
 
     result = self.deleteJobOversizedSandbox(jobList)  # This might set a request
     if not result['OK']:


### PR DESCRIPTION
Since v7r2p5 the sandboxes from jobs in the transformation system are kept permanently as the jobs are never unassigned. This is because the sandboxes are removed when the `JobCleaningAgent` moves jobs to the `Deleted` status:

https://github.com/DIRACGrid/DIRAC/blob/31229839611bbd75fc05eb6fb183b3acedfe0ac7/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py#L233

For jobs which are managed by the transformation system this is instead done by the `TransformationCleaningAgent`:

https://github.com/DIRACGrid/DIRAC/blob/31229839611bbd75fc05eb6fb183b3acedfe0ac7/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py#L645

This fixes it by moving the call to `SandboxStoreClient().unassignJobs` time that jobs are actually removed to ensure that there is no way for jobs to bypass the removal.

This problem was introduced by: https://github.com/DIRACGrid/DIRAC/commit/370b2fc20931d319fc9cfcff53e40a22c6182364

**Question**: Does the case where the  `deleteJobOversizedSandbox` also need to be handled somehow or can we assume oversized sandboxes don't get produced by the transformation system?

BEGINRELEASENOTES

*WorkloadManagement
FIX: Fix unassigning sandboxes when removing jobs from the transformation system

ENDRELEASENOTES

### Cleanup procedure

This leaves the problem that there are sandboxes that are assigned to jobs no longer exist and will therefore never be "unassigned". In LHCb we've decided to clean this removing the entries from `sb_EntityMapping` which have a last access time that is older than a few months as explicitly removing unknown jobs would take too long and the data in the sandboxes redundant for us. We're doing this on a month-by-month basis stating with jobs from before 2021. Only jobs which belong to the production users are being considered:

```sql
mysql> select * from sb_Owners where OwnerId in (1465,1466,1467);
+---------+---------+-------------+----------------------------------------------------------------------------------+
| Owner   | OwnerId | OwnerGroup  | OwnerDN                                                                          |
+---------+---------+-------------+----------------------------------------------------------------------------------+
| fstagni |    1465 | lhcb_mcproc | /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=fstagni/CN=693025/CN=Federico Stagni |
| fstagni |    1466 | lhcb_mc     | /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=fstagni/CN=693025/CN=Federico Stagni |
| fstagni |    1467 | lhcb_data   | /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=fstagni/CN=693025/CN=Federico Stagni |
+---------+---------+-------------+----------------------------------------------------------------------------------+
3 rows in set (0.00 sec)
```

Checking how much data this corresponds to:

```sql
mysql> SELECT COUNT(*), SUM(BYTES)/POWER(1000, 3) FROM sb_SandBoxes WHERE OwnerId IN (1467,1466,1465) AND LastAccessTime < "2021-01-01";
+----------+---------------------------+
| COUNT(*) | SUM(BYTES)/POWER(1000, 3) |
+----------+---------------------------+
|    93798 |               3.635945573 |
+----------+---------------------------+
1 row in set (25.44 sec)
```

Do the actually removal:

```sql
mysql> DELETE FROM `sb_EntityMapping` WHERE SBId IN (SELECT SBId FROM sb_SandBoxes WHERE OwnerId IN (1467,1466,1465) AND LastAccessTime < "2021-01-01");
Query OK, 106587 rows affected (11 min 12.73 sec)
```

Eventually we'll remove more recent data which corresponds to:

```sql
mysql> SELECT COUNT(*), SUM(BYTES)/POWER(1000, 3) FROM sb_SandBoxes WHERE OwnerId IN (1467,1466,1465) AND LastAccessTime < "2021-06-01";
+----------+---------------------------+
| COUNT(*) | SUM(BYTES)/POWER(1000, 3) |
+----------+---------------------------+
| 21275041 |            2259.967926131 |
+----------+---------------------------+
1 row in set (26.68 sec)
```

The queries will have to be repeated again in a few months to remove the entries for jobs that were recently removed from the transformation system.