### PR TITLE
[Integration] refactor: removing unused parameter form getSubLogger and improving l…

### DIFF
--- a/src/DIRAC/AccountingSystem/Agent/NetworkAgent.py
+++ b/src/DIRAC/AccountingSystem/Agent/NetworkAgent.py
@@ -30,7 +30,7 @@ class NetworkAgent(AgentModule):
 
     def initialize(self):
 
-        self.log = gLogger.getSubLogger("NetworkAgent")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         # API initialization is required to get an up-to-date configuration from the CS
         self.csAPI = CSAPI()

--- a/src/DIRAC/AccountingSystem/DB/MultiAccountingDB.py
+++ b/src/DIRAC/AccountingSystem/DB/MultiAccountingDB.py
@@ -11,7 +11,7 @@ class MultiAccountingDB(object):
         self.__readOnly = readOnly
         self.__dbByType = {}
         self.__defaultDB = "AccountingDB/AccountingDB"
-        self.__log = gLogger.getSubLogger("MultiAccDB")
+        self.__log = gLogger.getSubLogger(self.__class__.__name__)
         self.__generateDBs()
         self.__registerMethods()
 

--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -138,7 +138,7 @@ class VOMS2CSSynchronizer(object):
         :return: None
         """
 
-        self.log = gLogger.getSubLogger("VOMS2CSSynchronizer")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.csapi = CSAPI()
         self.vo = vo
         self.vomsVOName = getVOOption(vo, "VOMSName", "")

--- a/src/DIRAC/Core/Base/AgentModule.py
+++ b/src/DIRAC/Core/Base/AgentModule.py
@@ -98,7 +98,7 @@ class AgentModule:
         the configuration Option 'shifterProxy' must be set, a default may be given
         in the initialize() method.
         """
-        self.log = gLogger.getSubLogger(agentName, child=False)
+        self.log = gLogger.getSubLogger(agentName)
 
         self.__basePath = gConfig.getValue("/LocalSite/InstancePath", rootPath)
         self.__agentModule = None

--- a/src/DIRAC/Core/Base/ExecutorModule.py
+++ b/src/DIRAC/Core/Base/ExecutorModule.py
@@ -39,7 +39,7 @@ class ExecutorModule:
         cls.__mindExtraArgs = False
         cls.__freezeTime = 0
         cls.__fastTrackEnabled = True
-        cls.log = gLogger.getSubLogger(exeName, child=False)
+        cls.log = gLogger.getSubLogger(exeName)
 
         try:
             result = cls.initialize()  # pylint: disable=no-member

--- a/src/DIRAC/Core/DISET/private/FileHelper.py
+++ b/src/DIRAC/Core/DISET/private/FileHelper.py
@@ -12,8 +12,6 @@ from DIRAC.FrameworkSystem.Client.Logger import gLogger
 
 file_types = (io.IOBase,)
 
-gLogger = gLogger.getSubLogger("FileTransmissionHelper")
-
 
 class FileHelper(object):
 
@@ -29,7 +27,7 @@ class FileHelper(object):
         self.direction = False
         self.packetSize = 1048576
         self.__fileBytes = 0
-        self.__log = gLogger.getSubLogger("FileHelper")
+        self.__log = gLogger.getSubLogger(self.__class__.__name__)
 
     def disableCheckSum(self):
         self.__checkMD5 = False

--- a/src/DIRAC/Core/DISET/private/MessageBroker.py
+++ b/src/DIRAC/Core/DISET/private/MessageBroker.py
@@ -31,7 +31,7 @@ class MessageBroker(object):
         self.__callbacksLock = threading.Condition()
         self.__trInOutLock = threading.Lock()
         self.__msgFactory = MessageFactory()
-        self.__log = gLogger.getSubLogger("MSGBRK")
+        self.__log = gLogger.getSubLogger(self.__class__.__name__)
         if not transportPool:
             transportPool = getGlobalTransportPool()
         self.__trPool = transportPool

