### PR TITLE
[v7r2] Sleep instead of dropping requests when services are overloaded

### DIFF
--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -43,6 +43,10 @@ from DIRAC.ConfigurationSystem.Client import PathFinder
 
 __RCSID__ = "$Id$"
 
+#: Time during which the service does not accept new requests and handles those in the queue, if the backlog is too large
+#: This sleep is repeated for as long as Service.wantsThrottle is truthy
+THROTTLE_SERVICE_SLEEP_SECONDS = 0.25
+
 
 class ServiceReactor(object):
 
@@ -236,6 +240,9 @@ class ServiceReactor(object):
             # Handle connection
             self.__stats.connectionStablished()
             self.__services[svcName].handleConnection(clientTransport)
+            while self.__services[svcName].wantsThrottle:
+                gLogger.warn("Sleeping as service requested throttling", svcName)
+                time.sleep(THROTTLE_SERVICE_SLEEP_SECONDS)
             # Renew context?
             now = time.time()
             renewed = False


### PR DESCRIPTION
In LHCb the changes in #5394 have turned out to occasionally cause issues with operations which need to interactions with the master CS (e.g. making edits).

After discussing with @chaen we've come to the conclusion that sleeping is better than dropping requests directly. This also allows the kernel TCP backlog to be effective.

BEGINRELEASENOTES

*Core
CHANGE: Sleep instead of dropping requests when services are overloaded

ENDRELEASENOTES
