### PR TITLE
[integration] Reduce number of CI jobs

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -31,6 +31,28 @@ jobs:
       run: |
         find tests/CI -name '*.sh' -print0 | xargs -0 -n1 shellcheck --exclude=SC1090,SC1091 --external-source
 
+  pycodestyle:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Installing dependencies
+      run: |
+        python -m pip install pycodestyle
+    - name: Run pycodestyle
+      run: |
+        if [[ "${REFERENCE_BRANCH}" != "" ]]; then
+            git remote add upstream https://github.com/DIRACGrid/DIRAC.git
+            git fetch --no-tags upstream "${REFERENCE_BRANCH}"
+            git branch -vv
+            git diff -U0 "upstream/${REFERENCE_BRANCH}" ':(exclude)tests/formatting/pep8_bad.py' | pycodestyle --diff
+        fi
+
   check:
     runs-on: ubuntu-latest
     if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
@@ -49,13 +71,6 @@ jobs:
           #     DISET's string and unicode types being poorly defined
           - pytest --runslow -k 'not test_BaseType_Unicode and not test_nestedStructure'
           - pylint -E src/
-          - |
-            if [[ "${REFERENCE_BRANCH}" != "" ]]; then
-                git remote add upstream https://github.com/DIRACGrid/DIRAC.git
-                git fetch --no-tags upstream "${REFERENCE_BRANCH}"
-                git branch -vv
-                git diff -U0 "upstream/${REFERENCE_BRANCH}" ':(exclude)tests/formatting/pep8_bad.py' | pycodestyle --diff
-            fi
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -16,6 +16,21 @@ jobs:
     - name: Run pre-commit
       run: pre-commit run --all-files --show-diff-on-failure
 
+  shellcheck:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run shellcheck
+      # TODO This should cover more than just tests/CI
+      # Excluded codes related to sourcing files
+      #     SC1090: Can't follow non-constant source
+      #     SC1091: Not following sourced file
+      run: |
+        find tests/CI -name '*.sh' -print0 | xargs -0 -n1 shellcheck --exclude=SC1090,SC1091 --external-source
+
   check:
     runs-on: ubuntu-latest
     if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
@@ -33,7 +48,6 @@ jobs:
           #   * `test_BaseType_Unicode` and `test_nestedStructure` fail due to
           #     DISET's string and unicode types being poorly defined
           - pytest --runslow -k 'not test_BaseType_Unicode and not test_nestedStructure'
-          - find tests/CI -name '*.sh' -print0 | xargs -0 -n1 shellcheck --exclude=SC1090,SC1091 --external-source
           - pylint -E src/
           - |
             if [[ "${REFERENCE_BRANCH}" != "" ]]; then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,11 +31,16 @@ jobs:
       run: .github/workflows/fail-fast.sh
     - run: |
         git fetch --prune --unshallow
-    - uses: conda-incubator/setup-miniconda@master
+    - uses: actions/setup-python@v2
       with:
-        environment-file: environment.yml
-        miniforge-variant: Mambaforge
-        use-mamba: true
+        python-version: '3.9'
+    - name: Installing dependencies
+      run: |
+        python -m pip install \
+            gitpython \
+            packaging \
+            pyyaml \
+            typer
     - name: Prepare environment
       run: ./integration_tests.py prepare-environment ${{ matrix.ARGS }}
     - name: Install server

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,20 +16,12 @@ jobs:
       matrix:
         # TEST_NAME is a dummy variable used to make it easier to read the web interface
         include:
-          ###### MySQL versions
           - TEST_NAME: "MySQL 5.7"
             ARGS: MYSQL_VER=mysql:5.7
-          - TEST_NAME: "MariaDB 10.6"
-            ARGS: MYSQL_VER=mariadb:10.6.3
-          # ###### ES versions
+          - TEST_NAME: "MariaDB 10.6, opensearch:1.0.0"
+            ARGS: MYSQL_VER=mariadb:10.6.3 ES_VER=opensearchproject/opensearch:1.0.0
           - TEST_NAME: "Elasticsearch 6.6.0"
             ARGS: ES_VER=elasticsearch:6.6.0
-          - TEST_NAME: "OpenSearch 1.0.0"
-            ARGS: ES_VER=opensearchproject/opensearch:1.0.0
-          ###### Fewer cfg locks
-          - TEST_NAME: "Fewer cfg locks"
-            ARGS: DIRAC_FEWER_CFG_LOCKS=Yes
-          ###### HTTPS tests
           - TEST_NAME: "HTTPS"
             ARGS: TEST_HTTPS=Yes
 


### PR DESCRIPTION
To reduce the load on the CI I think we can remove some CI jobs without reducing the effective coverage.

Any thoughts?