### PR TITLE
[integration] feat (core): MultiVO shifter enhancements

### DIFF
--- a/src/DIRAC/Core/Base/AgentModule.py
+++ b/src/DIRAC/Core/Base/AgentModule.py
@@ -351,7 +351,10 @@ class AgentModule(object):
 
     def _setShifterProxy(self):
         if self.__moduleProperties["shifterProxy"]:
-            result = setupShifterProxyInEnv(self.__moduleProperties["shifterProxy"], self.am_getShifterProxyLocation())
+            vo = getattr(self, "vo", False)
+            result = setupShifterProxyInEnv(
+                self.__moduleProperties["shifterProxy"], self.am_getShifterProxyLocation(), vo=vo
+            )
             if not result["OK"]:
                 self.log.error("Failed to set shifter proxy", result["Message"])
                 return result

--- a/src/DIRAC/Core/Utilities/Shifter.py
+++ b/src/DIRAC/Core/Utilities/Shifter.py
@@ -17,7 +17,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers import cfgPath
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 
 
-def getShifterProxy(shifterType, fileName=False):
+def getShifterProxy(shifterType, fileName=False, vo=False):
     """This method returns a shifter's proxy
 
     :param str shifterType: ProductionManager / DataManager...
@@ -27,7 +27,7 @@ def getShifterProxy(shifterType, fileName=False):
     """
     if fileName:
         mkDir(os.path.dirname(fileName))
-    opsHelper = Operations()
+    opsHelper = Operations(vo=vo)
     userName = opsHelper.getValue(cfgPath("Shifter", shifterType, "User"), "")
     if not userName:
         return S_ERROR("No shifter User defined for %s" % shifterType)
@@ -58,7 +58,7 @@ def getShifterProxy(shifterType, fileName=False):
     return S_OK({"DN": userDN, "username": userName, "group": userGroup, "chain": chain, "proxyFile": fileName})
 
 
-def setupShifterProxyInEnv(shifterType, fileName=False):
+def setupShifterProxyInEnv(shifterType, fileName=False, vo=False):
     """Return the shifter's proxy and set it up as the default
     proxy via changing the environment.
     This method returns a shifter's proxy
@@ -68,7 +68,7 @@ def setupShifterProxyInEnv(shifterType, fileName=False):
 
     :return: S_OK(dict)/S_ERROR()
     """
-    result = getShifterProxy(shifterType, fileName)
+    result = getShifterProxy(shifterType, fileName, vo=vo)
     if not result["OK"]:
         return result
     proxyDict = result["Value"]


### PR DESCRIPTION
BEGINRELEASENOTES

*Core
NEW: A multi VO shifter enhancement when used by agents. Functions in `shifter.py` get a new argument, `vo`, which defaults to False and is used by `Operations()` constructor to access a VO-specific section in the CS. The feature is activated by an agent defining a `self.vo `attribute.  

ENDRELEASENOTES
