### PR TITLE
[integration] Fixing bug in nomenclature for PilotSubmissionMonitoring

### DIFF
--- a/src/DIRAC/MonitoringSystem/private/Plotters/PilotSubmissionMonitoringPlotter.py
+++ b/src/DIRAC/MonitoringSystem/private/Plotters/PilotSubmissionMonitoringPlotter.py
@@ -8,10 +8,10 @@ from DIRAC.MonitoringSystem.Client.Types.PilotSubmissionMonitoring import PilotS
 from DIRAC.MonitoringSystem.private.Plotters.BasePlotter import BasePlotter
 
 
-class PilotSubmissionPlotter(BasePlotter):
+class PilotSubmissionMonitoringPlotter(BasePlotter):
 
     """
-    .. class:: PilotSubMonitoringPlotter
+    .. class:: PilotSubmissionMonitoringPlotter
 
     It is used to crate the plots.
 


### PR DESCRIPTION
Monitoring of pilot submission was not working on the web app because the nomenclature was wrong. Changed the name to the right one.

BEGINRELEASENOTES

FIX: Changed the nomenclature for PilotSubmissionMonitoring

ENDRELEASENOTES