### PR TITLE
[sweep:integration] test: fix http/https typo in Test_Resources_GFAL2StorageBase

### DIFF
--- a/tests/Integration/Resources/Storage/Test_Resources_GFAL2StorageBase.py
+++ b/tests/Integration/Resources/Storage/Test_Resources_GFAL2StorageBase.py
@@ -341,7 +341,7 @@ class GFAL2_HTTPS_Test(basicTest):
     """Test using the GFAL2_HTTPS plugin"""
 
     def setUp(self):
-        basicTest.setUp(self, "GFAL2_HTTP")
+        basicTest.setUp(self, "GFAL2_HTTPS")
 
 
 @unittest.skipIf(


### PR DESCRIPTION
Sweep #5576 `test: fix http/https typo in Test_Resources_GFAL2StorageBase` to `integration`.

Adding original author @chaen as watcher.

Closes #5579

BEGINRELEASENOTES

*Test
FIX: fix typo in the HTTPs Resources tests

ENDRELEASENOTES