### PR TITLE
[8.0] deprecate DIRACScript

### DIFF
--- a/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
+++ b/docs/source/AdministratorGuide/Tutorials/dmsWithTs.rst
@@ -86,7 +86,7 @@ script that creates a removal transformation:
 
     # set up the DIRAC configuration, parse command line arguments
     from DIRAC import gLogger, S_OK, S_ERROR
-    from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+    from DIRAC.Core.Base.Script import Script
     Script.parseCommandLine()
 
     from DIRAC.TransformationSystem.Client.Transformation import Transformation

--- a/docs/source/AdministratorGuide/Tutorials/installWMS.rst
+++ b/docs/source/AdministratorGuide/Tutorials/installWMS.rst
@@ -153,7 +153,7 @@ Create a Python script to generate and submit a simple job. Copy paste the follo
   #!/bin/env python
   # Magic lines necessary to activate the DIRAC Configuration System
   # to discover all the required services
-  from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+  from DIRAC.Core.Base.Script import Script
   Script.parseCommandLine(ignoreErrors=True)
   from DIRAC.Interfaces.API.Job import Job
   from DIRAC.Interfaces.API.Dirac import Dirac

--- a/docs/source/DeveloperGuide/AddingNewComponents/DevelopingCommands/dirac_my_great_script.py
+++ b/docs/source/DeveloperGuide/AddingNewComponents/DevelopingCommands/dirac_my_great_script.py
@@ -10,7 +10,7 @@ Example:
   We are done with detail report.
 """
 from DIRAC import S_OK, S_ERROR, gLogger, exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 class Params:

--- a/docs/source/DeveloperGuide/AddingNewComponents/DevelopingCommands/dirac_ping_info.py
+++ b/docs/source/DeveloperGuide/AddingNewComponents/DevelopingCommands/dirac_ping_info.py
@@ -6,8 +6,8 @@ Example:
   $ dirac-ping-info MySystem
   Ping MySystem!
 """
-from DIRAC import S_OK, S_ERROR, gLogger, exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC import S_OK, S_ERROR, gLogger
+from DIRAC.Core.Base.Script import Script
 
 
 # Define a simple class to hold the script parameters

--- a/docs/source/DeveloperGuide/AddingNewComponents/DevelopingCommands/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/DevelopingCommands/index.rst
@@ -40,7 +40,7 @@ which will set the interpreter directive to the python on the environment.
 .. code-block:: python
 
    #Import the required DIRAC modules
-   from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+   from DIRAC.Core.Base.Script import Script
    from DIRAC.Interfaces.API.DIRAC import DIRAC
    from DIRAC import gLogger
 

--- a/docs/source/DeveloperGuide/AddingNewComponents/YourFirstDIRACCode/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/YourFirstDIRACCode/index.rst
@@ -61,7 +61,7 @@ Remember to start the script with:
    #!/usr/bin/env python
    """ Some doc: what does this script should do?
    """
-   from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+   from DIRAC.Core.Base.Script import Script
    Script.parseCommandLine()
 
 

--- a/docs/source/DeveloperGuide/Systems/Framework/stableconns/client.py
+++ b/docs/source/DeveloperGuide/Systems/Framework/stableconns/client.py
@@ -1,13 +1,9 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import sys
 import time
-from DIRAC import S_OK, S_ERROR
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC import S_ERROR, initialize
 from DIRAC.Core.DISET.MessageClient import MessageClient
 
-Script.parseCommandLine()
+initialize()
 
 
 def sendPingMsg(msgClient, pingid=0):

--- a/docs/source/DeveloperGuide/Systems/Transformation/bodyplugin.rst
+++ b/docs/source/DeveloperGuide/Systems/Transformation/bodyplugin.rst
@@ -93,10 +93,9 @@ When creating a transformation, just create the BodyPlugin object you want with 
    :caption: createReplicateOrMove.py
    :linenos:
 
-    from DIRAC import gLogger, S_OK, S_ERROR
-    from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+    from DIRAC import gLogger, initialize
 
