### PR TITLE
[integration] docs: replacing deprecated DIRACScript

### DIFF
--- a/docs/source/DeveloperGuide/AddingNewComponents/YourFirstDIRACCode/index.rst
+++ b/docs/source/DeveloperGuide/AddingNewComponents/YourFirstDIRACCode/index.rst
@@ -94,7 +94,7 @@ Remember to start the script with:
    #!/usr/bin/env python
    """ Some doc: what does this script should do?
    """
-   from DIRAC.Core.Utilities.DIRACScript import DIRACScript as Script
+   from DIRAC.Core.Base import Script
    Script.parseCommandLine()
 
 


### PR DESCRIPTION

BEGINRELEASENOTES

*docs
FIX: replaced deprecated DIRACScript with DIRAC.Core.Base.Script

ENDRELEASENOTES
