### PR TITLE
[v7r3] Return error if JobPolicy.getControlledUsers returns an empty list

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -401,6 +401,8 @@ class JobMonitoringHandlerMixin(object):
         result = jobPolicy.getControlledUsers(RIGHT_GET_INFO)
         if not result["OK"]:
             return result
+        if not result["Value"]:
+            return S_ERROR("User and group combination has no job rights (%r, %r)" % (ownerDN, ownerGroup))
         if result["Value"] != "ALL":
             selectDict[("Owner", "OwnerGroup")] = result["Value"]
 


### PR DESCRIPTION
⚠️ I'm not certain this is the right solution but somehow we have to prevent it going further and trying to do ``WHERE (`Owner`, `OwnerGroup`) IN (  ) AND``:

```
ERROR  _query (SELECT `Status`, COUNT(*) FROM `Jobs`    WHERE (`Owner`, `OwnerGroup`) IN (  ) AND `LastUpdateTime` < "2021-11-17 13:11" GROUP BY `Status...
```


BEGINRELEASENOTES

*WorkloadManagement
FIX: Return error if JobPolicy.getControlledUsers returns an empty list

ENDRELEASENOTES
