### PR TITLE
[v7r3] Add URLs to CS when installing HTTPS services

### DIFF
--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -876,12 +876,22 @@ class ComponentInstaller(object):
         # Add the service URL
         if componentType == "service":
             port = compCfg.getOption("Port", 0)
-            if port and self.host:
+            protocol = compCfg.getOption("Protocol", "dips")
+            if (port or protocol == "https") and self.host:
                 urlsPath = cfgPath("Systems", system, compInstance, "URLs")
                 cfg.createNewSection(urlsPath)
                 failoverUrlsPath = cfgPath("Systems", system, compInstance, "FailoverURLs")
                 cfg.createNewSection(failoverUrlsPath)
-                cfg.setOption(cfgPath(urlsPath, component), "dips://%s:%d/%s/%s" % (self.host, port, system, component))
+                if protocol == "https":
+                    cfg.setOption(
+                        # Strip "Tornado" from the beginning of component name if present
+                        cfgPath(urlsPath, component[len("Tornado") if component.startswith("Tornado") else 0 :]),
+                        "https://%s:8443/%s/%s" % (self.host, system, component),
+                    )
+                else:
+                    cfg.setOption(
+                        cfgPath(urlsPath, component), "dips://%s:%d/%s/%s" % (self.host, port, system, component)
+                    )
 
         return S_OK(cfg)
 

--- a/tests/CI/install_server.sh
+++ b/tests/CI/install_server.sh
@@ -89,25 +89,12 @@ then
   # We ignore the Configuration for now because it is a bit special (the master needs to run in a separate process)
   # system_component is a space separated System (without the word System), and Component, without the 'Handler.py'.
   # For example "DataManagement TornadoFileCatalog"
-
-  if [[ "${USE_PYTHON3:-}" == "Yes" ]]; then
-    find "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC" -name 'Tornado*Handler.py' | grep -v Configuration | sed -e 's/Handler.py//g' -e 's/System//g'| awk -F '/' '{print $(NF-2), $NF}' > tornadoServices
-    cfgProdFile="${SERVERINSTALLDIR}"/diracos/etc/Production.cfg
-  else
-    find "${SERVERINSTALLDIR}"/DIRAC/ -name 'Tornado*Handler.py' | grep -v Configuration | sed -e 's/Handler.py//g' -e 's/System//g'| awk -F '/' '{print $(NF-2), $NF}' > tornadoServices
-    cfgProdFile="${SERVERINSTALLDIR}"/etc/Production.cfg
-  fi
-
   while read -r system_component; do
     echo -e "*** $(date -u) **** Installing Tornado service ${system_component}"
     # do NOT put quotes around ${system_component} since
     # we want it to be seen as two arguments
     # shellcheck disable=SC2086
     dirac-install-tornado-service -ddd ${system_component};
-    # origin_component is the original service before Tornado (FileCatalog vs TornadoFileCatalog for example)
-    orig_component=$(echo "${system_component}" | sed 's/Tornado//g' | awk '{print $2}');
-    # Replace the dips url with the https url in the cs, assuming port 8443
-    sed -E "s|( +${orig_component} = )dips://([a-z]+)(:[0-9]+)(/.*/)(.*)|\1https://\2:8443\4Tornado\5|g" -i "$cfgProdFile"
     # Restart the CS to take all that into account
     sleep 1
     dirac-restart-component Configuration Server "$DEBUG"


### PR DESCRIPTION
Currently the integration test CI doesn't support HTTPS-only services as it adds them by running sed to change `dips://` URLs to `https://`. This change makes it so that `dirac-install-tornado-service` adds the service to the CS automatically, the same way that legacy services are done.

The reason for making this change is to support HTTPS-only services.

BEGINRELEASENOTES

*HTTPS
FIX: Add URLs to CS when installing HTTPS services

ENDRELEASENOTES
