### PR TITLE
[v7r2] fix (DMS): directory-sync: better failure logging, later abort

### DIFF
--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_directory_sync.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_directory_sync.py
@@ -149,20 +149,6 @@ def main():
 
         return S_OK(tree)
 
-    def isInFileCatalog(fc, path):
-        """
-        Check if the file is in the File Catalog
-        """
-
-        result = fc.listDirectory(path)
-        if result["OK"]:
-            if result["Value"]["Successful"]:
-                return S_OK()
-            else:
-                return S_ERROR()
-        else:
-            return S_ERROR()
-
     def getContentToSync(upload, fc, source_dir, dest_dir):
         """
         Return list of files and directories to be create and deleted


### PR DESCRIPTION
BEGINRELEASENOTES

*DMS
FIX: dirac-dms-directory-sync: The script will now try all files and not end a thread if one of the files assigned to be uploaded or downloaded to a thread fails. The script will also print out all failed files, and their error at the end of a thread. A few log messages have been corrected as well.

ENDRELEASENOTES

- [x] Draft PR: pending testing