### PR TITLE
[integration] Reorganizing monitoring flags

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -854,8 +854,10 @@ Operations
   # Any value here can be overwriten in the setup specific section
   Defaults
   {
-    # This will globally enable ES based monitoring for Service and AgentModule.
-    EnableActivityMonitoring = no
+    # This flag will globally enable Accounting and ES based monitoring of all types in DIRAC.
+    # `Accounting` is the default value, and `Monitoring` should be added if you wish to have both.
+    # For more info https://dirac.readthedocs.io/en/integration/AdministratorGuide/Systems/MonitoringSystem/index.html
+    MonitoringBackends = Accounting # Accounitng, Monitoring for both
     # Flag for globally disabling the use of the SecurityLogging service
     EnableSecurityLogging = False
     DataManagement

--- a/dirac.cfg
+++ b/dirac.cfg
@@ -857,7 +857,7 @@ Operations
     # This flag will globally enable Accounting and ES based monitoring of all types in DIRAC.
     # `Accounting` is the default value, and `Monitoring` should be added if you wish to have both.
     # For more info https://dirac.readthedocs.io/en/integration/AdministratorGuide/Systems/MonitoringSystem/index.html
-    MonitoringBackends = Accounting # Accounitng, Monitoring for both
+    MonitoringBackends = Accounting # Use "Accounitng, Monitoring" for both
     # Flag for globally disabling the use of the SecurityLogging service
     EnableSecurityLogging = False
     DataManagement

--- a/dirac.cfg
+++ b/dirac.cfg
@@ -850,14 +850,25 @@ Resources
 }
 Operations
 {
+
+  MonitoringBackends
+  {
+    # This flag will globally enable Accounting and ES based monitoring of all types in DIRAC.
+    # `Accounting` is the default value, and `Monitoring` should be added if you wish to have both.
+    # If you want to override it and have a specific backend for a monitoring type, you should add a flag for it.
+    # For more info https://dirac.readthedocs.io/en/integration/AdministratorGuide/Systems/MonitoringSystem/index.html
+    Default = Accounting
+    # WMSHistory = Monitoring
+    # PilotSubmission = Accounting
+    # DataOperation = Accounting, Monitoring
+    # Agent = ...
+    # Service = ...
+    # RMS = ...
+  }
   # This is the default section of operations.
   # Any value here can be overwriten in the setup specific section
   Defaults
   {
-    # This flag will globally enable Accounting and ES based monitoring of all types in DIRAC.
-    # `Accounting` is the default value, and `Monitoring` should be added if you wish to have both.
-    # For more info https://dirac.readthedocs.io/en/integration/AdministratorGuide/Systems/MonitoringSystem/index.html
-    MonitoringBackends = Accounting # Use "Accounitng, Monitoring" for both
     # Flag for globally disabling the use of the SecurityLogging service
     EnableSecurityLogging = False
     DataManagement

--- a/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
+++ b/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
@@ -12,13 +12,13 @@ Overview
 
 The Monitoring system is used to monitor various components of DIRAC. Currently, we have several monitoring types:
 
-  - WMSHistory: for monitoring the DIRAC WMS
-  - PilotsHistory: for monitoring of DIRAC pilots
-  - Agent Monitoring: for monitoring DIRAC agents
-  - Service Monitoring: for monitoring DIRAC services
+  - WMSHistory: for monitoring the DIRAC WorkloadManagementSystem.
+  - PilotsHistory: for monitoring of DIRAC pilots.
+  - Agent Monitoring: for monitoring the activity of DIRAC agents.
+  - Service Monitoring: for monitoring the activity of DIRAC services.
   - RMS Monitoring: for monitoring the DIRAC RequestManagement System (mostly the Request Executing Agent).
-  - PilotSubmission Monitoring: for monitoring the DIRAC pilot submission statistics from SiteDirector agents
-  - DataOperation Monitoring: for monitoring the DIRAC data operation statistics
+  - PilotSubmission Monitoring: for monitoring the DIRAC pilot submission statistics from SiteDirector agents.
+  - DataOperation Monitoring: for monitoring the DIRAC data operation statistics.
 
 It is based on Elasticsearch distributed search and analytics NoSQL database.
 If you want to use it, you have to install the Monitoring service, and of course connect to a ElasticSearch instance.
@@ -40,7 +40,7 @@ You can run your Elastic cluster even without authentication, or using User name
   - Port
 
 The *User* name and *Password* must be added to the local cfg file while the other can be added to the CS using the Configuration web application.
-You have to handle the ES secret information in a similar way to what is done for the other supported SQL databases, e.g. MySQL
+You have to handle the ES secret information in a similar way to what is done for the other supported SQL databases, e.g. MySQL.
 
 
 For example::
@@ -65,11 +65,6 @@ can be defined with::
 
    MonitoringTypes
    {
-     ComponentMonitoring
-     {
-       # Indexing strategy. Possible values: day, week, month, year, null
-       Period = month
-     }
      RMSMonitoring
      {
        # Indexing strategy. Possible values: day, week, month, year, null
@@ -84,13 +79,28 @@ can be defined with::
 
 The given periods above are also the default periods in the code.
 
-
-Enable WMSHistory monitoring
+Enable the Monitoring System
 ============================
 
-You have to add ``Monitoring`` to the ``Backends`` option of WorkloadManagement/StatesAccountingAgent.
-If you do so, this agent will collect information using the JobDB and send it to the Elasticsearch database.
-This same agent can also report to the MySQL backend of the Accounting system (which is in fact the default).
+In order to enable the monitoring of all the following types with an ElasticSearch-based backend, you should add the value `Monitoring` to the flag
+`MonitoringBackends` in Operations/Default where the default values is `Accounting`.
+
+This can be done either via the CS or directly in the web app in the Configuration Manager as following::
+
+   Operations
+   {
+     Defaults
+     {
+       MonitoringBackends = Accounting, Monitoring
+     }
+   }
+
+
+WMSHistory & PilotsHistory Monitoring
+=====================================
+
+When enabled, the WorkloadManagement/StatesAccountingAgent will collect information using the JobDB and the PilotAgentsDB and send it to the Elasticsearch database.
+This same agent can also report the WMSHistory to the MySQL backend of the Accounting system (which is in fact the default).
 
 Optionally, you can use an MQ system (like RabbitMQ) for failover, even though the agent already has a simple failover mechanism.
 You can configure the MQ in the local dirac.cfg file where the agent is running::
@@ -124,56 +134,32 @@ You can configure the MQ in the local dirac.cfg file where the agent is running:
   Note: the JSON file already contains the index patterns needed for the visualizations. You may need to adapt the index patterns to your existing ones.
 
 
-Enable PilotsHistory monitoring
-===============================
-In order to enable PilotsHistory monitoring you need to set the flag ``monitoringEnabled = True`` in Operations/Defaults.
+Monitoring of DIRAC Agents and Services
+=======================================
+
+When enabled, this will report the activity of agents and services of DIRAC by sending information about various parameters such as CPU and Memory usage, but also cycle duration of
+agents, or response time, queries and threads of the services.
 
 
-Enable Monitoring of DIRAC Agents and Services
-==============================================
+RMS Monitoring
+==============
 
-You have to set ``EnableActivityMonitoring=True`` in the CS.
-It can be done globally, the ``Operations`` section, or per single component.
+This type is used to monitor behaviour pattern of requests executed by RequestManagementSystem inside DataManagementSystem/Agent/RequestOperations.
 
+PilotSubmission Monitoring
+==========================
 
-Enable RMS Monitoring
-=====================
+This monitoring type reports statistics of the pilot submissions done by the SiteDirector, including parameters such as the total number of submissions and the succeded ones.
 
-In order to enable RMSMonitoring we need to set value of ``EnableRMSMonitoring`` flag to yes/true in the CS::
+Data Operation Monitoring
+=========================
 
-
-   Systems
-   {
-     RequestManagement
-     {
-       <instance>
-       {
-         Agents
-         {
-           RequestExecutingAgent
-           {
-             ...
-             EnableRMSMonitoring = True
-           }
-         }
-       }
-     }
-   }
-
-Enable Pilot Submission Monitoring
-==================================
-
-In order to enable the monitoring of the pilot submission so that they will be sent to ES backend (by default they are sent to Accounting), you need to set
-``sendPilotSubmissionMonitoring = True`` for this option in WorkloadManagement/SiteDirector.
-
-Enable Data Operation Monitoring
-==================================
-
-To enable the monitoring of data operation to have it sent to ES backend, you need to add ``Monitoring`` to the ``MonitoringBackends`` option in Operations/DataManagement.
-
+This monitoring enables the reporting of information about the data operation such as the cumulative transfer size or the number of succeded and failed transfers.
 
 
 Accessing the Monitoring information
 =====================================
 
-After you installed and configured the Monitoring system, you can use the Monitoring web application.
+After you installed and configured the Monitoring system, you can use the Monitoring web application for the types WMSHistory, PilotSubmission and DataOperation.
+
+However, every type can directly be monitored in the Kibana dashboards of the ElasticSearch instance. These can be found and imported from DIRAC.

--- a/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
+++ b/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
@@ -90,21 +90,23 @@ If, for example, you want both Monitoring and Accounting for WMSHistory (but not
 So what this does then is to first check if there is a specific flag for the type in question and then enable it, but if no specific flag is set for the type, the `Default` will be used.
 
 This can be done either via the CS or directly in the web app in the Configuration Manager as following::
+
    Operations
    {
      <VO|Setup|Defaults>
      {
        MonitoringBackends
        {
-        Default = Accounting
-        # WMSHistory = Monitoring
-        # PilotSubmission = Accounting
-        # DataOperation = Accounting, Monitoring
-        ...
+         # WMSHistory = Monitoring
+         # PilotSubmission = Accounting
+         # DataOperation = Accounting, Monitoring
+         # PilotsHistory = ...
+         # Agent = ...
+         # Service = ...
+         # RMS = ...
        }
      }
    }
-
 
 WMSHistory & PilotsHistory Monitoring
 =====================================
@@ -147,7 +149,7 @@ agents, or response time, queries and threads of the services.
 RMS Monitoring
 ==============
 
-This type is used to monitor behaviour pattern of requests executed by RequestManagementSystem inside DataManagementSystem/Agent/RequestOperations.
+This type is used to monitor behaviour pattern of requests executed by RequestManagementSystem.
 
 PilotSubmission Monitoring
 ==========================
@@ -163,13 +165,13 @@ This monitoring enables the reporting of information about the data operation su
 Accessing the Monitoring information
 =====================================
 
-After you installed and configured the Monitoring system, you can use the Monitoring web application for the types WMSHistory, PilotSubmission and DataOperation.
+After you installed and configured the Monitoring system, you can use the Monitoring web application for the types WMSHistory, PilotSubmission, DataOperation and RMS.
 
-However, every type can directly be monitored in Kibana dashboards that can be imported into your Elasticsearch (or OpenSearch) instance. You can find and import these dashboards from DIRAC/dashboards as per the following example.
+However, every type can directly be monitored in Kibana dashboards that can be imported into your Elasticsearch (or Opensearch) instance. You can find and import these dashboards from DIRAC/dashboards as per the following example.
 
 *Kibana dashboard for WMSHistory*
   A dashboard for WMSHistory monitoring ``WMSDashboard`` is available `here <https://github.com/DIRACGrid/DIRAC/tree/integration/dashboards/WMSDashboard>`__ for import as a NDJSON (as support for JSON is being removed in the latest versions of Kibana).
-  The dashboard is not compatible with older versions of ElasticSearch (such as ES6).
+  The dashboard may not be compatible with older versions of ElasticSearch.
   To import it in the Kibana UI, go to Management -> Saved Objects -> Import and import the JSON file.
 
   Note: the JSON file already contains the index patterns needed for the visualizations. You may need to adapt the index patterns to your existing ones.

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
@@ -221,3 +221,16 @@ class Operations(object):
             if value != "NoValue":
                 return optionPath
         return ""
+
+    def getMonitoringBackends(self, monitoringType=None):
+        """
+        Chooses the type of backend to use (Monitoring and/or Accounting) depending on the MonitoringType.
+        If a flag for the monitoringType specified is set, it will enable monitoring according to it,
+        otherwise it will use the `Default` value (Accounting set as default).
+
+        :param string MonitoringType: monitoring type to specify
+        """
+        if monitoringType and self.getValue(f"MonitoringBackends/{monitoringType}"):
+            return self.getValue("MonitoringBackends/%s" % monitoringType)
+        else:
+            return self.getValue("MonitoringBackends/Default", ["Accounting"])

--- a/src/DIRAC/Core/Base/AgentModule.py
+++ b/src/DIRAC/Core/Base/AgentModule.py
@@ -140,8 +140,7 @@ class AgentModule:
 
         self.activityMonitoring = False
         # Check if monitoring is enabled
-        self.monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
-        if "Monitoring" in self.monitoringOption:
+        if "Monitoring" in Operations().getValue("MonitoringBackends", ["Accounting"]):
             self.activityMonitoring = True
 
     def __getCodeInfo(self):
@@ -295,7 +294,7 @@ class AgentModule:
         """
         # This flag is used to activate ES based monitoring
         if self.activityMonitoring:
-            self.log.debug("Using activity monitoring of the agent")
+            self.log.debug("Monitoring of the agent is enabled.")
             # The import needs to be here because of the CS must be initialized before importing
             # this class (see https://github.com/DIRACGrid/DIRAC/issues/4793)
             from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter

--- a/src/DIRAC/Core/Base/AgentModule.py
+++ b/src/DIRAC/Core/Base/AgentModule.py
@@ -140,7 +140,7 @@ class AgentModule:
 
         self.activityMonitoring = False
         # Check if monitoring is enabled
-        if "Monitoring" in Operations().getValue("MonitoringBackends", ["Accounting"]):
+        if "Monitoring" in Operations().getMonitoringBackends(monitoringType="Agent"):
             self.activityMonitoring = True
 
     def __getCodeInfo(self):

--- a/src/DIRAC/Core/Base/AgentModule.py
+++ b/src/DIRAC/Core/Base/AgentModule.py
@@ -138,6 +138,12 @@ class AgentModule:
 
         self.__monitorLastStatsUpdate = -1
 
+        self.activityMonitoring = False
+        # Check if monitoring is enabled
+        self.monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
+        if "Monitoring" in self.monitoringOption:
+            self.activityMonitoring = True
+
     def __getCodeInfo(self):
 
         try:
@@ -288,10 +294,8 @@ class AgentModule:
         Initialize the system monitoring.
         """
         # This flag is used to activate ES based monitoring
-        # if the "EnableActivityMonitoring" flag in "yes" or "true" in the cfg file.
-        self.activityMonitoring = Operations().getValue("EnableActivityMonitoring", False)
         if self.activityMonitoring:
-            self.log.debug("Using activity monitoring")
+            self.log.debug("Using activity monitoring of the agent")
             # The import needs to be here because of the CS must be initialized before importing
             # this class (see https://github.com/DIRACGrid/DIRAC/issues/4793)
             from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter

--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -64,8 +64,7 @@ class Service(object):
         self.__maxFD = 0
         self.activityMonitoring = False
         # Check if monitoring is enabled
-        self.monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
-        if "Monitoring" in self.monitoringOption:
+        if "Monitoring" in Operations().getValue("MonitoringBackends", ["Accounting"]):
             self.activityMonitoring = True
 
     def setCloneProcessId(self, cloneId):

--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -64,7 +64,7 @@ class Service(object):
         self.__maxFD = 0
         self.activityMonitoring = False
         # Check if monitoring is enabled
-        if "Monitoring" in Operations().getValue("MonitoringBackends", ["Accounting"]):
+        if "Monitoring" in Operations().getMonitoringBackends(monitoringType="Service"):
             self.activityMonitoring = True
 
     def setCloneProcessId(self, cloneId):

--- a/src/DIRAC/Core/Tornado/Server/TornadoServer.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoServer.py
@@ -104,8 +104,7 @@ class TornadoServer(object):
         self.__monitoringLoopDelay = 60  # In secs
 
         self.activityMonitoring = False
-        self.monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
-        if "Monitoring" in self.monitoringOption:
+        if "Monitoring" in Operations().getMonitoringBackends(monitoringType="Service"):
             self.activityMonitoring = True
         # If services are defined, load only these ones (useful for debug purpose or specific services)
         retVal = self.handlerManager.loadServicesHandlers()

--- a/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
+++ b/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
@@ -23,9 +23,11 @@ class DataOperationSender:
 
     # Initialize the object so that the Reporters are created only once
     def __init__(self):
-        self.monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
+        monitoringType = "DataOperation"
+        # Will use the `MonitoringBackends/Default` value as monitoring backend unless a flag for `MonitoringBackends/DataOperation` is set.
+        self.monitoringOption = Operations().getMonitoringBackends(monitoringType)
         if "Monitoring" in self.monitoringOption:
-            self.dataOperationReporter = MonitoringReporter(monitoringType="DataOperation")
+            self.dataOperationReporter = MonitoringReporter(monitoringType)
         if "Accounting" in self.monitoringOption:
             self.dataOp = DataOperation()
 

--- a/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
+++ b/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
@@ -23,7 +23,7 @@ class DataOperationSender:
 
     # Initialize the object so that the Reporters are created only once
     def __init__(self):
-        self.monitoringOption = Operations().getValue("DataManagement/MonitoringBackends", ["Accounting"])
+        self.monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
         if "Monitoring" in self.monitoringOption:
             self.dataOperationReporter = MonitoringReporter(monitoringType="DataOperation")
         if "Accounting" in self.monitoringOption:

--- a/src/DIRAC/MonitoringSystem/Client/Types/RMSMonitoring.py
+++ b/src/DIRAC/MonitoringSystem/Client/Types/RMSMonitoring.py
@@ -11,9 +11,6 @@ Understanding the key fields:
 
 Understanding the monitoring fields:
 'nbObject': This field is used to describe the number of objects in question during the operation.
-
-In order to enable 'RMSMonitoring' we need to set value of 'EnableRMSMonitoring' flag to 'yes/true' inside
-'/Systems/RequestManagement/<Instance>/Agents/RequestExecutingAgent' of the 'cfg' file.
 """
 
 from DIRAC.MonitoringSystem.Client.Types.BaseType import BaseType

--- a/src/DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/src/DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -34,6 +34,7 @@ import errno
 # # from DIRAC
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.ConfigurationSystem.Client import PathFinder
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.Core.Utilities import Time, Network
@@ -109,6 +110,7 @@ class RequestExecutingAgent(AgentModule):
         # Size of the bulk if use of getRequests. If 0, use getRequest
         self.__bulkRequest = 0
         # Send the monitoring data to ES rather than the Framework/Monitoring
+        self.__monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
         self.__rmsMonitoring = False
 
     def processPool(self):
@@ -216,7 +218,10 @@ class RequestExecutingAgent(AgentModule):
         self.log.info("ProcessPool sleep time = %d seconds" % self.__poolSleep)
         self.__bulkRequest = self.am_getOption("BulkRequest", self.__bulkRequest)
         self.log.info("Bulk request size = %d" % self.__bulkRequest)
-        self.__rmsMonitoring = self.am_getOption("EnableRMSMonitoring", self.__rmsMonitoring)
+        # Check if monitoring is enabled
+        if "Monitoring" in self.__monitoringOption:
+            # Enable RMS monitoring
+            self.__rmsMonitoring = True
         self.log.info("Enable ES RMS Monitoring = %s" % self.__rmsMonitoring)
 
         # # keep config path and agent name

--- a/src/DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/src/DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -110,7 +110,7 @@ class RequestExecutingAgent(AgentModule):
         # Size of the bulk if use of getRequests. If 0, use getRequest
         self.__bulkRequest = 0
         # Send the monitoring data to ES rather than the Framework/Monitoring
-        self.__monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
+        self.__monitoringOption = Operations().getMonitoringBackends(monitoringType="RMS")
         self.__rmsMonitoring = False
 
     def processPool(self):

--- a/src/DIRAC/RequestManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/RequestManagementSystem/ConfigTemplate.cfg
@@ -57,8 +57,6 @@ Agents
     ProcessPoolSleep = 5
     # If a positive integer n is given, we fetch n requests at once from the DB. Otherwise, one by one
     BulkRequest = 0
-    # If set to True, the monitoring data is sent to ES instead of the Framework/Monitoring
-    EnableRMSMonitoring = False
     OperationHandlers
     {
       ForwardDISET

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -192,7 +192,7 @@ class SiteDirector(AgentModule):
         self.sendAccounting = self.am_getOption("SendPilotAccounting", self.sendAccounting)
 
         # Check whether to send to Monitoring or Accounting or both
-        monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
+        monitoringOption = Operations().getMonitoringBackends(monitoringType="PilotSubmission")
         if "Monitoring" in monitoringOption:
             self.sendSubmissionMonitoring = True
         if "Accounting" in monitoringOption:

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -190,13 +190,12 @@ class SiteDirector(AgentModule):
         self.updateStatus = self.am_getOption("UpdatePilotStatus", self.updateStatus)
         self.getOutput = self.am_getOption("GetPilotOutput", self.getOutput)
         self.sendAccounting = self.am_getOption("SendPilotAccounting", self.sendAccounting)
-        self.sendSubmissionAccounting = self.am_getOption(
-            "SendPilotSubmissionAccounting", self.sendSubmissionAccounting
-        )
-        self.sendSubmissionMonitoring = self.am_getOption(
-            "SendPilotSubmissionMonitoring", self.sendSubmissionMonitoring
-        )
-
+        # Check whether to send to Monitoring or Accounting or both
+        self.monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
+        if "Monitoring" in self.monitoringOption:
+            self.sendSubmissionMonitoring = True
+        if "Accounting" in self.monitoringOption:
+            self.sendSubmissionAccounting = True
         # Get the site description dictionary
         siteNames = None
         siteNamesOption = self.am_getOption("Site", ["any"])

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -190,11 +190,12 @@ class SiteDirector(AgentModule):
         self.updateStatus = self.am_getOption("UpdatePilotStatus", self.updateStatus)
         self.getOutput = self.am_getOption("GetPilotOutput", self.getOutput)
         self.sendAccounting = self.am_getOption("SendPilotAccounting", self.sendAccounting)
+
         # Check whether to send to Monitoring or Accounting or both
-        self.monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
-        if "Monitoring" in self.monitoringOption:
+        monitoringOption = Operations().getValue("MonitoringBackends", ["Accounting"])
+        if "Monitoring" in monitoringOption:
             self.sendSubmissionMonitoring = True
-        if "Accounting" in self.monitoringOption:
+        if "Accounting" in monitoringOption:
             self.sendSubmissionAccounting = True
         # Get the site description dictionary
         siteNames = None

--- a/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -303,10 +303,6 @@ Agents
     GetPilotOutput = False
     # Boolean value that indicates if the pilot job will send information for accounting
     SendPilotAccounting = True
-    # Boolean value that indicates if the pilot submission statistics will be sended for accounting
-    SendPilotSubmissionAccounting = True
-    # Boolean value that indicates if the pilot submission statistics will be sended for monitoring
-    SendPilotSubmissionMonitoring = False
   }
   ##END
   ##BEGIN PushJobAgent
@@ -335,8 +331,6 @@ Agents
   ##BEGIN StatesAccountingAgent
   StatesAccountingAgent
   {
-    # The backend used. Either "Accounting" or "Monitoring", or both
-    Backends = Accounting
     # the name of the message queue used for the failover
     MessageQueue = dirac.wmshistory
     # Polling time. For this agent it should always be 15 minutes.


### PR DESCRIPTION
The flags used to enable monitoring are all over the place and have different names for each monitoring type, which could be confusing.
I propose reorganizing all of the flags under one unique flag `MonitoringBackends/Default`, that enables all the monitoring types without needing to activate one by one.
There would also be the possibility to override this default flag manually and decide the monitoring option for any specific type.

BEGINRELEASENOTES

*Monitoring
CHANGE: Replaced the flags for monitoring with a new unified flag system


ENDRELEASENOTES
