### PR TITLE
[v7r2] Use selectors module

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -70,6 +70,7 @@ dependencies:
   - typing >=3.6.6
   # Pin OpenSSL to avoid: https://github.com/DIRACGrid/DIRAC/issues/4489
   - openssl <1.1
+  - selectors2
   - pip:
     - diraccfg
     # This is a fork of tornado with a patch to allow for configurable iostream


### PR DESCRIPTION
closes https://github.com/DIRACGrid/DIRAC/issues/5232

BEGINRELEASENOTES

*Core
FIX: Use selectors(2) instead of select.select to avoid issues with file descriptors > 1024

ENDRELEASENOTES
