### PR TITLE
[integration] fix: remove decode from proxy in CloudCE

### DIFF
--- a/src/DIRAC/Resources/Computing/CloudComputingElement.py
+++ b/src/DIRAC/Resources/Computing/CloudComputingElement.py
@@ -310,7 +310,7 @@ class CloudComputingElement(ComputingElement):
             template = yaml.safe_load(template_fd)
         for filedef in template["write_files"]:
             if filedef["content"] == "PROXY_STR":
-                filedef["content"] = self.proxy.decode()
+                filedef["content"] = self.proxy
             elif filedef["content"] == "EXECUTABLE_STR":
                 filedef["content"] = exe_str
         ext_packages = self.ceParameters.get("Context_ExtPackages", None)


### PR DESCRIPTION
Did the proxy dumpAllToString return type change in integration where it seems to be a str while in v7r3 it seems to be bytes ? 
BEGINRELEASENOTES

*Resources
FIX: remove decode from proxy in CloudCE

ENDRELEASENOTES
