### PR TITLE
[v7r3] Fix editing the CS when running with Python 3 + tornado

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/ConfigurationClient.py
+++ b/src/DIRAC/ConfigurationSystem/Client/ConfigurationClient.py
@@ -51,7 +51,7 @@ class CSJSONClient(TornadoClient):
 
       :param sData: Data to commit, you may call this method with CSAPI and Modificator
     """
-    return self.executeRPC('commitNewData', b64encode(sData))
+    return self.executeRPC('commitNewData', b64encode(sData).decode())
 
 
 class ConfigurationClient(Client):


### PR DESCRIPTION
```python
  File "/opt/dirac/versions/v7.3.0a20-1629294914/Linux-x86_64/lib/python3.9/site-packages/DIRAC/ConfigurationSystem/Client/ConfigurationClient.py", line 54, in commitNewData
    return self.executeRPC('commitNewData', b64encode(sData))
  File "/opt/dirac/versions/v7.3.0a20-1629294914/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Tornado/Client/TornadoClient.py", line 65, in executeRPC
    rpcCall = {'method': method, 'args': encode(args)}
  File "/opt/dirac/versions/v7.3.0a20-1629294914/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/JEncode.py", line 181, in encode
    return json.dumps(inData, cls=DJSONEncoder)
  File "/opt/dirac/versions/v7.3.0a20-1629294914/Linux-x86_64/lib/python3.9/json/__init__.py", line 234, in dumps
    return cls(
  File "/opt/dirac/versions/v7.3.0a20-1629294914/Linux-x86_64/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/opt/dirac/versions/v7.3.0a20-1629294914/Linux-x86_64/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/opt/dirac/versions/v7.3.0a20-1629294914/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/JEncode.py", line 110, in default
    return super(DJSONEncoder, self).default(obj)
  File "/opt/dirac/versions/v7.3.0a20-1629294914/Linux-x86_64/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```