### PR TITLE
[8.0][OAuth 2] use dirac-login instead of dirac-proxy-init for tests

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -241,13 +241,13 @@ Registry
       # Just for normal users:
       JobShare = 200
 
-      # Controls automatic Proxy upload by dirac-proxy-init:
+      # Controls automatic Proxy upload:
       AutoUploadProxy = True
 
-      # Controls automatic Proxy upload by dirac-proxy-init for Pilot groups:
+      # Controls automatic Proxy upload for Pilot groups:
       AutoUploadPilotProxy = True
 
-      # Controls automatic addition of VOMS extension by dirac-proxy-init:
+      # Controls automatic addition of VOMS extension:
       AutoAddVOMS = True
     }
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
@@ -173,7 +173,7 @@ class Params:
         Script.registerSwitch("T:", "lifetime=", "set access lifetime in hours", self.setLifetime)
         Script.registerSwitch(
             "O:",
-            "save-output=",
+            "out=",
             "where to save the authorization result(e.g: proxy or tokens). By default we will try to find a standard place.",
             self.setOutputFile,
         )

--- a/tests/Integration/Framework/Test_Proxy.sh
+++ b/tests/Integration/Framework/Test_Proxy.sh
@@ -19,16 +19,16 @@ echo
 echo
 
 echo "================================"
-echo "===  dirac-proxy-init $PARAMS"
+echo "===  dirac-login $PARAMS"
 echo
-dirac-proxy-init $PARAMS
+dirac-login $PARAMS
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi
 echo
 
 echo "====================="
-echo "===  dirac-proxy-info"
+echo "===  dirac-login --status"
 echo
 dirac-proxy-info
 if [[ "${?}" -ne 0 ]]; then
@@ -64,9 +64,9 @@ fi
 echo
 
 echo "==============================================="
-echo "===  dirac-proxy-init -g dirac_admin $PARAMS"
+echo "===  dirac-login dirac_admin $PARAMS"
 echo
-dirac-proxy-init -g dirac_admin $PARAMS
+dirac-login dirac_admin $PARAMS
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi

--- a/tests/Integration/all_integration_client_tests.sh
+++ b/tests/Integration/all_integration_client_tests.sh
@@ -12,7 +12,7 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo -e "THIS_DIR=${THIS_DIR}" |& tee -a clientTestOutputs.txt
 
 echo -e "*** $(date -u)  Getting a non privileged user\n" |& tee -a clientTestOutputs.txt
-dirac-proxy-init -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
+dirac-login -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 #-------------------------------------------------------------------------------#
 echo -e "*** $(date -u) **** Accounting TESTS ****\n"
@@ -24,13 +24,13 @@ pytest "${THIS_DIR}/AccountingSystem/Test_ReportsClient.py" |& tee -a clientTest
 echo -e "*** $(date -u)  **** RMS TESTS ****\n"
 
 echo -e "*** $(date -u)  Getting a non privileged user\n" |& tee -a clientTestOutputs.txt
-dirac-proxy-init -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
+dirac-login -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 
 echo -e "*** $(date -u)  Starting RMS Client test as a non privileged user\n" |& tee -a clientTestOutputs.txt
 pytest "${THIS_DIR}/RequestManagementSystem/Test_Client_Req.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 echo -e "*** $(date -u)  getting the prod role again\n" |& tee -a clientTestOutputs.txt
-dirac-proxy-init -g prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
+dirac-login prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 echo -e "*** $(date -u)  Starting RMS Client test as an admin user\n" |& tee -a clientTestOutputs.txt
 pytest "${THIS_DIR}/RequestManagementSystem/Test_Client_Req.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
@@ -56,7 +56,7 @@ python "${THIS_DIR}/WorkloadManagementSystem/Test_SandboxStoreClient.py" --cfg "
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_JobWrapper.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_PilotsClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 # Make sure we have the prod role for these tests to get the VmRpcOperator permission
-dirac-proxy-init -g prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
+dirac-login prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 pytest "${THIS_DIR}/WorkloadManagementSystem/Test_VirtualMachineManagerClient.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
 ## no real tests
@@ -88,14 +88,14 @@ echo -e "*** $(date -u) **** DataManager TESTS ****\n"
 
 
 echo -e "*** $(date -u)  Getting a non privileged user to find its VO dynamically\n" |& tee -a clientTestOutputs.txt
-dirac-proxy-init -g jenkins_user -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG |& tee -a clientTestOutputs.txt
+dirac-login jenkins_user -C $SERVERINSTALLDIR/user/client.pem -K $SERVERINSTALLDIR/user/client.key $DEBUG |& tee -a clientTestOutputs.txt
 
 userVO=$(python -c "import DIRAC; DIRAC.initialize(); from DIRAC.Core.Security.ProxyInfo import getVOfromProxyGroup; print(getVOfromProxyGroup().get('Value',''))")
 userVO="${userVO:-Jenkins}"
 echo -e "*** $(date -u) VO is "${userVO}"\n" |& tee -a clientTestOutputs.txt
 
 echo -e "*** $(date -u)  Getting a privileged user\n" |& tee -a clientTestOutputs.txt
