### PR TITLE
[8.0] common oauth 2, python 3 fixes

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/TornadoREST.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoREST.py
@@ -342,12 +342,9 @@ class TornadoREST(BaseRequestHandler):  # pylint: disable=abstract-method
         keywordArguments = {}
         positionalArguments = []
 
-        for i, a in enumerate(args):
-            if a:
-                if _type := self.methodObj.positional_arg_types[i]:
-                    positionalArguments.append(_type(unquote(a)))
-                else:
-                    positionalArguments.append(unquote(a))
+        for i, _type in enumerate(self.methodObj.positional_arg_types[: len(args)]):
+            if arg := args[i]:
+                positionalArguments.append(_type(unquote(arg)) if _type else unquote(arg))
 
         if self.request.headers.get("Content-Type") == "application/json":
             decoded = json_decode(body) if (body := self.request.body) else []

--- a/src/DIRAC/Core/scripts/dirac_info.py
+++ b/src/DIRAC/Core/scripts/dirac_info.py
@@ -68,7 +68,7 @@ def main():
             ),
         )
     )
-    records.append(("ConfigurationServer", gConfig.getValue("/DIRAC/Configuration/Servers", [])))
+    records.append(("ConfigurationServer", gConfig.getValue("/DIRAC/Configuration/Servers", "None found")))
     records.append(("Installation path", DIRAC.rootPath))
 
     if os.path.exists(os.path.join(DIRAC.rootPath, DIRAC.getPlatform(), "bin", "mysql")):

--- a/src/DIRAC/FrameworkSystem/API/AuthHandler.py
+++ b/src/DIRAC/FrameworkSystem/API/AuthHandler.py
@@ -40,8 +40,8 @@ class AuthHandler(TornadoREST):
         """Called at every request"""
         self.currentPath = self.request.protocol + "://" + self.request.host + self.request.path
 
-    @location(".well-known/(oauth-authorization-server|openid-configuration)")
-    def get_index(self, **kwargs):
+    @location(".well-known/(?:oauth-authorization-server|openid-configuration)")
+    def get_index(self):
         """Well known endpoint, specified by
         `RFC8414 <https://tools.ietf.org/html/rfc8414#section-3>`_
 
@@ -88,7 +88,7 @@ class AuthHandler(TornadoREST):
             resDict.pop("Clients", None)
             return resDict
 
-    def get_jwk(self, **kwargs):
+    def get_jwk(self):
         """JWKs endpoint
 
         Request example::
@@ -113,7 +113,7 @@ class AuthHandler(TornadoREST):
         result = self.server.db.getKeySet()
         return result["Value"].as_dict() if result["OK"] else {}
 
-    def post_revoke(self, **kwargs):
+    def post_revoke(self):
         """Revocation endpoint
 
         Request example::
@@ -128,7 +128,7 @@ class AuthHandler(TornadoREST):
         self.log.verbose("Initialize a Device authentication flow.")
         return self.server.create_endpoint_response(RevocationEndpoint.ENDPOINT_NAME, self.request)
 
-    def get_userinfo(self, **kwargs):
+    def get_userinfo(self):
         """The UserInfo endpoint can be used to retrieve identity information about a user,
         see `spec <https://openid.net/specs/openid-connect-core-1_0.html#UserInfo>`_
 
@@ -164,7 +164,7 @@ class AuthHandler(TornadoREST):
         """
         return self.getRemoteCredentials()
 
-    def post_device(self, provider=None, user_code=None, client_id=None, **kwargs):
+    def post_device(self, provider=None, user_code=None, client_id=None):
         """The device authorization endpoint can be used to request device and user codes.
         This endpoint is used to start the device flow authorization process and user code verification.
 
@@ -217,7 +217,7 @@ class AuthHandler(TornadoREST):
         self.log.verbose("Initialize a Device authentication flow.")
         return self.server.create_endpoint_response(DeviceAuthorizationEndpoint.ENDPOINT_NAME, self.request)
 
-    def get_device(self, provider=None, user_code=None, client_id=None, **kwargs):
+    def get_device(self, provider=None, user_code=None, client_id=None):
         """The device authorization endpoint can be used to request device and user codes.
         This endpoint is used to start the device flow authorization process and user code verification.
 
@@ -305,7 +305,7 @@ class AuthHandler(TornadoREST):
         """
         return self.server.validate_consent_request(self.request, provider)
 
