### PR TITLE
[v7r2] add support for execution of pilot wrappers when the python executable is not set

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
@@ -55,7 +55,12 @@ def treatCondorHistory(condorHistCall, qList):
   :type qList: python:list
   :returns: None
   """
-  sp = subprocess.Popen(shlex.split(condorHistCall), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  sp = subprocess.Popen(
+      shlex.split(condorHistCall),
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      universal_newlines=True,
+  )
   output, _ = sp.communicate()
   status = sp.returncode
 
@@ -121,7 +126,13 @@ class Condor(object):
 
     cmd = '%s; ' % preamble if preamble else ''
     cmd += 'condor_submit %s %s' % (submitOptions, jdlFile.name)
-    sp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 
@@ -178,7 +189,12 @@ class Condor(object):
     failed = []
     errors = ''
     for job in jobIDList:
-      sp = subprocess.Popen(shlex.split('condor_rm %s' % job), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          shlex.split('condor_rm %s' % job),
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
       if status != 0:
@@ -223,7 +239,12 @@ class Condor(object):
       return resultDict
 
     cmd = 'condor_q -submitter %s -af:j JobStatus' % user
-    sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 
@@ -270,7 +291,12 @@ class Condor(object):
     waitingJobs = 0
     runningJobs = 0
 
-    sp = subprocess.Popen(shlex.split('condor_q -submitter %s' % user), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split('condor_q -submitter %s' % user),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 

--- a/src/DIRAC/Resources/Computing/BatchSystems/GE.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/GE.py
@@ -47,7 +47,13 @@ class GE(object):
     for _i in range(int(nJobs)):
       cmd = '%s; ' % preamble if preamble else ''
       cmd += "qsub -o %(OutputDir)s -e %(ErrorDir)s -N DIRACPilot %(SubmitOptions)s %(Executable)s" % kwargs
-      sp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          cmd,
+          shell=True,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
       if status == 0:
@@ -59,7 +65,7 @@ class GE(object):
       resultDict['Status'] = 0
       resultDict['Jobs'] = []
       for output in outputs:
-        match = re.match('Your job (\d*) ', output)
+        match = re.match(r'Your job (\d*) ', output)
         if match:
           resultDict['Jobs'].append(match.groups()[0])
     else:
@@ -91,7 +97,12 @@ class GE(object):
     failed = []
     errors = ''
     for job in jobIDList:
-      sp = subprocess.Popen(shlex.split('qdel %s' % job), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          shlex.split('qdel %s' % job),
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
       if status != 0:
@@ -133,7 +144,12 @@ class GE(object):
       resultDict['Message'] = 'Empty job list'
       return resultDict
 
-    sp = subprocess.Popen(shlex.split('qstat -u %s' % user), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split('qstat -u %s' % user),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 
@@ -157,7 +173,12 @@ class GE(object):
             elif jobStatus in ['qw', 'h']:
               jobDict[job] = 'Waiting'
 
-    sp = subprocess.Popen(shlex.split('qstat -u %s -s -z' % user), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split('qstat -u %s -s -z' % user),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 
@@ -195,7 +216,12 @@ class GE(object):
       return resultDict
 
     cmd = 'qstat -u %s' % user
-    sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 

--- a/src/DIRAC/Resources/Computing/BatchSystems/Host.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Host.py
@@ -37,7 +37,7 @@ class Host(object):
     self.nCores = 1
     try:
       self.nCores = multiprocessing.cpu_count()
-    except BaseException:
+    except Exception:
       pass
 
   def submitJob(self, **kwargs):
@@ -104,7 +104,8 @@ exit 0
             stdout=subprocess.PIPE,
             shell=True,
             env=envDict,
-            universal_newlines=True)
+            universal_newlines=True,
+        )
         pid = popenObject.communicate()[0]
       except OSError as x:
         output = str(x)
@@ -194,9 +195,12 @@ exit 0
       infoFile.close()
       jobInfo = json.loads(jobInfo)
       pid = jobInfo['PID']
-      sp = subprocess.Popen(["ps", "-f", "-p", str(pid), "--no-headers"],
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          ["ps", "-f", "-p", str(pid), "--no-headers"],
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       if len(output.split('\n')) == 2 and 'wrapper' in output:
         running += 1
@@ -217,9 +221,12 @@ exit 0
 
     if pid == 0:
       return "Unknown"
-    sp = subprocess.Popen(["ps", "-f", "-p", str(pid), "--no-headers"],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        ["ps", "-f", "-p", str(pid), "--no-headers"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
     if status == 0 and len(output.split('\n')) == 2 and user in output:

--- a/src/DIRAC/Resources/Computing/BatchSystems/LSF.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/LSF.py
@@ -55,7 +55,13 @@ class LSF(object):
                                                              queue,
                                                              submitOptions,
                                                              executable)
-      sp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          cmd,
+          shell=True,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
       if status == 0:
@@ -99,7 +105,12 @@ class LSF(object):
     failed = []
     errors = ''
     for job in jobIDList:
-      sp = subprocess.Popen(shlex.split('bkill %s' % job), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          shlex.split('bkill %s' % job),
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
       if status != 0:
@@ -132,7 +143,12 @@ class LSF(object):
     queue = kwargs['Queue']
 
     cmd = "bjobs -q %s -a" % queue
-    sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 
@@ -176,7 +192,12 @@ class LSF(object):
       return resultDict
 
     cmd = 'bjobs ' + ' '.join(jobIDList)
-    sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 

--- a/src/DIRAC/Resources/Computing/BatchSystems/OAR.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/OAR.py
@@ -62,7 +62,13 @@ class OAR(object):
                                                                        queue,
                                                                        submitOptions,
                                                                        executable)
-      sp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          cmd,
+          shell=True,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
 
@@ -112,7 +118,12 @@ class OAR(object):
     failed = []
     errors = ''
     for job in jobIDList:
-      sp = subprocess.Popen(shlex.split('oardel %s' % job), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          shlex.split('oardel %s' % job),
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
       if status != 0:
@@ -157,7 +168,12 @@ class OAR(object):
       return resultDict
 
     cmd = "oarstat --sql \"project = '%s'\" -J" % user
-    sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
     if status != 0:
@@ -231,7 +247,12 @@ class OAR(object):
     waitingJobs = 0
     runningJobs = 0
 
-    sp = subprocess.Popen(shlex.split('oarstat -u %s -J' % user), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split('oarstat -u %s -J' % user),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
     if status != 0:

--- a/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
@@ -73,7 +73,13 @@ class SLURM(object):
         cmd += "--gpus-per-task=%d " % int(numberOfGPUs)
       # Additional options
       cmd += "%s %s" % (submitOptions, executable)
-      sp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          cmd,
+          shell=True,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
       if status != 0 or not output:
@@ -126,8 +132,13 @@ class SLURM(object):
     errors = ''
     for job in jobIDList:
       cmd = 'scancel --partition=%s %s' % (queue, job)
-      sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-      output, error = sp.communicate()
+      sp = subprocess.Popen(
+          shlex.split(cmd),
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
+      _, error = sp.communicate()
       status = sp.returncode
       if status != 0:
         failed.append(job)
@@ -168,7 +179,12 @@ class SLURM(object):
     # -P to make the output parseable (remove tabs, spaces, columns)
     # --delimiter to specify character that splits the fields
     cmd = "sacct -j %s -o JobID,STATE -X -n -P --delimiter=," % jobIDs
-    sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
     if status != 0:
@@ -229,7 +245,12 @@ class SLURM(object):
     queue = kwargs['Queue']
 
     cmd = "squeue --partition=%s --user=%s --format='%%j %%T' " % (queue, user)
-    sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
     if status != 0:

--- a/src/DIRAC/Resources/Computing/BatchSystems/Torque.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Torque.py
@@ -52,7 +52,13 @@ class Torque(object):
              "-q %(Queue)s " \
              "-N DIRACPilot " \
              "%(SubmitOptions)s %(Executable)s 2>/dev/null" % kwargs
-      sp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          cmd,
+          shell=True,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
       if status == 0:
@@ -95,7 +101,12 @@ class Torque(object):
       jobDict[jobNumber] = job
 
     cmd = 'qstat ' + ' '.join(jobIDList)
-    sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 
@@ -143,7 +154,12 @@ class Torque(object):
       return resultDict
 
     cmd = 'qselect -u %s -s WQ | wc -l; qselect -u %s -s R | wc -l' % (user, user)
-    sp = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen(
+        shlex.split(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
     output, error = sp.communicate()
     status = sp.returncode
 
@@ -189,7 +205,12 @@ class Torque(object):
     failed = []
     errors = ''
     for job in jobIDList:
-      sp = subprocess.Popen(shlex.split('qdel %s' % job), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      sp = subprocess.Popen(
+          shlex.split('qdel %s' % job),
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          universal_newlines=True,
+      )
       output, error = sp.communicate()
       status = sp.returncode
       if status != 0:

--- a/src/DIRAC/Resources/Computing/BatchSystems/executeBatch.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/executeBatch.py
@@ -6,7 +6,10 @@ from __future__ import print_function
 #  Simple executor script for Batch class methods.
 #
 #  The script is concatenated on the fly with the required
-#  batch system class definition
+#  batch system class definition.
+#
+#  NB: This scipt is executed using the local (to the WN)
+#  python version, so support for py2 and py3 is necessary.
 #
 #  15.11.2014
 #  Author: A.T.
@@ -18,6 +21,7 @@ if __name__ == "__main__":
 
   import sys
   import json
+  import traceback
   try:
     from six.moves.urllib.parse import quote as urlquote
     from six.moves.urllib.parse import unquote as urlunquote
@@ -39,8 +43,8 @@ if __name__ == "__main__":
 
   try:
     result = getattr(batch, method)(**inputDict)
-  except Exception as x:
-    result = 'Exception: %s' % str(x)
+  except Exception:
+    result = traceback.format_exc()
 
   resultJson = urlquote(json.dumps(result))
   print("============= Start output ===============")

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -530,7 +530,10 @@ class SSHComputingElement(ComputingElement):
     options = json.dumps(options)
     options = urlquote(options)
 
-    cmd = "bash --login -c 'python %s/execute_batch %s'" % (self.sharedArea, options)
+    cmd = (
+        "bash --login -c 'python %s/execute_batch %s || python3 %s/execute_batch %s || python2 %s/execute_batch %s'"
+        % (self.sharedArea, options)
+    )
 
     self.log.verbose('CE submission command: %s' % cmd)
 

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -532,7 +532,7 @@ class SSHComputingElement(ComputingElement):
 
     cmd = (
         "bash --login -c 'python %s/execute_batch %s || python3 %s/execute_batch %s || python2 %s/execute_batch %s'"
-        % (self.sharedArea, options)
+        % (self.sharedArea, options, self.sharedArea, options, self.sharedArea, options)
     )
 
     self.log.verbose('CE submission command: %s' % cmd)

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -21,7 +21,14 @@ import base64
 import bz2
 
 pilotWrapperContent = """#!/bin/bash
