### PR TITLE
[v7r3] feat(wms): enable logs from db12 in dirac-wms-cpu-normalization

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_cpu_normalization.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_cpu_normalization.py
@@ -47,6 +47,8 @@ def main():
         elif unprocSw[0] in ("R", "Reconfig"):
             configFile = unprocSw[1]
 
+    # we want to get the logs coming from db12
+    gLogger.enableLogsFromExternalLibs()
     result = singleDiracBenchmark()
 
     if result is None:


### PR DESCRIPTION
This PR enables logs coming from `db12` in the `dirac-wms-cpu-normalization` script.

BEGINRELEASENOTES
*WorkloadManagement
CHANGE: enable logs from db12 in dirac-wms-cpu-normalization
ENDRELEASENOTES
