### PR TITLE
[v7r2] fix: TransformationCleaningAgent 'deletes', do not 'remove' jobs

### DIFF
--- a/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -632,7 +632,7 @@ class TransformationCleaningAgent(AgentModule):
         return S_OK()
 
     def __removeWMSTasks(self, transJobIDs):
-        """wipe out jobs and their requests from the system
+        """delete jobs (mark their status as "JobStatus.DELETED") and their requests from the system
 
         :param self: self reference
         :param list trasnJobIDs: job IDs
@@ -654,26 +654,26 @@ class TransformationCleaningAgent(AgentModule):
                 self.log.error("Failed to kill jobs", "(n=%d)" % len(res["FailedJobIDs"]))
                 allRemove = False
 
-            res = self.wmsClient.removeJob(jobList)
+            res = self.wmsClient.deleteJob(jobList)
             if res["OK"]:
-                self.log.info("Successfully removed jobs from WMS", "(n=%d)" % len(jobList))
+                self.log.info("Successfully deleted jobs from WMS", "(n=%d)" % len(jobList))
             elif ("InvalidJobIDs" in res) and ("NonauthorizedJobIDs" not in res) and ("FailedJobIDs" not in res):
                 self.log.info("Found jobs which did not exist in the WMS", "(n=%d)" % len(res["InvalidJobIDs"]))
             elif "NonauthorizedJobIDs" in res:
                 self.log.error(
-                    "Failed to remove jobs because not authorized", "(n=%d)" % len(res["NonauthorizedJobIDs"])
+                    "Failed to delete jobs because not authorized", "(n=%d)" % len(res["NonauthorizedJobIDs"])
                 )
                 allRemove = False
             elif "FailedJobIDs" in res:
-                self.log.error("Failed to remove jobs", "(n=%d)" % len(res["FailedJobIDs"]))
+                self.log.error("Failed to delete jobs", "(n=%d)" % len(res["FailedJobIDs"]))
                 allRemove = False
 
         if not allRemove:
-            return S_ERROR("Failed to remove all remnants from WMS")
-        self.log.info("Successfully removed all tasks from the WMS")
+            return S_ERROR("Failed to delete all remnants from WMS")
+        self.log.info("Successfully deleted all tasks from the WMS")
 
         if not jobIDs:
-            self.log.info("JobIDs not present, unable to remove asociated requests.")
+            self.log.info("JobIDs not present, unable to delete associated requests.")
             return S_OK()
 
         failed = 0

--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
@@ -1,6 +1,8 @@
 """ The Job Cleaning Agent controls removing jobs from the WMS in the end of their life cycle.
 
-    This agent will take care of removing user jobs, while production jobs should be removed through the
+    This agent will take care of:
+    - removing all jobs that are in status JobStatus.DELETED
+    - deleting (sets status=JobStatus.DELETED) user jobs. The deletion of production jobs should be done by
     :mod:`~DIRAC.TransformationSystem.Agent.TransformationCleaningAgent`.
 
 .. literalinclude:: ../ConfigTemplate.cfg


### PR DESCRIPTION
This is a fix on the (wrong) fix originally provided in #5598 (for which the warning was not justified!)

BEGINRELEASENOTES

*TS
FIX: TransformationCleaningAgent 'deletes', do not 'remove' jobs

ENDRELEASENOTES
