### PR TITLE
[v7r3] Take into account pep-515 for Request names

### DIFF
--- a/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_request.py
+++ b/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_request.py
@@ -212,8 +212,14 @@ def main():
     for reqID in requests:
         # We allow reqID to be the requestName if it is unique
         try:
+            # PEP-515 allows for underscore in numerical literals
+            # So a request name 00123_00456
+            # is interpreted as a requestID 12300456
+            if not reqID.isdigit():
+                raise ValueError()
+
             requestID = int(reqID)
-        except ValueError:
+        except (ValueError, TypeError):
             requestID = reqClient.getRequestIDForName(reqID)
             if not requestID["OK"]:
                 gLogger.notice(requestID["Message"])


### PR DESCRIPTION
Thanks to the idiotic PEP-515, our request names `<transformationID>_<counter>` are considered as number... 
We could envisage using a `-` instead of a `_` but that could break some scripts relying on this convention. Not much though...

BEGINRELEASENOTES
*RMS
FIX: dirac-rms-request takes into account PEP-515 

ENDRELEASENOTES
