### PR TITLE
[8.0] TransformationDB: removing BLOB in favor of TEXT for non-binary data

### DIFF
--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.sql
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.sql
@@ -25,7 +25,7 @@ CREATE TABLE Transformations(
     TransformationID INTEGER NOT NULL AUTO_INCREMENT,
     TransformationName VARCHAR(255) NOT NULL,
     Description VARCHAR(255),
-    LongDescription BLOB,
+    LongDescription TEXT,
     CreationDate DATETIME,
     LastUpdate DATETIME,
     AuthorDN VARCHAR(255) NOT NULL,
@@ -39,7 +39,7 @@ CREATE TABLE Transformations(
     TransformationFamily varchar(64) default '0',
     GroupSize FLOAT NOT NULL DEFAULT 1,
     InheritedFrom INTEGER DEFAULT 0,
-    Body LONGBLOB,
+    Body LONGTEXT,
     MaxNumberOfTasks INTEGER NOT NULL DEFAULT 0,
     EventsPerTask INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY(TransformationID),
@@ -63,7 +63,7 @@ DROP TABLE IF EXISTS AdditionalParameters;
 CREATE TABLE AdditionalParameters(
     TransformationID INTEGER NOT NULL,
     ParameterName VARCHAR(32) NOT NULL,
-    ParameterValue LONGBLOB NOT NULL,
+    ParameterValue LONGTEXT NOT NULL,
     ParameterType VARCHAR(32) DEFAULT 'StringType',
     PRIMARY KEY(TransformationID, ParameterName),
     FOREIGN KEY(TransformationID) REFERENCES Transformations(TransformationID)
@@ -151,7 +151,7 @@ DROP TABLE IF EXISTS TransformationMetaQueries;
 CREATE TABLE TransformationMetaQueries(
     TransformationID INTEGER NOT NULL,
     MetaDataName VARCHAR(255) NOT NULL,
-    MetaDataValue BLOB NOT NULL,
+    MetaDataValue TEXT NOT NULL,
     MetaDataType VARCHAR(8) NOT NULL,
     QueryType ENUM('Input', 'Output') DEFAULT 'Input',
     PRIMARY KEY(TransformationID, MetaDataName, QueryType),


### PR DESCRIPTION
This of course requires a manual intervention, that can be done at any time (not really depending from this release). On LHCb clone of TransformationDB it took rather long:

```
MySQL [TransformationDB]> ALTER TABLE `TransformationMetaQueries` MODIFY COLUMN `MetaDataValue` TEXT;
Query OK, 0 rows affected (0.11 sec)
Records: 0  Duplicates: 0  Warnings: 0

MySQL [TransformationDB]> ALTER TABLE `AdditionalParameters` MODIFY COLUMN `ParameterValue` LONGTEXT;
Query OK, 2353784 rows affected (3 min 39.64 sec)
Records: 2353784  Duplicates: 0  Warnings: 0

MySQL [TransformationDB]> ALTER TABLE `Transformations` MODIFY COLUMN `Body` LONGTEXT;
Query OK, 145680 rows affected (27 min 9.51 sec)
Records: 145680  Duplicates: 0  Warnings: 0

MySQL [TransformationDB]> 
MySQL [TransformationDB]> ALTER TABLE `Transformations` MODIFY COLUMN `LongDescription` TEXT;

Query OK, 145680 rows affected (23 min 21.02 sec)
Records: 145680  Duplicates: 0  Warnings: 0
```
 (I will add the above to the wiki).

It can anyway be tested in the meanwhile in the coming DIRAC hackathon.

BEGINRELEASENOTES

*TransformationSystem
CHANGE: TransformationDB: removing BLOB in favor of TEXT for non-binary data

ENDRELEASENOTES