-    def get_redirect(self, state, error=None, error_description="", chooseScope=[], **kwargs):
+    def get_redirect(self, state, error=None, error_description="", chooseScope=[]):
         """Redirect endpoint.
         After a user successfully authorizes an application, the authorization server will redirect
         the user back to the application with either an authorization code or access token in the URL.
@@ -386,7 +386,7 @@ class AuthHandler(TornadoREST):
             resp.payload = getHTML("authorization response", state=resp.status_code, body=resp.payload)
         return resp
 
-    def post_token(self, **kwargs):
+    def post_token(self):
         """The token endpoint, the description of the parameters will differ depending on the selected grant_type
 
         POST LOCATION/token
@@ -441,7 +441,7 @@ class AuthHandler(TornadoREST):
         result = getGroupsForUser(username)
         if not result["OK"]:
             return None, self.server.handle_response(
-                getHTML("server error", theme="error", info=result["Message"]), delSession=True
+                payload=getHTML("server error", theme="error", info=result["Message"]), delSession=True
             )
         groups = result["Value"]
 
@@ -450,10 +450,10 @@ class AuthHandler(TornadoREST):
         ]
         if not validGroups:
             return None, self.server.handle_response(
-                getHTML(
+                payload=getHTML(
                     "groups not found.",
                     theme="error",
-                    info="No groups found for %s and for %s Identity Provider." % (username, provider),
+                    info=f"No groups found for {username} and for {provider} Identity Provider.",
                 ),
                 delSession=True,
             )

--- a/src/DIRAC/FrameworkSystem/private/authorization/AuthServer.py
+++ b/src/DIRAC/FrameworkSystem/private/authorization/AuthServer.py
@@ -295,7 +295,7 @@ class AuthServer(_AuthorizationServer):
         # Is ID registred?
         result = getUsernameForDN(credDict["DN"])
         if not result["OK"]:
-            comment = "ID %s is not registred in DIRAC." % credDict["ID"]
+            comment = f"ID {credDict['ID']} is not registred in DIRAC. "
             payload.update(idpObj.getUserProfile().get("Value", {}))
             result = self.__registerNewUser(providerName, payload)
 
@@ -345,7 +345,7 @@ class AuthServer(_AuthorizationServer):
         """
         sLog.debug(
             f"Handle authorization response with {status_code} status code:",
-            "HTML page" if payload.startswith("<!DOCTYPE html>") else payload,
+            "HTML page" if isinstance(payload, str) and payload.startswith("<!DOCTYPE html>") else payload,
         )
         resp = TornadoResponse(payload, status_code)
         if headers:
@@ -400,9 +400,9 @@ class AuthServer(_AuthorizationServer):
             if isinstance(req, six.string_types):
                 return req
 
-            sLog.info("Validate consent request for", req.state)
+            sLog.info("Validate consent request for ", req.state)
             grant = self.get_authorization_grant(req)
-            sLog.debug("Use grant:", grant)
+            sLog.debug("Use grant:", grant.GRANT_TYPE)
             grant.validate_consent_request()
             if not hasattr(grant, "prompt"):
                 grant.prompt = None

--- a/src/DIRAC/FrameworkSystem/private/authorization/utils/Clients.py
+++ b/src/DIRAC/FrameworkSystem/private/authorization/utils/Clients.py
@@ -1,9 +1,11 @@
 import six
 import time
 
-from DIRAC import gLogger
 from authlib.oauth2.rfc6749.util import scope_to_list, list_to_scope
 from authlib.integrations.sqla_oauth2 import OAuth2ClientMixin
+
+from DIRAC import gLogger
+from DIRAC.Core.Security import Locations
 from DIRAC.ConfigurationSystem.Client.Utilities import getAuthorizationServerMetadata
 
 
@@ -16,8 +18,8 @@ DEFAULT_CLIENTS = {
         response_types=["device"],
         grant_types=["urn:ietf:params:oauth:grant-type:device_code", "refresh_token"],
         token_endpoint_auth_method="none",
-        verify=False,
         ProviderType="OAuth2",
+        verify=Locations.getCAsLocation(),
     ),
     # These settings are for the web server
     "DIRACWeb": dict(
@@ -26,6 +28,7 @@ DEFAULT_CLIENTS = {
         response_types=["code"],
         grant_types=["authorization_code", "refresh_token"],
         ProviderType="OAuth2",
+        verify=Locations.getCAsLocation(),
     ),
 }
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
@@ -41,6 +41,10 @@ from DIRAC.FrameworkSystem.private.authorization.utils.Tokens import (
 class Params:
     """This class describes the input parameters"""
 
+    # A copy of the state of the environment variables will help
+    # at the end of the script when creating a message to the user
+    ENV = os.environ.copy()
+
     def __init__(self):
         """C`r"""
         self.group = None
@@ -251,12 +255,6 @@ class Params:
                     DIRAC.exit(1)
                 DIRAC.gConfig.setOptionValue("/DIRAC/Security/Authorization/issuer", self.issuer)
 
-            # Try to get user authorization information from token
-            result = readTokenFromFile(self.outputFile)
-            if not result["OK"]:
-                return result
-            gLogger.notice(result["Value"].getInfoAsString())
-
         return S_OK()
 
     def loginWithCertificate(self):
@@ -313,8 +311,8 @@ class Params:
 
     def howToSwitch(self) -> bool:
         """Helper message, how to switch access type(proxy or access token)"""
-        if "DIRAC_USE_ACCESS_TOKEN" in os.environ:
-            src, useTokens = ("env", os.environ.get("DIRAC_USE_ACCESS_TOKEN", "false").lower() in ("y", "yes", "true"))
+        if "DIRAC_USE_ACCESS_TOKEN" in self.ENV:
+            src, useTokens = ("env", self.ENV.get("DIRAC_USE_ACCESS_TOKEN", "false").lower() in ("y", "yes", "true"))
         else:
             src, useTokens = (
                 "conf",

--- a/src/DIRAC/Resources/IdProvider/CheckInIdProvider.py
+++ b/src/DIRAC/Resources/IdProvider/CheckInIdProvider.py
@@ -1,17 +1,10 @@
 """ IdProvider based on OAuth2 protocol
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from authlib.oauth2.rfc6749.util import scope_to_list
 
 from DIRAC import S_OK
 from DIRAC.Resources.IdProvider.OAuth2IdProvider import OAuth2IdProvider
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup, getGroupOption
-
-
-__RCSID__ = "$Id$"
 
 
 class CheckInIdProvider(OAuth2IdProvider):

--- a/src/DIRAC/Resources/IdProvider/IAMIdProvider.py
+++ b/src/DIRAC/Resources/IdProvider/IAMIdProvider.py
@@ -1,16 +1,10 @@
 """ IdProvider based on OAuth2 protocol
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from authlib.oauth2.rfc6749.util import scope_to_list
 
 from DIRAC import S_OK
 from DIRAC.Resources.IdProvider.OAuth2IdProvider import OAuth2IdProvider
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup, getGroupOption
-
-__RCSID__ = "$Id$"
 
 
 class IAMIdProvider(OAuth2IdProvider):

--- a/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
+++ b/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
@@ -1,11 +1,6 @@
 """ IdProvider based on OAuth2 protocol
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import re
-import six
 import time
 import pprint
 import requests
@@ -32,8 +27,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import (
 )
 from DIRAC.FrameworkSystem.private.authorization.utils.Tokens import OAuth2Token
 
-__RCSID__ = "$Id$"
-
 DEFAULT_HEADERS = {"Accept": "application/json", "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"}
 
 gJWKs = ThreadSafe.Synchronizer()
@@ -59,7 +52,7 @@ def claimParser(claimDict, attributes):
             result = claimParser(claimDict[claim], reg)
             if result:
                 profile[claim] = result
-        elif isinstance(claimDict[claim], six.string_types):
+        elif isinstance(claimDict[claim], str):
             result = re.compile(reg).match(claimDict[claim])
             if result:
                 for k, v in result.groupdict().items():
@@ -93,7 +86,7 @@ class OAuth2IdProvider(IdProvider, OAuth2Session):
         self.issuer = self.metadata["issuer"]
         self.scope = self.scope or ""
         self.jwks = kwargs.get("jwks")
-        self.verify = kwargs.get("verify", False)
+        self.verify = kwargs.get("verify", True)  # Decide if need to check CAs
         self.token_placement = kwargs.get("token_placement", "header")
         self.code_challenge_method = "S256"
         # self.token_endpoint_auth_method = kwargs.get('token_endpoint_auth_method') #, 'client_secret_post')


### PR DESCRIPTION
This PR contains some fixes related to python 3 and some bug fixes found during the last OAuth 2 tests.

BEGINRELEASENOTES

*Core
FIX: TorandoREST ignore arguments that not defined in the target method
FIX: dirac-info show "None found" instead of exception

*Framework
FIX: use payload keyword argument for handle_response method
CHANGE: use DIRAC CAs location to request DIRAC AS
FIX: fix message in dirac-login after authorization

*Resources
CHANGE: verify CAs when request IdP by default

ENDRELEASENOTES