-dirac-proxy-init -g jenkins_fcadmin -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
+dirac-login jenkins_fcadmin -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 
 cat >> dataManager_create_folders <<EOF
 
@@ -111,7 +111,7 @@ EOF
 dirac-dms-filecatalog-cli -f FileCatalog < dataManager_create_folders
 
 echo -e "*** $(date -u)  Getting a non privileged user\n" |& tee -a clientTestOutputs.txt
-dirac-proxy-init -g jenkins_user -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
+dirac-login jenkins_user -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 
 pytest "${THIS_DIR}/DataManagementSystem/Test_DataManager.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 
@@ -121,7 +121,7 @@ pytest "${THIS_DIR}/DataManagementSystem/Test_DataManager.py" |& tee -a clientTe
 # respectively.
 
 # normal user proxy
-dirac-proxy-init -g jenkins_user -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
+dirac-login jenkins_user -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}" |& tee -a clientTestOutputs.txt
 echo -e "*** $(date -u) **** MultiVO User Metadata TESTS ****\n"
 python -m pytest "${THIS_DIR}/DataManagementSystem/Test_UserMetadata.py" |& tee -a clientTestOutputs.txt; (( ERR |= "${?}" ))
 

--- a/tests/Integration/all_integration_server_tests.sh
+++ b/tests/Integration/all_integration_server_tests.sh
@@ -70,7 +70,7 @@ dirac-restart-component Tornado Tornado "${DEBUG}" |& tee -a "${SERVER_TEST_OUTP
 
 echo -e "*** $(date -u)  Run the DFC client tests as user without admin privileges" |& tee -a "${SERVER_TEST_OUTPUT}"
 echo -e "*** $(date -u)  Getting a non privileged user\n" |& tee -a "${SERVER_TEST_OUTPUT}"
-dirac-proxy-init -C "${WORKSPACE}/ServerInstallDIR/user/client.pem" -K "${WORKSPACE}/ServerInstallDIR/user/client.key" "${DEBUG}"
+dirac-login -C "${WORKSPACE}/ServerInstallDIR/user/client.pem" -K "${WORKSPACE}/ServerInstallDIR/user/client.key" "${DEBUG}"
 python "${THIS_DIR}/DataManagementSystem/Test_Client_DFC.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
 python "${THIS_DIR}/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
@@ -84,7 +84,7 @@ dirac-restart-component Tornado Tornado "${DEBUG}" |& tee -a "${SERVER_TEST_OUTP
 
 echo -e "*** $(date -u)  Run it with the admin privileges" |& tee -a "${SERVER_TEST_OUTPUT}"
 echo -e "*** $(date -u)  getting the prod role again\n" |& tee -a "${SERVER_TEST_OUTPUT}"
-dirac-proxy-init -g prod -C "${WORKSPACE}/ServerInstallDIR/user/client.pem" -K "${WORKSPACE}/ServerInstallDIR/user/client.key" "${DEBUG}" |& tee -a "${SERVER_TEST_OUTPUT}"
+dirac-login prod -C "${WORKSPACE}/ServerInstallDIR/user/client.pem" -K "${WORKSPACE}/ServerInstallDIR/user/client.key" "${DEBUG}" |& tee -a "${SERVER_TEST_OUTPUT}"
 python "${THIS_DIR}/DataManagementSystem/Test_Client_DFC.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))
 diracDFCDB |& tee -a "${SERVER_TEST_OUTPUT}"
 python "${THIS_DIR}/DataManagementSystem/Test_FileCatalogDB.py" |& tee -a "${SERVER_TEST_OUTPUT}"; (( ERR |= "${?}" ))

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -607,8 +607,8 @@ diracCredentials() {
   echo '==> [diracCredentials]'
 
   sed -i 's/commitNewData = CSAdministrator/commitNewData = authenticated/g' "${SERVERINSTALLDIR}/etc/Configuration_Server.cfg"
-  if ! dirac-proxy-init -g dirac_admin -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}"; then
-    echo 'ERROR: dirac-proxy-init failed' >&2
+  if ! dirac-login dirac_admin -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}"; then
+    echo 'ERROR: dirac-login failed' >&2
     exit 1
   fi
   sed -i 's/commitNewData = authenticated/commitNewData = CSAdministrator/g' "${SERVERINSTALLDIR}/etc/Configuration_Server.cfg"
@@ -685,13 +685,13 @@ diracUserAndGroup() {
 diracProxies() {
   echo '==> [diracProxies]'
   # User proxy, should be uploaded anyway
-  if ! dirac-proxy-init -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}"; then
-    echo 'ERROR: dirac-proxy-init failed' >&2
+  if ! dirac-login -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}"; then
+    echo 'ERROR: dirac-login failed' >&2
     exit 1
   fi
   # group proxy, will be uploaded explicitly
