### PR TITLE
[sweep:integration] fix: use correct environment for condor_rm

### DIFF
--- a/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -191,9 +191,11 @@ def test_killJob(setUp, mocker, jobIDList, jobID, ret, success, local):
     htce.ceParameters = ceParameters
     htce._reset()
 
-    commandsMock = mocker.patch(MODNAME + ".commands.getstatusoutput", return_value=(ret, ""))
-    ret = htce.killJob(jobIDList=jobIDList)
+    execMock = mocker.patch(MODNAME + ".executeGridCommand", return_value=S_OK((ret, "", "")))
+    with execMock:
+        ret = htce.killJob(jobIDList=jobIDList)
 
     assert ret["OK"] == success
     if jobID:
-        commandsMock.assert_called_with("condor_rm %s %s" % (htce.remoteScheddOptions, jobID))
+        expected = "condor_rm %s %s" % (htce.remoteScheddOptions.strip(), jobID)
+        assert " ".join(execMock.call_args_list[0][0][1]) == expected


### PR DESCRIPTION
Sweep #6013 `fix: use correct environment for condor_rm` to `integration`.

Adding original author @marianne013 as watcher.

BEGINRELEASENOTES

*Resources
FIX: HTCondorCE: make sure proxy is available when running condor_rm

ENDRELEASENOTES
Closes #6036