--- a/src/DIRAC/Core/Utilities/Devloader.py
+++ b/src/DIRAC/Core/Utilities/Devloader.py
@@ -12,7 +12,7 @@ from DIRAC.Core.Utilities.DIRACSingleton import DIRACSingleton
 
 class Devloader(metaclass=DIRACSingleton):
     def __init__(self):
-        self.__log = gLogger.getSubLogger("Devloader")
+        self.__log = gLogger.getSubLogger(self.__class__.__name__)
         self.__reloaded = False
         self.__enabled = True
         self.__reloadTask = False

--- a/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
+++ b/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
@@ -303,7 +303,7 @@ class ExecutorDispatcher(object):
         self.__tasksLock = threading.Lock()
         self.__freezerLock = threading.Lock()
         self.__tasks = {}
-        self.__log = gLogger.getSubLogger("ExecMind")
+        self.__log = gLogger.getSubLogger(self.__class__.__name__)
         self.__taskFreezer = []
         self.__queues = ExecutorQueues(self.__log)
         self.__states = ExecutorState(self.__log)

--- a/src/DIRAC/Core/Utilities/MJF.py
+++ b/src/DIRAC/Core/Utilities/MJF.py
@@ -39,7 +39,7 @@ class MJF(object):
     #############################################################################
     def __init__(self):
         """Standard constructor"""
-        self.log = gLogger.getSubLogger("MJF")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         capath = DIRAC.Core.Security.Locations.getCAsLocation()
 

--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -379,7 +379,7 @@ class MySQL(object):
         self._connected = False
 
         if "log" not in dir(self):
-            self.log = gLogger.getSubLogger("MySQL")
+            self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.logger = self.log
 
         # let the derived class decide what to do with if is not 1

--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -153,7 +153,7 @@ class Subprocess(object):
         :param int timeout: timeout in seconds
         :param int bufferLimit: buffer size, default 5MB
         """
-        self.log = gLogger.getSubLogger("Subprocess")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.timeout = False
         try:
             self.changeTimeout(timeout)

--- a/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
+++ b/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
@@ -284,9 +284,7 @@ class FTS3Job(JSerializable):
         :return: S_OK( (job object, list of ftsFileIDs in the job))
         """
 
-        log = gLogger.getSubLogger(
-            "constructTransferJob/%s/%s_%s" % (self.operationID, self.sourceSE, self.targetSE), True
-        )
+        log = gLogger.getSubLogger(f"constructTransferJob/{self.operationID}/{self.sourceSE}_{self.targetSE}")
 
         isMultiHop = False
 
@@ -568,7 +566,7 @@ class FTS3Job(JSerializable):
         :return: S_OK( (job object, list of ftsFileIDs in the job))
         """
 
-        log = gLogger.getSubLogger("constructStagingJob/%s/%s" % (self.operationID, self.targetSE), True)
+        log = gLogger.getSubLogger(f"constructStagingJob/{self.operationID}/{self.targetSE}")
 
         transfers = []
         fileIDsInTheJob = set()

--- a/src/DIRAC/DataManagementSystem/Client/FailoverTransfer.py
+++ b/src/DIRAC/DataManagementSystem/Client/FailoverTransfer.py
@@ -43,7 +43,7 @@ class FailoverTransfer(object):
         """
         self.log = log
         if not self.log:
-            self.log = gLogger.getSubLogger("FailoverTransfer")
+            self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         self.request = requestObject
         if not self.request:

--- a/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
@@ -191,7 +191,7 @@ class FTS3DB(object):
         if not parentLogger:
             parentLogger = gLogger
 
-        self.log = parentLogger.getSubLogger("FTS3DB")
+        self.log = parentLogger.getSubLogger(self.__class__.__name__)
 
         if not url:
             # Initialize the connection info

