### PR TITLE
[v7r2] fix: update PoolCE.innerCESubmissionType from JobAgent

### DIFF
--- a/src/DIRAC/Resources/Computing/PoolComputingElement.py
+++ b/src/DIRAC/Resources/Computing/PoolComputingElement.py
@@ -3,9 +3,26 @@
 # Author : A.T.
 ########################################################################
 
-""" The Pool Computing Element is an "inner" CE (meaning it's used by a jobAgent inside a pilot)
+"""The Pool Computing Element is an "inner" CE (meaning it's used by a jobAgent inside a pilot)
 
-    It's used running several jobs simultaneously in separate processes, managed by a ProcessPool
+It's used running several jobs simultaneously in separate processes, managed by a ProcessPool.
+
+**Configuration Parameters**
+
+LocalCEType:
+   Configuration for the PoolCE submission can be done via the CE configuration such as::
+
+     LocalCEType = Pool
+
+   The Pool Computing Element is specific: it embeds an additional "inner" CE
+   (`InProcess` by default, `Sudo`, `Singularity`). The "inner" CE can be specified such as::
+
+     LocalCEType = Pool/Singularity
+
+NumberOfProcessors:
+   Maximum number of processors that can be used to compute jobs.
+
+**Code Documentation**
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -99,7 +99,7 @@ class JobAgent(AgentModule):
             self.log.warn("Can't instantiate a CE", ceInstance["Message"])
             return ceInstance
         self.computingElement = ceInstance["Value"]
-        self.computingElement.ceParameters["InnerCESubmissionType"] = self.innerCESubmissionType
+        self.computingElement.setParameters({"InnerCESubmissionType": self.innerCESubmissionType})
 
         result = self.computingElement.getDescription()
         if not result["OK"]:


### PR DESCRIPTION
To execute jobs in parallel within a singularity container, one has to specify `LocalCEType = Pool/Singularity` in a given CE configuration.
It seems that the `InnerCESubmissionType` (`Singularity`) is not taken into account.

The `PoolComputingElement.innerCESubmissionType` is defined as `InProcess` by default.
The only way to update it is to `_reset` the CE, and the only way to reset it is to update its parameters using `setParameters()`.

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: update PoolCE.InnerCESubmissionType from JobAgent
ENDRELEASENOTES