-    Script.parseCommandLine()
+    initialize()
 
     from DIRAC.TransformationSystem.Client.Transformation import Transformation
     from DIRAC.TransformationSystem.Client.BodyPlugin.ReplicateOrMoveBody import (

--- a/docs/source/DeveloperGuide/Systems/Transformation/transformationplugin.rst
+++ b/docs/source/DeveloperGuide/Systems/Transformation/transformationplugin.rst
@@ -120,9 +120,9 @@ with `setEvenOdd`, and then execute this function to test it.
    :caption: createEvenOdd.py
    :linenos:
 
-    from DIRAC import gLogger, S_OK, S_ERROR
-    from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
-    Script.parseCommandLine()
+    from DIRAC import gLogger, initialize
+
+    initialize()
 
     from DIRAC.TransformationSystem.Client.Transformation import Transformation
 

--- a/docs/source/UserGuide/GettingStarted/UserJobs/DiracAPI/index.rst
+++ b/docs/source/UserGuide/GettingStarted/UserJobs/DiracAPI/index.rst
@@ -30,8 +30,9 @@ The API allows creating DIRAC jobs using the Job object, specifying job requirem
 .. code-block:: python
 
     # setup DIRAC
-    from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
-    Script.parseCommandLine(ignoreErrors=False)
+    from DIRAC import initialize
+
+    initialize()
 
     from DIRAC.Interfaces.API.Job import Job
     from DIRAC.Interfaces.API.Dirac import Dirac
@@ -70,11 +71,11 @@ Once you have submitted your jobs to the Grid, a little script can be used to mo
 .. code-block:: python
 
     # setup DIRAC
-    from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
-    Script.parseCommandLine(ignoreErrors=False)
+    from DIRAC import initialize
+
+    initialize()
 
     from DIRAC.Interfaces.API.Dirac import Dirac
-    from DIRAC.Interfaces.API.Job import Job
     import sys
     dirac = Dirac()
     jobid = sys.argv[1]
@@ -98,11 +99,11 @@ When the status of the job is done, the outputs can be retrieved using also a si
 
     import sys
 
-    from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
-    Script.parseCommandLine(ignoreErrors=False)
+    from DIRAC import initialize
+
+    initialize()
 
     from DIRAC.Interfaces.API.Dirac import Dirac
-    from DIRAC.Interfaces.API.Job import Job
 
     dirac = Dirac()
     jobid = sys.argv[1]

--- a/src/DIRAC/AccountingSystem/Client/ReportCLI.py
+++ b/src/DIRAC/AccountingSystem/Client/ReportCLI.py
@@ -5,7 +5,7 @@ ReportGenerator Service. It is not complete yet
 Once ready it could be used with a script as simple as:
 
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.localCfg.addDefaultEntry("LogLevel", "info")
 Script.parseCommandLine()
@@ -16,14 +16,8 @@ if __name__=="__main__":
     reli = ReportCLI()
     reli.start()
 
-
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import sys
-import datetime
 
 from DIRAC.Core.Base.CLI import CLI, colorize
 from DIRAC.AccountingSystem.Client.ReportsClient import ReportsClient
@@ -73,10 +67,3 @@ class ReportCLI(CLI):
         print("Exception", type, ":", value)
         traceback.print_tb(sys.exc_info()[2])
         print("________________________\n")
-
-    def __getDatetimeFromArg(self, dtString):
-        if len(dtString) != 12:
-            return False
-        dt = datetime.datetime(year=int(dtString[0:4]), month=int(dtString[4:6]), day=int(dtString[6:8]))
-        dt += datetime.timedelta(hours=int(dtString[8:10]), minutes=int(dtString[10:12]))
-        return dt

--- a/src/DIRAC/AccountingSystem/scripts/dirac_accounting_decode_fileid.py
+++ b/src/DIRAC/AccountingSystem/scripts/dirac_accounting_decode_fileid.py
@@ -6,15 +6,12 @@
 """
 Decode Accounting plot URLs
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import sys
 import pprint
 from urllib import parse
 
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/AccountingSystem/scripts/dirac_admin_accounting_cli.py
+++ b/src/DIRAC/AccountingSystem/scripts/dirac_admin_accounting_cli.py
@@ -6,10 +6,7 @@
 """
 Command line administrative interface to DIRAC Accounting DataStore Service
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_resources.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_resources.py
@@ -6,13 +6,10 @@
 """
 Add resources from the BDII database for a given VO
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import signal
 import shlex
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC import gLogger, exit as DIRACExit
 from DIRAC.ConfigurationSystem.Client.Utilities import getGridCEs, getSiteUpdates
 from DIRAC.Core.Utilities.Subprocess import systemCall

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_shifter.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_shifter.py
@@ -6,10 +6,7 @@
 """
 Adds or modify a shifter, in the operations section of the CS
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 from DIRAC import exit as DIRACExit, gLogger
 

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_site.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_site.py
@@ -11,10 +11,7 @@ If site is already in the CS with the right name, only new CEs will be added.
 Example:
   $ dirac-admin-add-site LCG.IN2P3.fr IN2P3-Site ce01.in2p3.fr
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC import exit as DIRACExit, gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getDIRACSiteName
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_check_config_options.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_check_config_options.py
@@ -13,15 +13,12 @@ This script should be run by dirac administrators after major updates.
 Usage:
   dirac-admin-check-config-options [options] -[MAUO] [-S <system>]
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 from pprint import pformat
 
 from diraccfg import CFG
 from DIRAC import gLogger, S_ERROR, S_OK, gConfig
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities.List import fromChar
 
 LOG = gLogger

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_sort_cs_sites.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_sort_cs_sites.py
@@ -11,11 +11,8 @@ Example:
   $ dirac-admin-sort-cs-sites -C CLOUDS DIRAC
   sort site names by country postfix in '/Resources/Sites/CLOUDS' and '/Resources/Sites/DIRAC' subsection
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from DIRAC import gLogger, exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getPropertiesForGroup
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_voms_sync.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_voms_sync.py
@@ -6,11 +6,8 @@
 """
 Synchronize VOMS user data with the DIRAC Registry
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from DIRAC import gLogger, exit as DIRACExit, S_OK
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.ConfigurationSystem.Client.VOMS2CSSynchronizer import VOMS2CSSynchronizer
 from DIRAC.Core.Utilities.Proxy import executeWithUserProxy
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOOption

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_cli.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_cli.py
@@ -6,10 +6,7 @@
 """
 Command line interface to DIRAC Configuration Server
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.ConfigurationSystem.Client.CSCLI import CSCLI
 
 

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_dump_local_cache.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_dump_local_cache.py
@@ -6,12 +6,9 @@
 """
 Dump DIRAC Configuration data
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import sys
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_shell.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_shell.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python
-
 """
 Script that emulates the behaviour of a shell to edit the CS config.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-import sys
-
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 # Invariants:
 # * root does not end with "/" or root is "/"

--- a/src/DIRAC/Core/Base/Script.py
+++ b/src/DIRAC/Core/Base/Script.py
@@ -22,7 +22,7 @@ from DIRAC.ConfigurationSystem.Client.LocalConfiguration import LocalConfigurati
 from DIRAC.Core.Utilities.Extensions import entrypointToExtension, extensionsByPriority
 
 
-class Script(object):
+class Script:
     """Decorator for providing command line executables
 
     All console-scripts entrypoints in DIRAC and downstream extensions should be

--- a/src/DIRAC/Core/Base/__init__.py
+++ b/src/DIRAC/Core/Base/__init__.py
@@ -1,2 +1,0 @@
-""" For backward compatability """
-from DIRAC.Core.Base.Script import Script

--- a/src/DIRAC/Core/Tornado/scripts/tornado_start_CS.py
+++ b/src/DIRAC/Core/Tornado/scripts/tornado_start_CS.py
@@ -5,13 +5,10 @@
 ########################################################################
 # Just run this script to start Tornado and CS service
 # Use dirac.cfg (or other cfg given in the command line) to change port
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 import sys
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
+++ b/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
@@ -5,13 +5,10 @@
 ########################################################################
 # Just run this script to start Tornado and all services
 # Use CS to change port
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 import sys
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Core/Utilities/DIRACScript.py
+++ b/src/DIRAC/Core/Utilities/DIRACScript.py
@@ -1,2 +1,7 @@
-""" For backward compatability """
-from DIRAC.Core.Base.Script import Script as DIRACScript
+from DIRAC.Core.Base.Script import Script
+from DIRAC.Core.Utilities.Decorators import deprecated
+
+# TODO: remove it in 8.1
+@deprecated("DIRACScript is deprecated, use 'from DIRAC.Core.Base.Script import Script' instead.")
+class DIRACScript(Script):
+    pass

--- a/src/DIRAC/Core/Utilities/Decorators.py
+++ b/src/DIRAC/Core/Utilities/Decorators.py
@@ -1,10 +1,5 @@
 """ Decorators for DIRAC.
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import os
 import inspect
 import functools

--- a/src/DIRAC/Core/Utilities/Decorators.py
+++ b/src/DIRAC/Core/Utilities/Decorators.py
@@ -75,10 +75,14 @@ def deprecated(reason, onlyOnce=False):
 
         decFunc.warningEn = True
 
-        if func.__doc__ is None:
-            func.__doc__ = "\n\n**Deprecated**: " + reason
-        else:
-            func.__doc__ += "\n\n**Deprecated**: " + reason
+        # Let's check whether the function is really a function, if not then `func` could be `__init__` come from `object`
+        # and its a slot wrapper, which does not allow to set the values of attributes(e.g.: `__doc__`)
+        # see https://doc.sagemath.org/html/en/reference/cpython/sage/cpython/wrapperdescr.html
+        if inspect.isfunction(func):
+            if func.__doc__ is None:
+                func.__doc__ = "\n\n**Deprecated**: " + reason
+            else:
+                func.__doc__ += "\n\n**Deprecated**: " + reason
 
         @functools.wraps(func)
         def innerFunc(*args, **kwargs):

--- a/src/DIRAC/Core/Utilities/__init__.py
+++ b/src/DIRAC/Core/Utilities/__init__.py
@@ -1,6 +1,3 @@
 """
    DIRAC.Core.Utilities package
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function

--- a/src/DIRAC/Core/scripts/dirac_agent.py
+++ b/src/DIRAC/Core/scripts/dirac_agent.py
@@ -6,15 +6,12 @@
 """
 This is a script to launch DIRAC agents. Mostly internal.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import sys
 
 from DIRAC import gLogger
 from DIRAC.Core.Base.AgentReactor import AgentReactor
 from DIRAC.Core.Utilities.DErrno import includeExtensionErrors
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Core/scripts/dirac_cert_convert.py
+++ b/src/DIRAC/Core/scripts/dirac_cert_convert.py
@@ -3,9 +3,6 @@
 Script converts the user certificate in the p12 format into a standard .globus usercert.pem and userkey.pem files.
 Creates the necessary directory, $HOME/.globus, if needed. Backs-up old pem files if any are found.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 import sys
 import shutil
@@ -13,7 +10,7 @@ from datetime import datetime
 
 from DIRAC import gLogger
 from DIRAC.Core.Utilities.Subprocess import shellCall
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -42,15 +42,12 @@
                       --SkipCAChecks
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import sys
 import os
 
 import DIRAC
 from DIRAC.Core.Utilities.File import mkDir
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.ConfigurationSystem.Client.Helpers import cfgInstallPath, cfgPath, Registry
 from DIRAC.Core.Utilities.SiteSEMapping import getSEsForSite

--- a/src/DIRAC/Core/scripts/dirac_executor.py
+++ b/src/DIRAC/Core/scripts/dirac_executor.py
@@ -6,15 +6,12 @@
 """
 This is a script to launch DIRAC executors
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import sys
 
 from DIRAC import gLogger
 from DIRAC.Core.Base.ExecutorReactor import ExecutorReactor
 from DIRAC.Core.Utilities.DErrno import includeExtensionErrors
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Core/scripts/dirac_generate_cas.py
+++ b/src/DIRAC/Core/scripts/dirac_generate_cas.py
@@ -2,13 +2,10 @@
 """
 Generate a single CA file with all the PEMs
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import sys
 
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Security import Utilities
 
 

--- a/src/DIRAC/Core/scripts/dirac_generate_crls.py
+++ b/src/DIRAC/Core/scripts/dirac_generate_crls.py
@@ -2,13 +2,10 @@
 """
 Generate a single CRLs file
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import sys
 
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Security import Utilities
 
 

--- a/src/DIRAC/Core/scripts/dirac_info.py
+++ b/src/DIRAC/Core/scripts/dirac_info.py
@@ -23,11 +23,7 @@ Example:
   Skip CA Checks         No
   DIRAC version          v7r2-pre33
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Core/scripts/dirac_install_db.py
+++ b/src/DIRAC/Core/scripts/dirac_install_db.py
@@ -2,11 +2,7 @@
 """
 Create a new DB in the MySQL server
 """
-# Script initialization and parseCommandLine
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Core/scripts/dirac_install_web_portal.py
+++ b/src/DIRAC/Core/scripts/dirac_install_web_portal.py
@@ -6,10 +6,7 @@
 """
 Do the initial installation of a DIRAC Web portal
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Core/scripts/dirac_platform.py
+++ b/src/DIRAC/Core/scripts/dirac_platform.py
@@ -18,10 +18,6 @@ Example:
   Linux_x86_64_glibc-2.5
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 try:
     from DIRAC.Core.Utilities.Platform import getPlatformString
 except Exception:
@@ -143,7 +139,7 @@ except Exception:
         print(getPlatformString())
 
 else:
-    from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+    from DIRAC.Core.Base.Script import Script
 
     @Script()
     def main():

--- a/src/DIRAC/Core/scripts/dirac_service.py
+++ b/src/DIRAC/Core/scripts/dirac_service.py
@@ -5,21 +5,13 @@
 ########################################################################
 """
 This is a script to launch DIRAC services. Mostly internal.
-
-Usage:
-  dirac-service [options] ...
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import sys
 
-from DIRAC.ConfigurationSystem.Client.LocalConfiguration import LocalConfiguration
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 from DIRAC.Core.DISET.ServiceReactor import ServiceReactor
 from DIRAC.Core.Utilities.DErrno import includeExtensionErrors
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Core/scripts/dirac_setup_site.py
+++ b/src/DIRAC/Core/scripts/dirac_setup_site.py
@@ -6,11 +6,8 @@
 """
 Initial installation and configuration of a new DIRAC server (DBs, Services, Agents, Web Portal,...)
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 from DIRAC import S_OK
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 class Params(object):

--- a/src/DIRAC/Core/scripts/dirac_version.py
+++ b/src/DIRAC/Core/scripts/dirac_version.py
@@ -13,13 +13,10 @@ Example:
   $ dirac-version
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import argparse
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_admin_allow_se.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_admin_allow_se.py
@@ -5,11 +5,8 @@ Enable using one or more Storage Elements
 Example:
   $ dirac-admin-allow-se M3PEC-disk
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_admin_ban_se.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_admin_ban_se.py
@@ -6,11 +6,8 @@ Ban one or more Storage Elements for usage
 Example:
   $ dirac-admin-ban-se M3PEC-disk
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_admin_user_quota.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_admin_user_quota.py
@@ -12,11 +12,8 @@ Example:
   vhamar         |           None
   ------------------------------
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_add_file.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_add_file.py
@@ -32,12 +32,9 @@ Example:
    'Successful': {'/formationes/user/v/vhamar/Example.txt': {'put': 0.70791220664978027,
                                                              'register': 0.61061787605285645}}}
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 from DIRAC import S_OK
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 overwrite = False
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_catalog_metadata.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_catalog_metadata.py
@@ -8,11 +8,8 @@ Example:
   FileName                                     Size        GUID                                     Status   Checksum
   /formation/user/v/vhamar/Example.txt         34          EDE6DDA4-3344-3F39-A993-8349BA41EB23     1        eed20d47
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 from DIRAC import exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_change_replica_status.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_change_replica_status.py
@@ -2,11 +2,8 @@
 """
 Change status of replica of a given file or a list of files at a given Storage Element
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 from DIRAC import exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_clean_directory.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_clean_directory.py
@@ -8,13 +8,10 @@ Example:
   $ dirac-dms-clean-directory /formation/user/v/vhamar/newDir
   Cleaning directory /formation/user/v/vhamar/newDir ...  OK
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 
 from DIRAC import exit as DIRACExit, gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_archive_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_archive_request.py
@@ -31,9 +31,6 @@ Default values for any of the command line options can also be set in the CS
 * Operations/DataManagement/ArchiveFiles/MaxFiles
 * ...
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 
 import DIRAC
@@ -41,7 +38,7 @@ from DIRAC import gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Utilities import DEncode
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
 from DIRAC.RequestManagementSystem.Client.File import File
 from DIRAC.RequestManagementSystem.Client.Request import Request
@@ -52,7 +49,7 @@ MAX_SIZE = 2 * 1024 * 1024 * 1024  # 2 GB
 MAX_FILES = 2000
 
 
-class CreateArchiveRequest(object):
+class CreateArchiveRequest:
     """Create the request to archive files."""
 
     def __init__(self):

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_moving_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_moving_request.py
@@ -7,15 +7,10 @@ List of operations:
 #. Check for Migration
 #. Remove all other replicas for these files
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 
-import DIRAC
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
@@ -26,7 +21,7 @@ from DIRAC.RequestManagementSystem.Client.Operation import Operation
 sLog = gLogger.getSubLogger("CreateMoving")
 
 
-class CreateMovingRequest(object):
+class CreateMovingRequest:
     """Create the request to move files from one SE to another."""
 
     def __init__(self):

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_removal_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_removal_request.py
@@ -2,16 +2,11 @@
 """
 Create a DIRAC RemoveReplica|RemoveFile request to be executed by the RMS
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
-__RCSID__ = "ea64b42 (2012-07-29 16:45:05 +0200) ricardo <Ricardo.Graciani@gmail.com>"
-
 import os
 from hashlib import md5
 import time
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_data_size.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_data_size.py
@@ -10,13 +10,10 @@ Example:
   1              |            0.0
   ------------------------------
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 import DIRAC
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_directory_sync.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_directory_sync.py
@@ -18,16 +18,12 @@ Example:
   or Upload
     dirac-dms-directory-sync Path LFN SE
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 from multiprocessing import Manager
 
 import DIRAC
 from DIRAC import S_OK, S_ERROR, gConfig, gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_filecatalog_cli.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_filecatalog_cli.py
