### PR TITLE
[v7r2] ForwardDISET request uses Client instead of RPCClient

### DIFF
--- a/src/DIRAC/Core/Base/Client.py
+++ b/src/DIRAC/Core/Base/Client.py
@@ -201,3 +201,20 @@ def createClient(serviceName):
         return type(clientCls.__name__, clientCls.__bases__, attrDict)
 
     return addFunctions
+
+
+def executeRPCStub(rpcStub):
+    """
+    Playback a stub with the correct client (https or dips)
+    """
+    baseStub, methName, args = rpcStub
+    url, callParams = baseStub
+    # Make a copy to update it
+    stub = dict(callParams)
+    stub["url"] = url
+    # Generate a RPCClient with the same parameters
+    client = Client(**stub)
+    # Get a functor to execute the RPC call
+    rpcFunc = getattr(client, methName)
+    # Reproduce the call
+    return rpcFunc(*args)

--- a/src/DIRAC/RequestManagementSystem/Agent/RequestOperations/ForwardDISET.py
+++ b/src/DIRAC/RequestManagementSystem/Agent/RequestOperations/ForwardDISET.py
@@ -31,7 +31,7 @@ __RCSID__ = "$Id $"
 # # imports
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.RequestManagementSystem.private.OperationHandlerBase import OperationHandlerBase
-from DIRAC.Core.DISET.RPCClient import executeRPCStub
+from DIRAC.Core.Base.Client import executeRPCStub
 from DIRAC.Core.Utilities import DEncode
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 


### PR DESCRIPTION
closes https://github.com/DIRACGrid/DIRAC/issues/5451

BEGINRELEASENOTES

*RMS
CHANGE: ForwardDISET uses Client to be able to talk to https services

ENDRELEASENOTES
