### PR TITLE
[v7r2] Fix UnicodeEncodeError when application log contains non-ascii characters

### DIFF
--- a/src/DIRAC/Workflow/Modules/Script.py
+++ b/src/DIRAC/Workflow/Modules/Script.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import os
 import sys
+import io
 import re
 import stat
 import shlex
@@ -111,10 +112,10 @@ class Script(ModuleBase):
     if os.path.exists(self.applicationLog):
       self.log.verbose('Removing existing %s' % self.applicationLog)
       os.remove(self.applicationLog)
-    with open('%s/%s' % (os.getcwd(), self.applicationLog), 'w') as fopen:
-      fopen.write("<<<<<<<<<< %s Standard Output >>>>>>>>>>\n\n%s " % (self.executable, stdout))
+    with io.open('%s/%s' % (os.getcwd(), self.applicationLog), 'wt') as fopen:
+      fopen.write(u"<<<<<<<<<< %s Standard Output >>>>>>>>>>\n\n%s " % (self.executable, stdout))
       if stderr:
-        fopen.write("<<<<<<<<<< %s Standard Error >>>>>>>>>>\n\n%s " % (self.executable, stderr))
+        fopen.write(u"<<<<<<<<<< %s Standard Error >>>>>>>>>>\n\n%s " % (self.executable, stderr))
     self.log.info("Output written to %s, execution complete." % (self.applicationLog))
 
     if failed:

--- a/src/DIRAC/Workflow/Modules/test/Test_Modules.py
+++ b/src/DIRAC/Workflow/Modules/test/Test_Modules.py
@@ -660,6 +660,37 @@ class ScriptSuccess(ModulesTestCase):
         self.script._executeCommand()
 
 
+class ScriptUnicode(ModulesTestCase):
+
+  #################################################
+
+  def test_execute(self):
+
+    self.script.jobType = 'merge'
+    self.script.stepInputData = ['foo', 'bar']
+
+    self.script.production_id = self.prod_id
+    self.script.prod_job_id = self.prod_job_id
+    self.script.jobID = self.wms_job_id
+    self.script.workflowStatus = self.workflowStatus
+    self.script.stepStatus = self.stepStatus
+    self.script.workflow_commons = self.wf_commons
+    self.script.step_commons = self.step_commons[0]
+    self.script.step_number = self.step_number
+    self.script.step_id = self.step_id
+    self.script.executable = 'echo'
+    self.script.arguments = r"-e '\xe2\x96\x88\xe2\x96\x88\xe2\x96\x88\xe2\x96\x88\xe2\x96\x88\xe2\x95\x97'"
+    self.script.applicationLog = 'applicationLog.txt'
+
+    # no errors, no input data
+    for wf_commons in copy.deepcopy(self.wf_commons):
+      for step_commons in self.step_commons:
+        self.script.workflow_commons = wf_commons
+        self.script.step_commons = step_commons
+        self.script._setCommand()
+        self.script._executeCommand()
+
+
 class ScriptFailure(ModulesTestCase):
 
   #################################################


### PR DESCRIPTION
Fixes this crash seen in some LHCb user jobs for Python 2 pilots (Python 3 works already, output is from the newly added test):
```python
      self.log.verbose(stdout)
      self.log.verbose(stderr)
      if os.path.exists(self.applicationLog):
        self.log.verbose('Removing existing %s' % self.applicationLog)
        os.remove(self.applicationLog)
      with open('%s/%s' % (os.getcwd(), self.applicationLog), 'w') as fopen:
>       fopen.write("<<<<<<<<<< %s Standard Output >>>>>>>>>>\n\n%s " % (self.executable, stdout))
E       UnicodeEncodeError: 'ascii' codec can't encode characters in position 44-49: ordinal not in range(128)

failed     = False
fopen      = <closed file '/home/cburr/Development/DIRAC-dev/DIRAC/applicationLog.txt', mode 'w' at 0x7fd8d666e030>
outputDict = {'OK': True, 'Value': (0, '█████╗
', '')}
self       = <DIRAC.Workflow.Modules.Script.Script object at 0x7fd8d66c53d0>
status     = 0
stderr     = ''
stdout     = '█████╗
'
```

BEGINRELEASENOTES

* Workflow
FIX: UnicodeEncodeError when application log contains non-ascii characters

ENDRELEASENOTES
