### PR TITLE
[v7r3] Correct docstring for DIRAC._computeRootPath

### DIFF
--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -160,11 +160,23 @@ def convertToPy3VersionNumber(releaseVersion):
 def _computeRootPath(rootPath):
     """Compute the root of the DIRAC installation
 
-    Detects if the installation is a server-style versioned installation by
-    recognising a folder structure like: ``versions/vX.Y.Z-$(uname -m)-TIMESTAMP/``
+    Nominally DIRACOS gives us a "sysroot" in that things like ``lib/``,
+    ``bin/``, ``share/``, ``etc/`` exist under ``$DIRACOS/``.
 
-    :param str rootPath: The result of ``sys.base_prefix``
-    :return: bool
+    In the case of an uncontainerised server installation it is useful to keep
+    multiple versions of DIRAC+DIRACOS available so we can switch between them
+    easily if something goes wrong during an upgrade. We also want to ensure
+    that fixed paths like ``etc/dirac.cfg``, ``runit/``, ``startup/`` are
+    preservered between versions.
+
+    To achieve this generically while mostly following the Python 2 style DIRAC
+    installation layout we start from ``sys.base_prefix`` and look if the
+    folder structure looks like a "server" layout, i.e.
+    ``versions/vX.Y.Z-$TIMESTAMP/$(uname -s)_$(uname -m)/``. If it does we
+    return the directory that contains ``versions/``.
+
+    :param str rootPath:
+    :return: The DIRAC rootPath, accounting for server-style installations.
     """
     import re
     from pathlib import Path  # pylint: disable=import-error


### PR DESCRIPTION
No need for release notes. The current docstring was only valid for v7r2.