### PR TITLE
[v7r2] Handle S_ERROR in Service._executeAction

### DIFF
--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -618,7 +618,9 @@ class Service(object):
   def _executeAction(self, trid, proposalTuple, handlerObj):
     try:
       response = handlerObj._rh_executeAction(proposalTuple)
-      if self.activityMonitoring and response["OK"]:
+      if not response["OK"]:
+        return response
+      if self.activityMonitoring:
         self.activityMonitoringReporter.addRecord({
             'timestamp': int(Time.toEpoch()),
             'host': Network.getFQDN(),


### PR DESCRIPTION
This causes a few errors each hour in the LHCb setup:

```
2021-09-07 08:11:47 UTC Configuration/Server [140400182417152] ERROR: ConnectionError ConnectionError: Error while receiving arguments ([2001:1458:301:21::100:54]:51290)[lhcb_user:mneedham] Error in _read: (104, 'Connection reset by peer'
) SSLError(104, 'Connection reset by peer')
2021-09-07 08:11:47 UTC Configuration/Server [140400182417152] ERROR: Exception while executing handler action
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/DISET/private/Service.py", line 631, in _executeAction
    return response["Value"][0]
KeyError: 'Value'
```


BEGINRELEASENOTES

*Core
FIX: Handle S_ERROR in Service._executeAction

ENDRELEASENOTES
