### PR TITLE
[integration] Remove __RCSID__

### DIFF
--- a/src/DIRAC/AccountingSystem/Agent/NetworkAgent.py
+++ b/src/DIRAC/AccountingSystem/Agent/NetworkAgent.py
@@ -21,8 +21,6 @@ from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 from DIRAC.Resources.MessageQueue.MQCommunication import createConsumer
 
-__RCSID__ = "$Id$"
-
 
 class NetworkAgent(AgentModule):
     """

--- a/src/DIRAC/AccountingSystem/Agent/test/Test_NetworkAgent.py
+++ b/src/DIRAC/AccountingSystem/Agent/test/Test_NetworkAgent.py
@@ -10,8 +10,6 @@ import DIRAC.AccountingSystem.Agent.NetworkAgent as module
 
 from mock.mock import MagicMock
 
-__RCSID__ = "$Id$"
-
 MQURI1 = "mq.dirac.net::Topics::perfsonar.summary.packet-loss-rate"
 MQURI2 = "mq.dirac.net::Queues::perfsonar.summary.histogram-owdelay"
 

--- a/src/DIRAC/AccountingSystem/Client/AccountingCLI.py
+++ b/src/DIRAC/AccountingSystem/Client/AccountingCLI.py
@@ -6,9 +6,6 @@ DIRAC Accounting DataStore Service
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC import gLogger

--- a/src/DIRAC/AccountingSystem/Client/DataStoreClient.py
+++ b/src/DIRAC/AccountingSystem/Client/DataStoreClient.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 import random
 import copy

--- a/src/DIRAC/AccountingSystem/Client/ReportCLI.py
+++ b/src/DIRAC/AccountingSystem/Client/ReportCLI.py
@@ -22,9 +22,6 @@ if __name__=="__main__":
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import sys
 import datetime
 

--- a/src/DIRAC/AccountingSystem/Client/ReportsClient.py
+++ b/src/DIRAC/AccountingSystem/Client/ReportsClient.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import tempfile
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/AccountingSystem/Client/Types/BaseAccountingType.py
+++ b/src/DIRAC/AccountingSystem/Client/Types/BaseAccountingType.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities import Time
 from DIRAC.Core.Base.Client import Client

--- a/src/DIRAC/AccountingSystem/Client/Types/DataOperation.py
+++ b/src/DIRAC/AccountingSystem/Client/Types/DataOperation.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 import DIRAC
 
-__RCSID__ = "$Id$"
-
 
 class DataOperation(BaseAccountingType):
     def __init__(self):

--- a/src/DIRAC/AccountingSystem/Client/Types/Job.py
+++ b/src/DIRAC/AccountingSystem/Client/Types/Job.py
@@ -10,8 +10,6 @@ from __future__ import print_function
 import DIRAC
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 
-__RCSID__ = "$Id$"
-
 
 class Job(BaseAccountingType):
     def __init__(self):

--- a/src/DIRAC/AccountingSystem/Client/Types/Network.py
+++ b/src/DIRAC/AccountingSystem/Client/Types/Network.py
@@ -6,9 +6,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 
 

--- a/src/DIRAC/AccountingSystem/Client/Types/Pilot.py
+++ b/src/DIRAC/AccountingSystem/Client/Types/Pilot.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 
 

--- a/src/DIRAC/AccountingSystem/Client/Types/StorageOccupancy.py
+++ b/src/DIRAC/AccountingSystem/Client/Types/StorageOccupancy.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 
 

--- a/src/DIRAC/AccountingSystem/Client/Types/WMSHistory.py
+++ b/src/DIRAC/AccountingSystem/Client/Types/WMSHistory.py
@@ -7,9 +7,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 
 

--- a/src/DIRAC/AccountingSystem/DB/AccountingDB.py
+++ b/src/DIRAC/AccountingSystem/DB/AccountingDB.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import datetime
 import time
 import threading

--- a/src/DIRAC/AccountingSystem/DB/MultiAccountingDB.py
+++ b/src/DIRAC/AccountingSystem/DB/MultiAccountingDB.py
@@ -3,10 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gConfig, S_OK, gLogger
 from DIRAC.Core.Utilities.Plotting.TypeLoader import TypeLoader
 from DIRAC.AccountingSystem.DB.AccountingDB import AccountingDB

--- a/src/DIRAC/AccountingSystem/Service/DataStoreHandler.py
+++ b/src/DIRAC/AccountingSystem/Service/DataStoreHandler.py
@@ -24,8 +24,6 @@ from DIRAC.Core.Utilities import Time
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.Core.Base.Client import Client
 
-__RCSID__ = "$Id$"
-
 
 class DataStoreHandler(RequestHandler):
     """DISET implementation of service for inserting records in accountingDB."""

--- a/src/DIRAC/AccountingSystem/Service/ReportGeneratorHandler.py
+++ b/src/DIRAC/AccountingSystem/Service/ReportGeneratorHandler.py
@@ -9,9 +9,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import datetime
 

--- a/src/DIRAC/AccountingSystem/private/Plotters/NetworkPlotter.py
+++ b/src/DIRAC/AccountingSystem/private/Plotters/NetworkPlotter.py
@@ -9,9 +9,6 @@ Supports:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import numpy as np
 
 from DIRAC import S_OK

--- a/src/DIRAC/AccountingSystem/private/Plotters/StorageOccupancyPlotter.py
+++ b/src/DIRAC/AccountingSystem/private/Plotters/StorageOccupancyPlotter.py
@@ -13,9 +13,6 @@ from DIRAC.AccountingSystem.private.Plotters.BaseReporter import BaseReporter
 from DIRAC.AccountingSystem.Client.Types.StorageOccupancy import StorageOccupancy
 
 
-__RCSID__ = "$Id$"
-
-
 class StorageOccupancyPlotter(BaseReporter):
     """StorageOccupancyPlotter as extension of BaseReporter."""
 

--- a/src/DIRAC/AccountingSystem/private/Policies/JobPolicy.py
+++ b/src/DIRAC/AccountingSystem/private/Policies/JobPolicy.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security import Properties
 from DIRAC.AccountingSystem.private.Policies.FilterExecutor import FilterExecutor

--- a/src/DIRAC/AccountingSystem/scripts/dirac_accounting_decode_fileid.py
+++ b/src/DIRAC/AccountingSystem/scripts/dirac_accounting_decode_fileid.py
@@ -9,9 +9,6 @@ Decode Accounting plot URLs
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import sys
 import pprint
 from urllib import parse

--- a/src/DIRAC/AccountingSystem/scripts/dirac_admin_accounting_cli.py
+++ b/src/DIRAC/AccountingSystem/scripts/dirac_admin_accounting_cli.py
@@ -9,9 +9,6 @@ Command line administrative interface to DIRAC Accounting DataStore Service
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/ConfigurationSystem/Agent/Bdii2CSAgent.py
+++ b/src/DIRAC/ConfigurationSystem/Agent/Bdii2CSAgent.py
@@ -15,9 +15,6 @@ The following options can be set for the Bdii2CSAgent.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath

--- a/src/DIRAC/ConfigurationSystem/Agent/GOCDB2CSAgent.py
+++ b/src/DIRAC/ConfigurationSystem/Agent/GOCDB2CSAgent.py
@@ -15,9 +15,6 @@ The following options can be set for the GOCDB2CSAgent.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.LCG.GOCDBClient import GOCDBClient

--- a/src/DIRAC/ConfigurationSystem/Agent/VOMS2CSAgent.py
+++ b/src/DIRAC/ConfigurationSystem/Agent/VOMS2CSAgent.py
@@ -38,8 +38,6 @@ from DIRAC.ConfigurationSystem.Client.VOMS2CSSynchronizer import VOMS2CSSynchron
 from DIRAC.FrameworkSystem.Client.NotificationClient import NotificationClient
 from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 
-__RCSID__ = "$Id$"
-
 
 class VOMS2CSAgent(AgentModule):
     def __init__(self, *args, **kwargs):

--- a/src/DIRAC/ConfigurationSystem/Agent/__init__.py
+++ b/src/DIRAC/ConfigurationSystem/Agent/__init__.py
@@ -4,5 +4,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/ConfigurationSystem/Client/CSAPI.py
+++ b/src/DIRAC/ConfigurationSystem/Client/CSAPI.py
@@ -17,8 +17,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getSites, getCESiteMapping
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
 
-__RCSID__ = "$Id$"
-
 
 class CSAPI(object):
     """CSAPI objects need an initialization phase"""

--- a/src/DIRAC/ConfigurationSystem/Client/CSCLI.py
+++ b/src/DIRAC/ConfigurationSystem/Client/CSCLI.py
@@ -20,8 +20,6 @@ from DIRAC.ConfigurationSystem.private.Modificator import Modificator
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 from DIRAC.ConfigurationSystem.Client.ConfigurationClient import ConfigurationClient
 
-__RCSID__ = "$Id$"
-
 
 def _showTraceback():
     import traceback

--- a/src/DIRAC/ConfigurationSystem/Client/CSShellCLI.py
+++ b/src/DIRAC/ConfigurationSystem/Client/CSShellCLI.py
@@ -4,9 +4,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import cmd
 import os
 

--- a/src/DIRAC/ConfigurationSystem/Client/Config.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Config.py
@@ -5,9 +5,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.ConfigurationSystem.private.ConfigurationClient import ConfigurationClient
 
 #: Global gConfig object of type :class:`~DIRAC.ConfigurationSystem.private.ConfigurationClient.ConfigurationClient`

--- a/src/DIRAC/ConfigurationSystem/Client/ConfigurationClient.py
+++ b/src/DIRAC/ConfigurationSystem/Client/ConfigurationClient.py
@@ -1,10 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
-
 from base64 import b64encode, b64decode
 
 from DIRAC.Core.Tornado.Client.TornadoClient import TornadoClient

--- a/src/DIRAC/ConfigurationSystem/Client/ConfigurationData.py
+++ b/src/DIRAC/ConfigurationSystem/Client/ConfigurationData.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
 from DIRAC.ConfigurationSystem.private.ConfigurationData import ConfigurationData
 
 gConfigurationData = ConfigurationData()

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Local.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Local.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
 

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Path.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Path.py
@@ -8,9 +8,6 @@ Some Helper class to build CFG paths from tuples
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 cfgInstallSection = "LocalInstallation"

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Registry.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Registry.py
@@ -10,8 +10,6 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import getVO
 
-__RCSID__ = "$Id$"
-
 ID_DN_PREFIX = "/O=DIRAC/CN="
 
 # pylint: disable=missing-docstring

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Resources.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Resources.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from urllib import parse
 from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
 

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/ResourcesDefaults.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/ResourcesDefaults.py
@@ -12,8 +12,6 @@ from __future__ import division
 from diraccfg import CFG
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgResourceSection, cfgPath, cfgInstallPath, cfgPathToList
 
-__RCSID__ = "$Id$"
-
 
 def defaultSection(resource):
     """

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/__init__.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/__init__.py
@@ -4,8 +4,5 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import *
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import getCSExtensions, getVO

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from urllib import parse
 
 from DIRAC.Core.Utilities import List

--- a/src/DIRAC/ConfigurationSystem/Client/Utilities.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Utilities.py
@@ -7,9 +7,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from copy import deepcopy
 import socket
 

--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from collections import defaultdict
 
 from DIRAC import S_OK, S_ERROR, gLogger, gConfig

--- a/src/DIRAC/ConfigurationSystem/Client/__init__.py
+++ b/src/DIRAC/ConfigurationSystem/Client/__init__.py
@@ -4,5 +4,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/ConfigurationSystem/Service/ConfigurationHandler.py
+++ b/src/DIRAC/ConfigurationSystem/Service/ConfigurationHandler.py
@@ -13,9 +13,6 @@ The following options can be set for the Configuration Service.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.ConfigurationSystem.private.ServiceInterface import ServiceInterface
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.Security.Properties import CS_ADMINISTRATOR

--- a/src/DIRAC/ConfigurationSystem/Service/TornadoConfigurationHandler.py
+++ b/src/DIRAC/ConfigurationSystem/Service/TornadoConfigurationHandler.py
@@ -9,9 +9,6 @@ In client side you must use a specific client
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from base64 import b64encode, b64decode
 
 from DIRAC import S_OK, S_ERROR, gLogger

--- a/src/DIRAC/ConfigurationSystem/Service/__init__.py
+++ b/src/DIRAC/ConfigurationSystem/Service/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/ConfigurationSystem/__init__.py
+++ b/src/DIRAC/ConfigurationSystem/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/ConfigurationSystem/private/ConfigurationClient.py
+++ b/src/DIRAC/ConfigurationSystem/private/ConfigurationClient.py
@@ -14,8 +14,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 from DIRAC.ConfigurationSystem.private.Refresher import gRefresher
 
-__RCSID__ = "$Id$"
-
 
 class ConfigurationClient(object):
     def __init__(self, fileToLoadList=None):

--- a/src/DIRAC/ConfigurationSystem/private/ConfigurationData.py
+++ b/src/DIRAC/ConfigurationSystem/private/ConfigurationData.py
@@ -18,8 +18,6 @@ from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.Utilities.LockRing import LockRing
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
-__RCSID__ = "$Id$"
-
 
 class ConfigurationData(object):
     def __init__(self, loadDefaultCFG=True):

--- a/src/DIRAC/ConfigurationSystem/private/Modificator.py
+++ b/src/DIRAC/ConfigurationSystem/private/Modificator.py
@@ -12,8 +12,6 @@ from DIRAC.Core.Utilities import List, Time
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 
-__RCSID__ = "$Id$"
-
 
 class Modificator(object):
     def __init__(self, rpcClient=False, commiterId="unknown"):

--- a/src/DIRAC/ConfigurationSystem/private/Refresher.py
+++ b/src/DIRAC/ConfigurationSystem/private/Refresher.py
@@ -4,9 +4,6 @@ Used each time you call gConfig. It keep your configuration up-to-date with the 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import threading
 import time
 import os

--- a/src/DIRAC/ConfigurationSystem/private/RefresherBase.py
+++ b/src/DIRAC/ConfigurationSystem/private/RefresherBase.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 import random
 

