### PR TITLE
[v7r3] do not calculate FQDN unnecessarily

### DIFF
--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -205,14 +205,6 @@ from DIRAC.FrameworkSystem.Client.Logger import gLogger
 # Configuration client
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 
-# Some Defaults if not present in the configuration
-FQDN = getFQDN()
-if len(FQDN.split(".")) > 2:
-    # Use the last component of the FQDN as country code if there are more than 2 components
-    _siteName = "DIRAC.Client.%s" % FQDN.split(".")[-1]
-else:
-    # else use local as country code
-    _siteName = "DIRAC.Client.local"
 
 __siteName = False
 
@@ -223,7 +215,17 @@ def siteName():
     """
     global __siteName
     if not __siteName:
-        __siteName = gConfig.getValue("/LocalSite/Site", _siteName)
+        __siteName = gConfig.getValue("/LocalSite/Site")
+        if not __siteName:
+            # Some Defaults if not present in the configuration
+            FQDN = getFQDN()
+            if len(FQDN.split(".")) > 2:
+                # Use the last component of the FQDN as country code if there are more than 2 components
+                __siteName = "DIRAC.Client.%s" % FQDN.split(".")[-1]
+            else:
+                # else use local as country code
+                __siteName = "DIRAC.Client.local"
+
     return __siteName
 
 


### PR DESCRIPTION
The current structure starts the `FQDN` search each time, regardless of whether the search result is used. Under certain circumstances, for example described [here](https://apple.stackexchange.com/questions/175320/why-is-my-hostname-resolution-taking-so-long), this process may take some time. Based on the code getting FQDN is used only in the case of `DIRAC.siteName()` and only if the configuration does not have the appropriate settings. Therefore, the logic of obtaining FQDN is transferred to the place where the result is applied. 

BEGINRELEASENOTES

CHANGE: do not calculate FQDN unnecessarily

ENDRELEASENOTES
