### PR TITLE
[v7r2] fix: ElasticJobParametersDB: get in output all entries

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
@@ -72,6 +72,7 @@ class ElasticJobParametersDB(ElasticDB):
             self.log.always("Index created:", self.indexName)
 
         self.dslSearch = self._Search(self.indexName)
+        self.dslSearch.extra(track_total_hits=True)
 
     def getJobParameters(self, jobID, paramList=None):
         """Get Job Parameters defined for jobID.
@@ -108,7 +109,7 @@ class ElasticJobParametersDB(ElasticDB):
 
         s = self.dslSearch.query("bool", filter=self._Q("term", JobID=jobID))
 
-        res = s.execute()
+        res = s.scan()
 
         for hit in res:
             name = hit.Name
@@ -151,7 +152,7 @@ class ElasticJobParametersDB(ElasticDB):
         self.log.debug("Inserting parameters", "in %s: for job %s : %s" % (self.indexName, jobID, parameters))
 
         parametersListDict = [
-            {"JobID": jobID, "Name": parName, "Value": parValue, "_id": str(parName) + str(parValue)}
+            {"JobID": jobID, "Name": parName, "Value": parValue, "_id": str(jobID) + str(parName) + str(parValue)}
             for parName, parValue in parameters
         ]
 


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: ElasticJobParametersDB: get in output all entries

ENDRELEASENOTES
