### PR TITLE
Sweep #5614 `getComponentsStatus bug whith empty service list` to `integration`

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/ComponentMonitoringDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ComponentMonitoringDB.py
@@ -396,6 +396,7 @@ class ComponentMonitoringDB(DB):
                     # systemURLs is a dict that contain a list of URLs for service
                     if not systemURLs[service]:
                         self.log.error("Not found URL for %s service." % service)
+                        continue
                     url = parse.urlparse(systemURLs[service][0])
                     if self.__componentMatchesCondition(
                         dict(


### PR DESCRIPTION
Sweep #5614 `getComponentsStatus bug whith empty service list` to `integration`.

Adding original author @chaen as watcher.

BEGINRELEASENOTES
*Framework
FIX: continue on empty service list in getComponentsStatus

ENDRELEASENOTES
Closes #<built-in function id>
Closes https://github.com/DIRACGrid/DIRAC/issues/5616