### PR TITLE
[8.0] solve the problem with bytes on the hackathon (wait #5811)

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/ConfigurationClient.py
+++ b/src/DIRAC/ConfigurationSystem/Client/ConfigurationClient.py
@@ -1,16 +1,11 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
-
-from base64 import b64encode, b64decode
+from base64 import b64decode
 
 from DIRAC.Core.Tornado.Client.TornadoClient import TornadoClient
 from DIRAC.Core.Base.Client import Client
 
 
+# All this class for backward compatability with 8.0
+# TODO: in 8.1 remove it
 class CSJSONClient(TornadoClient):
     """
     The specific Tornado client for configuration system.
@@ -29,7 +24,7 @@ class CSJSONClient(TornadoClient):
         :rtype: str
         """
         retVal = self.executeRPC("getCompressedData")
-        if retVal["OK"]:
+        if retVal["OK"] and isinstance(retVal["Value"], str):
             retVal["Value"] = b64decode(retVal["Value"])
         return retVal
 
@@ -41,17 +36,9 @@ class CSJSONClient(TornadoClient):
         :returns: Configuration data, if changed, compressed
         """
         retVal = self.executeRPC("getCompressedDataIfNewer", sClientVersion)
-        if retVal["OK"] and "data" in retVal["Value"]:
+        if retVal["OK"] and isinstance(retVal["Value"].get("data"), str):
             retVal["Value"]["data"] = b64decode(retVal["Value"]["data"])
         return retVal
-
-    def commitNewData(self, sData):
-        """
-        Transmit request to service by encoding data in base64.
-
-        :param sData: Data to commit, you may call this method with CSAPI and Modificator
-        """
-        return self.executeRPC("commitNewData", b64encode(sData).decode())
 
 
 class ConfigurationClient(Client):
@@ -65,7 +52,7 @@ class ConfigurationClient(Client):
     RPCCall can be made inside this class with executeRPC method.
     """
 
-    # The JSON decoder for Configuration Server
+    # The JSON decoder for Configuration Server for backward compatability with 8.0
     httpsClient = CSJSONClient
 
     def __init__(self, **kwargs):

--- a/src/DIRAC/ConfigurationSystem/Service/TornadoConfigurationHandler.py
+++ b/src/DIRAC/ConfigurationSystem/Service/TornadoConfigurationHandler.py
@@ -6,12 +6,7 @@ In client side you must use a specific client
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
+from typing import Dict, Union
 from base64 import b64encode, b64decode
 
 from DIRAC import S_OK, S_ERROR, gLogger
@@ -44,14 +39,17 @@ class TornadoConfigurationHandler(TornadoService):
         """
         return S_OK(self.ServiceInterface.getVersion())
 
-    def export_getCompressedData(self):
+    def export_getCompressedData(self) -> Dict[str, Union[bool, bytes]]:
         """
         Returns the configuration
         """
-        sData = self.ServiceInterface.getCompressedConfigurationData()
-        return S_OK(b64encode(sData).decode())
+        # TODO: in 8.1 replace it to:
+        # return S_OK(self.ServiceInterface.getCompressedConfigurationData())
+        return S_OK(b64encode(self.ServiceInterface.getCompressedConfigurationData()).decode())
 
-    def export_getCompressedDataIfNewer(self, sClientVersion):
+    def export_getCompressedDataIfNewer(
+        self, sClientVersion: str
+    ) -> Dict[str, Union[bool, Dict[str, Union[str, bytes]]]]:
         """
         Returns the configuration if a newer configuration exists, if not just returns the version
 
@@ -60,6 +58,8 @@ class TornadoConfigurationHandler(TornadoService):
         sVersion = self.ServiceInterface.getVersion()
         retDict = {"newestVersion": sVersion}
         if sClientVersion < sVersion:
+            # TODO: in 8.1 replace it to:
+            # retDict["data"] = self.ServiceInterface.getCompressedConfigurationData()
             retDict["data"] = b64encode(self.ServiceInterface.getCompressedConfigurationData()).decode()
         return S_OK(retDict)
 
@@ -72,14 +72,16 @@ class TornadoConfigurationHandler(TornadoService):
         self.ServiceInterface.publishSlaveServer(sURL)
         return S_OK()
 
-    def export_commitNewData(self, sData):
+    def export_commitNewData(self, sData: bytes) -> Dict[str, Union[str, bool, None]]:
         """
         Write the new configuration
         """
         credDict = self.getRemoteCredentials()
         if "DN" not in credDict or "username" not in credDict:
             return S_ERROR("You must be authenticated!")
-        sData = b64decode(sData)
+        # TODO: in 8.1 remove it
+        if isinstance(sData, str):
+            sData = b64decode(sData)  # 7.3 client send b64encoded data
         return self.ServiceInterface.updateConfiguration(sData, credDict["username"])
 
     def export_writeEnabled(self):

--- a/src/DIRAC/Core/Utilities/DEncode.py
+++ b/src/DIRAC/Core/Utilities/DEncode.py
@@ -17,7 +17,6 @@ from __future__ import division
 
 __RCSID__ = "$Id$"
 
-from past.builtins import long
 import six
 import datetime
 import os
@@ -44,11 +43,9 @@ def _ord(char):
 # part of the HTTPS transition.
 class types(object):
     IntType = int
-    LongType = long
     FloatType = float
     BooleanType = bool
     StringType = str
-    UnicodeType = type(u"")
     NoneType = type(None)
     ListType = list
     TupleType = tuple
@@ -248,20 +245,6 @@ def decodeInt(data, i):
 
 g_dEncodeFunctions[types.IntType] = encodeInt
 g_dDecodeFunctions[_ord("i")] = decodeInt
-
-
-def encodeLong(iValue, eList):
-    """Encoding longs"""
-    raise TypeError("Data type long is no longer supported, please use int or float.")
-
-
-def decodeLong(data, i):
-    """Decoding longs"""
-    raise TypeError("Data type long is no longer supported, please use int or float.")
-
-
-g_dEncodeFunctions[types.LongType] = encodeLong
-g_dDecodeFunctions[_ord("I")] = decodeLong
 
 
 def encodeFloat(iValue, eList):

--- a/src/DIRAC/Core/Utilities/DEncode.py
+++ b/src/DIRAC/Core/Utilities/DEncode.py
@@ -315,6 +315,7 @@ def decodeString(data, i):
 g_dEncodeFunctions[types.StringType] = encodeString
 g_dEncodeFunctions[bytes] = encodeString
 g_dDecodeFunctions[_ord("s")] = decodeString
+g_dDecodeFunctions[_ord("u")] = decodeString
 
 
 def encodeDateTime(oValue, eList):

--- a/src/DIRAC/Core/Utilities/DEncode.py
+++ b/src/DIRAC/Core/Utilities/DEncode.py
@@ -44,7 +44,7 @@ def _ord(char):
 # part of the HTTPS transition.
 class types(object):
     IntType = int
-    LongType = int
+    LongType = long
     FloatType = float
     BooleanType = bool
     StringType = str
@@ -252,20 +252,15 @@ g_dDecodeFunctions[_ord("i")] = decodeInt
 
 def encodeLong(iValue, eList):
     """Encoding longs"""
-
-    # corrected by KGG   eList.extend( ( "l", str( iValue ), "e" ) )
-    eList.extend((b"I", str(iValue).encode(), b"e"))
+    raise TypeError("Data type long is no longer supported, please use int or float.")
 
 
 def decodeLong(data, i):
     """Decoding longs"""
-
-    i += 1
-    end = data.index(_ord("e"), i)
-    value = long(data[i:end])
-    return (value, end + 1)
+    raise TypeError("Data type long is no longer supported, please use int or float.")
 
 
+g_dEncodeFunctions[types.LongType] = encodeLong
 g_dDecodeFunctions[_ord("I")] = decodeLong
 
 
@@ -337,26 +332,6 @@ def decodeString(data, i):
 g_dEncodeFunctions[types.StringType] = encodeString
 g_dEncodeFunctions[bytes] = encodeString
 g_dDecodeFunctions[_ord("s")] = decodeString
-
-
-def encodeUnicode(sValue, eList):
-    """Encoding unicode strings"""
-    valueStr = sValue.encode("utf-8")
-    eList.extend((b"u", str(len(valueStr)).encode(), b":", valueStr))
-
-
-def decodeUnicode(data, i):
-    """Decoding unicode strings"""
-
-    i += 1
-    colon = data.index(b":", i)
-    value = int(data[i:colon])
-    colon += 1
-    end = colon + value
-    return (six.text_type(data[colon:end].decode("utf-8")), end)
-
-
-g_dDecodeFunctions[_ord("u")] = decodeString
 
 
 def encodeDateTime(oValue, eList):

--- a/src/DIRAC/Core/Utilities/JEncode.py
+++ b/src/DIRAC/Core/Utilities/JEncode.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from base64 import b64encode, b64decode
 import datetime
 import json
 
@@ -107,7 +108,7 @@ class DJSONEncoder(json.JSONEncoder):
             return obj._toJSON()  # pylint: disable=protected-access
         # if the object a bytes, decode it
         elif isinstance(obj, bytes):
-            return obj.decode()
+            return {"__dCls": "b64", "obj": b64encode(obj).decode()}
 
         # otherwise, let the parent do
         return super(DJSONEncoder, self).default(obj)
@@ -143,6 +144,8 @@ class DJSONDecoder(json.JSONDecoder):
             return datetime.datetime.strptime(dataDict["obj"], DATETIME_DEFAULT_FORMAT)
         elif className == "date":
             return datetime.datetime.strptime(dataDict["obj"], DATETIME_DEFAULT_DATE_FORMAT).date()
+        elif className == "b64":
+            return b64decode(dataDict["obj"])
         elif className:
             import importlib
 

--- a/src/DIRAC/FrameworkSystem/private/monitoring/ServiceInterface.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/ServiceInterface.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
-from past.builtins import long
 from DIRAC import S_OK, S_ERROR
 
 from DIRAC import gLogger, rootPath, gConfig
@@ -198,7 +197,7 @@ class ServiceInterface(object):
                 entries.append((instant, acData[instant]))
             if len(entries) > 0:
                 gLogger.verbose("There are %s entries for %s" % (len(entries), acName))
-                retDict = rrdManager.update(acInfo[4], rrdFile, acInfo[7], entries, long(acInfo[8]))
+                retDict = rrdManager.update(acInfo[4], rrdFile, acInfo[7], entries, int(acInfo[8]))
                 if not retDict["OK"]:
                     gLogger.error("There was an error updating", "%s:%s activity [%s]" % (sourceId, acName, rrdFile))
                 else:

--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 # pylint: disable=arguments-differ
 
 # # imports
-from past.builtins import long
 import six
 import os
 import datetime
@@ -634,7 +633,7 @@ class GFAL2_StorageBase(StorageBase):
                 return S_ERROR(errno.EISDIR, errStr)
 
             self.log.debug("File size successfully determined %s" % statInfo.st_size)
-            return S_OK(long(statInfo.st_size))
+            return S_OK(statInfo.st_size)
         except gfal2.GError as e:
             errStr = "Failed to determine file size."
             self.log.debug(errStr, repr(e))
@@ -1048,7 +1047,7 @@ class GFAL2_StorageBase(StorageBase):
             metaDict["Links"] = statInfo.st_nlink
             metaDict["UserID"] = statInfo.st_uid
             metaDict["GroupID"] = statInfo.st_gid
-            metaDict["Size"] = long(statInfo.st_size)
+            metaDict["Size"] = statInfo.st_size
             metaDict["LastAccess"] = self.__convertTime(statInfo.st_atime) if statInfo.st_atime else "Never"
             metaDict["ModTime"] = self.__convertTime(statInfo.st_mtime) if statInfo.st_mtime else "Never"
             metaDict["StatusChange"] = self.__convertTime(statInfo.st_ctime) if statInfo.st_ctime else "Never"

--- a/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
-from past.builtins import long
 import six
 import inspect
 import threading
@@ -1343,7 +1342,7 @@ class StorageManagementDB(DB):
         resSummary = {}
         i = 1
         for status, se, numFiles, sumFiles in res["Value"]:
-            resSummary[i] = {"Status": status, "SE": se, "NumFiles": long(numFiles), "SumFiles": float(sumFiles)}
+            resSummary[i] = {"Status": status, "SE": se, int("NumFiles"): numFiles, "SumFiles": float(sumFiles)}
             i += 1
         return S_OK(resSummary)
 


### PR DESCRIPTION
The essence of the problem:
when checking compatibility with **JSON**, we are faced with the reality that bytes can also be in a result, and `JEncode` does not accept them.

`JEncode` already has primitive logic that converts bytes to string (**_utf-8_**), but as it turned out, this is not enough if we shove it into `DISET`, so I added `base64` here and now the `bytes` on the input remain `bytes` on the output.

This is the best solution I see at the moment, while we are thinking about an ideal/clean approach.

#5798 

BEGINRELEASENOTES

*Core
FIX:  handle bytes in JEncode 

*Framework
FIX: use int instead of long

*Resources
FIX: use int instead of long

*StorageManagement
FIX: use int instead of long

ENDRELEASENOTES
