### PR TITLE
[v7r3] fix (CI): fix click version for black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,4 @@ repos:
     rev: 21.9b0
     hooks:
       - id: black
-        additional_dependencies: [".[python2]"]
+        additional_dependencies: [".[python2]", "click==8.0.4"]


### PR DESCRIPTION
Due to https://github.com/psf/black/issues/2964

We still want an old version of black for python2 compatibility, so freeze click in the pre-commit hook

Do NOT propagate to integration, I will make another one for that