### PR TITLE
[WIP][8.0] Create a PilotsHistory Monitoring

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -1173,6 +1173,17 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)"
 
         return S_OK(resultDict)
 
+    def getSummarySnapshot(self):
+        """Get the summary snapshot for a given combination"""
+        requestedFields = ["TaskQueueID", "GridSite", "GridType", "Status"]
+        valueFields = ["COUNT(PilotID)"]
+        defString = ", ".join(requestedFields)
+        valueString = ", ".join(valueFields)
+        result = self._query(f"SELECT {defString}, {valueString} FROM PilotAgents GROUP BY {defString}")
+        if not result["OK"]:
+            return result
+        return S_OK(((requestedFields + valueFields), result["Value"]))
+
 
 class PivotedPilotSummaryTable:
     """


### PR DESCRIPTION
This PR is almost empty, just opening for discussion. (Following an idea from @VladimirRomanovsky) I propose to create an equivalent of the WMSHistory Accounting/Monitoring, but for Pilots. At the core there would be the method I coded here, which just creates a snapshot of PilotAgents. Such snapshot would be then invoked by an agent, at each cycle (equivalent of the StatesAccountingAgent) that would push the result to an ElasticSearch backend. Plots would follow (in Kibana/Grafana). 
I would not go through the hassle of creating the DIRAC plotters.

BEGINRELEASENOTES

*WMS
NEW: added a method to get a summary snapshot from PilotAgents

ENDRELEASENOTES
