### PR TITLE
[v7r3] Fix setJobStatus service

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/PilotStatusAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PilotStatusAgent.py
@@ -1,9 +1,11 @@
-########################################################################
-# File :    PilotStatusAgent.py
-# Author :  Stuart Paterson
-########################################################################
 """  The Pilot Status Agent updates the status of the pilot jobs in the
      PilotAgents database.
+
+.. literalinclude:: ../ConfigTemplate.cfg
+  :start-after: ##BEGIN PilotStatusAgent
+  :end-before: ##END
+  :dedent: 2
+  :caption: PilotStatusAgent options
 """
 
 from __future__ import absolute_import
@@ -12,7 +14,7 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
-from DIRAC import S_OK, S_ERROR, gConfig
+from DIRAC import S_OK, gConfig
 from DIRAC.AccountingSystem.Client.Types.Pilot import Pilot as PilotAccounting
 from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
@@ -24,9 +26,6 @@ from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
 from DIRAC.WorkloadManagementSystem.DB.PilotAgentsDB import PilotAgentsDB
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
-
-MAX_JOBS_QUERY = 10
-MAX_WAITING_STATE_LENGTH = 3
 
 
 class PilotStatusAgent(AgentModule):
@@ -52,9 +51,7 @@ class PilotStatusAgent(AgentModule):
     def initialize(self):
         """Sets defaults"""
 
-        self.am_setOption("PollingTime", 120)
         self.am_setOption("GridEnv", "")
-        self.am_setOption("PilotStalledDays", 3)
         self.pilotDB = PilotAgentsDB()
         self.diracadmin = DiracAdmin()
         self.jobDB = JobDB()
@@ -77,14 +74,13 @@ class PilotStatusAgent(AgentModule):
                 instance = gConfig.getValue("/DIRAC/Setups/%s/WorkloadManagement" % setup, "")
                 if instance:
                     self.gridEnv = gConfig.getValue("/Systems/WorkloadManagement/%s/GridEnv" % instance, "")
-        result = self.pilotDB._getConnection()
-        if result["OK"]:
-            connection = result["Value"]
-        else:
-            return result
 
-        # Now handle pilots not updated in the last N days (most likely the Broker is no
-        # longer available) and declare them Deleted.
+        result = self.pilotDB._getConnection()
+        if not result["OK"]:
+            return result
+        connection = result["Value"]
+
+        # Now handle pilots not updated in the last N days and declare them Deleted.
         result = self.handleOldPilots(connection)
 
         connection.close()

--- a/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -156,12 +156,14 @@ Agents
     IncludeMasterCS = True
   }
   ##END
+  ##BEGIN PilotStatusAgent
   PilotStatusAgent
   {
     PollingTime = 300
     # Flag enabling sending of the Pilot accounting info to the Accounting Service
     PilotAccountingEnabled = yes
   }
+  ##END
   JobAgent
   {
     FillingModeFlag = true
@@ -288,6 +290,8 @@ Agents
     Backends = Accounting
     # the name of the message queue used for the failover
     MessageQueue = dirac.wmshistory
+    # Polling time. For this agent it should always be 15 minutes.
+    PollingTime = 900
   }
   ##END
   CloudDirector

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -145,15 +145,13 @@ class JobStateUpdateHandlerMixin(object):
 
     @classmethod
     def __setJobStatusBulk(cls, jobID, statusDict, force=False):