--- a/src/DIRAC/DataManagementSystem/private/FTS3Utilities.py
+++ b/src/DIRAC/DataManagementSystem/private/FTS3Utilities.py
@@ -130,7 +130,7 @@ class FTS3ServerPolicy(object):
         Call the init of the parent, and initialize the list of FTS3 servers
         """
 
-        self.log = gLogger.getSubLogger("FTS3ServerPolicy")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         self._serverDict = serverDict
         self._serverList = list(serverDict)

--- a/src/DIRAC/FrameworkSystem/Client/BundleDeliveryClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/BundleDeliveryClient.py
@@ -30,7 +30,7 @@ class BundleDeliveryClient(Client):
         super(BundleDeliveryClient, self).__init__(**kwargs)
         self.setServer("Framework/BundleDelivery")
         self.transferClient = transferClient
-        self.log = gLogger.getSubLogger("BundleDelivery")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
     def __getTransferClient(self):
         """Get transfer client

--- a/src/DIRAC/FrameworkSystem/Client/NotificationClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/NotificationClient.py
@@ -13,7 +13,7 @@ class NotificationClient(Client):
         """Notification Client constructor"""
         super(NotificationClient, self).__init__(**kwargs)
 
-        self.log = gLogger.getSubLogger("NotificationClient")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.setServer("Framework/Notification")
 
     def sendMail(self, addresses, subject, body, fromAddress=None, localAttempt=True, html=False):

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Logging.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Logging.py
@@ -436,7 +436,7 @@ class Logging(object):
         """
         return self.debug("")
 
-    def getSubLogger(self, subName, child=True):
+    def getSubLogger(self, subName):
         """
         Create a new Logging object, child of this Logging, if it does not exists.
 
@@ -446,7 +446,7 @@ class Logging(object):
 
         :param str subName: name of the child Logging
         """
-        _ = child  # make pylint happy
+
         # lock to prevent that the method initializes two Logging for the same 'logging' logger
         # and to erase the existing _children[subName]
         self._lockInit.acquire()

--- a/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
+++ b/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
@@ -12,7 +12,7 @@ from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
 from DIRAC.AccountingSystem.Client.Types.DataOperation import DataOperation
 from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
 
-sLog = gLogger.getSubLogger("__name__")
+sLog = gLogger.getSubLogger(__name__)
 
 
 class DataOperationSender:

--- a/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
+++ b/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
@@ -209,8 +209,8 @@ class RequestDB(object):
 
         if not parentLogger:
             parentLogger = gLogger
+        self.log = parentLogger.getSubLogger(self.__class__.__name__)
 
-        self.log = parentLogger.getSubLogger("RequestDB")
         # Initialize the connection info
         self.__getDBConnectionInfo("RequestManagement/ReqDB")
 

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/PDP.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/PDP.py
@@ -40,7 +40,7 @@ class PDP:
         # RSS State Machine, used to calculate most penalizing state while merging them
         self.rssMachine = RSSMachine("Unknown")
 
-        self.log = gLogger.getSubLogger("PDP")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
     def setup(self, decisionParams=None):
         """method that sanitizes the decisionParams and ensures that at least it has
@@ -83,10 +83,10 @@ class PDP:
         if decisionParams is not None:
             standardParamsDict.update(decisionParams)
             if standardParamsDict["element"] is not None:
