### PR TITLE
[integration] allow DIRAC AS return proxy by default

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/Utilities.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Utilities.py
@@ -620,4 +620,4 @@ def isDownloadablePersonalProxy():
     :return: S_OK(bool)/S_ERROR()
     """
     cs_path = "/Systems/Framework/%s/APIs/Auth" % getSystemInstance("Framework")
-    return gConfig.getValue(cs_path + "/downloadablePersonalProxy", "true").lower() in ("y", "yes", "true")
+    return gConfig.getValue(cs_path + "/downloadablePersonalProxy", True)

--- a/src/DIRAC/ConfigurationSystem/Client/Utilities.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Utilities.py
@@ -620,4 +620,4 @@ def isDownloadablePersonalProxy():
     :return: S_OK(bool)/S_ERROR()
     """
     cs_path = "/Systems/Framework/%s/APIs/Auth" % getSystemInstance("Framework")
-    return gConfig.getValue(cs_path + "/downloadablePersonalProxy", "false").lower() in ("y", "yes", "true")
+    return gConfig.getValue(cs_path + "/downloadablePersonalProxy", "true").lower() in ("y", "yes", "true")

--- a/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
@@ -6,7 +6,7 @@ APIs
   {
     Port = 8000
     # Allow download personal proxy. By default: True
-    downloadablePersonalProxy = False
+    downloadablePersonalProxy = True
   }
   ##END
 }

--- a/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
@@ -5,8 +5,8 @@ APIs
   Auth
   {
     Port = 8000
-    # Allow download personal proxy
-    downloadablePersonalProxy = True
+    # Allow download personal proxy. By default: True
+    downloadablePersonalProxy = False
   }
   ##END
 }


### PR DESCRIPTION
Based on the discussion under #5397, the use of a **proxy** is likely to be preferred by users on the beginning, even when using the `DIRAC Authorization Service`. Therefore I think it will be more logical by default to allow users to receive **proxy** certificates in case of **successful** authorization through `DIRAC AS`, and the administrator will have an opportunity to forbid it using the `downloadablePersonalProxy` option.

BEGINRELEASENOTES

*Framework
CHANGE: allow DIRAC AS return proxy by default

ENDRELEASENOTES
