### PR TITLE
[v7r2] In OperationHandlerBase: Use request id instead of request name in logger

### DIFF
--- a/src/DIRAC/RequestManagementSystem/private/OperationHandlerBase.py
+++ b/src/DIRAC/RequestManagementSystem/private/OperationHandlerBase.py
@@ -141,8 +141,8 @@ class OperationHandlerBase(object):
             raise TypeError("expecting Operation instance")
         self.operation = operation
         self.request = operation._parent
-        self.log = gLogger.getSubLogger(
-            "pid_%s/%s/%s/%s" % (os.getpid(), self.request.RequestName, self.request.Order, self.operation.Type)
+        self.log = gLogger.getLocalSubLogger(
+            "pid_%s/%s/%s/%s" % (os.getpid(), self.request.RequestID, self.request.Order, self.operation.Type)
         )
 
     #   @classmethod


### PR DESCRIPTION
RequestID is unique, and shorter than RequestName, also using getLocalSubLogger makes sense here I think.

BEGINRELEASENOTES

*RMS
CHANGE: OperationHandlerBase: use the requestID instead of the requestName in the logger
CHANGE: OperationHandlerBase: use getLocalSubLogger

ENDRELEASENOTES
