### PR TITLE
[v7r3] Revert "moved initialization of monitoring after agent initialize()"

### DIFF
--- a/src/DIRAC/Core/Base/AgentModule.py
+++ b/src/DIRAC/Core/Base/AgentModule.py
@@ -24,9 +24,9 @@ from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.Core.Utilities import Time, MemStat, Network
 from DIRAC.Core.Utilities.Shifter import setupShifterProxyInEnv
 from DIRAC.Core.Utilities.ReturnValues import isReturnStructure
+from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.ConfigurationSystem.Client import PathFinder
 from DIRAC.FrameworkSystem.Client.MonitoringClient import MonitoringClient
-from DIRAC.FrameworkSystem.Client.MonitoringClient import gMonitor
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 
@@ -152,6 +152,8 @@ class AgentModule(object):
 
         self.__monitorLastStatsUpdate = -1
         self.monitor = None
+        self.__initializeMonitor()
+        self.__initialized = False
 
     def __getCodeInfo(self):
         try:
@@ -202,8 +204,6 @@ class AgentModule(object):
         # Set the work directory in an environment variable available to subprocesses if needed
         os.environ["AGENT_WORKDIRECTORY"] = workDirectory
 
-        self.__initializeMonitor()
-
         self.__moduleProperties["shifterProxy"] = self.am_getOption("shifterProxy")
         if self.am_monitoringEnabled() and not self.activityMonitoring:
             self.monitor.enable()
@@ -235,6 +235,7 @@ class AgentModule(object):
         else:
             self.log.notice(" Watchdog interval: disabled ")
         self.log.notice("=" * 40)
+        self.__initialized = True
         return S_OK()
 
     def am_getControlDirectory(self):


### PR DESCRIPTION
This reverts commit b8fd6a580ddd6c5264f6b237bceaf801bd0a13e9.

We've seen an issue that `self.__initializeMonitor()` is now called after `self.initialize(*initArgs)` meaning that any agents with an initialize that calls `gMonitor.registerActivity` silently fail as [this condition](https://github.com/DIRACGrid/DIRAC/blob/d9dd4c772f33116aa70578d803fbf397be17d55d/src/DIRAC/FrameworkSystem/Client/MonitoringClient.py#L221-L241) isn't met.

I'll assign to @fstagni as I'm not sure why this change was made in the first place.

BEGINRELEASENOTES

*Core
FIX: Revert "moved initialization of monitoring after agent initialize()"

ENDRELEASENOTES
