### PR TITLE
[v7r2] Fix click version for black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,4 @@ repos:
     rev: 21.9b0
     hooks:
       - id: black
-        additional_dependencies: [".[python2]"]
+        additional_dependencies: [".[python2]", "click==8.0.4"]


### PR DESCRIPTION
Backport #5997 for `rel-v7r2`.