### PR TITLE
[sweep:integration] fix: use ceType instead of ceName for CE parameters version 2

### DIFF
--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -58,7 +58,6 @@ from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 # arc.Logger_getRootLogger().addDestination(logstdout)
 # arc.Logger_getRootLogger().setThreshold(arc.VERBOSE)
 
-CE_NAME = "ARC"
 MANDATORY_PARAMETERS = ["Queue"]  # Mandatory for ARC CEs in GLUE2?
 STATES_MAP = {
     "Accepted": PilotStatus.WAITING,
@@ -84,7 +83,6 @@ class ARCComputingElement(ComputingElement):
         """Standard constructor."""
         super(ARCComputingElement, self).__init__(ceUniqueID)
 
-        self.ceType = CE_NAME
         self.submittedJobs = 0
         self.mandatoryParameters = MANDATORY_PARAMETERS
         self.pilotProxy = ""

--- a/src/DIRAC/Resources/Computing/ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ComputingElement.py
@@ -64,7 +64,6 @@ class ComputingElement(object):
         """Standard constructor"""
         self.log = gLogger.getSubLogger(ceName)
         self.ceName = ceName
-        self.ceType = ""
         self.ceParameters = {}
         self.proxy = ""
         self.valid = None
@@ -74,6 +73,13 @@ class ComputingElement(object):
         self.minProxyTime = gConfig.getValue("/Registry/MinProxyLifeTime", 10800)  # secs
         self.defaultProxyTime = gConfig.getValue("/Registry/DefaultProxyLifeTime", 43200)  # secs
         self.proxyCheckPeriod = gConfig.getValue("/Registry/ProxyCheckingPeriod", 3600)  # secs
+
+        clsName = self.__class__.__name__
+        if clsName.endswith("ComputingElement"):
+            self.ceType = clsName[: -len("ComputingElement")]
+        else:
+            self.log.warning("%s should end with 'ComputingElement'!" % clsName)
+            self.ceType = clsName
 
         self.initializeParameters()
         self.log.debug("CE parameters", self.ceParameters)
@@ -123,10 +129,7 @@ class ComputingElement(object):
         self.log.debug("Initializing the CE parameters")
 
         # Collect global defaults first
-        sections = ["/Resources/Computing/CEDefaults"]
-        if self.ceType:
-            sections.append("/Resources/Computing/%s" % self.ceType)
-        for section in sections:
+        for section in ["/Resources/Computing/CEDefaults", "/Resources/Computing/%s" % self.ceType]:
             result = gConfig.getOptionsDict(section)
 
             self.log.debug(result)

--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -71,7 +71,6 @@ from DIRAC.Core.Utilities.Subprocess import Subprocess
 
 from DIRAC.Resources.Computing.BatchSystems.Condor import parseCondorStatus, treatCondorHistory
 
-CE_NAME = "HTCondorCE"
 MANDATORY_PARAMETERS = ["Queue"]
 DEFAULT_WORKINGDIRECTORY = "/opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT"
 DEFAULT_DAYSTOKEEPREMOTELOGS = 1
@@ -136,7 +135,6 @@ class HTCondorCEComputingElement(ComputingElement):
         """Standard constructor."""
         super(HTCondorCEComputingElement, self).__init__(ceUniqueID)
 
-        self.ceType = CE_NAME
         self.submittedJobs = 0
         self.mandatoryParameters = MANDATORY_PARAMETERS
         self.pilotProxy = ""

--- a/src/DIRAC/Resources/Computing/InProcessComputingElement.py
+++ b/src/DIRAC/Resources/Computing/InProcessComputingElement.py
@@ -25,7 +25,6 @@ class InProcessComputingElement(ComputingElement):
         """Standard constructor."""
         super(InProcessComputingElement, self).__init__(ceUniqueID)
 
-        self.ceType = "InProcess"
         self.submittedJobs = 0
         self.runningJobs = 0
 

--- a/src/DIRAC/Resources/Computing/LocalComputingElement.py
+++ b/src/DIRAC/Resources/Computing/LocalComputingElement.py
@@ -60,7 +60,6 @@ class LocalComputingElement(ComputingElement):
         """Standard constructor."""
         super(LocalComputingElement, self).__init__(ceUniqueID)
 
-        self.ceType = ""
         self.execution = "Local"
         self.submittedJobs = 0
         self.userName = getpass.getuser()

--- a/src/DIRAC/Resources/Computing/PoolComputingElement.py
+++ b/src/DIRAC/Resources/Computing/PoolComputingElement.py
@@ -72,7 +72,6 @@ class PoolComputingElement(ComputingElement):
         """Standard constructor."""
         super(PoolComputingElement, self).__init__(ceUniqueID)
 
-        self.ceType = "Pool"
         self.submittedJobs = 0
         self.processors = 1
         self.pPool = None

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -314,7 +314,6 @@ class SSHComputingElement(ComputingElement):
         """Standard constructor."""
         super(SSHComputingElement, self).__init__(ceUniqueID)
 
-        self.ceType = "SSH"
         self.execution = "SSHCE"
         self.submittedJobs = 0
         self.outputTemplate = ""

--- a/src/DIRAC/Resources/Computing/SudoComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SudoComputingElement.py
@@ -20,7 +20,6 @@ class SudoComputingElement(ComputingElement):
         """Standard constructor."""
         super(SudoComputingElement, self).__init__(ceUniqueID)
 
-        self.ceType = "Sudo"
         self.submittedJobs = 0
         self.runningJobs = 0
 


### PR DESCRIPTION
Sweep #6079 `fix: use ceType instead of ceName for CE parameters version 2` to `integration`.

Adding original author @marianne013 as watcher.

BEGINRELEASENOTES

*Resources
FIX: use ceType instead of ceName for CE parameters

ENDRELEASENOTES
Closes #6089