### PR TITLE
[integration] remove unused 'rfc' argument

### DIFF
--- a/src/DIRAC/Core/Security/test/Test_X509Chain.py
+++ b/src/DIRAC/Core/Security/test/Test_X509Chain.py
@@ -103,7 +103,7 @@ def get_proxy(request):
         x509Chain.loadKeyFromFile(getCertOption(certFile, "keyFile"))
 
         # Generate the proxy string
-        res = x509Chain.generateProxyToString(lifetime, rfc=True, **kwargs)
+        res = x509Chain.generateProxyToString(lifetime, **kwargs)
 
         proxyString = res["Value"]
         # Load the proxy string as an X509Chain object
@@ -486,7 +486,7 @@ def test_tooLong_proxyLifetime(get_proxy, lifetime):
     assert notAfterDate == expectedEndDate
 
 
-# def generateProxyToString(self, lifeTime, diracGroup=False, strength=1024, limited=False, proxyKey=False, rfc = True):
+# def generateProxyToString(self, lifeTime, diracGroup=False, strength=1024, limited=False, proxyKey=False):
 
 # hypthesis successfully prove that m2crypto implementation does not work
 # for an empty group name, or 0, or whatever can be evaluated to False . Fine...
@@ -536,8 +536,7 @@ def test_getIssuerCert(get_proxy):
 #
 # retVal = chain.generateChainFromRequestString(reqDict['request'],
 #                                               lifetime=chainLifeTime,
-#                                               diracGroup=diracGroup,
-#                                               rfc = rfcIfPossible)
+#                                               diracGroup=diracGroup)
 @mark.slow
 @settings(max_examples=200, suppress_health_check=function_scoped)
 @given(diracGroup=text(ascii_letters + "-", min_size=1), lifetime=integers(min_value=1, max_value=TWENTY_YEARS_IN_SEC))

--- a/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
@@ -25,7 +25,6 @@ class CLIParams:
     userPasswd = ""
     checkClock = True
     embedDefaultGroup = True
-    rfc = True
 
     def setProxyLifeTime(self, arg):
         """Set proxy lifetime
@@ -40,26 +39,6 @@ class CLIParams:
         except Exception:
             gLogger.error("Can't parse time! Is it a HH:MM?", arg)
             return S_ERROR("Can't parse time argument")
-        return S_OK()
-
-    def setRFC(self, _arg):
-        """Set RFC
-
-        :param _arg: unuse
-
-        :return: S_OK()
-        """
-        self.rfc = True
-        return S_OK()
-
-    def setNoRFC(self, _arg):
-        """Unset RFC
-
-        :param _arg: unuse
-
-        :return: S_OK()
-        """
-        self.rfc = False
         return S_OK()
 
     def setProxyRemainingSecs(self, arg):
@@ -224,8 +203,6 @@ class CLIParams:
         Script.registerSwitch("x", "nocs", "Disable CS check", self.setDisableCSCheck)
         Script.registerSwitch("p", "pwstdin", "Get passwd from stdin", self.setStdinPasswd)
         Script.registerSwitch("j", "noclockcheck", "Disable checking if time is ok", self.disableClockCheck)
-        Script.registerSwitch("r", "rfc", "Create an RFC proxy, true by default, deprecated flag", self.setRFC)
-        Script.registerSwitch("L", "legacy", "Create a legacy non-RFC proxy", self.setNoRFC)
 
 
 from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-error
@@ -309,7 +286,7 @@ def generateProxy(params):
 
     if params.checkWithCS:
         retVal = chain.generateProxyToFile(
-            proxyLoc, params.proxyLifeTime, strength=params.proxyStrength, limited=params.limitedProxy, rfc=params.rfc
+            proxyLoc, params.proxyLifeTime, strength=params.proxyStrength, limited=params.limitedProxy
         )
 
         gLogger.info("Contacting CS...")
@@ -366,7 +343,6 @@ def generateProxy(params):
         params.diracGroup,
         strength=params.proxyStrength,
         limited=params.limitedProxy,
-        rfc=params.rfc,
     )
     if not retVal["OK"]:
         gLogger.warn(retVal["Message"])

--- a/src/DIRAC/FrameworkSystem/Client/ProxyUpload.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyUpload.py
@@ -1,8 +1,3 @@
-########################################################################
-# File :    dirac-proxy-init.py
-# Author :  Adrian Casajus
-########################################################################
-
 import sys
 from prompt_toolkit import prompt
 import DIRAC
@@ -19,7 +14,6 @@ class CLIParams:
     proxyLoc = False
     onTheFly = False
     stdinPasswd = False
-    rfcIfPossible = False
     userPasswd = ""
 
     def __str__(self):
@@ -122,7 +116,7 @@ def uploadProxy(params):
                 userPasswd = sys.stdin.readline().strip("\n")
             else:
                 try:
-                    userPasswd = prompt(u"Enter Certificate password: ", is_password=True)
+                    userPasswd = prompt("Enter Certificate password: ", is_password=True)
                 except KeyboardInterrupt:
                     return S_ERROR("Caught KeyboardInterrupt, exiting...")
             params.userPasswd = userPasswd
@@ -149,4 +143,4 @@ def uploadProxy(params):
         restrictLifeTime = 0
 
     DIRAC.gLogger.info(" Uploading...")
-    return gProxyManager.uploadProxy(proxy=chain, restrictLifeTime=restrictLifeTime, rfcIfPossible=params.rfcIfPossible)
+    return gProxyManager.uploadProxy(proxy=chain, restrictLifeTime=restrictLifeTime)

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
@@ -1,19 +1,11 @@
 #!/usr/bin/env python
-########################################################################
-# File :    dirac-proxy-init.py
-# Author :  Adrian Casajus
-########################################################################
 """
 Creating a proxy.
 
 Example:
