### PR TITLE
[v7r3] Fix running tornado-start-all without a proxy

### DIFF
--- a/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
+++ b/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
@@ -36,8 +36,6 @@ def main():
   from DIRAC.Core.Utilities.DErrno import includeExtensionErrors
   from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
-  Script.parseCommandLine()
-
   # We check if there is no configuration server started as master
   # If you want to start a master CS you should use Configuration_Server.cfg and
   # use tornado-start-CS.py


### PR DESCRIPTION
@fstagni you added this [here](https://github.com/DIRACGrid/DIRAC/pull/5214/files#diff-8990c56b0602bc15b3b5b3525ca77bd304daa6d4a725f060fe00da6d90c2e3daR39-R40) but I don't understand why it would be needed? It's a problem as it causes the configuration system to fail to initialise as it's before the option to use server certificates is set.