### PR TITLE
[v7r3] FileCatalogCLI: removed undefined command option

### DIFF
--- a/src/DIRAC/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/src/DIRAC/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -2238,14 +2238,13 @@ class FileCatalogClientCLI(CLI):
             records.append((key, str(value)))
         printTable(fields, records)
 
-    def do_rebuild(self, args):
-        """Rebuild auxiliary tables
+    def do_rebuild(self, _args):
+        """Rebuild auxiliary tables keeping the directory usage data
 
         Usage:
-           rebuild <option>
+           rebuild
         """
 
-        _argss = args.split()
         start = time.time()
         result = self.fc.rebuildDirectoryUsage(timeout=300)
         if not result["OK"]:

--- a/src/DIRAC/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/src/DIRAC/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -2245,8 +2245,7 @@ class FileCatalogClientCLI(CLI):
            rebuild <option>
         """
 
-        argss = args.split()
-        _option = argss[0]
+        _argss = args.split()
         start = time.time()
         result = self.fc.rebuildDirectoryUsage(timeout=300)
         if not result["OK"]:


### PR DESCRIPTION

BEGINRELEASENOTES

*DataManagement
FIX: FileCatalogCLI - removed faulty evaluation of undefined option to the rebuild command. Fixes #5759

ENDRELEASENOTES
