### PR TITLE
[v7r2] Pass --cfg /tmp/pilot.cfg when reusing host DIRAC installation in SingularityComputingElement

### DIFF
--- a/src/DIRAC/Resources/Computing/SingularityComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SingularityComputingElement.py
@@ -282,7 +282,8 @@ class SingularityComputingElement(ComputingElement):
                                        resourceParams=jobDesc.get('resourceParams', {}),
                                        optimizerParams=jobDesc.get('optimizerParams', {}),
                                        log=log,
-                                       logLevel=logLevel)
+                                       logLevel=logLevel,
+                                       extraOptions="" if self.__installDIRACInContainer else "/tmp/pilot.cfg")
     if not result['OK']:
       result['ReschedulePayload'] = True
       return result

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/Utils.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/Utils.py
@@ -84,7 +84,7 @@ def createRelocatedJobWrapper(wrapperPath, rootLocation,
   """ This method creates a job wrapper for a specific job in wrapperPath,
       but assumes this has been reloated to rootLocation before running it.
   """
-  if isinstance(extraOptions, six.string_types) and extraOptions.endswith('.cfg'):
+  if isinstance(extraOptions, six.string_types) and extraOptions.endswith('.cfg') and "--cfg" not in extraOptions:
     extraOptions = '--cfg %s' % extraOptions
 
   arguments = {'Job': jobParams,


### PR DESCRIPTION
BEGINRELEASENOTES

*Resources
FIX: Pass --cfg /tmp/pilot.cfg when reusing host DIRAC installation in SingularityComputingElement

ENDRELEASENOTES
