### PR TITLE
[v7r2 ONLY] Add selectors2 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,5 +65,6 @@ caniusepython3
 subprocess32
 flaky
 ldap3
+selectors2
 # setuptools_scm comes via tornado. newer versions of setuptools_scm do not support py2
 setuptools_scm<6.0


### PR DESCRIPTION
This is used by the LHCbDIRAC CI for the current production release so it should have been included in #5334.

For v7r3 the requirements.txt file has been removed and the LHCbDIRAC Python 2 CI has been moved to use conda.