@@ -20,13 +20,9 @@ Example:
 
   FC:/>
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import sys
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_find_lfns.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_find_lfns.py
@@ -6,12 +6,7 @@ Examples::
 
   $ dirac-dms-find-lfns Path=/lhcb/user "Size>1000" "CreationDate<2015-05-15"
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_move_replica_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_move_replica_request.py
@@ -2,17 +2,11 @@
 """
 Create a DIRAC MoveReplica request to be executed by the RMS
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-__RCSID__ = "$Id $"
-
 import os
 import time
 from hashlib import md5
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 def getLFNList(arg):

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_protocol_matrix.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_protocol_matrix.py
@@ -38,15 +38,10 @@ You can have the following combinations::
   Using sources: IN2P3-User
   Using target: IN2P3-User
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import csv
-import six
 from collections import defaultdict
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_put_and_register_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_put_and_register_request.py
@@ -5,12 +5,9 @@ Create and put 'PutAndRegister' request with a single local file
   warning: make sure the file you want to put is accessible from DIRAC production hosts,
            i.e. put file on network fs (AFS or NFS), otherwise operation will fail!!!
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_catalog_files.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_catalog_files.py
@@ -9,10 +9,7 @@ Example:
   $ dirac-dms-remove-catalog-files   /formation/user/v/vhamar/1/1134/StdOut
   Successfully removed 1 catalog files.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC import exit as dexit
 from DIRAC import gLogger
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_catalog_replicas.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_catalog_replicas.py
@@ -4,13 +4,10 @@ Remove the given file replica or a list of file replicas from the File Catalog
 This script should be used with great care as it may leave dark data in the storage!
 Use dirac-dms-remove-replicas instead
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import os
 
 from DIRAC import exit as dexit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC import gLogger
 
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_files.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_files.py
@@ -5,10 +5,7 @@ Remove the given file or a list of files from the File Catalog and from the stor
 Example:
   $ dirac-dms-remove-files /formation/user/v/vhamar/Test.txt
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_replicas.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_replicas.py
@@ -7,11 +7,7 @@ Example:
   $ dirac-dms-remove-replicas /formation/user/v/vhamar/Test.txt IBCP-disk
   Successfully removed DIRAC-USER replica of /formation/user/v/vhamar/Test.txt
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC import exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_replica_metadata.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_replica_metadata.py
@@ -2,13 +2,10 @@
 """
 Get the given file replica metadata from the File Catalog
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import os
 
 from DIRAC import exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_replicate_and_register_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_replicate_and_register_request.py
