### PR TITLE
[v7r3] Transformation system more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ src/etc/
 
 pilot.cfg
 DIRAC_containers
-
+docs/source/dirac.cfg
 # VSCode
 .vscode
 .env

--- a/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
+++ b/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
@@ -280,4 +280,4 @@ Conclusion
 You now have all the knowledge to perform DataManagement in DIRAC with the TransformationSystem.
 
 To learn how to extend the system by creating new transformation plugins, please see how to
-:ref:`dev-ts-transformationagent-plugins`.
+:ref:`dev-ts-transformationagent-plugins` and :ref:`dev-ts-body-plugins`

--- a/docs/source/DeveloperGuide/Systems/Transformation/bodyplugin.rst
+++ b/docs/source/DeveloperGuide/Systems/Transformation/bodyplugin.rst
@@ -1,0 +1,139 @@
+.. _dev-ts-body-plugins:
+
+Create a Body Plugin
+====================
+
+This page briefly explains the steps necessary to add a new BodyPlugin  or an extension.
+It assumes the reader has some form of a development and testing setup available to them.
+
+The module :py:mod:`DIRAC.TransformationSystem.Client.BodyPlugin.BaseBody` contains documentation on how to code such a plugin
+
+
+The ReplicateOrMove Plugin Example
+----------------------------------
+
+Imagine a world where you would have storages that are reliable, and some that are less. And imagine that you are creating a transformation to shuffle data around. Now, if the destination of your file is a trustworthy one, you could imagine deleting the original copy. But if the destination is likely to lose your file, you are better off keeping a second copy. That's what our example plugin will do.
+
+.. code-block:: python
+   :caption: ReplicateOrMoveBody.py
+   :linenos:
+
+
+    from DIRAC import gLogger
+    from DIRAC.RequestManagementSystem.Client.Request import Request
+    from DIRAC.RequestManagementSystem.Client.Operation import Operation
+    from DIRAC.RequestManagementSystem.Client.File import File
+
+    from DIRAC.TransformationSystem.Client.BodyPlugin.BaseBody import BaseBody
+
+
+    sLog = gLogger.getLocalSubLogger(__name__)
+
+
+    class ReplicateOrMoveBody(BaseBody):
+        """
+        If the destination storage is trustworthy, move the file there,
+        otherwise, just do a copy of the file
+        """
+
+        # This is needed to know how to serialize the object,
+        # all attributes that need to be persisted should be in this list.
+        # See :py:class:`~DIRAC.Core.Utilities.JEncode.JSerializable` for more details.
+        _attrToSerialize = ["trustworthy", "undependable"]
+
+        def __init__(self, trustworthy=None, undependable=None):
+            """C'tor
+
+            :param list trustworthy: trustworthy storage to which we will move the file
+            :param list undependable: doubtful storage to which we will rather just copy
+            """
+            self.trustworthy = trustworthy
+            self.undependable = undependable
+
+        def taskToRequest(self, taskID, task, transID):
+            """
+            Convert a task into a Request with either a ReplicateAndRegister
+            or a Move Operation
+            """
+            req = Request()
+            op = Operation()
+
+            # Decide on an operation type
+            targetSE = task["TargetSE"]
+            if targetSE in self.trustworthy:
+                op.Type = "MoveReplica"
+            elif targetSE in self.undependable:
+                op.Type = "ReplicateAndRegister"
+            else:
+                sLog.warn("Hum, SE is not in a known list... let's try to assess the quality of the storage...")
+                # VERY doubtful storage
+                if "RAL" in targetSE:
+                    op.Type = "ReplicateAndRegister"
+                else:
+                    op.Type = "MoveReplica"
+
+            for lfn in task["InputData"]:
+                trFile = File()
+                trFile.LFN = lfn
+
+                op.addFile(trFile)
+
+            req.addOperation(op)
+
+            return req
+
+
+
+Using the Body Plugin
+---------------------
+
+When creating a transformation, just create the BodyPlugin object you want with the appropriate parameters, and set it using ``setBody``
+
+.. code-block:: python
+   :caption: createReplicateOrMove.py
+   :linenos:
+
+    from DIRAC import gLogger, S_OK, S_ERROR
+    from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+
+    Script.parseCommandLine()
+
+    from DIRAC.TransformationSystem.Client.Transformation import Transformation
+    from DIRAC.TransformationSystem.Client.BodyPlugin.ReplicateOrMoveBody import (
+        ReplicateOrMoveBody,
+    )
+
+    myTrans = Transformation()
+    uniqueIdentifier = "sensitiveData"
+    myTrans.setTransformationName("ReplicateOrMove_%s" % uniqueIdentifier)
+    myTrans.setDescription("Move only to trustworthy storages")
+    myTrans.setType("Replication")
+    myTrans.setTransformationGroup("MyGroup")
+    myTrans.setGroupSize(2)
+
+    # Set the Broadcast plugin
+    myTrans.setPlugin("Broadcast")
+    myTrans.Destinations(1)
+
+
+    myBody = ReplicateOrMoveBody(
+        trustworthy=["CERN-Storage", "CNAF-Storage"], undependable=["NIPNE-Storage"]
+    )
+
+    myTrans.setBody(myBody)
+
+    metadata = {"TransformationID": 2}
+    myTrans.setInputMetaQuery(metadata)
+
+    res = myTrans.addTransformation()
+    if not res["OK"]:
+        gLogger.error("Failed to add the transformation: %s" % res["Message"])
+        exit(1)
+
+    # now activate the transformation
+    myTrans.setStatus("Active")
+    myTrans.setAgentType("Automatic")
+    transID = myTrans.getTransformationID()["Value"]
+
+    gLogger.notice("Created ReplicateOrMove transformation: %r" % transID)
+    exit(0)

