### PR TITLE
[v7r3] ProxyDB sender email taken from the service/agent config

### DIFF
--- a/src/DIRAC/FrameworkSystem/Agent/MyProxyRenewalAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/MyProxyRenewalAgent.py
@@ -1,5 +1,11 @@
 """  Proxy Renewal agent is the key element of the Proxy Repository
      which maintains the user proxies alive
+
+    .. literalinclude:: ../ConfigTemplate.cfg
+      :start-after: ##BEGIN MyProxyRenewalAgent
+      :end-before: ##END
+      :dedent: 2
+      :caption: MyProxyRenewalAgent options
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -14,13 +20,16 @@ from DIRAC import gLogger, S_OK
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.FrameworkSystem.DB.ProxyDB import ProxyDB
 
+DEFAULT_MAIL_FROM = "proxymanager@diracgrid.org"
+
 
 class MyProxyRenewalAgent(AgentModule):
     def initialize(self):
 
         requiredLifeTime = self.am_getOption("MinimumLifeTime", 3600)
         renewedLifeTime = self.am_getOption("RenewedLifeTime", 54000)
-        self.proxyDB = ProxyDB(useMyProxy=True)
+        mailFrom = self.am_getOption("MailFrom", DEFAULT_MAIL_FROM)
+        self.proxyDB = ProxyDB(useMyProxy=True, mailFrom=mailFrom)
 
         gLogger.info("Minimum Life time      : %s" % requiredLifeTime)
         gLogger.info("Life time on renew     : %s" % renewedLifeTime)

--- a/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
@@ -22,6 +22,8 @@ Services
     MaxThreads = 100
     # Flag to use myproxy server
     UseMyProxy = False
+    # Email to use as a sender for the expiration reminder
+    MailFrom = "proxymanager@diracgrid.org"
     # Description of rules for access to methods
     Authorization
     {
@@ -144,13 +146,17 @@ Services
 }
 Agents
 {
+  ##BEGIN MyProxyRenewalAgent
   MyProxyRenewalAgent
   {
     PollingTime = 1800
     MinValidity = 10000
     #The period for which the proxy will be extended. The value is in hours
     ValidityPeriod = 15
+    # Email to use as a sender for the expiration reminder
+    MailFrom = proxymanager@diracgrid.org
   }
+  ##END
   CAUpdateAgent
   {
     PollingTime = 21600

--- a/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -14,11 +14,14 @@ __RCSID__ = "$Id$"
 
 import six
 from DIRAC import gLogger, S_OK, S_ERROR
-from DIRAC.Core.DISET.RequestHandler import RequestHandler
+from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
 from DIRAC.Core.Security import Properties
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
+
+
+DEFAULT_MAIL_FROM = "proxymanager@diracgrid.org"
 
 
 class ProxyManagerHandler(RequestHandler):
@@ -29,6 +32,8 @@ class ProxyManagerHandler(RequestHandler):
     @classmethod
     def initializeHandler(cls, serviceInfoDict):
         useMyProxy = cls.srv_getCSOption("UseMyProxy", False)
+        mailFrom = getServiceOption(serviceInfoDict, "MailFrom", DEFAULT_MAIL_FROM)
+
         try:
             result = ObjectLoader().loadObject("FrameworkSystem.DB.ProxyDB")
             if not result["OK"]:
@@ -36,7 +41,7 @@ class ProxyManagerHandler(RequestHandler):
                 return result
             dbClass = result["Value"]
 
-            cls.__proxyDB = dbClass(useMyProxy=useMyProxy)
+            cls.__proxyDB = dbClass(useMyProxy=useMyProxy, mailFrom=mailFrom)
 
         except RuntimeError as excp:
             return S_ERROR("Can't connect to ProxyDB: %s" % excp)


### PR DESCRIPTION
The email address used to send reminder emails about expired proxy was configured in the DB... 
This refactoring makes it take from the Service or Agent config, which is much more sensible. I will update the wiki accordingly once merged and released

BEGINRELEASENOTES

*Framework
CHANGE: proxy expiration emails are sent from an address taken from the Service/Agent config instead of the DB

ENDRELEASENOTES
