### PR TITLE
[sweep:integration] LHCbDIRAC Hackthon fixes

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/__init__.py
+++ b/src/DIRAC/Core/Utilities/Graphs/__init__.py
@@ -11,7 +11,7 @@ from __future__ import division
 
 __RCSID__ = "$Id$"
 
-from os.path import dirname, join
+import importlib.resources
 
 # Make sure the the Agg backend is used despite arbitrary configuration
 import matplotlib
@@ -140,7 +140,7 @@ def graph(data, fileName, *args, **kw):
 
 def __checkKW(kw):
     if "watermark" not in kw:
-        kw["watermark"] = join(dirname(DIRAC.__file__), "Core/Utilities/Graphs/Dwatermark.png")
+        kw["watermark"] = str(importlib.resources.files("DIRAC.Core.Utilities.Graphs") / "Dwatermark.png")
     return kw
 
 

--- a/src/DIRAC/WorkloadManagementSystem/Executor/Base/OptimizerExecutor.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/Base/OptimizerExecutor.py
@@ -149,11 +149,13 @@ class OptimizerExecutor(ExecutorModule):
             return result
         valenc = result["Value"]
         try:
+            if not isinstance(valenc, bytes):
+                valenc = valenc.encode()
             value, encLength = DEncode.decode(valenc)
             if encLength == len(valenc):
                 return S_OK(value)
         except Exception:
-            self.jobLog.warn("Opt param %s doesn't seem to be dencoded %s" % (name, valenc))
+            self.jobLog.exception("Opt param %s doesn't seem to be dencoded %r" % (name, valenc))
         return S_OK(eval(valenc))
 
     @property


### PR DESCRIPTION
Sweep #5515 `LHCbDIRAC Hackthon fixes` to `integration`.

Adding original author @chrisburr as watcher.

BEGINRELEASENOTES

*Core
FIX: Fix finding Dwatermark.png for the accounting watermark

*WorkloadManagement
FIX: Ensure valenc is bytes before decoding in retrieveOptimizerParam

ENDRELEASENOTES