### PR TITLE
[sweep:integration] Allow rootPath override

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -50,6 +50,10 @@ DIRAC_M2CRYPTO_SSL_METHODS
 DIRAC_NO_CFG
   If set to anything, cfg files on the command line must be passed to the command using the --cfg option.
 
+DIRAC_ROOT_PATH
+  If set, overwrites the value of DIRAC.rootPath.
+  Useful for using a non-standard location for `etc/dirac.cfg`, `runit/`, `startup/`, etc.
+
 DIRACSYSCONFIG
   If set, its value should be (the full locations on the file system of) one of more DIRAC cfg file(s) (comma separated), whose content will be used for the DIRAC configuration
   (see :ref:`dirac-cs-structure`)

--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -149,6 +149,8 @@ def _computeRootPath(rootPath):
 
 # Set rootPath of DIRAC installation
 rootPath = _computeRootPath(sys.base_prefix)
+if "DIRAC_ROOT_PATH" in os.environ:
+    rootPath = os.environ["DIRAC_ROOT_PATH"]
 
 # Import DIRAC.Core.Utils modules
 


### PR DESCRIPTION
Sweep #6011 `Allow rootPath override` to `integration`.

Adding original author @sfayer as watcher.

BEGINRELEASENOTES
*Core
FIX: Allow rootPath to be overridden with DIRAC_ROOT_PATH  environment variable
ENDRELEASENOTES
Closes #6030