### PR TITLE
[v7r3] fix: use correct environment for condor_rm

### DIFF
--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -321,9 +321,16 @@ Queue %(nJobs)s
         for jobRef in jobIDList:
             job, _, jobID = condorIDAndPathToResultFromJobRef(jobRef)
             self.log.verbose("Killing pilot %s " % job)
-            status, stdout = commands.getstatusoutput("condor_rm %s %s" % (self.remoteScheddOptions, jobID))
+            cmd = ["condor_rm"]
+            cmd.extend(self.remoteScheddOptions.strip().split(" "))
+            cmd.append(jobID)
+            result = executeGridCommand(self.proxy, cmd, self.gridEnv)
+            if not result["OK"]:
+                return S_ERROR("condor_rm failed completely: %s" % result["Message"])
+            status, stdout, stderr = result["Value"]
             if status != 0:
-                return S_ERROR("Failed to kill pilot %s: %s" % (job, stdout))
+                self.log.warn("Failed to kill pilot %s: %s, %s" % (job, stdout, stderr))
+                return S_ERROR("Failed to kill pilot %s: %s" % (job, stderr))
 
         return S_OK()
 

--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -329,7 +329,7 @@ Queue %(nJobs)s
                 return S_ERROR("condor_rm failed completely: %s" % result["Message"])
             status, stdout, stderr = result["Value"]
             if status != 0:
-                self.log.warn("Failed to kill pilot %s: %s, %s" % (job, stdout, stderr))
+                self.log.warn("Failed to kill pilot", "%s: %s, %s" % (job, stdout, stderr))
                 return S_ERROR("Failed to kill pilot %s: %s" % (job, stderr))
 
         return S_OK()

--- a/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -198,10 +198,11 @@ def test_killJob(setUp, mocker, jobIDList, jobID, ret, success, local):
     htce.ceParameters = ceParameters
     htce._reset()
 
-    commandsMock = mocker.patch(MODNAME + ".commands.getstatusoutput", return_value=(ret, ""))
-    with commandsMock:
+    execMock = mocker.patch(MODNAME + ".executeGridCommand", return_value=S_OK((ret, "", "")))
+    with execMock:
         ret = htce.killJob(jobIDList=jobIDList)
 
     assert ret["OK"] == success
     if jobID:
-        commandsMock.assert_called_with("condor_rm %s %s" % (htce.remoteScheddOptions, jobID))
+        expected = "condor_rm %s %s" % (htce.remoteScheddOptions.strip(), jobID)
+        assert " ".join(execMock.call_args_list[0][0][1]) == expected


### PR DESCRIPTION
Previous version didn't use the proxy set by setproxy, so it always failed with an auth error.
BEGINRELEASENOTES

*Resources
FIX: HTCondorCE: make sure proxy is available when running condor_rm

ENDRELEASENOTES