--- a/docs/source/DeveloperGuide/Systems/Transformation/index.rst
+++ b/docs/source/DeveloperGuide/Systems/Transformation/index.rst
@@ -7,3 +7,4 @@ TransformationSystem
 
    architecture
    transformationplugin
+   bodyplugin

--- a/src/DIRAC/TransformationSystem/Client/BodyPlugin/BaseBody.py
+++ b/src/DIRAC/TransformationSystem/Client/BodyPlugin/BaseBody.py
@@ -1,0 +1,31 @@
+"""
+BaseBody serves as a base class for all the BodyPlugin, as well as documentation
+reference for that object.
+"""
+
+from DIRAC.Core.Utilities.JEncode import JSerializable
+
+
+class BaseBody(JSerializable):
+    """
+    Body plugins are meant to add evolved logic into the process of
+    turning a TransformationSystem Task into an RMS Request.
+
+    All your BodyPlugins should inherit from this class. Note that ``BaseBody``
+    inherit from :py:class:`DIRAC.Core.Utilities.JEncode.JSerializable`, so you
+    should follow the guidelines from this class too.
+    """
+
+    def taskToRequest(self, taskID, task, transID):
+        """
+        This is the only method needed by your plugin. Its role
+        is to turn the task into a Request.
+        Note that this method is called for one task at the time.
+
+        :param taskID: id for the task
+        :param task: dict describing the task
+        :param transID: id of the transformation
+
+        :return: A request object
+        """
+        raise NotImplementedError()

--- a/src/DIRAC/TransformationSystem/Client/BodyPlugin/DummyBody.py
+++ b/src/DIRAC/TransformationSystem/Client/BodyPlugin/DummyBody.py
@@ -18,6 +18,7 @@ class DummyBody(BaseBody):
 
     def __init__(self, factor=0):
         """C'tor
+
         :param factor: multiplying factor
         """
         self.factor = factor

--- a/src/DIRAC/TransformationSystem/Client/BodyPlugin/DummyBody.py
+++ b/src/DIRAC/TransformationSystem/Client/BodyPlugin/DummyBody.py
@@ -1,0 +1,34 @@
+import json
+
+from DIRAC.RequestManagementSystem.Client.Request import Request
+from DIRAC.RequestManagementSystem.Client.Operation import Operation
+
+from DIRAC.TransformationSystem.Client.BodyPlugin.BaseBody import BaseBody
+
+
+class DummyBody(BaseBody):
+    """Dummy BodyPlugin class that just creates
+    a ForwardDISET operation, whose argument
+    is the number of LFNs multiplied by a factor
+    It is used mostly as an example and for unit tests.
+    """
+
+    # This is needed to know how to serialize the object
+    _attrToSerialize = ["factor"]
+
+    def __init__(self, factor=0):
+        """C'tor
+        :param factor: multiplying factor
+        """
+        self.factor = factor
+
+    def taskToRequest(self, taskID, task, transID):
+        """Convert a task into an RMS with a single ForwardDISET
+        Operation whose attribute is the number of files in the task
+        """
+        req = Request()
+        op = Operation()
+        op.Type = "ForwardDISET"
+        op.Arguments = json.dumps(len(task["InputData"]) * self.factor)
+        req.addOperation(op)
+        return req