@@ -2,11 +2,8 @@
 """
 Create and put 'ReplicateAndRegister' request.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC import gLogger
 import DIRAC
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_resolve_guid.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_resolve_guid.py
@@ -2,10 +2,7 @@
 """
 Returns the LFN matching given GUIDs
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_set_replica_status.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_set_replica_status.py
@@ -2,10 +2,7 @@
 """
 Set the status of the replicas of given files at the provided SE
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_show_se_status.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_show_se_status.py
@@ -15,12 +15,8 @@ Example:
   M3PEC-disk                         Active          Active
   ProductionSandboxSE                Active          Active
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 from DIRAC import S_OK, exit as DIRACexit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 vo = None
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_user_lfns.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_user_lfns.py
@@ -15,10 +15,7 @@ Example:
   /formation/user/v/vhamar/0/20: 1 files, 0 sub-directories
   16 matched files have been put in formation-user-v-vhamar.lfns
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_user_quota.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_user_quota.py
@@ -9,10 +9,7 @@ Example:
   $ dirac-dms-user-quota
   Current quota found to be 0.0 GB
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
@@ -5,7 +5,7 @@
 import sys
 from prompt_toolkit import prompt
 from DIRAC import S_OK, S_ERROR, gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities.NTP import getClockDeviation
 
 

--- a/src/DIRAC/FrameworkSystem/Client/ProxyUpload.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyUpload.py
@@ -3,7 +3,7 @@ from prompt_toolkit import prompt
 import DIRAC
 
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 class CLIParams:

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_get_CAs.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_get_CAs.py
@@ -12,12 +12,8 @@ invalid.
 Example:
   $ dirac-admin-get-CAs
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClient
 
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_get_proxy.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_get_proxy.py
@@ -10,15 +10,11 @@ Example:
   $ dirac-admin-get-proxy vhamar dirac_user
   Proxy downloaded to /afs/in2p3.fr/home/h/hamar/proxy.vhamar.dirac_user
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import os
 
 import DIRAC
 from DIRAC import gLogger, S_OK, S_ERROR
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_proxy_upload.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_proxy_upload.py
@@ -9,12 +9,9 @@ Upload proxy.
 Example:
   $ dirac-admin-proxy-upload
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import sys
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.Client.ProxyUpload import CLIParams, uploadProxy
 
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_sysadmin_cli.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_sysadmin_cli.py
@@ -7,10 +7,7 @@ Example:
   DIRAC Root Path = /afs/in2p3.fr/home/h/hamar/DIRAC-v5r12
   dirac.in2p3.fr >
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_instance.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_instance.py
@@ -2,13 +2,10 @@
 """
 Script to apply update to all or some dirac servers and restart them
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from io import open
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_pilot.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_pilot.py
@@ -2,11 +2,8 @@
 """
 Script to update pilot version in CS
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_users_with_proxy.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_users_with_proxy.py
@@ -20,13 +20,9 @@ Example:
   not after  : 2011-06-29 12:04:30
   persistent : True
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import DIRAC
 from DIRAC.Core.Utilities import Time
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_install_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_install_component.py
@@ -2,14 +2,9 @@
 """
 Do the initial installation and configuration of a DIRAC component
 """
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from DIRAC import exit as DIRACexit
 from DIRAC import gConfig, gLogger, S_OK
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities.Extensions import extensionsByPriority
 from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_install_tornado_service.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_install_tornado_service.py
@@ -2,13 +2,9 @@
 """
 Do the initial installation and configuration of a DIRAC service based on tornado
 """
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from DIRAC import exit as DIRACexit
 from DIRAC import gConfig, gLogger, S_OK
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities.Extensions import extensionsByPriority
 from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
@@ -28,7 +28,7 @@ from DIRAC.Core.Security.ProxyFile import writeToProxyFile
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo, formatProxyInfoAsString
 from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-error
 from DIRAC.Core.Utilities.NTP import getClockDeviation
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Resources.IdProvider.IdProviderFactory import IdProviderFactory
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 from DIRAC.FrameworkSystem.private.authorization.utils.Tokens import (

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_logout.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_logout.py
@@ -11,7 +11,7 @@ import sys
 import DIRAC
 from DIRAC import gLogger, S_OK, S_ERROR, gConfig
 from DIRAC.Core.Security import Locations
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Resources.IdProvider.IdProviderFactory import IdProviderFactory
 from DIRAC.FrameworkSystem.private.authorization.utils.Tokens import (
     readTokenFromFile,

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_monitoring_get_components_status.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_monitoring_get_components_status.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import sys
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_myproxy_upload.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_myproxy_upload.py
@@ -5,7 +5,7 @@
 ########################################################################
 import sys
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 class Params:

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_populate_component_db.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_populate_component_db.py
@@ -5,16 +5,11 @@ Populates the database with the current installations of components
 This script assumes that the InstalledComponentsDB, the
 ComponentMonitoring service and the Notification service are installed and running
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-
 from datetime import datetime
 from DIRAC import exit as DIRACexit
 from DIRAC import S_OK, gLogger, gConfig
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.Client.NotificationClient import NotificationClient
 from DIRAC.FrameworkSystem.Client.SystemAdministratorIntegrator import SystemAdministratorIntegrator
 from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient import ComponentMonitoringClient

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_destroy.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_destroy.py
@@ -5,14 +5,11 @@ Command line tool to remove local and remote proxies
 Example:
   $ dirac-proxy-destroy -a
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 
 import DIRAC
 from DIRAC import gLogger, S_OK
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 from DIRAC.Core.Security import Locations, ProxyInfo
 from DIRAC.Core.Base.Client import Client
@@ -20,7 +17,7 @@ from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 
 
-class Params(object):
+class Params:
     """
     handles input options for dirac-proxy-destroy
     """

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_get_uploaded_info.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_get_uploaded_info.py
@@ -15,13 +15,10 @@ Example:
   | /O=GRID-FR/C=FR/O=CNRS/OU=CPPM/CN=Vanessa Hamar | dirac_user  | 2011-06-29 12:04:25 | True           |
   --------------------------------------------------------------------------------------------------------
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import sys
 
 from DIRAC import gLogger, S_OK
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import ProxyManagerClient
 from DIRAC.Core.Security import Properties
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_info.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_info.py
@@ -20,11 +20,11 @@ Example:
 """
 import sys
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities.ReturnValues import S_OK
 
 
-class Params(object):
+class Params:
 
     proxyLoc = False
     vomsEnabled = True

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
@@ -15,7 +15,7 @@ import datetime
 import DIRAC
 
 from DIRAC import gLogger, S_OK, S_ERROR
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.Client import ProxyGeneration, ProxyUpload
 from DIRAC.Core.Security import X509Chain, ProxyInfo, VOMS
 from DIRAC.Core.Security.Locations import getCAsLocation

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_restart_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_restart_component.py
@@ -2,10 +2,7 @@
 """
 Restart DIRAC component using runsvctrl utility
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_start_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_start_component.py
@@ -2,10 +2,7 @@
 """
 Start DIRAC component using runsvctrl utility
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_status_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_status_component.py
@@ -9,11 +9,7 @@ Example:
             WorkloadManagement_PilotStatusAgent : Run        4029     1697
              WorkloadManagement_JobHistoryAgent : Run        4029     167
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_stop_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_stop_component.py
@@ -2,11 +2,7 @@
 """
 Stop DIRAC component using runsvctrl utility
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_sys_sendmail.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_sys_sendmail.py
@@ -18,16 +18,12 @@ Examples:
   $ dirac-sys-sendmail "From: source@email.com\\nTo: destination@email.com\\nSubject: Test\\n\\nMessage body"
   echo "From: source@email.com\\nSubject: Test\\n\\nMessage body" | dirac-sys-sendmail destination@email.com
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import socket
 import sys
 import os
 
 from DIRAC import gLogger, exit as DIRACexit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.Client.NotificationClient import NotificationClient
 
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_uninstall_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_uninstall_component.py
@@ -2,16 +2,12 @@
 """
 Uninstallation of a DIRAC component
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import socket
 
 from DIRAC import exit as DIRACexit
 from DIRAC import gLogger, S_OK
 from DIRAC.Core.Utilities.PromptUser import promptUser
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient import ComponentMonitoringClient
 

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_add_group.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_add_group.py
@@ -9,7 +9,7 @@ Example:
 
 import DIRAC
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 groupName = None
 groupProperties = []

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_add_host.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_add_host.py
@@ -7,7 +7,7 @@ Example:
 """
 import DIRAC
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 hostName = None
 hostDN = None

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_add_user.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_add_user.py
@@ -7,7 +7,7 @@ Example:
 """
 import DIRAC
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 userName = None
 userDN = None

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_allow_site.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_allow_site.py
@@ -11,7 +11,7 @@ Example:
 """
 import time
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_ban_site.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_ban_site.py
@@ -11,7 +11,7 @@ Example:
 """
 import time
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_ce_info.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_ce_info.py
@@ -10,7 +10,7 @@ Example:
   $ dirac-admin-ce-info LCG.IN2P3.fr
 """
 from DIRAC import gConfig, gLogger, exit as Dexit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_delete_user.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_delete_user.py
@@ -9,7 +9,7 @@ Remove User from Configuration
 Example:
   $ dirac-admin-delete-user vhamar
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_get_banned_sites.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_get_banned_sites.py
@@ -10,7 +10,7 @@ Example:
   $ dirac-admin-get-banned-sites
   LCG.IN2P3.fr                      Site not present in logging table
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_get_job_pilot_output.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_get_job_pilot_output.py
@@ -9,7 +9,7 @@ Retrieve the output of the pilot that executed a given job
 Example:
   $ dirac-admin-get-job-pilot-output 34
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_get_job_pilots.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_get_job_pilots.py
@@ -28,7 +28,7 @@ Example:
                                                           'TaskQueueID': 399L}}
 """
 # pylint: disable=wrong-import-position
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_get_pilot_info.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_get_pilot_info.py
@@ -27,7 +27,7 @@ Example:
                                                           'TaskQueueID': 399L}}
 """
 # pylint: disable=wrong-import-position
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 extendedPrint = False
 

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_get_pilot_logging_info.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_get_pilot_logging_info.py
@@ -26,7 +26,7 @@ Example:
   - Source    =  NetworkServer
 """
 # pylint: disable=wrong-import-position
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_get_pilot_output.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_get_pilot_output.py
@@ -11,7 +11,7 @@ Example:
   $ ls -la
   drwxr-xr-x  2 hamar marseill      2048 Feb 21 14:13 pilot_26KCLKBFtxXKHF4_ZrQjkw
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_get_site_mask.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_get_site_mask.py
@@ -15,7 +15,7 @@ Example:
   LCG.M3PEC.fr
   LCG.MSFG.fr
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_list_hosts.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_list_hosts.py
@@ -11,7 +11,7 @@ Example:
   dirac.in2p3.fr
   host-dirac.in2p3.fr
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_list_users.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_list_users.py
@@ -13,7 +13,7 @@ Example:
   msapunov
   atsareg
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_modify_user.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_modify_user.py
@@ -10,7 +10,7 @@ Example:
   $ dirac-admin-modify-user vhamar /C=FR/O=Org/CN=User dirac_user
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_pilot_summary.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_pilot_summary.py
@@ -26,7 +26,7 @@ Example:
 """
 # pylint: disable=wrong-import-position
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_reset_job.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_reset_job.py
@@ -11,7 +11,7 @@ Example:
   Reset Job 1848
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_service_ports.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_service_ports.py
@@ -18,7 +18,7 @@ Example:
    'WorkloadManagement/WMSAdministrator': 9145}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_set_site_protocols.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_set_site_protocols.py
@@ -10,7 +10,7 @@ Example:
   $ dirac-admin-set-site-protocols --Site=LCG.IN2P3.fr SRM2
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_site_info.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_site_info.py
@@ -16,7 +16,7 @@ Example:
    'SE': 'IN2P3-disk, DIRAC-USER'}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_site_mask_logging.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_site_mask_logging.py
@@ -12,7 +12,7 @@ Example:
   Active  2010-12-08 21:28:16 ( atsareg )
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_sync_users_from_file.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_sync_users_from_file.py
@@ -12,7 +12,7 @@ Example:
 from diraccfg import CFG
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_dms_get_file.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_dms_get_file.py
@@ -12,7 +12,7 @@ Example:
    'Successful': {'/formation/user/v/vhamar/Example.txt': '/afs/in2p3.fr/home/h/hamar/Tests/DMS/Example.txt'}}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_dms_lfn_accessURL.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_dms_lfn_accessURL.py
@@ -13,7 +13,7 @@ Example:
    /formation/user/v/vhamar/Example.txt'}}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_dms_lfn_metadata.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_dms_lfn_metadata.py
@@ -24,7 +24,7 @@ Example:
                                                         'UID': 2}}}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_dms_lfn_replicas.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_dms_lfn_replicas.py
@@ -13,7 +13,7 @@ Example:
    {'M3PEC-disk': 'srm://se0.m3pec.u-bordeaux1.fr/dpm/m3pec.u-bordeaux1.fr/home/formation/user/v/vhamar/Test.txt'}}}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_dms_pfn_accessURL.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_dms_pfn_accessURL.py
@@ -7,7 +7,7 @@
 Retrieve an access URL for a PFN given a valid DIRAC SE
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_dms_pfn_metadata.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_dms_pfn_metadata.py
@@ -7,7 +7,7 @@
 Retrieve metadata for a PFN given a valid DIRAC SE
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_dms_replicate_lfn.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_dms_replicate_lfn.py
@@ -13,7 +13,7 @@ Example:
                                                         'replicate': 11.878520965576172}}}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_framework_ping_service.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_framework_ping_service.py
@@ -31,7 +31,7 @@ Example:
                ())}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_framework_self_ping.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_framework_self_ping.py
@@ -9,7 +9,7 @@ or 1 in case of error """
 import sys
 import os
 import time
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_repo_monitor.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_repo_monitor.py
@@ -3,7 +3,7 @@
 Monitor the jobs present in the repository
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_utils_file_adler.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_utils_file_adler.py
@@ -9,7 +9,7 @@ Example:
   $ dirac-utils-file-adler Example.tgz
   Example.tgz 88b4ca8b
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_utils_file_md5.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_utils_file_md5.py
@@ -10,7 +10,7 @@ Example:
   $ dirac-utils-file-md5 Example.tgz
   Example.tgz 5C1A1102-EAFD-2CBA-25BD-0EFCCFC3623E
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_get_normalized_queue_length.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_get_normalized_queue_length.py
@@ -14,7 +14,7 @@ Example:
   cclcgceli03.in2p3.fr:2119/jobmanager-bqs-long 857400.0
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.WorkloadManagementSystem.Client.CPUNormalization import queueNormalizedCPU
 
 

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_get_queue_normalization.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_get_queue_normalization.py
@@ -10,7 +10,7 @@ Example:
   $ dirac-wms-get-queue-normalization cclcgceli03.in2p3.fr:2119/jobmanager-bqs-long
   cclcgceli03.in2p3.fr:2119/jobmanager-bqs-long 2500.0
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_attributes.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_attributes.py
@@ -44,7 +44,7 @@ Example:
    'VerifiedFlag': 'True'}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_delete.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_delete.py
