### PR TITLE
[8.0] edit response messages (Tornado Server) (hackathon fixes)

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -593,7 +593,7 @@ class BaseRequestHandler(RequestHandler):
         if isReturnStructure(self.result):
             argsString = "OK" if self.result["OK"] else f"ERROR: {self.result['Message']}"
         # If bad HTTP status code
-        elif self._status_code >= 400:
+        if self._status_code >= 400:
             argsString = f"ERROR {self._status_code}: {self._reason}"
 
         sLog.notice("Returning response", f"{credentials} {self._serviceName} ({elapsedTime:.2f} ms) {argsString}")


### PR DESCRIPTION
The last hackathon found many error messages that were not really errors. This PR is intended to fix messages about return response.

BEGINRELEASENOTES

*Core
FIX: change tornado response messages

ENDRELEASENOTES
