### PR TITLE
[integration] Allow GitHub PR commentBody to be None

### DIFF
--- a/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
+++ b/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
@@ -134,6 +134,7 @@ def _parsePrintLevel(level):
 
 def parseForReleaseNotes(commentBody):
   """Look for "BEGINRELEASENOTES / ENDRELEASENOTES" and extend releaseNoteList if there are entries."""
+  commentBody = commentBody or ""
   if not all(tag in commentBody for tag in ("BEGINRELEASENOTES", "ENDRELEASENOTES")):
     return ''
   return commentBody.split("BEGINRELEASENOTES")[1].split("ENDRELEASENOTES")[0]


### PR DESCRIPTION
Fixes the issue that caused this DIRACOS pipeline to fail: https://gitlab.cern.ch/CLICdp/iLCDirac/DIRACOS/-/jobs/15899525