-/usr/bin/env python << EOF
+if command -v python &> /dev/null; then
+  py='python'
+elif command -v python3 &> /dev/null; then
+  py='python3'
+elif command -v python2 &> /dev/null; then
+  py='python2'
+fi
+/usr/bin/env $py << EOF
 
 # imports
 from __future__ import print_function
@@ -248,7 +255,7 @@ if os.path.exists('checksums.sha512'):
 
   localPilot += """
 # now finally launching the pilot script (which should be called dirac-pilot.py)
-cmd = "python dirac-pilot.py %s"
+cmd = "$py dirac-pilot.py %s"
 logger.info('Executing: %%s' %% cmd)
 sys.stdout.flush()
 ret = os.system(cmd)

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
@@ -18,7 +18,7 @@ def test_scriptEmpty():
   """
   res = pilotWrapperScript()
 
-  assert 'cmd = "python dirac-pilot.py "' in res
+  assert 'cmd = "$py dirac-pilot.py "' in res
   assert 'os.environ["someName"]="someValue"' not in res
 
 


### PR DESCRIPTION
Draft because:
- make a review already
- fixes in https://github.com/DIRACGrid/DIRAC/commit/ba83558af4d852093bab2f6eb32de9af1bf64d9a can be propagated to other batch systems, if these ones are considered OK


BEGINRELEASENOTES

*WMS
NEW: add support for execution of pilot wrappers when the python executable is not set

ENDRELEASENOTES
