### PR TITLE
[v7r2] Do not import error definitions from "empty" extension

### DIFF
--- a/src/DIRAC/Core/Utilities/DErrno.py
+++ b/src/DIRAC/Core/Utilities/DErrno.py
@@ -340,21 +340,22 @@ def includeExtensionErrors():
     from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
 
     for extension in CSGlobals.getCSExtensions():
-        try:
-            ext_derrno = importlib.import_module("%sDIRAC.Core.Utilities.DErrno" % extension)
-        except ImportError:
-            pass
-        else:
-            # The next 3 dictionary MUST be present for consistency
-            # Global name of errors
-            sys.modules[__name__].__dict__.update(ext_derrno.extra_dErrName)
-            # Dictionary with the error codes
-            sys.modules[__name__].dErrorCode.update(ext_derrno.extra_dErrorCode)
-            # Error description string
-            sys.modules[__name__].dStrError.update(ext_derrno.extra_dStrError)
+        if extension:
+            try:
+                ext_derrno = importlib.import_module("%sDIRAC.Core.Utilities.DErrno" % extension)
+            except ImportError:
+                pass
+            else:
+                # The next 3 dictionary MUST be present for consistency
+                # Global name of errors
+                sys.modules[__name__].__dict__.update(ext_derrno.extra_dErrName)
+                # Dictionary with the error codes
+                sys.modules[__name__].dErrorCode.update(ext_derrno.extra_dErrorCode)
+                # Error description string
+                sys.modules[__name__].dStrError.update(ext_derrno.extra_dStrError)
 
-            # extra_compatErrorString is optional
-            for err in getattr(ext_derrno, "extra_compatErrorString", []):
-                sys.modules[__name__].compatErrorString.setdefault(err, []).extend(
-                    ext_derrno.extra_compatErrorString[err]
-                )
+                # extra_compatErrorString is optional
+                for err in getattr(ext_derrno, "extra_compatErrorString", []):
+                    sys.modules[__name__].compatErrorString.setdefault(err, []).extend(
+                        ext_derrno.extra_compatErrorString[err]
+                    )

--- a/src/DIRAC/Core/Utilities/DErrno.py
+++ b/src/DIRAC/Core/Utilities/DErrno.py
@@ -340,22 +340,23 @@ def includeExtensionErrors():
     from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
 
     for extension in CSGlobals.getCSExtensions():
-        if extension:
-            try:
-                ext_derrno = importlib.import_module("%sDIRAC.Core.Utilities.DErrno" % extension)
-            except ImportError:
-                pass
-            else:
-                # The next 3 dictionary MUST be present for consistency
-                # Global name of errors
-                sys.modules[__name__].__dict__.update(ext_derrno.extra_dErrName)
-                # Dictionary with the error codes
-                sys.modules[__name__].dErrorCode.update(ext_derrno.extra_dErrorCode)
-                # Error description string
-                sys.modules[__name__].dStrError.update(ext_derrno.extra_dStrError)
+        if not extension:
+            continue
+        try:
+            ext_derrno = importlib.import_module("%sDIRAC.Core.Utilities.DErrno" % extension)
+        except ImportError:
+            pass
+        else:
+            # The next 3 dictionary MUST be present for consistency
+            # Global name of errors
+            sys.modules[__name__].__dict__.update(ext_derrno.extra_dErrName)
+            # Dictionary with the error codes
+            sys.modules[__name__].dErrorCode.update(ext_derrno.extra_dErrorCode)
+            # Error description string
+            sys.modules[__name__].dStrError.update(ext_derrno.extra_dStrError)
 
-                # extra_compatErrorString is optional
-                for err in getattr(ext_derrno, "extra_compatErrorString", []):
-                    sys.modules[__name__].compatErrorString.setdefault(err, []).extend(
-                        ext_derrno.extra_compatErrorString[err]
-                    )
+            # extra_compatErrorString is optional
+            for err in getattr(ext_derrno, "extra_compatErrorString", []):
+                sys.modules[__name__].compatErrorString.setdefault(err, []).extend(
+                    ext_derrno.extra_compatErrorString[err]
+                )


### PR DESCRIPTION
The pilot parameters may by construction add "-e DIRAC" to add DIRAC as extension. In this case, the extra error definitions are attempted to be loaded from DIRAC itself and fail obviously. Even if this pilot logic is questionable, the fix provided here avoids the failure with no extra harm.

BEGINRELEASENOTES

*Core
FIX: DErrno.py - do not attempt to add extra error definitions from DIRAC core

ENDRELEASENOTES