### PR TITLE
[8.0] Propagate loggers from services to DBs

### DIFF
--- a/docs/source/DeveloperGuide/AddingNewComponents/DevelopingServices/HelloHandler.py
+++ b/docs/source/DeveloperGuide/AddingNewComponents/DevelopingServices/HelloHandler.py
@@ -4,8 +4,6 @@
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 
-sLog = gLogger.getSubLogger(__name__)
-
 
 class HelloHandler(TornadoService):
     @classmethod
@@ -23,14 +21,15 @@ class HelloHandler(TornadoService):
     def export_sayHello(self, whom):
         """Say hello to somebody"""
 
-        sLog.notice("Called sayHello of HelloHandler with whom", whom)
+        # self.log is defined in TornadoService
+        self.log.notice("Called sayHello of HelloHandler with whom", whom)
 
         if not whom:
             whom = self.requestDefaultWhom
 
         # Create a local logger which will always contain
         # the whom parameter
-        log = sLog.getLocalSubLogger(whom)
+        log = self.log.getLocalSubLogger(whom)
 
         if whom.lower() == "nobody":
             log.notice("Mummy !!! The weird guy over there offered me candies !")

--- a/src/DIRAC/AccountingSystem/DB/AccountingDB.py
+++ b/src/DIRAC/AccountingSystem/DB/AccountingDB.py
@@ -15,8 +15,8 @@ gSynchro = ThreadSafe.Synchronizer()
 
 
 class AccountingDB(DB):
-    def __init__(self, name="Accounting/AccountingDB", readOnly=False):
-        DB.__init__(self, "AccountingDB", name)
+    def __init__(self, name="Accounting/AccountingDB", readOnly=False, parentLogger=None):
+        DB.__init__(self, "AccountingDB", name, parentLogger=parentLogger)
         self.maxBucketTime = 604800  # 1 w
         self.autoCompact = False
         self.__readOnly = readOnly

--- a/src/DIRAC/Core/Base/DB.py
+++ b/src/DIRAC/Core/Base/DB.py
@@ -9,7 +9,7 @@ from DIRAC.ConfigurationSystem.Client.Utilities import getDBParameters
 class DB(DIRACDB, MySQL):
     """All DIRAC DB classes should inherit from this one (unless using sqlalchemy)"""
 
-    def __init__(self, dbname, fullname, debug=False):
+    def __init__(self, dbname, fullname, debug=False, parentLogger=None):
 
         self.fullname = fullname
 
@@ -31,6 +31,7 @@ class DB(DIRACDB, MySQL):
             dbName=self.dbName,
             port=self.dbPort,
             debug=debug,
+            parentLogger=parentLogger,
         )
 
         if not self._connected:

--- a/src/DIRAC/Core/Base/DIRACDB.py
+++ b/src/DIRAC/Core/Base/DIRACDB.py
@@ -14,7 +14,10 @@ class DIRACDB:
 
         :param self: self reference
         """
-        self.log = gLogger.getSubLogger(self.fullname)  # pylint: disable=no-member
+        parentLogger = kwargs.pop("parentLogger", None)
+        if not parentLogger:
+            parentLogger = gLogger
+        self.log = parentLogger.getSubLogger(self.fullname)  # pylint: disable=no-member
         super(DIRACDB, self).__init__(*args, **kwargs)
 
     def getCSOption(self, optionName, defaultValue=None):

--- a/src/DIRAC/Core/Base/ElasticDB.py
+++ b/src/DIRAC/Core/Base/ElasticDB.py
@@ -9,13 +9,14 @@ class ElasticDB(DIRACDB, ElasticSearchDB):
     """Class for interfacing DIRAC ES DB definitions to ES clusters"""
 
     ########################################################################
-    def __init__(self, dbname, fullName, indexPrefix=""):
+    def __init__(self, dbname, fullName, indexPrefix="", parentLogger=None):
         """c'tor
 
         :param self: self reference
         :param str dbName: DIRAC name of the database for example: 'MonitoringDB'
         :param str fullName: The DIRAC full name of the database for example: 'Monitoring/MonitoringDB'
         :param str indexPrefix: it is the indexPrefix used to load all indexes
+        :param parentLogger: logger to use as parentLogger
         """
         self.fullname = fullName
 
@@ -46,6 +47,7 @@ class ElasticDB(DIRACDB, ElasticSearchDB):
             ca_certs=self.__ca_certs,
             client_key=self.__client_key,
             client_cert=self.__client_cert,
+            parentLogger=parentLogger,
         )
 
         if not self._connected:

--- a/src/DIRAC/Core/Tornado/Server/TornadoREST.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoREST.py
@@ -14,8 +14,6 @@ from DIRAC import gLogger
 from DIRAC.ConfigurationSystem.Client import PathFinder
 from DIRAC.Core.Tornado.Server.private.BaseRequestHandler import *
 
-sLog = gLogger.getSubLogger(__name__)
-
 # decorator to determine the path to access the target method
 location = partial(set_attribute, "location")
 location.__doc__ = """
@@ -192,7 +190,7 @@ class TornadoREST(BaseRequestHandler):  # pylint: disable=abstract-method
 
             # if the method exists we will continue
             if callable(mObj) and (methodName := mName[prefix:]):
