### PR TITLE
[v7r3] fix: Extension ordering in DIRACScript

### DIFF
--- a/src/DIRAC/Core/Utilities/DIRACScript.py
+++ b/src/DIRAC/Core/Utilities/DIRACScript.py
@@ -62,7 +62,7 @@ class DIRACScript(object):
 
         # Call the entry_point from the extension with the highest priority
         rankedExtensions = extensionsByPriority()
-        entrypoint = max(
+        entrypoint = min(
             matches,
             key=lambda e: rankedExtensions.index(entrypointToExtension(e)),
         )


### PR DESCRIPTION
In https://github.com/DIRACGrid/DIRAC/pull/5216 I fixed `extensionsByPriority()` to return the highest priority extension first to be more consistent in the SystemAdministrator. When doing this I forgot to fix it in DIRACScript so the DIRAC versions of scripts were being preffered to the LHCbDIRAC versions.

BEGINRELEASENOTES

*Core
FIX: Extension ordering in DIRACScript

ENDRELEASENOTES
