### PR TITLE
[8.0] fix (JEncode): do NOT blindy decode bytes

### DIFF
--- a/src/DIRAC/Core/Utilities/JEncode.py
+++ b/src/DIRAC/Core/Utilities/JEncode.py
@@ -105,9 +105,6 @@ class DJSONEncoder(json.JSONEncoder):
         # if the object inherits from JSJerializable, try to serialize it
         elif isinstance(obj, JSerializable):
             return obj._toJSON()  # pylint: disable=protected-access
-        # if the object a bytes, decode it
-        elif isinstance(obj, bytes):
-            return obj.decode()
 
         # otherwise, let the parent do
         return super(DJSONEncoder, self).default(obj)


### PR DESCRIPTION
This was triggered by this issue during the hackaton (https://trello.com/c/GQo62UoN/15-verify-monitoring-application)

```python
2022-01-13 10:07:54 UTC Monitoring/Monitoring VERBOSE: Time for WMSHistory:NumberOfJobs - Report 0.00 Plot 0.00 (99.34% r/p)
2022-01-13 10:07:54 UTC Monitoring/Monitoring INFO: Returning plot file: 9a889123620787924c02fcbd8b36b24b.png
2022-01-13 10:07:54 UTC Monitoring/Monitoring ERROR: Uncaught exception when serving Transfer toClient
Traceback (most recent call last):
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/DISET/RequestHandler.py", line 198, in __doFileTransfer
    uRetVal = self.transfer_toClient(fileInfo[0], fileInfo[1], fileHelper)
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/site-packages/DIRAC/MonitoringSystem/Service/MonitoringHandler.py", line 137, in transfer_toClient
    retVal = fileHelper.sendData(retVal["Value"])
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/DISET/private/FileHelper.py", line 65, in sendData
    retVal = self.oTransport.sendData(S_OK([True, sBuffer]))
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/DISET/private/Transports/BaseTransport.py", line 169, in sendData
    sCodedData = MixedEncode.encode(uData)
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/MixedEncode.py", line 22, in encode
    return JEncode.encode(inData)
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/JEncode.py", line 183, in encode
    return json.dumps(inData, cls=DJSONEncoder)
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/json/__init__.py", line 234, in dumps
    return cls(
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/opt/dirac/versions/v8.0.0a12-1642062208/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/JEncode.py", line 110, in default
    return obj.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
```
The `bytes` decoding was added in `JEncode` by this commit https://github.com/DIRACGrid/DIRAC/pull/5149/commits/64910e5e8e5bf0368081b5376a9750baaabe9fca  so this is basically reverting it.

First of all, changing something as low level and fundamental as `JEncode` without updating the unit tests is borderline criminal. 

Secondly, we should not blindly try to decode, since what you are given is not necessarily `utf-8` compatible (and above is such an example). What reaches `JEncode` should be serializable over `json` so it is up to the caller to do what is needed, for example converting in `base64`. 

This PR will not fix the issue that the `Monitoring` has with `JEncode`, the error will just be different. 

The adoption of `JEncode` comes again 5 years too late, since the original idea was to make the adoption of `https` easier. So I think we should let `Monitoring` be as it is, just disable `JEncode` for it. If we do an `https` version, we can use `base64`. That is exactly what the CS does. 
Now, ultimately, as I already said, we should not be sending files with Tornado and instead of wasting even more time in trying to force that to happen, we should just run with what we have and focus on a clean solution


BEGINRELEASENOTES
*Core
FIX: JEncode do not transparently decode bytes

ENDRELEASENOTES
