### PR TITLE
[8.0] Show which handler is being loaded by tornado service

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/HandlerManager.py
+++ b/src/DIRAC/Core/Tornado/Server/HandlerManager.py
@@ -116,7 +116,7 @@ class HandlerManager(object):
                 # Define the system and component name as the attributes of the handler that belongs to them
                 handler.SYSTEM_NAME, handler.COMPONENT_NAME = fullComponentName.split("/")
 
-                gLogger.info(f"Found new handler {fullComponentName}")
+                gLogger.info("Found new handler", f"{fullComponentName}: {handler}")
 
                 # at this stage we run the basic handler initialization
                 # see DIRAC.Core.Tornado.Server.private.BaseRequestHandler for more details


### PR DESCRIPTION
No need for release notes but I think this would be useful for being able to tell if extensions are being loaded correctly.