### PR TITLE
[sweep:integration] Factorize version number check, and change dirac-admin-update-instance for py3 transition

### DIFF
--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_instance.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_instance.py
@@ -116,7 +116,16 @@ def main():
             gLogger.error("Cannot connect to %s" % host)
             return result
 
-        gLogger.notice("Initiating software update of %s, this can take a while, please be patient ..." % host)
+        # If the server is already running python 3,
+        # convert the version to be installed to python3
+        existingVersion = result["Value"]["version"]
+        if DIRAC.isPy3VersionNumber(existingVersion):
+            version = DIRAC.convertToPy3VersionNumber(version)
+
+        gLogger.notice(
+            "Initiating software update of %s to %s, this can take a while, please be patient ..." % (host, version)
+        )
+
         result = client.updateSoftware(version, "", "", timeout=600)
         if not result["OK"]:
             return result

--- a/src/DIRAC/WorkloadManagementSystem/Client/Matcher.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/Matcher.py
@@ -11,7 +11,7 @@ __RCSID__ = "$Id"
 import time
 import re
 
-from DIRAC import gLogger
+from DIRAC import gLogger, convertToPy3VersionNumber
 
 from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Utilities.PrettyPrint import printDict
@@ -389,9 +389,10 @@ class Matcher(object):
                 pilotVersion = resourceDict["ReleaseVersion"]
 
             validVersions = [
-                parseVersion(newStyleVersion) for newStyleVersion in self.opsHelper.getValue("Pilot/Version", [])
+                convertToPy3VersionNumber(newStyleVersion)
+                for newStyleVersion in self.opsHelper.getValue("Pilot/Version", [])
             ]
-            if validVersions and parseVersion(pilotVersion) not in validVersions:
+            if validVersions and convertToPy3VersionNumber(pilotVersion) not in validVersions:
                 raise PilotVersionError(
                     "Pilot version does not match the production version: %s not in ( %s )"
                     % (pilotVersion, ",".join(validVersions))
@@ -408,22 +409,3 @@ class Matcher(object):
                         "Version check requested but expected project %s != received %s"
                         % (validProject, resourceDict["ReleaseProject"])
                     )
-
-
-def parseVersion(releaseVersion):
-    """Convert the releaseVersion into a PEP-440 style string
-
-    :param str releaseVersion: The software version to use
-    """
-    VERSION_PATTERN = re.compile(r"^(?:v)?(\d+)[r\.](\d+)(?:[p\.](\d+))?(?:(?:-pre|a)?(\d+))?$")
-
-    match = VERSION_PATTERN.match(releaseVersion)
-    # If the regex fails just return the original version
-    if not match:
-        return releaseVersion
-    major, minor, patch, pre = match.groups()
-    version = major + "." + minor
-    version += "." + (patch or "0")
-    if pre:
-        version += "a" + pre
-    return version

--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -65,6 +65,8 @@ from __future__ import division
 
 import sys
 import os
+import re
+import six
 import platform as pyPlatform
 from pkgutil import extend_path
 from pkg_resources import get_distribution, DistributionNotFound
@@ -98,6 +100,40 @@ except DistributionNotFound:
 
 errorMail = "dirac.alarms@gmail.com"
 alarmMail = "dirac.alarms@gmail.com"
+
+
+def isPy3VersionNumber(releaseVersion):
+    """Returns True if the releaseVersion is a PEP-440 style string.
+    This is the `is_canonical` function defined in PEP-440 Appendix B
+
+    :param str releaseVersion: The software version to use
+    """
+    return (
+        re.match(
+            r"^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$",
+            version,
+        )
+        is not None
+    )
+
+
+def convertToPy3VersionNumber(releaseVersion):
+    """Convert the releaseVersion into a PEP-440 style string
+
+    :param str releaseVersion: The software version to use
+    """
+    VERSION_PATTERN = re.compile(r"^(?:v)?(\d+)[r\.](\d+)(?:[p\.](\d+))?(?:(?:-pre|a)?(\d+))?$")
+
+    match = VERSION_PATTERN.match(releaseVersion)
+    # If the regex fails just return the original version
+    if not match:
+        return releaseVersion
+    major, minor, patch, pre = match.groups()
+    version = major + "." + minor
+    version += "." + (patch or "0")
+    if pre:
+        version += "a" + pre
+    return version
 
 
 def _computeRootPath(rootPath):


### PR DESCRIPTION
Sweep #5525 `Factorize version number check, and change dirac-admin-update-instance for py3 transition` to `integration`.

Adding original author @chaen as watcher.

BEGINRELEASENOTES

*Core

NEW: Utility for parsing DIRAC version number to Py3

*Framework
NEW: dirac-admin-update-instance converts version number to PEP-440 style if needed

ENDRELEASENOTES