### PR TITLE
[sweep:integration] added op_type option in elasticsearch options

### DIFF
--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -370,11 +370,12 @@ class ElasticSearchDB(object):
 
         return S_ERROR(retVal)
 
-    def index(self, indexName, body=None, docID=None):
+    def index(self, indexName, body=None, docID=None, op_type="index"):
         """
         :param str indexName: the name of the index to be used
         :param dict body: the data which will be indexed (basically the JSON)
         :param int id: optional document id
+        :param str op_type: Explicit operation type. (options: 'index' (default) or 'create')
         :return: the index name in case of success.
         """
 
@@ -384,7 +385,7 @@ class ElasticSearchDB(object):
             return S_ERROR("Missing index or body")
 
         try:
-            res = self.client.index(index=indexName, body=body, id=docID)
+            res = self.client.index(index=indexName, body=body, id=docID, params={"op_type": op_type})
         except (RequestError, TransportError) as e:
             sLog.exception()
             return S_ERROR(e)


### PR DESCRIPTION
Sweep #6067 `added op_type option in elasticsearch options` to `integration`.

Adding original author @panta-123 as watcher.

BEGINRELEASENOTES

*Elasticsearch
NEW: option op_type in index API for Elasticsearch

ENDRELEASENOTES
Closes #6093