### PR TITLE
[v7r3] Show callstack in service logs before cleaning it

### DIFF
--- a/src/DIRAC/Core/DISET/RequestHandler.py
+++ b/src/DIRAC/Core/DISET/RequestHandler.py
@@ -481,6 +481,8 @@ class RequestHandler(object):
             argsString = "OK"
         else:
             argsString = "ERROR: %s" % retVal["Message"]
+            if "CallStack" in retVal:
+                argsString += "\n" + "".join(retVal["CallStack"])
         gLogger.notice(
             "Returning response",
             "%s (%.2f secs) %s" % (self.srv_getFormattedRemoteCredentials(), elapsedTime, argsString),


### PR DESCRIPTION
Currently when services return `S_ERROR` the callstack gets stripped from the object. This is nice from a security perspective however this information can be useful when debugging.

Instead I propose we include the callstack in the service logs when showing the error's `["Message"]`.

Any thoughts?


BEGINRELEASENOTES

*Core
CHANGE: Show callstack in service logs when returning S_ERROR

ENDRELEASENOTES
