### PR TITLE
[v7r3] Fix reading/writing TransformationAgent cache files for Python 3

### DIFF
--- a/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
@@ -630,7 +630,7 @@ class TransformationAgent(AgentModule, TransformationAgentsUtilities):
       if not os.path.exists(fileName):
         self.replicaCache[transID] = {}
       else:
-        with open(fileName, 'r') as cacheFile:
+        with open(fileName, 'rb') as cacheFile:
           self.replicaCache[transID] = pickle.load(cacheFile)
         self._logInfo("Successfully loaded replica cache from file %s (%d files)" %
                       (fileName, self.__filesInCache(transID)),
@@ -660,7 +660,7 @@ class TransformationAgent(AgentModule, TransformationAgentsUtilities):
         # write to a temporary file in order to avoid corrupted files
         cacheFile = self.__cacheFile(t_id)
         tmpFile = cacheFile + '.tmp'
-        with open(tmpFile, 'w') as fd:
+        with open(tmpFile, 'wb') as fd:
           pickle.dump(self.replicaCache.get(t_id, {}), fd)
         # Now rename the file as it shold
         os.rename(tmpFile, cacheFile)


### PR DESCRIPTION
```python
2021-08-19 05:43:42 UTC Transformation/TransformationAgent/[192] .__writeCache ERROR: Could not write replica cache file /opt/dirac/work/Transformation/TransformationAgent/ReplicaCache_192.pkl
Traceback (most recent call last):
  File "/opt/dirac/versions/v7.3.0a20-1629294914/Linux-x86_64/lib/python3.9/site-packages/DIRAC/TransformationSystem/Agent/TransformationAgent.py", line 656, in __writeCache
    pickle.dump(self.replicaCache.get(t_id, {}), fd)
TypeError: write() argument must be str, not bytes
```