-                sLog.debug(f"  Find {mName} method")
+                cls.log.debug(f"  Find {mName} method")
 
                 # Find target method URL
                 url = os.path.join(
@@ -202,7 +200,7 @@ class TornadoREST(BaseRequestHandler):  # pylint: disable=abstract-method
                     url = cls.BASE_URL.strip("/") + (f"/{url}" if (url := url.strip("/")) else "")
                 url = f"/{url.strip('/')}/?"
 
-                sLog.verbose(f" - Route {url} ->  {cls.__name__}.{mName}")
+                cls.log.verbose(f" - Route {url} ->  {cls.__name__}.{mName}")
 
                 # Discover positional arguments
                 mObj.var_kwargs = False  # attribute indicating the presence of `**kwargs``
@@ -267,7 +265,7 @@ class TornadoREST(BaseRequestHandler):  # pylint: disable=abstract-method
 
                 # We collect all generated tornado url for target handler methods
                 if url not in urls:
-                    sLog.debug(f"  * {url}")
+                    cls.log.debug(f"  * {url}")
                     urls.append(TornadoURL(url, cls, dict(method=methodName)))
         return urls
 

--- a/src/DIRAC/Core/Tornado/Server/TornadoService.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoService.py
@@ -16,8 +16,6 @@ from DIRAC.Core.Utilities.JEncode import decode, encode
 from DIRAC.Core.Tornado.Server.private.BaseRequestHandler import BaseRequestHandler
 from DIRAC.ConfigurationSystem.Client import PathFinder
 
-sLog = gLogger.getSubLogger(__name__)
-
 
 class TornadoService(BaseRequestHandler):  # pylint: disable=abstract-method
     """
@@ -135,7 +133,7 @@ class TornadoService(BaseRequestHandler):  # pylint: disable=abstract-method
         """
         # Expected path: ``/<System>/<Component>``
         cls._serviceName = cls._fullComponentName
-        sLog.verbose(f" - Route /{cls._serviceName.strip('/')} ->  {cls.__name__}")
+        cls.log.verbose(f" - Route /{cls._serviceName.strip('/')} ->  {cls.__name__}")
         return [TornadoURL(f"/{cls._serviceName.strip('/')}", cls)]
 
     @classmethod

--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -335,7 +335,6 @@ class BaseRequestHandler(RequestHandler):
         cls._authManager = AuthManager(cls._getCSAuthorizarionSection(cls._fullComponentName))
 
         if not (urls := cls._pre_initialize()):
-            # cls.log is not yet available
             cls.log.warn("no target method found", f"{cls.__name__}")
         return urls
 

--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -29,8 +29,6 @@ from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-er
 from DIRAC.Resources.IdProvider.Utilities import getProvidersForInstance
 from DIRAC.Resources.IdProvider.IdProviderFactory import IdProviderFactory
 
-sLog = gLogger.getSubLogger(__name__.split(".")[-1])
-
 
 def set_attribute(attr, val):
     """Decorator to determine target method settings. Set method attribute.
@@ -247,6 +245,7 @@ class BaseRequestHandler(RequestHandler):
     The first request starts the process of initializing the handler, see the :py:meth:`initialize` method:
 
         - load all registered identity providers for authentication with access token, see :py:meth:`__loadIdPs`.
+        - create a ``cls.log`` logger that should be used in the children classes instead of directly ``gLogger`` (this allows to carry the ``tornadoComponent`` information, crutial for centralized logging)
         - initialization of the monitoring specific to this handler, see :py:meth:`__initMonitoring`.
         - initialization of the target handler that inherit this one, see :py:meth:`initializeHandler`.
 
@@ -309,6 +308,9 @@ class BaseRequestHandler(RequestHandler):
     # Note that `auth_methodName` will have a higher priority.
     DEFAULT_AUTHORIZATION = None
 
+    # This will be overridden in __initialize to be handler specific
+    log = gLogger.getSubLogger(__name__.split(".")[-1])
+
     @classmethod
     def __pre_initialize(cls) -> list:
         """This method is run by the Tornado server to prepare the handler for launch,
@@ -333,7 +335,8 @@ class BaseRequestHandler(RequestHandler):
         cls._authManager = AuthManager(cls._getCSAuthorizarionSection(cls._fullComponentName))
 
         if not (urls := cls._pre_initialize()):
-            sLog.warn("no target method found", f"{cls.__name__}")
+            # cls.log is not yet available
+            cls.log.warn("no target method found", f"{cls.__name__}")
         return urls
 
     @classmethod
@@ -390,7 +393,7 @@ class BaseRequestHandler(RequestHandler):
     @classmethod
     def __loadIdPs(cls) -> None:
         """Load identity providers that will be used to verify tokens"""
-        sLog.debug("Load identity providers..")
+        cls.log.debug("Load identity providers..")
         # Research Identity Providers
         result = getProvidersForInstance("Id")
         if result["OK"]:
@@ -399,7 +402,7 @@ class BaseRequestHandler(RequestHandler):
                 if result["OK"]:
                     cls._idp[result["Value"].issuer.strip("/")] = result["Value"]
                 else:
-                    sLog.error("Error getting IDP", "%s: %s" % (providerName, result["Message"]))
+                    cls.log.error("Error getting IDP", "%s: %s" % (providerName, result["Message"]))
 
     @classmethod
     def _getCSAuthorizarionSection(cls, fullComponentName: str) -> str:
@@ -444,6 +447,9 @@ class BaseRequestHandler(RequestHandler):
             if cls.__init_done:
                 return S_OK()
 
+            cls.log = gLogger.getSubLogger(cls.__name__)
+            cls.log._setOption("tornadoComponent", cls._fullComponentName)
+
             # Load all registered identity providers
             cls.__loadIdPs()
 
@@ -452,7 +458,7 @@ class BaseRequestHandler(RequestHandler):
 
             # The time at which the handler was initialized
             cls._startTime = datetime.utcnow()
-            sLog.info("Initializing method for first use", f"{cls._fullComponentName}, initializing..")
+            cls.log.info("Initializing method for first use", f"{cls._fullComponentName}, initializing..")
 
             # component monitoring initialization
             cls.__initMonitoring(cls._fullComponentName, absoluteUrl)
@@ -507,7 +513,7 @@ class BaseRequestHandler(RequestHandler):
                 if not res["OK"]:
                     raise Exception(res["Message"])
             except Exception as e:
-                sLog.error("Error in initialization", repr(e))
+                self.log.error("Error in initialization", repr(e))
                 raise
 
     def _monitorRequest(self) -> None:
@@ -572,7 +578,7 @@ class BaseRequestHandler(RequestHandler):
         """
         # Define the target method
         if not (method := self._getMethod()):
-            sLog.error("The appropriate method could not be found.")
+            self.log.error("The appropriate method could not be found.")
             raise HTTPError(status_code=HTTPStatus.BAD_REQUEST)
 
         if isinstance(method, str):
@@ -583,7 +589,7 @@ class BaseRequestHandler(RequestHandler):
             methodName = method.__name__
 
         if not callable(self.methodObj):
-            sLog.error("Invalid method", methodName)
+            self.log.error("Invalid method", methodName)
             raise HTTPError(status_code=HTTPStatus.NOT_IMPLEMENTED)
 
         # Get target method core name
@@ -595,8 +601,8 @@ class BaseRequestHandler(RequestHandler):
             # If an error occur when reading certificates we close connection
             # It can be strange but the RFC, for HTTP, say's that when error happend
             # before authentication we return 401 UNAUTHORIZED instead of 403 FORBIDDEN
-            sLog.exception(e)
-            sLog.error("Error gathering credentials ", "%s; path %s" % (self.getRemoteAddress(), self.request.path))
+            self.log.exception(e)
+            self.log.error("Error gathering credentials ", "%s; path %s" % (self.getRemoteAddress(), self.request.path))
             raise HTTPError(HTTPStatus.UNAUTHORIZED, str(e))
 
         # Check whether we are authorized to perform the query
@@ -608,7 +614,7 @@ class BaseRequestHandler(RequestHandler):
                 extraInfo += "ID: %s" % self.credDict["ID"]
             elif self.credDict.get("DN"):
                 extraInfo += "DN: %s" % self.credDict["DN"]
-            sLog.error(
+            self.log.error(
                 "Unauthorized access",
                 "Identity %s; path %s; %s" % (self.srv_getFormattedRemoteCredentials(), self.request.path, extraInfo),
             )
@@ -630,13 +636,13 @@ class BaseRequestHandler(RequestHandler):
         args, kwargs = self._getMethodArgs(args, kwargs)
 
         credentials = self.srv_getFormattedRemoteCredentials()
-        sLog.notice("Incoming request", f"{credentials} {self._fullComponentName}: {self.__methodName}")
+        self.log.notice("Incoming request", f"{credentials} {self._fullComponentName}: {self.__methodName}")
         # Execute
         try:
             self.initializeRequest()
             return self.methodObj(*args, **kwargs)
         except Exception as e:  # pylint: disable=broad-except
-            sLog.exception("Exception serving request", "%s:%s" % (str(e), repr(e)))
+            self.log.exception("Exception serving request", "%s:%s" % (str(e), repr(e)))
             raise e if isinstance(e, HTTPError) else HTTPError(HTTPStatus.INTERNAL_SERVER_ERROR, str(e))
 
     def on_finish(self):
@@ -660,7 +666,7 @@ class BaseRequestHandler(RequestHandler):
         if self._status_code >= 400:
             argsString = f"ERROR {self._status_code}: {self._reason}"
 
-        sLog.notice(
+        self.log.notice(
             "Returning response", f"{credentials} {self._fullComponentName} ({elapsedTime:.2f} ms) {argsString}"
         )
 
@@ -695,8 +701,8 @@ class BaseRequestHandler(RequestHandler):
             result = grantFunc() if callable(grantFunc) else S_ERROR("%s authentication type is not supported." % grant)
             if result["OK"]:
                 for e in err:
-                    sLog.debug(e)
-                sLog.debug("%s authentication success." % grant)
+                    self.log.debug(e)
+                self.log.debug("%s authentication success." % grant)
                 return result["Value"]
             err.append("%s authentication: %s" % (grant, result["Message"]))
 
@@ -791,10 +797,6 @@ class BaseRequestHandler(RequestHandler):
         :return: S_OK(dict)
         """
         return S_OK({})
-
-    @property
-    def log(self):
-        return sLog
 
     def getUserDN(self):
         return self.credDict.get("DN", "")

--- a/src/DIRAC/DataManagementSystem/DB/DataIntegrityDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/DataIntegrityDB.py
@@ -30,9 +30,9 @@ class DataIntegrityDB(DB):
 
     """
 
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """Standard Constructor"""
-        DB.__init__(self, "DataIntegrityDB", "DataManagement/DataIntegrityDB")
+        DB.__init__(self, "DataIntegrityDB", "DataManagement/DataIntegrityDB", parentLogger=parentLogger)
 
         self.tableName = "Problematics"
         self.fieldList = ["FileID", "LFN", "PFN", "Size", "SE", "GUID", "Prognosis"]

--- a/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
@@ -180,7 +180,7 @@ class FTS3DB(object):
         self.dbPass = dbParameters["Password"]
         self.dbName = dbParameters["DBName"]
 
-    def __init__(self, pool_size=15, url=None):
+    def __init__(self, pool_size=15, url=None, parentLogger=None):
         """c'tor
 
         :param self: self reference
@@ -188,7 +188,10 @@ class FTS3DB(object):
 
         """
 
-        self.log = gLogger.getSubLogger("FTS3DB")
+        if not parentLogger:
+            parentLogger = gLogger
+
+        self.log = parentLogger.getSubLogger("FTS3DB")
 
         if not url:
             # Initialize the connection info

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogDB.py
@@ -10,14 +10,14 @@ from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 
 
 class FileCatalogDB(DB):
-    def __init__(self, databaseLocation="DataManagement/FileCatalogDB"):
+    def __init__(self, databaseLocation="DataManagement/FileCatalogDB", parentLogger=None):
         # The database location can be specified in System/Database form or in just the Database name
         # in the DataManagement system
         db = databaseLocation
         if "/" not in db:
             db = "DataManagement/" + db
 
-        super(FileCatalogDB, self).__init__("FileCatalogDB", db)
+        super(FileCatalogDB, self).__init__("FileCatalogDB", db, parentLogger=parentLogger)
 
         self.ugManager = None
         self.seManager = None

--- a/src/DIRAC/DataManagementSystem/Service/DataIntegrityHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/DataIntegrityHandler.py
@@ -25,7 +25,7 @@ class DataIntegrityHandlerMixin:
     def initializeHandler(cls, serviceInfoDict):
         """Initialization of DB object"""
 
-        cls.dataIntegrityDB = DataIntegrityDB()
+        cls.dataIntegrityDB = DataIntegrityDB(parentLogger=cls.log)
         return S_OK()
 
     types_removeProblematic = [[int, list]]

--- a/src/DIRAC/DataManagementSystem/Service/FTS3ManagerHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/FTS3ManagerHandler.py
@@ -35,7 +35,7 @@ class FTS3ManagerHandlerMixin:
         """initialize handler"""
         try:
             maxThreads = getServiceOption(serviceInfoDict, "MaxThreads", 15)
-            cls.fts3db = FTS3DB(pool_size=maxThreads)
+            cls.fts3db = FTS3DB(pool_size=maxThreads, parentLogger=cls.log)
         except RuntimeError as error:
             gLogger.exception(error)
             return S_ERROR(error)

--- a/src/DIRAC/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/FileCatalogHandler.py
@@ -23,7 +23,7 @@ class FileCatalogHandlerMixin:
         """Handler  initialization"""
 
         dbLocation = getServiceOption(serviceInfo, "Database", "DataManagement/FileCatalogDB")
-        cls.fileCatalogDB = FileCatalogDB(dbLocation)
+        cls.fileCatalogDB = FileCatalogDB(dbLocation, parentLogger=cls.log)
 
         databaseConfig = {}
         # Obtain the plugins to be used for DB interaction

--- a/src/DIRAC/DataManagementSystem/Service/TornadoDataIntegrityHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/TornadoDataIntegrityHandler.py
@@ -9,14 +9,11 @@ Service handler for DataIntegrity using https
 
 """
 
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.DataManagementSystem.Service.DataIntegrityHandler import DataIntegrityHandlerMixin
-
-sLog = gLogger.getSubLogger(__name__)
 
 
 class TornadoDataIntegrityHandler(DataIntegrityHandlerMixin, TornadoService):
     """Tornado handler for the DataIntegrityHandler"""
 
-    log = sLog
+    pass

--- a/src/DIRAC/DataManagementSystem/Service/TornadoFTS3ManagerHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/TornadoFTS3ManagerHandler.py
@@ -1,11 +1,8 @@
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.DataManagementSystem.Service.FTS3ManagerHandler import FTS3ManagerHandlerMixin
-
-sLog = gLogger.getSubLogger(__name__)
 
 
 class TornadoFTS3ManagerHandler(FTS3ManagerHandlerMixin, TornadoService):
     """Tornado handler for the FTS3Manager"""
 
-    log = sLog
+    pass

--- a/src/DIRAC/DataManagementSystem/Service/TornadoFileCatalogHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/TornadoFileCatalogHandler.py
@@ -17,14 +17,11 @@ from io import StringIO
 
 # from DIRAC
 
-from DIRAC import gLogger, S_ERROR
+from DIRAC import S_ERROR
 from DIRAC.Core.Utilities.ReturnValues import returnValueOrRaise
 from DIRAC.DataManagementSystem.Service.FileCatalogHandler import FileCatalogHandlerMixin
 
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
-
-
-sLog = gLogger.getSubLogger(__name__)
 
 
 class TornadoFileCatalogHandler(FileCatalogHandlerMixin, TornadoService):
@@ -33,9 +30,6 @@ class TornadoFileCatalogHandler(FileCatalogHandlerMixin, TornadoService):
 
     A simple Replica and Metadata Catalog service.
     """
-
-    # This is needed because the mixin class uses `cls.log`
-    log = sLog
 
     def export_streamToClient(self, jsonSENames):
         """This method is used to transfer the SEDump to the client,
@@ -61,7 +55,7 @@ class TornadoFileCatalogHandler(FileCatalogHandlerMixin, TornadoService):
             return ret
 
         except Exception as e:
-            sLog.exception("Exception while sending seDump", repr(e))
+            self.log.exception("Exception while sending seDump", repr(e))
             return S_ERROR("Exception while sendind seDump: %s" % repr(e))
         finally:
             if csvOutput is not None:

--- a/src/DIRAC/FrameworkSystem/DB/ComponentMonitoringDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ComponentMonitoringDB.py
@@ -9,12 +9,12 @@ from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemURLs
 
 
 class ComponentMonitoringDB(DB):
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """c'tor
 
         Initialize the DB
         """
-        DB.__init__(self, "ComponentMonitoringDB", "Framework/ComponentMonitoringDB")
+        DB.__init__(self, "ComponentMonitoringDB", "Framework/ComponentMonitoringDB", parentLogger=parentLogger)
         retVal = self.__initializeDB()
         if not retVal["OK"]:
             raise Exception("Can't create tables: %s" % retVal["Message"])

--- a/src/DIRAC/FrameworkSystem/DB/NotificationDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/NotificationDB.py
@@ -10,8 +10,8 @@ from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 
 
 class NotificationDB(DB):
-    def __init__(self):
-        DB.__init__(self, "NotificationDB", "Framework/NotificationDB")
+    def __init__(self, parentLogger=None):
+        DB.__init__(self, "NotificationDB", "Framework/NotificationDB", parentLogger=parentLogger)
         result = self.__initializeDB()
         if not result["OK"]:
             self.log.fatal("Cannot initialize DB!", result["Message"])

--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -37,12 +37,12 @@ class ProxyDB(DB):
 
     NOTIFICATION_TIMES = [2592000, 1296000]
 
-    def __init__(self, useMyProxy=False, mailFrom=None):
+    def __init__(self, useMyProxy=False, mailFrom=None, parentLogger=None):
         """
         :param bool useMyProxy: use MyProxy...
         :param str mailFrom: address to use as sender for the expiration reminder emails
         """
-        DB.__init__(self, "ProxyDB", "Framework/ProxyDB")
+        DB.__init__(self, "ProxyDB", "Framework/ProxyDB", parentLogger=parentLogger)
         self._mailFrom = mailFrom if mailFrom else DEFAULT_MAIL_FROM
         self.__defaultRequestLifetime = 300  # 5min
         self.__defaultTokenLifetime = 86400 * 7  # 1 week

--- a/src/DIRAC/FrameworkSystem/DB/TokenDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/TokenDB.py
@@ -41,9 +41,9 @@ class Token(Model, OAuth2TokenMixin):
 class TokenDB(SQLAlchemyDB):
     """TokenDB class is a front-end to the TokenDB Database"""
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """Constructor"""
-        super(TokenDB, self).__init__()
+        super(TokenDB, self).__init__(*args, **kwargs)
         self._initializeConnection("Framework/TokenDB")
         result = self.__initializeDB()
         if not result["OK"]:

--- a/src/DIRAC/FrameworkSystem/DB/UserProfileDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/UserProfileDB.py
@@ -62,12 +62,12 @@ class UserProfileDB(DB):
         },
     }
 
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """Constructor"""
         self.__permValues = ["USER", "GROUP", "VO", "ALL"]
         self.__permAttrs = ["ReadAccess", "PublishAccess"]
         self.__cache = cachetools.TTLCache(1024, 15)
