### PR TITLE
[v7r2] fix problem in VOMS2CSAgent for users that are suspended and have multiple DNs

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/CSAPI.py
+++ b/src/DIRAC/ConfigurationSystem/Client/CSAPI.py
@@ -409,7 +409,7 @@ class CSAPI(object):
             if createIfNonExistant:
                 gLogger.info("Registering user %s" % username)
                 return self.addUser(username, properties)
-            gLogger.error("User is not registered", username)
+            gLogger.error("User is not registered: ", repr(username))
             return S_OK(False)
         for prop in properties:
             if prop == "Groups":

--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -256,14 +256,16 @@ class VOMS2CSSynchronizer(object):
             diracName = ""
             if dn in existingDNs:
                 for user in diracUserDict:
-                    if dn == diracUserDict[user]["DN"]:
+                    if dn in fromChar(diracUserDict[user]["DN"]):
                         diracName = user
+                        break
 
             if dn in newDNs:
                 # Find if the DN is already registered in the DIRAC CS
                 for user in nonVOUserDict:
-                    if dn == nonVOUserDict[user]["DN"]:
+                    if dn in fromChar(nonVOUserDict[user]["DN"]):
                         diracName = user
+                        break
 
                 # Check the nickName in the same VO to see if the user is already registered
                 # with another DN
@@ -334,7 +336,7 @@ class VOMS2CSSynchronizer(object):
             suspendedVOList = getUserOption(diracName, "Suspended", [])
             knownEmail = getUserOption(diracName, "Email", None)
             userDict = {
-                "DN": dn,
+                "DN": diracUserDict[diracName]["DN"],
                 "CA": self.vomsUserDict[dn]["CA"],
                 "Email": self.vomsUserDict[dn].get("mail", self.vomsUserDict[dn].get("emailAddress")) or knownEmail,
             }


### PR DESCRIPTION

BEGINRELEASENOTES

*Configuration
FIX: VOMS2CSAgent: VOMS users that have multiple DNs and are suspended should no longer lead to "User not registered" errors and have their status correctly set

ENDRELEASENOTES
