### PR TITLE
[v7r2] return error in StompMQConnector.put()

### DIFF
--- a/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
+++ b/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
@@ -161,7 +161,7 @@ class StompMQConnector(MQConnector):
       self.connection.send(body=json.dumps(message), destination=destination)
     except Exception as e:
       log.debug("Failed to send message", repr(e))
-      S_ERROR(EMQUKN, 'Failed to send message: %s' % repr(e))
+      return S_ERROR(EMQUKN, 'Failed to send message: %s' % repr(e))
 
     return S_OK('Message sent successfully')
 


### PR DESCRIPTION
BEGINRELEASENOTES
I think it would be useful to return `StompMQConnector`/`put` error when an exception raised.

*Resources
FIX: return error for StompMQConnector

ENDRELEASENOTES