--- a/src/DIRAC/TransformationSystem/Client/test/Test_Client_RequestTasks.py
+++ b/src/DIRAC/TransformationSystem/Client/test/Test_Client_RequestTasks.py
@@ -1,0 +1,321 @@
+""" pytest for WorkflowTasks
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# pylint: disable=protected-access,missing-docstring,invalid-name
+
+from mock import MagicMock
+import json
+import pytest
+
+from pytest import mark
+
+parametrize = mark.parametrize
+
+from hypothesis import given, settings, HealthCheck
+from hypothesis.strategies import (
+    composite,
+    builds,
+    integers,
+    lists,
+    recursive,
+    floats,
+    text,
+    booleans,
+    none,
+    dictionaries,
+    tuples,
+    dates,
+    datetimes,
+    from_regex,
+)
+from string import ascii_letters, digits
+
+from DIRAC.TransformationSystem.Client.RequestTasks import RequestTasks
+
+# from DIRAC import gLogger
+# from DIRAC.Interfaces.API.Job import Job
+
+# # sut
+# from DIRAC.TransformationSystem.Client.WorkflowTasks import WorkflowTasks
+
+# gLogger.setLevel("DEBUG")
+
+
+@composite
+def taskStrategy(draw):
+    """Generate a strategy that returns a task dictionnary"""
+    transformationID = draw(integers(min_value=1))
+    targetSE = ",".join(draw(lists(text(ascii_letters, min_size=5, max_size=10), min_size=1, max_size=3)))
+    inputData = draw(lists(from_regex("(/[a-z]+)+", fullmatch=True), min_size=1, max_size=10))
+
+    return {"TransformationID": transformationID, "TargetSE": targetSE, "InputData": inputData}
+
+
+def taskDictStrategy():
+    return dictionaries(integers(min_value=1), taskStrategy(), min_size=1, max_size=10)
+
+
+mockTransClient = MagicMock()
+mockReqClient = MagicMock()
+mockReqValidator = MagicMock()
+
+
+reqTasks = RequestTasks(
+    transClient=mockTransClient,
+    requestClient=mockReqClient,
+    requestValidator=mockReqValidator,
+)
+# odm_o = MagicMock()
+# odm_o.execute.return_value = {"OK": True, "Value": {}}
+# wfTasks.outputDataModule_o = odm_o
+
+
+@parametrize(
+    "transBody",
+    [
+        "removal;RemoveFile",  # Transformation to remove files
+        "removal;RemoveReplica",  # Transformation to remove Replicas
+        "anything;ReplicateAndRegister",  # Transformation to replicate and register, first parameter is useless
+        "",  # if no Body, we expect replicateAndRegister
+    ],
+)
+@settings(max_examples=10)
+@given(
+    owner=text(ascii_letters + "-_" + digits, min_size=1),
+    taskDict=taskDictStrategy(),
+)
+def test_prepareSingleOperationsBody(transBody, owner, taskDict):
+    """Test different bodies that should be routed through the
+    singleOperationBody method.
+    """
+
+    # keep the number of tasks for later
+    originalNbOfTasks = len(taskDict)
+
+    # Make up the DN and the group
+    ownerDN = "DN_" + owner
+    ownerGroup = "group_" + owner
+
+    res = reqTasks.prepareTransformationTasks(transBody, taskDict, owner=owner, ownerGroup=ownerGroup, ownerDN=ownerDN)
+
+    assert res["OK"], res
+
+    # prepareTransformationTasks can pop tasks if a problem occurs,
+    # so check that this did not happen
+    assert len(res["Value"]) == originalNbOfTasks
+
+    for _taskID, task in taskDict.items():
+
+        req = task.get("TaskObject")
+
+        # Checks whether we got a Request assigned
+        assert req
+
+        # Check that the attributes of the request are what
+        # we expect them to be
+        assert req.OwnerDN == ownerDN
+        assert req.OwnerGroup == ownerGroup
+
+        # Make sure we only have one operation
+        assert len(req) == 1
+
+        ops = req[0]
+
+        # Check the operation type
+        # The operation type is either given as second parameter of the body
+        # or if not, it is ReplicateAndRegister
+
+        expectedOpsType = transBody.split(";")[-1] if transBody else "ReplicateAndRegister"
+        assert ops.Type == expectedOpsType
+
+        # Check that the targetSE is set correctly
+        assert ops.TargetSE == task["TargetSE"]
+
+        # Make sure we have one file per LFN in the task
+        assert len(ops) == len(task["InputData"])
+
+        # Checks that there is one file per LFN
+        assert set([f.LFN for f in ops]) == set(task["InputData"])
+
+
+@parametrize(
+    "transBody",
+    [
+        [
+            ("ReplicateAndRegister", {"TargetSE": "BAR-SRM"}),
+        ],
+        [
+            ("ReplicateAndRegister", {"TargetSE": "TASK:TargetSE"}),
+        ],
+        [
+            ("ReplicateAndRegister", {"SourceSE": "FOO-SRM", "TargetSE": "BAR-SRM"}),
+            ("RemoveReplica", {"TargetSE": "FOO-SRM"}),
+        ],
+        [
+            ("ReplicateAndRegister", {"SourceSE": "FOO-SRM", "TargetSE": "TASK:TargetSE"}),
+            ("RemoveReplica", {"TargetSE": "FOO-SRM"}),
+        ],
+    ],
+    ids=[
+        "Single operation, no substitution",
+        "Single operation, with substitution",
+        "Multiple operations, no substitution",
+        "Multiple operations, with substitution",
+    ],
+)
+@settings(max_examples=10)
+@given(
+    owner=text(ascii_letters + "-_" + digits, min_size=1),
+    taskDict=taskDictStrategy(),
+)
+def test_prepareMultiOperationsBody(transBody, owner, taskDict):
+    """Test different bodies that should be routed through the
+    multiOperationsBody method.
+    """
+
+    # keep the number of tasks for later
+    originalNbOfTasks = len(taskDict)
+
+    # Make up the DN and the group
+    ownerDN = "DN_" + owner
+    ownerGroup = "group_" + owner
+
+    res = reqTasks.prepareTransformationTasks(
+        json.dumps(transBody), taskDict, owner=owner, ownerGroup=ownerGroup, ownerDN=ownerDN
+    )
+
+    assert res["OK"], res
+
+    # prepareTransformationTasks can pop tasks if a problem occurs,
+    # so check that this did not happen
+    assert len(res["Value"]) == originalNbOfTasks
+
+    for _taskID, task in taskDict.items():
+
+        req = task.get("TaskObject")
+
+        # Checks whether we got a Request assigned
+        assert req
+
+        # Check that the attributes of the request are what
+        # we expect them to be
+        assert req.OwnerDN == ownerDN
+        assert req.OwnerGroup == ownerGroup
+
+        # Make sure we have as many operations as tuple in the body
+        assert len(req) == len(transBody)
+
+        # Loop over each operation
+        # to check their attributes
+        for opsID, ops in enumerate(req):
+
+            expectedOpsType, expectedOpsAttributes = transBody[opsID]
+
+            # Compare the operation type with what we want
+            assert ops.Type == expectedOpsType
+
+            # Check the operation attributes one after the other
+            for opsAttr, opsVal in expectedOpsAttributes.items():
+
+                # If the expected value starts with 'TASK:'
+                # we should make the substitution with whatever is in
+                # the taskDict.
+                # So it should be different
+                if opsVal.startswith("TASK:"):
+                    assert getattr(ops, opsAttr) != opsVal
+                # Otherwise, make sure it matches
+                else:
+                    assert getattr(ops, opsAttr) == opsVal
+
+                # Make sure we have one file per LFN in the task
+                assert len(ops) == len(task["InputData"])
+
+                # Checks that there is one file per LFN
+                assert set([f.LFN for f in ops]) == set(task["InputData"])
+
+
+@parametrize(
+    "transBody",
+    [
+        [
+            ("ReplicateAndRegister", {"TargetSE": "TASK:NotInTaskDict"}),
+        ],
+    ],
+    ids=[
+        "Non existing substituation",
+    ],
+)
+@settings(max_examples=10)
+@given(
+    owner=text(ascii_letters + "-_" + digits, min_size=1),
+    taskDict=taskDictStrategy(),
+)
+def test_prepareProblematicMultiOperationsBody(transBody, owner, taskDict):
+    """Test different bodies that should be routed through the
+    multiOperationBody method, but that have a problem
+    """
+
+    # keep the number of tasks for later
+    originalNbOfTasks = len(taskDict)
+
+    # Make up the DN and the group
+    ownerDN = "DN_" + owner
+    ownerGroup = "group_" + owner
+
+    res = reqTasks.prepareTransformationTasks(
+        json.dumps(transBody), taskDict, owner=owner, ownerGroup=ownerGroup, ownerDN=ownerDN
+    )
+
+    assert res["OK"], res
+
+    # prepareTransformationTasks pop tasks if a problem occurs,
+    # so make sure it happened
+    assert len(res["Value"]) != originalNbOfTasks
+
+    # Check that other tasks are fine
+    for _taskID, task in taskDict.items():
+
+        req = task.get("TaskObject")
+
+        # Checks whether we got a Request assigned
+        assert req
+
+        # Check that the attributes of the request are what
+        # we expect them to be
+        assert req.OwnerDN == ownerDN
+        assert req.OwnerGroup == ownerGroup
+
+        # Make sure we have as many operations as tuple in the body
+        assert len(req) == len(transBody)
+
+        # Loop over each operation
+        # to check their attributes
+        for opsID, ops in enumerate(req):
+
+            expectedOpsType, expectedOpsAttributes = transBody[opsID]
+
+            # Compare the operation type with what we want
+            assert ops.Type == expectedOpsType
+
+            # Check the operation attributes one after the other
+            for opsAttr, opsVal in expectedOpsAttributes.items():
+
+                # If the expected value starts with 'TASK:'
+                # we should make the substitution with whatever is in
+                # the taskDict.
+                # So it should be different
+                if opsVal.startswith("TASK:"):
+                    assert getattr(ops, opsAttr) != opsVal
+                # Otherwise, make sure it matches
+                else:
+                    # Check that the targetSE is set correctly
+                    assert getattr(ops, opsAttr) == opsVal
+
+                # Make sure we have one file per LFN in the task
+                assert len(ops) == len(task["InputData"])
+
+                # Checks that there is one file per LFN
+                assert set([f.LFN for f in ops]) == set(task["InputData"])

--- a/src/DIRAC/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/src/DIRAC/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -16,6 +16,7 @@ from DIRAC.TransformationSystem.Client.TaskManager import TaskBase
 from DIRAC.TransformationSystem.Client.RequestTasks import RequestTasks
 from DIRAC.TransformationSystem.Client.Transformation import Transformation
 from DIRAC.TransformationSystem.Client.Utilities import PluginUtilities
+from DIRAC.TransformationSystem.Client.BodyPlugin.DummyBody import DummyBody
 
 
 class reqValFake_C(object):
@@ -269,6 +270,10 @@ class TransformationSuccess(ClientsTestCase):
         # It is enough to check one case, unlike above
         with self.assertRaisesRegexp(TypeError, "Expected 2-tuple"):
             self.transformation.setBody([(u"RemoveReplica", {u"TargetSE": u"FOO-SRM"}), ("One", "too long", "tuple")])
+
+        # Test setting a body plugin as body
+        complexBody = DummyBody()
+        self.transformation.setBody(complexBody)
 
     def test_SetGetReset(self):
         """Testing of the set, get and reset methods.


### PR DESCRIPTION
Hopefully the tests and documentation in this PR are clear enough to explain what is achieved. 

The basic aim is to be able to have a more dynamic way of creating `Requests` from a `Task`. 
The first attempt was with 2685bb53565b9b4c70ef40f75e7cc398d618022f and this worked nicely.
But then I wanted more, so I introduced Body Plugins a5823faf1e5e9ee373285b5ef1afda1499876cc6

The driving reason is the data export of LHCb. 

@andresailer this is what we talked about. Inheriting from the `Transformation` object was highly impractical for several reasons. 

BEGINRELEASENOTES
*TS
NEW: Allow MultiOperation body to fetch values from the task dict
NEW: Introduce Body Plugins for DMS transformations

ENDRELEASENOTES
