### PR TITLE
[v7r3] Add Emies endpoint to ARCCE

### DIFF
--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
@@ -107,20 +107,7 @@ These parameters are valid for all types of computing elements
 ARC CE Parameters
 -----------------
 
-+---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
-| **Name**                        | **Description**                                   | **Example**                                                 |
-+---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
-| XRSLExtraString                 |  Default additional string for ARC submit files   |                                                             |
-+---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
-| XRSLMPExtraString               | Default additional string for ARC submit files    |                                                             |
-|                                 | for multi-processor jobs.                         |                                                             |
-+---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
-| Host                            | The host for the ARC CE, used to overwrite the    |                                                             |
-|                                 | ce name                                           |                                                             |
-+---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
-| WorkingDirectory                | Directory where the pilot log files are stored    | /opt/dirac/pro/runit/WorkloadManagement/SiteDirectorArc     |
-|                                 | locally.                                          |                                                             |
-+---------------------------------+---------------------------------------------------+-------------------------------------------------------------+
+For the options for the HTCondorCEs see :mod:`~DIRAC.Resources.Computing.ARCComputingElement`
 
 
 Singularity CE Parameters

--- a/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
+++ b/docs/source/AdministratorGuide/Configuration/ConfReference/Resources/Computing/index.rst
@@ -107,7 +107,7 @@ These parameters are valid for all types of computing elements
 ARC CE Parameters
 -----------------
 
-For the options for the HTCondorCEs see :mod:`~DIRAC.Resources.Computing.ARCComputingElement`
+For the options for the ARC Computing Element see :mod:`~DIRAC.Resources.Computing.ARCComputingElement`
 
 
 Singularity CE Parameters

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -1,11 +1,37 @@
-########################################################################
-# File :   ARCComputingElement.py
-# Author : A.T.
-# Update to use ARC API : Raja Nandakumar
-########################################################################
-
 """ ARC Computing Element
     Using the ARC API now
+
+**Configuration Parameters**
+
+Configuration for the ARCComputingElement submission can be done via the configuration system. See the page about
+configuring :ref:`resourcesComputing` for where the options can be placed.
+
+XRSLExtraString:
+   Default additional string for ARC submit files. Should be written in the following format::
+
+     (key = "value")
+
+XRSLMPExtraString:
+   Default additional string for ARC submit files for multi-processor jobs. Should be written in the following format::
+
+     (key = "value")
+
+Host:
+   The host for the ARC CE, used to overwrite the CE name.
+
+WorkingDirectory:
+   Directory where the pilot log files are stored locally. For instance::
+
+     /opt/dirac/pro/runit/WorkloadManagement/SiteDirectorArc
+
+EndpointType:
+   Name of the protocol to use to interact with ARC services: Emies and Gridftp are supported.
+   Gridftp communicates with gridftpd services providing authentication and encryption for file transfers.
+   ARC developers are going to drop it in the future.
+   Emies is another protocol that allows to interact with A-REX services that provide additional features
+   (support of OIDC tokens).
+
+**Code Documentation**
 """
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
This PR integrates the `emies` endpoint to the ARC CE.
Here are some slides from July 2020 presenting a status of ARC: https://indico.cern.ch/event/813749/contributions/3925796/attachments/2070723/3476159/ARC-July2020-gdb.pdf.

- We currently rely on `gridftp` that is, IIUC, going to be dropped in the future (slide 9).
- `emies` allows to interact directly with Arex services that will probably replace gridftpd services.
- We need `emies` to interact with some arc instances.

BEGINRELEASENOTES
*Resources
NEW: Add emies endpoint to the ARC CE
ENDRELEASENOTES
