### PR TITLE
[8.0] Allow pre-releases if the primary extension is a pre-release

### DIFF
--- a/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -291,6 +291,7 @@ class SystemAdministratorHandler(RequestHandler):
         except InvalidVersion:
             self.log.exception("Invalid version passed", version)
             return S_ERROR("Invalid version passed %r" % version)
+        isPrerelease = version.is_prerelease
         version = "v%s" % version
 
         # Find what to install
@@ -343,15 +344,13 @@ class SystemAdministratorHandler(RequestHandler):
                 return S_ERROR("Failed to install DIRACOS2 %s" % stderr)
 
         # Install DIRAC
+        cmd = ["%s/bin/pip" % installPrefix, "install", "--no-color", "-v"]
+        if isPrerelease:
+            cmd += ["--pre"]
+        cmd += ["%s[server]==%s" % (primaryExtension, version)]
+        cmd += ["{%s}[server]" % e for e in otherExtensions]
         r = subprocess.run(
-            [
-                "%s/bin/pip" % installPrefix,
-                "install",
-                "--no-color",
-                "-v",
-                "%s[server]==%s" % (primaryExtension, version),
-            ]
-            + ["%s[server]" % e for e in otherExtensions],
+            cmd,
             stderr=subprocess.PIPE,
             universal_newlines=True,
             check=False,


### PR DESCRIPTION
I'm sweeping this one by hand pre-emptively as there is a `# pylint: disable=no-member` comment which causes a conflict.

BEGINRELEASENOTES

*Framework
FIX: Allow Python 3 style pre-releases to be installed if the primary extension is a pre-release

ENDRELEASENOTES
