### PR TITLE
[v7r2] Executors fix: do not push the task back in the queue if it's not anymore there

### DIFF
--- a/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
+++ b/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
@@ -803,7 +803,7 @@ class ExecutorDispatcher(object):
       return S_ERROR(str(e))
     except Exception:
       self.__log.exception("Exception while sending task to executor")
-      self.__queues.pushTask(eType, taskId, ahead=True)
+      self.__queues.pushTask(eType, taskId, ahead=False)
       self.__states.removeTask(taskId)
       return S_ERROR("Exception while sending task to executor")
     else:

--- a/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
+++ b/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
@@ -798,7 +798,6 @@ class ExecutorDispatcher(object):
     self.__states.addTask(eId, taskId)
     result = self.__msgTaskToExecutor(taskId, eId, eType)
     if not result['OK']:
-      self.__queues.pushTask(eType, taskId, ahead=True)
       self.__states.removeTask(taskId)
       return result
     return S_OK(taskId)

--- a/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
+++ b/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
@@ -796,24 +796,30 @@ class ExecutorDispatcher(object):
     taskId, eType = pData
     self.__log.verbose("Sending task %s to %s=%s" % (taskId, eType, eId))
     self.__states.addTask(eId, taskId)
-    result = self.__msgTaskToExecutor(taskId, eId, eType)
-    if not result['OK']:
+    try:
+      self.__msgTaskToExecutor(taskId, eId, eType)
+    except UnrecoverableTaskException as e:
+      self.__log.exception("Failed to call __msgTaskToExecutor for", taskId)
+      return S_ERROR(str(e))
+    except Exception:
+      self.__log.exception("Exception while sending task to executor")
+      self.__queues.pushTask(eType, taskId, ahead=True)
       self.__states.removeTask(taskId)
-      return result
-    return S_OK(taskId)
+      return S_ERROR("Exception while sending task to executor")
+    else:
+      return S_OK(taskId)
 
   def __msgTaskToExecutor(self, taskId, eId, eType):
     try:
       self.__tasks[taskId].sendTime = time.time()
     except KeyError:
-      return S_ERROR("Task %s has been deleted" % taskId)
-    try:
-      result = self.__cbHolder.cbSendTask(taskId, self.__tasks[taskId].taskObj, eId, eType)
-    except BaseException:
-      self.__log.exception("Exception while sending task to executor")
-      return S_ERROR("Exception while sending task to executor")
-    if isReturnStructure(result):
-      return result
-    errMsg = "Send task callback did not send back an S_OK/S_ERROR structure"
-    self.__log.fatal(errMsg)
-    return S_ERROR(errMsg)
+      raise UnrecoverableTaskException("Task %s has been deleted" % taskId)
+    result = self.__cbHolder.cbSendTask(taskId, self.__tasks[taskId].taskObj, eId, eType)
+    if not isReturnStructure(result):
+      errMsg = "Send task callback did not send back an S_OK/S_ERROR structure"
+      self.__log.fatal(errMsg)
+      raise ValueError(errMsg)
+
+
+class UnrecoverableTaskException(Exception):
+  pass

--- a/src/DIRAC/Core/Utilities/test/Test_ExecutorDispatcher.py
+++ b/src/DIRAC/Core/Utilities/test/Test_ExecutorDispatcher.py
@@ -9,7 +9,10 @@ from __future__ import print_function
 __RCSID__ = "$Id$"
 
 
-from DIRAC.Core.Utilities.ExecutorDispatcher import ExecutorState, ExecutorQueues
+from DIRAC.Core.Utilities.ExecutorDispatcher import (
+    ExecutorState,
+    ExecutorQueues,
+)
 
 
 execState = ExecutorState()
@@ -42,15 +45,62 @@ def test_execQueues():
     for i in range(3):
       assert eQ.pushTask("type%s" % y, "t%s%s" % (y, i)) == i + 1
   assert "DONE IN"
+  res_internals = eQ._internals()
+  assert res_internals['queues'] == {'type0': ['t00', 't01', 't02'], 'type1': ['t10', 't11', 't12']}
+  assert set(res_internals['lastUse'].keys()) == {'type0', 'type1'}
+  assert res_internals['taskInQueue'] == {
+      't00': 'type0',
+      't01': 'type0',
+      't02': 'type0',
+      't10': 'type1',
+      't11': 'type1',
+      't12': 'type1',
+  }
   assert eQ.pushTask("type0", "t01") == 3
   assert eQ.getState()
   assert eQ.popTask("type0")[0] == "t00"
   assert eQ.pushTask("type0", "t00", ahead=True) == 3
   assert eQ.popTask("type0")[0] == "t00"
   assert eQ.deleteTask("t01")
+  res_internals = eQ._internals()
+  assert res_internals['queues'] == {'type0': ['t02'], 'type1': ['t10', 't11', 't12']}
+  assert set(res_internals['lastUse'].keys()) == {'type0', 'type1'}
+  assert res_internals['taskInQueue'] == {
+      't02': 'type0',
+      't10': 'type1',
+      't11': 'type1',
+      't12': 'type1',
+  }
   assert eQ.getState()
   assert eQ.deleteTask("t02")
+  res_internals = eQ._internals()
+  assert res_internals['queues'] == {'type0': [], 'type1': ['t10', 't11', 't12']}
+  assert set(res_internals['lastUse'].keys()) == {'type0', 'type1'}
+  assert res_internals['taskInQueue'] == {
+      't10': 'type1',
+      't11': 'type1',
+      't12': 'type1',
+  }
   assert eQ.getState()
   for i in range(3):
     assert eQ.popTask("type1")[0] == "t1%s" % i
-  assert eQ._internals()
+  res_internals = eQ._internals()
+  assert res_internals['queues'] == {'type0': [], 'type1': []}
+  assert set(res_internals['lastUse'].keys()) == {'type0', 'type1'}
+  assert res_internals['taskInQueue'] == {}
+
+  assert eQ.pushTask("type0", "t00") == 1
+  assert eQ.popTask("type0") == ("t00", "type0")
+  res_internals = eQ._internals()
+  assert res_internals['queues'] == {'type0': [], 'type1': []}
+  assert set(res_internals['lastUse'].keys()) == {'type0', 'type1'}
+  assert res_internals['taskInQueue'] == {}
+
+  assert eQ.pushTask("type0", "t00") == 1
+  assert eQ.deleteTask("t00")
+  res_internals = eQ._internals()
+  assert res_internals['queues'] == {'type0': [], 'type1': []}
+  assert set(res_internals['lastUse'].keys()) == {'type0', 'type1'}
+  assert res_internals['taskInQueue'] == {}
+
+  assert not eQ.deleteTask("t00")


### PR DESCRIPTION
Explanation by ChrisB in https://codimd.web.cern.ch/j7tlF5_aRqmndtKMh96bgA?view


BEGINRELEASENOTES

*WorkloadManagement
FIX: Ensure invalid tasks don't get rescheduled by ExecutorDispatcher

ENDRELEASENOTES

really unsure about this.
