### PR TITLE
[v7r2] Reintroduce proxyChain parameter

### DIFF
--- a/src/DIRAC/Core/DISET/private/Transports/SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/SSLTransport.py
@@ -54,7 +54,7 @@ def checkSanity(urlTuple, kwargs):
     certFile = certTuple[0]
     useCerts = True
   elif "proxyString" in kwargs:
-    if not isinstance(kwargs['proxyString'], six.string_types):
+    if not isinstance(kwargs['proxyString'], six.string_types if six.PY2 else bytes):
       gLogger.error("proxyString parameter is not a valid type", str(type(kwargs['proxyString'])))
       return S_ERROR("proxyString parameter is not a valid type")
   else:

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -32,8 +32,10 @@ __RCSID__ = "$Id$"
 
 from io import open
 import errno
+import os
 import requests
 import six
+import tempfile
 from six.moves import http_client
 
 
@@ -505,6 +507,12 @@ class TornadoBaseClient(object):
     # Do we use the server certificate ?
     if self.kwargs[self.KW_USE_CERTIFICATES]:
       cert = Locations.getHostCertificateAndKeyLocation()
+    elif self.kwargs.get(self.KW_PROXY_STRING):
+      tmpHandle, cert = tempfile.mkstemp()
+      fp = os.fdopen(tmpHandle, "wb")
+      fp.write(self.kwargs[self.KW_PROXY_STRING])
+      fp.close()
+
     # CHRIS 04.02.21
     # TODO: add proxyLocation check ?
     else:


### PR DESCRIPTION
Addresses https://github.com/DIRACGrid/DIRAC/issues/5114

Running the following code

```python
from DIRAC.Core.Base import Script
from DIRAC.Core.Base.Client import Client
from DIRAC.Core.Security.X509Chain import X509Chain

Script.parseCommandLine()

#service = 'Framework/ProxyManager'
service = 'WorkloadManagement/JobMonitoring'
print("With standard proxy")
c = Client()
c.setServer(service)
res = c.whoami()
print( res['Value']['DN'] if res['OK'] else res)

print("With a stolen proxy")
proxy = X509Chain()
proxy.loadProxyFromFile('/tmp/chaen/proxy.fstagni.lhcb_user')
c = Client(proxyChain=proxy)
c.setServer(service)
res = c.whoami()
print( res['Value']['DN'] if res['OK'] else res)


```

Without the fix
```bash
With standard proxy
/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=chaen/CN=705305/CN=Christophe Haen
With a stolen proxy

Traceback (most recent call last):
  File "/tmp/chaen/CC7py3/10.3.0a3/diracos/lib/python3.9/site-packages/DIRAC/Core/DISET/private/BaseClient.py", line 469, in _connect
    transport = gProtocolDict[self.__URLTuple[0]]['transport'](self.__URLTuple[1:3], **self.kwargs)
  File "/tmp/chaen/CC7py3/10.3.0a3/diracos/lib/python3.9/site-packages/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py", line 94, in __init__
    self.__ctx = getM2SSLContext(**kwargs)
  File "/tmp/chaen/CC7py3/10.3.0a3/diracos/lib/python3.9/site-packages/DIRAC/Core/DISET/private/Transports/SSL/M2Utils.py", line 111, in getM2SSLContext
    raise RuntimeError("Proxy string no longer supported.")
RuntimeError: Proxy string no longer supported.

```

With the fix
```bash
With standard proxy
/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=chaen/CN=705305/CN=Christophe Haen
With a stolen proxy
/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=fstagni/CN=693025/CN=Federico Stagni
```

I also fixed it for https

BEGINRELEASENOTES

*Core
FIX: RPCClient and TornadoClient support proxyChain 

ENDRELEASENOTES
