### PR TITLE
[integration] add target method docstring (Synchronizer decorator)

### DIFF
--- a/src/DIRAC/Core/Utilities/ThreadSafe.py
+++ b/src/DIRAC/Core/Utilities/ThreadSafe.py
@@ -29,6 +29,8 @@ class Synchronizer(object):
                     print("UNLOCKING", self.__lockName)
                 self.__lock.release()
 
+        # Add target method docstring that this description appeared when compiling the documentation
+        lockedFunc.__doc__ = funcToCall.__doc__
         return lockedFunc
 
     def lock(self):


### PR DESCRIPTION
When constructing documentation, the description of the methods marked by the decorator disappears.

BEGINRELEASENOTES

*Core
FIX: ThreadSafe.Synchronizer: Add target method docstring to preserve docstring of decorated function

ENDRELEASENOTES
