### PR TITLE
[v7r2] JobMonitoring.getCurrentJobCounters uses cls.jobDB

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -246,7 +246,7 @@ class JobMonitoringHandler(RequestHandler):
     """
 
     _, _, attrDict = cls.parseSelectors(attrDict)
-    return cls.gJobDB.getCounters('Jobs', attrList, attrDict, newer=str(cutDate), timeStamp='LastUpdateTime')
+    return cls.jobDB.getCounters('Jobs', attrList, attrDict, newer=str(cutDate), timeStamp='LastUpdateTime')
 
 ##############################################################################
   types_getCurrentJobCounters = []
@@ -257,7 +257,7 @@ class JobMonitoringHandler(RequestHandler):
         the last day.
     """
     _, _, attrDict = cls.parseSelectors(attrDict)
-    result = cls.gJobDB.getCounters('Jobs', ['Status'], attrDict, timeStamp='LastUpdateTime')
+    result = cls.jobDB.getCounters('Jobs', ['Status'], attrDict, timeStamp='LastUpdateTime')
     if not result['OK']:
       return result
     last_update = Time.dateTime() - Time.day
@@ -505,7 +505,7 @@ class JobMonitoringHandler(RequestHandler):
     """ Get job statistics distribution per attribute value with a given selection
     """
     startDate, endDate, selectDict = cls.parseSelectors(selectDict)
-    result = cls.gJobDB.getCounters('Jobs', [attribute], selectDict,
+    result = cls.jobDB.getCounters('Jobs', [attribute], selectDict,
                                     newer=startDate,
                                     older=endDate,
                                     timeStamp='LastUpdateTime')


### PR DESCRIPTION
Fixes the bad merge. The https://github.com/DIRACGrid/DIRAC/pull/5376 worked because the methods are not tested anymore in integration.. 
and pylint, although should detect it, does not, because of the Mixing probably

BEGINRELEASENOTES

*WMS
FIX: JobMonitoring uses cls.jobDB

ENDRELEASENOTES
