### PR TITLE
[integration] print error details/callstack in BaseRequestHandler

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -616,7 +616,7 @@ class BaseRequestHandler(RequestHandler):
             # If an error occur when reading certificates we close connection
             # It can be strange but the RFC, for HTTP, say's that when error happend
             # before authentication we return 401 UNAUTHORIZED instead of 403 FORBIDDEN
-            sLog.debug(str(e))
+            sLog.exception(e)
             sLog.error("Error gathering credentials ", "%s; path %s" % (self.getRemoteAddress(), self.request.path))
             raise HTTPError(HTTPStatus.UNAUTHORIZED, str(e))
 


### PR DESCRIPTION
`sLog.debug` dont'n show all useful details about raised errors from `_gatherPeerCredentials` method.

BEGINRELEASENOTES

*Core
FIX: print error details/callstack in BaseRequestHandler

ENDRELEASENOTES
