### PR TITLE
[v7r2] added op_type option in elasticsearch options

### DIFF
--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -391,7 +391,7 @@ class ElasticSearchDB(object):
             return S_ERROR("Missing index or body")
 
         try:
-            res = self.client.index(index=indexName, doc_type="_doc", body=body, id=docID, op_type=op_type)
+            res = self.client.index(index=indexName, doc_type="_doc", body=body, id=docID, params={'op_type':op_type})
         except (RequestError, TransportError) as e:
             sLog.exception()
             return S_ERROR(e)

--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -376,11 +376,12 @@ class ElasticSearchDB(object):
 
         return S_ERROR(retVal)
 
-    def index(self, indexName, body=None, docID=None):
+    def index(self, indexName, body=None, docID=None, op_type='index'):
         """
         :param str indexName: the name of the index to be used
         :param dict body: the data which will be indexed (basically the JSON)
         :param int id: optional document id
+        :parm str op_type: Explicit operation type. (options: 'index' (default) or 'create')
         :return: the index name in case of success.
         """
 
@@ -390,7 +391,7 @@ class ElasticSearchDB(object):
             return S_ERROR("Missing index or body")
 
         try:
-            res = self.client.index(index=indexName, doc_type="_doc", body=body, id=docID)
+            res = self.client.index(index=indexName, doc_type="_doc", body=body, id=docID, op_type=op_type)
         except (RequestError, TransportError) as e:
             sLog.exception()
             return S_ERROR(e)

--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -381,7 +381,7 @@ class ElasticSearchDB(object):
         :param str indexName: the name of the index to be used
         :param dict body: the data which will be indexed (basically the JSON)
         :param int id: optional document id
-        :parm str op_type: Explicit operation type. (options: 'index' (default) or 'create')
+        :param str op_type: Explicit operation type. (options: 'index' (default) or 'create')
         :return: the index name in case of success.
         """
 

--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -391,7 +391,7 @@ class ElasticSearchDB(object):
             return S_ERROR("Missing index or body")
 
         try:
-            res = self.client.index(index=indexName, doc_type="_doc", body=body, id=docID, params={'op_type':op_type})
+            res = self.client.index(index=indexName, doc_type="_doc", body=body, id=docID, params={"op_type": op_type})
         except (RequestError, TransportError) as e:
             sLog.exception()
             return S_ERROR(e)


### PR DESCRIPTION

Added option op_type in index API for Elasticsearch. This option can be used to make sure the document will created rather tahn updated resulting in unique document once created.

BEGINRELEASENOTES

*Elasticsearch
NEW: option op_type in index API for Elasticsearch

ENDRELEASENOTES

Closes #5920 