-  if ! dirac-proxy-init -g prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}"; then
-    echo 'ERROR: dirac-proxy-init failed' >&2
+  if ! dirac-login prod -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" "${DEBUG}"; then
+    echo 'ERROR: dirac-login failed' >&2
     exit 1
   fi
 }

--- a/tests/System/client_core.sh
+++ b/tests/System/client_core.sh
@@ -10,8 +10,15 @@ echo " ########################## REAL BASICS #############################"
 echo " "
 echo " "
 
-echo "dirac-proxy-init"
-dirac-proxy-init
+echo "dirac-login"
+dirac-login
+if [[ "${?}" -ne 0 ]]; then
+   exit 1
+fi
+
+echo " "
+echo "======  dirac-login --status"
+dirac-login --status
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi
@@ -52,8 +59,8 @@ if [[ "${?}" -eq 0 ]]; then
 fi
 
 echo " "
-echo "dirac-proxy-init"
-dirac-proxy-init
+echo "dirac-login"
+dirac-login
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi

--- a/tests/System/client_dms.sh
+++ b/tests/System/client_dms.sh
@@ -6,8 +6,8 @@ echo " ########################## BEGIN OF USER FILES TEST #####################
 echo " "
 echo " "
 
-echo "====== dirac-proxy-init -g dteam_user" #this is necesary to upload user files
-dirac-proxy-init -g dteam_user
+echo "====== dirac-login -g dteam_user" #this is necesary to upload user files
+dirac-login dteam_user
 
 dirac_user=$( dirac-proxy-info | awk '/^username / {print $3}' )
 #userdir="/dteam/user/$( echo "$USER" | cut -c 1)/$USER"

--- a/tests/System/client_multivo.sh
+++ b/tests/System/client_multivo.sh
@@ -35,8 +35,8 @@ echo -e "\nTesting first VO: gridpp"
 # just writing the proxy to a different file causes this command to fail
 # need to tell DIRAC beforehand where the user proxy will be
 export X509_USER_PROXY="${testdir}/gridpp.proxy"
-echo "dirac-proxy-init -g gridpp_user --out ${testdir}/gridpp.proxy"
-dirac-proxy-init -g gridpp_user --out "${testdir}/gridpp.proxy"
+echo "dirac-login gridpp_user --out ${testdir}/gridpp.proxy"
+dirac-login gridpp_user --out "${testdir}/gridpp.proxy"
 if [[ "${?}" -ne 0 ]]; then
    echo "Could not acquire gridpp proxy. Giving up."
    exit 1
@@ -58,8 +58,8 @@ dirac-dms-remove-files "/gridpp/diraccert/testfile.${MYDATE}.txt"
 
 export X509_USER_PROXY="${testdir}/dteam.proxy"
 echo -e "\nChanging VO to dteam."
-echo "dirac-proxy-init -g dteam_user --out ${testdir}/dteam.proxy"
-dirac-proxy-init -g dteam_user --out "${testdir}/dteam.proxy"
+echo "dirac-login dteam_user --out ${testdir}/dteam.proxy"
+dirac-login dteam_user --out "${testdir}/dteam.proxy"
 if [[ "${?}" -ne 0 ]]; then
    echo "Could not acquire dteam proxy. Giving up."
    exit 1

--- a/tests/System/client_scripts.sh
+++ b/tests/System/client_scripts.sh
@@ -9,8 +9,8 @@ echo " ########################## Getting a proxy #############################"
 echo " "
 echo " "
 
-echo "dirac-proxy-init -g dirac_prod"
-dirac-proxy-init -g dirac_prod
+echo "dirac-login dirac_prod"
+dirac-login dirac_prod
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi

--- a/tests/System/transformationSystem.sh
+++ b/tests/System/transformationSystem.sh
@@ -21,8 +21,8 @@ fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-echo "dirac-proxy-init -g dirac_prod"
-dirac-proxy-init -g dirac_prod
+echo "dirac-login dirac_prod"
+dirac-login dirac_prod
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi

--- a/tests/System/transformation_replication.sh
+++ b/tests/System/transformation_replication.sh
@@ -24,8 +24,8 @@ fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-echo "dirac-proxy-init -g dirac_prod"
-dirac-proxy-init -g dirac_prod --VOMS
+echo "dirac-login dirac_prod"
+dirac-login dirac_prod --VOMS
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi

--- a/tests/System/wms-scripts.sh
+++ b/tests/System/wms-scripts.sh
@@ -23,8 +23,8 @@ echo " ########################## Getting a proxy #############################"
 echo " "
 echo " "
 
-echo "dirac-proxy-init -g dirac_prod"
-dirac-proxy-init -g dirac_prod
+echo "dirac-login dirac_prod"
+dirac-login dirac_prod
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi


### PR DESCRIPTION
This change help to test future `dirac-login` main command in all cases.

BEGINRELEASENOTES

*tests
CHANGE: use dirac-login instead of dirac-proxy-init for tests

ENDRELEASENOTES
