### PR TITLE
[v7r3] Take the BringOnline timeout from the SE configuration

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -625,6 +625,8 @@ Resources
       RemoveAccess = True # Allowed for Remove if no RSS enabled
       OccupancyLFN = /lhcb/storageDetails.json # Json containing occupancy details
       SpaceReservation = LHCb-EOS # Space reservation name if any. Concept like SpaceToken
+      ArchiveTimeout = 84600 # Timeout for the FTS archiving
+      BringOnlineTimeout = 84600 # Timeout for the bring online operation used by FTS
       # Protocol section, see http://dirac.readthedocs.io/en/latest/AdministratorGuide/Resources/Storages/index.html#available-protocol-plugins
       GFAL2_SRM2
       {

--- a/docs/source/AdministratorGuide/Resources/storage.rst
+++ b/docs/source/AdministratorGuide/Resources/storage.rst
@@ -58,6 +58,7 @@ Configuration options are:
 * ``OccupancyPlugin``: default (``empty``). Plugin to find the occupancy of a given storage.
 * ``SpaceReservation``: just a name of a zone of the physical storage which can have some space reserved. Extends the SRM ``SpaceToken`` concept.
 * ``ArchiveTimeout``: for tape SE only. If set to a value in seconds, enables the `FTS Archive Monitoring feature <https://fts3-docs.web.cern.ch/fts3-docs/docs/archive_monitoring.html>`_
+* ``BringOnlineTimeout``: for tape SE only. If set to a value in seconds, specify the BringOnline parameter for FTS transfers. Otherwise, the default is whatever is in the ``FTS3Job`` class.
 
 VO specific paths
 -----------------

--- a/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
+++ b/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
@@ -302,8 +302,13 @@ class FTS3Job(JSerializable):
         # copy_pin_lifetime and bring_online params to None,
         # otherwise they will do an extra useless queue in FTS
         sourceIsTape = self.__isTapeSE(self.sourceSE, self.vo)
-        copy_pin_lifetime = pinTime if sourceIsTape else None
-        bring_online = BRING_ONLINE_TIMEOUT if sourceIsTape else None
+        copy_pin_lifetime = None
+        bring_online = None
+
+        if sourceIsTape:
+            copy_pin_lifetime = pinTime
+            bring_online = srcSE.options.get("BringOnlineTimeout", BRING_ONLINE_TIMEOUT)
+
         archive_timeout = None
 
         # getting all the (source, dest) surls


### PR DESCRIPTION
It makes sense to have a BringOnline timeout setting per SE, as this is very dependent on many settings that are site specific



BEGINRELEASENOTES
*DMS
NEW: BringOnline setting for FTS transfers can be SE dependant

ENDRELEASENOTES
