### PR TITLE
[v7r2] JobCleaningAgent uses user DN to put the sandbox removal request

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
@@ -366,7 +366,8 @@ class JobCleaningAgent(AgentModule):
     removeFile.addFile(removedFile)
     oRequest.addOperation(removeFile)
 
-    return ReqClient().putRequest(oRequest)
+    # put the request with the owner certificate to make sure it's still a valid DN
+    return ReqClient(useCertificates=True, delegatedDN=ownerDN, delegatedGroup=ownerGroup).putRequest(oRequest)
 
   def removeHeartBeatLoggingInfo(self, status, delayDays):
     """Remove HeartBeatLoggingInfo for jobs with given status after given number of days.


### PR DESCRIPTION
Continue the https://github.com/DIRACGrid/DIRAC/issues/5355  saga
Since the requests are send before the job deletion attempt, a failed job deletion will result in multiple removal request (one at each loop). 
In the case of expired DN, the job deletion fails because we use the user credentials. 
I apply the same trick for putting the request.

BEGINRELEASENOTES

*WMS
FIX: JobCleaningAgent uses OwnerDN to put the sandbox removal request


ENDRELEASENOTES
