### PR TITLE
[v7r2] return standard result in PublisherHandler.getSite

### DIFF
--- a/src/DIRAC/ResourceStatusSystem/Service/PublisherHandler.py
+++ b/src/DIRAC/ResourceStatusSystem/Service/PublisherHandler.py
@@ -183,9 +183,10 @@ class PublisherHandler(RequestHandler):
         finds its parent site and returns all descendants of that site.
         """
 
-        site = self.getSite(elementType, elementName)
-        if not site:
-            return S_ERROR("No site")
+        result = self.getSite(elementType, elementName)
+        if not result["OK"]:
+            return result
+        site = result["Value"]
 
         siteStatus = self.rsClient.selectStatusElement(
             "Site", "Status", name=site, meta={"columns": ["StatusType", "Status"]}
@@ -284,10 +285,10 @@ class PublisherHandler(RequestHandler):
         if elementType == "StorageElement":
             elementType = "SE"
 
-        domainNames = gConfig.getSections("Resources/Sites")
-        if not domainNames["OK"]:
-            return domainNames
-        domainNames = domainNames["Value"]
+        result = gConfig.getSections("Resources/Sites")
+        if not result["OK"]:
+            return result
+        domainNames = result["Value"]
 
         for domainName in domainNames:
 
@@ -299,9 +300,9 @@ class PublisherHandler(RequestHandler):
 
                 elements = gConfig.getValue("Resources/Sites/%s/%s/%s" % (domainName, site, elementType), "")
                 if elementName in elements:
-                    return site
+                    return S_OK(site)
 
-        return ""
+        return S_ERROR("No site")
 
     # ResourceManagementClient ...................................................
 


### PR DESCRIPTION
Essence:
`getSite` can return `S_ERROR` result or just a `str`. `S_ERROR` result can be passed to `selectStatusElement` and I think its not very good.

```python
        site = self.getSite(elementType, elementName)
        if not site:
            return S_ERROR("No site")

        siteStatus = self.rsClient.selectStatusElement(
            "Site", "Status", name=site, ...
```

Fix:
Force `getSite` to return `S_OK`/`S_ERROR`

BEGINRELEASENOTES

*ResourceStatus
FIX: return S_OK/S_ERROR in PublisherHandler.getSite

ENDRELEASENOTES