@@ -12,7 +12,7 @@ Example:
 """
 import os.path
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_get_input.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_get_input.py
@@ -13,7 +13,7 @@ Example:
 import os
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_get_jdl.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_get_jdl.py
@@ -33,7 +33,7 @@ Example:
    'Priority': '1'}
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_get_output.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_get_output.py
@@ -14,7 +14,7 @@ import os
 import shutil
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_get_output_data.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_get_output_data.py
@@ -7,7 +7,7 @@
 Retrieve the output data files of a DIRAC job
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_kill.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_kill.py
@@ -23,7 +23,7 @@ Example:
   - otherwise, it will be marked directly as 'Killed'.
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_logging_info.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_logging_info.py
@@ -25,7 +25,7 @@ Example:
   Done                          Execution Complete                  Unknown                       2011-02-14 11:28:07
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_parameters.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_parameters.py
@@ -33,7 +33,7 @@ Example:
 """
 import DIRAC
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_peek.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_peek.py
@@ -10,7 +10,7 @@ Example:
   $ dirac-wms-job-peek 1
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_reschedule.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_reschedule.py
@@ -11,7 +11,7 @@ Example:
   Rescheduled job 1
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_status.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_status.py
@@ -11,7 +11,7 @@ Example:
   JobID=2 Status=Done; MinorStatus=Execution Complete; Site=EELA.UTFSM.cl;
 """
 import os
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_submit.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_submit.py
@@ -13,7 +13,7 @@ Example:
 import os
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_jobs_select_output_search.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_jobs_select_output_search.py
@@ -10,7 +10,7 @@ import os
 from shutil import rmtree
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/Interfaces/scripts/dirac_wms_select_jobs.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_select_jobs.py
@@ -8,7 +8,7 @@ Select DIRAC jobs matching the given conditions
 """
 import DIRAC
 from DIRAC import gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_add_trans.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_add_trans.py
