### PR TITLE
[v7r3] Fix installing extensions on Python 3 based servers

### DIFF
--- a/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -363,7 +363,7 @@ class SystemAdministratorHandler(RequestHandler):
         if isPrerelease:
             cmd += ["--pre"]
         cmd += ["%s[server]==%s" % (primaryExtension, version)]
-        cmd += ["{%s}[server]" % e for e in otherExtensions]
+        cmd += ["%s[server]" % e for e in otherExtensions]
         r = subprocess.run(  # pylint: disable=no-member
             cmd,
             stderr=subprocess.PIPE,


### PR DESCRIPTION

BEGINRELEASENOTES

*Framework
FIX: Issue installing DIRAC and extensions on servers running Python 3

ENDRELEASENOTES
