### PR TITLE
[v7r3] hackaton fix (wms): JobAgent submitJob inputs

### DIFF
--- a/src/DIRAC/Resources/Computing/InProcessComputingElement.py
+++ b/src/DIRAC/Resources/Computing/InProcessComputingElement.py
@@ -45,6 +45,7 @@ class InProcessComputingElement(ComputingElement):
         :param str executableFile: file to execute via systemCall.
                                    Normally the JobWrapperTemplate when invoked by the JobAgent.
         :param str proxy: the proxy used for running the job (the payload). It will be dumped to a file.
+        :param list inputs: dependencies of executableFile
         """
         payloadEnv = dict(os.environ)
         payloadProxy = ""

--- a/src/DIRAC/Resources/Computing/PoolComputingElement.py
+++ b/src/DIRAC/Resources/Computing/PoolComputingElement.py
@@ -101,6 +101,7 @@ class PoolComputingElement(ComputingElement):
 
         :param str executableFile: location of the executable file
         :param str proxy: payload proxy
+        :param list inputs: dependencies of executableFile
 
         :return: S_OK/S_ERROR of the result of the job submission
         """

--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -622,7 +622,7 @@ class JobAgent(AgentModule):
             return result
 
         wrapperFile = result["Value"][0]
-        inputs = result["Value"][1:]
+        inputs = list(result["Value"][1:])
         jobReport.setJobStatus(minorStatus="Submitting To CE")
 
         self.log.info("Submitting JobWrapper", "%s to %sCE" % (os.path.basename(wrapperFile), self.ceName))


### PR DESCRIPTION
Quick fix to convert a tuple into a list in `JobAgent`.
This should resolve one of the issue we had during the hackaton with the `InProcessCE`. 

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: convert inputs from tuple to list in JobAgent before submitting to a CE
ENDRELEASENOTES
