### PR TITLE
[v7r2] ElasticSearchDB: use ca certs file if requested

### DIFF
--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -105,7 +105,7 @@ class ElasticSearchDB(object):
     :param str indexPrefix: it is the indexPrefix used to get all indexes
     :param bool useSSL: We can disable using secure connection. By default we use secure connection.
     :param bool useCRT: Use certificates.
-    :param str ca_certs: Server certificate.
+    :param str ca_certs: CA certificates bundle.
     :param str client_key: Client key.
     :param str client_cert: Client certificate.
     """
@@ -131,14 +131,17 @@ class ElasticSearchDB(object):
       sLog.verbose("Connecting to %s, useSSL = %s" % (host, useSSL))
 
     if useSSL:
-      bd = BundleDeliveryClient()
-      retVal = bd.getCAs()
-      casFile = None
-      if not retVal['OK']:
-        sLog.error("CAs file does not exists:", retVal['Message'])
-        casFile = certifi.where()
+      if ca_certs:
+        casFile = ca_certs
       else:
-        casFile = retVal['Value']
+        bd = BundleDeliveryClient()
+        retVal = bd.getCAs()
+        casFile = None
+        if not retVal['OK']:
+          sLog.error("CAs file does not exists:", retVal['Message'])
+          casFile = certifi.where()
+        else:
+          casFile = retVal['Value']
 
       self.client = Elasticsearch(self.__url,
                                   timeout=self.__timeout,


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: ElasticSearchDB: use ca certs file if requested

ENDRELEASENOTES
