### PR TITLE
[integration] feat: BaseRequestHandler encode/decode static methods

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/TornadoService.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoService.py
@@ -12,7 +12,6 @@ from tornado.web import url as TornadoURL
 import DIRAC
 
 from DIRAC import gLogger, S_OK
-from DIRAC.Core.Utilities.JEncode import decode, encode
 from DIRAC.Core.Tornado.Server.private.BaseRequestHandler import BaseRequestHandler
 from DIRAC.ConfigurationSystem.Client import PathFinder
 
@@ -170,8 +169,8 @@ class TornadoService(BaseRequestHandler):  # pylint: disable=abstract-method
 
     def _getMethodArgs(self, args: tuple, kwargs: dict) -> tuple:
         """Decode target function arguments."""
-        args_encoded = self.get_body_argument("args", default=encode([]))
-        return (decode(args_encoded)[0], {})
+        args_encoded = self.get_body_argument("args", default=self.encode([]))
+        return (self.decode(args_encoded)[0], {})
 
     auth_ping = ["all"]
 

--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -311,6 +311,11 @@ class BaseRequestHandler(RequestHandler):
     # This will be overridden in __initialize to be handler specific
     log = gLogger.getSubLogger(__name__.split(".")[-1])
 
+    # This defines a static method to encode and decode results
+    # By default JEncode is used, but encode/decode can be overriden
+    encode = staticmethod(encode)
+    decode = staticmethod(decode)
+
     @classmethod
     def __pre_initialize(cls) -> list:
         """This method is run by the Tornado server to prepare the handler for launch,
@@ -760,7 +765,7 @@ class BaseRequestHandler(RequestHandler):
         if "extraCredentials" in self.request.arguments:
             extraCred = self.get_argument("extraCredentials")
             if extraCred:
-                credDict["extraCredentials"] = decode(extraCred)[0]
+                credDict["extraCredentials"] = self.decode(extraCred)[0]
         return S_OK(credDict)
 
     def _authzJWT(self, accessToken=None):
@@ -949,7 +954,7 @@ class BaseRequestHandler(RequestHandler):
         # JSON
         else:
             self.set_header("Content-Type", "application/json")
-            self.finish(encode(self.__result))
+            self.finish(self.encode(self.__result))
 
     # Make a coroutine, see https://www.tornadoweb.org/en/branch5.1/guide/coroutines.html#coroutines for details
     async def get(self, *args, **kwargs):  # pylint: disable=arguments-differ


### PR DESCRIPTION
This PR, associated with this [WebApp PR](https://github.com/DIRACGrid/WebAppDIRAC/pull/646) aims to resolve the issues with the datetime values in the webapp.

Here is the issue:
- WebApp (`JobMonitorHandler`) calls the DIRAC service `JobMonitoringHandler`: JEncode.encode()
- DIRAC service `JobMonitoringHandler` receives the request: JEncode.decode()
- DIRAC service `JobMonitoringHandler` processes the request and returns the result: JEncode.encode()
- WebApp (`JobMonitorHandler`) gets the result: JEncode.decode()
- WebApp (`JobMonitorHandler`) returns the result to `_WebHandler`: JEncode.encode()
- `_WebHandler` finishes the operation but tries to encode the result again and in a different way: DefaultEncoder.encode() :arrow_right: Error

Therefore, we introduce a new method withing the `BaseRequestHandler` to change the way we encode/decode data.
By default, `BaseRequestHandler` is using `JEncode`, but in this PR, the `_WebHandler` overrides the encode method to use the `DefaultEncoder`, which provides a readable date format for the view.

Thus the new workflow is:
- WebApp (`JobMonitorHandler`) calls the DIRAC service `JobMonitoringHandler`: JEncode.encode()
- DIRAC service `JobMonitoringHandler` receives the request: JEncode.decode()
- DIRAC service `JobMonitoringHandler` processes the request and returns the result: JEncode.encode()
- WebApp (`JobMonitorHandler`) gets the result: JEncode.decode()
- WebApp (`JobMonitorHandler`) returns the result to `_WebHandler`: DefaultEncoder.encode()
- `_WebHandler` finishes the operation without trying to encode/decode because it has already been done in the previous stage

Thanks @chaen, who quickly understood the issue and brought me the solution on a silver platter.

BEGINRELEASENOTES
*Core
CHANGE: BaseRequestHandler encode/decode static methods
ENDRELEASENOTES
