### PR TITLE
[v7r3] feat (RMS): ReqProxy takes the number of request to sweep from the CS

### DIFF
--- a/src/DIRAC/RequestManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/RequestManagementSystem/ConfigTemplate.cfg
@@ -24,15 +24,18 @@ Services
     }
   }
   ##END
+  ##BEGIN ReqProxy
   ReqProxy
   {
     Port = 9161
+    # Number of request to sweep at once
+    SweepSize = 10
     Authorization
     {
       Default = authenticated
     }
   }
-
+  ##END
 }
 Agents
 {


### PR DESCRIPTION
Until now, we were sweeping 10 requests every 2 minutes, and this is hardcoded. Needless to say that when you have thousands of requests in the cache, it sucks :-)

BEGINRELEASENOTES
*RMS
NEW: add SweepSize option to the ReqProxy


ENDRELEASENOTES
