### PR TITLE
[v7r2] Fix deployment CI job

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,12 +22,14 @@ jobs:
           python -m pip install \
               build \
               diraccfg \
+              packaging \
               python-dateutil \
               pytz \
               readme_renderer \
               requests \
               setuptools_scm \
-              six
+              six \
+              uritemplate
       - name: Validate README for PyPI
         run: |
           python -m readme_renderer README.rst -o /tmp/README.html
@@ -40,6 +42,7 @@ jobs:
       - name: Make PEP-440 style release on GitHub
         if: steps.check-tag.outputs.create-release == 'true'
         run: |
+          set -e
           OLD_STYLE=${GITHUB_REF##*/}
           NEW_STYLE=$(python -c "import diraccfg; major, minor, patch, pre = diraccfg.parseVersion('${OLD_STYLE}'); print(f'{major}.{minor}.{patch}', f'a{pre}' if pre else '', sep='')")
           echo "Converted ${OLD_STYLE} version to ${NEW_STYLE}"


### PR DESCRIPTION
The deployment of v7r2p29 failed with this error which was silently ignored by the CI:
```
Run OLD_STYLE=${GITHUB_REF##*/}
  OLD_STYLE=${GITHUB_REF##*/}
  NEW_STYLE=$(python -c "import diraccfg; major, minor, patch, pre = diraccfg.parseVersion('${OLD_STYLE}'); print(f'{major}.{minor}.{patch}', f'a{pre}' if pre else '', sep='')")
  echo "Converted ${OLD_STYLE} version to ${NEW_STYLE}"
  .github/workflows/make_release.py \
    --token="***" \
    --version="v${NEW_STYLE}" \
    --rev="$(git rev-parse HEAD)"
  git fetch --all --tags
  shell: /usr/bin/bash -l {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.9.7/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.9.7/x64/lib
Converted v7r2p29 version to 7.2.29
Traceback (most recent call last):
  File "/home/runner/work/DIRAC/DIRAC/.github/workflows/make_release.py", line 6, in <module>
    from uritemplate import expand as uri_expand
ModuleNotFoundError: No module named 'uritemplate'
Fetching origin
From https://github.com/DIRACGrid/DIRAC
 * [new tag]             v6r12p17   -> v6r12p17
 * [new tag]             v6r4p15    -> v6r4p15
 * [new tag]             v6r8-pre1  -> v6r8-pre1
```
Hopefully this fixes everything 🤞 