### PR TITLE
[sweep:integration] Get Tornado's port from the CS when adding URLs

### DIFF
--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -871,10 +871,14 @@ class ComponentInstaller(object):
                 failoverUrlsPath = cfgPath("Systems", system, compInstance, "FailoverURLs")
                 cfg.createNewSection(failoverUrlsPath)
                 if protocol == "https":
+                    tornadoPort = gConfig.getValue(
+                        "/Systems/Tornado/%s/Port" % PathFinder.getSystemInstance("Tornado"),
+                        8443,
+                    )
                     cfg.setOption(
                         # Strip "Tornado" from the beginning of component name if present
                         cfgPath(urlsPath, component[len("Tornado") if component.startswith("Tornado") else 0 :]),
-                        "https://%s:8443/%s/%s" % (self.host, system, component),
+                        "https://%s:%s/%s/%s" % (self.host, tornadoPort, system, component),
                     )
                 else:
                     cfg.setOption(


### PR DESCRIPTION
Sweep #5729 `Get Tornado's port from the CS when adding URLs` to `integration`.

Adding original author @chrisburr as watcher.

BEGINRELEASENOTES

*Framework
FIX: Get Tornado's port from the CS when adding URLs

ENDRELEASENOTES
Closes #5731