### PR TITLE
[sweep:integration] Yet more executor fixes

### DIFF
--- a/src/DIRAC/Core/Base/ExecutorMindHandler.py
+++ b/src/DIRAC/Core/Base/ExecutorMindHandler.py
@@ -79,7 +79,8 @@ class ExecutorMindHandler(RequestHandler):
             gThreadScheduler.addPeriodicTask(
                 10,
                 lambda: cls.log.verbose(
-                    "== Internal state ==\n%s\n===========" % pprint.pformat(cls.__eDispatch._internals())
+                    "== Internal state ==",
+                    "\n%s\n===========" % pprint.pformat(cls.__eDispatch._internals()),
                 ),
             )
         return S_OK()
@@ -97,12 +98,12 @@ class ExecutorMindHandler(RequestHandler):
             if not result["OK"]:
                 return result
         except Exception as excp:
-            gLogger.exception("Exception while executing prepareToSend: %s" % str(excp), lException=excp)
+            gLogger.exception("Exception while executing prepareToSend:", taskId, lException=excp)
             return S_ERROR("Cannot presend task")
         try:
             result = self.exec_serializeTask(taskObj)
         except Exception as excp:
-            gLogger.exception("Exception while serializing task %s" % taskId, lException=excp)
+            gLogger.exception("Exception while serializing task", taskId, lException=excp)
             return S_ERROR("Cannot serialize task %s: %s" % (taskId, str(excp)))
         if not isReturnStructure(result):
             raise Exception("exec_serializeTask does not return a return structure")
@@ -151,6 +152,7 @@ class ExecutorMindHandler(RequestHandler):
     auth_conn_drop = ["all"]
 
     def conn_drop(self, trid):
+        gLogger.warn("Triggered conn_drop for", trid)
         self.__eDispatch.removeExecutor(trid)
         return self.srv_disconnect(trid)
 
@@ -161,7 +163,7 @@ class ExecutorMindHandler(RequestHandler):
         try:
             result = self.exec_deserializeTask(msgObj.taskStub)
         except Exception as excp:
-            gLogger.exception("Exception while deserializing task %s" % taskId, lException=excp)
+            gLogger.exception("Exception while deserializing task", taskId, lException=excp)
             return S_ERROR("Cannot deserialize task %s: %s" % (taskId, str(excp)))
         if not isReturnStructure(result):
             raise Exception("exec_deserializeTask does not return a return structure")
@@ -180,7 +182,7 @@ class ExecutorMindHandler(RequestHandler):
         try:
             result = self.exec_deserializeTask(msgObj.taskStub)
         except Exception as excp:
-            gLogger.exception("Exception while deserializing task %s" % taskId, lException=excp)
+            gLogger.exception("Exception while deserializing task", taskId, lException=excp)
             return S_ERROR("Cannot deserialize task %s: %s" % (taskId, str(excp)))
         if not isReturnStructure(result):
             raise Exception("exec_deserializeTask does not return a return structure")
@@ -199,7 +201,7 @@ class ExecutorMindHandler(RequestHandler):
         try:
             result = self.exec_deserializeTask(msgObj.taskStub)
         except Exception as excp:
-            gLogger.exception("Exception while deserializing task %s" % taskId, lException=excp)
+            gLogger.exception("Exception while deserializing task", taskId, lException=excp)
             return S_ERROR("Cannot deserialize task %s: %s" % (taskId, str(excp)))
         if not isReturnStructure(result):
             raise Exception("exec_deserializeTask does not return a return structure")
@@ -211,13 +213,13 @@ class ExecutorMindHandler(RequestHandler):
         try:
             self.exec_taskError(msgObj.taskId, taskObj, msgObj.errorMsg)
         except Exception as excp:
-            gLogger.exception("Exception when processing task %s" % msgObj.taskId, lException=excp)
+            gLogger.exception("Exception when processing task", msgObj.taskId, lException=excp)
         return S_OK()
 
     auth_msg_ExecutorError = ["all"]
 
     def msg_ExecutorError(self, msgObj):
-        gLogger.info("Disconnecting executor by error: %s" % msgObj.errorMsg)
+        gLogger.info("Disconnecting executor by error:", msgObj.errorMsg)
         self.__eDispatch.removeExecutor(self.srv_getTransportID())
         return self.srv_disconnect()
 

--- a/src/DIRAC/Core/DISET/MessageClient.py
+++ b/src/DIRAC/Core/DISET/MessageClient.py
@@ -1,4 +1,5 @@
 import random
+import threading
 from hashlib import md5
 
 from DIRAC.Core.Utilities.ThreadSafe import Synchronizer
@@ -23,6 +24,7 @@ class MessageClient(BaseClient):
         self.__callbacks = {}
         self.__connectExtraParams = {}
         self.__specialCallbacks = {"drop": [], "msg": []}
+        self.__connectionLock = threading.Lock()
 
     def __generateUniqueClientName(self):
         hashStr = ":".join((Time.toString(), str(random.random()), Network.getFQDN(), gLogger.getName()))
@@ -47,9 +49,14 @@ class MessageClient(BaseClient):
     def connect(self, **extraParams):
         if extraParams:
             self.__connectExtraParams = extraParams
+        # Avoid acquiring the lock if it's clear we already have a connection
         if self.__trid:
             return S_ERROR("Already connected")
+        self.__connectionLock.acquire()
         try:
+            if self.__trid:
+                return S_ERROR("Already connected")
+
             trid, transport = self.__checkResult(self._connect())
             self.__checkResult(self._proposeAction(transport, ("Connection", "new")))
             self.__checkResult(transport.sendData(S_OK([self.__uniqueName, self.__connectExtraParams])))
@@ -66,6 +73,8 @@ class MessageClient(BaseClient):
             self.__transport = transport
         except self.MSGException as e:
             return S_ERROR(str(e))
+        finally:
+            self.__connectionLock.release()
         return S_OK()
 
     def __cbDisconnect(self, trid):

--- a/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
+++ b/src/DIRAC/Core/Utilities/ExecutorDispatcher.py
@@ -771,7 +771,8 @@ class ExecutorDispatcher(object):
             self.__msgTaskToExecutor(taskId, eId, eType)
         except Exception:
             self.__log.exception("Exception while sending task to executor")
-            self.__queues.pushTask(eType, taskId, ahead=False)
+            if taskId in self.__tasks:
+                self.__queues.pushTask(eType, taskId, ahead=False)
             self.__states.removeTask(taskId)
             return S_ERROR("Exception while sending task to executor")
         return S_OK(taskId)


### PR DESCRIPTION
Sweep #5672 `Yet more executor fixes` to `integration`.

Adding original author @chrisburr as watcher.

BEGINRELEASENOTES

*Core
FIX: Race condition which causes multiple connectioons to be opened when the connection to an executor drops
CHANGE: Improve logging split between message/varmessage in execuctors

*WorkloadManagement
FIX: Avoid producing massive log output in OptimizationMind

ENDRELEASENOTES

Closes #5675