-        DB.__init__(self, "UserProfileDB", "Framework/UserProfileDB")
+        DB.__init__(self, "UserProfileDB", "Framework/UserProfileDB", parentLogger=parentLogger)
         retVal = self.__initializeDB()
         if not retVal["OK"]:
             raise Exception("Can't create tables: %s" % retVal["Message"])

--- a/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -33,7 +33,7 @@ class ProxyManagerHandlerMixin:
                 return result
             dbClass = result["Value"]
 
-            cls.__proxyDB = dbClass(useMyProxy=useMyProxy, mailFrom=mailFrom)
+            cls.__proxyDB = dbClass(useMyProxy=useMyProxy, mailFrom=mailFrom, parentLogger=cls.log)
 
         except RuntimeError as excp:
             return S_ERROR("Can't connect to ProxyDB", repr(excp))

--- a/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
@@ -57,7 +57,7 @@ class TokenManagerHandler(TornadoService):
         """
         # Let's try to connect to the database
         try:
-            cls.__tokenDB = TokenDB()
+            cls.__tokenDB = TokenDB(parentLogger=cls.log)
         except Exception as e:
             cls.log.exception(e)
             return S_ERROR(f"Could not connect to the database {repr(e)}")

--- a/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
@@ -31,7 +31,7 @@ is taken and the **exchange token** request to Identity Provider is made. The re
 
 import pprint
 
-from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security import Properties
 from DIRAC.Core.Utilities import ThreadSafe
 from DIRAC.Core.Utilities.DictCache import DictCache
@@ -59,7 +59,7 @@ class TokenManagerHandler(TornadoService):
         try:
             cls.__tokenDB = TokenDB()
         except Exception as e:
-            gLogger.exception(e)
+            cls.log.exception(e)
             return S_ERROR(f"Could not connect to the database {repr(e)}")
 
         # Cache containing tokens from scope requested by the client
@@ -109,7 +109,7 @@ class TokenManagerHandler(TornadoService):
                 if uid:
                     result = self.__tokenDB.getTokensByUserID(uid)
                     if not result["OK"]:
-                        gLogger.error(result["Message"])
+                        self.log.error(result["Message"])
                     else:
                         for tokenDict in result["Value"]:
                             if tokenDict not in tokensInfo:

--- a/src/DIRAC/FrameworkSystem/Service/TornadoBundleDeliveryHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TornadoBundleDeliveryHandler.py
@@ -2,18 +2,13 @@
 """
 from base64 import b64encode
 
