### PR TITLE
[v7r3] Fix installing Python 3 releases of DIRAC from Python 2

### DIFF
--- a/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -303,6 +303,14 @@ class SystemAdministratorHandler(RequestHandler):
     if rootPath_:
       return S_ERROR("rootPath argument is not supported for Python 3 installations")
     # Validate and normalise the requested version
+    primaryExtension = None
+    if "==" in version:
+      primaryExtension, version = version.split("==")
+    elif six.PY2:
+      return S_ERROR(
+          "The extension must be specified like DIRAC==vX.Y.Z if installing "
+          "a Python 3 version from an exisiting Python 3 installation."
+      )
     try:
       version = Version(version)
     except InvalidVersion:
@@ -311,11 +319,9 @@ class SystemAdministratorHandler(RequestHandler):
     version = "v%s" % version
 
     # Find what to install
-    primaryExtension = None
     otherExtensions = []
     for extension in extensionsByPriority():
-      extensionMetadata = getExtensionMetadata(extension)
-      if primaryExtension is None and extensionMetadata.get("primary_extension", False):
+      if primaryExtension is None and getExtensionMetadata(extension).get("primary_extension", False):
         primaryExtension = extension
       else:
         otherExtensions.append(extension)
@@ -341,8 +347,12 @@ class SystemAdministratorHandler(RequestHandler):
       installer.flush()
       self.log.info("Downloaded DIRACOS installer to", installer.name)
 
+      if six.PY2:
+        newProPrefix = os.path.dirname(os.path.realpath(os.path.join(rootPath, "bashrc")))
+      else:
+        newProPrefix = rootPath
       newProPrefix = os.path.join(
-          rootPath,
+          newProPrefix,
           "versions",
           "%s-%s" % (version, datetime.utcnow().strftime("%s")),
       )
@@ -351,7 +361,7 @@ class SystemAdministratorHandler(RequestHandler):
       r = subprocess.run(  # pylint: disable=no-member
           ["bash", installer.name, "-p", installPrefix],
           stderr=subprocess.PIPE,
-          text=True,
+          universal_newlines=True,
           check=False,
           timeout=300,
       )
@@ -373,7 +383,7 @@ class SystemAdministratorHandler(RequestHandler):
             "%s[server]==%s" % (primaryExtension, version),
         ] + ["%s[server]" % e for e in otherExtensions],
         stderr=subprocess.PIPE,
-        text=True,
+        universal_newlines=True,
         check=False,
         timeout=300,
     )


### PR DESCRIPTION

BEGINRELEASENOTES

*Framework
FIX: Fix using the System Administrator to install Python 3 releases of DIRAC from Python 2

ENDRELEASENOTES
