### PR TITLE
[v7r2] Bdii2CSAgent features: bannedCEs, SingleCoreQueues

### DIFF
--- a/docs/source/AdministratorGuide/Resources/computingelements.rst
+++ b/docs/source/AdministratorGuide/Resources/computingelements.rst
@@ -112,7 +112,10 @@ of CEs are describe in the subsections below
 
 Note that there's no absolute need to define a 1-to-1 relation between CEs and Queues in DIRAC and "in real".
 If for example you want to send, to the same queue, a mix of single processor and multiprocessor Pilots,
-you can define two queues identical but for the NumberOfProcessors parameter.
+you can define two queues identical but for the NumberOfProcessors parameter. To avoid sending single
+processor jobs to multiprocessor queues, add the ``RequiredTag=MultiProcessor`` option to a multiprocessor queue. To
+automatically create the equivalent single core queues, see the :mod:`~DIRAC.ConfigurationSystem.Agent.Bdii2CSAgent`
+configuration.
 
 
 CREAM Computing Element

--- a/src/DIRAC/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/src/DIRAC/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -249,12 +249,17 @@ class Bdii2CSAgent(AgentModule):
         """Update the Site/CE/queue settings in the CS if they were changed in the BDII"""
 
         bdiiChangeSet = set()
+        bannedCEs = self.am_getOption("BannedCEs", [])
 
         for vo in self.voName:
             result = self.__getBdiiCEInfo(vo)
             if not result["OK"]:
                 continue
             ceBdiiDict = result["Value"]
+
+            for _siteName, ceDict in ceBdiiDict.items():
+                for bannedCE in bannedCEs:
+                    ceDict["CEs"].pop(bannedCE, None)
 
             result = getSiteUpdates(vo, bdiiInfo=ceBdiiDict, log=self.log, onecore=self.injectSingleCoreQueues)
 

--- a/src/DIRAC/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/src/DIRAC/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -45,7 +45,7 @@ class Bdii2CSAgent(AgentModule):
         self.host = "cclcgtopbdii01.in2p3.fr:2170"
         self.glue2URLs = []
         self.glue2Only = True
-
+        self.injectSingleCoreQueues = False
         self.csAPI = None
 
         # What to get
@@ -65,6 +65,7 @@ class Bdii2CSAgent(AgentModule):
         self.host = self.am_getOption("Host", self.host)
         self.glue2URLs = self.am_getOption("GLUE2URLs", self.glue2URLs)
         self.glue2Only = self.am_getOption("GLUE2Only", self.glue2Only)
+        self.injectSingleCoreQueues = self.am_getOption("InjectSingleCoreQueues", self.injectSingleCoreQueues)
 
         # Check if the bdii url is appended by a port number, if not append the default 2170
         for index, url in enumerate(self.alternativeBDIIs):
@@ -254,7 +255,9 @@ class Bdii2CSAgent(AgentModule):
             if not result["OK"]:
                 continue
             ceBdiiDict = result["Value"]
-            result = getSiteUpdates(vo, bdiiInfo=ceBdiiDict, log=self.log)
+
+            result = getSiteUpdates(vo, bdiiInfo=ceBdiiDict, log=self.log, onecore=self.injectSingleCoreQueues)
+
             if not result["OK"]:
                 continue
             bdiiChangeSet = bdiiChangeSet.union(result["Value"])

--- a/src/DIRAC/ConfigurationSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/ConfigurationSystem/ConfigTemplate.cfg
@@ -42,10 +42,15 @@ Agents
     DryRun = True
     # Host to query, must include port
     Host = cclcgtopbdii01.in2p3.fr:2170
-    # URLs for Glue2, if filled and GLUE2Only is False, the agent will look under theses URLs for Glue2 information
+    # URLs for Glue2, if filled and GLUE2Only is False, the agent will look under theses URLs
+    # for Glue2 information
     GLUE2URLs =
     # If True, only look for Glue2 information. If True, uses URLs from the Host option
     GLUE2Only = True
+    # If True, add single core queues for each Multi Core Queue and set
+    # RequiredTag=MultiProcessor for those
+    InjectSingleCoreQueues = False
+
   }
   ##END
   ##BEGIN VOMS2CSAgent

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_resources.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_resources.py
@@ -30,7 +30,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOOption
 
 def processScriptSwitches():
 
-    global vo, dry, doCEs, hostURL, glue2
+    global vo, dry, doCEs, hostURL, glue2, onecore
 
     Script.registerSwitch("V:", "vo=", "Virtual Organization")
     Script.registerSwitch("D", "dry", "Dry run")
@@ -38,6 +38,9 @@ def processScriptSwitches():
     Script.registerSwitch("H:", "host=", "use this url for information querying")
     Script.registerSwitch("G", "glue2", "DEPRECATED: query GLUE2 information schema")
     Script.registerSwitch("g", "glue1", "query GLUE1 information schema")
+    Script.registerSwitch(
+        "", "onecore", "Add Single Core Queues for each MultiCore Queue, set RequiredTag for those Queues"
+    )
     Script.parseCommandLine(ignoreErrors=True)
 
     vo = ""
@@ -45,6 +48,7 @@ def processScriptSwitches():
     doCEs = False
     hostURL = None
     glue2 = True
+    onecore = False
     for sw in Script.getUnprocessedSwitches():
         if sw[0] in ("V", "vo"):
             vo = sw[1]
@@ -58,6 +62,8 @@ def processScriptSwitches():
             gLogger.notice(" The '-G' flag is deprecated, Glue2 is the default now")
         if sw[0] in ("g", "glue1"):
             glue2 = False
+        if sw[0] in ("onecore",):
+            onecore = True
 
 
 ceBdiiDict = None
@@ -251,9 +257,9 @@ def updateCS(changeSet):
 
 def updateSites():
 
-    global vo, dry, ceBdiiDict, glue2
+    global vo, dry, ceBdiiDict, glue2, onecore
 
-    result = getSiteUpdates(vo, bdiiInfo=ceBdiiDict, glue2=glue2)
+    result = getSiteUpdates(vo, bdiiInfo=ceBdiiDict, glue2=glue2, onecore=onecore)
     if not result["OK"]:
         gLogger.error("Failed to get site updates", result["Message"])
         DIRACExit(-1)

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_resources.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_resources.py
@@ -116,7 +116,7 @@ def checkUnusedCEs():
 
     inp = six.moves.input("\nDo you want to add sites ? [default=yes] [yes|no]: ")
     inp = inp.strip()
-    if not inp and inp.lower().startswith("n"):
+    if inp and inp.lower().startswith("n"):
         return
 
     gLogger.notice("\nAdding new sites/CEs interactively\n")


### PR DESCRIPTION
BEGINRELEASENOTES
*CS
CHANGE: Bdii2CSAgent: add InjectSingleCoreQueue option to automatically create single core equivalents for MutliCore Queues , kind of fixes #5582
CHANGE: Bdii2CSAgent: CEs in the BannedCEs list are no longer updated by the agent, previously this list only concerned CEs that are not already in the Configuration, fixes  #5224 
CHANGE: dirac-admin-add-resources: add --onecore option to automatically create single core equivalents for MutliCore Queues
FIX: dirac-admin-add-resources: fix the query about adding new CEs, this can now be answered in the negative

ENDRELEASENOTES
