### PR TITLE
[8.0] fix (dirac-login): pass the file location to setVOMSAttributes

### DIFF
--- a/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
@@ -278,7 +278,7 @@ class Params:
                     print(HTML(f"<yellow>No VOMS attribute foud for {self.group}</yellow>"))
                 else:
                     vo = getVOMSVOForGroup(self.group)
-                    if not (result := VOMS().setVOMSAttributes(chain, attribute=vomsAttr, vo=vo))["OK"]:
+                    if not (result := VOMS().setVOMSAttributes(self.outputFile, attribute=vomsAttr, vo=vo))["OK"]:
                         return S_ERROR(f"Failed adding VOMS attribute: {result['Message']}")
                     chain = result["Value"]
                     result = chain.generateProxyToFile(*parameters)


### PR DESCRIPTION
The problem observed in today hackaton was due to an incorrect call to `setVOMSAttributes`.  
The `chain` given was actually the certificate, while what you want to give it is the proxy generated from the chain. But `chain.generateProxyToFile` does generate a proxy, but does not update the `chain` object (and it is not what we want). 
So the solution is to give the generated proxy location to `setVOMSAttributes`

BEGINRELEASENOTES
*Framework
FIX: dirac-login uses the correct proxy to add VOMS attributes

ENDRELEASENOTES
