### PR TITLE
[v7r2] Use proper Client and credentials in ReqProxy

### DIFF
--- a/src/DIRAC/Core/Base/Client.py
+++ b/src/DIRAC/Core/Base/Client.py
@@ -80,6 +80,10 @@ class Client(object):
     """
     self.serverURL = url
 
+  def getClientKWArgs(self):
+    """ Returns a copy of the connection arguments"""
+    return dict(self.__kwargs)
+
   def getServer(self):
     """ Getter for the server url. Useful ?
     """

--- a/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
+++ b/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
@@ -18,7 +18,6 @@ import datetime
 
 # # from DIRAC
 from DIRAC import gLogger, S_OK, S_ERROR
-from DIRAC.Core.DISET.RPCClient import RPCClient
 from DIRAC.Core.Utilities.List import randomize, fromChar
 from DIRAC.Core.Utilities.JEncode import strToIntDict
 from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
@@ -28,15 +27,14 @@ from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.private.RequestValidator import RequestValidator
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
 from DIRAC.WorkloadManagementSystem.Client import JobMinorStatus
+from DIRAC.WorkloadManagementSystem.Client.JobStateUpdateClient import JobStateUpdateClient
+from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
 
 
 @createClient('RequestManagement/ReqManager')
 class ReqClient(Client):
   """ReqClient is a class manipulating and operation on Requests.
 
-  :param ~RPCClient.RPCClient requestManager: RPC client to RequestManager
-  :param dict requestProxiesDict: RPC client to ReqestProxy
-  :param ~DIRAC.RequestManagementSystem.private.RequestValidator.RequestValidator requestValidator: RequestValidator instance
   """
   __requestProxiesDict = {}
   __requestValidator = None
@@ -302,8 +300,8 @@ class ReqClient(Client):
     :param str requestID: request id
     :param int jobID: job id
     """
-    # FIXME: use JobStateUpdateClient
-    stateServer = RPCClient("WorkloadManagement/JobStateUpdate", useCertificates=useCertificates)
+
+    stateServer = JobStateUpdateClient(useCertificates=useCertificates)
 
     # Checking if to update the job status - we should fail here, so it will be re-tried later
     # Checking the state, first
@@ -317,8 +315,8 @@ class ReqClient(Client):
                      (requestID, res['Value']))
 
     # The request is 'Done', let's update the job status. If we fail, we should re-try later
-    # FIXME: use JobMonitoringClient
-    monitorServer = RPCClient("WorkloadManagement/JobMonitoring", useCertificates=useCertificates)
+
+    monitorServer = JobMonitoringClient(useCertificates=useCertificates)
     res = monitorServer.getJobSummary(int(jobID))
     if not res["OK"]:
       self.log.error("finalizeRequest: Failed to get job status", "JobID: %d" % jobID)

--- a/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
+++ b/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
@@ -56,6 +56,11 @@ class ReqClient(Client):
 
   def requestProxies(self, timeout=120):
     """ get request proxies dict """
+    # Forward all the connection options to the requestClient
+    # (e.g. the userDN to use)
+    kwargs = self.getClientKWArgs()
+    kwargs['timeout'] = timeout
+
     if not self.__requestProxiesDict:
       self.__requestProxiesDict = {}
       proxiesURLs = fromChar(PathFinder.getServiceURL("RequestManagement/ReqProxyURLs"))
@@ -63,7 +68,10 @@ class ReqClient(Client):
         self.log.warn("CS option RequestManagement/ReqProxyURLs is not set!")
       for proxyURL in proxiesURLs:
         self.log.debug("creating RequestProxy for url = %s" % proxyURL)
-        self.__requestProxiesDict[proxyURL] = RPCClient(proxyURL, timeout=timeout)
+        pc = Client(**kwargs)
+        pc.setServer(proxyURL)
+        self.__requestProxiesDict[proxyURL] = pc
+
     return self.__requestProxiesDict
 
   def requestValidator(self):


### PR DESCRIPTION

BEGINRELEASENOTES
*RMS
FIX: ReqClient uses correct credentials to talk to ReqProxies
FIX: ReqClient uses proper WMS client insteand of RPCClient

ENDRELEASENOTES
