### PR TITLE
[v7r3] Fix DIRAC.isPy3VersionNumber always returns True

### DIFF
--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -132,7 +132,7 @@ def isPy3VersionNumber(releaseVersion):
     return (
         re.match(
             r"^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$",
-            version,
+            releaseVersion,
         )
         is not None
     )


### PR DESCRIPTION
BEGINRELEASENOTES

*Core
FIX: DIRAC.isPy3VersionNumber always returns True

ENDRELEASENOTES
