### PR TITLE
[v7r3] fix (wms): additional fixes for the PushJobAgent

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
@@ -74,22 +74,6 @@ class PushJobAgent(JobAgent):
         self.resourcesModule = res["Value"]
         self.opsHelper = Operations()
 
-        # Disable Watchdog: we don't need it as pre/post processing occurs locally
-        setup = gConfig.getValue("/DIRAC/Setup", "")
-        if not setup:
-            return S_ERROR("Cannot get the DIRAC Setup value")
-        wms_instance = getSystemInstance("WorkloadManagement")
-        if not wms_instance:
-            return S_ERROR("Cannot get the WorkloadManagement system instance")
-        section = "/Systems/WorkloadManagement/%s/JobWrapper" % wms_instance
-        self._updateConfiguration("CheckWallClockFlag", 0, path=section)
-        self._updateConfiguration("CheckDiskSpaceFlag", 0, path=section)
-        self._updateConfiguration("CheckLoadAvgFlag", 0, path=section)
-        self._updateConfiguration("CheckCPUConsumedFlag", 0, path=section)
-        self._updateConfiguration("CheckCPULimitFlag", 0, path=section)
-        self._updateConfiguration("CheckMemoryLimitFlag", 0, path=section)
-        self._updateConfiguration("CheckTimeLeftFlag", 0, path=section)
-
         return S_OK()
 
     def beginExecution(self):
@@ -198,13 +182,6 @@ class PushJobAgent(JobAgent):
                 # Information about number of processors might not be returned in CE.getCEStatus()
                 ceDict["NumberOfProcessors"] = ce.ceParameters.get("NumberOfProcessors")
                 self._setCEDict(ceDict)
-
-            # Update the configuration with the names of the Site, CE and queue to target
-            # This is used in the next stages
-            self._updateConfiguration("Site", queueDictionary["Site"])
-            self._updateConfiguration("GridCE", queueDictionary["CEName"])
-            self._updateConfiguration("CEQueue", queueDictionary["QueueName"])
-            self._updateConfiguration("RemoteExecution", True)
 
             # Try to match a job
             jobRequest = self._matchAJob(ceDictList)
@@ -406,6 +383,9 @@ class PushJobAgent(JobAgent):
         project = self.opsHelper.getValue("Pilot/Project", "")
         if project:
             ceDict["ReleaseProject"] = project
