### PR TITLE
[8.0] fix (CI): upgrade black for pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         exclude: |
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: black
         name: black for files with Python 2.7 compatibility
-        additional_dependencies: [".[python2]"]
+        additional_dependencies: [".[python2]", "click==8.0.4"]
         args: ["--target-version=py27"]
         files: |
           (?x)^(


### PR DESCRIPTION
Upgrade black version for python3, and fix click version for python2 compatible files