### PR TITLE
[v7r2] fix: Limit reoccurrences of subprocess unicode error

### DIFF
--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -372,6 +372,7 @@ class Subprocess(object):
     def __readFromFile(self, fd, baseLength):
         """read from file descriptor :fd: and save it to the dedicated buffer"""
         try:
+            numErrors = 0
             dataString = ""
             fn = fd.fileno()
 
@@ -389,7 +390,11 @@ class Subprocess(object):
                 try:
                     dataString += nB.decode()
                 except UnicodeDecodeError as e:
-                    self.log.warn("Unicode decode error in readFromFile", "(%r): %r" % (e, dataString))
+                    if numErrors < 5:
+                        self.log.warn("Unicode decode error in readFromFile", "(%r): %r" % (e, dataString))
+                        numErrors += 1
+                        if numErrors == 5:
+                            self.log.warn("Max unicode decode errors reached, further errors will not be logged.")
                     dataString += nB.decode("utf-8", "replace")
                 # break out of potential infinite loop, indicated by dataString growing beyond reason
                 if len(dataString) + baseLength > self.bufferLimit:

--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -391,7 +391,10 @@ class Subprocess(object):
                     dataString += nB.decode()
                 except UnicodeDecodeError as e:
                     if numErrors < 5:
-                        self.log.warn("Unicode decode error in readFromFile", "(%r): %r" % (e, dataString))
+                        self.log.warn(
+                            "Unicode decode error in readFromFile",
+                            "(%r): %r" % (e, dataString[max(0, e.start - 10) : e.end + 10]),
+                        )
                         numErrors += 1
                         if numErrors == 5:
                             self.log.warn("Max unicode decode errors reached, further errors will not be logged.")


### PR DESCRIPTION
Hi,

Here is the patch to limit the number of times the unicode error message will be printed for #5968.

Regards,
Simon

BEGINRELEASENOTES
*Core
FIX: Limit reoccurrences of subprocess unicode error
ENDRELEASENOTES
