### PR TITLE
[v7r2] Error propagation from ProxyDB and remove callstack when returning

### DIFF
--- a/src/DIRAC/Core/DISET/RequestHandler.py
+++ b/src/DIRAC/Core/DISET/RequestHandler.py
@@ -142,9 +142,14 @@ class RequestHandler(object):
       retVal = S_ERROR(message)
     elapsedTime = time.time() - startTime
     self.__logRemoteQueryResponse(retVal, elapsedTime)
-    # Strip the exception info from S_ERROR responses
-    if isinstance(retVal, dict) and "ExecInfo" in retVal:
+    # Strip the exception/callstack info from S_ERROR responses
+    if isinstance(retVal, dict):
+      # ExecInfo comes from the exception
+      if "ExecInfo" in retVal:
         del retVal["ExecInfo"]
+      # CallStack comes from the S_ERROR construction
+      if "CallStack" in retVal:
+        del retVal["CallStack"]
     result = self.__trPool.send(self.__trid, retVal)  # this will delete the value from the S_OK(value)
     del retVal
     return S_OK([result, elapsedTime])

--- a/src/DIRAC/Core/Tornado/Server/TornadoService.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoService.py
@@ -370,6 +370,15 @@ class TornadoService(RequestHandler):  # pylint: disable=abstract-method
     # retVal is :py:class:`tornado.concurrent.Future`
     self.result = retVal.result()
 
+    # Strip the exception/callstack info from S_ERROR responses
+    if isinstance(self.result, dict):
+      # ExecInfo comes from the exception
+      if "ExecInfo" in self.result:
+        del self.result["ExecInfo"]
+      # CallStack comes from the S_ERROR construction
+      if "CallStack" in self.result:
+        del self.result["CallStack"]
+
     # Here it is safe to write back to the client, because we are not
     # in a thread anymore
 

--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -559,7 +559,7 @@ class ProxyDB(DB):
       userMask = "%s@%s" % (userDN, userGroup)
     else:
       userMask = userDN
-    return S_ERROR("%s has no proxy registered" % userMask)
+    return S_ERROR(DErrno.EPROXYFIND, "%s has no proxy registered" % userMask)
 
   def renewFromMyProxy(self, userDN, userGroup, lifeTime=None, chain=None):
     """ Renew proxy from MyProxy
@@ -797,7 +797,7 @@ class ProxyDB(DB):
         errMsg += 'Stored proxy is not long lived enough, try to generate new'
         retVal = self.__getProxyFromProxyProviders(userDN, userGroup, requiredLifeTime=requiredLifeTime)
     if not retVal['OK']:
-      return S_ERROR("%s; %s" % (errMsg, retVal['Message']))
+      return S_ERROR(DErrno.EPROXYFIND, "%s; %s" % (errMsg, retVal['Message']))
     pemData = retVal['Value'][0]
     timeLeft = retVal['Value'][1]
     chain = X509Chain()
@@ -815,7 +815,7 @@ class ProxyDB(DB):
     # Proxy is invalid for some reason, let's delete it
     if not chain.isValidProxy()['OK']:
       self.deleteProxy(userDN, userGroup)
-      return S_ERROR("%s@%s has no proxy registered" % (userDN, userGroup))
+      return S_ERROR(DErrno.EPROXYFIND, "%s@%s has no proxy registered" % (userDN, userGroup))
     return S_OK((chain, timeLeft))
 
   def __getVOMSAttribute(self, userGroup, requiredVOMSAttribute=False):
@@ -893,7 +893,7 @@ class ProxyDB(DB):
       else:
         retVal = vomsMgr.setVOMSAttributes(chain, vomsAttr, vo=vomsVO)
         if not retVal['OK']:
-          return S_ERROR("Cannot append voms extension: %s" % retVal['Message'])
+          return retVal
         chain = retVal['Value']
 
     # We have got the VOMS proxy, store it into the cache


### PR DESCRIPTION
@atsareg @TaykYoku I have absolutely no idea how the Tornado change will propagate to future branches, since I don't yet understand the refactoring

BEGINRELEASENOTES

*Core
CHANGE: RequestHandler/TornadoService do not propagate callstack to client

*Framework
NEW: ProxyDB returns more DErrno

ENDRELEASENOTES
