### PR TITLE
[v7r2] JobSanity doesn't handle input sanboxes named "LFN:"

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py
@@ -145,7 +145,7 @@ class JobSanity(OptimizerExecutor):
                 sbsToAssign.append((isb, "Input"))
             if isb.startswith("LFN:"):
                 self.jobLog.debug("Found a LFN sandbox", isb)
-                if isb[4] != "/":  # the LFN does not start with /
+                if len(isb) < 5 or isb[4] != "/":  # the LFN does not start with /
                     return S_ERROR("LFNs should always start with '/'")
         numSBsToAssign = len(sbsToAssign)
         if not numSBsToAssign:


### PR DESCRIPTION
The LHCb optimisers failed spectacularly with:
```
11:53 AM
2021-12-16 10:53:24 UTC WorkloadManagement/Optimizers ERROR: Error while processing task 565300222
Traceback (most recent call last):
  File "/opt/dirac/versions/v10.3.3-1638280653/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Base/ExecutorReactor.py", line 184, in __moduleProcess
    result = modInstance._ex_processTask(taskId, taskStub)
  File "/opt/dirac/versions/v10.3.3-1638280653/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Base/ExecutorModule.py", line 146, in _ex_processTask
    result = self.processTask(taskId, taskObj)
  File "/opt/dirac/versions/v10.3.3-1638280653/Linux-x86_64/lib/python3.9/site-packages/DIRAC/WorkloadManagementSystem/Executor/Base/OptimizerExecutor.py", line 84, in processTask
    optResult = self.optimizeJob(jid, jobState)
  File "/opt/dirac/versions/v10.3.3-1638280653/Linux-x86_64/lib/python3.9/site-packages/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py", line 72, in optimizeJob
    result = self.checkInputSandbox(jobState, manifest)
  File "/opt/dirac/versions/v10.3.3-1638280653/Linux-x86_64/lib/python3.9/site-packages/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py", line 148, in checkInputSandbox
    if isb[4] != "/":  # the LFN does not start with /
IndexError: string index out of range
```


BEGINRELEASENOTES

*WorkloadManagement
FIX: JobSanity doesn't handle input sanboxes named "LFN:"

ENDRELEASENOTES