-from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security import Utilities
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.FrameworkSystem.Service.BundleDeliveryHandler import BundleDeliveryHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoBundleDeliveryHandler(BundleDeliveryHandlerMixin, TornadoService):
-
-    log = sLog
 
     types_streamToClient = []
 

--- a/src/DIRAC/FrameworkSystem/Service/TornadoProxyManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TornadoProxyManagerHandler.py
@@ -6,13 +6,9 @@
       :dedent: 2
       :caption: TornadoProxyManager options
 """
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.FrameworkSystem.Service.ProxyManagerHandler import ProxyManagerHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoProxyManagerHandler(ProxyManagerHandlerMixin, TornadoService):
-    log = sLog
+    pass

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Logging.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Logging.py
@@ -137,7 +137,7 @@ class Logging(object):
         # lock to prevent that two threads change the options at the same time
         self._lockOptions.acquire()
         try:
-            if self._optionsModified[optionName] and not directCall:
+            if self._optionsModified.get(optionName) and not directCall:
                 return
 
             if directCall:

--- a/src/DIRAC/MonitoringSystem/Service/TornadoMonitoringHandler.py
+++ b/src/DIRAC/MonitoringSystem/Service/TornadoMonitoringHandler.py
@@ -9,19 +9,14 @@
 """
 from base64 import b64encode
 
