### PR TITLE
[v7r3] ComputingElement remove redundant warnings

### DIFF
--- a/src/DIRAC/Resources/Computing/ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ComputingElement.py
@@ -138,9 +138,7 @@ class ComputingElement(object):
 
             self.log.debug(result)
 
-            if not result["OK"]:
-                self.log.warn(result["Message"])
-            else:
+            if result["OK"]:
                 ceOptions = result["Value"]
                 for key in ceOptions:
                     if key in INTEGER_PARAMETERS:

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/QueueUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/QueueUtilities.py
@@ -83,7 +83,7 @@ def getQueuesResolved(
                     queueDict[queueName]["CE"] = queueCE
                     result = queueDict[queueName]["CE"].isValid()
                     if not result["OK"]:
-                        return result
+                        continue
 
                 queueDict[queueName]["CEName"] = ce
                 queueDict[queueName]["CEType"] = ceDict["CEType"]


### PR DESCRIPTION
BEGINRELEASENOTES

*Resources
FIX: ComputingElement - remove unnecessary warning

*WMS
FIX: QueueUtilities - do not stop queue instantiation in case of failures

ENDRELEASENOTES
