### PR TITLE
[sweep:integration] Fix typo in OptimizationMindHandler.exec_taskError

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/OptimizationMindHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/OptimizationMindHandler.py
@@ -210,6 +210,6 @@ class OptimizationMindHandler(ExecutorMindHandler):
             if result["Value"][0].lower() == "failed":
                 return S_OK()
         else:
-            cls.log.error("Could not get status of job %s: %s" % (jid, result["Message "]))
+            cls.log.error("Could not get status of job %s: %s" % (jid, result["Message"]))
         cls.log.notice("Job %s: Setting to Failed|%s" % (jid, errorMsg))
         return jobState.setStatus("Failed", errorMsg, source="OptimizationMindHandler")


### PR DESCRIPTION
Sweep #5639 `Fix typo in OptimizationMindHandler.exec_taskError` to `integration`.

Adding original author @chrisburr as watcher.

BEGINRELEASENOTES

*WorkloadManagement
FIX: Bad error handling in OptimizationMindHandler.exec_taskError

ENDRELEASENOTES
Closes #5640