### PR TITLE
[v7r3] don't run Integration tests for documentation changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,14 @@
 name: Integration tests
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.rst'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.rst'
 
 jobs:
   Integration:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,12 +3,19 @@ name: Integration tests
 on:
   push:
     paths-ignore:
+      # Docs
       - 'docs/**'
       - 'README.rst'
+      # When push new release
+      - 'release.notes'
+      - 'src/DIRAC/__init__.py'  # It is expected that only the version number will change here
+      - 'releases.cfg'
   pull_request:
     paths-ignore:
+      # RPs with docs
       - 'docs/**'
       - 'README.rst'
+      - 'release.notes'
 
 jobs:
   Integration:


### PR DESCRIPTION
BEGINRELEASENOTES

Integration tests are fragile and take resources and a lot of time and I don't see the need for them when changing documentation or README for example. So I think it would be wise to turn them off in these cases.

*CI
CHANGE: don't run Integration tests for documentation changes

ENDRELEASENOTES
