### PR TITLE
[integration] [hackathon] fix(transformation): convert task/file ID to integer to fix type mismatch

### DIFF
--- a/src/DIRAC/TransformationSystem/Client/TaskManager.py
+++ b/src/DIRAC/TransformationSystem/Client/TaskManager.py
@@ -68,7 +68,7 @@ class TaskBase(TransformationAgentsUtilities):
         for taskID, task in taskDict.items():
             transID = task["TransformationID"]
             if task["Success"]:
-                res = self.transClient.setTaskStatusAndWmsID(transID, taskID, "Submitted", str(task["ExternalID"]))
+                res = self.transClient.setTaskStatusAndWmsID(transID, int(taskID), "Submitted", str(task["ExternalID"]))
                 if not res["OK"]:
                     self._logWarn(
                         "Failed to update task status after submission",

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -705,7 +705,8 @@ class TransformationDB(DB):
 
         for error, fileIDStatusList in statusFileDict.items():
             req = reqBase + ",".join(
-                "(%d, %d, '%s', 0, UTC_TIMESTAMP())" % (transID, fileID, status) for fileID, status in fileIDStatusList
+                "(%d, %d, '%s', 0, UTC_TIMESTAMP())" % (transID, int(fileID), status)
+                for fileID, status in fileIDStatusList
             )
             if error:
                 # Increment the error counter when we requested

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -705,7 +705,7 @@ class TransformationDB(DB):
 
         for error, fileIDStatusList in statusFileDict.items():
             req = reqBase + ",".join(
-                "(%d, %d, '%s', 0, UTC_TIMESTAMP())" % (transID, int(fileID), status)
+                f"({transID}, {fileID}, '{status}', 0, UTC_TIMESTAMP())"
                 for fileID, status in fileIDStatusList
             )
             if error:


### PR DESCRIPTION
The fix in TaksManager fixes the original problem discovered during the hackathon, the fix in transformationDB is a followup issue.

I guess this comes from the JSON encode/decode where integer keys are no longer supported?

BEGINRELEASENOTES

*TS
FIX: Convert fileID / taskID to fix issue when task status is updated in transformation treatment

ENDRELEASENOTES
