### PR TITLE
[v7r2] fix(resources): string format for future in PoolCE

### DIFF
--- a/src/DIRAC/Resources/Computing/PoolComputingElement.py
+++ b/src/DIRAC/Resources/Computing/PoolComputingElement.py
@@ -208,7 +208,7 @@ class PoolComputingElement(ComputingElement):
         if result["OK"]:
             self.log.info("Task %s finished successfully, %d processor(s) freed" % (future, nProc))
         else:
-            self.log.error("Task failed submission", "%d, message: %s" % (future, result["Message"]))
+            self.log.error("Task failed submission", "%s, message: %s" % (future, result["Message"]))
         self.taskResults[future] = result
 
     def getCEStatus(self):


### PR DESCRIPTION
Very small issue in `PoolComputingElement.finalizeJob()`, which can hide the actual error:

```python
self.log.error("Task failed submission", "%d, message: %s" % (future, result["Message"]))\n'b'TypeError: %d format: a number is required, not Future\n'
```

BEGINRELEASENOTES
*Resources
FIX: string format for future in PoolCE
ENDRELEASENOTES
