### PR TITLE
[v7r1] fix: update `PoolCE.innerCESubmissionType` from JobAgent

### DIFF
--- a/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/WorkloadManagementSystem/Agent/JobAgent.py
@@ -96,7 +96,7 @@ class JobAgent(AgentModule):
       self.log.warn("Can't instantiate a CE", ceInstance['Message'])
       return ceInstance
     self.computingElement = ceInstance['Value']
-    self.computingElement.ceParameters['InnerCESubmissionType'] = self.innerCESubmissionType
+    self.computingElement.setParameters({"InnerCESubmissionType": self.innerCESubmissionType})
 
     result = self.computingElement.getDescription()
     if not result['OK']:


### PR DESCRIPTION
To execute jobs in parallel within a singularity container, one has to specify `LocalCEType = Pool/Singularity` in a given CE configuration.
It seems that the `InnerCESubmissionType` (`Singularity`) is not taken into account.

The `PoolComputingElement.innerCESubmissionType` is defined as `InProcess` by default.
The only way to update it is to `_reset` the CE, and the only way to reset it is to update its parameters using `setParameters()`.

The fix goes to `v7r1` because @zhangxiaomei reported the problem and is still using `v7r1`.

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: update PoolCE.InnerCESubmissionType from JobAgent
ENDRELEASENOTES
