### PR TITLE
[v7r2] Increased failover request delay

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -1288,7 +1288,7 @@ class JobWrapper(object):
     def sendFailoverRequest(self):
         """Create and send a combined job failover request if any"""
         request = Request()
-        # Forbid the request to be executed within the requested delay (default 45 minutes)
+        # Forbid the request to be executed within the requested delay
         request.delayNextExecution(self.failoverRequestDelay)
 
         requestName = "job_%s" % self.jobID

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -29,7 +29,6 @@ import glob
 import json
 import six
 import distutils.spawn
-import datetime
 
 from six.moves.urllib.parse import unquote as urlunquote
 

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -27,8 +27,8 @@ import threading
 import tarfile
 import glob
 import json
-import six
 import distutils.spawn
+import six
 
 from six.moves.urllib.parse import unquote as urlunquote
 
@@ -1287,8 +1287,8 @@ class JobWrapper(object):
     def sendFailoverRequest(self):
         """Create and send a combined job failover request if any"""
         request = Request()
-        # Forbid the request to be executed within the next 2 minutes
-        request.NotBefore = datetime.datetime.utcnow() + datetime.timedelta(seconds=120)
+        # Forbid the request to be executed within the next 45 minutes
+        request.delayNextExecution(60*45)
 
         requestName = "job_%s" % self.jobID
         if "JobName" in self.jobArgs:

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -1288,7 +1288,7 @@ class JobWrapper(object):
     def sendFailoverRequest(self):
         """Create and send a combined job failover request if any"""
         request = Request()
-        # Forbid the request to be executed within the requested delay
+        # Forbid the request to be executed within the requested delay (default 45 minutes)
         request.delayNextExecution(self.failoverRequestDelay)
 
         requestName = "job_%s" % self.jobID

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -119,6 +119,7 @@ class JobWrapper(object):
         self.defaultErrorFile = gConfig.getValue(self.section + "/DefaultErrorFile", "std.err")
         self.diskSE = gConfig.getValue(self.section + "/DiskSE", ["-disk", "-DST", "-USER"])
         self.tapeSE = gConfig.getValue(self.section + "/TapeSE", ["-tape", "-RDST", "-RAW"])
+        self.failoverRequestDelay = gConfig.getValue(self.section + "/FailoverRequestDelay", 45) * 60
         self.sandboxSizeLimit = gConfig.getValue(self.section + "/OutputSandboxLimit", 1024 * 1024 * 10)
         self.cleanUpFlag = gConfig.getValue(self.section + "/CleanUpFlag", True)
         self.boincUserID = gConfig.getValue("/LocalSite/BoincUserID", 0)
@@ -1287,8 +1288,8 @@ class JobWrapper(object):
     def sendFailoverRequest(self):
         """Create and send a combined job failover request if any"""
         request = Request()
-        # Forbid the request to be executed within the next 45 minutes
-        request.delayNextExecution(60 * 45)
+        # Forbid the request to be executed within the requested delay
+        request.delayNextExecution(self.failoverRequestDelay)
 
         requestName = "job_%s" % self.jobID
         if "JobName" in self.jobArgs:

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -119,7 +119,7 @@ class JobWrapper(object):
         self.defaultErrorFile = gConfig.getValue(self.section + "/DefaultErrorFile", "std.err")
         self.diskSE = gConfig.getValue(self.section + "/DiskSE", ["-disk", "-DST", "-USER"])
         self.tapeSE = gConfig.getValue(self.section + "/TapeSE", ["-tape", "-RDST", "-RAW"])
-        self.failoverRequestDelay = gConfig.getValue(self.section + "/FailoverRequestDelay", 45) * 60
+        self.failoverRequestDelay = gConfig.getValue(self.section + "/FailoverRequestDelay", 45)
         self.sandboxSizeLimit = gConfig.getValue(self.section + "/OutputSandboxLimit", 1024 * 1024 * 10)
         self.cleanUpFlag = gConfig.getValue(self.section + "/CleanUpFlag", True)
         self.boincUserID = gConfig.getValue("/LocalSite/BoincUserID", 0)

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -1288,7 +1288,7 @@ class JobWrapper(object):
         """Create and send a combined job failover request if any"""
         request = Request()
         # Forbid the request to be executed within the next 45 minutes
-        request.delayNextExecution(60*45)
+        request.delayNextExecution(60 * 45)
 
         requestName = "job_%s" % self.jobID
         if "JobName" in self.jobArgs:


### PR DESCRIPTION

BEGINRELEASENOTES
* JobWrapper
CHANGE: We have race conditions between the termination of jobs and the failover request. There is also a problem with RAL storage as a failed upload would remove the file recovered by failover if this is too soon. Hence delay to 45 minutes the execution of failover requests

ENDRELEASENOTES