-  $ dirac-proxy-init -g dirac_user -t --rfc
-  Enter Certificate password:
+  $ dirac-proxy-init -g dirac_user
+  Enter Certificate password: **************
 """
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import sys
 import glob
@@ -29,8 +21,6 @@ from DIRAC.Core.Security import X509Chain, ProxyInfo, VOMS
 from DIRAC.Core.Security.Locations import getCAsLocation
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClient
-
-__RCSID__ = "$Id$"
 
 
 class Params(ProxyGeneration.CLIParams):
@@ -55,7 +45,7 @@ class Params(ProxyGeneration.CLIParams):
         Script.registerSwitch("M", "VOMS", "Add voms extension", self.setVOMSExt)
 
 
-class ProxyInit(object):
+class ProxyInit:
     def __init__(self, piParams):
         self.__piParams = piParams
         self.__issuerCert = False
@@ -153,7 +143,6 @@ class ProxyInit(object):
         upParams = ProxyUpload.CLIParams()
         upParams.onTheFly = True
         upParams.proxyLifeTime = issuerCert.getRemainingSecs()["Value"] - 300  # pylint: disable=no-member
-        upParams.rfcIfPossible = self.__piParams.rfc
         for k in ("certLoc", "keyLoc", "userPasswd"):
             setattr(upParams, k, getattr(self.__piParams, k))
         resultProxyUpload = ProxyUpload.uploadProxy(upParams)

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -607,7 +607,7 @@ diracCredentials() {
   echo '==> [diracCredentials]'
 
   sed -i 's/commitNewData = CSAdministrator/commitNewData = authenticated/g' "${SERVERINSTALLDIR}/etc/Configuration_Server.cfg"
-  if ! dirac-proxy-init -g dirac_admin -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" --rfc; then
+  if ! dirac-proxy-init -g dirac_admin -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}"; then
     echo 'ERROR: dirac-proxy-init failed' >&2
     exit 1
   fi
@@ -685,12 +685,12 @@ diracUserAndGroup() {
 diracProxies() {
   echo '==> [diracProxies]'
   # User proxy, should be uploaded anyway
-  if ! dirac-proxy-init -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" --rfc "${DEBUG}"; then
+  if ! dirac-proxy-init -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}"; then
     echo 'ERROR: dirac-proxy-init failed' >&2
     exit 1
   fi
   # group proxy, will be uploaded explicitly
-  if ! dirac-proxy-init -g prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" --rfc "${DEBUG}"; then
+  if ! dirac-proxy-init -g prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}"; then
     echo 'ERROR: dirac-proxy-init failed' >&2
     exit 1
   fi
@@ -747,7 +747,7 @@ diracServices(){
 
   # group proxy, will be uploaded explicitly
   #  echo '==> getting/uploading proxy for prod'
-  #  dirac-proxy-init -U -g prod -C ${SERVERINSTALLDIR}/user/client.pem -K ${SERVERINSTALLDIR}/user/client.key --rfc "${DEBUG}"
+  #  dirac-proxy-init -U -g prod -C ${SERVERINSTALLDIR}/user/client.pem -K ${SERVERINSTALLDIR}/user/client.key "${DEBUG}"
 
   for serv in $services; do
     echo "==> calling dirac-install-component $serv ${DEBUG}"
@@ -798,7 +798,7 @@ diracUninstallServices(){
 
   # group proxy, will be uploaded explicitly
   #  echo '==> getting/uploading proxy for prod'
-  #  dirac-proxy-init -U -g prod -C ${SERVERINSTALLDIR}/user/client.pem -K ${SERVERINSTALLDIR}/user/client.key --rfc "${DEBUG}"
+  #  dirac-proxy-init -U -g prod -C ${SERVERINSTALLDIR}/user/client.pem -K ${SERVERINSTALLDIR}/user/client.key "${DEBUG}"
 
   # check if errexit mode is set and disabling as the component may not exist
   local save=$-


### PR DESCRIPTION
it seems that the definition of `rfc` parameter does not affect anything anymore, this PR remove it

BEGINRELEASENOTES

*Framework
CHANGE: remove unused 'rfc' argument

ENDRELEASENOTES
