### PR TITLE
[v7r3] Fixerrormess

### DIFF
--- a/src/DIRAC/Core/Utilities/DErrno.py
+++ b/src/DIRAC/Core/Utilities/DErrno.py
@@ -121,6 +121,7 @@ EWMSSUBM = 1503
 EWMSJMAN = 1504
 EWMSSTATUS = 1505
 EWMSNOMATCH = 1510
+EWMSPLTVER = 1511
 EWMSNOPILOT = 1550
 
 # ## DMS/StorageManagement (16XX)
@@ -197,6 +198,7 @@ dErrorCode = {
     1504: "EWMSJMAN",
     1505: "EWMSSTATUS",
     1510: "EWMSNOMATCH",
+    1511: "EWMSPLTVER",
     1550: "EWMSNOPILOT",
     # DMS/StorageManagement
     1601: "EFILESIZE",
@@ -269,6 +271,7 @@ dStrError = {  # Generic (10XX)
     EWMSJMAN: "Job management error",
     EWMSSTATUS: "Job status error",
     EWMSNOPILOT: "No pilots found",
+    EWMSPLTVER: "Pilot version does not match",
     EWMSNOMATCH: "No match found",
     # DMS/StorageManagement
     EFILESIZE: "Bad file size",

--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -559,10 +559,8 @@ class JobAgent(AgentModule):
         :param dict jobRequest: S_ERROR returned by the matcher
         :return: S_OK/S_ERROR
         """
-
-        if jobRequest["Message"].find("Pilot version does not match") != -1:
-            errorMsg = "Pilot version does not match the production version"
-            self.log.error(errorMsg, jobRequest["Message"].replace(errorMsg, ""))
+        if DErrno.cmpError(jobRequest, DErrno.EWMSPLTVER):
+            self.log.error("Pilot version mismatch", jobRequest["Message"])
             return jobRequest
 
         if DErrno.cmpError(jobRequest, DErrno.EWMSNOMATCH):

--- a/src/DIRAC/WorkloadManagementSystem/Service/MatcherHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/MatcherHandler.py
@@ -89,7 +89,7 @@ class MatcherHandlerMixin(object):
             return S_ERROR("Error requesting job")
         except PilotVersionError as pve:
             self.log.warn("Pilot version error for pilot", "[%s] %s" % (pilotRef, pve))
-            return S_ERROR("Error requesting job")
+            return S_ERROR(DErrno.EWMSPLTVER, callStack=[])
 
         # result can be empty, meaning that no job matched
         if result:


### PR DESCRIPTION
This is to address the problem with the non-matching pilot version that I found in the hackathon for v8.0.0a20.

BEGINRELEASENOTES

*WorkloadManagement
FIX: In case of a pilot version not matching the production version, the JobAgent expects the error message to contain the words "Pilot version does not match", so the error message was updated accordingly.

ENDRELEASENOTES