@@ -3,11 +3,8 @@
 Add an existing transformation to an existing production.
 Transformations already belonging to another production cannot be added.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_clean.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_clean.py
@@ -2,11 +2,8 @@
 """
 Clean a given production
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_delete.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_delete.py
@@ -3,11 +3,8 @@
 """
 Delete a given production
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_get.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_get.py
@@ -5,11 +5,8 @@ Get informations for a given production
 Example:
   $ dirac-prod-get 381
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_all.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_all.py
@@ -2,12 +2,9 @@
 """
 Get summary informations of all productions
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
 from DIRAC.Core.Utilities.PrettyPrint import printTable
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_description.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_description.py
@@ -5,11 +5,8 @@ Get the description of a given production
 Example:
   $ dirac-prod-get-description 381
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_trans.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_trans.py
@@ -5,12 +5,9 @@ Get the transformations belonging to a given production
 Example:
   $ dirac-prod-get-trans 381
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
 from DIRAC.Core.Utilities.PrettyPrint import printTable
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_start.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_start.py
@@ -5,11 +5,8 @@ Start a given production
 Example:
   $ dirac-prod-start 381
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_stop.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_stop.py
@@ -5,11 +5,8 @@ Stop a given production
 Example:
   $ dirac-prod-stop 381
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_list_req_cache.py
+++ b/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_list_req_cache.py
@@ -2,11 +2,8 @@
 """
 List the number of requests in the caches of all the ReqProxyies
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_reqdb_summary.py
+++ b/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_reqdb_summary.py
@@ -2,10 +2,7 @@
 """
 Show ReqDB summary
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_request.py
+++ b/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_request.py
@@ -2,12 +2,9 @@
 """
 Show request given its ID, a jobID or a transformation and a task
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import datetime
 import os
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 def convertDate(date):

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_list_status.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_list_status.py
@@ -4,7 +4,7 @@ Script that dumps the DB information for the elements into the standard output.
 If returns information concerning the StatusType and Status attributes.
 """
 from DIRAC import gLogger, exit as DIRACExit, version
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.ResourceStatusSystem.Client import ResourceStatusClient
 from DIRAC.Core.Utilities.PrettyPrint import printTable
 

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_query_db.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_query_db.py
@@ -5,7 +5,7 @@ If returns information concerning the StatusType and Status attributes.
 """
 import datetime
 from DIRAC import gLogger, exit as DIRACExit, S_OK, version
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.ResourceStatusSystem.Client import ResourceStatusClient
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_query_dtcache.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_query_dtcache.py
@@ -5,7 +5,7 @@ Select/Add/Delete a new DownTime entry for a given Site or Service.
 import datetime
 
 from DIRAC import gLogger, exit as DIRACExit, version
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities import Time
 from DIRAC.Core.Utilities.PrettyPrint import printTable
 from DIRAC.ResourceStatusSystem.Utilities import Utils

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_status.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_status.py
@@ -7,7 +7,7 @@ issuer with a duration of 1 day.
 from datetime import datetime, timedelta
 
 from DIRAC import gLogger, exit as DIRACExit, S_OK, version
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.ResourceStatusSystem.Client import ResourceStatusClient
 from DIRAC.ResourceStatusSystem.PolicySystem import StateMachine

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_token.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_token.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 
 # DIRAC
 from DIRAC import gLogger, exit as DIRACExit, S_OK, version
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.ResourceStatusSystem.Client.ResourceStatusClient import ResourceStatusClient
 

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_sync.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_sync.py
@@ -7,7 +7,7 @@ the RSS. Important: If the StatusType is not defined on the CS, it will set
 it to Banned !
 """
 from DIRAC import version, gLogger, exit as DIRACExit, S_OK
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 subLogger = None
 switchDict = {}

--- a/src/DIRAC/Resources/scripts/dirac_resource_get_parameters.py
+++ b/src/DIRAC/Resources/scripts/dirac_resource_get_parameters.py
@@ -2,11 +2,8 @@
 """
 Get parameters assigned to the CE
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import json
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 ceName = ""
 Queue = ""

