### PR TITLE
[v7r3] fix: StalledJobAgent can force status from Submitting to Failed

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -570,7 +570,7 @@ class StalledJobAgent(AgentModule):
             return result
 
         for jobID in result["Value"]:
-            result = self._updateJobStatus(jobID, JobStatus.FAILED)
+            result = self._updateJobStatus(jobID, JobStatus.FAILED, force=True)
             if not result["OK"]:
                 self.log.error("Failed to update job status", result["Message"])
                 continue


### PR DESCRIPTION
BEGINRELEASENOTES

*WMS
FIX: StalledJobAgent can force status from Submitting to Failed
FIX: ElasticJobParametersDB: make sure the docID is less than 512 characters

ENDRELEASENOTES
