### PR TITLE
[v7r2] Add semantic tests for commits

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,33 @@
+# Check that the commit messages are between 20 and 150 chars,
+# and that they follow the rule
+# <type> (<scope>): <subject>
+# type: docs, feat, fix, refactor, style or test
+# scope (optional): any extra info, (like DMS or whatever)
+
+name: 'Commit Message Check'
+on: pull_request
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Commit Format
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^(docs|feat|fix|refactor|style|test)( ?\(.*\))?: .+$'
+          excludeDescription: 'true' # optional: this excludes the description body of a pull request
+          excludeTitle: 'true' # optional: this excludes the title of a pull request
+          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
+          flags: 'gm'
+          error: 'Your commit has to follow the format "<type>(<scope>): <subject>"".'
+      - name: Check Commit Length
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^.{20,150}$'
+          error: 'Commit messages should be between 20 and 150 chars'
+          excludeDescription: 'true' # optional: this excludes the description body of a pull request
+          excludeTitle: 'true' # optional: this excludes the title of a pull request
+          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true

--- a/docs/source/DeveloperGuide/CodingConvention/index.rst
+++ b/docs/source/DeveloperGuide/CodingConvention/index.rst
@@ -57,6 +57,15 @@ In order to ensure that the formatting preference of the developer's editor does
 
 Note that pycodestyle will still complain about the ambiguous variable in the good file, since autopep8 will not remove them. Also, autopep8 will not modify comment inside docstrings, hence the first warning on the good file.
 
+Commit messages
+---------------
+
+Commit messages must be between 20 and 150 chars, and follow the format
+``<type>(<scope>): <subject>``:
+* ``type``: docs, feat, fix, refactor, style or test
+* ``scope`` (optional): any extra info, (like DMS or whatever)
+
+
 Code Organization
 ------------------------------
 


### PR DESCRIPTION
Because I am more than fed up to browse a history with 376 consecutive "typo" or "fix" commit messages for a single file, I propose this extra action check which enforces a specific format (inspired by https://www.conventionalcommits.org/en/v1.0.0/#summary)

Details in the PR directly 

It's nothing really new, we already do the same effort to write it in a sort of similar way for the release news. 
That's an extra step towards a better life together.

BEGINRELEASENOTES
*Test
NEW: force commit format

ENDRELEASENOTES
