### PR TITLE
[v7r3] fix (WMS): Tag and RequiredTag format in Matcher

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/Matcher.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/Matcher.py
@@ -191,15 +191,17 @@ class Matcher(object):
         if resourceDescription.get("Tag"):
             tags = resourceDescription["Tag"]
             resourceDict["Tag"] = (
-                tags if isinstance(tags, list) else list({tag.strip("\"'") for tag in tags.strip("[]").split(",")})
+                tags
+                if isinstance(tags, list)
+                else list({tag.strip("u").strip("\"'") for tag in tags.strip("[]").split(",")})
             )
             if "RequiredTag" in resourceDescription:
-                requiredTagsList = (
-                    resourceDescription["RequiredTag"].split(",")
-                    if isinstance(resourceDescription["RequiredTag"], str)
-                    else resourceDescription["RequiredTag"]
+                requiredTags = resourceDescription["RequiredTag"]
+                resourceDict["RequiredTag"] = (
+                    requiredTags
+                    if isinstance(requiredTags, list)
+                    else list({tag.strip("u").strip("\"'") for tag in requiredTags.strip("[]").split(",")})
                 )
-                resourceDict["RequiredTag"] = requiredTagsList
 
         if "JobID" in resourceDescription:
             resourceDict["JobID"] = resourceDescription["JobID"]


### PR DESCRIPTION
Fix a bug from the hackaton:

```
2021-12-02 09:54:44 UTC WorkloadManagement/Matcher ERROR: Error requesting job for pilot [...] Wrong conditions
```

I am not entirely sure whether the fix should be here.

IIUC the `JobAgent/SiteDirector` submits tags such as `[u'MultiProcessor']` to the `Matcher`.
The `Matcher` gets `"[u'MultiProcessor']"`: it does include the `u` of unicode in the string while it should probably not.
And it does not care of it and tries to strip the string, but it does not work properly because the `u` is here and we obtain: `["u'MultiProcessor"]`

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: Tag and RequiredTag format in Matcher
ENDRELEASENOTES
