### PR TITLE
[v7r2] Reduce the number of CI jobs

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -19,8 +19,6 @@ jobs:
           #     SC1091: Not following sourced file
           - find tests/CI -name '*.sh' -print0 | xargs -0 -n1 shellcheck --exclude=SC1090,SC1091 --external-source
           - tests/runPylint.sh
-          - tests/py3Check.sh
-          - CHECK=pylintPY3K tests/runPylint.sh
           - |
             if [[ "${REFERENCE_BRANCH}" != "" ]]; then
                 git remote add upstream https://github.com/DIRACGrid/DIRAC.git

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,15 +19,9 @@ jobs:
           ###### MySQL versions
           - TEST_NAME: "MySQL 5.7"
             ARGS: MYSQL_VER=5.7
-          # ###### ES versions
-          - TEST_NAME: "Elasticsearch 6.6.0"
-            ARGS: ES_VER=6.6.0
-          ###### Thread pool
-          - TEST_NAME: "New thread pool"
-            ARGS: DIRAC_USE_NEWTHREADPOOL=No
-          ###### Thread pool
-          - TEST_NAME: "Fewer cfg locks"
-            ARGS: DIRAC_FEWER_CFG_LOCKS=Yes
+          # ###### ES versions and old thread pool
+          - TEST_NAME: "Elasticsearch 6.6.0 and old thread pool"
+            ARGS: ES_VER=6.6.0 DIRAC_USE_NEWTHREADPOOL=No
           ###### HTTPS tests
           - TEST_NAME: "HTTPS"
             ARGS: TEST_HTTPS=Yes


### PR DESCRIPTION
To reduce the load on the CI I think we can remove some CI jobs without reducing the effective coverage.

Any thoughts?