### PR TITLE
[v7r2] Fix encodeDict when the dict keys have mixed types

### DIFF
--- a/src/DIRAC/Core/Utilities/DEncode.py
+++ b/src/DIRAC/Core/Utilities/DEncode.py
@@ -499,7 +499,13 @@ def encodeDict(dValue, eList):
             printDebugCallstack("Encoding dict with numeric keys")
 
     eList.append(b"d")
-    for key in sorted(dValue):
+    if six.PY2:
+        iterVar = sorted(dValue)
+    else:
+        # Some systems write dictionaries which a mix of string + int keys
+        # Only remove sorted with Python 3 to minimise the chance of regressions
+        iterVar = dValue
+    for key in iterVar:
         g_dEncodeFunctions[type(key)](key, eList)
         g_dEncodeFunctions[type(dValue[key])](dValue[key], eList)
     eList.append(b"e")


### PR DESCRIPTION
```log
2021-12-07 13:51:41 UTC Transformation/TransformationManager ERROR: Exception while executing handler action
Traceback (most recent call last):
  File "/opt/dirac/versions/v10.3.3-1638259177/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/DISET/private/Service.py", line 608, in _executeAction
    response = handlerObj._rh_executeAction(proposalTuple)
  File "/opt/dirac/versions/v10.3.3-1638259177/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/DISET/RequestHandler.py", line 156, in _rh_executeAction
    result = self.__trPool.send(self.__trid, retVal)  # this will delete the value from the S_OK(value)
  File "/opt/dirac/versions/v10.3.3-1638259177/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/DISET/private/TransportPool.py", line 113, in send
    return transport.sendData(msg)
  File "/opt/dirac/versions/v10.3.3-1638259177/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/DISET/private/Transports/BaseTransport.py", line 174, in sendData
    sCodedData = MixedEncode.encode(uData)
  File "/opt/dirac/versions/v10.3.3-1638259177/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/MixedEncode.py", line 23, in encode
    return DEncode.encode(inData)
  File "/opt/dirac/versions/v10.3.3-1638259177/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/DEncode.py", line 534, in encode
    g_dEncodeFunctions[type(uObject)](uObject, eList)
  File "/opt/dirac/versions/v10.3.3-1638259177/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/DEncode.py", line 504, in encodeDict
    g_dEncodeFunctions[type(dValue[key])](dValue[key], eList)
  File "/opt/dirac/versions/v10.3.3-1638259177/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/DEncode.py", line 502, in encodeDict
    for key in sorted(dValue):
TypeError: '<' not supported between instances of 'str' and 'int'
```

BEGINRELEASENOTES

*Core
FIX: encodeDict when the dict keys have mixed types

ENDRELEASENOTES
