### PR TITLE
[sweep:v7r3] Sleep instead of dropping requests when services are overloaded

### DIFF
--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -43,6 +43,10 @@ from DIRAC.ConfigurationSystem.Client import PathFinder
 
 __RCSID__ = "$Id$"
 
+#: Time during which the service does not accept new requests and handles those in the queue, if the backlog is too large
+#: This sleep is repeated for as long as Service.wantsThrottle is truthy
+THROTTLE_SERVICE_SLEEP_SECONDS = 0.25
+
 
 class ServiceReactor(object):
 
@@ -236,6 +240,9 @@ class ServiceReactor(object):
             # Handle connection
             self.__stats.connectionStablished()
             self.__services[svcName].handleConnection(clientTransport)
+            while self.__services[svcName].wantsThrottle:
+                gLogger.warn("Sleeping as service requested throttling", svcName)
+                time.sleep(THROTTLE_SERVICE_SLEEP_SECONDS)
             # Renew context?
             now = time.time()
             renewed = False

--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -335,17 +335,13 @@ class Service(object):
         if not self.activityMonitoring:
             self._stats["connections"] += 1
             self._monitor.setComponentExtraParam("queries", self._stats["connections"])
-        # TODO: remove later
-        nQueued = self._threadPool._work_queue.qsize()
-        if nQueued > self._cfg.getMaxWaitingPetitions():
-            gLogger.warn(
-                "Dropping request due to too many tasks",
-                "queued: %s limit: %s source: %s"
-                % (nQueued, self._cfg.getMaxWaitingPetitions(), clientTransport.getFormattedCredentials()),
-            )
-            clientTransport.close()
-            return
         self._threadPool.submit(self._processInThread, clientTransport)
+
+    @property
+    def wantsThrottle(self):
+        """Boolean property for if the service wants requests to stop being accepted"""
+        nQueued = self._threadPool._work_queue.qsize()
+        return nQueued > self._cfg.getMaxWaitingPetitions()
 
     # Threaded process function
     def _processInThread(self, clientTransport):


### PR DESCRIPTION
Sweep #5461 `Sleep instead of dropping requests when services are overloaded` to `rel-v7r3`.

Adding original author @chrisburr as watcher.