### PR TITLE
[v7r3] fix (API): checkJobStateTransition needs a single jobID

### DIFF
--- a/src/DIRAC/Interfaces/API/Dirac.py
+++ b/src/DIRAC/Interfaces/API/Dirac.py
@@ -1673,13 +1673,15 @@ class Dirac(API):
         ret = self._checkJobArgument(jobID, multiple=True)
         if not ret["OK"]:
             return ret
-        jobID = ret["Value"]
+        jobIDs = ret["Value"]
 
-        res = JobStatus.checkJobStateTransition(jobID, JobStatus.DELETED)
-        if not res["OK"]:
-            return res
+        jobIDsToDelete = []
+        for jobID in jobIDs:
+            res = JobStatus.checkJobStateTransition(jobID, JobStatus.DELETED)
+            if res["OK"]:
+                jobIDsToDelete.append(jobID)
 
-        result = WMSClient(useCertificates=self.useCertificates).deleteJob(jobID)
+        result = WMSClient(useCertificates=self.useCertificates).deleteJob(jobIDsToDelete)
         if result["OK"]:
             if self.jobRepo:
                 for jID in result["Value"]:
@@ -1707,13 +1709,15 @@ class Dirac(API):
         ret = self._checkJobArgument(jobID, multiple=True)
         if not ret["OK"]:
             return ret
-        jobID = ret["Value"]
+        jobIDs = ret["Value"]
 
-        res = JobStatus.checkJobStateTransition(jobID, JobStatus.RESCHEDULED)
-        if not res["OK"]:
-            return res
+        jobIDsToReschedule = []
+        for jobID in jobIDs:
+            res = JobStatus.checkJobStateTransition(jobID, JobStatus.RESCHEDULED)
+            if res["OK"]:
+                jobIDsToReschedule.append(jobID)
 
-        result = WMSClient(useCertificates=self.useCertificates).rescheduleJob(jobID)
+        result = WMSClient(useCertificates=self.useCertificates).rescheduleJob(jobIDsToReschedule)
         if result["OK"]:
             if self.jobRepo:
                 repoDict = {}
@@ -1740,13 +1744,15 @@ class Dirac(API):
         ret = self._checkJobArgument(jobID, multiple=True)
         if not ret["OK"]:
             return ret
-        jobID = ret["Value"]
+        jobIDs = ret["Value"]
 
-        res = JobStatus.checkJobStateTransition(jobID, JobStatus.KILLED)
-        if not res["OK"]:
-            return res
+        jobIDsToKill = []
+        for jobID in jobIDs:
+            res = JobStatus.checkJobStateTransition(jobID, JobStatus.KILLED)
+            if res["OK"]:
+                jobIDsToKill.append(jobID)
 
-        result = WMSClient(useCertificates=self.useCertificates).killJob(jobID)
+        result = WMSClient(useCertificates=self.useCertificates).killJob(jobIDsToKill)
         if result["OK"]:
             if self.jobRepo:
                 for jID in result["Value"]:


### PR DESCRIPTION
#5752 introduced a check of the job status transition in the API. However, this check only accepts single job ID, while the methods calling it used list of job IDs. This resulted in exceptions like this one

```python
>>> dirac.deleteJob(577500249)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v10.4.6-x86_64-1641914322/lib/python3.9/site-packages/DIRAC/Interfaces/API/Dirac.py", line 1678, in deleteJob
    res = JobStatus.checkJobStateTransition(jobID, JobStatus.DELETED)
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v10.4.6-x86_64-1641914322/lib/python3.9/site-packages/DIRAC/WorkloadManagementSystem/Client/JobStatus.py", line 114, in checkJobStateTransition
    currentStatus = res["Value"][jobID]["Status"]
TypeError: unhashable type: 'list'
```
A nicer fix could maybe be to accept directly list of job IDs in `checkJobStateTransition`, however I am wondering whether this check really should be on the client side ? 

BEGINRELEASENOTES

*Interface
FIX: send only single jobID to checkJobStateTransition

ENDRELEASENOTES
