### PR TITLE
[v7r3] feat (wms): use db12 package to compute cpu power

### DIFF
--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -16,6 +16,7 @@ dependencies:
   - cachetools
   - certifi
   - cmreshandler >1.0.0b4
+  - db12
   - elasticsearch <7.14
   - elasticsearch-dsl
   - fts3

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - certifi
   - cmreshandler >1.0.0b4
   - cachetools <4
+  - db12
   - elasticsearch <7.14
   - elasticsearch-dsl ~=6.3.1
   - fts-rest

--- a/src/DIRAC/WorkloadManagementSystem/Client/CPUNormalization.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/CPUNormalization.py
@@ -13,11 +13,15 @@ from __future__ import print_function
 import os
 from six.moves.urllib.request import urlopen
 
+try:
+    from db12 import single_dirac_benchmark as singleDiracBenchmark
+except ImportError:
+    from DIRAC.WorkloadManagementSystem.Client.DIRACbenchmark import singleDiracBenchmark
+
 import DIRAC
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getCESiteMapping
 from DIRAC.Resources.Computing.BatchSystems.TimeLeft.TimeLeft import TimeLeft
-from DIRAC.WorkloadManagementSystem.Client.DIRACbenchmark import singleDiracBenchmark
 
 __RCSID__ = "$Id$"
 

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_cpu_normalization.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_cpu_normalization.py
@@ -20,11 +20,15 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
+try:
+    from db12 import single_dirac_benchmark as singleDiracBenchmark
+except ImportError:
+    from DIRAC.WorkloadManagementSystem.Client.DIRACbenchmark import singleDiracBenchmark
+
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 from DIRAC import gLogger, gConfig
-from DIRAC.WorkloadManagementSystem.Client.DIRACbenchmark import singleDiracBenchmark
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 
 
@@ -43,7 +47,7 @@ def main():
         elif unprocSw[0] in ("R", "Reconfig"):
             configFile = unprocSw[1]
 
-    result = singleDiracBenchmark(1)
+    result = singleDiracBenchmark()
 
     if result is None:
         gLogger.error("Cannot make benchmark measurements")


### PR DESCRIPTION
This PR aims to replace the copy of the old `DB12.py` by the new db12 package.
Before merging this PR, the following PRs should be merged:
- https://github.com/DIRACGrid/DIRACOS/pull/192
- https://github.com/DIRACGrid/DIRACOS2/pull/61

BEGINRELEASENOTES
*WorkloadManagementSystem
CHANGE: Replace DB12.py with the db12 package
ENDRELEASENOTES
