### PR TITLE
[sweep:integration] fix (docs): remove docutils from the requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - cachetools
   - certifi
   - cmreshandler >1.0.0b4
-  - docutils
   - elasticsearch <7.14
   - elasticsearch-dsl
   - fts3


### PR DESCRIPTION
Sweep #5556 `fix (docs): remove docutils from the requirements` to `integration`.

Adding original author @chaen as watcher.

BEGINRELEASENOTES
*Docs
CHANGE: Forces docutils to 0.17 because of bug with sphynx


ENDRELEASENOTES