### PR TITLE
[integration] use importlib instead of  imp

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/CSGlobals.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/CSGlobals.py
@@ -5,7 +5,7 @@
 """
 Some Helper functions to retrieve common location from the CS
 """
-import imp
+import importlib.util
 from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Core.Utilities.DIRACSingleton import DIRACSingleton
 from DIRAC.Core.Utilities.Extensions import extensionsByPriority
@@ -22,7 +22,7 @@ class Extensions(metaclass=DIRACSingleton):
             return
         for extName in extensionsByPriority():
             try:
-                res = imp.find_module(extName)
+                res = importlib.util.find_spec(extName)
                 if res[0]:
                     res[0].close()
                 self.__orderedExtNames.append(extName)


### PR DESCRIPTION
This PR to fix `DeprecationWarning` and  use `importlib` instead of deprecated `imp` package.

```
src/DIRAC/ConfigurationSystem/Client/Helpers/CSGlobals.py:8
  /home/runner/work/DIRAC/DIRAC/src/DIRAC/ConfigurationSystem/Client/Helpers/CSGlobals.py:8: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp
```
BEGINRELEASENOTES

*Configuration
FIX: use `importlib` instead of deprecated `imp`

ENDRELEASENOTES
