### PR TITLE
[sweep:integration] Fix installing extensions on Python 3 based servers

### DIFF
--- a/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -348,7 +348,7 @@ class SystemAdministratorHandler(RequestHandler):
         if isPrerelease:
             cmd += ["--pre"]
         cmd += ["%s[server]==%s" % (primaryExtension, version)]
-        cmd += ["{%s}[server]" % e for e in otherExtensions]
+        cmd += ["%s[server]" % e for e in otherExtensions]
         r = subprocess.run(
             cmd,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
Sweep #5600 `Fix installing extensions on Python 3 based servers` to `integration`.

Adding original author @chrisburr as watcher.

Closes #5602

BEGINRELEASENOTES

*Framework
FIX: Issue installing DIRAC and extensions on servers running Python 3

ENDRELEASENOTES