### PR TITLE
[integration] rename downloadablePersonalProxy value

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/Utilities.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Utilities.py
@@ -671,10 +671,10 @@ def getAuthorizationServerMetadata(issuer=None, ignoreErrors=False):
     return S_OK(data) if data["issuer"] else S_ERROR("Cannot find DIRAC Authorization Server issuer.")
 
 
-def isDownloadablePersonalProxy():
-    """Get downloadablePersonalProxy flag
+def isDownloadProxyAllowed():
+    """Get allowProxyDownload flag
 
     :return: S_OK(bool)/S_ERROR()
     """
     cs_path = "/Systems/Framework/%s/APIs/Auth" % getSystemInstance("Framework")
-    return gConfig.getValue(cs_path + "/downloadablePersonalProxy", True)
+    return gConfig.getValue(cs_path + "/allowProxyDownload", True)

--- a/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
@@ -6,7 +6,7 @@ APIs
   {
     Port = 8000
     # Allow download personal proxy. By default: True
-    downloadablePersonalProxy = True
+    allowProxyDownload = True
   }
   ##END
 }

--- a/src/DIRAC/FrameworkSystem/private/authorization/AuthServer.py
+++ b/src/DIRAC/FrameworkSystem/private/authorization/AuthServer.py
@@ -15,7 +15,7 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.FrameworkSystem.DB.AuthDB import AuthDB
 from DIRAC.Resources.IdProvider.Utilities import getProvidersForInstance, getProviderInfo
 from DIRAC.Resources.IdProvider.IdProviderFactory import IdProviderFactory
-from DIRAC.ConfigurationSystem.Client.Utilities import isDownloadablePersonalProxy
+from DIRAC.ConfigurationSystem.Client.Utilities import isDownloadProxyAllowed
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import (
     getUsernameForDN,
     getEmailsForGroup,
@@ -143,10 +143,10 @@ class AuthServer(_AuthorizationServer):
         # User request a proxy
         if "proxy" in scope_to_list(scope):
             # Try to return user proxy if proxy scope present in the authorization request
-            if not isDownloadablePersonalProxy():
-                raise OAuth2Error("You can't get proxy, configuration(downloadablePersonalProxy) not allow to do that.")
-            self.log.debug(
-                "Try to query %s@%s proxy%s" % (user, group, (" with lifetime:%s" % lifetime) if lifetime else "")
+            if not isDownloadProxyAllowed():
+                raise OAuth2Error("You can't get proxy, configuration(allowProxyDownload) not allow to do that.")
+            sLog.debug(
+                "Try to query %s@%s proxy%s" % (user, group, ("with lifetime:%s" % lifetime) if lifetime else "")
             )
             # Get user DNs
             result = getDNForUsername(userName)
@@ -368,7 +368,7 @@ class AuthServer(_AuthorizationServer):
         :return: TornadoResponse object
         """
         try:
-            response = super(AuthServer, self).create_authorization_response(response, username)
+            response = super().create_authorization_response(response, username)
             response.clear_cookie("auth_session")
             return response
         except Exception as e:

--- a/tests/Integration/Framework/Test_AuthServer.py
+++ b/tests/Integration/Framework/Test_AuthServer.py
@@ -35,7 +35,7 @@ class TokenManagerClient(object):
 mockgetIdPForGroup = MagicMock(return_value=S_OK("IdP"))
 mockgetDNForUsername = MagicMock(return_value=S_OK("DN"))
 mockgetUsernameForDN = MagicMock(return_value=S_OK("user"))
-mockisDownloadablePersonalProxy = MagicMock(return_value=True)
+mockisDownloadProxyAllowed = MagicMock(return_value=True)
 mockgetAuthorizationServerMetadata = MagicMock(return_value=S_OK(dict(issuer="https://issuer.url/")))
 
 
@@ -48,7 +48,7 @@ def auth_server(monkeypatch):
     monkeypatch.setattr(AuthServer, "getUsernameForDN", mockgetUsernameForDN)
     monkeypatch.setattr(AuthServer, "ProxyManagerClient", ProxyManagerClient)
     monkeypatch.setattr(AuthServer, "TokenManagerClient", TokenManagerClient)
-    monkeypatch.setattr(AuthServer, "isDownloadablePersonalProxy", mockisDownloadablePersonalProxy)
+    monkeypatch.setattr(AuthServer, "isDownloadProxyAllowed", mockisDownloadProxyAllowed)
     return AuthServer.AuthServer()
 
 


### PR DESCRIPTION
From discussion https://codimd.web.cern.ch/2ctS6OH5QZiMJqJLXaMivw?view.

BEGINRELEASENOTES

*Framework
FIX: rename downloadablePersonalProxy value to allowProxyDownload

ENDRELEASENOTES