-from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.Core.Utilities.Plotting import gDataCache
 from DIRAC.Core.Utilities.Plotting.Plots import generateErrorMessagePlot
 from DIRAC.MonitoringSystem.Service.MonitoringHandler import MonitoringHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoMonitoringHandler(MonitoringHandlerMixin, TornadoService):
-    log = sLog
-
     def initializeRequest(self):
         self.diracSetup = self.get_argument("clientSetup")
         return S_OK()

--- a/src/DIRAC/ProductionSystem/DB/ProductionDB.py
+++ b/src/DIRAC/ProductionSystem/DB/ProductionDB.py
@@ -21,7 +21,7 @@ MAX_ERROR_COUNT = 10
 class ProductionDB(DB):
     """ProductionDB class"""
 
-    def __init__(self, dbname=None, dbconfig=None, dbIn=None):
+    def __init__(self, dbname=None, dbconfig=None, dbIn=None, parentLogger=None):
         """The standard constructor takes the database name (dbname) and the name of the
         configuration section (dbconfig)
         """
@@ -31,7 +31,7 @@ class ProductionDB(DB):
             dbconfig = "Production/ProductionDB"
 
         if not dbIn:
-            DB.__init__(self, dbname, dbconfig)
+            DB.__init__(self, dbname, dbconfig, parentLogger=parentLogger)
 
         self.lock = threading.Lock()
 

--- a/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
+++ b/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
@@ -201,13 +201,16 @@ class RequestDB(object):
         self.dbPass = dbParameters["Password"]
         self.dbName = dbParameters["DBName"]
 
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """c'tor
 
         :param self: self reference
         """
 
-        self.log = gLogger.getSubLogger("RequestDB")
+        if not parentLogger:
+            parentLogger = gLogger
+
+        self.log = parentLogger.getSubLogger("RequestDB")
         # Initialize the connection info
         self.__getDBConnectionInfo("RequestManagement/ReqDB")
 

--- a/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -46,7 +46,7 @@ class ReqManagerHandlerMixin:
         """initialize handler"""
 
         try:
-            cls.__requestDB = RequestDB()
+            cls.__requestDB = RequestDB(parentLogger=cls.log)
         except RuntimeError as error:
             gLogger.exception(error)
             return S_ERROR(error)

--- a/src/DIRAC/RequestManagementSystem/Service/TornadoReqManagerHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/TornadoReqManagerHandler.py
@@ -1,11 +1,8 @@
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.RequestManagementSystem.Service.ReqManagerHandler import ReqManagerHandlerMixin
-
-sLog = gLogger.getSubLogger(__name__)
 
 
 class TornadoReqManagerHandler(ReqManagerHandlerMixin, TornadoService):
     """Tornado handler for the ReqManager"""
 
-    log = sLog
+    pass

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -396,13 +396,13 @@ class ResourceManagementDB(SQLAlchemyDB):
     Class that defines the methods to interact to the ResourceManagementDB tables
     """
 
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """c'tor
 
         :param self: self reference
         """
 
-        super(ResourceManagementDB, self).__init__()
+        super(ResourceManagementDB, self).__init__(parentLogger=parentLogger)
 
         # This is the list of tables that will be created.
         # It can be extended in an extension module

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -291,13 +291,13 @@ class ResourceStatusDB(SQLAlchemyDB):
     Class that defines the interactions with the tables of the ResourceStatusDB.
     """
 
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """c'tor
 
         :param self: self reference
         """
 
-        super(ResourceStatusDB, self).__init__()
+        super(ResourceStatusDB, self).__init__(parentLogger=parentLogger)
 
         # These are the list of tables that will be created.
         # They can be extended in an extension module

--- a/src/DIRAC/ResourceStatusSystem/Service/ResourceManagementHandler.py
+++ b/src/DIRAC/ResourceStatusSystem/Service/ResourceManagementHandler.py
@@ -36,7 +36,7 @@ class ResourceManagementHandlerMixin:
         """
         defaultOption, defaultClass = "ResourceManagementDB", "ResourceManagementDB"
         configValue = getServiceOption(serviceInfoDict, defaultOption, defaultClass)
-        result = loadResourceStatusComponent(configValue, configValue)
+        result = loadResourceStatusComponent(configValue, configValue, parentLogger=cls.log)
 
         if not result["OK"]:
             return result

--- a/src/DIRAC/ResourceStatusSystem/Service/ResourceStatusHandler.py
+++ b/src/DIRAC/ResourceStatusSystem/Service/ResourceStatusHandler.py
@@ -8,12 +8,13 @@ from DIRAC.Core.DISET.RequestHandler import RequestHandler, getServiceOption
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 
 
-def loadResourceStatusComponent(moduleName, className):
+def loadResourceStatusComponent(moduleName, className, parentLogger=None):
     """
     Create an object of a given database component.
 
     :param moduleName: module name to be loaded
     :param className: class name
