### PR TITLE
[v7r2] Avoid producing massive log output in OptimizationMind

### DIFF
--- a/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
+++ b/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
@@ -826,7 +826,8 @@ class ExecutorDispatcher(object):
             self.__msgTaskToExecutor(taskId, eId, eType)
         except Exception:
             self.__log.exception("Exception while sending task to executor")
-            self.__queues.pushTask(eType, taskId, ahead=False)
+            if taskId in self.__tasks:
+                self.__queues.pushTask(eType, taskId, ahead=False)
             self.__states.removeTask(taskId)
             return S_ERROR("Exception while sending task to executor")
         return S_OK(taskId)


### PR DESCRIPTION
The OptimizationMind suffers from a rare race condition that causes tasks
to get lost occasionally. I thought I'd fixed this in #5667 however it's
much too difficult to fix completely it would require the internal state
to be entirely refactored. Reverting this line avoids massive amounts of
log output when this happens.


BEGINRELEASENOTES

*WorkloadManagement
FIX: Avoid producing massive log output in OptimizationMind

ENDRELEASENOTES
