### PR TITLE
[v7r2] Fix utf-8 support in job output for python2

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -30,6 +30,8 @@ import json
 import distutils.spawn
 import six
 
+if six.PY2:
+    from codecs import open
 from six.moves.urllib.parse import unquote as urlunquote
 
 import DIRAC
@@ -1474,10 +1476,10 @@ class ExecutionThread(threading.Thread):
     #############################################################################
     def sendOutput(self, stdid, line):
         if stdid == 0 and self.stdout:
-            with open(self.stdout, "a+") as outputFile:
+            with open(self.stdout, "a+", encoding="utf-8", errors="backslashreplace") as outputFile:
                 print(line, file=outputFile)
         elif stdid == 1 and self.stderr:
-            with open(self.stderr, "a+") as errorFile:
+            with open(self.stderr, "a+", encoding="utf-8", errors="backslashreplace") as errorFile:
                 print(line, file=errorFile)
         self.outputLines.append(line)
         size = len(self.outputLines)


### PR DESCRIPTION
Fixes #5968.

BEGINRELEASENOTES

*WorkloadManagementSystem
FIX: utf-8 support in job output for python2

ENDRELEASENOTES
