### PR TITLE
[v7r3] JobAgent polling time fix

### DIFF
--- a/src/DIRAC/Core/Base/AgentReactor.py
+++ b/src/DIRAC/Core/Base/AgentReactor.py
@@ -66,7 +66,7 @@ class AgentReactor(object):
         self.__loader = ModuleLoader("Agent", PathFinder.getAgentSection, AgentModule)
         self.__tasks = {}
         self.__baseAgentName = baseAgentName
-        self.__scheduler = ThreadScheduler.ThreadScheduler(enableReactorThread=False, minPeriod=30)
+        self.__scheduler = ThreadScheduler.ThreadScheduler(enableReactorThread=False, minPeriod=10)
         self.__alive = True
         self.__running = False
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -181,14 +181,17 @@ class JobAgent(AgentModule):
 
         self.stopAfterFailedMatches = self.am_getOption("StopAfterFailedMatches", self.stopAfterFailedMatches)
         if not jobRequest["OK"]:
-            # if we don't match a job, independently from the reason,
-            # we wait a bit longer before trying again
-            self.am_setOption("PollingTime", int(self.am_getOption("PollingTime") * 1.5))
             res = self._checkMatchingIssues(jobRequest)
             if not res["OK"]:
                 self._finish(res["Message"])
+                return res
+
+            # if we don't match a job, independently from the reason,
+            # we wait a bit longer before trying again
+            time.sleep(int(self.am_getOption("PollingTime")) * (self.matchFailedCount + 1) * 2)
             return res
 
+        # If we are, we matched a job
         # Reset the Counter
         self.matchFailedCount = 0
 


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: fix: allow for agents to loop every 10 seconds

*WMS
FIX: can't change the polling time of JobAgent from inside an already running agent


ENDRELEASENOTES
