### PR TITLE
[integration] remove CSGlobals.Extensions class

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/__init__.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/__init__.py
@@ -8,4 +8,4 @@ from __future__ import print_function
 __RCSID__ = "$Id$"
 
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import *
-from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import getCSExtensions, getInstalledExtensions, getVO
+from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import getCSExtensions, getVO


### PR DESCRIPTION
The result of `importlib.import_module` is a bit different than `imp.find_module`, so I think that without this fix it will work differently. I have already expressed my opinion https://github.com/DIRACGrid/DIRAC/pull/5617#discussion_r758307808.

BEGINRELEASENOTES

*Configuration
FIX: fix CSGlobals.Extensions class

ENDRELEASENOTES
