### PR TITLE
[v7r2] Fixes to X509CRL and X509Chain

### DIFF
--- a/src/DIRAC/Core/Security/m2crypto/X509CRL.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509CRL.py
@@ -23,8 +23,7 @@ from DIRAC.Core.Utilities import DErrno
 
 class X509CRL(object):
     def __init__(self, cert=None):
-
-        self.__pemData = None
+        self.__pemData = b""
 
         if cert:
             self.__loadedCert = True
@@ -46,7 +45,6 @@ class X509CRL(object):
         Load a x509CRL certificate from a pem file
         Return : S_OK / S_ERROR
         """
-
         self.__loadedCert = False
         try:
             self.__revokedCert = M2Crypto.X509.load_crl(crlLocation)
@@ -61,7 +59,7 @@ class X509CRL(object):
     def __str__(self):
         if not self.__loadedCert:
             return "No certificate loaded"
-        return self.__pemData
+        return self.__pemData.decode("utf-8")
 
     def dumpAllToString(self):
         """
@@ -69,7 +67,6 @@ class X509CRL(object):
         """
         if not self.__loadedCert:
             return S_ERROR(DErrno.ECERTREAD, "No certificate loaded")
-
         return S_OK(self.__pemData)
 
     def dumpAllToFile(self, filename=False):
@@ -81,11 +78,9 @@ class X509CRL(object):
         try:
             if not filename:
                 fd, filename = tempfile.mkstemp()
-                os.write(fd, str(self))
                 os.close(fd)
-            else:
-                with open(filename, "wb") as fd:
-                    fd.write(str(self))
+            with open(filename, "wb") as fd:
+                fd.write(self.__pemData)
         except Exception as e:
             return S_ERROR(DErrno.EWF, "%s: %s" % (filename, repr(e).replace(",)", ")")))
         try:
@@ -97,7 +92,7 @@ class X509CRL(object):
     def hasExpired(self):
         if not self.__loadedCert:
             return S_ERROR("No certificate loaded")
-        # XXX It sould be done better, for now M2Crypto doesn't offer access to fields like Next Update
+        # XXX It should be done better, for now M2Crypto doesn't offer access to fields like Next Update
         txt = self.__revokedCert.as_text()
         pattern = r"Next Update: (?P<nextUpdate>.*)\n"
         dateStr = re.search(pattern.encode("utf-8"), txt).group("nextUpdate")
@@ -107,7 +102,7 @@ class X509CRL(object):
     def getIssuer(self):
         if not self.__loadedCert:
             return S_ERROR("No certificate loaded")
-        # XXX It sould be done better, for now M2Crypto doesn't offer access to fields like Issuer
+        # XXX It should be done better, for now M2Crypto doesn't offer access to fields like Issuer
         txt = self.__revokedCert.as_text()
         pattern = r"Issuer: (?P<issuer>.*)\n"
         return S_OK(re.search(pattern.encode("utf-8"), txt).group("issuer"))

--- a/src/DIRAC/Core/Security/m2crypto/X509Chain.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Chain.py
@@ -881,16 +881,14 @@ class X509Chain(object):
         try:
             if not filename:
                 fd, filename = tempfile.mkstemp()
-            else:
-                fd = os.open(filename, os.O_RDWR | os.O_CREAT)
-
-            os.write(fd, pemData)
-            os.close(fd)
-        except BaseException as e:
+                os.close(fd)
+            with open(filename, "wb") as fp:
+                fp.write(pemData)
+        except Exception as e:
             return S_ERROR(DErrno.EWF, "%s :%s" % (filename, repr(e).replace(",)", ")")))
         try:
             os.chmod(filename, stat.S_IRUSR | stat.S_IWUSR)
-        except BaseException as e:
+        except Exception as e:
             return S_ERROR(DErrno.ESPF, "%s :%s" % (filename, repr(e).replace(",)", ")")))
         return S_OK(filename)
 
@@ -901,10 +899,7 @@ class X509Chain(object):
 
         :returns: S_OK(pem chain)
         """
-        data = b""
-        for cert in self._certList:
-            data += cert.asPem()
-        return S_OK(data)
+        return S_OK(b"".join(cert.asPem() for cert in self._certList))
 
     @needPKey
     def dumpPKeyToString(self):
@@ -918,7 +913,6 @@ class X509Chain(object):
 
     def __str__(self):
         """String representation"""
-
         repStr = "<X509Chain"
         if self._certList:
             repStr += " %s certs " % len(self._certList)


### PR DESCRIPTION
1. `os.open` doesn't clear the file before writing causing junk data to be appended if the original file is larger than the new data:

```python
import os
!echo "0123456789" > "example.txt"

# GOOD: All is well as expected
!cat example.txt
0123456789

fd = os.open("example.txt", os.O_RDWR | os.O_CREAT)
os.write(fd, b"abcdef")
os.close(fd)

# ERROR: The end of the file has not been truncated
!cat example.txt
abcdef6789
```

2. `X509CRL.__str__` returns `bytes` instead of `str` for Python 3


BEGINRELEASENOTES

*Core
FIX: Fix overwriting files from an X509Chain object

ENDRELEASENOTES
