### PR TITLE
[v7r3] docs: add info on installing non-released code from within the pilot

### DIFF
--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -68,3 +68,17 @@ DIRAC_JOB_PROCESSORS
 
 DIRAC_WHOLENODE
   A boolean flag indicating the pilot is exploiting the whole node (normally, False)
+
+
+Install non-released code from within the Pilot
+===============================================
+
+To install non-released code from within the pilot, the dirac-pilot command can be run with the --modules option. This option can be steered from the CS too.
+
+For example:
+
+   dirac-pilot.py --modules=https://github.com/chaen/DIRAC.git:::DIRAC:::rel-v7r3_FEAT_proxyStrength
+
+would end up installing a specific branch (rel-v7r3_FEAT_proxyStrength) pushed to github.
+
+An easy way to try is to in the CS configuration of one of your ComputingElements the option Modules=https://github.com/chaen/DIRAC.git:::DIRAC:::rel-v7r3_FEAT_proxyStrength

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -75,10 +75,12 @@ Install non-released code from within the Pilot
 
 To install non-released code from within the pilot, the dirac-pilot command can be run with the --modules option. This option can be steered from the CS too.
 
-For example:
+For example::
 
    dirac-pilot.py --modules=https://github.com/chaen/DIRAC.git:::DIRAC:::rel-v7r3_FEAT_proxyStrength
 
-would end up installing a specific branch (rel-v7r3_FEAT_proxyStrength) pushed to github.
+would end up installing a specific branch (``rel-v7r3_FEAT_proxyStrength``) pushed to github.
 
-An easy way to try is to in the CS configuration of one of your ComputingElements the option Modules=https://github.com/chaen/DIRAC.git:::DIRAC:::rel-v7r3_FEAT_proxyStrength
+An easy way to try is to in the CS configuration of one of your ComputingElements the option::
+
+    Modules=https://github.com/chaen/DIRAC.git:::DIRAC:::rel-v7r3_FEAT_proxyStrength

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -81,6 +81,6 @@ For example::
 
 would end up installing a specific branch (``rel-v7r3_FEAT_proxyStrength``) pushed to github.
 
-An easy way to try is to in the CS configuration of one of your ComputingElements the option::
+An easy way to try is to add the ``Modules`` option in the CS configuration of one of your ComputingElements::
 
     Modules=https://github.com/chaen/DIRAC.git:::DIRAC:::rel-v7r3_FEAT_proxyStrength


### PR DESCRIPTION

BEGINRELEASENOTES

*docs
NEW: add info on installing non-released code from within the pilot

ENDRELEASENOTES
