### PR TITLE
[sweep:integration] JobSanity doesn't handle input sanboxes named "LFN:"

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py
@@ -139,7 +139,7 @@ class JobSanity(OptimizerExecutor):
                 sbsToAssign.append((isb, "Input"))
             if isb.startswith("LFN:"):
                 self.jobLog.debug("Found a LFN sandbox", isb)
-                if isb[4] != "/":  # the LFN does not start with /
+                if len(isb) < 5 or isb[4] != "/":  # the LFN does not start with /
                     return S_ERROR("LFNs should always start with '/'")
         numSBsToAssign = len(sbsToAssign)
         if not numSBsToAssign:


### PR DESCRIPTION
Sweep #5749 `JobSanity doesn't handle input sanboxes named "LFN:"` to `integration`.

Adding original author @chrisburr as watcher.

BEGINRELEASENOTES

*WorkloadManagement
FIX: JobSanity doesn't handle input sanboxes named "LFN:"

ENDRELEASENOTES
Closes #5750