### PR TITLE
[v7r3] VOMS2CS: update correctly CAs for users with multiple DNs

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -338,7 +338,7 @@ class VOMS2CSSynchronizer(object):
             knownEmail = getUserOption(diracName, "Email", None)
             userDict = {
                 "DN": diracUserDict[diracName]["DN"],
-                "CA": self.vomsUserDict[dn]["CA"],
+                "CA": diracUserDict[diracName]["CA"],
                 "Email": self.vomsUserDict[dn].get("mail", self.vomsUserDict[dn].get("emailAddress")) or knownEmail,
             }
 
@@ -361,6 +361,9 @@ class VOMS2CSSynchronizer(object):
 
             if newDNForExistingUser:
                 userDict["DN"] = ",".join([dn, diracUserDict.get(diracName, newAddedUserDict.get(diracName))["DN"]])
+                userDict["CA"] = ",".join(
+                    [self.vomsUserDict[dn]["CA"], diracUserDict.get(diracName, newAddedUserDict.get(diracName))["CA"]]
+                )
                 modified = True
             existingGroups = diracUserDict.get(diracName, {}).get("Groups", [])
             nonVOGroups = list(set(existingGroups) - set(diracVOMSMapping))


### PR DESCRIPTION
We had the problem that when a user  has 2 DNs from 2 CAs, the `VOMS2CS` agent will correctly set 2 DNs in the `Users` registry, but the `CA` would be oscillating at each run.
This PR makes sure that the 2 CAs are added.
Caution: an incorrect CS will not be modified, i.e. if you have that case, you have to fix it by hand. The easier is to keep in the CS only one DN with the correct CA, and run the agent. The new DN and new CA will be correctly added  

BEGINRELEASENOTES
*Configuration
FIX: VOMS2CSAgent correctly takes into account multiple CAs for users with multiple DNs

ENDRELEASENOTES