--- a/src/DIRAC/ConfigurationSystem/private/ServiceInterface.py
+++ b/src/DIRAC/ConfigurationSystem/private/ServiceInterface.py
@@ -12,8 +12,6 @@ from DIRAC import gLogger
 from DIRAC.ConfigurationSystem.private.ServiceInterfaceBase import ServiceInterfaceBase
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 
-__RCSID__ = "$Id$"
-
 
 class ServiceInterface(ServiceInterfaceBase, threading.Thread):
     """

--- a/src/DIRAC/ConfigurationSystem/private/ServiceInterfaceBase.py
+++ b/src/DIRAC/ConfigurationSystem/private/ServiceInterfaceBase.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import time
 import re

--- a/src/DIRAC/ConfigurationSystem/private/ServiceInterfaceTornado.py
+++ b/src/DIRAC/ConfigurationSystem/private/ServiceInterfaceTornado.py
@@ -5,9 +5,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from tornado import gen
 from tornado.ioloop import IOLoop
 from DIRAC.ConfigurationSystem.private.ServiceInterfaceBase import ServiceInterfaceBase

--- a/src/DIRAC/ConfigurationSystem/private/TornadoRefresher.py
+++ b/src/DIRAC/ConfigurationSystem/private/TornadoRefresher.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from six import PY3
 import time
 

--- a/src/DIRAC/ConfigurationSystem/private/__init__.py
+++ b/src/DIRAC/ConfigurationSystem/private/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_resources.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_resources.py
@@ -9,9 +9,6 @@ Add resources from the BDII database for a given VO
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import signal
 import shlex
 

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_shifter.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_shifter.py
@@ -9,9 +9,6 @@ Adds or modify a shifter, in the operations section of the CS
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 from DIRAC import exit as DIRACExit, gLogger

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_site.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_add_site.py
@@ -14,9 +14,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC import exit as DIRACExit, gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getDIRACSiteName

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_check_config_options.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_check_config_options.py
@@ -16,9 +16,6 @@ Usage:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 from pprint import pformat
 

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_sort_cs_sites.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_sort_cs_sites.py
@@ -14,9 +14,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger, exit as DIRACExit
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_voms_sync.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_voms_sync.py
@@ -9,9 +9,6 @@ Synchronize VOMS user data with the DIRAC Registry
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger, exit as DIRACExit, S_OK
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.ConfigurationSystem.Client.VOMS2CSSynchronizer import VOMS2CSSynchronizer

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_cli.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_cli.py
@@ -9,9 +9,6 @@ Command line interface to DIRAC Configuration Server
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.ConfigurationSystem.Client.CSCLI import CSCLI
 

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_dump_local_cache.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_dump_local_cache.py
@@ -9,9 +9,6 @@ Dump DIRAC Configuration data
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import sys
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_shell.py
+++ b/src/DIRAC/ConfigurationSystem/scripts/dirac_configuration_shell.py
@@ -6,9 +6,6 @@ Script that emulates the behaviour of a shell to edit the CS config.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/Core/DISET/MessageClient.py
+++ b/src/DIRAC/Core/DISET/MessageClient.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import random
 from hashlib import md5
 

--- a/src/DIRAC/Core/DISET/RPCClient.py
+++ b/src/DIRAC/Core/DISET/RPCClient.py
@@ -3,10 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
-
 from DIRAC.Core.DISET.private.InnerRPCClient import InnerRPCClient
 
 

--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -40,9 +40,6 @@ from DIRAC.Core.DISET.private.Protocols import gProtocolDict
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.ConfigurationSystem.Client import PathFinder
 
-
-__RCSID__ = "$Id$"
-
 #: Time during which the service does not accept new requests and handles those in the queue, if the backlog is too large
 #: This sleep is repeated for as long as Service.wantsThrottle is truthy
 THROTTLE_SERVICE_SLEEP_SECONDS = 0.25

--- a/src/DIRAC/Core/DISET/TransferClient.py
+++ b/src/DIRAC/Core/DISET/TransferClient.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/Core/DISET/__init__.py
+++ b/src/DIRAC/Core/DISET/__init__.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # Define here a few constants useful for all the transport layer
 
 #: Default timeout for the RPC call

--- a/src/DIRAC/Core/DISET/private/GatewayService.py
+++ b/src/DIRAC/Core/DISET/private/GatewayService.py
@@ -38,8 +38,6 @@ from DIRAC.Core.DISET.RPCClient import RPCClient
 from DIRAC.Core.DISET.TransferClient import TransferClient
 from DIRAC.Core.DISET.private.BaseClient import BaseClient
 
-__RCSID__ = "$Id$"
-
 
 class GatewayService(Service):
     """Inherits from Service so it can (and should) be run as a DIRAC service,

--- a/src/DIRAC/Core/DISET/private/InnerRPCClient.py
+++ b/src/DIRAC/Core/DISET/private/InnerRPCClient.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.DISET.private.BaseClient import BaseClient
 from DIRAC.Core.Utilities.ReturnValues import S_OK
 from DIRAC.Core.Utilities.DErrno import cmpError, ENOAUTH

--- a/src/DIRAC/Core/DISET/private/LockManager.py
+++ b/src/DIRAC/Core/DISET/private/LockManager.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import threading
 
 

--- a/src/DIRAC/Core/DISET/private/MessageBroker.py
+++ b/src/DIRAC/Core/DISET/private/MessageBroker.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import threading
 import time
 import select

