### PR TITLE
[sweep:integration] Fix previous fix in RMS

### DIFF
--- a/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_request.py
+++ b/src/DIRAC/RequestManagementSystem/scripts/dirac_rms_request.py
@@ -8,6 +8,7 @@ from DIRAC.Core.Base.Script import Script
 
 
 def convertDate(date):
+    """Get the date of 24 hours ago"""
     try:
         value = datetime.datetime.strptime(date, "%Y-%m-%d")
         return value
@@ -25,6 +26,9 @@ def convertDate(date):
 
 @Script()
 def main():
+    """
+    Main executive code
+    """
     Script.registerSwitch("", "Job=", "   JobID[,jobID2,...]")
     Script.registerSwitch("", "Transformation=", "   transformation ID")
     Script.registerSwitch("", "Tasks=", "      Associated to --Transformation, list of taskIDs")
@@ -167,7 +171,7 @@ def main():
     elif not jobs:
         requests = []
         # Get full list of arguments, with and without comma
-        for arg in [x.strip() for arg in Script.getPositionalArgs() for x in arg.split(",")]:
+        for arg in [x.strip() for ar in Script.getPositionalArgs() for x in ar.split(",")]:
             if os.path.exists(arg):
                 lines = open(arg, "r").readlines()
                 requests += [reqID.strip() for line in lines for reqID in line.split(",")]
@@ -201,7 +205,6 @@ def main():
         gLogger.notice("No request selected....")
         Script.showHelp(exitCode=2)
     okRequests = []
-    warningPrinted = False
     jobIDList = []
     for reqID in requests:
         # We allow reqID to be the requestName if it is unique
@@ -209,7 +212,8 @@ def main():
             # PEP-515 allows for underscore in numerical literals
             # So a request name 00123_00456
             # is interpreted as a requestID 12300456
-            if not reqID.isdigit():
+            # Using an exception here for non-string is not an option
+            if isinstance(reqID, str) and not reqID.isdigit():
                 raise ValueError()
 
             requestID = int(reqID)


### PR DESCRIPTION
Sweep #6020 `Fix previous fix in RMS` to `integration`.

Adding original author @phicharp as watcher.

BEGINRELEASENOTES

* RMS

FIX: if the request ID is an integer the test `is digit()` throws an exception


ENDRELEASENOTES
Closes #6024