### PR TITLE
[8.0] feat (SRM): allow SRM+HTTPs as default

### DIFF
--- a/src/DIRAC/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_SRM2Storage.py
@@ -23,8 +23,8 @@ from DIRAC.Resources.Storage.Utilities import checkArgumentFormat
 class GFAL2_SRM2Storage(GFAL2_StorageBase):
     """SRM2 SE class that inherits from GFAL2StorageBase"""
 
-    _INPUT_PROTOCOLS = ["file", "root", "srm", "gsiftp"]
-    _OUTPUT_PROTOCOLS = ["file", "root", "dcap", "gsidcap", "rfio", "srm", "gsiftp"]
+    _INPUT_PROTOCOLS = ["file", "root", "srm", "gsiftp", "https"]
+    _OUTPUT_PROTOCOLS = ["file", "root", "dcap", "gsidcap", "rfio", "srm", "gsiftp", "https"]
 
     def __init__(self, storageName, parameters):
         """ """


### PR DESCRIPTION
By the time 8.0 is out, I suspect most sites will have it working. In the case of LHCb, all sites have it, and it runs fine.
As soon as it is merged, I will add a note in the wiki to describe the change

@iueda this is probably of interest to you

BEGINRELEASENOTES
*Resources
NEW: add SRM+HTTPs as a default TPC protocol in SRM

ENDRELEASENOTES