+    :param parentLogger: the parentLogger to use in the DB
     :return: object instance wrapped in a standard Dirac return object.
     """
 
@@ -24,7 +25,7 @@ def loadResourceStatusComponent(moduleName, className):
         gLogger.error("Failed to load RSS component", "%s: %s" % (moduleName, result["Message"]))
         return result
     componentClass = result["Value"]
-    component = componentClass()
+    component = componentClass(parentLogger=parentLogger)
     return S_OK(component)
 
 
@@ -60,7 +61,7 @@ class ResourceStatusHandlerMixin:
 
         defaultOption, defaultClass = "ResourceStatusDB", "ResourceStatusDB"
         configValue = getServiceOption(serviceInfoDict, defaultOption, defaultClass)
-        result = loadResourceStatusComponent(configValue, configValue)
+        result = loadResourceStatusComponent(configValue, configValue, parentLogger=cls.log)
 
         if not result["OK"]:
             return result

--- a/src/DIRAC/ResourceStatusSystem/Service/TornadoPublisherHandler.py
+++ b/src/DIRAC/ResourceStatusSystem/Service/TornadoPublisherHandler.py
@@ -1,12 +1,8 @@
 """ Tornado-based HTTPs Publisher service.
 """
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.ResourceStatusSystem.Service.PublisherHandler import PublisherHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoPublisherHandler(PublisherHandlerMixin, TornadoService):
-    log = sLog
+    pass

--- a/src/DIRAC/ResourceStatusSystem/Service/TornadoResourceManagementHandler.py
+++ b/src/DIRAC/ResourceStatusSystem/Service/TornadoResourceManagementHandler.py
@@ -1,12 +1,8 @@
 """ Tornado-based HTTPs ResourceManagement service.
 """
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.ResourceStatusSystem.Service.ResourceManagementHandler import ResourceManagementHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoResourceManagementHandler(ResourceManagementHandlerMixin, TornadoService):
-    log = sLog
+    pass

--- a/src/DIRAC/ResourceStatusSystem/Service/TornadoResourceStatusHandler.py
+++ b/src/DIRAC/ResourceStatusSystem/Service/TornadoResourceStatusHandler.py
@@ -1,12 +1,9 @@
 """ Tornado-based HTTPs ResourceStatus service.
 """
-from DIRAC import gLogger
+
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.ResourceStatusSystem.Service.ResourceStatusHandler import ResourceStatusHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoResourceStatusHandler(ResourceStatusHandlerMixin, TornadoService):
-    log = sLog
+    pass

--- a/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
@@ -33,8 +33,8 @@ THROTTLING_STEPS = 12
 
 
 class StorageManagementDB(DB):
-    def __init__(self, systemInstance="Default"):
-        DB.__init__(self, "StorageManagementDB", "StorageManagement/StorageManagementDB")
+    def __init__(self, systemInstance="Default", parentLogger=None):
+        DB.__init__(self, "StorageManagementDB", "StorageManagement/StorageManagementDB", parentLogger=parentLogger)
         self.lock = threading.Lock()
         self.TASKPARAMS = [
             "TaskID",

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -31,7 +31,7 @@ MAX_ERROR_COUNT = 10
 class TransformationDB(DB):
     """TransformationDB class"""
 
-    def __init__(self, dbname=None, dbconfig=None, dbIn=None):
+    def __init__(self, dbname=None, dbconfig=None, dbIn=None, parentLogger=None):
         """The standard constructor takes the database name (dbname) and the name of the
         configuration section (dbconfig)
         """
@@ -42,7 +42,7 @@ class TransformationDB(DB):
             dbconfig = "Transformation/TransformationDB"
 
         if not dbIn:
-            DB.__init__(self, dbname, dbconfig)
+            DB.__init__(self, dbname, dbconfig, parentLogger=parentLogger)
 
         self.lock = threading.Lock()
 

--- a/src/DIRAC/TransformationSystem/Service/TornadoTransformationManagerHandler.py
+++ b/src/DIRAC/TransformationSystem/Service/TornadoTransformationManagerHandler.py
@@ -1,12 +1,8 @@
 """ Tornado-based HTTPs TransformationManager service.
 """
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.TransformationSystem.Service.TransformationManagerHandler import TransformationManagerHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoTransformationManagerHandler(TransformationManagerHandlerMixin, TornadoService):
-    log = sLog
+    pass

--- a/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
@@ -41,7 +41,7 @@ mapping = {"properties": {"JobID": {"type": "long"}, "Name": {"type": "keyword"}
 
 
 class ElasticJobParametersDB(ElasticDB):
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """Standard Constructor"""
 
         try:
@@ -49,7 +49,7 @@ class ElasticJobParametersDB(ElasticDB):
             indexPrefix = gConfig.getValue("%s/IndexPrefix" % section, CSGlobals.getSetup()).lower()
 
             # Connecting to the ES cluster
-            super().__init__(name, "WorkloadManagement/ElasticJobParametersDB", indexPrefix)
+            super().__init__(name, "WorkloadManagement/ElasticJobParametersDB", indexPrefix, parentLogger=parentLogger)
         except Exception as ex:
             self.log.error("Can't connect to ElasticJobParametersDB", repr(ex))
             raise RuntimeError("Can't connect to ElasticJobParametersDB")

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -60,10 +60,10 @@ def extractJDL(compressedJDL):
 class JobDB(DB):
     """Interface to MySQL-based JobDB"""
 
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """Standard Constructor"""
 
-        DB.__init__(self, "JobDB", "WorkloadManagement/JobDB")
+        DB.__init__(self, "JobDB", "WorkloadManagement/JobDB", parentLogger=parentLogger)
 
         # data member to check if __init__ went through without error
         self.__initialized = False

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -20,10 +20,10 @@ MAGIC_EPOC_NUMBER = 1270000000
 class JobLoggingDB(DB):
     """Frontend to JobLoggingDB MySQL table"""
 
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """Standard Constructor"""
 
-        DB.__init__(self, "JobLoggingDB", "WorkloadManagement/JobLoggingDB")
+        DB.__init__(self, "JobLoggingDB", "WorkloadManagement/JobLoggingDB", parentLogger=parentLogger)
 
     #############################################################################
     def addLoggingRecord(

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -32,9 +32,9 @@ from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 
 
 class PilotAgentsDB(DB):
-    def __init__(self):
+    def __init__(self, parentLogger=None):
 
-        super().__init__("PilotAgentsDB", "WorkloadManagement/PilotAgentsDB")
+        super().__init__("PilotAgentsDB", "WorkloadManagement/PilotAgentsDB", parentLogger=parentLogger)
         self.lock = threading.Lock()
 
     ##########################################################################################

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotsLoggingDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotsLoggingDB.py
@@ -30,9 +30,12 @@ Base = declarative_base()
 
 #############################################################################
 class PilotsLoggingDB:
-    def __init__(self):
+    def __init__(self, parentLogger=None):
 
-        self.log = gLogger.getSubLogger("PilotsLoggingDB")
+        if not parentLogger:
+            parentLogger = gLogger
+
+        self.log = parentLogger.getSubLogger("PilotsLoggingDB")
 
         result = getDBParameters("WorkloadManagement/PilotsLoggingDB")
         if not result["OK"]:

--- a/src/DIRAC/WorkloadManagementSystem/DB/SandboxMetadataDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/SandboxMetadataDB.py
@@ -8,8 +8,8 @@ from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 
 
 class SandboxMetadataDB(DB):
-    def __init__(self):
-        DB.__init__(self, "SandboxMetadataDB", "WorkloadManagement/SandboxMetadataDB")
+    def __init__(self, parentLogger=None):
+        DB.__init__(self, "SandboxMetadataDB", "WorkloadManagement/SandboxMetadataDB", parentLogger=parentLogger)
         result = self.__initializeDB()
         if not result["OK"]:
             raise RuntimeError(f"Can't create tables: {result['Message']}")

--- a/src/DIRAC/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -35,8 +35,8 @@ def _lowerAndRemovePunctuation(s):
 class TaskQueueDB(DB):
     """MySQL DB of "Task Queues" """
 
-    def __init__(self):
-        DB.__init__(self, "TaskQueueDB", "WorkloadManagement/TaskQueueDB")
+    def __init__(self, parentLogger=None):
+        DB.__init__(self, "TaskQueueDB", "WorkloadManagement/TaskQueueDB", parentLogger=parentLogger)
         self.__maxJobsInTQ = 5000
         self.__defaultCPUSegments = [
             6 * 60,

--- a/src/DIRAC/WorkloadManagementSystem/DB/VirtualMachineDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/VirtualMachineDB.py
@@ -107,8 +107,8 @@ class VirtualMachineDB(DB):
     # VirtualDB constructor
     #######################
 
-    def __init__(self, maxQueueSize=10):
-        super().__init__("VirtualMachineDB", "WorkloadManagement/VirtualMachineDB")
+    def __init__(self, maxQueueSize=10, parentLogger=None):
+        super().__init__("VirtualMachineDB", "WorkloadManagement/VirtualMachineDB", parentLogger=parentLogger)
         result = self.__initializeDB()
         if not result["OK"]:
             raise Exception("Can't create tables: %s" % result["Message"])

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -43,22 +43,22 @@ class JobManagerHandlerMixin:
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
             if not result["OK"]:
                 return result
-            cls.jobDB = result["Value"]()
+            cls.jobDB = result["Value"](parentLogger=cls.log)
 
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobLoggingDB", "JobLoggingDB")
             if not result["OK"]:
                 return result
-            cls.jobLoggingDB = result["Value"]()
+            cls.jobLoggingDB = result["Value"](parentLogger=cls.log)
 
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.TaskQueueDB", "TaskQueueDB")
             if not result["OK"]:
                 return result
-            cls.taskQueueDB = result["Value"]()
+            cls.taskQueueDB = result["Value"](parentLogger=cls.log)
 
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.PilotAgentsDB", "PilotAgentsDB")
             if not result["OK"]:
                 return result
-            cls.pilotAgentsDB = result["Value"]()
+            cls.pilotAgentsDB = result["Value"](parentLogger=cls.log)
 
         except RuntimeError as excp:
             return S_ERROR("Can't connect to DB: %s" % excp)

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -70,7 +70,7 @@ class JobManagerHandlerMixin:
                 result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.PilotsLoggingDB", "PilotsLoggingDB")
                 if not result["OK"]:
                     return result
-                cls.pilotsLoggingDB = result["Value"]()
+                cls.pilotsLoggingDB = result["Value"](parentLogger=cls.log)
             except RuntimeError as excp:
                 return S_ERROR("Can't connect to DB: %s" % excp)
 

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -51,7 +51,7 @@ class JobMonitoringHandlerMixin:
                 )
                 if not result["OK"]:
                     return result
-                cls.elasticJobParametersDB = result["Value"]()
+                cls.elasticJobParametersDB = result["Value"](parentLogger=cls.log)
             except RuntimeError as excp:
                 return S_ERROR("Can't connect to DB: %s" % excp)
 

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -27,17 +27,17 @@ class JobMonitoringHandlerMixin:
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
             if not result["OK"]:
                 return result
-            cls.jobDB = result["Value"]()
+            cls.jobDB = result["Value"](parentLogger=cls.log)
 
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobLoggingDB", "JobLoggingDB")
             if not result["OK"]:
                 return result
-            cls.jobLoggingDB = result["Value"]()
+            cls.jobLoggingDB = result["Value"](parentLogger=cls.log)
 
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.TaskQueueDB", "TaskQueueDB")
             if not result["OK"]:
                 return result
-            cls.taskQueueDB = result["Value"]()
+            cls.taskQueueDB = result["Value"](parentLogger=cls.log)
 
         except RuntimeError as excp:
             return S_ERROR("Can't connect to DB: %s" % excp)

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -27,12 +27,12 @@ class JobStateUpdateHandlerMixin:
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
             if not result["OK"]:
                 return result
-            cls.jobDB = result["Value"]()
+            cls.jobDB = result["Value"](parentLogger=cls.log)
 
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobLoggingDB", "JobLoggingDB")
             if not result["OK"]:
                 return result
-            cls.jobLoggingDB = result["Value"]()
+            cls.jobLoggingDB = result["Value"](parentLogger=cls.log)
 
         except RuntimeError as excp:
             return S_ERROR("Can't connect to DB: %s" % excp)

--- a/src/DIRAC/WorkloadManagementSystem/Service/MatcherHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/MatcherHandler.py
@@ -22,22 +22,22 @@ class MatcherHandlerMixin:
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
             if not result["OK"]:
                 return result
-            cls.jobDB = result["Value"]()
+            cls.jobDB = result["Value"](parentLogger=cls.log)
 
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobLoggingDB", "JobLoggingDB")
             if not result["OK"]:
                 return result
-            cls.jobLoggingDB = result["Value"]()
+            cls.jobLoggingDB = result["Value"](parentLogger=cls.log)
 
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.TaskQueueDB", "TaskQueueDB")
             if not result["OK"]:
                 return result
-            cls.taskQueueDB = result["Value"]()
+            cls.taskQueueDB = result["Value"](parentLogger=cls.log)
 
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.PilotAgentsDB", "PilotAgentsDB")
             if not result["OK"]:
                 return result
-            cls.pilotAgentsDB = result["Value"]()
+            cls.pilotAgentsDB = result["Value"](parentLogger=cls.log)
 
         except RuntimeError as excp:
             return S_ERROR("Can't connect to DB: %s" % excp)

--- a/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -28,7 +28,7 @@ class PilotManagerHandler(RequestHandler):
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.PilotAgentsDB", "PilotAgentsDB")
             if not result["OK"]:
                 return result
-            cls.pilotAgentsDB = result["Value"]()
+            cls.pilotAgentsDB = result["Value"](parentLogger=cls.log)
 
         except RuntimeError as excp:
             return S_ERROR("Can't connect to DB: %s" % excp)
@@ -40,7 +40,7 @@ class PilotManagerHandler(RequestHandler):
                 result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.PilotsLoggingDB", "PilotsLoggingDB")
                 if not result["OK"]:
                     return result
-                cls.pilotsLoggingDB = result["Value"]()
+                cls.pilotsLoggingDB = result["Value"](parentLogger=cls.log)
             except RuntimeError as excp:
                 return S_ERROR("Can't connect to DB: %s" % excp)
 

--- a/src/DIRAC/WorkloadManagementSystem/Service/PilotsLoggingHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/PilotsLoggingHandler.py
@@ -25,7 +25,7 @@ class PilotsLoggingHandler(RequestHandler):
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.PilotsLoggingDB", "PilotsLoggingDB")
             if not result["OK"]:
                 return result
-            cls.pilotsLoggingDB = result["Value"]()
+            cls.pilotsLoggingDB = result["Value"](parentLogger=cls.log)
 
         except RuntimeError as excp:
             return S_ERROR("Can't connect to DB: %s" % excp)

--- a/src/DIRAC/WorkloadManagementSystem/Service/TornadoJobManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/TornadoJobManagerHandler.py
@@ -7,17 +7,11 @@
   :caption: JobManager options
 
 """
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.WorkloadManagementSystem.Service.JobManagerHandler import JobManagerHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoJobManagerHandler(JobManagerHandlerMixin, TornadoService):
-    log = sLog
-
     def initializeRequest(self):
         self.diracSetup = self.get_argument("clientSetup")
         return JobManagerHandlerMixin.initializeRequest(self)

