### PR TITLE
[v7r3] Don't use __RCSID__ for Python 3 based installations

### DIFF
--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -19,6 +19,7 @@ import threading
 
 from concurrent.futures import ThreadPoolExecutor
 
+import six
 import DIRAC
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client import PathFinder
@@ -299,7 +300,10 @@ class Service(object):
       self._monitor.setComponentExtraParam('DIRACVersion', DIRAC.version)
       self._monitor.setComponentExtraParam('platform', DIRAC.getPlatform())
       self._monitor.setComponentExtraParam('startTime', Time.dateTime())
-      for prop in (("__RCSID__", "version"), ("__doc__", "description")):
+      props = [("__doc__", "description")]
+      if six.PY2:
+        props += [("__RCSID__", "version")]
+      for prop in props:
         try:
           value = getattr(self._handler['module'], prop[0])
         except Exception as e:


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
CHANGE: __RCSID__ is no longer access for Python 3 based installations

ENDRELEASENOTES
