### PR TITLE
[v7r2] Fix mocking of psutil

### DIFF
--- a/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
@@ -446,7 +446,7 @@ class TestComponentSupervisionAgent(unittest.TestCase):
         psMock = self.getPSMock()
         psMock.Process = MagicMock("RaisingProc")
         psMock.Error = psutil.Error
-        psMock.Process.side_effect = psutil.Error()
+        psMock.Process.side_effect = psutil.AccessDenied()
         with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.psutil", new=psMock):
             res = self.restartAgent.restartInstance(12345, "agentX", True)
         self.assertFalse(res["OK"])


### PR DESCRIPTION
Currently the tests use `psutil.Error` when mocking which isn't intended to be used directly (see [here](https://github.com/giampaolo/psutil/blob/18348c9b6b66ff12abbbfeaebbe2218cdc6b5556/psutil/_common.py#L279-L310)) causing the CI to fail. Even though it's been fixed upstream I think it's better to raise one of the specialised exception classes instead.

No need for release notes.