--- a/src/DIRAC/WorkloadManagementSystem/Service/TornadoJobMonitoringHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/TornadoJobMonitoringHandler.py
@@ -7,13 +7,9 @@
   :caption: JobMonitoring options
 
 """
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.WorkloadManagementSystem.Service.JobMonitoringHandler import JobMonitoringHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoJobMonitoringHandler(JobMonitoringHandlerMixin, TornadoService):
-    log = sLog
+    pass

--- a/src/DIRAC/WorkloadManagementSystem/Service/TornadoJobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/TornadoJobStateUpdateHandler.py
@@ -7,13 +7,9 @@
   :caption: JobStateUpdate options
 
 """
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.WorkloadManagementSystem.Service.JobStateUpdateHandler import JobStateUpdateHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoJobStateUpdateHandler(JobStateUpdateHandlerMixin, TornadoService):
-    log = sLog
+    pass

--- a/src/DIRAC/WorkloadManagementSystem/Service/TornadoWMSAdministratorHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/TornadoWMSAdministratorHandler.py
@@ -7,13 +7,9 @@
   :caption: WMSAdministrator options
 
 """
-from DIRAC import gLogger
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.WorkloadManagementSystem.Service.WMSAdministratorHandler import WMSAdministratorHandlerMixin
 
 
-sLog = gLogger.getSubLogger(__name__)
-
-
 class TornadoWMSAdministratorHandler(WMSAdministratorHandlerMixin, TornadoService):
-    log = sLog
+    pass

--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -18,7 +18,7 @@ class WMSAdministratorHandlerMixin:
             result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
             if not result["OK"]:
                 return result
-            cls.jobDB = result["Value"]()
+            cls.jobDB = result["Value"](parentLogger=cls.log)
         except RuntimeError as excp:
             return S_ERROR(f"Can't connect to DB: {excp!r}")
 

--- a/tests/Integration/TornadoServices/DB/UserDB.py
+++ b/tests/Integration/TornadoServices/DB/UserDB.py
@@ -9,12 +9,12 @@ from DIRAC import gLogger, S_OK, S_ERROR
 class UserDB(DB):
     """Database system for users"""
 
-    def __init__(self):
+    def __init__(self, parentLogger=None):
         """
         Initialize the DB
         """
 
-        super(UserDB, self).__init__("UserDB", "Framework/UserDB")
+        super(UserDB, self).__init__("UserDB", "Framework/UserDB", parentLogger=parentLogger)
         retVal = self.__initializeDB()
         if not retVal["OK"]:
             raise Exception("Can't create tables: %s" % retVal["Message"])

--- a/tests/Integration/TornadoServices/Services/UserHandler.py
+++ b/tests/Integration/TornadoServices/Services/UserHandler.py
@@ -3,7 +3,7 @@
 """
 
 from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
