### PR TITLE
[WIP][v7r2] fix (Stomp): reconnect in case of MQ producer

### DIFF
--- a/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
+++ b/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
@@ -158,7 +158,11 @@ class StompMQConnector(MQConnector):
     destination = parameters.get('destination', '')
 
     try:
-      self.connection.send(body=json.dumps(message), destination=destination)
+      try:
+        self.connection.send(body=json.dumps(message), destination=destination)
+      except stomp.exception.StompException:
+        self.connect()
+        self.connection.send(body=json.dumps(message), destination=destination)
     except Exception as e:
       log.debug("Failed to send message", repr(e))
       return S_ERROR(EMQUKN, 'Failed to send message: %s' % repr(e))


### PR DESCRIPTION
The reconnection mechanism was effective only for listener.
Now, I just try to reconnect once in case a message cannot be sent

BEGINRELEASENOTES
*Resources
FIX: Stomp MQ: reconnect in case of lost connection

ENDRELEASENOTES
