### PR TITLE
Fix cloudinit

### DIFF
--- a/src/DIRAC/Resources/Cloud/cloudinit.template
+++ b/src/DIRAC/Resources/Cloud/cloudinit.template
@@ -143,6 +143,7 @@ write_files:
                      -o /Cloud/%(running-pod)s/JobWrappersLocation=/mnt/dirac \
                      --UseServerCertificate
      mkdir -p runit/VirtualMachineMonitorAgent/log
+     sleep 180
      exec dirac-agent WorkloadManagement/VirtualMachineMonitorAgent
 
 yum_repos:

--- a/src/DIRAC/Resources/Cloud/cloudinit.template
+++ b/src/DIRAC/Resources/Cloud/cloudinit.template
@@ -106,6 +106,7 @@ write_files:
             --name "%(dirac-site)s" \
             -Q "%(vmtype)s" \
             --cert \
+            --userEnvVariables DIRACSYSCONFIG:::/mnt/dirac/pilot.cfg \
             -o /LocalSite/VMID=%(vm-uuid)s \
             -o /LocalSite/LocalCE=%(ce-type)s \
             -o /Resources/Computing/CEDefaults/VirtualOrganization=%(vo)s \


### PR DESCRIPTION

BEGINRELEASENOTES

*Resources
FIX: cloudinit-template - allow time in the monitor for the pilot to start 
FIX: cloudinit-template - set DIRACSYSCONFIG to point to the pilot.cfg in order to allow its use in the user applications

ENDRELEASENOTES
