### PR TITLE
[v7r3] Don't run JobsStateMachine if newStat is ''

### DIFF
--- a/src/DIRAC/Core/Utilities/StateMachine.py
+++ b/src/DIRAC/Core/Utilities/StateMachine.py
@@ -129,7 +129,6 @@ class StateMachine(object):
         :type state: None or str
         :return: S_OK || S_ERROR
         """
-
         if candidateState == self.state:
             return S_OK(candidateState)
 
@@ -148,7 +147,7 @@ class StateMachine(object):
             self.state = result["Value"]
             # If the StateMachine does not accept the candidate, return error message
         else:
-            return S_ERROR("%s is not a valid state" % candidateState)
+            return S_ERROR("setState: %r is not a valid state" % candidateState)
 
         return S_OK(self.state)
 
@@ -182,9 +181,8 @@ class StateMachine(object):
         :param str candidateState: name of the next state
         :return: S_OK(nextState) || S_ERROR
         """
-
         if candidateState not in self.states:
-            return S_ERROR("%s is not a valid state" % candidateState)
+            return S_ERROR("getNextState: %r is not a valid state" % candidateState)
 
         # FIXME: do we need this anymore ?
         if self.state is None:

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -204,7 +204,7 @@ class JobStateUpdateHandlerMixin(object):
             newStat = sDict.get("Status", newStat)
 
             # evaluate the state machine
-            if not force:
+            if not force and newStat:
                 res = JobStatus.JobsStateMachine(currentStatus).getNextState(newStat)
                 if not res["OK"]:
                     return res


### PR DESCRIPTION
Fixes jobs that get stuck in completing with requests that are failing with:
```python
jsuc.setJobStatusBulk(
    552878361,
    {'2021-11-16 21:06:35.884937': {'ApplicationStatus': 'Executing RunScriptStep1', 'Source': 'Job_552878361'},
    '2021-11-16 22:34:19.002077': {'ApplicationStatus': 'exe-script.py successful', 'Source': 'Job_552878361'}},
    False
)['Message'] ==  "getNextState: '' is not a valid state"
```

BEGINRELEASENOTES

*WorkloadManagement
FIX: Don't run JobsStateMachine if newStat is ''

ENDRELEASENOTES
