### PR TITLE
[v7r2] Fix exploit in JEncode

### DIFF
--- a/src/DIRAC/Core/Utilities/JEncode.py
+++ b/src/DIRAC/Core/Utilities/JEncode.py
@@ -150,6 +150,12 @@ class DJSONDecoder(json.JSONDecoder):
             mod = importlib.import_module(modName)
             # import the class
             cl = getattr(mod, className)
+
+            # Check that cl is a subclass of JSerializable,
+            # and that we are not putting ourselves in trouble...
+            if not (isinstance(cl, type) and issubclass(cl, JSerializable)):
+                raise TypeError("Only subclasses of JSerializable can be decoded")
+
             # Instantiate the object
             obj = cl()
 

--- a/src/DIRAC/Core/Utilities/test/Test_Encode.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Encode.py
@@ -343,6 +343,15 @@ def test_missingAttrToSerialize():
         agnosticTestFunction(jsonTuple, objData)
 
 
+def test_JSerializableExploit():
+    """Test that we cannot execute arbitrary code with JENcode"""
+
+    exploit = '{"__dCls": "exit", "__dMod": "sys"}'
+
+    with raises(TypeError):
+        jsonDecode(exploit)
+
+
 @mark.slow
 @settings(suppress_health_check=function_scoped)
 @given(data=nestedStrategyJson)


### PR DESCRIPTION
`JEncode` is very permissive when it comes to deserializing objects. Although not perfect, this fix strongly limits the issue by making sure that the object we are loading inherits from `JSerializable`

BEGINRELEASENOTES
*Core
FIX:  do not allow arbitrary code execution in JEncode

ENDRELEASENOTES