--- a/src/DIRAC/Core/DISET/private/Protocols.py
+++ b/src/DIRAC/Core/DISET/private/Protocols.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.DISET.private.Transports import PlainTransport, SSLTransport
 
 gProtocolDict = {

--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -37,8 +37,6 @@ from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.FrameworkSystem.Client.MonitoringClient import MonitoringClient
 from DIRAC.FrameworkSystem.Client.SecurityLogClient import SecurityLogClient
 
-__RCSID__ = "$Id$"
-
 
 class Service(object):
 

--- a/src/DIRAC/Core/DISET/private/ServiceConfiguration.py
+++ b/src/DIRAC/Core/DISET/private/ServiceConfiguration.py
@@ -5,9 +5,6 @@ which can be configured in CS.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities import Network, List
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
 from DIRAC.ConfigurationSystem.Client import PathFinder

--- a/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
@@ -5,9 +5,6 @@ M2Crypto SSLTransport Library
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import socket
 from M2Crypto import SSL, threading as M2Threading

--- a/src/DIRAC/Core/DISET/private/Transports/PlainTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/PlainTransport.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import socket
 import time
 import os

--- a/src/DIRAC/Core/DISET/private/Transports/SSL/FakeSocket.py
+++ b/src/DIRAC/Core/DISET/private/Transports/SSL/FakeSocket.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import socket
 
 ##############################################################

--- a/src/DIRAC/Core/DISET/private/Transports/SSL/__init__.py
+++ b/src/DIRAC/Core/DISET/private/Transports/SSL/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Core/DISET/private/Transports/SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/SSLTransport.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 

--- a/src/DIRAC/Core/DISET/private/Transports/__init__.py
+++ b/src/DIRAC/Core/DISET/private/Transports/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Core/DISET/private/__init__.py
+++ b/src/DIRAC/Core/DISET/private/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Core/DISET/test/Test_AuthManager.py
+++ b/src/DIRAC/Core/DISET/test/Test_AuthManager.py
@@ -10,8 +10,6 @@ from diraccfg import CFG
 from DIRAC import gConfig
 from DIRAC.Core.DISET.AuthManager import AuthManager
 
-__RCSID__ = "$Id$"
-
 testSystemsCFG = """
 Systems
 {

--- a/src/DIRAC/Core/LCG/GGUSTicketsClient.py
+++ b/src/DIRAC/Core/LCG/GGUSTicketsClient.py
@@ -11,8 +11,6 @@ from suds.client import Client
 
 from DIRAC import gConfig, S_OK, S_ERROR
 
-__RCSID__ = "$Id$"
-
 
 def getGGUSURL(vo=None, siteName=None):
     """create the URL to get tickets relative to the site ( opened only ! ):"""

--- a/src/DIRAC/Core/LCG/__init__.py
+++ b/src/DIRAC/Core/LCG/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Core/LCG/test/Test_LCG.py
+++ b/src/DIRAC/Core/LCG/test/Test_LCG.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import mock
 
 from datetime import datetime, timedelta

--- a/src/DIRAC/Core/Security/BaseSecurity.py
+++ b/src/DIRAC/Core/Security/BaseSecurity.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import tempfile
 

--- a/src/DIRAC/Core/Security/Locations.py
+++ b/src/DIRAC/Core/Security/Locations.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import DIRAC
 from DIRAC import gConfig

--- a/src/DIRAC/Core/Security/MyProxy.py
+++ b/src/DIRAC/Core/Security/MyProxy.py
@@ -4,9 +4,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import re
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.Subprocess import shellCall

--- a/src/DIRAC/Core/Security/Properties.py
+++ b/src/DIRAC/Core/Security/Properties.py
@@ -5,9 +5,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
-
 #: A host property. This property is used::
 #: * For a host to forward credentials in a DISET call
 TRUSTED_HOST = "TrustedHost"

--- a/src/DIRAC/Core/Security/VOMS.py
+++ b/src/DIRAC/Core/Security/VOMS.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import stat
 import tempfile

--- a/src/DIRAC/Core/Security/VOMSService.py
+++ b/src/DIRAC/Core/Security/VOMSService.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import requests
 
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR

--- a/src/DIRAC/Core/Security/__init__.py
+++ b/src/DIRAC/Core/Security/__init__.py
@@ -4,10 +4,6 @@ Just a selector for X509Certificate
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
-
 from pkgutil import extend_path
 
 

--- a/src/DIRAC/Core/Security/m2crypto/X509CRL.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509CRL.py
@@ -4,10 +4,6 @@ This class is used to manage the revoked certificates....
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
-
 import stat
 import os
 import tempfile

--- a/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
@@ -8,9 +8,6 @@ X509RFC: https://tools.ietf.org/html/rfc5280
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import datetime
 import os
 import random

--- a/src/DIRAC/Core/Security/m2crypto/X509Request.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Request.py
@@ -4,9 +4,6 @@ It's main use is for proxy delegation.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import M2Crypto
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities import DErrno

--- a/src/DIRAC/Core/Tornado/Client/ClientSelector.py
+++ b/src/DIRAC/Core/Tornado/Client/ClientSelector.py
@@ -12,9 +12,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import functools
 
 from DIRAC import gLogger

--- a/src/DIRAC/Core/Tornado/Client/TornadoClient.py
+++ b/src/DIRAC/Core/Tornado/Client/TornadoClient.py
@@ -25,8 +25,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # pylint: disable=broad-except
 
 from DIRAC.Core.Tornado.Client.private.TornadoBaseClient import TornadoBaseClient

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -27,9 +27,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from io import open
 import errno
 import os

--- a/src/DIRAC/Core/Tornado/Server/TornadoServer.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoServer.py
@@ -6,9 +6,6 @@ It may work better with TornadoClient but as it accepts HTTPS you can create you
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 import datetime
 import os

--- a/src/DIRAC/Core/Tornado/Server/TornadoService.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoService.py
@@ -6,9 +6,6 @@ It directly inherits from :py:class:`tornado.web.RequestHandler`
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from io import open
 
 import os

--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 import inspect
 import threading

--- a/src/DIRAC/Core/Tornado/scripts/tornado_start_CS.py
+++ b/src/DIRAC/Core/Tornado/scripts/tornado_start_CS.py
@@ -9,9 +9,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import sys
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
+++ b/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
@@ -9,9 +9,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import sys
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/Core/Utilities/ClassAd/__init__.py
+++ b/src/DIRAC/Core/Utilities/ClassAd/__init__.py
@@ -4,5 +4,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Core/Utilities/CountryMapping.py
+++ b/src/DIRAC/Core/Utilities/CountryMapping.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gConfig, S_OK, S_ERROR
 
 

--- a/src/DIRAC/Core/Utilities/DEncode.py
+++ b/src/DIRAC/Core/Utilities/DEncode.py
@@ -14,9 +14,6 @@ Encoding and decoding for dirac, Ids:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from past.builtins import long
 import six
 import datetime

--- a/src/DIRAC/Core/Utilities/Decorators.py
+++ b/src/DIRAC/Core/Utilities/Decorators.py
@@ -10,8 +10,6 @@ import inspect
 import functools
 import traceback
 
-__RCSID__ = "$Id$"
-
 
 def deprecated(reason, onlyOnce=False):
     """A decorator to mark a class or function as deprecated.

--- a/src/DIRAC/Core/Utilities/DictCache.py
+++ b/src/DIRAC/Core/Utilities/DictCache.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import datetime
 import threading
 

--- a/src/DIRAC/Core/Utilities/DirectoryExplorer.py
+++ b/src/DIRAC/Core/Utilities/DirectoryExplorer.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 
 class DirectoryExplorer(object):
     def __init__(self, sort=False, reverse=False):

--- a/src/DIRAC/Core/Utilities/EventDispatcher.py
+++ b/src/DIRAC/Core/Utilities/EventDispatcher.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import threading
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.Utilities.ThreadSafe import Synchronizer

--- a/src/DIRAC/Core/Utilities/File.py
+++ b/src/DIRAC/Core/Utilities/File.py
@@ -7,9 +7,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import os
 import hashlib
 import random

--- a/src/DIRAC/Core/Utilities/Glue2.py
+++ b/src/DIRAC/Core/Utilities/Glue2.py
@@ -25,9 +25,6 @@ from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Utilities.Grid import ldapsearchBDII
 
-__RCSID__ = "$Id$"
-
-
 sLog = gLogger.getSubLogger(__name__)
 
 

--- a/src/DIRAC/Core/Utilities/Graphs/BarGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/BarGraph.py
@@ -24,9 +24,6 @@ from DIRAC.Core.Utilities.Graphs.GraphUtilities import (
 )
 
 
-__RCSID__ = "$Id$"
-
-
 class BarGraph(PlotBase):
 
     """

--- a/src/DIRAC/Core/Utilities/Graphs/CurveGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/CurveGraph.py
@@ -6,9 +6,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.Graphs.PlotBase import PlotBase
 from DIRAC.Core.Utilities.Graphs.GraphUtilities import (
     darkenColor,

--- a/src/DIRAC/Core/Utilities/Graphs/Graph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/Graph.py
@@ -8,9 +8,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import datetime
 import time
 import os

--- a/src/DIRAC/Core/Utilities/Graphs/LineGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/LineGraph.py
@@ -7,9 +7,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.Graphs.PlotBase import PlotBase
 from DIRAC.Core.Utilities.Graphs.GraphUtilities import (
     to_timestamp,

--- a/src/DIRAC/Core/Utilities/Graphs/Palette.py
+++ b/src/DIRAC/Core/Utilities/Graphs/Palette.py
@@ -6,9 +6,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import hashlib
 
 from DIRAC.WorkloadManagementSystem.Client import JobStatus

--- a/src/DIRAC/Core/Utilities/Graphs/PieGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/PieGraph.py
@@ -16,8 +16,6 @@ from DIRAC.Core.Utilities.Graphs.PlotBase import PlotBase
 from DIRAC.Core.Utilities.Graphs.GraphData import GraphData
 from DIRAC.Core.Utilities.Graphs.GraphUtilities import *
 
-__RCSID__ = "$Id$"
-
 
 class PieGraph(PlotBase):
     def __init__(self, data, ax, prefs, *args, **kw):

--- a/src/DIRAC/Core/Utilities/Graphs/PlotBase.py
+++ b/src/DIRAC/Core/Utilities/Graphs/PlotBase.py
@@ -13,8 +13,6 @@ from DIRAC.Core.Utilities.Graphs.GraphUtilities import pixelToPoint, evalPrefs
 from matplotlib.axes import Axes
 from matplotlib.pylab import setp
 
-__RCSID__ = "$Id$"
-
 
 class PlotBase(object):
     def __init__(self, data=None, axes=None, *aw, **kw):

--- a/src/DIRAC/Core/Utilities/Graphs/QualityMapGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/QualityMapGraph.py
@@ -24,9 +24,6 @@ from DIRAC.Core.Utilities.Graphs.GraphUtilities import (
     PrettyScalarFormatter,
 )
 
-__RCSID__ = "$Id$"
-
-
 cdict = {
     "red": ((0.0, 1.0, 1.0), (0.5, 0.0, 0.0), (1.0, 0.0, 0.0)),
     "green": ((0.0, 0.1, 0.1), (0.5, 0.9, 0.9), (1.0, 0.7, 0.7)),

--- a/src/DIRAC/Core/Utilities/Graphs/__init__.py
+++ b/src/DIRAC/Core/Utilities/Graphs/__init__.py
@@ -8,9 +8,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import importlib.resources
 
 # Make sure the the Agg backend is used despite arbitrary configuration

--- a/src/DIRAC/Core/Utilities/Grid.py
+++ b/src/DIRAC/Core/Utilities/Grid.py
@@ -10,8 +10,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers import Local
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Subprocess import systemCall, shellCall
 
-__RCSID__ = "$Id$"
-
 
 def executeGridCommand(proxy, cmd, gridEnvScript=None):
     """

--- a/src/DIRAC/Core/Utilities/JDL.py
+++ b/src/DIRAC/Core/Utilities/JDL.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from diraccfg import CFG
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities import List

--- a/src/DIRAC/Core/Utilities/List.py
+++ b/src/DIRAC/Core/Utilities/List.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import random
 import sys
 

--- a/src/DIRAC/Core/Utilities/MJF.py
+++ b/src/DIRAC/Core/Utilities/MJF.py
@@ -19,8 +19,6 @@ import DIRAC
 
 from DIRAC import gLogger, gConfig
 
-__RCSID__ = "$Id$"
-
 
 class MJF(object):
     """Machine/Job Features methods"""

--- a/src/DIRAC/Core/Utilities/Mail.py
+++ b/src/DIRAC/Core/Utilities/Mail.py
@@ -16,8 +16,6 @@ from getpass import getuser
 
 from DIRAC import gLogger, S_OK, S_ERROR
 
-__RCSID__ = "$Id$"
-
 
 class Mail(object):
     def __init__(self):

--- a/src/DIRAC/Core/Utilities/MemStat.py
+++ b/src/DIRAC/Core/Utilities/MemStat.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 
 import os
 
-__RCSID__ = "$Id$"
-
 
 def VmB(vmKey):
     __memScale = {"kB": 1024.0, "mB": 1024.0 * 1024.0, "KB": 1024.0, "MB": 1024.0 * 1024.0}

--- a/src/DIRAC/Core/Utilities/MixedEncode.py
+++ b/src/DIRAC/Core/Utilities/MixedEncode.py
@@ -8,8 +8,6 @@ from __future__ import print_function
 import os
 from DIRAC.Core.Utilities import DEncode, JEncode
 
-__RCSID__ = "$Id$"
-
 
 def encode(inData):
     """Encode the input data

--- a/src/DIRAC/Core/Utilities/ModuleFactory.py
+++ b/src/DIRAC/Core/Utilities/ModuleFactory.py
@@ -9,9 +9,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR, gLogger
 
 

--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -162,9 +162,6 @@ from DIRAC.Core.Utilities.Time import fromString
 from DIRAC.Core.Utilities import DErrno
 
 gInstancesCount = 0
-
-__RCSID__ = "$Id$"
-
 MAXCONNECTRETRY = 10
 RETRY_SLEEP_DURATION = 5
 

--- a/src/DIRAC/Core/Utilities/NTP.py
+++ b/src/DIRAC/Core/Utilities/NTP.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from socket import socket, AF_INET, SOCK_DGRAM
 import struct
 import time as time

--- a/src/DIRAC/Core/Utilities/Network.py
+++ b/src/DIRAC/Core/Utilities/Network.py
@@ -5,9 +5,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import socket
 import os
 import struct

--- a/src/DIRAC/Core/Utilities/Os.py
+++ b/src/DIRAC/Core/Utilities/Os.py
@@ -14,9 +14,6 @@ import DIRAC
 from DIRAC.Core.Utilities.Subprocess import shellCall, systemCall
 from DIRAC.Core.Utilities import List
 
-__RCSID__ = "$Id$"
-
-
 DEBUG = 0
 
 

--- a/src/DIRAC/Core/Utilities/Pfn.py
+++ b/src/DIRAC/Core/Utilities/Pfn.py
@@ -12,8 +12,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # # imports
 import os
 from urllib import parse

--- a/src/DIRAC/Core/Utilities/Platform.py
+++ b/src/DIRAC/Core/Utilities/Platform.py
@@ -9,8 +9,6 @@ import sys
 import os
 import re
 
-__RCSID__ = "$Id$"
-
 # We need to patch python platform module. It does a string comparison for the libc versions.
 # it fails when going from 2.9 to 2.10,
 # the fix converts the version to a tuple and attempts a numeric comparison

--- a/src/DIRAC/Core/Utilities/Plotting/DataCache.py
+++ b/src/DIRAC/Core/Utilities/Plotting/DataCache.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os.path
 import time
 import threading

--- a/src/DIRAC/Core/Utilities/Plotting/FileCoding.py
+++ b/src/DIRAC/Core/Utilities/Plotting/FileCoding.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import base64
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities import DEncode

--- a/src/DIRAC/Core/Utilities/Plotting/TypeLoader.py
+++ b/src/DIRAC/Core/Utilities/Plotting/TypeLoader.py
@@ -12,8 +12,6 @@ from DIRAC.Core.Utilities.ObjectLoader import loadObjects
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 from DIRAC.MonitoringSystem.Client.Types.BaseType import BaseType
 
-__RCSID__ = "$Id$"
-
 ########################################################################
 
 

--- a/src/DIRAC/Core/Utilities/ProcessPool.py
+++ b/src/DIRAC/Core/Utilities/ProcessPool.py
@@ -96,9 +96,6 @@ everywhere.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import errno
 import inspect
 import multiprocessing

--- a/src/DIRAC/Core/Utilities/Profiler.py
+++ b/src/DIRAC/Core/Utilities/Profiler.py
@@ -4,9 +4,6 @@ Profiling class for updated information on process status
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import datetime
 import errno
 import psutil

--- a/src/DIRAC/Core/Utilities/Proxy.py
+++ b/src/DIRAC/Core/Utilities/Proxy.py
@@ -46,8 +46,6 @@ from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationDat
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOMSAttributeForGroup, getDNForUsername
 from DIRAC.Core.Utilities.LockRing import LockRing
 
-__RCSID__ = "$Id$"
-
 
 def executeWithUserProxy(fcn):
     """

--- a/src/DIRAC/Core/Utilities/Shifter.py
+++ b/src/DIRAC/Core/Utilities/Shifter.py
@@ -4,9 +4,6 @@ Handling the download of the shifter Proxy
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC import S_OK, S_ERROR, gLogger

--- a/src/DIRAC/Core/Utilities/SiteSEMapping.py
+++ b/src/DIRAC/Core/Utilities/SiteSEMapping.py
@@ -7,10 +7,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger, S_OK
 from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers, siteGridName
 

--- a/src/DIRAC/Core/Utilities/StateMachine.py
+++ b/src/DIRAC/Core/Utilities/StateMachine.py
@@ -8,8 +8,6 @@ from __future__ import print_function
 
 from DIRAC import S_OK, S_ERROR, gLogger
 
-__RCSID__ = "$Id$"
-
 
 class State(object):
     """

--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -53,8 +53,6 @@ from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 # from DIRAC import gLogger
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
-__RCSID__ = "$Id$"
-
 USE_WATCHDOG = False
 
 

--- a/src/DIRAC/Core/Utilities/ThreadPool.py
+++ b/src/DIRAC/Core/Utilities/ThreadPool.py
@@ -71,9 +71,6 @@ soon as the requests have finished. To enable this mode call::
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import time
 import sys
 import queue

--- a/src/DIRAC/Core/Utilities/ThreadSafe.py
+++ b/src/DIRAC/Core/Utilities/ThreadSafe.py
@@ -2,8 +2,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-__RCSID__ = "$Id$"
-
 
 class Synchronizer(object):
     """Class encapsulating a lock

--- a/src/DIRAC/Core/Utilities/ThreadScheduler.py
+++ b/src/DIRAC/Core/Utilities/ThreadScheduler.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import hashlib
 import threading
 import time

--- a/src/DIRAC/Core/Utilities/Version.py
+++ b/src/DIRAC/Core/Utilities/Version.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import importlib
 from importlib.metadata import version as get_version
 

--- a/src/DIRAC/Core/Utilities/test/Test_Adler.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Adler.py
@@ -35,8 +35,6 @@ import zlib
 # from DIRAC
 from DIRAC.Core.Utilities import Adler
 
-__RCSID__ = "$Id$"
-
 ########################################################################
 
 

--- a/src/DIRAC/Core/Utilities/test/Test_ExecutorDispatcher.py
+++ b/src/DIRAC/Core/Utilities/test/Test_ExecutorDispatcher.py
@@ -5,10 +5,6 @@ from __future__ import division
 from __future__ import print_function
 
 # pylint: disable=protected-access
-
-__RCSID__ = "$Id$"
-
-
 from DIRAC.Core.Utilities.ExecutorDispatcher import (
     ExecutorState,
     ExecutorQueues,

--- a/src/DIRAC/Core/Utilities/test/Test_File.py
+++ b/src/DIRAC/Core/Utilities/test/Test_File.py
@@ -33,9 +33,6 @@ from DIRAC.Core.Utilities.File import (
 parametrize = mark.parametrize
 
 
-__RCSID__ = "$Id$"
-
-
 def testCheckGuid():
     """checkGuid tests"""
     # empty string

--- a/src/DIRAC/Core/Utilities/test/Test_List.py
+++ b/src/DIRAC/Core/Utilities/test/Test_List.py
@@ -17,9 +17,6 @@ import unittest
 # sut
 from DIRAC.Core.Utilities import List
 
-__RCSID__ = "$Id$"
-
-
 ########################################################################
 class ListTestCase(unittest.TestCase):
     """py:class ListTestCase

--- a/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
@@ -15,9 +15,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from os.path import dirname, join
 
 # imports

--- a/src/DIRAC/Core/Utilities/test/Test_Time.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Time.py
@@ -5,8 +5,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-__RCSID__ = "$Id$"
-
 # imports
 import unittest
 

--- a/src/DIRAC/Core/Workflow/__init__.py
+++ b/src/DIRAC/Core/Workflow/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Core/scripts/dirac_agent.py
+++ b/src/DIRAC/Core/scripts/dirac_agent.py
@@ -9,9 +9,6 @@ This is a script to launch DIRAC agents. Mostly internal.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC import gLogger

--- a/src/DIRAC/Core/scripts/dirac_cert_convert.py
+++ b/src/DIRAC/Core/scripts/dirac_cert_convert.py
@@ -6,9 +6,6 @@ Creates the necessary directory, $HOME/.globus, if needed. Backs-up old pem file
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import sys
 import shutil

--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -56,8 +56,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers import cfgInstallPath, cfgPath, Re
 from DIRAC.Core.Utilities.SiteSEMapping import getSEsForSite
 from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClient
 
-__RCSID__ = "$Id$"
-
 
 class Params(object):
     def __init__(self):

--- a/src/DIRAC/Core/scripts/dirac_executor.py
+++ b/src/DIRAC/Core/scripts/dirac_executor.py
@@ -9,9 +9,6 @@ This is a script to launch DIRAC executors
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC import gLogger

--- a/src/DIRAC/Core/scripts/dirac_generate_cas.py
+++ b/src/DIRAC/Core/scripts/dirac_generate_cas.py
@@ -5,9 +5,6 @@ Generate a single CA file with all the PEMs
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC import gLogger

--- a/src/DIRAC/Core/scripts/dirac_generate_crls.py
+++ b/src/DIRAC/Core/scripts/dirac_generate_crls.py
@@ -5,9 +5,6 @@ Generate a single CRLs file
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC import gLogger

--- a/src/DIRAC/Core/scripts/dirac_info.py
+++ b/src/DIRAC/Core/scripts/dirac_info.py
@@ -27,9 +27,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/Core/scripts/dirac_install_db.py
+++ b/src/DIRAC/Core/scripts/dirac_install_db.py
@@ -6,9 +6,6 @@ Create a new DB in the MySQL server
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/Core/scripts/dirac_install_web_portal.py
+++ b/src/DIRAC/Core/scripts/dirac_install_web_portal.py
@@ -9,9 +9,6 @@ Do the initial installation of a DIRAC Web portal
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/Core/scripts/dirac_platform.py
+++ b/src/DIRAC/Core/scripts/dirac_platform.py
@@ -22,9 +22,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-__RCSID__ = "$Id$"
-
-
 try:
     from DIRAC.Core.Utilities.Platform import getPlatformString
 except Exception:

--- a/src/DIRAC/Core/scripts/dirac_service.py
+++ b/src/DIRAC/Core/scripts/dirac_service.py
@@ -21,8 +21,6 @@ from DIRAC.Core.DISET.ServiceReactor import ServiceReactor
 from DIRAC.Core.Utilities.DErrno import includeExtensionErrors
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
-__RCSID__ = "$Id$"
-
 
 @Script()
 def main():

--- a/src/DIRAC/Core/scripts/dirac_setup_site.py
+++ b/src/DIRAC/Core/scripts/dirac_setup_site.py
@@ -9,9 +9,6 @@ Initial installation and configuration of a new DIRAC server (DBs, Services, Age
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/Core/scripts/dirac_version.py
+++ b/src/DIRAC/Core/scripts/dirac_version.py
@@ -16,9 +16,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import argparse
 
 import DIRAC

--- a/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
+++ b/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
@@ -15,9 +15,6 @@ It is in charge of submitting and monitoring all the transfers. It can be duplic
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import errno
 import time
 

--- a/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ArchiveFiles.py
+++ b/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ArchiveFiles.py
@@ -24,8 +24,6 @@ from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.RequestManagementSystem.private.OperationHandlerBase import OperationHandlerBase
 
-__RCSID__ = "$Id$"
-
 
 class ArchiveFiles(OperationHandlerBase):
     """ArchiveFiles operation handler."""

--- a/src/DIRAC/DataManagementSystem/Agent/RequestOperations/CheckMigration.py
+++ b/src/DIRAC/DataManagementSystem/Agent/RequestOperations/CheckMigration.py
@@ -11,8 +11,6 @@ from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.RequestManagementSystem.private.OperationHandlerBase import OperationHandlerBase
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 
-__RCSID__ = "$Id$"
-
 
 class CheckMigration(OperationHandlerBase):
     """CheckMigration operation handler."""

--- a/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
+++ b/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
 # #
 # @file ReplicateAndRegister.py
 # @author Krzysztof.Ciba@NOSPAMgmail.com

--- a/src/DIRAC/DataManagementSystem/Agent/RequestOperations/StagingCallback.py
+++ b/src/DIRAC/DataManagementSystem/Agent/RequestOperations/StagingCallback.py
@@ -2,10 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
-
 from DIRAC import S_OK
 from DIRAC.RequestManagementSystem.private.OperationHandlerBase import OperationHandlerBase
 from DIRAC.WorkloadManagementSystem.Client.JobStateUpdateClient import JobStateUpdateClient

--- a/src/DIRAC/DataManagementSystem/Client/DataIntegrityClient.py
+++ b/src/DIRAC/DataManagementSystem/Client/DataIntegrityClient.py
@@ -15,8 +15,6 @@ from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.Core.Base.Client import Client, createClient
 
-__RCSID__ = "$Id$"
-
 
 @createClient("DataManagement/DataIntegrity")
 class DataIntegrityClient(Client):

--- a/src/DIRAC/DataManagementSystem/Client/DataManager.py
+++ b/src/DIRAC/DataManagementSystem/Client/DataManager.py
@@ -38,9 +38,6 @@ from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
 
 # # RSCID
-__RCSID__ = "$Id$"
-
-
 def _isOlderThan(stringTime, days):
     """Check if a time stamp is older than a given number of days"""
     timeDelta = timedelta(days=days)

--- a/src/DIRAC/DataManagementSystem/Client/DirectoryListing.py
+++ b/src/DIRAC/DataManagementSystem/Client/DirectoryListing.py
@@ -7,9 +7,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import stat
 
 from DIRAC import gConfig

--- a/src/DIRAC/DataManagementSystem/Client/FailoverTransfer.py
+++ b/src/DIRAC/DataManagementSystem/Client/FailoverTransfer.py
@@ -19,9 +19,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 
 from DIRAC import S_OK, S_ERROR, gLogger

--- a/src/DIRAC/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/src/DIRAC/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -27,8 +27,6 @@ from DIRAC.DataManagementSystem.Client.MetaQuery import MetaQuery, FILE_STANDARD
 from DIRAC.DataManagementSystem.Client.CmdDirCompletion.AbstractFileSystem import DFCFileSystem, UnixLikeFileSystem
 from DIRAC.DataManagementSystem.Client.CmdDirCompletion.DirectoryCompletion import DirectoryCompletion
 
-__RCSID__ = "$Id$"
-
 
 class FileCatalogClientCLI(CLI):
     """usage: FileCatalogClientCLI.py xmlrpc-url.

--- a/src/DIRAC/DataManagementSystem/Client/MetaQuery.py
+++ b/src/DIRAC/DataManagementSystem/Client/MetaQuery.py
@@ -10,9 +10,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR
 import DIRAC.Core.Utilities.Time as Time
 

--- a/src/DIRAC/DataManagementSystem/DB/DataIntegrityDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/DataIntegrityDB.py
@@ -7,8 +7,6 @@ from __future__ import print_function
 from DIRAC import S_OK
 from DIRAC.Core.Base.DB import DB
 
-__RCSID__ = "$Id$"
-
 #############################################################################
 
 

--- a/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
@@ -41,9 +41,6 @@ from DIRAC.DataManagementSystem.Client.FTS3File import FTS3File
 from DIRAC.DataManagementSystem.Client.FTS3Job import FTS3Job
 from DIRAC.ConfigurationSystem.Client.Utilities import getDBParameters
 
-__RCSID__ = "$Id$"
-
-
 metadata = MetaData()
 
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import hashlib
 import os
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
@@ -18,8 +18,6 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.List import intListToString, stringListToString
 from DIRAC.DataManagementSystem.DB.FileCatalogComponents.DirectoryManager.DirectoryTreeBase import DirectoryTreeBase
 
-__RCSID__ = "$Id$"
-
 
 class DirectoryClosure(DirectoryTreeBase):
     """Class managing Directory Tree with a closure table

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryFlatTree.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryFlatTree.py
@@ -5,9 +5,6 @@ from __future__ import division
 from __future__ import print_function
 
 # pylint: disable=protected-access
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 import stat

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
@@ -5,10 +5,6 @@ from __future__ import division
 from __future__ import print_function
 
 # pylint: disable=protected-access
-
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryNodeTree.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryNodeTree.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import time
 import threading

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -5,9 +5,6 @@ from __future__ import division
 from __future__ import print_function
 
 # pylint: disable=protected-access
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
@@ -3,9 +3,6 @@
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.DataManagementSystem.DB.FileCatalogComponents.DirectoryMetadata.DirectoryMetadata import DirectoryMetadata

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManager.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import six
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # pylint: disable=protected-access
 
 import six

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 import datetime

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Time import queryTime

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/MultiVOFileMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/MultiVOFileMetadata.py
@@ -3,9 +3,6 @@
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK
 from DIRAC.DataManagementSystem.DB.FileCatalogComponents.FileMetadata.FileMetadata import FileMetadata
 from DIRAC.DataManagementSystem.DB.FileCatalogComponents.DirectoryMetadata.MultiVODirectoryMetadata import (

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerBase.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import threading
 
 from DIRAC import S_ERROR

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import time
 import random

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/DirectorySecurityManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/DirectorySecurityManager.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC import S_OK

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/DirectorySecurityManagerWithDelete.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/DirectorySecurityManagerWithDelete.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK
 from DIRAC.DataManagementSystem.DB.FileCatalogComponents.SecurityManager.DirectorySecurityManager import (
     DirectorySecurityManager,

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/FullSecurityManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/FullSecurityManager.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC import S_OK

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/NoSecurityManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/NoSecurityManager.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK
 from DIRAC.DataManagementSystem.DB.FileCatalogComponents.SecurityManager.SecurityManagerBase import SecurityManagerBase
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/SecurityManagerBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/SecurityManagerBase.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security.Properties import FC_MANAGEMENT
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/VOMSSecurityManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/VOMSSecurityManager.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import datetime
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerBase.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 import threading
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerCS.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerCS.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 import threading
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerDB.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import time
 import threading

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.List import intListToString

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogDB.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import errno
 
 from DIRAC import gLogger, S_OK, S_ERROR

--- a/src/DIRAC/DataManagementSystem/Service/DataIntegrityHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/DataIntegrityHandler.py
@@ -20,8 +20,6 @@ from DIRAC import S_OK
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.DataManagementSystem.DB.DataIntegrityDB import DataIntegrityDB
 
-__RCSID__ = "$Id$"
-
 
 class DataIntegrityHandler(RequestHandler):
     """

--- a/src/DIRAC/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -11,9 +11,6 @@ Service handler for FTS3DB using DISET
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 
 # from DIRAC

--- a/src/DIRAC/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/FileCatalogHandler.py
@@ -6,9 +6,6 @@ in the DIRAC framework
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import csv
 import os
 from io import StringIO

--- a/src/DIRAC/DataManagementSystem/Service/FileCatalogProxyHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/FileCatalogProxyHandler.py
@@ -21,8 +21,6 @@ from DIRAC.Resources.Catalog.FileCatalogFactory import FileCatalogFactory
 from DIRAC.Core.Utilities.Subprocess import pythonCall
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 
-__RCSID__ = "$Id$"
-
 
 def initializeFileCatalogProxyHandler(serviceInfo):
     """service initalisation"""

--- a/src/DIRAC/DataManagementSystem/Service/S3GatewayHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/S3GatewayHandler.py
@@ -14,9 +14,6 @@ This service can serve presigned URL for any S3 storage it has the credentials f
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import errno
 
 # from DIRAC

--- a/src/DIRAC/DataManagementSystem/Service/StorageElementHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/StorageElementHandler.py
@@ -25,8 +25,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # imports
 import os
 import shutil

--- a/src/DIRAC/DataManagementSystem/Service/StorageElementProxyHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/StorageElementProxyHandler.py
@@ -32,8 +32,6 @@ from DIRAC.DataManagementSystem.private.HttpStorageAccessHandler import HttpStor
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 
-__RCSID__ = "$Id$"
-
 # globals
 BASE_PATH = ""
 HTTP_FLAG = False

--- a/src/DIRAC/DataManagementSystem/Service/TornadoFTS3ManagerHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/TornadoFTS3ManagerHandler.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.DataManagementSystem.Service.FTS3ManagerHandler import FTS3ManagerHandlerMixin

--- a/src/DIRAC/DataManagementSystem/Service/TornadoFileCatalogHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/TornadoFileCatalogHandler.py
@@ -14,8 +14,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # imports
 import csv
 

--- a/src/DIRAC/DataManagementSystem/private/FTS3Plugins/__init__.py
+++ b/src/DIRAC/DataManagementSystem/private/FTS3Plugins/__init__.py
@@ -1,3 +1,1 @@
 """ DIRAC.DataManagementSystem.private.FTS3Plugins package """
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/DataManagementSystem/private/test/Test_FTS3Utilities.py
+++ b/src/DIRAC/DataManagementSystem/private/test/Test_FTS3Utilities.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import unittest
 
 import mock

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_admin_allow_se.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_admin_allow_se.py
@@ -8,9 +8,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_admin_ban_se.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_admin_ban_se.py
@@ -9,9 +9,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_admin_user_quota.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_admin_user_quota.py
@@ -15,9 +15,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_add_file.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_add_file.py
@@ -35,9 +35,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 from DIRAC import S_OK
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_catalog_metadata.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_catalog_metadata.py
@@ -11,9 +11,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC import exit as DIRACExit
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_change_replica_status.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_change_replica_status.py
@@ -5,9 +5,6 @@ Change status of replica of a given file or a list of files at a given Storage E
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC import exit as DIRACExit
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_clean_directory.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_clean_directory.py
@@ -11,9 +11,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC import exit as DIRACExit, gLogger

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_archive_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_archive_request.py
@@ -48,7 +48,6 @@ from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.Client.Operation import Operation
 
 sLog = gLogger.getSubLogger("AddArchive")
-__RCSID__ = "$Id$"
 MAX_SIZE = 2 * 1024 * 1024 * 1024  # 2 GB
 MAX_FILES = 2000
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_moving_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_moving_request.py
@@ -24,7 +24,6 @@ from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.Client.Operation import Operation
 
 sLog = gLogger.getSubLogger("CreateMoving")
-__RCSID__ = "$Id$"
 
 
 class CreateMovingRequest(object):

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_data_size.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_data_size.py
@@ -13,9 +13,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import DIRAC
 from DIRAC import gLogger

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_directory_sync.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_directory_sync.py
@@ -31,8 +31,6 @@ from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 
-__RCSID__ = "$Id$"
-
 
 def getSetOfLocalDirectoriesAndFiles(path):
     """Return a set of all directories and subdirectories and a set of

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_put_and_register_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_put_and_register_request.py
@@ -8,9 +8,6 @@ Create and put 'PutAndRegister' request with a single local file
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_catalog_files.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_catalog_files.py
@@ -12,9 +12,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC import exit as dexit
 from DIRAC import gLogger

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_catalog_replicas.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_catalog_replicas.py
@@ -7,9 +7,6 @@ Use dirac-dms-remove-replicas instead
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC import exit as dexit

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_files.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_files.py
@@ -8,9 +8,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_replicas.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_remove_replicas.py
@@ -10,9 +10,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC import exit as DIRACExit
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_replica_metadata.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_replica_metadata.py
@@ -5,9 +5,6 @@ Get the given file replica metadata from the File Catalog
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC import exit as DIRACExit

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_replicate_and_register_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_replicate_and_register_request.py
@@ -5,8 +5,6 @@ Create and put 'ReplicateAndRegister' request.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
 import os
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC import gLogger

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_resolve_guid.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_resolve_guid.py
@@ -5,9 +5,6 @@ Returns the LFN matching given GUIDs
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_set_replica_status.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_set_replica_status.py
@@ -5,9 +5,6 @@ Set the status of the replicas of given files at the provided SE
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_show_se_status.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_show_se_status.py
@@ -22,8 +22,6 @@ from __future__ import division
 from DIRAC import S_OK, exit as DIRACexit
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
-__RCSID__ = "$Id$"
-
 vo = None
 
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_user_lfns.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_user_lfns.py
@@ -18,9 +18,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_user_quota.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_user_quota.py
@@ -12,9 +12,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/FrameworkSystem/Agent/CAUpdateAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/CAUpdateAgent.py
@@ -5,9 +5,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClient

--- a/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
@@ -73,7 +73,6 @@ from DIRAC.FrameworkSystem.Client.SystemAdministratorClient import SystemAdminis
 from DIRAC.FrameworkSystem.Client.NotificationClient import NotificationClient
 from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
 
-__RCSID__ = "$Id$"
 AGENT_NAME = "Framework/ComponentSupervisionAgent"
 
 # Define units

--- a/src/DIRAC/FrameworkSystem/Agent/MyProxyRenewalAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/MyProxyRenewalAgent.py
@@ -10,9 +10,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import concurrent.futures
 
 from DIRAC import gLogger, S_OK

--- a/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
@@ -17,9 +17,6 @@ import DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent as MAA
 from DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent import ComponentSupervisionAgent, NO_RESTART
 
 
-__RCSID__ = "$Id$"
-
-
 def clientMock(ret):
     """Return an Client which returns **ret**."""
     clientModuleMock = MagicMock(name="Client Module")

--- a/src/DIRAC/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -19,9 +19,6 @@ from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import skipCACheck
 
 
-__RCSID__ = "$Id$"
-
-
 class BundleDeliveryJSONClient(TornadoClient):
     def receiveFile(self, buff, fileId):
         retVal = self.executeRPC("streamToClient", fileId)

--- a/src/DIRAC/FrameworkSystem/Client/ComponentMonitoringClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentMonitoringClient.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Base.Client import Client, createClient
 
 

--- a/src/DIRAC/FrameworkSystem/Client/Logger.py
+++ b/src/DIRAC/FrameworkSystem/Client/Logger.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.FrameworkSystem.private.standardLogging.LoggingRoot import LoggingRoot
 
 gLogger = LoggingRoot()

--- a/src/DIRAC/FrameworkSystem/Client/MonitoringClientIOLoop.py
+++ b/src/DIRAC/FrameworkSystem/Client/MonitoringClientIOLoop.py
@@ -6,9 +6,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import tornado.ioloop
 from DIRAC import gLogger
 

--- a/src/DIRAC/FrameworkSystem/Client/NotificationClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/NotificationClient.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 from DIRAC import gLogger, S_ERROR
 from DIRAC.Core.Base.Client import Client, createClient

--- a/src/DIRAC/FrameworkSystem/Client/PlottingClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/PlottingClient.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import tempfile
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Tornado.Client.ClientSelector import TransferClientSelector as TransferClient

--- a/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClient.py
@@ -5,9 +5,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Base.Client import Client, createClient
 
 SYSADMIN_PORT = 9162

--- a/src/DIRAC/FrameworkSystem/Client/SystemAdministratorIntegrator.py
+++ b/src/DIRAC/FrameworkSystem/Client/SystemAdministratorIntegrator.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK
 from DIRAC.Core.Utilities.ThreadPool import ThreadPool
 from DIRAC.FrameworkSystem.Client.SystemAdministratorClient import SystemAdministratorClient

--- a/src/DIRAC/FrameworkSystem/DB/ComponentMonitoringDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ComponentMonitoringDB.py
@@ -12,8 +12,6 @@ from DIRAC.Core.Base.DB import DB
 from DIRAC.Core.Utilities import Time, Network
 from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemURLs
 
-__RCSID__ = "$Id$"
-
 
 class ComponentMonitoringDB(DB):
     def __init__(self):

--- a/src/DIRAC/FrameworkSystem/DB/InstalledComponentsDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/InstalledComponentsDB.py
@@ -18,8 +18,6 @@ from sqlalchemy.sql.expression import null
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client.Utilities import getDBParameters
 
-__RCSID__ = "$Id$"
-
 metadata = MetaData()
 componentsBase = declarative_base()
 

--- a/src/DIRAC/FrameworkSystem/DB/NotificationDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/NotificationDB.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR

--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -16,9 +16,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 import random
 import hashlib

--- a/src/DIRAC/FrameworkSystem/DB/UserProfileDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/UserProfileDB.py
@@ -4,9 +4,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import six
 
 import cachetools

--- a/src/DIRAC/FrameworkSystem/private/authorization/utils/Utilities.py
+++ b/src/DIRAC/FrameworkSystem/private/authorization/utils/Utilities.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import traceback
 

--- a/src/DIRAC/FrameworkSystem/private/monitoring/Activity.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/Activity.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from string import Template
 import six
 

--- a/src/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/ColorGenerator.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 
 class ColorGenerator:
     def __init__(self):

--- a/src/DIRAC/FrameworkSystem/private/monitoring/PlotCache.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/PlotCache.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import hashlib
 import time

--- a/src/DIRAC/FrameworkSystem/private/monitoring/RRDManager.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/RRDManager.py
@@ -13,8 +13,6 @@ from DIRAC.FrameworkSystem.private.monitoring.ColorGenerator import ColorGenerat
 from DIRAC.Core.Utilities import Subprocess, Time
 from DIRAC.Core.Utilities.File import mkDir
 
-__RCSID__ = "$Id$"
-
 
 class RRDManager(object):
 

--- a/src/DIRAC/FrameworkSystem/private/monitoring/ServiceInterface.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/ServiceInterface.py
@@ -7,9 +7,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from past.builtins import long
 from DIRAC import S_OK, S_ERROR
 

--- a/src/DIRAC/FrameworkSystem/private/monitoring/__init__.py
+++ b/src/DIRAC/FrameworkSystem/private/monitoring/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/BaseFormatter.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/BaseFormatter.py
@@ -4,9 +4,6 @@ BaseFormatter
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import logging
 import sys
 

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/ColoredBaseFormatter.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/ColoredBaseFormatter.py
@@ -4,9 +4,6 @@ ColoredBaseFormatter
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC.FrameworkSystem.private.standardLogging.Formatter.BaseFormatter import BaseFormatter

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Handler/MessageQueueHandler.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Handler/MessageQueueHandler.py
@@ -4,9 +4,6 @@ Message Queue Handler
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import json
 import logging
 import socket

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/LogLevels.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/LogLevels.py
@@ -4,9 +4,6 @@ LogLevels wrapper
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import logging
 
 

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Logging.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Logging.py
@@ -4,9 +4,6 @@ Logging
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import logging
 import os
 

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/__init__.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/TestLogUtilities.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/TestLogUtilities.py
@@ -1,9 +1,6 @@
 """
 Test Logger Wrapper
 """
-
-__RCSID__ = "$Id$"
-
 import logging
 from io import StringIO
 

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_LogLevels.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_LogLevels.py
@@ -1,9 +1,6 @@
 """
 Test LogLevels module
 """
-
-__RCSID__ = "$Id$"
-
 import logging
 import pytest
 

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_LoggingRoot_ConfigForExternalLibs.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_LoggingRoot_ConfigForExternalLibs.py
@@ -5,9 +5,6 @@ Test Config for External Libraries:
 - We want to make sure this does not affect the DIRAC logging system based on it
 
 """
-
-__RCSID__ = "$Id$"
-
 import logging
 from io import StringIO
 import pytest

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_Backends.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_Backends.py
@@ -1,9 +1,6 @@
 """
 Test backend attachment
 """
-
-__RCSID__ = "$Id$"
-
 import pytest
 
 from DIRAC.FrameworkSystem.private.standardLogging.test.TestLogUtilities import gLogger, gLoggerReset, cleaningLog

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_CreationLogRecord.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_CreationLogRecord.py
@@ -5,9 +5,6 @@ Test LogRecord Creation
 - debug, verbose, info, warn, notice, error, fatal, always
 
 """
-
-__RCSID__ = "$Id$"
-
 import pytest
 
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_FormatOptions.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_FormatOptions.py
@@ -1,9 +1,6 @@
 """
 Test properties of log records
 """
-
-__RCSID__ = "$Id$"
-
 import _thread
 import pytest
 

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_GetSubLogger.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_GetSubLogger.py
@@ -1,9 +1,6 @@
 """
 Test SubLogger
 """
-
-__RCSID__ = "$Id$"
-
 import pytest
 from flaky import flaky
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_Levels.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_Levels.py
@@ -6,9 +6,6 @@ Test Levels
 - setLevel
 
 """
-
-__RCSID__ = "$Id$"
-
 import pytest
 
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_get_CAs.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_get_CAs.py
@@ -20,8 +20,6 @@ import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClient
 
-__RCSID__ = "$Id$"
-
 
 @Script()
 def main():

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_get_proxy.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_get_proxy.py
@@ -22,8 +22,6 @@ from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 
-__RCSID__ = "$Id$"
-
 
 class Params(object):
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_proxy_upload.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_proxy_upload.py
@@ -12,9 +12,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_sysadmin_cli.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_sysadmin_cli.py
@@ -10,9 +10,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_instance.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_instance.py
@@ -5,9 +5,6 @@ Script to apply update to all or some dirac servers and restart them
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from io import open
 
 import DIRAC

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_pilot.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_update_pilot.py
@@ -5,9 +5,6 @@ Script to update pilot version in CS
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_admin_users_with_proxy.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_admin_users_with_proxy.py
@@ -29,8 +29,6 @@ from DIRAC.Core.Utilities import Time
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 
-__RCSID__ = "$Id$"
-
 
 class Params(object):
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_install_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_install_component.py
@@ -13,8 +13,6 @@ from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.Core.Utilities.Extensions import extensionsByPriority
 from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 
-__RCSID__ = "$Id$"
-
 overwrite = False
 module = ""
 specialOptions = {}

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_install_tornado_service.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_install_tornado_service.py
@@ -6,9 +6,6 @@ Do the initial installation and configuration of a DIRAC service based on tornad
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import exit as DIRACexit
 from DIRAC import gConfig, gLogger, S_OK
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_monitoring_get_components_status.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_monitoring_get_components_status.py
@@ -6,8 +6,6 @@ from __future__ import division
 import sys
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
-__RCSID__ = "$Id$"
-
 
 @Script()
 def main():

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_populate_component_db.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_populate_component_db.py
@@ -22,8 +22,6 @@ from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 
-__RCSID__ = "$Id$"
-
 global excludedHosts
 excludedHosts = []
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_destroy.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_destroy.py
@@ -8,9 +8,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 import DIRAC

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_get_uploaded_info.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_get_uploaded_info.py
@@ -18,9 +18,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC import gLogger, S_OK

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_restart_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_restart_component.py
@@ -5,9 +5,6 @@ Restart DIRAC component using runsvctrl utility
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_start_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_start_component.py
@@ -5,9 +5,6 @@ Start DIRAC component using runsvctrl utility
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_sys_sendmail.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_sys_sendmail.py
@@ -22,9 +22,6 @@ Examples:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import socket
 import sys
 import os

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_uninstall_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_uninstall_component.py
@@ -15,8 +15,6 @@ from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient import ComponentMonitoringClient
 
-__RCSID__ = "$Id$"
-
 force = False
 
 

--- a/src/DIRAC/Interfaces/API/test/Test_JobAPI.py
+++ b/src/DIRAC/Interfaces/API/test/Test_JobAPI.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from os.path import dirname, join
 
 import pytest

--- a/src/DIRAC/MonitoringSystem/Client/MonitoringClient.py
+++ b/src/DIRAC/MonitoringSystem/Client/MonitoringClient.py
@@ -8,8 +8,6 @@ from __future__ import print_function
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.Core.Utilities.Plotting.FileCoding import codeRequestInFileId
 
-__RCSID__ = "$Id$"
-
 
 @createClient("Monitoring/Monitoring")
 class MonitoringClient(Client):

--- a/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
+++ b/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 
 def getDBOrClient(DB, serverName):
     """Tries to instantiate the DB object and returns it if we manage to connect to the DB,

--- a/src/DIRAC/MonitoringSystem/Client/Types/BaseType.py
+++ b/src/DIRAC/MonitoringSystem/Client/Types/BaseType.py
@@ -5,9 +5,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
-__RCSID__ = "$Id$"
-
 ########################################################################
 
 

--- a/src/DIRAC/MonitoringSystem/Client/Types/ComponentMonitoring.py
+++ b/src/DIRAC/MonitoringSystem/Client/Types/ComponentMonitoring.py
@@ -7,8 +7,6 @@ from __future__ import print_function
 
 from DIRAC.MonitoringSystem.Client.Types.BaseType import BaseType
 
-__RCSID__ = "$Id$"
-
 
 class ComponentMonitoring(BaseType):
     """

--- a/src/DIRAC/MonitoringSystem/Client/Types/RMSMonitoring.py
+++ b/src/DIRAC/MonitoringSystem/Client/Types/RMSMonitoring.py
@@ -19,9 +19,6 @@ In order to enable 'RMSMonitoring' we need to set value of 'EnableRMSMonitoring'
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.MonitoringSystem.Client.Types.BaseType import BaseType
 
 

--- a/src/DIRAC/MonitoringSystem/DB/test/Test_monitoringdb.py
+++ b/src/DIRAC/MonitoringSystem/DB/test/Test_monitoringdb.py
@@ -9,8 +9,6 @@ import unittest
 
 import DIRAC.MonitoringSystem.private.DBUtils as moduleTested
 
-__RCSID__ = "$Id$"
-
 ################################################################################
 
 

--- a/src/DIRAC/MonitoringSystem/Service/MonitoringHandler.py
+++ b/src/DIRAC/MonitoringSystem/Service/MonitoringHandler.py
@@ -30,8 +30,6 @@ from DIRAC.Core.Utilities.File import mkDir
 
 from DIRAC.MonitoringSystem.private.MainReporter import MainReporter
 
-__RCSID__ = "$Id$"
-
 
 class MonitoringHandler(RequestHandler):
 

--- a/src/DIRAC/MonitoringSystem/private/DBUtils.py
+++ b/src/DIRAC/MonitoringSystem/private/DBUtils.py
@@ -8,8 +8,6 @@ from __future__ import print_function
 
 from DIRAC import S_OK, S_ERROR
 
-__RCSID__ = "$Id$"
-
 
 def _convertToSeconds(interval):
     """

--- a/src/DIRAC/MonitoringSystem/private/MainReporter.py
+++ b/src/DIRAC/MonitoringSystem/private/MainReporter.py
@@ -13,8 +13,6 @@ from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceSection
 from DIRAC.MonitoringSystem.private.Plotters.BasePlotter import BasePlotter as myBasePlotter
 from DIRAC.Core.Utilities.ObjectLoader import loadObjects
 
-__RCSID__ = "$Id$"
-
 
 class PlottersList(object):
 

--- a/src/DIRAC/MonitoringSystem/private/Plotters/BasePlotter.py
+++ b/src/DIRAC/MonitoringSystem/private/Plotters/BasePlotter.py
@@ -20,8 +20,6 @@ from DIRAC.Core.Utilities.Plotting.Plots import (
 
 from DIRAC.MonitoringSystem.private.DBUtils import DBUtils
 
-__RCSID__ = "$Id$"
-
 
 class BasePlotter(DBUtils):
 

--- a/src/DIRAC/MonitoringSystem/private/Plotters/ComponentMonitoringPlotter.py
+++ b/src/DIRAC/MonitoringSystem/private/Plotters/ComponentMonitoringPlotter.py
@@ -10,8 +10,6 @@ from DIRAC import S_OK, gLogger
 from DIRAC.MonitoringSystem.Client.Types.ComponentMonitoring import ComponentMonitoring
 from DIRAC.MonitoringSystem.private.Plotters.BasePlotter import BasePlotter
 
-__RCSID__ = "$Id$"
-
 
 class ComponentMonitoringPlotter(BasePlotter):
 

--- a/src/DIRAC/MonitoringSystem/private/Plotters/RMSMonitoringPlotter.py
+++ b/src/DIRAC/MonitoringSystem/private/Plotters/RMSMonitoringPlotter.py
@@ -7,8 +7,6 @@ from DIRAC import S_OK, gLogger
 from DIRAC.MonitoringSystem.Client.Types.RMSMonitoring import RMSMonitoring
 from DIRAC.MonitoringSystem.private.Plotters.BasePlotter import BasePlotter
 
-__RCSID__ = "$Id$"
-
 
 class RMSMonitoringPlotter(BasePlotter):
 

--- a/src/DIRAC/ProductionSystem/Client/ProductionClient.py
+++ b/src/DIRAC/ProductionSystem/Client/ProductionClient.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.ProductionSystem.Utilities.StateMachine import ProductionsStateMachine

--- a/src/DIRAC/ProductionSystem/Client/ProductionStep.py
+++ b/src/DIRAC/ProductionSystem/Client/ProductionStep.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import json
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/ProductionSystem/DB/ProductionDB.py
+++ b/src/DIRAC/ProductionSystem/DB/ProductionDB.py
@@ -18,9 +18,6 @@ from DIRAC.ProductionSystem.Utilities.ProdValidator import ProdValidator
 from DIRAC.ProductionSystem.Utilities.ProdTransManager import ProdTransManager
 from DIRAC.Core.Utilities.List import intListToString
 
-
-__RCSID__ = "$Id$"
-
 MAX_ERROR_COUNT = 10
 
 #############################################################################

--- a/src/DIRAC/ProductionSystem/Service/ProductionManagerHandler.py
+++ b/src/DIRAC/ProductionSystem/Service/ProductionManagerHandler.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 
 from DIRAC import gLogger, S_OK, S_ERROR

--- a/src/DIRAC/ProductionSystem/Utilities/StateMachine.py
+++ b/src/DIRAC/ProductionSystem/Utilities/StateMachine.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.StateMachine import State, StateMachine
 
 

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_add_trans.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_add_trans.py
@@ -6,9 +6,6 @@ Transformations already belonging to another production cannot be added.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_clean.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_clean.py
@@ -5,9 +5,6 @@ Clean a given production
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_delete.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_delete.py
@@ -6,9 +6,6 @@ Delete a given production
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_get.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_get.py
@@ -8,9 +8,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_all.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_all.py
@@ -5,9 +5,6 @@ Get summary informations of all productions
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.PrettyPrint import printTable
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_description.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_description.py
@@ -8,9 +8,6 @@ Example:
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_trans.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_get_trans.py
@@ -8,9 +8,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.PrettyPrint import printTable
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_start.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_start.py
@@ -8,9 +8,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/ProductionSystem/scripts/dirac_prod_stop.py
+++ b/src/DIRAC/ProductionSystem/scripts/dirac_prod_stop.py
@@ -8,9 +8,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/RequestManagementSystem/Agent/CleanReqDBAgent.py
+++ b/src/DIRAC/RequestManagementSystem/Agent/CleanReqDBAgent.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
 # #
 # @file CleanReqDBAgent.py
 # @author Krzysztof.Ciba@NOSPAMgmail.com

--- a/src/DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/src/DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -24,8 +24,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # #
 # @file RequestExecutingAgent.py
 # @author Krzysztof.Ciba@NOSPAMgmail.com

--- a/src/DIRAC/RequestManagementSystem/Client/File.py
+++ b/src/DIRAC/RequestManagementSystem/Client/File.py
@@ -16,9 +16,6 @@ from __future__ import print_function
 
 # Disable invalid names warning
 # pylint: disable=invalid-name
-
-__RCSID__ = "$Id$"
-
 # # imports
 import datetime
 import os

--- a/src/DIRAC/RequestManagementSystem/Client/Operation.py
+++ b/src/DIRAC/RequestManagementSystem/Client/Operation.py
@@ -17,8 +17,6 @@ from __future__ import print_function
 
 # Disable invalid names warning
 # pylint: disable=invalid-name
-__RCSID__ = "$Id$"
-
 import datetime
 import json
 import six

--- a/src/DIRAC/RequestManagementSystem/Client/Request.py
+++ b/src/DIRAC/RequestManagementSystem/Client/Request.py
@@ -16,9 +16,6 @@ from __future__ import print_function
 
 # Disable invalid names warning
 # pylint: disable=invalid-name
-__RCSID__ = "$Id$"
-
-
 # # imports
 import datetime
 import json

--- a/src/DIRAC/RequestManagementSystem/Client/test/Test_File.py
+++ b/src/DIRAC/RequestManagementSystem/Client/test/Test_File.py
@@ -11,9 +11,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import pytest
 
 from DIRAC.RequestManagementSystem.Client.Operation import Operation

--- a/src/DIRAC/RequestManagementSystem/Client/test/Test_Request.py
+++ b/src/DIRAC/RequestManagementSystem/Client/test/Test_Request.py
@@ -11,9 +11,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import datetime
 
 import six

--- a/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
+++ b/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
@@ -51,10 +51,6 @@ from DIRAC.RequestManagementSystem.Client.Operation import Operation
 from DIRAC.RequestManagementSystem.Client.File import File
 from DIRAC.ConfigurationSystem.Client.Utilities import getDBParameters
 
-
-__RCSID__ = "$Id$"
-
-
 # Metadata instance that is used to bind the engine, Object and tables
 metadata = MetaData()
 

--- a/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # # imports
 import six
 import json

--- a/src/DIRAC/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -26,8 +26,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # #
 # @file RequestProxyHandler.py
 # @author Krzysztof.Ciba@NOSPAMgmail.com

--- a/src/DIRAC/RequestManagementSystem/Service/TornadoReqManagerHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/TornadoReqManagerHandler.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.RequestManagementSystem.Service.ReqManagerHandler import ReqManagerHandlerMixin

--- a/src/DIRAC/RequestManagementSystem/private/RequestTask.py
+++ b/src/DIRAC/RequestManagementSystem/private/RequestTask.py
@@ -20,8 +20,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # #
 # @file RequestTask.py
 # @author Krzysztof.Ciba@NOSPAMgmail.com

--- a/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_list_req_cache.py
+++ b/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_list_req_cache.py
@@ -5,10 +5,6 @@ List the number of requests in the caches of all the ReqProxyies
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_reqdb_summary.py
+++ b/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_reqdb_summary.py
@@ -5,9 +5,6 @@ Show ReqDB summary
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_request.py
+++ b/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_request.py
@@ -5,9 +5,6 @@ Show request given its ID, a jobID or a transformation and a task
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import datetime
 import os
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/ResourceStatusSystem/__init__.py
+++ b/src/DIRAC/ResourceStatusSystem/__init__.py
@@ -4,5 +4,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Resources/Catalog/ConditionPlugins/FCConditionBasePlugin.py
+++ b/src/DIRAC/Resources/Catalog/ConditionPlugins/FCConditionBasePlugin.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 
 class FCConditionBasePlugin(object):
     """Base class to give baseline for all the FCCondition plugins.

--- a/src/DIRAC/Resources/Catalog/FileCatalogClient.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalogClient.py
@@ -13,8 +13,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOMSAttributeFo
 from DIRAC.Resources.Catalog.Utilities import checkCatalogArguments
 from DIRAC.Resources.Catalog.FileCatalogClientBase import FileCatalogClientBase
 
-__RCSID__ = "$Id$"
-
 
 class FileCatalogClient(FileCatalogClientBase):
     """Client code to the DIRAC File Catalogue"""

--- a/src/DIRAC/Resources/Catalog/FileCatalogClientBase.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalogClientBase.py
@@ -14,9 +14,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.Core.Utilities.ReturnValues import S_OK
 from DIRAC.Resources.Catalog.Utilities import checkCatalogArguments

--- a/src/DIRAC/Resources/Catalog/FileCatalogFactory.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalogFactory.py
@@ -10,8 +10,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getCatalogPath
 from DIRAC.Resources.Catalog.FileCatalogProxyClient import FileCatalogProxyClient
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 
-__RCSID__ = "$Id$"
-
 
 class FileCatalogFactory(object):
     """Factory of file catalog objects. Only exposes createCatalog() method"""

--- a/src/DIRAC/Resources/Catalog/FileCatalogProxyClient.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalogProxyClient.py
@@ -5,9 +5,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Base.Client import Client
 
 

--- a/src/DIRAC/Resources/Catalog/PoolXMLCatalog.py
+++ b/src/DIRAC/Resources/Catalog/PoolXMLCatalog.py
@@ -6,9 +6,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import os
 import xml.dom.minidom
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/Resources/Catalog/PoolXMLFile.py
+++ b/src/DIRAC/Resources/Catalog/PoolXMLFile.py
@@ -14,8 +14,6 @@ from DIRAC.Resources.Catalog.PoolXMLCatalog import PoolXMLCatalog
 from DIRAC.Core.Utilities.List import uniqueElements
 from DIRAC.Core.Utilities.File import makeGuid
 
-__RCSID__ = "$Id$"
-
 #############################################################################
 
 

--- a/src/DIRAC/Resources/Catalog/TSCatalogClient.py
+++ b/src/DIRAC/Resources/Catalog/TSCatalogClient.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Resources.Catalog.Utilities import checkCatalogArguments

--- a/src/DIRAC/Resources/Catalog/Utilities.py
+++ b/src/DIRAC/Resources/Catalog/Utilities.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 import errno

--- a/src/DIRAC/Resources/Cloud/CloudEndpoint.py
+++ b/src/DIRAC/Resources/Cloud/CloudEndpoint.py
@@ -6,9 +6,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-
-__RCSID__ = "$Id$"
-
 import os
 import ssl
 import time

--- a/src/DIRAC/Resources/Cloud/EC2Endpoint.py
+++ b/src/DIRAC/Resources/Cloud/EC2Endpoint.py
@@ -14,8 +14,6 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.File import makeGuid
 from DIRAC.Resources.Cloud.Endpoint import Endpoint
 
-__RCSID__ = "$Id$"
-
 
 class EC2Endpoint(Endpoint):
     def __init__(self, parameters=None):

--- a/src/DIRAC/Resources/Cloud/Endpoint.py
+++ b/src/DIRAC/Resources/Cloud/Endpoint.py
@@ -12,8 +12,6 @@ import os
 from DIRAC import S_ERROR, S_OK
 from DIRAC.Resources.Cloud.Utilities import createUserDataScript, createPilotDataScript, createCloudInitScript
 
-__RCSID__ = "$Id$"
-
 
 class Endpoint(object):
     """Endpoint base class"""

--- a/src/DIRAC/Resources/Cloud/EndpointFactory.py
+++ b/src/DIRAC/Resources/Cloud/EndpointFactory.py
@@ -8,8 +8,6 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getVMTypeConfig
 
-__RCSID__ = "$Id$"
-
 
 class EndpointFactory(object):
     def __init__(self):

--- a/src/DIRAC/Resources/Cloud/KeystoneClient.py
+++ b/src/DIRAC/Resources/Cloud/KeystoneClient.py
@@ -10,8 +10,6 @@ import requests
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities.Time import fromString, dateTime
 
-__RCSID__ = "$Id$"
-
 
 class KeystoneClient(object):
     def __init__(self, url, parameters):

--- a/src/DIRAC/Resources/Cloud/OcciEndpoint.py
+++ b/src/DIRAC/Resources/Cloud/OcciEndpoint.py
@@ -5,9 +5,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-
-__RCSID__ = "$Id$"
-
 import os
 import requests
 from requests.auth import HTTPBasicAuth

--- a/src/DIRAC/Resources/Cloud/OpenStackEndpoint.py
+++ b/src/DIRAC/Resources/Cloud/OpenStackEndpoint.py
@@ -5,9 +5,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-
-__RCSID__ = "$Id$"
-
 import requests
 import json
 import base64

--- a/src/DIRAC/Resources/Cloud/RocciEndpoint.py
+++ b/src/DIRAC/Resources/Cloud/RocciEndpoint.py
@@ -15,8 +15,6 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.File import makeGuid
 from DIRAC.Resources.Cloud.Endpoint import Endpoint
 
-__RCSID__ = "$Id$"
-
 
 class RocciEndpoint(Endpoint):
     def __init__(self, parameters=None):

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -39,9 +39,6 @@ Preamble:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 import stat

--- a/src/DIRAC/Resources/Computing/BOINCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/BOINCComputingElement.py
@@ -9,9 +9,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import os
 import bz2
 import base64

--- a/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
@@ -18,8 +18,6 @@ import subprocess
 import shlex
 import os
 
-__RCSID__ = "$Id$"
-
 
 def parseCondorStatus(lines, jobID):
     """parse the condor_q or condor_history output for the job status

--- a/src/DIRAC/Resources/Computing/BatchSystems/GE.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/GE.py
@@ -22,8 +22,6 @@ import shlex
 import subprocess
 import os
 
-__RCSID__ = "$Id$"
-
 
 class GE(object):
     def submitJob(self, **kwargs):

--- a/src/DIRAC/Resources/Computing/BatchSystems/Host.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Host.py
@@ -26,8 +26,6 @@ import json
 import multiprocessing
 from datetime import datetime, timedelta
 
-__RCSID__ = "$Id$"
-
 # Clean job info and output after so many days
 CLEAN_DELAY = timedelta(7)
 

--- a/src/DIRAC/Resources/Computing/BatchSystems/LSF.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/LSF.py
@@ -17,8 +17,6 @@ import subprocess
 import shlex
 import os
 
-__RCSID__ = "$Id$"
-
 
 class LSF(object):
     def submitJob(self, **kwargs):

--- a/src/DIRAC/Resources/Computing/BatchSystems/OAR.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/OAR.py
@@ -18,8 +18,6 @@ import shlex
 import os
 import json
 
-__RCSID__ = "$Id$"
-
 
 class OAR(object):
     def submitJob(self, **kwargs):

--- a/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
@@ -13,8 +13,6 @@ import subprocess
 import shlex
 import random
 
-__RCSID__ = "$Id$"
-
 
 class SLURM(object):
     def submitJob(self, **kwargs):

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/HTCondorResourceUsage.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/HTCondorResourceUsage.py
@@ -10,8 +10,6 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Resources.Computing.BatchSystems.TimeLeft.TimeLeft import runCommand
 from DIRAC.Resources.Computing.BatchSystems.TimeLeft.ResourceUsage import ResourceUsage
 
-__RCSID__ = "$Id$"
-
 
 class HTCondorResourceUsage(ResourceUsage):
     """

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/LSFResourceUsage.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/LSFResourceUsage.py
@@ -16,8 +16,6 @@ from DIRAC.Resources.Computing.BatchSystems.TimeLeft.ResourceUsage import Resour
 
 from DIRAC.Core.Utilities.Os import sourceEnv
 
-__RCSID__ = "$Id$"
-
 
 class LSFResourceUsage(ResourceUsage):
     """

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/MJFResourceUsage.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/MJFResourceUsage.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import time
 from urllib.request import urlopen

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/PBSResourceUsage.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/PBSResourceUsage.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import re
 import time

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/SGEResourceUsage.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/SGEResourceUsage.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import re
 import time

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/SLURMResourceUsage.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Resources.Computing.BatchSystems.TimeLeft.TimeLeft import runCommand
 from DIRAC.Resources.Computing.BatchSystems.TimeLeft.ResourceUsage import ResourceUsage

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
@@ -12,9 +12,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import shlex
 

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/__init__.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/__init__.py
@@ -4,5 +4,3 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Resources/Computing/BatchSystems/Torque.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Torque.py
@@ -17,8 +17,6 @@ import subprocess
 import shlex
 import os
 
-__RCSID__ = "$Id$"
-
 
 class Torque(object):
     def submitJob(self, **kwargs):

--- a/src/DIRAC/Resources/Computing/CREAMComputingElement.py
+++ b/src/DIRAC/Resources/Computing/CREAMComputingElement.py
@@ -8,9 +8,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 import re

--- a/src/DIRAC/Resources/Computing/ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ComputingElement.py
@@ -29,9 +29,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 
@@ -55,9 +52,6 @@ from DIRAC.WorkloadManagementSystem.Utilities.JobParameters import (
 
 INTEGER_PARAMETERS = ["CPUTime", "NumberOfProcessors", "NumberOfPayloadProcessors", "MaxRAM"]
 FLOAT_PARAMETERS = ["WaitingToRunningRatio"]
-
-__RCSID__ = "$Id$"
-
 LIST_PARAMETERS = ["Tag", "RequiredTag"]
 WAITING_TO_RUNNING_RATIO = 0.5
 MAX_WAITING_JOBS = 1

--- a/src/DIRAC/Resources/Computing/ComputingElementFactory.py
+++ b/src/DIRAC/Resources/Computing/ComputingElementFactory.py
@@ -13,8 +13,6 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Resources.Computing.ComputingElement import getCEConfigDict
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 
-__RCSID__ = "$Id$"
-
 
 class ComputingElementFactory(object):
 

--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -76,8 +76,6 @@ from DIRAC.Core.Utilities.Subprocess import Subprocess
 
 from DIRAC.Resources.Computing.BatchSystems.Condor import parseCondorStatus, treatCondorHistory
 
-__RCSID__ = "$Id$"
-
 CE_NAME = "HTCondorCE"
 MANDATORY_PARAMETERS = ["Queue"]
 DEFAULT_WORKINGDIRECTORY = "/opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT"

--- a/src/DIRAC/Resources/Computing/InProcessComputingElement.py
+++ b/src/DIRAC/Resources/Computing/InProcessComputingElement.py
@@ -11,9 +11,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import stat
 

--- a/src/DIRAC/Resources/Computing/PoolComputingElement.py
+++ b/src/DIRAC/Resources/Computing/PoolComputingElement.py
@@ -10,9 +10,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import concurrent.futures
 

--- a/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
@@ -9,9 +9,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 import socket

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -61,9 +61,6 @@ SSHType:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import os
 import json

--- a/src/DIRAC/Resources/Computing/SudoComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SudoComputingElement.py
@@ -16,8 +16,6 @@ from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement
 
-__RCSID__ = "$Id$"
-
 
 class SudoComputingElement(ComputingElement):
 

--- a/src/DIRAC/Resources/Computing/__init__.py
+++ b/src/DIRAC/Resources/Computing/__init__.py
@@ -5,5 +5,3 @@ DIRAC.Resources.Computing package
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Resources/IdProvider/IdProvider.py
+++ b/src/DIRAC/Resources/IdProvider/IdProvider.py
@@ -6,8 +6,6 @@ from __future__ import print_function
 
 from DIRAC import gLogger
 
-__RCSID__ = "$Id$"
-
 
 class IdProvider(object):
 

--- a/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
+++ b/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
@@ -19,8 +19,6 @@ from DIRAC.Resources.IdProvider.Utilities import getProviderInfo, getSettingsNam
 from DIRAC.FrameworkSystem.private.authorization.utils.Clients import getDIRACClients
 from DIRAC.FrameworkSystem.private.authorization.utils.Utilities import collectMetadata
 
-__RCSID__ = "$Id$"
-
 gCacheMetadata = ThreadSafe.Synchronizer()
 
 

--- a/src/DIRAC/Resources/IdProvider/Utilities.py
+++ b/src/DIRAC/Resources/IdProvider/Utilities.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, S_ERROR, gConfig
 
 

--- a/src/DIRAC/Resources/LogBackends/AbstractBackend.py
+++ b/src/DIRAC/Resources/LogBackends/AbstractBackend.py
@@ -4,9 +4,6 @@ Backend wrapper
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
 
 

--- a/src/DIRAC/Resources/LogBackends/ElasticSearchBackend.py
+++ b/src/DIRAC/Resources/LogBackends/ElasticSearchBackend.py
@@ -4,9 +4,6 @@ ElasticSearch wrapper
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import logging
 from cmreslogging.handlers import CMRESHandler
 

--- a/src/DIRAC/Resources/LogBackends/FileBackend.py
+++ b/src/DIRAC/Resources/LogBackends/FileBackend.py
@@ -4,9 +4,6 @@ FileBackend wrapper
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import logging
 from os import getpid
 

--- a/src/DIRAC/Resources/LogBackends/MessageQueueBackend.py
+++ b/src/DIRAC/Resources/LogBackends/MessageQueueBackend.py
@@ -4,9 +4,6 @@ Message Queue wrapper
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 from pythonjsonlogger.jsonlogger import JsonFormatter
 

--- a/src/DIRAC/Resources/LogBackends/StderrBackend.py
+++ b/src/DIRAC/Resources/LogBackends/StderrBackend.py
@@ -4,9 +4,6 @@ StderrBackend wrapper
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import logging
 import sys
 

--- a/src/DIRAC/Resources/LogBackends/StdoutBackend.py
+++ b/src/DIRAC/Resources/LogBackends/StdoutBackend.py
@@ -4,9 +4,6 @@ StdoutBackend wrapper
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import logging
 import sys
 

--- a/src/DIRAC/Resources/LogFilters/ModuleFilter.py
+++ b/src/DIRAC/Resources/LogFilters/ModuleFilter.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
 
 DOT = "."

--- a/src/DIRAC/Resources/LogFilters/PatternFilter.py
+++ b/src/DIRAC/Resources/LogFilters/PatternFilter.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 
 class PatternFilter(object):
     """Filter module to set loglevel per module.

--- a/src/DIRAC/Resources/MessageQueue/MQCommunication.py
+++ b/src/DIRAC/Resources/MessageQueue/MQCommunication.py
@@ -11,8 +11,6 @@ from DIRAC.Resources.MessageQueue.MQConnectionManager import MQConnectionManager
 from DIRAC.Resources.MessageQueue.Utilities import getMQParamsFromCS
 from DIRAC.Resources.MessageQueue.Utilities import generateDefaultCallback
 
-__RCSID__ = "$Id$"
-
 connectionManager = MQConnectionManager()  # To manage the active MQ connections.
 
 

--- a/src/DIRAC/Resources/MessageQueue/MQConnector.py
+++ b/src/DIRAC/Resources/MessageQueue/MQConnector.py
@@ -9,8 +9,6 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.Core.Utilities.DErrno import EMQUKN
 
-__RCSID__ = "$Id$"
-
 
 def createMQConnector(parameters=None):
     """Function creates and returns the MQConnector object based.

--- a/src/DIRAC/Resources/MessageQueue/Utilities.py
+++ b/src/DIRAC/Resources/MessageQueue/Utilities.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import queue
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI

--- a/src/DIRAC/Resources/MessageQueue/test/Test_MQ_Utilities.py
+++ b/src/DIRAC/Resources/MessageQueue/test/Test_MQ_Utilities.py
@@ -11,9 +11,6 @@ import queue
 
 from mock import MagicMock
 
-__RCSID__ = "$Id$"
-
-
 ROOT_PATH = "/Resources/MQServices/"
 MQSERVICE_NAME = "mq.dirac.net"
 QUEUE_TYPE = "Queue"

--- a/src/DIRAC/Resources/ProxyProvider/DIRACCAProxyProvider.py
+++ b/src/DIRAC/Resources/ProxyProvider/DIRACCAProxyProvider.py
@@ -33,9 +33,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import re
 import time
 import random

--- a/src/DIRAC/Resources/ProxyProvider/PUSPProxyProvider.py
+++ b/src/DIRAC/Resources/ProxyProvider/PUSPProxyProvider.py
@@ -17,8 +17,6 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-error
 from DIRAC.Resources.ProxyProvider.ProxyProvider import ProxyProvider
 
-__RCSID__ = "$Id$"
-
 
 class PUSPProxyProvider(ProxyProvider):
     def __init__(self, parameters=None):

--- a/src/DIRAC/Resources/ProxyProvider/ProxyProvider.py
+++ b/src/DIRAC/Resources/ProxyProvider/ProxyProvider.py
@@ -5,8 +5,6 @@ from __future__ import division
 from __future__ import print_function
 from DIRAC import S_OK, S_ERROR
 
-__RCSID__ = "$Id$"
-
 
 class ProxyProvider(object):
     def __init__(self, parameters=None):

--- a/src/DIRAC/Resources/ProxyProvider/ProxyProviderFactory.py
+++ b/src/DIRAC/Resources/ProxyProvider/ProxyProviderFactory.py
@@ -13,8 +13,6 @@ from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getInfoAboutProviders
 
-__RCSID__ = "$Id$"
-
 
 class ProxyProviderFactory(object):
 

--- a/src/DIRAC/Resources/ProxyProvider/test/Test_ProxyProviderFactory.py
+++ b/src/DIRAC/Resources/ProxyProvider/test/Test_ProxyProviderFactory.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import mock
 import unittest

--- a/src/DIRAC/Resources/Storage/DIPStorage.py
+++ b/src/DIRAC/Resources/Storage/DIPStorage.py
@@ -13,9 +13,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import random
 

--- a/src/DIRAC/Resources/Storage/FCOnlyStorage.py
+++ b/src/DIRAC/Resources/Storage/FCOnlyStorage.py
@@ -21,9 +21,6 @@ Operations/DataManagement section.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger, S_OK
 from DIRAC.Resources.Storage.Utilities import checkArgumentFormat
 from DIRAC.Resources.Storage.StorageBase import StorageBase

--- a/src/DIRAC/Resources/Storage/FileStorage.py
+++ b/src/DIRAC/Resources/Storage/FileStorage.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import shutil
 import errno

--- a/src/DIRAC/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_SRM2Storage.py
@@ -24,9 +24,6 @@ from DIRAC.Resources.Storage.GFAL2_StorageBase import GFAL2_StorageBase
 from DIRAC.Resources.Storage.Utilities import checkArgumentFormat
 
 
-__RCSID__ = "$Id$"
-
-
 class GFAL2_SRM2Storage(GFAL2_StorageBase):
     """SRM2 SE class that inherits from GFAL2StorageBase"""
 

--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -45,9 +45,6 @@ from DIRAC.Core.Utilities.Pfn import pfnparse, pfnunparse
 
 
 # # RCSID
-__RCSID__ = "$Id$"
-
-
 class GFAL2_StorageBase(StorageBase):
     """.. class:: GFAL2_StorageBase
 

--- a/src/DIRAC/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
+++ b/src/DIRAC/Resources/Storage/OccupancyPlugins/BDIIOccupancy.py
@@ -4,9 +4,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 
 from DIRAC import S_OK

--- a/src/DIRAC/Resources/Storage/ProxyStorage.py
+++ b/src/DIRAC/Resources/Storage/ProxyStorage.py
@@ -13,9 +13,6 @@ from DIRAC.Core.Base.Client import Client
 from DIRAC.Core.Utilities.File import getSize
 
 
-__RCSID__ = "$Id$"
-
-
 class ProxyStorage(StorageBase):
 
     _INPUT_PROTOCOLS = ["file", "dip", "dips"]

--- a/src/DIRAC/Resources/Storage/RFIOStorage.py
+++ b/src/DIRAC/Resources/Storage/RFIOStorage.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import re
 import os
 import time

--- a/src/DIRAC/Resources/Storage/S3Storage.py
+++ b/src/DIRAC/Resources/Storage/S3Storage.py
@@ -17,10 +17,6 @@ The Path should be the BucketName
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
-
 import copy
 import errno
 import functools

--- a/src/DIRAC/Resources/Storage/StorageBase.py
+++ b/src/DIRAC/Resources/Storage/StorageBase.py
@@ -36,9 +36,6 @@ These are the methods for getting information about the Storage:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import errno
 import json
 import os

--- a/src/DIRAC/Resources/Storage/StorageElement.py
+++ b/src/DIRAC/Resources/Storage/StorageElement.py
@@ -40,8 +40,6 @@ from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
 from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 
-__RCSID__ = "$Id$"
-
 DEFAULT_OCCUPANCY_FILE = "occupancy.json"
 
 sLog = gLogger.getSubLogger(__name__)

--- a/src/DIRAC/Resources/Storage/StorageFactory.py
+++ b/src/DIRAC/Resources/Storage/StorageFactory.py
@@ -14,9 +14,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR
 from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus

--- a/src/DIRAC/Resources/Storage/Utilities.py
+++ b/src/DIRAC/Resources/Storage/Utilities.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import errno
 

--- a/src/DIRAC/Resources/Storage/test/FIXME_Test_RFIOPlugIn.py
+++ b/src/DIRAC/Resources/Storage/test/FIXME_Test_RFIOPlugIn.py
@@ -25,8 +25,6 @@ from DIRAC.Resources.Storage.test.Test_FilePlugin import (
 from DIRAC.Resources.Storage.StorageElement import StorageElementItem
 from DIRAC.Core.Utilities.File import getSize
 
-__RCSID__ = "$Id$"
-
 
 def mock_StorageFactory_getCurrentURL(storageName, derivedStorageName):
     """Get the options associated to the StorageElement as defined in the CS"""

--- a/src/DIRAC/Resources/Storage/test/FIXME_Test_StorageElement.py
+++ b/src/DIRAC/Resources/Storage/test/FIXME_Test_StorageElement.py
@@ -23,9 +23,6 @@ from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.Core.Utilities.File import getSize
 
 positionalArgs = getPositionalArgs()
-
-__RCSID__ = "$Id$"
-
 if len(positionalArgs) < 3:
     print("Usage: TestStoragePlugIn.py StorageElement <lfnDir> <localFile>")
     sys.exit()

--- a/src/DIRAC/Resources/Storage/test/FIXME_Test_StoragePlugIn.py
+++ b/src/DIRAC/Resources/Storage/test/FIXME_Test_StoragePlugIn.py
@@ -21,9 +21,6 @@ from DIRAC.Resources.Storage.StorageFactory import StorageFactory
 from DIRAC.Core.Utilities.File import getSize
 
 positionalArgs = getPositionalArgs()
-
-__RCSID__ = "$Id$"
-
 if len(positionalArgs) < 2:
     print("Usage: TestStoragePlugIn.py StorageElement plugin")
     sys.exit()

--- a/src/DIRAC/Resources/Storage/test/Test_StorageFactory.py
+++ b/src/DIRAC/Resources/Storage/test/Test_StorageFactory.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import copy
 import unittest
 import mock

--- a/src/DIRAC/Resources/__init__.py
+++ b/src/DIRAC/Resources/__init__.py
@@ -5,5 +5,3 @@ DIRAC.Resources package
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"

--- a/src/DIRAC/Resources/scripts/dirac_resource_get_parameters.py
+++ b/src/DIRAC/Resources/scripts/dirac_resource_get_parameters.py
@@ -5,9 +5,6 @@ Get parameters assigned to the CE
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import json
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/Resources/scripts/dirac_resource_info.py
+++ b/src/DIRAC/Resources/scripts/dirac_resource_info.py
@@ -6,9 +6,6 @@ By default, resources for the VO corresponding to the current user identity are 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/StorageManagementSystem/Agent/RequestFinalizationAgent.py
+++ b/src/DIRAC/StorageManagementSystem/Agent/RequestFinalizationAgent.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK, gLogger
 
 from DIRAC.Core.Base.AgentModule import AgentModule

--- a/src/DIRAC/StorageManagementSystem/Agent/RequestPreparationAgent.py
+++ b/src/DIRAC/StorageManagementSystem/Agent/RequestPreparationAgent.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger, S_OK
 
 from DIRAC.Core.Base.AgentModule import AgentModule

--- a/src/DIRAC/StorageManagementSystem/Agent/StageMonitorAgent.py
+++ b/src/DIRAC/StorageManagementSystem/Agent/StageMonitorAgent.py
@@ -12,9 +12,6 @@ This agents queries the storage element about staging requests, to see if files 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger, S_OK, S_ERROR, siteName
 
 from DIRAC.Core.Base.AgentModule import AgentModule

--- a/src/DIRAC/StorageManagementSystem/Agent/StageRequestAgent.py
+++ b/src/DIRAC/StorageManagementSystem/Agent/StageRequestAgent.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import gLogger, S_OK
 
 from DIRAC.Core.Base.AgentModule import AgentModule

--- a/src/DIRAC/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/src/DIRAC/StorageManagementSystem/Client/StorageManagerClient.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 import random
 import errno

--- a/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
@@ -12,9 +12,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from past.builtins import long
 import six
 import inspect

--- a/src/DIRAC/StorageManagementSystem/Service/StorageManagerHandler.py
+++ b/src/DIRAC/StorageManagementSystem/Service/StorageManagerHandler.py
@@ -3,9 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 
 from DIRAC import gLogger, S_OK

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_file.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_file.py
@@ -34,9 +34,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_jobs.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_jobs.py
@@ -79,9 +79,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_request.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_request.py
@@ -9,9 +9,6 @@ Report the summary of the stage task from the DB.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_requests.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_monitor_requests.py
@@ -27,9 +27,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC import gConfig, gLogger, exit as DIRACExit, S_OK, version
 

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_show_stats.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_show_stats.py
@@ -25,9 +25,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC import gConfig, gLogger, exit as DIRACExit, S_OK, version
 

--- a/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_stage_files.py
+++ b/src/DIRAC/StorageManagementSystem/scripts/dirac_stager_stage_files.py
@@ -32,9 +32,6 @@ Example:
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/TransformationSystem/Agent/DataRecoveryAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/DataRecoveryAgent.py
@@ -76,8 +76,6 @@ from DIRAC.TransformationSystem.Utilities.TransformationInfo import Transformati
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
 from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
 
-__RCSID__ = "$Id$"
-
 AGENT_NAME = "Transformation/DataRecoveryAgent"
 
 ASSIGNEDSTATES = [TransformationFilesStatus.ASSIGNED, TransformationFilesStatus.PROCESSED]

--- a/src/DIRAC/TransformationSystem/Agent/InputDataAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/InputDataAgent.py
@@ -31,8 +31,6 @@ from DIRAC.TransformationSystem.Client.TransformationClient import Transformatio
 from DIRAC.Resources.Catalog.FileCatalogClient import FileCatalogClient
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 
-__RCSID__ = "$Id$"
-
 AGENT_NAME = "Transformation/InputDataAgent"
 
 

--- a/src/DIRAC/TransformationSystem/Agent/MCExtensionAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/MCExtensionAgent.py
@@ -16,8 +16,6 @@ from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 
-__RCSID__ = "$Id$"
-
 AGENT_NAME = "Transformation/MCExtensionAgent"
 
 

--- a/src/DIRAC/TransformationSystem/Agent/RequestOperations/SetFileStatus.py
+++ b/src/DIRAC/TransformationSystem/Agent/RequestOperations/SetFileStatus.py
@@ -11,8 +11,6 @@ from DIRAC.Core.Utilities import DEncode
 from DIRAC.RequestManagementSystem.private.OperationHandlerBase import OperationHandlerBase
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 
-__RCSID__ = "$Id$"
-
 
 class SetFileStatus(OperationHandlerBase):
     """

--- a/src/DIRAC/TransformationSystem/Agent/RequestTaskAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/RequestTaskAgent.py
@@ -31,8 +31,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.TransformationSystem.Agent.TaskManagerAgentBase import TaskManagerAgentBase
 
-__RCSID__ = "$Id$"
-
 AGENT_NAME = "Transformation/RequestTaskAgent"
 
 

--- a/src/DIRAC/TransformationSystem/Agent/TaskManagerAgentBase.py
+++ b/src/DIRAC/TransformationSystem/Agent/TaskManagerAgentBase.py
@@ -10,9 +10,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 import datetime
 import concurrent.futures

--- a/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
@@ -28,8 +28,6 @@ from DIRAC.TransformationSystem.Client import TransformationFilesStatus
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 from DIRAC.TransformationSystem.Agent.TransformationAgentsUtilities import TransformationAgentsUtilities
 
-__RCSID__ = "$Id$"
-
 AGENT_NAME = "Transformation/TransformationAgent"
 gSynchro = Synchronizer()
 

--- a/src/DIRAC/TransformationSystem/Agent/TransformationAgentsUtilities.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationAgentsUtilities.py
@@ -8,8 +8,6 @@ from __future__ import print_function
 import time
 from DIRAC import gLogger
 
-__RCSID__ = "$Id$"
-
 AGENT_NAME = ""
 
 

--- a/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -11,8 +11,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # # imports
 import re
 import ast

--- a/src/DIRAC/TransformationSystem/Agent/TransformationPlugin.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationPlugin.py
@@ -34,8 +34,6 @@ from DIRAC.TransformationSystem.Client.PluginBase import PluginBase
 from DIRAC.TransformationSystem.Client.Utilities import PluginUtilities, getFileGroups
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 
-__RCSID__ = "$Id$"
-
 
 class TransformationPlugin(PluginBase):
     """A TransformationPlugin object should be instantiated by every transformation.

--- a/src/DIRAC/TransformationSystem/Agent/ValidateOutputDataAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/ValidateOutputDataAgent.py
@@ -11,9 +11,6 @@ The following options can be set for the ValidateOutputDataAgent.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import re
 import ast
 

--- a/src/DIRAC/TransformationSystem/Agent/WorkflowTaskAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/WorkflowTaskAgent.py
@@ -23,9 +23,6 @@ need to be assigned any non-empty value to be activated
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC import S_OK
 
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations

--- a/src/DIRAC/TransformationSystem/Client/FileReport.py
+++ b/src/DIRAC/TransformationSystem/Client/FileReport.py
@@ -11,8 +11,6 @@ from DIRAC.Core.Utilities import DEncode
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 from DIRAC.RequestManagementSystem.Client.Operation import Operation
 
-__RCSID__ = "$Id$"
-
 
 class FileReport(object):
     """A stateful object for reporting to TransformationDB"""

--- a/src/DIRAC/TransformationSystem/Client/TaskManager.py
+++ b/src/DIRAC/TransformationSystem/Client/TaskManager.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__RCSID__ = "$Id$"
-
 # pylint: disable=protected-access
 
 

--- a/src/DIRAC/TransformationSystem/Client/TaskManagerPlugin.py
+++ b/src/DIRAC/TransformationSystem/Client/TaskManagerPlugin.py
@@ -13,8 +13,6 @@ from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getSites
 from DIRAC.TransformationSystem.Client.PluginBase import PluginBase
 
-__RCSID__ = "$Id$"
-
 
 class TaskManagerPlugin(PluginBase):
     """A TaskManagerPlugin object should be instantiated by every TaskManager object.

--- a/src/DIRAC/TransformationSystem/Client/Transformation.py
+++ b/src/DIRAC/TransformationSystem/Client/Transformation.py
@@ -22,8 +22,6 @@ from DIRAC.RequestManagementSystem.Client.Operation import Operation
 
 COMPONENT_NAME = "Transformation"
 
-__RCSID__ = "$Id$"
-
 
 class Transformation(API):
 

--- a/src/DIRAC/TransformationSystem/Client/TransformationClient.py
+++ b/src/DIRAC/TransformationSystem/Client/TransformationClient.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import six
 
 from DIRAC import S_OK, S_ERROR, gLogger

--- a/src/DIRAC/TransformationSystem/Client/TransformationFilesStatus.py
+++ b/src/DIRAC/TransformationSystem/Client/TransformationFilesStatus.py
@@ -5,9 +5,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
-__RCSID__ = "$Id$"
-
 #:
 UNUSED = "Unused"
 #:

--- a/src/DIRAC/TransformationSystem/Client/Utilities.py
+++ b/src/DIRAC/TransformationSystem/Client/Utilities.py
@@ -26,8 +26,6 @@ from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
 
-__RCSID__ = "$Id$"
-
 
 class PluginUtilities(object):
     """

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_add_files.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_add_files.py
@@ -5,9 +5,6 @@ Add files to an existing transformation
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import os
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_archive.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_archive.py
@@ -5,9 +5,6 @@ Archive a transformation
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_clean.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_clean.py
@@ -5,9 +5,6 @@ Clean a tranformation
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_cli.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_cli.py
@@ -5,9 +5,6 @@ Command to launch the Transformation Shell
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_get_files.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_get_files.py
@@ -6,9 +6,6 @@ Get the files attached to a transformation
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import DIRAC
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_recover_data.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_recover_data.py
@@ -9,8 +9,6 @@ from __future__ import print_function
 from DIRAC import S_OK, gLogger
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
-__RCSID__ = "$Id$"
-
 
 class Params(object):
     """Collection of Parameters set via CLI switches."""

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_replication.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_replication.py
@@ -9,9 +9,6 @@ Create a production to replicate files from some storage elements to others
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 

--- a/src/DIRAC/TransformationSystem/scripts/dirac_transformation_verify_outputdata.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_transformation_verify_outputdata.py
@@ -6,9 +6,6 @@ Runs checkTransformationIntegrity from ValidateOutputDataAgent on selected Tranf
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 import sys
 
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script

--- a/src/DIRAC/TransformationSystem/test/Test_DRA.py
+++ b/src/DIRAC/TransformationSystem/test/Test_DRA.py
@@ -17,8 +17,6 @@ from DIRAC.TransformationSystem.Utilities.JobInfo import TaskInfoException
 
 from DIRAC.tests.Utilities.utils import MatchStringWith
 
-__RCSID__ = "$Id$"
-
 MODULE_NAME = "DIRAC.TransformationSystem.Agent.DataRecoveryAgent"
 
 

--- a/src/DIRAC/TransformationSystem/test/Test_JobInfo.py
+++ b/src/DIRAC/TransformationSystem/test/Test_JobInfo.py
@@ -18,9 +18,6 @@ from DIRAC.TransformationSystem.Utilities.JobInfo import TaskInfoException, JobI
 import DIRAC.Interfaces.API.Dirac
 
 gLogger.setLevel("DEBUG")
-
-__RCSID__ = "$Id$"
-
 # pylint: disable=W0212, E1101
 
 

--- a/src/DIRAC/TransformationSystem/test/Test_TransformationInfo.py
+++ b/src/DIRAC/TransformationSystem/test/Test_TransformationInfo.py
@@ -19,8 +19,6 @@ from DIRAC.TransformationSystem.Utilities.TransformationInfo import Transformati
 
 from DIRAC.tests.Utilities.utils import MatchStringWith
 
-__RCSID__ = "$Id$"
-
 # pylint: disable=W0212, redefined-outer-name
 
 

--- a/src/DIRAC/TransformationSystem/test/Test_replicationTransformation.py
+++ b/src/DIRAC/TransformationSystem/test/Test_replicationTransformation.py
@@ -12,8 +12,6 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.TransformationSystem.Utilities.ReplicationTransformation import createDataTransformation
 from DIRAC.TransformationSystem.Utilities.ReplicationCLIParameters import Params
 
-__RCSID__ = "$Id$"
-
 GET_VOMS = "DIRAC.TransformationSystem.Utilities.ReplicationCLIParameters.getVOMSVOForGroup"
 GET_PROXY = "DIRAC.TransformationSystem.Utilities.ReplicationCLIParameters.getProxyInfo"
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
@@ -6,9 +6,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import sys
 import re
 import time

--- a/tests/Integration/Resources/IdProvider/Test_IdProviderFactory.py
+++ b/tests/Integration/Resources/IdProvider/Test_IdProviderFactory.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-__RCSID__ = "$Id$"
-
 import time
 
 from diraccfg import CFG

--- a/tests/Integration/TornadoServices/Services/UserDiracHandler.py
+++ b/tests/Integration/TornadoServices/Services/UserDiracHandler.py
@@ -1,9 +1,6 @@
 """ Dummy Service is a service for testing new dirac protocol
   This file must be copied in FrameworkSystem/Service to run tests
 """
-
-__RCSID__ = "$Id$"
-
 import six
 
 from DIRAC import S_OK

--- a/tests/Jenkins/dirac-cfg-add-option.py
+++ b/tests/Jenkins/dirac-cfg-add-option.py
@@ -4,9 +4,6 @@ Do the initial configuration of a DIRAC component
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 
 Script.setUsageMessage(

--- a/tests/Performance/DFCPerformance/FIXME_Test_FC_scaling.py
+++ b/tests/Performance/DFCPerformance/FIXME_Test_FC_scaling.py
@@ -8,9 +8,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
-
-__RCSID__ = "$Id$"
-
 from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
 from DIRAC import S_OK
 import sys


### PR DESCRIPTION
Littering unrelated commits with the removal `__RCSID__ ` makes PRs harder to review for no good reason so I propose we do it in one go and be done with it.

This PR is simply replacing `\n+__RCSID__ = "\$Id\$"\n+` with `\n` and letting pre-commit fix the whitespace.