### PR TITLE
[integration] fix: Documentation on dashboards 

### DIFF
--- a/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
+++ b/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
@@ -113,10 +113,11 @@ You can configure the MQ in the local dirac.cfg file where the agent is running:
      }
    }
 
-A dashboard for WMSHistory monitoring ``WMSDashboard.json`` is available for import as a JSON file `here <https://github.com/DIRACGrid/DIRAC/tree/integration/dashboards/WMSDashboard>`__.
-The dashboard is compatible with ElasticSearch (not older versions such as ES6) and Opensearch visualization softwares such as Kibana or Opensearch Dashboards.
+A dashboard for WMSHistory monitoring ``WMSDashboard.json`` is available for import as a JSON file `here <https://github.com/DIRACGrid/DIRAC/tree/integration/dashboards/WMSDashboard.json>`__.
+The dashboard is not compatible with older versions of ElasticSearch (such as ES6).
 To import it in the Kibana UI, go to Management -> Saved Objects -> Import and import the JSON file.
-Note: the JSON file already contains the index patterns needed for the visualizations. In case your indices have different nomenclature, you may need to adapt the index patterns to your already existing ones. They can be easily overwritten to your own patterns through the UI.
+
+Note: the JSON file already contains the index patterns needed for the visualizations. You may need to adapt the index patterns to your existing ones.
 
 
 Enable Component monitoring


### PR DESCRIPTION

BEGINRELEASENOTES

*Monitoring
FIX: Wrong link on the docs page for the WMSHistory dashboard. Fixed the link and edited some of the text.

ENDRELEASENOTES
