### PR TITLE
Revert "fix: use ceType instead of ceName for CE parameters"

### DIFF
--- a/src/DIRAC/Resources/Computing/ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ComputingElement.py
@@ -132,10 +132,7 @@ class ComputingElement(object):
         self.log.debug("Initializing the CE parameters")
 
         # Collect global defaults first
-        sections = ["/Resources/Computing/CEDefaults"]
-        if self.ceType:
-            sections.append("/Resources/Computing/%s" % self.ceType)
-        for section in sections:
+        for section in ["/Resources/Computing/CEDefaults", "/Resources/Computing/%s" % self.ceName]:
             result = gConfig.getOptionsDict(section)
 
             self.log.debug(result)


### PR DESCRIPTION
This reverts commit 4ccabe9add2ee2e962ceea288191d986aa93457f for the reason that was apparently already known: https://github.com/DIRACGrid/DIRAC/issues/6014#issuecomment-1105069909

For most (all?) CE types as the parameters are extracted from the CS in `ComputingElement.__init__` which is called before setting in the subclasses:

https://github.com/DIRACGrid/DIRAC/blob/f55dc1086d97df8f0f7ae4dce2c827daaf8a664c/src/DIRAC/Resources/Computing/ComputingElement.py#L87

https://github.com/DIRACGrid/DIRAC/blob/f55dc1086d97df8f0f7ae4dce2c827daaf8a664c/src/DIRAC/Resources/Computing/SSHComputingElement.py#L321-L323

https://github.com/DIRACGrid/DIRAC/blob/f55dc1086d97df8f0f7ae4dce2c827daaf8a664c/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py#L143-L145

In the case of `SingularityComputingElement` `ceType` is never set. Perhaps the right thing to do is to use this in the parent class rather than relying on the child classes to be correct:
```python
if self.__name__.endswith("ComputingElement"):
    self.ceType = self.__name__[:len("ComputingElement")]
else:
    sel.log.warning(f"{self.__name__!r} should end with 'ComputingElement'!")
    self.ceType = self.__name__
```

BEGINRELEASENOTES

* WMS
FIX: Revert use ceType instead of ceName for CE parameters

ENDRELEASENOTES
