### PR TITLE
[v7r3] Allow to specify input protocol in the CS 

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -548,6 +548,8 @@ Resources
         Access = remote
         SpaceToken = LHCb-EOS
         WSUrl = /srm/v2/server?SFN=
+        InputProtocols = file, https, root, srm, gsiftp # Allow to overwrite the list of protocols understood as input
+        OutputProtocols = file, https, root, srm, gsiftp # Allow to overwrite the list of protocols that can be generated
       }
     }
   }

--- a/docs/source/AdministratorGuide/Resources/storage.rst
+++ b/docs/source/AdministratorGuide/Resources/storage.rst
@@ -220,7 +220,7 @@ There are also a set of plugins based on the `gfal2 libraries <https://dmc-docs.
 Default plugin options:
 
 * ``Access``: ``Remote`` or ``Local``. If ``Local``, then this protocol can be used only if we are running at the site to which the SE is associated. Typically, if a site mounts the storage as NFS, the ``file`` protocol can be used.
-
+* InputProtocols/OutputProtocols: a given plugin normally contain a hard coded list of protocol it is able to generate or accept as input. There are however seldom cases (like SRM) where the site configuration may change these lists. These options are here to accomodate for that case.
 
 GRIDFTP Optimisation
 ^^^^^^^^^^^^^^^^^^^^

--- a/src/DIRAC/Resources/Storage/GFAL2_XROOTStorage.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_XROOTStorage.py
@@ -27,7 +27,7 @@ class GFAL2_XROOTStorage(GFAL2_StorageBase):
     Xroot interface to StorageElement using gfal2
     """
 
-    _INPUT_PROTOCOLS = ["file", "root"]
+    _INPUT_PROTOCOLS = ["file", "root", "xroot"]
     _OUTPUT_PROTOCOLS = ["root"]
 
     PROTOCOL_PARAMETERS = GFAL2_StorageBase.PROTOCOL_PARAMETERS + ["SvcClass"]

--- a/src/DIRAC/Resources/Storage/StorageBase.py
+++ b/src/DIRAC/Resources/Storage/StorageBase.py
@@ -78,12 +78,16 @@ class StorageBase(object):
         # be so strict about the possible content.
         self._allProtocolParameters = parameterDict
 
-        if hasattr(self, "_INPUT_PROTOCOLS"):
+        if "InputProtocols" in parameterDict:
+            self.protocolParameters["InputProtocols"] = parameterDict["InputProtocols"].replace(" ", "").split(",")
+        elif hasattr(self, "_INPUT_PROTOCOLS"):
             self.protocolParameters["InputProtocols"] = getattr(self, "_INPUT_PROTOCOLS")
         else:
             self.protocolParameters["InputProtocols"] = [self.protocolParameters["Protocol"], "file"]
 
-        if hasattr(self, "_OUTPUT_PROTOCOLS"):
+        if "OutputProtocols" in parameterDict:
+            self.protocolParameters["OutputProtocols"] = parameterDict["OutputProtocols"].replace(" ", "").split(",")
+        elif hasattr(self, "_OUTPUT_PROTOCOLS"):
             self.protocolParameters["OutputProtocols"] = getattr(self, "_OUTPUT_PROTOCOLS")
         else:
             self.protocolParameters["OutputProtocols"] = [self.protocolParameters["Protocol"]]


### PR DESCRIPTION
There are cases when specific storage can input/output more protocols with a given plugin than other storages (e.g. some tape are SRM+HTTPs ready, some aren't, `dCache` can return `xroot` instead of `root`, `Storm` can return `file`, etc). 
This PR allows to overwrite the hardcoded default with a CS configuration. This was meant to be possible from the beginning when I introduced multi protocol, but somehow, it did not make it into the code. Now, it's here

(triggered by https://github.com/DIRACGrid/DIRAC/issues/5727)



BEGINRELEASENOTES
*Resources
NEW: allow to overwrite input/output  storage plugin parameter with the CS
CHANGE: add "xroot" to the list of input protocol for the XROOT plugin

ENDRELEASENOTES
