### PR TITLE
[v7r3] fix: autodetect cvmfs proxy in default cloudce template

### DIFF
--- a/src/DIRAC/Resources/Computing/cloudinit.template
+++ b/src/DIRAC/Resources/Computing/cloudinit.template
@@ -66,7 +66,8 @@ write_files:
  - path: /etc/cvmfs/default.local
    content: |
      CVMFS_CACHE_BASE=/mnt/cvmfs
-     CVMFS_HTTP_PROXY="DIRECT"
+     CVMFS_HTTP_PROXY="auto;DIRECT"
+     CVMFS_PAC_URLS="http://grid-wpad/wpad.dat;http://wpad/wpad.dat;http://cernvm-wpad.cern.ch/wpad.dat;http://cernvm-wpad.fnal.gov/wpad.dat"
  - path: /root/proxy.pem
    permissions: '0600'
    content: PROXY_STR


### PR DESCRIPTION
This is a sensible default mechanism for detecting the proxies: It's how the main CernVM works.

BEGINRELEASENOTES

*Resources
FIX: autodetect cvmfs proxy in default cloudce template

ENDRELEASENOTES
