### PR TITLE
[integration] Downloading job sandboxes from the web

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -942,7 +942,7 @@ class BaseRequestHandler(RequestHandler):
             self.finish(self.__result)
 
         # Return simple text or html
-        elif isinstance(self.__result, str):
+        elif isinstance(self.__result, (str, bytes)):
             self.finish(self.__result)
 
         # JSON


### PR DESCRIPTION
The WebApp assumes Tornado will return the binary content from the sandbox store:

https://github.com/DIRACGrid/WebAppDIRAC/blob/26565c2c4d6368971971757127a0b56581fa7bbd/src/WebAppDIRAC/WebApp/handler/JobMonitorHandler.py#L473-L480

BEGINRELEASENOTES

*Web
FIX: Fix downloading sandboxes from the Job Manager in the WebApp

ENDRELEASENOTES
