### PR TITLE
[v7r2]csv library expects bytes in py2, str in py3

### DIFF
--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_protocol_matrix.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_protocol_matrix.py
@@ -43,6 +43,7 @@ from __future__ import division
 from __future__ import print_function
 
 import csv
+import six
 from collections import defaultdict
 
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript
@@ -183,7 +184,7 @@ def main():
     gLogger.verbose("%s -> %s: %s" % (src, dst, proto))
 
   # Write the matrix in the file
-  with open(outputFile, 'wb') as csvfile:
+  with open(outputFile, 'wb' if six.PY2 else 'w') as csvfile:
     csvWriter = csv.writer(csvfile, delimiter=';', quoting=csv.QUOTE_MINIMAL)
 
     csvWriter.writerow(['src/dst'] + targetSE)

--- a/tests/Integration/DataManagementSystem/Test_Client_DFC.py
+++ b/tests/Integration/DataManagementSystem/Test_Client_DFC.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 import csv
+import six
 import filecmp
 
 import os
@@ -375,7 +376,7 @@ class FileCase(DFCTestCase):
     # So we dump the expected content in a file
     _, expectedDumpFn = tempfile.mkstemp()
 
-    with open(expectedDumpFn, 'w') as expectedDumpFd:
+    with open(expectedDumpFn, 'wb' if six.PY2 else 'w') as expectedDumpFd:
       csvWriter = csv.writer(expectedDumpFd, delimiter='|')
       csvWriter.writerow([testFile, '0', 123])
 


### PR DESCRIPTION

BEGINRELEASENOTES

*DMS
FIX: adapt csv use to py3

*Test
FIX: adapt csv use to py3

ENDRELEASENOTES
