### PR TITLE
[sweep:v7r3] JobSanity doesn't handle input sanboxes named "LFN:"

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py
@@ -145,7 +145,7 @@ class JobSanity(OptimizerExecutor):
                 sbsToAssign.append((isb, "Input"))
             if isb.startswith("LFN:"):
                 self.jobLog.debug("Found a LFN sandbox", isb)
-                if isb[4] != "/":  # the LFN does not start with /
+                if len(isb) < 5 or isb[4] != "/":  # the LFN does not start with /
                     return S_ERROR("LFNs should always start with '/'")
         numSBsToAssign = len(sbsToAssign)
         if not numSBsToAssign:


### PR DESCRIPTION
Sweep #5742 `JobSanity doesn't handle input sanboxes named "LFN:"` to `rel-v7r3`.

Adding original author @chrisburr as watcher.

BEGINRELEASENOTES

*WorkloadManagement
FIX: JobSanity doesn't handle input sanboxes named "LFN:"

ENDRELEASENOTES
Closes #5747