--- a/src/DIRAC/Resources/scripts/dirac_resource_info.py
+++ b/src/DIRAC/Resources/scripts/dirac_resource_info.py
@@ -3,10 +3,7 @@
 Get information on resources available for the given VO: Computing and Storage.
 By default, resources for the VO corresponding to the current user identity are displayed
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_file.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_file.py
@@ -31,10 +31,7 @@ Example:
   SRM PinExpiryTime: None
   SRM PinLength: 43200
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_jobs.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_jobs.py
@@ -76,10 +76,7 @@ Example:
       Reason  : None
       --------------------
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_request.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_request.py
@@ -6,10 +6,7 @@
 """
 Report the summary of the stage task from the DB.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_requests.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_requests.py
@@ -24,11 +24,8 @@ Example:
   Staged   2013-06-06 11:11:50 /lhcb/LHCb/2.full.dst GRIDKA-RDST None    ['48515072']  2013-06-06 12:11:50  43200
   Staged   2013-06-07 03:19:26 /lhcb/LHCb/2.full.dst GRIDKA-RDST None    ['48515600']  2013-06-07 04:19:26  43200
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
-from DIRAC import gConfig, gLogger, exit as DIRACExit, S_OK, version
+from DIRAC.Core.Base.Script import Script
+from DIRAC import gLogger, exit as DIRACExit
 
 subLogger = None
 

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_show_stats.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_show_stats.py
@@ -22,11 +22,8 @@ Example:
    GRIDKA-RDST    :      6 replicas with a size of 29.141 GB.
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
-from DIRAC import gConfig, gLogger, exit as DIRACExit, S_OK, version
+from DIRAC.Core.Base.Script import Script
+from DIRAC import gLogger, exit as DIRACExit
 
 
 @Script()

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_stage_files.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_stage_files.py
@@ -29,10 +29,7 @@ Example:
   SE= GRIDKA-RDST
   You can check their status and progress with dirac-stager-monitor-file <LFN> <SE>
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()
@@ -49,7 +46,6 @@ def main():
 
     import os
     from DIRAC import exit as DIRACExit, gLogger
-    from DIRAC.Interfaces.API.Dirac import Dirac
     from DIRAC.StorageManagementSystem.Client.StorageManagerClient import StorageManagerClient
 
     stageLfns = {}

--- a/src/DIRAC/TransformationSystem/scripts/dirac_production_runjoblocal.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_production_runjoblocal.py
@@ -14,7 +14,7 @@ from urllib.request import urlopen
 
 from DIRAC.Interfaces.API.Dirac import Dirac
 from DIRAC.Core.Utilities.File import mkDir
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import getVO, getSetup
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_add_files.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_add_files.py
@@ -2,12 +2,9 @@
 """
 Add files to an existing transformation
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import os
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_archive.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_archive.py
@@ -2,12 +2,7 @@
 """
 Archive a transformation
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-import sys
-
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()
@@ -19,7 +14,6 @@ def main():
     transIDs = [int(arg) for arg in args]
 
     from DIRAC.TransformationSystem.Agent.TransformationCleaningAgent import TransformationCleaningAgent
-    from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 
     agent = TransformationCleaningAgent(
         "Transformation/TransformationCleaningAgent",
@@ -28,7 +22,6 @@ def main():
     )
     agent.initialize()
 
-    client = TransformationClient()
     for transID in transIDs:
         agent.archiveTransformation(transID)
 

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_clean.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_clean.py
@@ -2,12 +2,7 @@
 """
 Clean a tranformation
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-import sys
-
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()
@@ -17,7 +12,6 @@ def main():
     _, args = Script.parseCommandLine()
 
     from DIRAC.TransformationSystem.Agent.TransformationCleaningAgent import TransformationCleaningAgent
-    from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 
     transIDs = [int(arg) for arg in args]
 
@@ -28,7 +22,6 @@ def main():
     )
     agent.initialize()
 
-    client = TransformationClient()
     for transID in transIDs:
         agent.cleanTransformation(transID)
 

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_cli.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_cli.py
@@ -2,10 +2,7 @@
 """
 Command to launch the Transformation Shell
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_get_files.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_get_files.py
@@ -3,11 +3,8 @@
 """
 Get the files attached to a transformation
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_recover_data.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_recover_data.py
@@ -2,15 +2,11 @@
 """
 Script to call the DataRecoveryAgent functionality by hand.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from DIRAC import S_OK, gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
-class Params(object):
+class Params:
     """Collection of Parameters set via CLI switches."""
 
     def __init__(self):

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_remove_output.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_remove_output.py
@@ -2,14 +2,7 @@
 """
 Remove the outputs produced by a transformation
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
-import sys
-
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()
@@ -21,7 +14,6 @@ def main():
     transIDs = [int(arg) for arg in args]
 
     from DIRAC.TransformationSystem.Agent.TransformationCleaningAgent import TransformationCleaningAgent
-    from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 
     agent = TransformationCleaningAgent(
         "Transformation/TransformationCleaningAgent",
@@ -30,7 +22,6 @@ def main():
     )
     agent.initialize()
 
-    client = TransformationClient()
     for transID in transIDs:
         agent.removeTransformationOutput(transID)
 

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_replication.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_replication.py
@@ -5,11 +5,7 @@ Create a production to replicate files from some storage elements to others
 :since:  May 31, 2018
 :author: A. Sailer
 """
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_verify_outputdata.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_verify_outputdata.py
@@ -2,13 +2,7 @@
 """
 Runs checkTransformationIntegrity from ValidateOutputDataAgent on selected Tranformation
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-import sys
-
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()
@@ -20,7 +14,6 @@ def main():
     transIDs = [int(arg) for arg in args]
 
     from DIRAC.TransformationSystem.Agent.ValidateOutputDataAgent import ValidateOutputDataAgent
-    from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 
     agent = ValidateOutputDataAgent(
         "Transformation/ValidateOutputDataAgent",
@@ -29,7 +22,6 @@ def main():
     )
     agent.initialize()
 
-    client = TransformationClient()
     for transID in transIDs:
         agent.checkTransformationIntegrity(transID)
 

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapperTemplate.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapperTemplate.py
@@ -11,10 +11,6 @@
     - the resolution of the inpt data failed
     - the JobWrapper ended with the status DErrno.EWMSRESC
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import sys
 import json
 import ast
