### PR TITLE
[v7r2] Fix (Resources): Slurm getJobStatus split fields

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
@@ -191,7 +191,7 @@ class SLURM(object):
         lines = output.strip().split("\n")
         jids = set()
         for line in lines:
-            jid, status = line.split(',')
+            jid, status = line.split(",")
             jids.add(jid)
             if jid in jobIDList:
                 if status in ["PENDING", "SUSPENDED", "CONFIGURING"]:


### PR DESCRIPTION
Forgot to edit a line when working on: https://github.com/DIRACGrid/DIRAC/pull/5421
This should resolve issues to get job status on computing resources using Slurm.

BEGINRELEASENOTES
*Resources
FIX: Slurm getJobStatus split fields
ENDRELEASENOTES
