### PR TITLE
[v7r3] Better estimate of last sign of life of jobs in web Job Monitor

### DIFF
--- a/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
+++ b/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
@@ -390,13 +390,16 @@ class ReqClient(Client):
                     return S_ERROR("Unexpected jobMinorStatus")
 
             if newJobStatus:
-                self.log.info("finalizeRequest: Updating job status for %d to %s/Requests done" % (jobID, newJobStatus))
+                self.log.info(
+                    "finalizeRequest: Updating job status",
+                    "for %d to '%s/%s'" % (jobID, newJobStatus, JobMinorStatus.REQUESTS_DONE),
+                )
             else:
                 self.log.info(
                     "finalizeRequest: Updating job minor status",
-                    "for %d to 'Requests done' (current status is %s)" % (jobID, jobStatus),
+                    "for %d to '%s' (current status is %s)" % (jobID, JobMinorStatus.REQUESTS_DONE, jobStatus),
                 )
-            stateUpdate = stateServer.setJobStatus(jobID, newJobStatus, "Requests done", "RMS")
+            stateUpdate = stateServer.setJobStatus(jobID, newJobStatus, JobMinorStatus.REQUESTS_DONE, "RMS")
             if jobAppStatus and stateUpdate["OK"]:
                 stateUpdate = stateServer.setJobApplicationStatus(jobID, jobAppStatus, "RMS")
             if not stateUpdate["OK"]:

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobMinorStatus.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobMinorStatus.py
@@ -38,6 +38,8 @@ PILOT_AGENT_SUBMISSION = "Pilot Agent Submission"
 #
 PENDING_REQUESTS = "Pending Requests"
 #
+REQUESTS_DONE = "Requests done"
+#
 JOB_EXCEEDED_CPU = "Job has reached the CPU limit of the queue"
 #
 JOB_EXCEEDED_WALL_CLOCK = "Job has exceeded maximum wall clock time"

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -1949,14 +1949,15 @@ class JobDB(DB):
             return ret
         e_jobID = ret["Value"]
 
-        # If there is no data to set, just update the time stamp as it is not a real heart beat...
-        if dynamicDataDict:
+        # If HeartBeatTime is being set, set it...
+        timeStamp = dynamicDataDict.pop("HeartBeatTime", None)
+        if timeStamp:
+            req = "UPDATE Jobs SET HeartBeatTime=%s WHERE JobID=%s" % (timeStamp, e_jobID)
+        else:
             req = "UPDATE Jobs SET HeartBeatTime=UTC_TIMESTAMP(), Status='%s' WHERE JobID=%s" % (
                 JobStatus.RUNNING,
                 e_jobID,
             )
-        else:
-            req = "UPDATE Jobs SET HeartBeatTime=UTC_TIMESTAMP() WHERE JobID=%s" % e_jobID
 
         result = self._update(req)
         if not result["OK"]:

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -1949,14 +1949,21 @@ class JobDB(DB):
             return ret
         e_jobID = ret["Value"]
 
-        req = "UPDATE Jobs SET HeartBeatTime=UTC_TIMESTAMP(), Status='%s' WHERE JobID=%s" % (JobStatus.RUNNING, e_jobID)
+        # If there is no data to set, just update the time stamp as it is not a real heart beat...
+        if dynamicDataDict:
+            req = "UPDATE Jobs SET HeartBeatTime=UTC_TIMESTAMP(), Status='%s' WHERE JobID=%s" % (
+                JobStatus.RUNNING,
+                e_jobID,
+            )
+        else:
+            req = "UPDATE Jobs SET HeartBeatTime=UTC_TIMESTAMP() WHERE JobID=%s" % e_jobID
+
         result = self._update(req)
         if not result["OK"]:
             return S_ERROR("Failed to set the heart beat time: " + result["Message"])
 
         ok = True
         # Add dynamic data to the job heart beat log
-        # start = time.time()
         valueList = []
         for key, value in dynamicDataDict.items():
             result = self._escapeString(key)
@@ -1979,11 +1986,9 @@ class JobDB(DB):
             result = self._update(req)
             if not result["OK"]:
                 ok = False
-                self.log.warn(result["Message"])
+                self.log.warn("Error storing heart beat data", result["Message"])
 
-        if ok:
-            return S_OK()
-        return S_ERROR("Failed to store some or all the parameters")
+        return S_OK() if ok else S_ERROR("Failed to store some or all the parameters")
 
     #####################################################################################
     def getHeartBeatData(self, jobID):

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -271,6 +271,7 @@ class JobStateUpdateHandlerMixin(object):
                 return result
 
         # Update the JobLoggingDB records
+        heartBeatTime = None
         for updTime in updateTimes:
             sDict = statusDict[updTime]
             status = sDict.get("Status", "idem")
@@ -282,11 +283,13 @@ class JobStateUpdateHandlerMixin(object):
             )
             if not result["OK"]:
                 return result
-            # If the update comes from a job, update the heart beat time stamp
+            # If the update comes from a job, update the heart beat time stamp with this item's stamp
             if source.startswith("Job"):
-                result = cls.jobDB.setHeartBeatData(jobID, {})
-                if not result["OK"]:
-                    return result
+                heartBeatTime = updTime
+        if heartBeatTime is not None:
+            result = cls.jobDB.setHeartBeatData(jobID, {"HeartBeatTime": heartBeatTime})
+            if not result["OK"]:
+                return result
 
         return S_OK((attrNames, attrValues))
 

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -282,7 +282,7 @@ class JobStateUpdateHandlerMixin(object):
             )
             if not result["OK"]:
                 return result
-            # If the update comes form the job, update the heart beat time stamp
+            # If the update comes from a job, update the heart beat time stamp
             if source.startswith("Job"):
                 result = cls.jobDB.setHeartBeatData(jobID, {})
                 if not result["OK"]:

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -282,6 +282,11 @@ class JobStateUpdateHandlerMixin(object):
             )
             if not result["OK"]:
                 return result
+            # If the update comes form the job, update the heart beat time stamp
+            if source.startswith("Job"):
+                result = cls.jobDB.setHeartBeatData(jobID, {})
+                if not result["OK"]:
+                    return result
 
         return S_OK((attrNames, attrValues))
 


### PR DESCRIPTION
In order to better reflect the last sign of life of a job in the web Job Monitor page, we changed the following: the HeartBeatTime is set every time a status is changed by the job itself (i.e. from JobAgent, Job watch dog or JobWrapper), and the `LastSignOfLife` is using the `HeartBeatTime` if it is set.

BEGINRELEASENOTES

*WMS
CHANGE: HeartBeatTime is set every time a status is changed by the job itself

ENDRELEASENOTES

In passing add a minor status in `JobMinorStatus.py` to avoid strings in the code
