### PR TITLE
[v7r2] Drop requests if a service is overloaded

### DIFF
--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -360,6 +360,16 @@ class Service(object):
       self._monitor.setComponentExtraParam('queries', self._stats['connections'])
     # TODO: remove later
     if useThreadPoolExecutor:
+      nQueued = self._threadPool._work_queue.qsize()
+      if nQueued > self._cfg.getMaxWaitingPetitions():
+        gLogger.warn(
+            "Dropping request due to too many tasks",
+            "queued: %s limit: %s source: %s" % (
+                nQueued, self._cfg.getMaxWaitingPetitions(), clientTransport.getFormattedCredentials()
+            )
+        )
+        clientTransport.close()
+        return
       self._threadPool.submit(self._processInThread, clientTransport)
     else:
       self._threadPool.generateJobAndQueueIt(self._processInThread,

--- a/src/DIRAC/Core/DISET/private/ServiceConfiguration.py
+++ b/src/DIRAC/Core/DISET/private/ServiceConfiguration.py
@@ -74,7 +74,7 @@ class ServiceConfiguration:
     try:
       return int(self.getOption("MaxWaitingPetitions"))
     except BaseException:
-      return 500
+      return 100
 
   def getMaxMessagingConnections(self):
     try:


### PR DESCRIPTION
In the LHCb master CS we've had an issue that it became overloaded. This was made worse by the fact that the new connections are added the the thread pool forever until the service is unable to serve any requests. This PR makes it so that if there are more than (approximately) 100 tasks queued up the service drops new connections.

BEGINRELEASENOTES

*Core
CHANGE: Requests are now dropped if the backlog is too large 

ENDRELEASENOTES
