### PR TITLE
[v7r3] getComponentsStatus bug whith empty service list

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/ComponentMonitoringDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ComponentMonitoringDB.py
@@ -397,6 +397,7 @@ class ComponentMonitoringDB(DB):
                     # systemURLs is a dict that contain a list of URLs for service
                     if not systemURLs[service]:
                         self.log.error("Not found URL for %s service." % service)
+                        continue
                     url = urlparse.urlparse(systemURLs[service][0])
                     if self.__componentMatchesCondition(
                         dict(


### PR DESCRIPTION
Trivial bug fix 

```
2021-11-18 09:59:19 UTC Framework/Monitoring/Framework/ComponentMonitoringDB ERROR: Not found URL for allVoBoxes service.
2021-11-18 09:59:19 UTC Framework/Monitoring ERROR: Uncaught exception when serving RPC Function getComponentsStatus
Traceback (most recent call last):
  File "/opt/dirac/pro/DIRAC/Core/DISET/RequestHandler.py", line 302, in __RPCCallFunction
    uReturnValue = oMethod(*args)
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/Service/MonitoringHandler.py", line 248, in export_getComponentsStatus
    return gServiceInterface.getComponentsStatus(condDict)
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/private/monitoring/ServiceInterface.py", line 639, in getComponentsStatus
    return self.compmonDB.getComponentsStatus(condDict)
  File "/opt/dirac/pro/DIRAC/FrameworkSystem/DB/ComponentMonitoringDB.py", line 400, in getComponentsStatus
    url = urlparse.urlparse(systemURLs[service][0])
IndexError: list index out of range
2021-11-18 09:59:19 UTC Framework/Monitoring NOTICE: Returning response ([2001:1458:201:e4::100:378]:32954)[diracAdmin:chaen] (0.08 secs) ERROR: Server error while serving getComponentsStatus: list index out of range
```


BEGINRELEASENOTES
*Framework
FIX: continue on empty service list in getComponentsStatus

ENDRELEASENOTES