-from DIRAC import S_OK, gLogger
+from DIRAC import S_OK
 
 # You need to copy ../DB/UserDB in DIRAC/FrameworkSystem/DB
 from DIRAC.FrameworkSystem.DB.UserDB import UserDB  # pylint: disable=no-name-in-module, import-error


### PR DESCRIPTION
One major difference between `dips` and `diset` is that every DISET service was running in it's own process. This mean that the global `gLogger` could be configured with the name of the service. 
With Tornado, the only global name that makes sense is `Tornado/Tornado`. But it is then very difficult to distinguish between the different services. 

In order to do that, every `TornadoService` now declare a class attribute `self.log`, and adds an extra option to the dictionary sent to the centralized logging: `tornadoComponent`.  (3e640c0022b44c0203e4a78c5a9d5202f070c4c4)

This allows to further split down the logs.

The problem is that this logger is only used in the service, and not in the DB classes. So in order to allow for that attribute to be propagated, the services now CAN pass their logger as a parent logger to the DB classes. (9e40bffad19623ce0699d3d33c714703d340643d)
Of course, there will always be some loggers instantiated here and there that will not have that attributes, but we will track them down little by little

All the other commits of that PR are just about using these two previous features everywhere

I first developed it and tested in in LHCb production setup for v7r3. Migrating it to `integration` was a major pain, due to all the tornado rewrite that happened (I tried turning a blind eyes on the many crazy things like https://github.com/DIRACGrid/DIRAC/blob/14956b316cb07d8abb1996d4268106cec338bf47/src/DIRAC/Core/Tornado/Server/HandlerManager.py#L125)


BEGINRELEASENOTES

*Core
NEW: TornadoBaseRequestHandler define a class logger with an extra attribute "tornadoComponent"
NEW: DIRACDB can now use a parentLogger instead of direct gLogger

*All
CHANGE: services propagate their local loggers to the DB
CHANGE: tornado services use local logger



ENDRELEASENOTES
