### PR TITLE
[v7r2] Add SourceSE filter to RMS ReplicateAndRegister

### DIFF
--- a/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
+++ b/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
@@ -52,7 +52,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
 
 
-def filterReplicas(opFile, logger=None, dataManager=None):
+def filterReplicas(opFile, logger=None, dataManager=None, opSources=None):
     """filter out banned/invalid source SEs"""
 
     if logger is None:
@@ -76,6 +76,11 @@ def filterReplicas(opFile, logger=None, dataManager=None):
         return S_ERROR(failed)
 
     replicas = replicas["Successful"].get(opFile.LFN, {})
+
+    # If user set sourceSEs, only consider those replicas
+    if opSources:
+        replicas = {x: y for (x, y) in replicas.items() if x in opSources}
+
     noReplicas = False
     if not replicas:
         allReplicas = dataManager.getReplicas(opFile.LFN, getUrl=False)
@@ -291,7 +296,7 @@ class ReplicateAndRegister(DMSRequestOperationsBase):
 
     def _filterReplicas(self, opFile):
         """filter out banned/invalid source SEs"""
-        return filterReplicas(opFile, logger=self.log, dataManager=self.dm)
+        return filterReplicas(opFile, logger=self.log, dataManager=self.dm, opSources=self.operation.sourceSEList)
 
     def _checkExistingFTS3Operations(self):
         """

--- a/src/DIRAC/DataManagementSystem/Agent/RequestOperations/test/Test_CheckMigration.py
+++ b/src/DIRAC/DataManagementSystem/Agent/RequestOperations/test/Test_CheckMigration.py
@@ -45,6 +45,7 @@ def checkRequestAndOp(listOfLFNs):
     req.RequestName = "MyRequest"
     op = Operation()
     op.Type = "CheckMigration"
+    op.TargetSE = "Foo-SE"
     for index, lfn in enumerate(listOfLFNs):
         oFile = File()
         oFile.LFN = lfn
@@ -93,7 +94,7 @@ def test_run_NotMigrated(checkMigration, seMock, multiRetVal):
     seClassMock.getFileMetadata = MagicMock(side_effect=functools.partial(multiRetVal, Migrated=0))
     checkMigration._run()
     assert len(checkMigration.waitingFiles) == N_FILES
-    seModMock.assert_called_with("")
+    seModMock.assert_called_with("Foo-SE")
     for opFile in checkMigration.operation:
         assert opFile.Status == "Waiting"
 

--- a/src/DIRAC/RequestManagementSystem/Client/Operation.py
+++ b/src/DIRAC/RequestManagementSystem/Client/Operation.py
@@ -227,7 +227,7 @@ class Operation(object):
     @property
     def targetSEList(self):
         """helper property returning target SEs as a list"""
-        return self.TargetSE.split(",") if self.TargetSE else [""]
+        return self.TargetSE.split(",") if self.TargetSE else []
 
     @property
     def Arguments(self):

--- a/src/DIRAC/RequestManagementSystem/Client/Operation.py
+++ b/src/DIRAC/RequestManagementSystem/Client/Operation.py
@@ -222,7 +222,7 @@ class Operation(object):
     @property
     def sourceSEList(self):
         """helper property returning source SEs as a list"""
-        return self.SourceSE.split(",") if self.SourceSE else [""]
+        return self.SourceSE.split(",") if self.SourceSE else []
 
     @property
     def targetSEList(self):


### PR DESCRIPTION
Hi,

This is the patch to filter the replicas by the SourceSE when preparing a R&R request to avoid contacting SEs unnecessarily.

Closes #5893.

Regards,
Simon

BEGINRELEASENOTES
*RequestManagementSystem
FIX: filter by SourceSE in ReplicateAndRegister preparation
FIX: Change RMS.Operation sourceSEList and targtSEList default to empty list
ENDRELEASENOTES
