### PR TITLE
[v7r3]fix(wms): DIRACBenchmark client typeError

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/DIRACbenchmark.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/DIRACbenchmark.py
@@ -136,7 +136,7 @@ def multipleDiracBenchmark(copies=1, iterations=1, extraIteration=False):
         "sum": sum(raw),
         "arithmetic_mean": sum(raw) / copies,
         "geometric_mean": product ** (1.0 / copies),
-        "median": raw[(copies - 1) / 2],
+        "median": raw[(copies - 1) // 2],
     }
 
 


### PR DESCRIPTION
Will resolve the following issue (affecting python2 installations): https://github.com/DIRACGrid/DIRAC/issues/6053

BEGINRELEASENOTES
*WorkloadManagement
FIX: DIRACBenchmark client TypeError
ENDRELEASENOTES
