### PR TITLE
[v7r3] feat (GFAL2): redefine ECOMM in case it is not in errno

### DIFF
--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -43,6 +43,12 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
 from DIRAC.Core.Utilities.File import getSize
 from DIRAC.Core.Utilities.Pfn import pfnparse, pfnunparse
 
+# MacOS does not know ECOMM...
+try:
+    ECOMM = errno.ECOMM
+except AttributeError:
+    ECOMM = 70
+
 
 # # RCSID
 __RCSID__ = "$Id$"
@@ -1126,7 +1132,7 @@ class GFAL2_StorageBase(StorageBase):
             # encounter ECOMM when creating an existing directory
             # This will be fixed in the future versions of DPM,
             # but in the meantime, we catch it ourselves.
-            if e.code in (errno.EEXIST, errno.ECOMM):
+            if e.code in (errno.EEXIST, ECOMM):
                 log.debug("Directory already exists")
                 return S_OK()
             # any other error: failed to create directory


### PR DESCRIPTION
Solves https://github.com/DIRACGrid/DIRAC/issues/5915

BEGINRELEASENOTES
*Resources
CHANGE: GFAL2_StorageBase redefine ECOMM if it does not exist

ENDRELEASENOTES