-        """Set various status fields for job specified by its JobId.
+        """Set various status fields for job specified by its jobId.
         Set only the last status in the JobDB, updating all the status
         logging information in the JobLoggingDB. The statusDict has datetime
         as a key and status information dictionary as values
         """
-        status = ""
-        minor = ""
-        application = ""
         jobID = int(jobID)
+        log = gLogger.getLocalSubLogger("JobStatusBulk/Job-%d" % jobID)
 
         result = cls.jobDB.getJobAttributes(jobID, ["Status", "StartExecTime", "EndExecTime"])
         if not result["OK"]:
@@ -165,7 +163,7 @@ class JobStateUpdateHandlerMixin(object):
         # If the current status is Stalled and we get an update, it should probably be "Running"
         currentStatus = result["Value"]["Status"]
         if currentStatus == JobStatus.STALLED:
-            status = JobStatus.RUNNING
+            currentStatus = JobStatus.RUNNING
         startTime = result["Value"].get("StartExecTime")
         endTime = result["Value"].get("EndExecTime")
         # getJobAttributes only returns strings :(
@@ -173,67 +171,76 @@ class JobStateUpdateHandlerMixin(object):
             startTime = None
         if endTime == "None":
             endTime = None
-
-        # Get the latest WN time stamps of status updates
-        result = cls.jobLoggingDB.getWMSTimeStamps(int(jobID))
-        if not result["OK"]:
-            return result
-        lastTime = max([float(t) for s, t in result["Value"].items() if s != "LastTime"])
-        lastTime = Time.toString(Time.fromEpoch(lastTime))
-
-        dates = sorted(statusDict)
-        # If real updates, start from the current status
-        if dates[0] >= lastTime and not status:
-            status = currentStatus
-        log = gLogger.getLocalSubLogger("JobStatusBulk/Job-%s" % jobID)
-        log.debug("*** New call ***", "Last update time %s - Sorted new times %s" % (lastTime, dates))
         # Remove useless items in order to make it simpler later, although there should not be any
         for sDict in statusDict.values():
             for item in sorted(sDict):
                 if not sDict[item]:
                     sDict.pop(item, None)
-        # Pick up start and end times from all updates, if they don't exist
-        newStat = status
-        for date in dates:
-            sDict = statusDict[date]
+
+        # Get the latest time stamps of major status updates
+        result = cls.jobLoggingDB.getWMSTimeStamps(int(jobID))
+        if not result["OK"]:
+            return result
+        # This is more precise than "LastTime". timeStamps is a sorted list of tuples...
+        timeStamps = sorted((float(t), s) for s, t in result["Value"].items() if s != "LastTime")
+        lastTime = Time.toString(Time.fromEpoch(timeStamps[-1][0]))
+
+        # Get chronological order of new updates
+        updateTimes = sorted(statusDict)
+        log.debug("*** New call ***", "Last update time %s - Sorted new times %s" % (lastTime, updateTimes))
+        # Get the status (if any) at the time of the first update
+        newStat = ""
+        firstUpdate = Time.toEpoch(Time.fromString(updateTimes[0]))
+        for ts, st in timeStamps:
+            if firstUpdate >= ts:
+                newStat = st
+        # Pick up start and end times from all updates, if they don't exist, and set Running if needed
+        for updTime in updateTimes:
+            sDict = statusDict[updTime]
             # This is to recover Matched jobs that set the application status: they are running!
             if sDict.get("ApplicationStatus") and newStat == JobStatus.MATCHED:
                 sDict["Status"] = JobStatus.RUNNING
             newStat = sDict.get("Status", newStat)
 
-            # evaluate the state machine
-            if not force and newStat:
-                res = JobStatus.JobsStateMachine(currentStatus).getNextState(newStat)
-                if not res["OK"]:
-                    return res
-                nextState = res["Value"]
-
-                # If the JobsStateMachine does not accept the candidate, don't update
-                if newStat != nextState:
-                    log.error(
-                        "Job Status Error",
-                        "%s can't move from %s to %s: using %s" % (jobID, currentStatus, newStat, nextState),
-                    )
-                    newStat = nextState
-                sDict["Status"] = newStat
-                currentStatus = newStat
-
-            if newStat == JobStatus.RUNNING and not startTime:
+            if not startTime and newStat == JobStatus.RUNNING:
                 # Pick up the start date when the job starts running if not existing
-                startTime = date
+                startTime = updTime
                 log.debug("Set job start time", startTime)
-            elif newStat in JobStatus.JOB_FINAL_STATES and not endTime:
+            elif not endTime and newStat in JobStatus.JOB_FINAL_STATES:
                 # Pick up the end time when the job is in a final status
-                endTime = date
+                endTime = updTime
                 log.debug("Set job end time", endTime)
 
-        # We should only update the status if its time stamp is more recent than the last update
-        if dates[-1] >= lastTime:
-            # Get the last status values
-            for date in [dt for dt in dates if dt >= lastTime]:
-                sDict = statusDict[date]
-                log.debug("\t", "Time %s - Statuses %s" % (date, str(sDict)))
-                status = sDict.get("Status", status)
+        # We should only update the status to the last one if its time stamp is more recent than the last update
+        if updateTimes[-1] >= lastTime:
+            minor = ""
+            application = ""
+            # Get the last status values looping on the most recent upupdateTimes in chronological order
+            for updTime in [dt for dt in updateTimes if dt >= lastTime]:
+                sDict = statusDict[updTime]
+                log.debug("\t", "Time %s - Statuses %s" % (updTime, str(sDict)))
+                status = sDict.get("Status", currentStatus)
+                # evaluate the state machine if the status is changing
+                if not force and status != currentStatus:
+                    res = JobStatus.JobsStateMachine(currentStatus).getNextState(status)
+                    if not res["OK"]:
+                        return res
+                    newStat = res["Value"]
+                    # If the JobsStateMachine does not accept the candidate, don't update
+                    if newStat != status:
+                        # FIXME: what should we do here: keeping the same status or exit with an error???
+                        log.error(
+                            "Job Status Error",
+                            "%s can't move from %s to %s: using %s" % (jobID, currentStatus, newStat, newStat),
+                        )
+                        status = newStat
+                        sDict["Status"] = newStat
+                        # Change the source to indicate this is not what was requested
+                        source = sDict.get("Source", "")
+                        sDict["Source"] = source + "(SM)"
+                    # at this stage status == newStat. Set currentStatus to this new status
+                    currentStatus = newStat
+
                 minor = sDict.get("MinorStatus", minor)
                 application = sDict.get("ApplicationStatus", application)
 
@@ -265,14 +272,14 @@ class JobStateUpdateHandlerMixin(object):
                 return result
 
         # Update the JobLoggingDB records
-        for date in dates:
-            sDict = statusDict[date]
+        for updTime in updateTimes:
+            sDict = statusDict[updTime]
             status = sDict.get("Status", "idem")
             minor = sDict.get("MinorStatus", "idem")
             application = sDict.get("ApplicationStatus", "idem")
             source = sDict.get("Source", "Unknown")
             result = cls.jobLoggingDB.addLoggingRecord(
-                jobID, status=status, minorStatus=minor, applicationStatus=application, date=date, source=source
+                jobID, status=status, minorStatus=minor, applicationStatus=application, date=updTime, source=source
             )
             if not result["OK"]:
                 return result

--- a/src/DIRAC/WorkloadManagementSystem/Service/tests/Test_JobStateUpdate.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/tests/Test_JobStateUpdate.py
@@ -1,0 +1,229 @@
+""" unit test (pytest) of JobStateUpdate service
+"""
+
+from mock import MagicMock
+import pytest
+
+from DIRAC import gLogger
+
+gLogger.setLevel("DEBUG")
+
+from DIRAC.WorkloadManagementSystem.Client import JobStatus
+from DIRAC.WorkloadManagementSystem.Client import JobMinorStatus
+
+# sut
+from DIRAC.WorkloadManagementSystem.Service.JobStateUpdateHandler import JobStateUpdateHandlerMixin
+
+# mocks
+jobDB_mock = MagicMock()
+jobLoggingDB_mock = MagicMock()
+
+
+@pytest.mark.parametrize(
+    "statusDict_in, "
+    + "jobDB_getJobAttributes_rv, jobDB_setJobAttributes_rv, jobLoggingDB_getWMSTimeStamps_rv, force, "
+    + "resExpected, resExpected_value",
+    [
+        ({}, {"OK": False}, {"OK": False}, {"OK": False}, False, False, None),
+        ({}, {"OK": True, "Value": None}, {"OK": False}, {"OK": False}, False, False, None),
+        ({}, {"OK": True, "Value": {"Status": JobStatus.WAITING}}, {"OK": False}, {"OK": False}, False, False, None),
+        (
+            {},
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": False},
+            {"OK": True, "Value": {}},
+            False,
+            False,
+            None,
+        ),
+        (
+            {"2002-01-01 00:00:00": {"Status": JobStatus.MATCHED}},
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": False},
+            {
+                "OK": True,
+                "Value": {
+                    JobStatus.RECEIVED: "1000000001.001",
+                    JobStatus.CHECKING: "1000000002.002",
+                    JobStatus.WAITING: "1000000003.003",
+                    "LastTime": "2001-09-09 03:46:43",
+                },
+            },
+            False,
+            False,
+            None,
+        ),
+        (
+            {"2002-01-01 00:00:00": {"Status": JobStatus.MATCHED}},
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": True},
+            {
+                "OK": True,
+                "Value": {
+                    JobStatus.RECEIVED: "1000000001.001",
+                    JobStatus.CHECKING: "1000000002.002",
+                    JobStatus.WAITING: "1000000003.003",
+                    "LastTime": "2001-09-09 03:46:43",
+                },
+            },
+            False,
+            True,
+            (["Status"], [JobStatus.MATCHED]),
+        ),
+        (
+            {
+                "2002-01-01 00:00:00": {"Status": JobStatus.MATCHED},
+                "2003-01-01 00:00:00": {"MinorStatus": "some_minor_status"},
+                "2004-01-01 00:00:00": {"Status": JobStatus.RUNNING, "ApplicationStatus": "some_app_status"},
+                "2005-01-01 00:00:00": {"MinorStatus": JobMinorStatus.APPLICATION},
+            },
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": True},
+            {
+                "OK": True,
+                "Value": {
+                    JobStatus.RECEIVED: "1000000001.001",
+                    JobStatus.CHECKING: "1000000002.002",
+                    JobStatus.WAITING: "1000000003.003",
+                    "LastTime": "2001-09-09 03:46:43",
+                },
+            },
+            False,
+            True,
+            (
+                ["Status", "MinorStatus", "ApplicationStatus"],
+                [JobStatus.RUNNING, JobMinorStatus.APPLICATION, "some_app_status"],
+            ),
+        ),
+        (
+            {
+                "2002-01-01 00:00:00": {"Status": JobStatus.MATCHED},
+                "2003-01-01 00:00:00": {"Status": JobStatus.MATCHED, "MinorStatus": "some_minor_status"},
+                "2004-01-01 00:00:00": {"Status": JobStatus.RUNNING, "ApplicationStatus": "some_app_status"},
+                "2005-01-01 00:00:00": {"Status": JobStatus.RUNNING, "MinorStatus": JobMinorStatus.APPLICATION},
+            },
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": True},
+            {
+                "OK": True,
+                "Value": {
+                    JobStatus.RECEIVED: "1000000001.001",
+                    JobStatus.CHECKING: "1000000002.002",
+                    JobStatus.WAITING: "1000000003.003",
+                    "LastTime": "2001-09-09 03:46:43",
+                },
+            },
+            False,
+            True,
+            (
+                ["Status", "MinorStatus", "ApplicationStatus"],
+                [JobStatus.RUNNING, JobMinorStatus.APPLICATION, "some_app_status"],
+            ),
+        ),
+        (
+            {
+                "2002-01-01 00:00:00": {"Status": JobStatus.DONE},  # try inserting a "wrong" one
+            },
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": True},
+            {
+                "OK": True,
+                "Value": {
+                    JobStatus.RECEIVED: "1000000001.001",
+                    JobStatus.CHECKING: "1000000002.002",
+                    JobStatus.WAITING: "1000000003.003",
+                    "LastTime": "2001-09-09 03:46:43",
+                },
+            },
+            False,
+            True,
+            (["Status"], [JobStatus.WAITING]),
+        ),
+        (
+            {
+                "2002-01-01 00:00:00": {"Status": JobStatus.RUNNING},  # this would trigger a wrong update
+                "2003-01-01 00:00:00": {"Status": JobStatus.MATCHED},
+            },
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": True},
+            {
+                "OK": True,
+                "Value": {
+                    JobStatus.RECEIVED: "1000000001.001",
+                    JobStatus.CHECKING: "1000000002.002",
+                    JobStatus.WAITING: "1000000003.003",
+                    "LastTime": "2001-09-09 03:46:43",
+                },
+            },
+            False,
+            True,
+            (["Status"], [JobStatus.MATCHED]),
+        ),
+        (
+            {},
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": True},
+            {"OK": True, "Value": {}},
+            True,
+            False,
+            None,
+        ),
+        (
+            {"2002-01-01 00:00:00": {"Status": JobStatus.MATCHED}},
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": True},
+            {
+                "OK": True,
+                "Value": {
+                    JobStatus.RECEIVED: "1000000001.001",
+                    JobStatus.CHECKING: "1000000002.002",
+                    JobStatus.WAITING: "1000000003.003",
+                    "LastTime": "2001-09-09 03:46:43",
+                },
+            },
+            True,
+            True,
+            (["Status"], [JobStatus.MATCHED]),
+        ),
+        (
+            {"2002-01-01 00:00:00": {"Status": JobStatus.DONE}},
+            {"OK": True, "Value": {"Status": JobStatus.WAITING}},
+            {"OK": True},
+            {
+                "OK": True,
+                "Value": {
+                    JobStatus.RECEIVED: "1000000001.001",
+                    JobStatus.CHECKING: "1000000002.002",
+                    JobStatus.WAITING: "1000000003.003",
+                    "LastTime": "2001-09-09 03:46:43",
+                },
+            },
+            True,
+            True,
+            (["Status"], [JobStatus.DONE]),
+        ),
+    ],
+)
+def test__setJobStatusBulk(
+    mocker,
+    statusDict_in,
+    jobDB_getJobAttributes_rv,
+    jobDB_setJobAttributes_rv,
+    jobLoggingDB_getWMSTimeStamps_rv,
+    force,
+    resExpected,
+    resExpected_value,
+):
+    JobStateUpdateHandlerMixin.jobDB = jobDB_mock
+    JobStateUpdateHandlerMixin.jobLoggingDB = jobLoggingDB_mock
+
+    jobDB_mock.getJobAttributes.return_value = jobDB_getJobAttributes_rv
+    jobDB_mock.setJobAttributes.return_value = jobDB_setJobAttributes_rv
+    jobLoggingDB_mock.getWMSTimeStamps.return_value = jobLoggingDB_getWMSTimeStamps_rv
+
+    jsu = JobStateUpdateHandlerMixin()
+
+    res = jsu._setJobStatusBulk(1, statusDict_in, force)
+    assert res["OK"] is resExpected
+    if res["OK"]:
+        assert res["Value"] == resExpected_value


### PR DESCRIPTION
BEGINRELEASENOTES

*WMS
FIX: better use the job state machine when setting the job status, in particular when it comes from failover requests that may be inserted between 2 successful updates. 


ENDRELEASENOTES


Note: there is still a pending question about what to do if the state machine refuses the status change... Currently it basically remains unchanged, but is it the right thing?