+
+        # Add a remoteExecution tag, which can be used in the next stages
+        ceDict["RemoteExecution"] = True
 
     def _checkMatchingIssues(self, jobRequest):
         """Check the source of the matching issue

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_PushJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_PushJobAgent.py
@@ -52,11 +52,11 @@ def test__allowedToSubmit(mocker, queue, failedQueues, failedQueueCycleFactor, e
 @pytest.mark.parametrize(
     "ceDict, pilotVersion, pilotProject, expected",
     [
-        ({}, None, None, {}),
-        ({}, "8.0.0", None, {"ReleaseVersion": "8.0.0"}),
-        ({}, ["8.0.0", "7.3.7"], None, {"ReleaseVersion": "8.0.0"}),
-        ({}, None, "Project", {"ReleaseProject": "Project"}),
-        ({}, "8.0.0", "Project", {"ReleaseVersion": "8.0.0", "ReleaseProject": "Project"}),
+        ({}, None, None, {"RemoteExecution": True}),
+        ({}, "8.0.0", None, {"ReleaseVersion": "8.0.0", "RemoteExecution": True}),
+        ({}, ["8.0.0", "7.3.7"], None, {"ReleaseVersion": "8.0.0", "RemoteExecution": True}),
+        ({}, None, "Project", {"ReleaseProject": "Project", "RemoteExecution": True}),
+        ({}, "8.0.0", "Project", {"ReleaseVersion": "8.0.0", "ReleaseProject": "Project", "RemoteExecution": True}),
     ],
 )
 def test__setCEDict(mocker, ceDict, pilotVersion, pilotProject, expected):

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -70,7 +70,32 @@ def test_performChecks():
 
 
 @pytest.mark.slow
-def test_execute(mocker):
+@pytest.mark.parametrize(
+    "executable, args, src, expectedResult",
+    [
+        ("/bin/ls", None, None, "Application Finished Successfully"),
+        (
+            "script-OK.sh",
+            None,
+            "src/DIRAC/WorkloadManagementSystem/JobWrapper/test/",
+            "Application Finished Successfully",
+        ),
+        ("script.sh", "111", "src/DIRAC/WorkloadManagementSystem/JobWrapper/test/", "Application Finished With Errors"),
+        ("script.sh", 111, "src/DIRAC/WorkloadManagementSystem/JobWrapper/test/", "Application Finished With Errors"),
+        ("script-RESC.sh", None, "src/DIRAC/WorkloadManagementSystem/JobWrapper/test/", "Going to reschedule job"),
+        (
+            "src/DIRAC/WorkloadManagementSystem/scripts/dirac_jobexec.py",
+            "src/DIRAC/WorkloadManagementSystem/JobWrapper/test/jobDescription.xml -o /DIRAC/Setup=Test",
+            None,
+            "Application Finished Successfully",
+        ),
+    ],
+)
+def test_execute(mocker, executable, args, src, expectedResult):
+    """Test the status of the job after JobWrapper.execute().
+
+    The returned value of JobWrapper.execute() is not checked as it can apparently be wrong depending on the shell used.
+    """
 
     mocker.patch(
         "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
@@ -79,41 +104,21 @@ def test_execute(mocker):
         "DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemInstance", side_effect=getSystemSectionMock
     )
 
-    jw = JobWrapper()
-    jw.jobArgs = {"Executable": "/bin/ls"}
-    res = jw.execute()
-    print("jw.execute() returns", str(res))
-    assert res["OK"]
+    if src:
+        shutil.copy(os.path.join(src, executable), executable)
 
-    shutil.copy("src/DIRAC/WorkloadManagementSystem/JobWrapper/test/script-OK.sh", "script-OK.sh")
     jw = JobWrapper()
-    jw.jobArgs = {"Executable": "script-OK.sh"}
+    jw.jobArgs = {"Executable": executable}
+    if args:
+        jw.jobArgs["Arguments"] = args
     res = jw.execute()
-    assert res["OK"]
-    os.remove("script-OK.sh")
+    assert expectedResult in jw.jobReport.jobStatusInfo[-1]
 
-    shutil.copy("src/DIRAC/WorkloadManagementSystem/JobWrapper/test/script.sh", "script.sh")
-    jw = JobWrapper()
-    jw.jobArgs = {"Executable": "script.sh", "Arguments": "111"}
-    res = jw.execute()
-    assert res["OK"]  # In this case the application finished with errors,
-    # but the JobWrapper executed successfully
-    os.remove("script.sh")
+    if src:
+        os.remove(executable)
 
-    # this will reschedule
-    shutil.copy("src/DIRAC/WorkloadManagementSystem/JobWrapper/test/script-RESC.sh", "script-RESC.sh")
-    jw = JobWrapper()
-    jw.jobArgs = {"Executable": "script-RESC.sh"}
-    res = jw.execute()
-    if res["OK"]:  # FIXME: This may happen depending on the shell - not the best test admittedly!
-        print("We should not be here, unless the 'Execution thread status' is equal to 1")
-        assert res["OK"]
-    else:
-        assert res["OK"] is False  # In this case the application finished with an error code
-        # that the JobWrapper interpreted as "to reschedule"
-        # so in this case the "execute" is considered an error
-    os.remove("script-RESC.sh")
-    os.remove("std.out")
+    if os.path.exists("std.out"):
+        os.remove("std.out")
 
 
 @pytest.mark.parametrize(

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/jobDescription.xml
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/jobDescription.xml
@@ -1,0 +1,58 @@
+<Workflow>
+<descr_short></descr_short>
+<description><![CDATA[]]></description>
+<name>List files</name>
+<origin></origin>
+<type></type>
+<version>0.0</version>
+<Parameter name="JobType" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="Job Type"><value><![CDATA[User]]></value></Parameter>
+<Parameter name="Priority" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="User Job Priority"><value><![CDATA[1]]></value></Parameter>
+<Parameter name="JobGroup" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="Name of the JobGroup"><value><![CDATA[dteam]]></value></Parameter>
+<Parameter name="JobName" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="User specified name"><value><![CDATA[helloWorldSSHBatch]]></value></Parameter>
+<Parameter name="StdOutput" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="Standard output file"><value><![CDATA[std.out]]></value></Parameter>
+<Parameter name="StdError" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="Standard error file"><value><![CDATA[std.err]]></value></Parameter>
+<Parameter name="InputData" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="Default null input data value"><value><![CDATA[]]></value></Parameter>
+<Parameter name="LogLevel" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="Job Logging Level"><value><![CDATA[INFO]]></value></Parameter>
+<Parameter name="arguments" type="string" linked_module="" linked_parameter="" in="True" out="False" description="Arguments to executable Step"><value><![CDATA[]]></value></Parameter>
+<Parameter name="ParametricInputData" type="string" linked_module="" linked_parameter="" in="True" out="False" description="Default null parametric input data value"><value><![CDATA[]]></value></Parameter>
+<Parameter name="ParametricInputSandbox" type="string" linked_module="" linked_parameter="" in="True" out="False" description="Default null parametric input sandbox value"><value><![CDATA[]]></value></Parameter>
+<Parameter name="CPUTime" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="CPU time in secs"><value><![CDATA[17800]]></value></Parameter>
+<Parameter name="InputSandbox" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="Input sandbox file list"><value><![CDATA[/tmp/cburr/CC7py3/v7.3/diracos/lib/python3.9/site-packages/DIRAC/tests/Workflow/Integration/exe-script.py]]></value></Parameter>
+<Parameter name="Site" type="JDL" linked_module="" linked_parameter="" in="True" out="False" description="User specified destination site"><value><![CDATA[DIRAC.Jenkins_SSHBatch.ch]]></value></Parameter>
+<ModuleDefinition>
+<body><![CDATA[
+from DIRAC.Workflow.Modules.Script import Script
+]]></body>
+<descr_short></descr_short>
+<description><![CDATA[ The Script class provides a simple way for users to specify an executable
+    or file to run (and is also a simple example of a workflow module).
+]]></description>
+<origin></origin>
+<required></required>
+<type>Script</type>
+<version>0.0</version>
+</ModuleDefinition>
+<StepDefinition>
+<descr_short></descr_short>
+<description><![CDATA[]]></description>
+<origin></origin>
+<type>ScriptStep1</type>
+<version>0.0</version>
+<Parameter name="executable" type="string" linked_module="" linked_parameter="" in="True" out="False" description="Executable Script"><value><![CDATA[]]></value></Parameter>
+<Parameter name="arguments" type="string" linked_module="" linked_parameter="" in="True" out="False" description="Arguments for executable Script"><value><![CDATA[]]></value></Parameter>
+<Parameter name="applicationLog" type="string" linked_module="" linked_parameter="" in="True" out="False" description="Log file name"><value><![CDATA[]]></value></Parameter>
+<ModuleInstance>
+<descr_short></descr_short>
+<name>Script</name>
+<type>Script</type>
+</ModuleInstance>
+</StepDefinition>
+<StepInstance>
+<descr_short></descr_short>
+<name>RunScriptStep1</name>
+<type>ScriptStep1</type>
+<Parameter name="executable" type="string" linked_module="" linked_parameter="" in="True" out="False" description="Executable Script"><value><![CDATA[/bin/ls]]></value></Parameter>
+<Parameter name="arguments" type="string" linked_module="" linked_parameter="" in="True" out="False" description="Arguments for executable Script"><value><![CDATA[]]></value></Parameter>
+<Parameter name="applicationLog" type="string" linked_module="" linked_parameter="" in="True" out="False" description="Log file name"><value><![CDATA[std.out]]></value></Parameter>
+</StepInstance>
+</Workflow>


### PR DESCRIPTION
Fixing some issues with `PushJobAgent`.
Instead of writing CE details in the DIRAC configuration (which was not ideal at all), passing parameters to the `dirac-jobexec`.

BEGINRELEASENOTES
*WorkloadManagement
FIX: pass CE parameters to dirac-jobexec instead of writing them in the configuration
ENDRELEASENOTES

One question:
At the end of a job execution, the `JobWrapper` submits a report to the `Accounting` service.
In this report, the `CPUTime` is field is wrong because the application was actually executed on a remote resource. (https://github.com/DIRACGrid/DIRAC/blob/integration/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py#L1242)
2 solutions:
- We assume `CPUTime` plots are wrong for sites associated with the `PushJobAgent`, we don't look at this information.
- We use the wallclock time instead of the `CPUTime` in this case, which might be a bit different but still provide valuable information. 

Any thought?