### PR TITLE
[v7r2] Transformation.setBody correctly checks all the operation tuples

### DIFF
--- a/src/DIRAC/TransformationSystem/Client/Transformation.py
+++ b/src/DIRAC/TransformationSystem/Client/Transformation.py
@@ -141,7 +141,7 @@ class Transformation(API):
           raise ValueError("Unknown attribute for Operation: %s" % par)
         if not isinstance(val, six.string_types + six.integer_types + (float, list, tuple, dict)):
           raise TypeError("Cannot encode %r, in json" % (val))
-      return self.__setParam(json.dumps(body))
+    return self.__setParam(json.dumps(body))
 
   def setInputMetaQuery(self, query):
     """Set the input meta query.

--- a/src/DIRAC/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/src/DIRAC/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -238,6 +238,13 @@ class TransformationSuccess(ClientsTestCase):
     with self.assertRaisesRegexp(TypeError, "Cannot encode"):
       self.transformation.setBody([("ReplicateAndRegister", {"Arguments": Request()})])
 
+    # Check that all tuples are checked by passing first a valid one,
+    # then a faulty one.
+    # It is enough to check one case, unlike above
+    with self.assertRaisesRegexp(TypeError, "Expected 2-tuple"):
+      self.transformation.setBody([(u"RemoveReplica", {u"TargetSE": u"FOO-SRM"}),
+                                   ("One", "too long", "tuple")])
+
   def test_SetGetReset(self):
     """ Testing of the set, get and reset methods.
 


### PR DESCRIPTION

BEGINRELEASENOTES
*TS
FIX: Transformation.setBody correctly checks all the operation tuples

ENDRELEASENOTES
