### PR TITLE
[v7r3] add CloudComputingElement

### DIFF
--- a/environment-py3.yml
+++ b/environment-py3.yml
@@ -32,6 +32,7 @@ dependencies:
   - pyasn1-modules
   - python-json-logger >=0.1.8
   - pytz >=2015.7
+  - pyyaml
   - recommonmark
   - requests >=2.9.1
   - six >=1.10

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - pyasn1-modules
   - python-json-logger >=0.1.8
   - pytz >=2015.7
+  - pyyaml
   - recommonmark
   - requests >=2.9.1
   - six >=1.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ server =
     numpy
     pillow
     python-json-logger
+    pyyaml
     stomp.py
     suds-jurko
     tornado ~=5.1.1

--- a/src/DIRAC/Resources/Computing/CloudComputingElement.py
+++ b/src/DIRAC/Resources/Computing/CloudComputingElement.py
@@ -1,0 +1,564 @@
+""" Cloud Computing Element
+
+This allows submission to cloud sites using libcloud (via the standard
+SiteDirector agent). The instances are contextualised using cloud-init.
+
+Running cloud VM instances containing pilots is very analogous to classic cloud
+jobs. There are however some things that work differently:
+
+- File I/O: A small amount of input may be transferred through the
+  instance metadata, but after that the VM is inaccessible.
+- Authentication: Most cloud endpoints use a password or API style credentials
+  rather than a grid style proxy based authentication. The pilot still requires
+  a suitable proxy, but this cannot be renewed via the cloud interface due to
+  the I/O limitations.
+- Pilot (VM) Tidy-up: Cloud providers will not remove stopped instances by
+  default.
+
+To avoid the proxy renewal limitations, an alternate pilot proxy is used within
+the instances. This can either be a longer version of the usual pilot proxy or
+a pilot proxy generated from another dedicated cert/user. The proxy contains
+the DIRAC group, but no VOMS (as this would likely expire too quickly).
+
+By default it is assumed that a generic CentOS7 base image is being used. This
+will be fully contextualised using cloud-init:
+
+- CVMFS & Singularity will be installed.
+- A dirac user will be created to run the jobs.
+- Pilot proxy and start-up scripts will be installed in /mnt.
+- The usual pilot script will be placed in the dirac home directory and
+  the start-up scripts are run (as the dirac user).
+- After the pilot terminates, the machine is stopped by calling halt.
+
+A partially or fully pre-configured image may be used instead and the
+cloud-init template can be customised as necessary for this or any use case.
+This is recommended on production systems to cut-down on the overhead when
+starting many new instances.
+
+The majority of cloud providers identify instances with some form of unique
+identifier (generally a UUID), this is used in the pilot references. Each
+instance can generally also have a "friendly name" associated with it, which
+may not be unique. We set the friendly name to match a string that can be
+pattern matched; this allows any stopped instances to be found & removed
+automatically without affecting other VMs potentially running as the same user.
+
+Instances that match the "friendly name" prefix and have been running above a
+maximum lifetime are assumed to be stuck or lost and will be removed. This is
+to ensure that instances don't reserve/consume resources indefinitely.
+
+Most cloud authentication systems require some form of static secret such as a
+password or token. To store these securely we load them from an ini format
+file, which should only be readable by the dirac service user on the host. The
+values can be stored in the DEFAULT section of the ini file, or a more specific
+section using the CE hostname can be used.
+
+The special value PROXY will cause the secret to be replaced with the path to
+the proxy that the site director would normally use to submit a job. This is
+typically used for FedCloud sites using the libcloud OpenStack VOMS auth
+plugin.
+::
+
+  [DEFAULT]
+  key = "myusername"
+  secret = "mypassword"
+
+  [cloudprov.mysite.example]
+  key = "cloudprovuser"
+  secret = "01234567"
+
+  [fedcloud.othersite.example]
+  key = "fedclouduser"
+  secret = "PROXY"
+
+Configuration
+-------------
+
+The configuration is made up of a number of categories: These options are
+loaded from the CE level, but can be overridden by the queue.
+
+CloudType:
+  (Required) This should match the libcloud driver name for the Cloud you're
+  trying to access. e.g. For OpenStack this should be "OPENSTACK".
+
+CloudAuth:
+  (Optional) This sets the path to the authentication ini file as described
+  above. Should be an absolute path but may use environment variables.
+  Defaults to (DIRAC.rootPath)/etc/cloud.auth.
+
+Driver\_\*:
+  (Required) All options starting with Driver\_ will have the prefix stripped
+  and be passed to the libcloud Driver object constructor. See the libcloud
+  manual/examples for the options required for any given driver.
+
+Instance_Image:
+  (Required) The raw ID of the image to use or the name of the image prefixed
+  by "name:".
+
+Instance_Flavor:
+  (Required) The raw ID of the flavor to use or the name of a flavor
+  prefixed by "name:".
+
+Instance_SSHKey:
+  (Optional) The ID of an SSH key (on OpenStack this is just a plain name).
+  If not specified the node will be booted without an extra key.
+
+Context_Template:
+  (Optional) The path to the cloudinit.template file to use for these
+  instances. If unset the default template file will be used.
+
+Context_ExtPackages:
+  (Optional) Comma separated list of extra packages to install on the VM.
+  Note: It is highly recommended to use SingularityCE with a container
+  image with the required packages instead.
+
+Context_ProxyLifetime:
+  (Optional) When submitting an instance, it will be provisioned with a new
+  proxy with the same properties as the one provided by the SiteDirector but
+  with an extended lifetime. This option sets the lifetime of the new proxy
+  in seconds: It must be greater than the maximum time jobs can run for in
+  the instance. Defaults to two weeks.
+
+Context_MaxLifetime:
+  (Optional) The maximum lifetime of an instance in seconds. Any instances
+  older than this will be removed regardless of state. Defaults to two weeks.
+
+Example
+-------
+
+The following is an example set of settings for an OpenStack based cloud::
+
+  CE = cloudprov.mysite.example
+  CEType = Cloud
+  CloudType = OPENSTACK
+  Driver_ex_force_auth_url = https://cloudprov.mysite.example:5000
+  Driver_ex_force_auth_version = 3.x_password
+  Driver_ex_tenant_name = clouduser
+  Instance_Image = name:CentOS-7-x86_64-GenericCloud-1905
+  Instance_Flavor = name:m1.medium
+  Instance_SSHKey = mysshkey
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import uuid
+import os
+import sys
+import yaml
+import configparser
+from datetime import datetime
+from libcloud.compute.types import Provider, NodeState
+from libcloud.compute.providers import get_driver
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+
+from DIRAC import S_OK, S_ERROR, gConfig, rootPath
+from DIRAC.Resources.Computing.ComputingElement import ComputingElement
+from DIRAC.Core.Security.ProxyInfo import getProxyInfo
+from DIRAC.Core.Utilities.Time import dateTime, second, dt
+from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC.FrameworkSystem.Client.ProxyManagerClient import ProxyManagerClient
+from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
+
+# Standard CE name
+CE_NAME = "CloudCE"
+# The string prefix used to construct & find instance friendly names
+# A random 8-character hexadecimal string will be appended to this to
+# construct the full name.
+VM_NAME_PREFIX = "VMDIRAC3_"
+VM_ID_PREFIX = "cloud://"
+OPT_PROVIDER = "CloudType"
+OPT_AUTHFILE = "CloudAuth"
+DEF_AUTHFILE = os.path.join(rootPath, "etc/cloud.auth")
+# default proxy lifetime (2 weeks)
+DEF_PROXYLIFETIME = 1209600
+DEF_PROXYGRACE = 86400
+# default max instance lifetime in seconds
+# all instances older than this will be removed
+DEF_MAXLIFETIME = 1209600
+
+
+class CloudComputingElement(ComputingElement):
+    """Cloud computing element class
+    Submits pilot jobs as VMs with libcloud.
+    """
+
+    def _getDriverOptions(self):
+        """Extracts driver options from CE parameters.
+
+        :return: dictionary of driver constructor parameters
+        """
+        # Slice Driver_ off start of names
+        return {k[7:]: v for k, v in self.ceParameters.items() if k.startswith("Driver_")}
+
+    def _getDriverAuth(self):
+        """Gets driver authentication parameters
+        from auth config file.
+
+        :return: tuple containing key and secret strings
+        """
+        config = configparser.ConfigParser()
+        configFile = self.ceParameters.get(OPT_AUTHFILE, DEF_AUTHFILE)
+        if not os.path.exists(configFile):
+            raise RuntimeError("cloud auth config file not found: %s" % configFile)
+        config.read(configFile)
+        sectionName = self.ceName
+        if sectionName not in config:
+            sectionName = "DEFAULT"
+        try:
+            key = config[sectionName]["key"]
+            secret = config[sectionName]["secret"]
+        except KeyError:
+            raise RuntimeError("Invalid auth config for host %s" % self.ceName)
+        # If the secret is set to the magic string "PROXY"
+        # we instead return a path to a grid proxy file
+        if secret == "PROXY":
+            if self._origProxy:
+                secret = self._origProxy
+            else:
+                self.log.warn("Proxy for %s not set!" % self.ceName)
+                secret = ""
+        return (key, secret)
+
+    def _getDriver(self, refresh=False):
+        """Return an instance of libcloud Driver for this CE.
+
+        :param: refresh If set to true, force the driver instance
+                        to be recreated.
+
+        :return: libcloud Driver instance.
+        """
+        if self._cloudDriver and not refresh:
+            return self._cloudDriver
+
+        provName = self.ceParameters.get(OPT_PROVIDER).upper()
+        # check if provider (type of cloud) exists
+        if not hasattr(Provider, provName):
+            self.log.error("Provider %s not found in libcloud." % provName)
+            raise RuntimeError("Provider %s not found in libcloud." % provName)
+        provIntName = getattr(Provider, provName)
+        provCls = get_driver(provIntName)
+        driverOpts = self._getDriverOptions()
+        driverKey, driverOpts["secret"] = self._getDriverAuth()
+        self._cloudDriver = provCls(driverKey, **driverOpts)
+        return self._cloudDriver
+
+    def _getImage(self):
+        """Extracts image id from configuration system.
+
+        :return: image object
+        """
+        rawID = self.ceParameters.get("Instance_Image", None)
+        if not rawID:
+            raise KeyError("Image not set in Configuration")
+        imageName = None
+        if rawID.startswith("name:"):
+            imageName = rawID[5:]
+        drv = self._getDriver()
+        for image in drv.list_images():
+            if not imageName and image.id == rawID:
+                return image
+            elif imageName and image.name == imageName:
+                return image
+        raise KeyError("No matching image found for %s" % rawID)
+
+    def _getFlavor(self):
+        """Extracts flavor from configuration system.
+
+        :return: flavor object
+        """
+        rawID = self.ceParameters.get("Instance_Flavor", None)
+        if not rawID:
+            raise KeyError("Flavor not set in Configuration")
+        flavorName = None
+        if rawID.startswith("name:"):
+            flavorName = rawID[5:]
+        drv = self._getDriver()
+        for flavor in drv.list_sizes():
+            if not flavorName and flavor.id == rawID:
+                return flavor
+            elif flavorName and flavor.name == flavorName:
+                return flavor
+        raise KeyError("No matching flavor found for %s" % rawID)
+
+    def _getSSHKeyID(self):
+        """Extract ssh key id from configuration system.
+
+        :return: ssh id string or None if not set
+        """
+        return self.ceParameters.get("Instance_SSHKey", None)
+
+    def _getMetadata(self, executableFile):
+        """Builds metadata from configuration system, cloudinit template
+         and dirac pilot job wrapper
+
+        :param str executableFile: path to pilot wrapper script to include in metadata.
+
+        :return: instance specific metadata in mime string format
+        """
+
+        default_template = os.path.join(os.path.dirname(__file__), "cloudinit.template")
+        template_file = self.ceParameters.get("Context_Template", default_template)
+
+        exe_str = ""
+        with open(executableFile) as efile:
+            exe_str = efile.read().strip()
+        template = ""
+        with open(template_file) as template_fd:
+            template = yaml.safe_load(template_fd)
+        for filedef in template["write_files"]:
+            if filedef["content"] == "PROXY_STR":
+                filedef["content"] = self.proxy.decode()
+            elif filedef["content"] == "EXECUTABLE_STR":
+                filedef["content"] = exe_str
+        ext_packages = self.ceParameters.get("Context_ExtPackages", None)
+        if ext_packages:
+            packages = [x.strip() for x in ext_packages.split(",")]
+            if "packages" in template:
+                template["packages"].extend(packages)
+            else:
+                template["packages"] = packages
+
+        template_str = yaml.dump(template)
+        userData = MIMEMultipart()
+        mimeText = MIMEText(template_str, "cloud-config", sys.getdefaultencoding())
+        mimeText.add_header("Content-Disposition", 'attachment; filename="pilotconfig"')
+        userData.attach(mimeText)
+        return str(userData)
+
+    def _renewCloudProxy(self):
+        """Takes short lived proxy from the site director and
+        promotes it to a long lived proxy keeping the DIRAC group.
+
+        :returns: True on success, false otherwise.
+        :rtype: bool
+        """
+        if not self._cloudDN or not self._cloudGroup:
+            self.log.error("Could not renew cloud proxy, DN and/or Group not set.")
+            return False
+
+        proxyLifetime = int(self.ceParameters.get("Context_ProxyLifetime", DEF_PROXYLIFETIME))
+        # only renew proxy if lifetime is less than configured lifetime
+        # self.valid is a datetime
+        if self.valid - dateTime() > proxyLifetime * second:
+            return True
+        proxyLifetime += DEF_PROXYGRACE
+        proxyManager = ProxyManagerClient()
+        self.log.info("Downloading proxy with cloudDN and cloudGroup: %s, %s" % (self._cloudDN, self._cloudGroup))
+        res = proxyManager.downloadProxy(self._cloudDN, self._cloudGroup, limited=True, requiredTimeLeft=proxyLifetime)
+        if not res["OK"]:
+            self.log.error("Could not download proxy", res["Message"])
+            return False
+        resdump = res["Value"].dumpAllToString()
+        if not resdump["OK"]:
+            self.log.error("Failed to dump proxy to string", resdump["Message"])
+            return False
+        self.proxy = resdump["Value"]
+        self.valid = dateTime() + proxyLifetime * second
+        return True
+
+    def __init__(self, *args, **kwargs):
+        """Constructor
+        Takes the standard CE parameters.
+        See ComputeElement base class for details.
+        """
+        super(CloudComputingElement, self).__init__(*args, **kwargs)
+        self.ceType = CE_NAME
+        self.proxy = ""
+        # proxy expiry time (in date time)
+        self.valid = dt
+        self._cloudDriver = None
+        self._cloudDN = None
+        self._cloudGroup = None
+        self._origProxy = None
+
+    def setProxy(self, proxy, valid=0):
+        """Take existing proxy, and extract group name.
+        Then create new proxy for the cloud pilot user
+        bound to the same group with the lifetime set to
+        the value specified in the CE config.
+
+        :return: S_OK() or S_ERROR(error string)
+        """
+        # Store original proxy for FedCloud submission/auth
+        # We write this to a file as that's the format we need
+        ret = gProxyManager.dumpProxyToFile(proxy)
+        if not ret["OK"]:
+            self.log.error("Failed to write proxy file", "for %s: %s" % (self.ceName, ret["Message"]))
+        self._origProxy = ret["Value"]
+        # For a driver refresh to reload the proxy
+        self._getDriver(refresh=True)
+        # we deliberately log extra errors here,
+        # as the return value is not always checked
+        res = getProxyInfo(proxy, disableVOMS=True)
+        if not res["OK"]:
+            self.log.error("getProxyInfo failed", res["Message"])
+            return S_ERROR("getProxyInfo did not return OK: %s" % str(res))
+        info = res["Value"]
+        if not "group" in info:
+            self.log.error("No group found in proxy")
+            return S_ERROR("No group found in proxy")
+        if not "subject" in info:
+            self.log.error("No user DN (subject) found in proxy")
+            return S_ERROR("No user DN (subject) found in proxy")
+        pilotGroup = info["group"]
+        pilotDN = info["subject"]
+        opsHelper = Operations(group=pilotGroup)
+        self._cloudDN = opsHelper.getValue("Pilot/GenericCloudDN", pilotDN)
+        self._cloudGroup = pilotGroup
+        if not self._renewCloudProxy():
+            self.log.error("Failed to renew proxy.")
+            return S_ERROR("Failed to renew proxy.")
+        return S_OK()
+
+    def submitJob(self, executableFile, proxy, numberOfJobs=1):
+        """Creates VM instances
+
+        :param str executableFile: Path to pilot job wrapper file to use
+        :param str proxy: Unused, see setProxy()
+        :param int numberOfJobs: Number of instances to start
+        :return: S_OK/S_ERROR
+        """
+        if not self._renewCloudProxy():
+            return S_ERROR("Failed to renew proxy during job submission.")
+
+        instIDs = []
+
+        # these parameters are identical for each job
+        instParams = {}
+        instParams["image"] = self._getImage()
+        instParams["size"] = self._getFlavor()
+        instParams["ex_keyname"] = self._getSSHKeyID()
+        instParams["ex_userdata"] = self._getMetadata(executableFile)
+        instParams["ex_config_drive"] = True
+
+        driver = self._getDriver()
+
+        for _ in range(numberOfJobs):
+            # generates an 8 character hex string
+            instRandom = str(uuid.uuid4()).upper()[:8]
+            instName = VM_NAME_PREFIX + instRandom
+            instParams["name"] = instName
+            try:
+                node = driver.create_node(**instParams)
+            except Exception as err:
+                self.log.error("Failed to create_node", str(err))
+                continue
+            instIDs.append(VM_ID_PREFIX + node.id)
+        if not instIDs:
+            return S_ERROR("Failed to submit any instances.")
+        return S_OK(instIDs)
+
+    def killJob(self, jobIDList):
+        """Stops VM instances
+
+        :param list jobIDList: Instance IDs to delete.
+        :return: S_OK
+        """
+        driver = self._getDriver()
+        for job in jobIDList:
+            job = job.replace(VM_ID_PREFIX, "", 1)
+            try:
+                node = driver.ex_get_node_details(job)
+                driver.destroy_node(node)
+            except Exception as err:
+                self.log.error("Failed to destroy_node", str(err))
+                continue
+        return S_OK()
+
+    def getCEStatus(self):
+        """Counts number of running jobs
+
+        :return: S_OK
+        :rtype: dict
+        """
+        driver = self._getDriver()
+        count = 0
+        for node in driver.list_nodes():
+            if node.name.startswith(VM_NAME_PREFIX):
+                count += 1
+        result = S_OK()
+        result["SubmittedJobs"] = 0
+        result["RunningJobs"] = count
+        result["WaitingJobs"] = 0
+        return result
+
+    def getJobStatus(self, jobIDList):
+        """Lookup the status of the given pilot job IDs
+
+        :return: S_OK(dict(jobID -> str(state))
+        :rtype: dict
+        """
+        driver = self._getDriver()
+        result = {}
+        for jobRef in jobIDList:
+            pilotUUID = jobRef.replace(VM_ID_PREFIX, "", 1)
+            try:
+                node = driver.ex_get_node_details(pilotUUID)
+                if not node:
+                    # instance cannot be found on the cloud
+                    result[jobRef] = "Deleted"
+                    continue
+                if node.state == NodeState.STOPPED:
+                    result[jobRef] = "Done"
+                    continue
+                else:
+                    result[jobRef] = "Running"
+                    continue
+            except Exception as err:
+                # general libcloud error, cloud probably inaccessible
+                self.log.warn("Failed to get instance", "%s state: %s" % (pilotUUID, repr(err)))
+                result[jobRef] = "Unknown"
+                continue
+        return S_OK(result)
+
+    def getJobOutput(self, *args, **kwargs):
+        """Not implemented:
+        There is no standard way of getting files back from an instance.
+        We rely on remote pilot logging to collect logs for debugging (or
+        an admin logging on to an instance manually).
+
+        :return: S_ERROR, not implemented.
+        """
+        return S_ERROR("Not Implemented for CloudCE")
+
+    def cleanupPilots(self):
+        """Removes all stopped instances and
+         removes all instances with a lifetime above threshold from config
+         as a fallback to remove instances that have been lost.
+
+        :return: S_OK
+        """
+        self.log.info("Starting cleanup for %s" % self.ceName)
+        try:
+            maxLifetime = int(self.ceParameters.get("Context_MaxLifetime", DEF_MAXLIFETIME))
+            now = datetime.utcnow()
+            driver = self._getDriver()
+            for node in driver.list_nodes():
+                if not node.name.startswith(VM_NAME_PREFIX):
+                    continue
+                # remove shutoff nodes
+                if node.state == NodeState.STOPPED:
+                    self.log.info("Deleting shutoff node: %s (%s)" % (node.name, node.id))
+                    driver.destroy_node(node)
+                    continue
+                # log error'd node seperately
+                if node.state == NodeState.ERROR:
+                    self.log.info("Deleting node in ERROR state: %s (%s)" % (node.name, node.id))
+                    driver.destroy_node(node)
+                    continue
+
+                # calculate lifetime (instance age in seconds) in a timezone agnostic way
+                datetmp = node.created_at.utctimetuple()[0:6]
+                created_at = datetime(*datetmp)
+                lifetime = (now - created_at).total_seconds()
+                # remove all nodes older than maxLifetime, independent of their state
+                if lifetime > maxLifetime:
+                    self.log.info("Deleting old node: %s (%s) with lifetime %s" % (node.name, node.id, int(lifetime)))
+                    driver.destroy_node(node)
+        except Exception as err:
+            self.log.error("Failed to clean up instances (%s): %s" % (self.ceName, err))
+            return S_ERROR("Failed to clean up instances (%s): %s" % (self.ceName, err))
+        return S_OK()

--- a/src/DIRAC/Resources/Computing/cloudinit.template
+++ b/src/DIRAC/Resources/Computing/cloudinit.template
@@ -1,0 +1,123 @@
+#cloud-config
+
+disable_ec2_metadata: true
+timezone: UTC
+
+fs_setup:
+ - filesystem: ext4
+   device: ephemeral0
+   partition: none
+   overwrite: true
+
+write_files:
+ - encoding: gz+b64
+   path: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+   content: |
+      H4sIABpPZl0CA32Vya6z1haE5zzFGd4r9Idm00bKgN4bMH0/A4xpDAYb0z59zkmi3NldUk2qarSk
+      T/Xr1/eJigatL0dzvpxQNKH0ZSjpl2jakvGT/kKi6j234/P3L+25ONrXSv6G/0aSX//RrBAz2+ey
+      /xdBBldrRWXRHCb1REGOOL4sVGoZlYTjXW7Z7UcP5UhvbF1QjQwA07+dlxW0dvHsRnqjkK0oOLX1
+      2zc1xnX+FsqRWvCHRxxGd9EBGCOR3AfHPmNgxeMFsrmjsh+pHlk15RtrlBDKUh7WUa7F3R8lv5xX
+      8kjp10m+yDklzFjLtCJMOnE1ikHwK37WVUOPWGseNqlmmRhD8mt+9tXlkD/jKHOfB8jidTJKGfNq
+      mrDzG5qZJdtQ9CZfL1Mur7ZYaeMxoQ9Wr90bxyKXe9LqnxpzmfMItncEVsldr9MGNK/zHplYOrUX
+      F8w7fDDczeTuOVkGewP9hMZk6J4lMgyLnONKLWmaYIQZVVxeebWr6nPCRDQyRGfVl93M8VKUb0xV
+      bbu1fS46jyv5tRJP7YYwZ0h+f9/m0yJplevLe9wj87msMq0BAov1bL3fE2mfp6d/r3kSyAU045xa
+      rZi/mtfZQGB0WY/ojQ+Zyu23w7UiJ0wARi15Y1ypZlvU1604usXUFKiCkAU51HE0lasJQyFzhIiu
+      XZ77wSk7mhMJbHSi8SGLjnnv3z7ohk0KQMmre4R3X3b8JBKA6aIuGR1Fn1lQUR9IEfdLnlh4Oah4
+      AWBtaBZZxOrjxzd8gUt/ys/sYw5/e//r6sJPhhQt3eUyA5PaDRQXCpcaFsKWmpJbX4QNyqoLZWFP
+      JcGF1beSWgilaLPTRy0Ykid0iBy0t3bxShpXCEHnhXS9YOVxk1mc5LtdK2fO4Nh+BJ0g3ZSmkDpQ
+      ds48kSEW36faIBDRta/tVtFCjSs+lWIvUYCCCebYSFxjKqA9bQk6WAkJIzLZLfEKjLRLbaVtGabl
+      8wlxRiAKgM/5eODXhnik8BI8Gt59FdxGg6akBOsRBWiZnntyfBpN7OLR/GzSaUjOGxYs4rm6V/I0
+      Y3/wF/Ua+jJUtJY+q7sPRz3z6O7w2Hfmo4Rj6SnE6T0lUSVviIUP93d/isiFlqV5DV+BZRBk/HZg
+      WwzmyC3oAWW92+qGt+kUBhJafbCaYi3znt1aQXNMpVt11WsRVl9Q7thsQN78SHR0V3583rQo8TQu
+      G9lF4J/orDOgVUHvYLkUKNK07+EriaJXO47FhtT08ekZvNl4yM/3TXSYk3c8HvfKIyB6qm5b8eTN
+      CDWmUhC2EApGJezCW8v1/YzP1kBmVuaCYFFo3NpQH3haE52bbxwswYGMIFr7m49iILFzmxh6Ux/P
+      j2QMpiE/tTmoVWtC5g881E0fOkAJ+8RawNBeyTOAqA/dGxMNp0tMzX6X7I2D2lLZHpNC1ie0NP6w
+      8jhXSGaclBLf1kSyH67QFPsLuwRkCdpmn5f9rbz3k3U/Vp7aatIuZgeG9MIn3ywrFec8ehQ5Di9Y
+      j9Dqr3DBWpZ/3VE37OeWwJ9SOHBc6Sdua8S2TmltOAZoJ7OTRY3NTTC9qMc/SI8phxNsaD5roHcb
+      J0PnsV/1ZEJb1lDZ5/Y8EllkQGxdCNonJte8Pl/SoknqUdV3pkOeth7iwgv6rpv+wCS5sJD/Aabe
+      /gbmX14A1QmGvGC8mIXg3b6V6xuRF60YLLD04RUNa+lesX1Nv95aEp5Zr6vBM8iD2gcZ7tV/IH/c
+      52lA/hodxZL/zyL9CUAskc+3BgAA
+ - encoding: gz+b64
+   path: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+   content: |
+      H4sIAEFTZl0CA31VR67z6AHb6xRvmcCYsaxqBfgXn3rvfaduVau3089LDhACXJHghgT411+/oDlB
+      0n9MwfwxPVqVmB+Fi35o1WCU/6p/QX4xL/V3+M+PMGym8LO//sb+fr1+/iXo3lOth+38NwT1lqTT
+      vLIlkkVzgHl54yc8tIkByWx64jNeDH7pkrRwfQMZ2RaPBoMiysdcxTR5gpmGDKewWpKm4Hpy5Df+
+      zEjEAANmhNHuEmhVMkU4yguukUUftuaiW0HgNBtFdcEDTI7eQ00UfHq7U22hgw2DrKSjIUkil8I9
+      03S+ux2zgWEdOcHUaGnTDT4yIEkKOLyaCH+cTGjnQ/8qZz95bkn3rVi/L4kPsmJ2Ptbl9J5ccRF5
+      Dz1H5n64xDMXAkWwMCS2SjdRB1aDGvcLlj6CwVXsrZSGRB376y3syRCNZhYEWAjbrJmNU8nrcUtg
+      6Clh3RI/IoSbqWjDIef5PuHueqx9L33bhIOPI829jcTgyI0bpljmbxTUdoXfm4WcpXLKXx/nHtzn
+      sUaHwMrQQIhl8LGrYctt+9g3GcPvNfJXZeuU421ZY444bjBnlsXKiR30g/b9hk8TuG7D0NxJQ1Te
+      3uibnbe9JaVW1NZFmroWGJaWL+ErR93vTtAcErKNJMA3f6r5Jgupf2RPYpYyCodcGMcblOBuWJyb
+      Mx9dwTDE0540Be+psuPT5DxXdnDIgySD6Q5IseFnFvYL90T2oWkgYco+ImeNJTvyxp2+VZf/VFGd
+      X7bulZ0VoXigGreq+4/RRwsLlavXy+OPonN0dSqtEtp4W8ged3a0eiN+8Mvce+qb2y9aKieZWBTB
+      FNLV1MMvydmafY3BZd/wXcPrAWxgARpamY8QB/ae9Vxl+zTvMuCrX21lCv4RByeIe79NUfmTifKe
+      9H6TM/ivN3vUloTRtEZDoAI1bcnO3Ncc+CwmXS0yAzIWVJHPAElmqoXjK4kFllT8MqwAUBibnlSC
+      qHXnbCE8KwX2iS3jNC5us7IaOY3XqqiiMm/xum9BPa24Xe4udRyU4Hm8FmNxLITY4IUVRk1QfbJq
+      cgX2O8+F54K3l1GjDLyFT6Ie7iS67OpBf0g4nSfFU14Y/6Ln2awRqkiUUngIG6Txa5jTApKQxmr2
+      B3ptSj9R3PjbPtybBIcrTr47tjPJwSpkgDhs53mwdyhzujjicwFR0tKjTHTl4wULqg3w44uVJo1v
+      au59VM5j9w+iKM9nqTVNgn5h9eHo91uHEza+BhycEONRNo1yYuYWGV99L3zr7Yai6HguUvulGw+s
+      oud6l8p8Z7FS1kudFsPj44gUYARG3yFxCP1GtHiqFgMwKq0tFZ83PyMDnq+lzPGkw4VvIQ1JPl2C
+      L0K1oTb7lT6J+sUO5e8O/K+5pZWVr3Ist34M2kScte0NrvVwCcTCCn3qZemVBGls6RLeBNGUEbay
+      MQrx5KnfFtYP71KVbLzIx2VvKuHtyHOvbt9+2UJ++KpydF4jmKCJym5krCPQAHDOeqc284pMMYO4
+      2ZlTW4CPRiqBje7b8jIc40TPWIzHkC97y11Yk/xNNNTbp942Kh88OGXseU6FoWPQzpi8RxiLi3aB
+      9T7IusO/n4jCj35rypno2jfVcrecG+6dDSRLp968oShjaYISo9y+QnazMCTPpir8IqfTecQ+eIpC
+      e5X1hmVj5b99b0inDi9A/HipHcEef/5Afz65mUD/+w5OZ//PsfwDIDTlCX4GAAA=
+ - path: /etc/cvmfs/default.local
+   content: |
+     CVMFS_CACHE_BASE=/mnt/cvmfs
+     CVMFS_HTTP_PROXY="DIRECT"
+ - path: /root/proxy.pem
+   permissions: '0600'
+   content: PROXY_STR
+ - path: /root/run_pilot.sh
+   permissions: '0755'
+   content: EXECUTABLE_STR
+ - path: /root/startup.sh
+   permissions: '0755'
+   content: |
+     #!/bin/bash
+     cd /mnt/dirac
+     export X509_USER_PROXY=/mnt/proxy.pem
+     export PILOT_UUID="cloud://$(cat /var/lib/cloud/data/instance-id)"
+     bash /mnt/run_pilot.sh &> /mnt/dirac/startup.log
+
+yum_repos:
+  cernvm:
+    name: CernVM packages
+    baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
+    enabled: true
+    gpgcheck: true
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+  epel:
+    name: Extra Packages for Enterprise Linux 7 - $basearch
+    baseurl: http://download.fedoraproject.org/pub/epel/7/$basearch
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+    failovermethod: priority
+    enabled: true
+    gpgcheck: true
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+
+packages:
+ - cvmfs
+
+runcmd:
+ # Allow nested singularity
+ - [ sysctl, user.max_user_namespaces=150000 ]
+ - [ sysctl, user.max_net_namespaces=0 ]
+ # Enable CVMFS
+ - [ mkdir, -p, /mnt/cvmfs ]
+ - [ cvmfs_config, setup ]
+ # Create DIRAC user
+ - [ useradd, -m, -d, /mnt/dirac, dirac ]
+ - [ passwd, -l, dirac ]
+ - [ mkdir, -p, /mnt/dirac/etc/grid-security ]
+ - [ cp, /root/proxy.pem, /mnt/proxy.pem ]
+ - [ chmod, 600, /mnt/proxy.pem ]
+ - [ chown, "dirac:dirac", /mnt/proxy.pem ]
+ - [ chown, -R, "dirac:dirac", /mnt/dirac/etc ]
+ - [ ln, -s, /cvmfs/grid.cern.ch/etc/grid-security/certificates, /mnt/dirac/etc/grid-security/certificates ]
+ - [ cp, /root/run_pilot.sh, /mnt/run_pilot.sh ]
+ - [ cp, /root/startup.sh, /mnt/startup.sh ]
+ - [ sudo, -u, dirac, /mnt/startup.sh ]
+ - [ poweroff ]

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1080,6 +1080,9 @@ class SiteDirector(AgentModule):
                 proxy = result["Value"]
                 ce.setProxy(proxy, 940)
 
+            if callable(getattr(ce, "cleanupPilots", None)):
+                ce.cleanupPilots()
+
             ceName = self.queueDict[queue]["CEName"]
             queueName = self.queueDict[queue]["QueueName"]
             ceType = self.queueDict[queue]["CEType"]


### PR DESCRIPTION
This code will enable DIRAC to (eventually) get rid of the CloudDirector. 
The goal is to use the same mechanisms for cloud as for grid resources and to deprecate the VMDIRAC components.
- relies on libcloud to minimize back ends
- uses the pilot job references to track the instance 
- uses the standard pilot wrapper
- needs a hook in SiteDirector to be able to clean up the pilots without having to have a separate agent
- See issue #5282

We'd be happy to discuss this at the next BiLD meeting.

BEGINRELEASENOTES
*Resources
NEW:  add CloudComputingElement
*WorkloadManagementSystem
CHANGE:  add hook for pilot cleanup
ENDRELEASENOTES