-                self.log = gLogger.getSubLogger("PDP/%s" % standardParamsDict["element"])
+                self.log = gLogger.getSubLogger(f"{self.__class__.__name__}/{standardParamsDict['element']}")
                 if standardParamsDict["name"] is not None:
                     self.log = gLogger.getSubLogger(
-                        "PDP/%s/%s" % (standardParamsDict["element"], standardParamsDict["name"])
+                        f"{self.__class__.__name__}/{standardParamsDict['element']}/{standardParamsDict['name']}"
                     )
                     self.log.verbose(
                         "Setup - statusType: %s, status: %s"

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/PEP.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/PEP.py
@@ -107,10 +107,10 @@ class PEP:
         standardParamsDict.update(decisionParams)
 
         if standardParamsDict["element"] is not None:
-            self.log = gLogger.getSubLogger("PEP/%s" % standardParamsDict["element"])
+            self.log = gLogger.getSubLogger(f"{self.__class__.__name__}/{standardParamsDict['element']}")
             if standardParamsDict["name"] is not None:
                 self.log = gLogger.getSubLogger(
-                    "PEP/%s/%s" % (standardParamsDict["element"], standardParamsDict["name"])
+                    f"{self.__class__.__name__}/{standardParamsDict['element']}/{standardParamsDict['name']}"
                 )
                 self.log.verbose(
                     "Enforce - statusType: %s, status: %s"

--- a/src/DIRAC/Resources/Catalog/FCConditionParser.py
+++ b/src/DIRAC/Resources/Catalog/FCConditionParser.py
@@ -197,7 +197,7 @@ class FCConditionParser(object):
 
         self.ro_methods = ro_methods if ro_methods else []
 
-        self.log = gLogger.getSubLogger("FCConditionParser")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
     def __evaluateCondition(self, conditionString, **kwargs):
         """Evaluate a condition against attributes, typically lfn.

--- a/src/DIRAC/Resources/Catalog/FileCatalog.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalog.py
@@ -69,7 +69,7 @@ class FileCatalog(object):
         self.writeCatalogs = []
         self.rootConfigPath = "/Resources/FileCatalogs"
         self.vo = vo if vo else getVOfromProxyGroup().get("Value", None)
-        self.log = gLogger.getSubLogger("FileCatalog")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         self.opHelper = Operations(vo=self.vo)
 

--- a/src/DIRAC/Resources/Catalog/FileCatalogFactory.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalogFactory.py
@@ -11,7 +11,7 @@ class FileCatalogFactory(object):
     """Factory of file catalog objects. Only exposes createCatalog() method"""
 
     def __init__(self):
-        self.log = gLogger.getSubLogger("FileCatalogFactory")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.catalogPath = ""
 
     def createCatalog(self, catalogName, useProxy=False):

--- a/src/DIRAC/Resources/Cloud/CloudEndpoint.py
+++ b/src/DIRAC/Resources/Cloud/CloudEndpoint.py
@@ -26,7 +26,7 @@ class CloudEndpoint(Endpoint):
     def __init__(self, parameters=None):
         super(CloudEndpoint, self).__init__(parameters=parameters)
         # logger
-        self.log = gLogger.getSubLogger("CloudEndpoint")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.valid = False
         result = self.initialize()
         if result["OK"]:

--- a/src/DIRAC/Resources/Cloud/EC2Endpoint.py
+++ b/src/DIRAC/Resources/Cloud/EC2Endpoint.py
@@ -14,7 +14,7 @@ class EC2Endpoint(Endpoint):
     def __init__(self, parameters=None):
         super(EC2Endpoint, self).__init__(parameters=parameters)
         # logger
-        self.log = gLogger.getSubLogger("EC2Endpoint")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.valid = False
         result = self.initialize()
         if result["OK"]:

--- a/src/DIRAC/Resources/Cloud/EndpointFactory.py
+++ b/src/DIRAC/Resources/Cloud/EndpointFactory.py
@@ -8,7 +8,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getVMTypeConfig
 class EndpointFactory(object):
     def __init__(self):
         """Standard constructor"""
-        self.log = gLogger.getSubLogger("EndpointFactory")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
     def getCE(self, site, endpoint, image=""):
 

--- a/src/DIRAC/Resources/Cloud/KeystoneClient.py
+++ b/src/DIRAC/Resources/Cloud/KeystoneClient.py
@@ -8,7 +8,7 @@ from DIRAC.Core.Utilities.Time import fromString, dateTime
 
 class KeystoneClient(object):
     def __init__(self, url, parameters):
-        self.log = gLogger.getSubLogger("Keystone")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.url = url
         self.apiVersion = None
         if "v3" in url:

--- a/src/DIRAC/Resources/Cloud/OcciEndpoint.py
+++ b/src/DIRAC/Resources/Cloud/OcciEndpoint.py
@@ -23,7 +23,7 @@ class OcciEndpoint(Endpoint):
     def __init__(self, parameters=None):
         super(OcciEndpoint, self).__init__(parameters=parameters)
         # logger
-        self.log = gLogger.getSubLogger("OcciEndpoint")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.valid = False
         self.vmType = self.parameters.get("VMType")
         self.site = self.parameters.get("Site")

--- a/src/DIRAC/Resources/Cloud/OpenNebulaEndpoint.py
+++ b/src/DIRAC/Resources/Cloud/OpenNebulaEndpoint.py
@@ -32,7 +32,7 @@ class OpenNebulaEndpoint(Endpoint):
         self.bootstrapParameters["HostCert"] = self.parameters["HostCert"]
         self.bootstrapParameters["HostKey"] = self.parameters["HostKey"]
 
-        self.log = gLogger.getSubLogger("OpenNebulaEndpoint")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         self.valid = False
         self.vmType = self.parameters.get("VMType")

--- a/src/DIRAC/Resources/Cloud/OpenStackEndpoint.py
+++ b/src/DIRAC/Resources/Cloud/OpenStackEndpoint.py
@@ -21,7 +21,7 @@ class OpenStackEndpoint(Endpoint):
     def __init__(self, parameters=None, bootstrapParameters=None):
         super(OpenStackEndpoint, self).__init__(parameters=parameters, bootstrapParameters=bootstrapParameters)
         # logger
-        self.log = gLogger.getSubLogger("OpenStackEndpoint")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.ks = None
         self.flavors = {}
         self.images = {}

--- a/src/DIRAC/Resources/Cloud/RocciEndpoint.py
+++ b/src/DIRAC/Resources/Cloud/RocciEndpoint.py
@@ -15,7 +15,7 @@ class RocciEndpoint(Endpoint):
     def __init__(self, parameters=None):
         super(RocciEndpoint, self).__init__(parameters=parameters)
         # logger
-        self.log = gLogger.getSubLogger("RocciEndpoint")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.valid = False
         result = self.initialize()
         if result["OK"]:

--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
@@ -23,7 +23,7 @@ class TimeLeft(object):
 
     def __init__(self):
         """Standard constructor"""
-        self.log = gLogger.getSubLogger("TimeLeft")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         self.cpuPower = gConfig.getValue("/LocalSite/CPUNormalizationFactor", 0.0)
         if not self.cpuPower:

--- a/src/DIRAC/Resources/Computing/ComputingElementFactory.py
+++ b/src/DIRAC/Resources/Computing/ComputingElementFactory.py
@@ -17,7 +17,7 @@ class ComputingElementFactory(object):
     def __init__(self, ceType=""):
         """Standard constructor"""
         self.ceType = ceType
-        self.log = gLogger.getSubLogger("ComputingElementFactory")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
     #############################################################################
     def getCE(self, ceType="", ceName="", ceParametersDict={}):

--- a/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
+++ b/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
@@ -21,7 +21,7 @@ gCacheMetadata = ThreadSafe.Synchronizer()
 class IdProviderFactory(object):
     def __init__(self):
         """Standard constructor"""
-        self.log = gLogger.getSubLogger("IdProviderFactory")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.cacheMetadata = DictCache()
 
     @gCacheMetadata

--- a/src/DIRAC/Resources/Storage/DIPStorage.py
+++ b/src/DIRAC/Resources/Storage/DIPStorage.py
@@ -32,7 +32,7 @@ class DIPStorage(StorageBase):
         StorageBase.__init__(self, storageName, parameters)
         self.pluginName = "DIP"
 
-        self.log = gLogger.getSubLogger("DIPStorage")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         # Several ports can be specified as comma separated list, choose
         # randomly one of those ports

--- a/src/DIRAC/Resources/Storage/EchoStorage.py
+++ b/src/DIRAC/Resources/Storage/EchoStorage.py
@@ -71,7 +71,7 @@ class EchoStorage(GFAL2_StorageBase):
         super(EchoStorage, self).__init__(storageName, parameters)
         self.srmSpecificParse = False
 
-        self.log = gLogger.getSubLogger("EchoStorage")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         self.pluginName = "Echo"
 

--- a/src/DIRAC/Resources/Storage/FileStorage.py
+++ b/src/DIRAC/Resources/Storage/FileStorage.py
@@ -29,7 +29,7 @@ class FileStorage(StorageBase):
 
         # # init base class
         StorageBase.__init__(self, storageName, parameters)
-        self.log = gLogger.getSubLogger("FileStorage")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         #     self.log.setLevel( "DEBUG" )
 
         self.pluginName = "File"

--- a/src/DIRAC/Resources/Storage/GFAL2_GSIFTPStorage.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_GSIFTPStorage.py
@@ -21,7 +21,7 @@ class GFAL2_GSIFTPStorage(GFAL2_StorageBase):
         super(GFAL2_GSIFTPStorage, self).__init__(storageName, parameters)
         self.srmSpecificParse = False
 
-        self.log = gLogger.getSubLogger("GFAL2_GSIFTPStorage")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         self.pluginName = "GFAL2_GSIFTP"
 

--- a/src/DIRAC/Resources/Storage/GFAL2_HTTPSStorage.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_HTTPSStorage.py
@@ -21,7 +21,7 @@ class GFAL2_HTTPSStorage(GFAL2_StorageBase):
         super(GFAL2_HTTPSStorage, self).__init__(storageName, parameters)
         self.srmSpecificParse = False
 
-        self.log = gLogger.getSubLogger("GFAL2_HTTPSStorage")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         self.pluginName = "GFAL2_HTTPS"
 

--- a/src/DIRAC/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_SRM2Storage.py
@@ -29,7 +29,7 @@ class GFAL2_SRM2Storage(GFAL2_StorageBase):
     def __init__(self, storageName, parameters):
         """ """
         super(GFAL2_SRM2Storage, self).__init__(storageName, parameters)
-        self.log = gLogger.getSubLogger("GFAL2_SRM2Storage")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.log.debug("GFAL2_SRM2Storage.__init__: Initializing object")
         self.pluginName = "GFAL2_SRM2"
 

--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -62,7 +62,7 @@ class GFAL2_StorageBase(StorageBase):
 
         StorageBase.__init__(self, storageName, parameters)
 
-        self.log = gLogger.getSubLogger("GFAL2_StorageBase")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         # Some storages have problem to compute the checksum with xroot while getting the files
         # This allows to disable the checksum calculation while transferring, and then we compare the

--- a/src/DIRAC/TransformationSystem/Client/RequestTasks.py
+++ b/src/DIRAC/TransformationSystem/Client/RequestTasks.py
@@ -49,7 +49,7 @@ class RequestTasks(TaskBase):
         """
 
         if not logger:
-            logger = gLogger.getSubLogger("RequestTasks")
+            logger = gLogger.getSubLogger(self.__class__.__name__)
 
         super(RequestTasks, self).__init__(transClient, logger)
         useCertificates = True if (bool(ownerDN) and bool(ownerGroup)) else False

--- a/src/DIRAC/TransformationSystem/Client/WorkflowTasks.py
+++ b/src/DIRAC/TransformationSystem/Client/WorkflowTasks.py
@@ -40,7 +40,7 @@ class WorkflowTasks(TaskBase):
         """
 
         if not logger:
-            logger = gLogger.getSubLogger("WorkflowTasks")
+            logger = gLogger.getSubLogger(self.__class__.__name__)
 
         super(WorkflowTasks, self).__init__(transClient, logger)
 

--- a/src/DIRAC/Workflow/Modules/FailoverRequest.py
+++ b/src/DIRAC/Workflow/Modules/FailoverRequest.py
@@ -18,7 +18,7 @@ class FailoverRequest(ModuleBase):
     def __init__(self):
         """Module initialization."""
 
-        self.log = gLogger.getSubLogger("FailoverRequest")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         super(FailoverRequest, self).__init__(self.log)
 
     #############################################################################

--- a/src/DIRAC/Workflow/Modules/ModuleBase.py
+++ b/src/DIRAC/Workflow/Modules/ModuleBase.py
@@ -36,7 +36,7 @@ class ModuleBase:
         """
 
         if not loggerIn:
-            self.log = gLogger.getSubLogger("ModuleBase")
+            self.log = gLogger.getSubLogger(self.__class__.__name__)
         else:
             self.log = loggerIn
 

--- a/src/DIRAC/Workflow/Modules/Script.py
+++ b/src/DIRAC/Workflow/Modules/Script.py
@@ -24,7 +24,7 @@ class Script(ModuleBase):
         if log is not None:
             self.log = log
         else:
-            self.log = gLogger.getSubLogger("Script")
+            self.log = gLogger.getSubLogger(self.__class__.__name__)
         super(Script, self).__init__(self.log)
 
         # Set defaults for all workflow parameters here

--- a/src/DIRAC/Workflow/Modules/UploadOutputs.py
+++ b/src/DIRAC/Workflow/Modules/UploadOutputs.py
@@ -15,7 +15,7 @@ class UploadOutputs(ModuleBase):
 
     def __init__(self):
         """c'tor"""
-        self.log = gLogger.getSubLogger("UploadOutputs")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         super(UploadOutputs, self).__init__(self.log)
 
         self.outputDataStep = ""

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobState/CachedJobState.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobState/CachedJobState.py
@@ -13,10 +13,8 @@ from DIRAC.WorkloadManagementSystem.Client.JobState.JobManifest import JobManife
 
 
 class CachedJobState:
-
-    log = gLogger.getSubLogger("CachedJobState")
-
     def __init__(self, jid, skipInitState=False):
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.dOnlyCache = False
         self.__jid = jid
         self.__jobState = JobState(jid)

--- a/src/DIRAC/WorkloadManagementSystem/Client/Limiter.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/Limiter.py
@@ -30,10 +30,10 @@ class Limiter:
             self.jobDB = JobDB()
 
         if pilotRef:
-            self.log = gLogger.getSubLogger("[%s]Limiter" % pilotRef)
-            self.jobDB.log = gLogger.getSubLogger("[%s]Limiter" % pilotRef)
+            self.log = gLogger.getSubLogger(f"[{pilotRef}]{self.__class__.__name__}")
+            self.jobDB.log = gLogger.getSubLogger(f"[{pilotRef}]{self.__class__.__name__}")
         else:
-            self.log = gLogger.getSubLogger("Limiter")
+            self.log = gLogger.getSubLogger(self.__class__.__name__)
 
         if opsHelper:
             self.__opsHelper = opsHelper

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotsLoggingDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotsLoggingDB.py
@@ -34,8 +34,7 @@ class PilotsLoggingDB:
 
         if not parentLogger:
             parentLogger = gLogger
-
-        self.log = parentLogger.getSubLogger("PilotsLoggingDB")
+        self.log = parentLogger.getSubLogger(self.__class__.__name__)
 
         result = getDBParameters("WorkloadManagement/PilotsLoggingDB")
         if not result["OK"]:

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -89,7 +89,7 @@ class JobWrapper(object):
             self.jobReport = JobReport(self.jobID, "JobWrapper@%s" % self.siteName)
         self.failoverTransfer = FailoverTransfer()
 
-        self.log = gLogger.getSubLogger("JobWrapper[%s]" % self.jobID)
+        self.log = gLogger.getSubLogger(f"[{self.jobID}]{self.__class__.__name__}")
         self.log.showHeaders(True)
 
         # self.root is the path the Wrapper is running at
@@ -1435,7 +1435,7 @@ class ExecutionThread(threading.Thread):
         """Method representing the thread activity.
         This one overrides the ~threading.Thread `run` method
         """
-        log = gLogger.getSubLogger("ExecutionThread")
+        log = gLogger.getSubLogger(self.__class__.__name__)
 
         # FIXME: why local instances of object variables are created?
         cmd = self.cmd

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -50,7 +50,7 @@ class Watchdog:
         self.stopSigRegex = jobArgs.get("StopSigRegex", None)
         self.stopSigSent = False
 
-        self.log = gLogger.getSubLogger("Watchdog")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.exeThread = exeThread
         self.wrapperPID = pid
         self.appPID = self.exeThread.getCurrentPID()

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
@@ -19,7 +19,7 @@ from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 
 class RemoteRunner(object):
     def __init__(self):
-        self.log = gLogger.getSubLogger("RemoteRunner")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.remoteExecution = gConfig.getValue("/LocalSite/RemoteExecution", "false")
 
     def is_remote_execution(self):

--- a/src/DIRAC/WorkloadManagementSystem/private/SharesCorrector.py
+++ b/src/DIRAC/WorkloadManagementSystem/private/SharesCorrector.py
@@ -11,7 +11,7 @@ class SharesCorrector:
         if not opsHelper:
             opsHelper = Operations()
         self.__opsHelper = opsHelper
-        self.__log = gLogger.getSubLogger("SharesCorrector")
+        self.__log = gLogger.getSubLogger(self.__class__.__name__)
         self.__shareCorrectors = {}
         self.__correctorsOrder = []
         self.__baseCS = "JobScheduling/ShareCorrections"

--- a/src/DIRAC/WorkloadManagementSystem/private/correctors/BaseHistoryCorrector.py
+++ b/src/DIRAC/WorkloadManagementSystem/private/correctors/BaseHistoryCorrector.py
@@ -16,7 +16,7 @@ class BaseHistoryCorrector(BaseCorrector):
     _SLICE_MAX_CORRECTION = "MaxCorrection"
 
     def initialize(self):
-        self.log = gLogger.getSubLogger("HistoryCorrector")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         self.__usageHistory = {}
         self.__slices = {}
         self.__lastHistoryUpdate = 0

--- a/src/DIRAC/WorkloadManagementSystem/private/correctors/MonitoringHistoryCorrector.py
+++ b/src/DIRAC/WorkloadManagementSystem/private/correctors/MonitoringHistoryCorrector.py
@@ -13,7 +13,7 @@ from DIRAC.MonitoringSystem.Client.MonitoringClient import MonitoringClient
 class MonitoringHistoryCorrector(BaseHistoryCorrector):
     def initialize(self):
         super().initialize()
-        self.log = gLogger.getSubLogger("MonitoringHistoryCorrector")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         return S_OK()
 
     def _getHistoryData(self, timeSpan, groupToUse):

--- a/src/DIRAC/WorkloadManagementSystem/private/correctors/WMSHistoryCorrector.py
+++ b/src/DIRAC/WorkloadManagementSystem/private/correctors/WMSHistoryCorrector.py
@@ -14,7 +14,7 @@ from DIRAC.AccountingSystem.Client.ReportsClient import ReportsClient
 class WMSHistoryCorrector(BaseHistoryCorrector):
     def initialize(self):
         super().initialize()
-        self.log = gLogger.getSubLogger("WMSHistoryCorrector")
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
         return S_OK()
 
     def _getHistoryData(self, timeSpan, groupToUse):


### PR DESCRIPTION
When trying to understand how getSubLogger works, i noticed 2 things:
- the child parameter was not being used
- the logger subname attribute was inconsintent across the calls and sometimes hard written ("Foo" instead of self.__class__.__name__). However, most of the classes use the __name__ attribute as the subName parameter for the getSubLogger method.

To fix this, I removed the child parameter and change the hard written names for the __name__ attribute. (/!\ : __name__ is the module name, while self.__class__.__name__ is only the class name. Therefore, the logs will change if this PR is merged)