### PR TITLE
fix (WMS): Fix UnicodeDecodeErrors in JobDB.getJobParameters

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -195,7 +195,7 @@ class JobDB(DB):
             if result["OK"]:
                 if result["Value"]:
                     for res_jobID, res_name, res_value in result["Value"]:
-                        resultDict.setdefault(int(res_jobID), {})[res_name] = res_value.decode()
+                        resultDict.setdefault(int(res_jobID), {})[res_name] = res_value.decode(errors="replace")
 
                 return S_OK(resultDict)  # there's a slim chance that this is an empty dictionary
             else:
@@ -207,7 +207,7 @@ class JobDB(DB):
                 return result
 
             for res_jobID, res_name, res_value in result["Value"]:
-                resultDict.setdefault(int(res_jobID), {})[res_name] = res_value.decode()
+                resultDict.setdefault(int(res_jobID), {})[res_name] = res_value.decode(errors="replace")
 
             return S_OK(resultDict)  # there's a slim chance that this is an empty dictionary
 


### PR DESCRIPTION
These are caused by StandardOutput containing binary data like:

From 552833084 in LHCbDIRAC:

```
2021-11-16 18:56:44 UTC dirac-jobexec/Subprocess WARN: Unicode decode error in readFromFile (UnicodeDecodeError('utf-8', b'Warning in <TBasket::ReadBasketBuffers>: basket:sgp�8¶£xKvùÂ zõ=í$´õs,ÿf<VR¨Ív&üÏF;xÆ%°;þîÎ.
ï%N>_ð]z4,ôxÖI`À¨Þeq	)A¼è-Ý)¨Â§{Uã¶ H-3ïqü²ë(ç has fNevBuf=0 but fEntryOffset=0, pos=4608182585, len=272, fNbytes=300394531, fObjlen=111323652, trying to repair
Error in <TBranchElement::GetBasket>: File: root://proxy@ccxrootdlhcb.in2p3.fr//pnfs/in2p3.fr/data/lhcb/LHCb-Disk/lhcb/LHCb/Collision17/IFT.DST/00105545/0001/00105545_00019294_1.ift.dst at byte:936353968, branch:_Event., entry:129100, badread=0, nerrors=9, basketnumber=1292
', 54, 55, 'invalid start byte')): 'Error in <TNetXNGFile::ReadBuffers>: [ERROR] Server responded with an error: [3010] org.dcache.uuid is no longer valid.

Error in <TBranchElement::GetBasket>: File: root://proxy@ccxrootdlhcb.in2p3.fr//pnfs/in2p3.fr/data/lhcb/LHCb-Disk/lhcb/LHCb/Collision17/IFT.DST/00105545/0001/00105545_00019294_1.ift.dst at byte:4604921968, branch:_Event., entry:129100, badread=1, nerrors=1, basketnumber=1292
Warning in <TBasket::ReadBasketBuffers>: basket:sgp��8��x�Kv�� z�=�$��s�,��f<V��R��v�&��F;x�%�;����.
�%N>_�]z4,�x�I�`���eq	)A��-݈)�§�{U㓶 H-3�q����(��� has fNevBuf=0 but fEntryOffset=0, pos=4608182585, len=272, fNbytes=300394531, fObjlen=111323652, trying to repair
Error in <TBranchElement::GetBasket>: File: root://proxy@ccxrootdlhcb.in2p3.fr//pnfs/in2p3.fr/data/lhcb/LHCb-Disk/lhcb/LHCb/Collision17/IFT.DST/00105545/0001/00105545_00019294_1.ift.dst at byte:936353968, branch:_Event., entry:129100, badread=0, nerrors=2, basketnumber=1292
Warning in <TBasket::ReadBasketBuffers>: basket:sgp��8��x�Kv�� z�=�$��s�,��f<V��R��v�&��F;x�%�;����.
�%N>_�]z4,�x�I�`���eq	)A��-݈)�§�{U
```

```python
28535 Traceback (most recent call last):
28536   File "/opt/dirac/pro/DIRAC/Core/DISET/RequestHandler.py", line 302, in __RPCCallFunction
28537     uReturnValue = oMethod(*args)
28538   File "/opt/dirac/pro/DIRAC/Core/Utilities/DEncode.py", line 101, in inner
28539     return meth(*args, **kwargs)
28540   File "/opt/dirac/pro/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py", line 593, in export_getJobParameters
28541     return cls.jobDB.getJobParameters(jobIDs, parName)
28542   File "/opt/dirac/pro/DIRAC/WorkloadManagementSystem/DB/JobDB.py", line 210, in getJobParameters
28543     resultDict.setdefault(int(res_jobID), {})[res_name] = res_value.decode()
28544 UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 1725: ordinal not in range(128)
```


BEGINRELEASENOTES

*WorkloadManagement
FIX: UnicodeDecodeErrors in JobDB.getJobParameters

ENDRELEASENOTES