### PR TITLE
[v7r3] fix newer ldapsearch arguments

### DIFF
--- a/src/DIRAC/Core/Utilities/Grid.py
+++ b/src/DIRAC/Core/Utilities/Grid.py
@@ -93,7 +93,7 @@ def ldapsearchBDII(filt=None, attr=None, host=None, base=None, selectionString="
     if isinstance(attr, list):
         attr = " ".join(attr)
 
-    cmd = 'ldapsearch -x -LLL -o ldif-wrap=no -h %s -b %s "%s" %s' % (host, base, filt, attr)
+    cmd = 'ldapsearch -x -LLL -o ldif-wrap=no -H ldap://%s -b %s "%s" %s' % (host, base, filt, attr)
     result = shellCall(0, cmd)
 
     response = []

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -485,11 +485,11 @@ class ARCComputingElement(ComputingElement):
                 self.log.error("ARCComputingElement: No queue ...")
                 res = S_ERROR("Unknown queue (%s) failure for site %s" % (self.queue, self.ceHost))
                 return res
-            cmd1 = "ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135  -b 'o=glue' " % self.ceHost
+            cmd1 = "ldapsearch -x -o ldif-wrap=no -LLL -H ldap://%s:2135  -b 'o=glue' " % self.ceHost
             cmd2 = '"(&(objectClass=GLUE2MappingPolicy)(GLUE2PolicyRule=vo:%s))"' % vo.lower()
             cmd3 = " | grep GLUE2MappingPolicyShareForeignKey | grep %s" % (self.queue.split("-")[-1])
             cmd4 = " | sed 's/GLUE2MappingPolicyShareForeignKey: /GLUE2ShareID=/' "
-            cmd5 = " | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -h %s:2135 -b 'o=glue' " % self.ceHost
+            cmd5 = " | xargs -L1 ldapsearch -x -o ldif-wrap=no -LLL -H ldap://%s:2135 -b 'o=glue' " % self.ceHost
             cmd6 = " | egrep '(ShareWaiting|ShareRunning)'"
             res = shellCall(0, cmd1 + cmd2 + cmd3 + cmd4 + cmd5 + cmd6)
             if not res["OK"]:


### PR DESCRIPTION
As discussed https://trello.com/c/KecLX68w/11-visually-verify-cs-agents, thanks to @marianne013 

BEGINRELEASENOTES
*Core
FIX: Grid: BDII make ldapsearch call forward compatible with newer ldapsearch versions

*Resources
FIX: ARCCE  make ldapsearch call forward compatible with newer ldapsearch versions

ENDRELEASENOTES
