### PR TITLE
[WIP] [v7r3] More debug for tornado

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -38,10 +38,6 @@ DIRAC_USE_JSON_DECODE
 DIRAC_USE_JSON_ENCODE
   Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page (default=No)
 
-DIRAC_USE_M2CRYPTO
-  If anything else than ``true`` or ``yes`` (default) DIRAC will revert back to using pyGSI instead of m2crypto for handling certificates, proxies, etc.
-  Unused since v7r2.
-
 DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
   If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
 

--- a/src/DIRAC/Core/Tornado/Server/TornadoServer.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoServer.py
@@ -36,6 +36,7 @@ from DIRAC.Core.Utilities import MemStat
 from DIRAC.FrameworkSystem.Client.MonitoringClient import MonitoringClient
 
 sLog = gLogger.getSubLogger(__name__)
+DEBUG_M2CRYPTO = os.getenv("DIRAC_DEBUG_M2CRYPTO", "No").lower() in ("yes", "true")
 
 
 class TornadoServer(object):
@@ -136,7 +137,7 @@ class TornadoServer(object):
             "keyfile": certs[1],
             "cert_reqs": M2Crypto.SSL.verify_peer,
             "ca_certs": ca,
-            "sslDebug": False,  # Set to true if you want to see the TLS debug messages
+            "sslDebug": DEBUG_M2CRYPTO,  # Set to true if you want to see the TLS debug messages
         }
 
         self.__monitorLastStatsUpdate = time.time()


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
CHANGE: use DIRAC_DEBUG_M2CRYPTO to enable SSL debugging in tornado

ENDRELEASENOTES
