### PR TITLE
[8.0] Discard dfbb532.

### DIFF
--- a/src/DIRAC/Interfaces/API/Dirac.py
+++ b/src/DIRAC/Interfaces/API/Dirac.py
@@ -1772,7 +1772,7 @@ class Dirac(API):
     if self.jobRepo:
       self.jobRepo.updateJobs(repoDict)
     for job, vals in siteDict.items():  # can be an iterator
-      result[str(job)].update(vals)
+      result[job].update(vals)
 
     return S_OK(result)
 


### PR DESCRIPTION
BEGINRELEASENOTES

Discard https://github.com/DIRACGrid/DIRAC/commit/dfbb53232dba40aff4bf0f04802877c51d078ab1 that resolve error described in previous hackathon https://trello.com/c/y7TgEuF7/40-multi-vo-tests. Now after the last lot of changes, this key returns correctly, so I canceled the last adjustment.

*Interfaces
FIX: Discard https://github.com/DIRACGrid/DIRAC/commit/dfbb53232dba40aff4bf0f04802877c51d078ab1.

ENDRELEASENOTES
