### PR TITLE
[v7r2] fix (docs): remove docutils from the requirements

### DIFF
--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -15,7 +15,6 @@ dependencies:
   - cachetools
   - certifi
   - cmreshandler >1.0.0b4
-  - docutils
   - elasticsearch <7.14
   - elasticsearch-dsl
   - future

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ dependencies:
   - certifi
   - cmreshandler >1.0.0b4
   - cachetools <4
-  - docutils
   - elasticsearch <7.14
   - elasticsearch-dsl ~=6.3.1
   - fts-rest


### PR DESCRIPTION
There is an incompatibility between sphynx and the new docutils release that is exhibited in LHCbDIRAC 
Details: https://sourceforge.net/p/docutils/bugs/431/

```
sphinx-build -b html -d build/doctrees  -wsphinxWarnings source build/html
Running Sphinx v4.0.0
conf.py:     INFO: LHCbDIRACVERSION is 'integration'
conf.py:     INFO: Current location '/builds/chaen/LHCbDIRAC/docs/source'
conf.py:     INFO: DiracDocTools location '/opt/conda/envs/test-env/lib/python3.9/site-packages/diracdoctools/__init__.py'
conf.py:     INFO: DiracDocTools location '/opt/conda/envs/test-env/lib/python3.9/site-packages/diracdoctools/Utilities.py'
conf.py:     INFO: DiracDocTools location '/opt/conda/envs/test-env/lib/python3.9/site-packages/diracdoctools/cmd/__init__.py'
WARNING: while setting up extension sphinx.addnodes: node class 'meta' is already registered, its visitors will be overridden

Extension error:
Could not import extension sphinx.directives.patches (exception: cannot import name 'html' from 'docutils.parsers.rst.directives' (/opt/conda/envs/test-env/lib/python3.9/site-packages/docutils/parsers/rst/directives/__init__.py))
make: *** [Makefile:62: htmlall] Error 2
```


BEGINRELEASENOTES
*Docs
CHANGE: Forces docutils to 0.17 because of bug with sphynx


ENDRELEASENOTES
