### PR TITLE
[V7r2] voms2cs agent fix when joining second VO

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -265,6 +265,7 @@ class VOMS2CSSynchronizer(object):
                 for user in nonVOUserDict:
                     if dn in fromChar(nonVOUserDict[user]["DN"]):
                         diracName = user
+                        diracUserDict[diracName] = nonVOUserDict[user]
                         break
 
                 # Check the nickName in the same VO to see if the user is already registered


### PR DESCRIPTION
From the hackathon

BEGINRELEASENOTES

*CS
FIX: fix an exception in the VOMS2CSAgent when a user joins a second VO

ENDRELEASENOTES
