### PR TITLE
[v7r2] fix: always removing the flag for skipping the CA checks

### DIFF
--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -285,7 +285,6 @@ def main():
                                     '  %s [options] ...\n' % Script.scriptName]))
 
   Script.parseCommandLine(ignoreErrors=True)
-  args = Script.getExtraCLICFGFiles()
 
   if not logLevel:
     logLevel = DIRAC.gConfig.getValue(cfgInstallPath('LogLevel'), '')
@@ -425,9 +424,7 @@ def main():
     except Exception as e:
       DIRAC.gLogger.error('Failed to sync CAs and CRLs: %s' % str(e))
 
-    if not skipCAChecks:
-      Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
-      DIRAC.gConfig.removeOption(cfgInstallPath('SkipCAChecks'))
+    Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
 
   if ceName or siteName:
     # This is used in the pilot context, we should have a proxy, or a certificate, and access to CS

--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -404,9 +404,6 @@ def main():
 
   if skipCAChecks:
     DIRAC.gLogger.verbose('/DIRAC/Security/SkipCAChecks =', 'yes')
-    # Being sure it was not there before
-    Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
-    Script.localCfg.addDefaultEntry('/DIRAC/Security/SkipCAChecks', 'yes')
   else:
     # Necessary to allow initial download of CA's
     if not skipCADownload:
@@ -430,6 +427,7 @@ def main():
 
     if not skipCAChecks:
       Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
+      DIRAC.gConfig.removeOption(cfgInstallPath('SkipCAChecks'))
 
   if ceName or siteName:
     # This is used in the pilot context, we should have a proxy, or a certificate, and access to CS

--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -403,6 +403,9 @@ def main():
 
   if skipCAChecks:
     DIRAC.gLogger.verbose('/DIRAC/Security/SkipCAChecks =', 'yes')
+    # Being sure it was not there before
+    Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
+    Script.localCfg.addDefaultEntry('/DIRAC/Security/SkipCAChecks', 'yes')
   else:
     # Necessary to allow initial download of CA's
     if not skipCADownload:
@@ -496,7 +499,7 @@ def main():
       if not result['OK']:
         DIRAC.gLogger.notice('Configuration is not completed because no user proxy is available')
         DIRAC.gLogger.notice('Create one using dirac-proxy-init and execute again with -F option')
-        sys.exit(1)
+        return 1
     else:
       Script.localCfg.deleteOption('/DIRAC/Security/UseServerCertificate')
       # When using Server Certs CA's will be checked, the flag only disables initial download
@@ -522,11 +525,11 @@ def main():
 
   if skipVOMSDownload:
     # We stop here
-    sys.exit(0)
+    return 0
 
   result = Registry.getVOMSServerInfo()
   if not result['OK']:
-    sys.exit(1)
+    return 1
 
   error = ''
   vomsDict = result['Value']
@@ -572,10 +575,12 @@ def main():
     Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
 
   if error:
-    sys.exit(1)
+    return 1
 
-  sys.exit(0)
+  return 0
 
 
 if __name__ == "__main__":
-  main()
+  exitCode = main()
+  Script.localCfg.deleteOption('/DIRAC/Security/SkipCAChecks')
+  sys.exit(exitCode)

--- a/src/DIRAC/Core/scripts/dirac_deploy_scripts.py
+++ b/src/DIRAC/Core/scripts/dirac_deploy_scripts.py
@@ -125,6 +125,10 @@ if not rootPath:
   print("Error: Cannot find DIRAC root!")
   sys.exit(1)
 
+# hack alert!
+# Removing 'DIRAC/src/', which is added when installing py2 releases with dirac-install and "-m" flag
+rootPath = rootPath.replace('DIRAC/src/', '')
+
 targetScriptsPath = os.path.join(rootPath, "scripts")
 pythonScriptRE = re.compile("(.*/)*([a-z]+-[a-zA-Z0-9-]+|[a-z]+_[a-zA-Z0-9_]+|d[a-zA-Z0-9-]+).py$")
 print("Scripts will be deployed at %s" % targetScriptsPath)

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -523,7 +523,10 @@ generateCA() {
 
   # Generate the hash link file required by openSSL to index CA certificates
   caHash=$(openssl x509 -in ca.cert.pem -noout -hash)
-  ln -s "${SERVERINSTALLDIR}/etc/grid-security/certificates/ca.cert.pem" "${SERVERINSTALLDIR}/etc/grid-security/certificates/$caHash.0"
+  # We make a relative symlink on purpose (i.e. not the full path to ca.cert.pem)
+  # because otherwsie the BundleDeliveryClient will send the full path, which
+  # will be wrong on the client
+  ln -s "ca.cert.pem" "${SERVERINSTALLDIR}/etc/grid-security/certificates/$caHash.0"
 }
 
 #.............................................................................


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: unless explicitly set, do not skip the CA checks

ENDRELEASENOTES
