### PR TITLE
[v7r3] Only expose masterCS if not using replicas

### DIFF
--- a/src/DIRAC/ConfigurationSystem/private/ServiceInterfaceBase.py
+++ b/src/DIRAC/ConfigurationSystem/private/ServiceInterfaceBase.py
@@ -105,7 +105,7 @@ class ServiceInterfaceBase(object):
             gLogger.info("New slave registered", sSlaveURL)
         self.dAliveSlaveServers[sSlaveURL] = time.time()
         if bNewSlave:
-            gConfigurationData.setServers("%s, %s" % (self.sURL, ", ".join(self.dAliveSlaveServers.keys())))
+            gConfigurationData.setServers(", ".join(self.dAliveSlaveServers))
             self.__generateNewVersion()
 
     def _checkSlavesStatus(self, forceWriteConfiguration=False):
@@ -124,7 +124,7 @@ class ServiceInterfaceBase(object):
                 del self.dAliveSlaveServers[sSlaveURL]
                 bModifiedSlaveServers = True
         if bModifiedSlaveServers or forceWriteConfiguration:
-            gConfigurationData.setServers("%s, %s" % (self.sURL, ", ".join(list(self.dAliveSlaveServers))))
+            gConfigurationData.setServers(", ".join(self.dAliveSlaveServers))
             self.__generateNewVersion()
 
     @staticmethod


### PR DESCRIPTION
This solves the problem of the master CS being overloaded by not keeping it in the list of CS once new slaves are added 



BEGINRELEASENOTES
*Configuration
CHANGE: do not add the master CS first in the list of CS when new slaves are added

ENDRELEASENOTES