@@ -27,7 +23,7 @@ sitePython = "@SITEPYTHON@"
 if sitePython:
     sys.path.insert(0, "@SITEPYTHON@")
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.parseCommandLine()
 

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_kill_pilot.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_kill_pilot.py
@@ -7,7 +7,7 @@
 Kill the specified pilot
 """
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_pilot_logging_info.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_pilot_logging_info.py
@@ -6,7 +6,7 @@ WARNING: Only one option (either uuid or jobid) should be used.
 """
 import DIRAC
 from DIRAC import S_OK, gLogger
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 uuid = None
 jobid = None

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_show_task_queues.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_show_task_queues.py
@@ -21,7 +21,7 @@ from DIRAC.Core.Utilities.PrettyPrint import printTable
 
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getUsernameForDN
 from DIRAC.WorkloadManagementSystem.Client.MatcherClient import MatcherClient
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 verbose = False
 

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_sync_pilot.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_sync_pilot.py
@@ -9,7 +9,7 @@ import hashlib
 
 
 from DIRAC import S_OK
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 includeMasterCS = True

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_jobexec.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_jobexec.py
@@ -7,17 +7,12 @@
     are specified via their XML description.  The main client of
     this script is the Job Wrapper.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-
 import os
 import os.path
 import sys
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_vm_endpoint_status.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_vm_endpoint_status.py
@@ -3,7 +3,7 @@
   Get VM instances available in the configured cloud sites
 """
 from DIRAC import gLogger, exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 site = None
 ce = None

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_vm_get_pilot_output.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_vm_get_pilot_output.py
@@ -3,7 +3,7 @@
   Get pilot output from a VM
 """
 from DIRAC import gLogger, exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_vm_instance_stop.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_vm_instance_stop.py
@@ -3,7 +3,7 @@
   Get VM instances available in the configured cloud sites
 """
 from DIRAC import gLogger, exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_cpu_normalization.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_cpu_normalization.py
@@ -14,15 +14,10 @@ Pilots invoke dirac-wms-cpu-normalization which
 
 DB12measured is up to now wrote down but never used.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-
 from db12 import single_dirac_benchmark
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 from DIRAC import gLogger, gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_get_queue_cpu_time.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_get_queue_cpu_time.py
@@ -7,12 +7,8 @@
 Report CPU length of queue, in seconds
 This script is used by the dirac-pilot script to set the CPUTime left, which is a limit for the matching
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_get_wn.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_get_wn.py
@@ -10,7 +10,7 @@ import datetime
 from functools import cmp_to_key
 
 import DIRAC
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 @Script()

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_get_wn_parameters.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_get_wn_parameters.py
@@ -2,11 +2,7 @@
 """
 Determine number of processors and memory for the worker node
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC import gLogger
 from DIRAC.WorkloadManagementSystem.Utilities import JobParameters
 

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_match.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_match.py
@@ -7,7 +7,7 @@ can fail matching due to their dynamic state, e.g. occupancy by other jobs. Also
 proximity is not taken into account.
 """
 from DIRAC import S_OK, gLogger, exit as DIRACExit
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 fullMatch = False
 sites = None

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_pilot_job_info.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_wms_pilot_job_info.py
@@ -6,7 +6,7 @@
 """
 Retrieve info about jobs run by the given pilot
 """
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 def _stringInList(subStr, sList):

--- a/tests/Integration/DataManagementSystem/FIXME_DataLoggingDBTests.py
+++ b/tests/Integration/DataManagementSystem/FIXME_DataLoggingDBTests.py
@@ -112,7 +112,7 @@
 #
 # ## test execution
 # if __name__ == "__main__":
-#   from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+#   from DIRAC.Core.Base.Script import Script
 #   Script.parseCommandLine()
 #   gLogger.setLevel( 'VERBOSE' )
 #

--- a/tests/Integration/Resources/Storage/Test_Resources_GFAL2StorageBase.py
+++ b/tests/Integration/Resources/Storage/Test_Resources_GFAL2StorageBase.py
@@ -17,10 +17,6 @@ Examples:
 """
 
 # pylint: disable=invalid-name,wrong-import-position
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import unittest
 import sys
 import os
@@ -28,7 +24,7 @@ import tempfile
 import shutil
 
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 
 Script.setUsageMessage(

--- a/tests/Jenkins/dirac-cfg-add-option.py
+++ b/tests/Jenkins/dirac-cfg-add-option.py
@@ -1,10 +1,7 @@
 """
 Do the initial configuration of a DIRAC component
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.setUsageMessage(
     "\n".join(

--- a/tests/Jenkins/dirac-cfg-update-dbs.py
+++ b/tests/Jenkins/dirac-cfg-update-dbs.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
 """ update local cfg
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import os
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 
 Script.setUsageMessage("\n".join([__doc__.split("\n")[1], "Usage:", "  %s [options] " % Script.scriptName]))

--- a/tests/Jenkins/dirac-cfg-update-server.py
+++ b/tests/Jenkins/dirac-cfg-update-server.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
 """ update local cfg
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import os
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.setUsageMessage("\n".join([__doc__.split("\n")[1], "Usage:", "  %s [options] ... DB ..." % Script.scriptName]))
 

--- a/tests/Jenkins/dirac-cfg-update-services.py
+++ b/tests/Jenkins/dirac-cfg-update-services.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
 """ update local cfg
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.setUsageMessage(
     "\n".join(

--- a/tests/Jenkins/dirac-cfg-update.py
+++ b/tests/Jenkins/dirac-cfg-update.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
 """ update local cfg
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import os
 
 from diraccfg import CFG
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.setUsageMessage("\n".join([__doc__.split("\n")[1], "Usage:", "  %s [options]" % Script.scriptName]))
 

--- a/tests/Jenkins/dirac-drop-db.py
+++ b/tests/Jenkins/dirac-drop-db.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
 """ Drop DBs from the MySQL server
 """
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.setUsageMessage(
     "\n".join(

--- a/tests/Jenkins/dirac-proxy-download.py
+++ b/tests/Jenkins/dirac-proxy-download.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 """ Get a proxy from the proxy manager
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import os
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.setUsageMessage(
     "\n".join(

--- a/tests/Performance/DFCPerformance/FIXME_Test_FC_scaling.py
+++ b/tests/Performance/DFCPerformance/FIXME_Test_FC_scaling.py
@@ -5,10 +5,7 @@
 """
   Test suite for a generic File Catalog scalability tests
 """
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 from DIRAC import S_OK
 import sys
 import pprint

--- a/tests/System/dirac-test-prod-sys.py
+++ b/tests/System/dirac-test-prod-sys.py
@@ -1,15 +1,11 @@
 """ This script submits a test production
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 # pylint: disable=wrong-import-position, protected-access
 
 import os
 import json
 
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.parseCommandLine()
 

--- a/tests/System/dirac-test-production.py
+++ b/tests/System/dirac-test-production.py
@@ -1,16 +1,11 @@
 """ This script submits a test prodJobuction with filter
 """
-
 # pylint: disable=wrong-import-position, protected-access
-
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 import time
 import os
 
 import json
-from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+from DIRAC.Core.Base.Script import Script
 
 Script.setUsageMessage("\n".join([__doc__.split("\n")[1], "Usage:", "  %s test directory" % Script.scriptName]))
 


### PR DESCRIPTION
Related to https://github.com/DIRACGrid/DIRAC/pull/5713#discussion_r803462839

There are fixes related to unused imports and python 3 things.

There are a lot of changes, but 99% are monotonous changes.

BEGINRELEASENOTES

*Core
FIX: allow to use `deprecated` decorator with classes without predefined `__init__` function.

*All
CHANGE: use DIRAC.Core.Base.Script.Script instead of DIRAC.Core.Utilities.DIRACScript.DIRACScript
CHANGE: add deprecation message

ENDRELEASENOTES
