### PR TITLE
[8.1] refactor: making JobState use the setJobStatus method from JobStateUp…

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/JobState/CachedJobState.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobState/CachedJobState.py
@@ -306,21 +306,8 @@ class CachedJobState:
         self.__addLogRecord(majorStatus, minorStatus, appStatus, source)
         return S_OK()
 
-    def setMinorStatus(self, minorStatus, source=None):
-        self.__cacheAdd("att.MinorStatus", minorStatus)
-        self.__addLogRecord(minorStatus=minorStatus, source=source)
-        return S_OK()
-
     def getStatus(self):
         return self.__cacheResult(("att.Status", "att.MinorStatus"), self.__jobState.getStatus)
-
-    def setAppStatus(self, appStatus, source=None):
-        self.__cacheAdd("att.ApplicationStatus", appStatus)
-        self.__addLogRecord(appStatus=appStatus, source=source)
-        return S_OK()
-
-    def getAppStatus(self):
-        return self.__cacheResult("att.ApplicationStatus", self.__jobState.getAppStatus)
 
     #
     # Attribs

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobState.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobState.py
@@ -1,7 +1,5 @@
 """ This object is a wrapper for setting and getting jobs states
 """
-import datetime
-
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.WorkloadManagementSystem.Client.JobState.JobManifest import JobManifest
 from DIRAC.WorkloadManagementSystem.Client import JobStatus

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobState.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobState.py
@@ -10,6 +10,7 @@ from DIRAC.WorkloadManagementSystem.DB.JobLoggingDB import JobLoggingDB
 from DIRAC.WorkloadManagementSystem.DB.TaskQueueDB import TaskQueueDB, singleValueDefFields, multiValueDefFields
 from DIRAC.WorkloadManagementSystem.Service.JobPolicy import RIGHT_GET_INFO, RIGHT_RESCHEDULE
 from DIRAC.WorkloadManagementSystem.Service.JobPolicy import RIGHT_RESET, RIGHT_CHANGE_STATUS
+from DIRAC.WorkloadManagementSystem.Utilities.JobStatusUtility import JobStatusUtility
 
 
 class JobState:
@@ -34,17 +35,13 @@ class JobState:
             JobState.__db.logDB = JobLoggingDB()
             JobState.__db.tqDB = TaskQueueDB()
 
-    def __init__(self, jid, source="Unknown"):
+    def __init__(self, jid):
         self.__jid = jid
-        self.__source = str(source)
         self.checkDBAccess()
 
     @property
     def jid(self):
         return self.__jid
-
-    def setSource(self, source):
-        self.__source = source
 
     def getManifest(self, rawData=False):
         result = JobState.__db.jobDB.getJobJDL(self.__jid)
@@ -164,50 +161,10 @@ class JobState:
 
     right_setStatus = RIGHT_GET_INFO
 
-    def setStatus(self, majorStatus, minorStatus=None, appStatus=None, source=None, updateTime=None):
-        try:
-            self.__checkType(majorStatus, str)
-            self.__checkType(minorStatus, str, canBeNone=True)
-            self.__checkType(appStatus, str, canBeNone=True)
-            self.__checkType(source, str, canBeNone=True)
-            self.__checkType(updateTime, datetime.datetime, canBeNone=True)
-        except TypeError as excp:
-            return S_ERROR(str(excp))
-        result = JobState.__db.jobDB.setJobStatus(
-            self.__jid, status=majorStatus, minorStatus=minorStatus, applicationStatus=appStatus
+    def setStatus(self, majorStatus=None, minorStatus=None, appStatus=None, source=None):
+        return JobStatusUtility(self.__db.jobDB, self.__db.logDB).setJobStatus(
+            self.jid, status=majorStatus, minorStatus=minorStatus, appStatus=appStatus, source=source
         )
-        if not result["OK"]:
-            return result
-        # HACK: Cause joblogging is crappy
-        if not minorStatus:
-            minorStatus = "idem"
-        if not appStatus:
-            appStatus = "idem"
-        if not source:
-            source = self.__source
-        return JobState.__db.logDB.addLoggingRecord(
-            self.__jid,
-            status=majorStatus,
-            minorStatus=minorStatus,
-            applicationStatus=appStatus,
-            date=updateTime,
-            source=source,
-        )
-
-    right_getMinorStatus = RIGHT_GET_INFO
-
-    def setMinorStatus(self, minorStatus, source=None, updateTime=None):
-        try:
-            self.__checkType(minorStatus, str)
-            self.__checkType(source, str, canBeNone=True)
-        except TypeError as excp:
-            return S_ERROR(str(excp))
-        result = JobState.__db.jobDB.setJobStatus(self.__jid, minorStatus=minorStatus)
-        if not result["OK"]:
-            return result
-        if not source:
-            source = self.__source
-        return JobState.__db.logDB.addLoggingRecord(self.__jid, minorStatus=minorStatus, date=updateTime, source=source)
 
     def getStatus(self):
         result = JobState.__db.jobDB.getJobAttributes(self.__jid, ["Status", "MinorStatus"])
@@ -217,23 +174,6 @@ class JobState:
         if data:
             return S_OK((data["Status"], data["MinorStatus"]))
         return S_ERROR("Job %d not found in the JobDB" % int(self.__jid))
-
-    right_setAppStatus = RIGHT_GET_INFO
-
-    def setAppStatus(self, appStatus, source=None, updateTime=None):
-        try:
-            self.__checkType(appStatus, str)
-            self.__checkType(source, str, canBeNone=True)
-        except TypeError as excp:
-            return S_ERROR(str(excp))
-        result = JobState.__db.jobDB.setJobStatus(self.__jid, applicationStatus=appStatus)
-        if not result["OK"]:
-            return result
-        if not source:
-            source = self.__source
-        return JobState.__db.logDB.addLoggingRecord(
-            self.__jid, applicationStatus=appStatus, date=updateTime, source=source
-        )
 
     right_getAppStatus = RIGHT_GET_INFO
 
@@ -379,27 +319,6 @@ class JobState:
 
     def getInputData(self):
         return JobState.__db.jobDB.getInputData(self.__jid)
-
-    @classmethod
-    def checkInputDataStructure(cls, pDict):
-        if not isinstance(pDict, dict):
-            return S_ERROR("Input data has to be a dictionary")
-        for lfn in pDict:
-            if "Replicas" not in pDict[lfn]:
-                return S_ERROR("Missing replicas for lfn %s" % lfn)
-                replicas = pDict[lfn]["Replicas"]
-                for seName in replicas:
-                    if "SURL" not in replicas or "Disk" not in replicas:
-                        return S_ERROR(f"Missing SURL or Disk for {seName}:{lfn} replica")
-        return S_OK()
-
-    right_setInputData = RIGHT_GET_INFO
-
-    def set_InputData(self, lfnData):
-        result = self.checkInputDataStructure(lfnData)
-        if not result["OK"]:
-            return result
-        return JobState.__db.jobDB.setInputData(self.__jid, lfnData)
 
     right_insertIntoTQ = RIGHT_CHANGE_STATUS
 

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
@@ -4,7 +4,7 @@ This module contains constants and lists for the possible job states.
 
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.StateMachine import State, StateMachine
-
+from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
 
 #:
 SUBMITTING = "Submitting"
@@ -97,8 +97,6 @@ def checkJobStateTransition(jobID, candidateState, currentStatus=None, jobMonito
     """Utility to check if a job state transition is allowed"""
     if not currentStatus:
         if not jobMonitoringClient:
-            from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
-
             jobMonitoringClient = JobMonitoringClient()
 
         res = jobMonitoringClient.getJobsStatus(jobID)

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
@@ -4,7 +4,7 @@ This module contains constants and lists for the possible job states.
 
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.StateMachine import State, StateMachine
-from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
+
 
 #:
 SUBMITTING = "Submitting"
@@ -97,6 +97,8 @@ def checkJobStateTransition(jobID, candidateState, currentStatus=None, jobMonito
     """Utility to check if a job state transition is allowed"""
     if not currentStatus:
         if not jobMonitoringClient:
+            from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
+
             jobMonitoringClient = JobMonitoringClient()
 
         res = jobMonitoringClient.getJobsStatus(jobID)

--- a/src/DIRAC/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -23,6 +23,7 @@ from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.ResourceStatusSystem.Client.SiteStatus import SiteStatus
 from DIRAC.StorageManagementSystem.Client.StorageManagerClient import StorageManagerClient, getFilesToStage
+from DIRAC.WorkloadManagementSystem.Client.JobState.JobState import JobState
 from DIRAC.WorkloadManagementSystem.Executor.Base.OptimizerExecutor import OptimizerExecutor
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
@@ -300,13 +301,13 @@ class JobScheduling(OptimizerExecutor):
             filtered -= set(banned)
         return list(filtered)
 
-    def __holdJob(self, jobState, holdMsg, delay=0):
+    def __holdJob(self, jobState: JobState, holdMsg, delay=0):
         if delay:
             self.freezeTask(delay)
         else:
             self.freezeTask(self.ex_getOption("HoldTime", 300))
         self.jobLog.info("On hold", holdMsg)
-        return jobState.setAppStatus(holdMsg, source=self.ex_optimizerName())
+        return jobState.setStatus(appStatus=holdMsg, source=self.ex_optimizerName())
 
     def __getSitesRequired(self, jobManifest):
         """Returns any candidate sites specified by the job or sites that have been

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -7,15 +7,14 @@
 
 """
 import time
-import datetime as dateTime
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
-from DIRAC.Core.Utilities import TimeUtilities
 from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
+from DIRAC.WorkloadManagementSystem.Utilities.JobStatusUtility import JobStatusUtility
 
 
 class JobStateUpdateHandlerMixin:
@@ -83,7 +82,9 @@ class JobStateUpdateHandlerMixin:
         if status != JobStatus.STAGING:
             return S_OK("Job is not in Staging after %d seconds" % trials)
 
-        result = cls.__setJobStatus(int(jobID), status=jobStatus, minorStatus=minorStatus, source="StagerSystem")
+        result = JobStatusUtility(cls.jobDB, cls.jobLoggingDB).setJobStatus(
+            int(jobID), status=jobStatus, minorStatus=minorStatus, source="StagerSystem"
+        )
         if not result["OK"]:
             if result["Message"].find("does not exist") != -1:
                 return S_OK()
@@ -101,32 +102,9 @@ class JobStateUpdateHandlerMixin:
         Sets optionally the status date and source component which sends the status information.
         The "force" flag will override the WMS state machine decision.
         """
-        return cls.__setJobStatus(
+        return JobStatusUtility(cls.jobDB, cls.jobLoggingDB).setJobStatus(
             int(jobID), status=status, minorStatus=minorStatus, source=source, datetime=datetime, force=force
         )
-
-    @classmethod
-    def __setJobStatus(
-        cls, jobID, status=None, minorStatus=None, appStatus=None, source=None, datetime=None, force=False
-    ):
-        """update the job provided statuses (major, minor and application)
-        If sets also the source and the time stamp (or current time)
-        This method calls the bulk method internally
-        """
-        sDict = {}
-        if status:
-            sDict["Status"] = status
-        if minorStatus:
-            sDict["MinorStatus"] = minorStatus
-        if appStatus:
-            sDict["ApplicationStatus"] = appStatus
-        if sDict:
-            if source:
-                sDict["Source"] = source
-            if not datetime:
-                datetime = str(dateTime.datetime.utcnow())
-            return cls._setJobStatusBulk(jobID, {datetime: sDict}, force=force)
-        return S_OK()
 
     ###########################################################################
     types_setJobStatusBulk = [[str, int], dict]
@@ -134,161 +112,7 @@ class JobStateUpdateHandlerMixin:
     @classmethod
     def export_setJobStatusBulk(cls, jobID, statusDict, force=False):
         """Set various job status fields with a time stamp and a source"""
-        return cls._setJobStatusBulk(jobID, statusDict, force=force)
-
-    @classmethod
-    def _setJobStatusBulk(cls, jobID, statusDict, force=False):
-        """Set various status fields for job specified by its jobId.
-        Set only the last status in the JobDB, updating all the status
-        logging information in the JobLoggingDB. The statusDict has datetime
-        as a key and status information dictionary as values
-        """
-        jobID = int(jobID)
-        log = cls.log.getLocalSubLogger("JobStatusBulk/Job-%d" % jobID)
-
-        result = cls.jobDB.getJobAttributes(jobID, ["Status", "StartExecTime", "EndExecTime"])
-        if not result["OK"]:
-            return result
-        if not result["Value"]:
-            # if there is no matching Job it returns an empty dictionary
-            return S_ERROR("No Matching Job")
-
-        # If the current status is Stalled and we get an update, it should probably be "Running"
-        currentStatus = result["Value"]["Status"]
-        if currentStatus == JobStatus.STALLED:
-            currentStatus = JobStatus.RUNNING
-        startTime = result["Value"].get("StartExecTime")
-        endTime = result["Value"].get("EndExecTime")
-        # getJobAttributes only returns strings :(
-        if startTime == "None":
-            startTime = None
-        if endTime == "None":
-            endTime = None
-
-        # Remove useless items in order to make it simpler later, although there should not be any
-        for sDict in statusDict.values():
-            for item in sorted(sDict):
-                if not sDict[item]:
-                    sDict.pop(item, None)
-
-        # Get the latest time stamps of major status updates
-        result = cls.jobLoggingDB.getWMSTimeStamps(int(jobID))
-        if not result["OK"]:
-            return result
-        if not result["Value"]:
-            return S_ERROR("No registered WMS timeStamps")
-        # This is more precise than "LastTime". timeStamps is a sorted list of tuples...
-        timeStamps = sorted((float(t), s) for s, t in result["Value"].items() if s != "LastTime")
-        lastTime = TimeUtilities.toString(TimeUtilities.fromEpoch(timeStamps[-1][0]))
-
-        # Get chronological order of new updates
-        updateTimes = sorted(statusDict)
-        log.debug("*** New call ***", f"Last update time {lastTime} - Sorted new times {updateTimes}")
-        # Get the status (if any) at the time of the first update
-        newStat = ""
-        firstUpdate = TimeUtilities.toEpoch(TimeUtilities.fromString(updateTimes[0]))
-        for ts, st in timeStamps:
-            if firstUpdate >= ts:
-                newStat = st
-        # Pick up start and end times from all updates
-        for updTime in updateTimes:
-            sDict = statusDict[updTime]
-            newStat = sDict.get("Status", newStat)
-
-            if not startTime and newStat == JobStatus.RUNNING:
-                # Pick up the start date when the job starts running if not existing
-                startTime = updTime
-                log.debug("Set job start time", startTime)
-            elif not endTime and newStat in JobStatus.JOB_FINAL_STATES:
-                # Pick up the end time when the job is in a final status
-                endTime = updTime
-                log.debug("Set job end time", endTime)
-
-        # We should only update the status to the last one if its time stamp is more recent than the last update
-        attrNames = []
-        attrValues = []
-        if updateTimes[-1] >= lastTime:
-            minor = ""
-            application = ""
-            # Get the last status values looping on the most recent upupdateTimes in chronological order
-            for updTime in [dt for dt in updateTimes if dt >= lastTime]:
-                sDict = statusDict[updTime]
-                log.debug("\t", f"Time {updTime} - Statuses {str(sDict)}")
-                status = sDict.get("Status", currentStatus)
-                # evaluate the state machine if the status is changing
-                if not force and status != currentStatus:
-                    res = JobStatus.JobsStateMachine(currentStatus).getNextState(status)
-                    if not res["OK"]:
-                        return res
-                    newStat = res["Value"]
-                    # If the JobsStateMachine does not accept the candidate, don't update
-                    if newStat != status:
-                        # keeping the same status
-                        log.error(
-                            "Job Status Error",
-                            f"{jobID} can't move from {currentStatus} to {status}: using {newStat}",
-                        )
-                        status = newStat
-                        sDict["Status"] = newStat
-                        # Change the source to indicate this is not what was requested
-                        source = sDict.get("Source", "")
-                        sDict["Source"] = source + "(SM)"
-                    # at this stage status == newStat. Set currentStatus to this new status
-                    currentStatus = newStat
-
-                minor = sDict.get("MinorStatus", minor)
-                application = sDict.get("ApplicationStatus", application)
-
-            log.debug("Final statuses:", f"status '{status}', minor '{minor}', application '{application}'")
-            if status:
-                attrNames.append("Status")
-                attrValues.append(status)
-            if minor:
-                attrNames.append("MinorStatus")
-                attrValues.append(minor)
-            if application:
-                attrNames.append("ApplicationStatus")
-                attrValues.append(application)
-            # Here we are forcing the update as it's always updating to the last status
-            result = cls.jobDB.setJobAttributes(jobID, attrNames, attrValues, update=True, force=True)
-            if not result["OK"]:
-                return result
-            if cls.elasticJobParametersDB:
-                result = cls.elasticJobParametersDB.setJobParameter(int(jobID), "Status", status)
-                if not result["OK"]:
-                    return result
-        # Update start and end time if needed
-        if endTime:
-            result = cls.jobDB.setEndExecTime(jobID, endTime)
-            if not result["OK"]:
-                return result
-        if startTime:
-            result = cls.jobDB.setStartExecTime(jobID, startTime)
-            if not result["OK"]:
-                return result
-
-        # Update the JobLoggingDB records
-        heartBeatTime = None
-        for updTime in updateTimes:
-            sDict = statusDict[updTime]
-            status = sDict.get("Status", "idem")
-            minor = sDict.get("MinorStatus", "idem")
-            application = sDict.get("ApplicationStatus", "idem")
-            source = sDict.get("Source", "Unknown")
-            result = cls.jobLoggingDB.addLoggingRecord(
-                jobID, status=status, minorStatus=minor, applicationStatus=application, date=updTime, source=source
-            )
-            if not result["OK"]:
-                return result
-            # If the update comes from a job, update the heart beat time stamp with this item's stamp
-            if source.startswith("Job"):
-                heartBeatTime = updTime
-        if heartBeatTime is not None:
-            result = cls.jobDB.setHeartBeatData(jobID, {"HeartBeatTime": heartBeatTime})
-            if not result["OK"]:
-                return result
-
-        return S_OK((attrNames, attrValues))
+        return JobStatusUtility(cls.jobDB, cls.jobLoggingDB).setJobStatusBulk(int(jobID), statusDict, force=force)
 
     ###########################################################################
     types_setJobAttribute = [[str, int], str, str]
@@ -330,7 +154,7 @@ class JobStateUpdateHandlerMixin:
         """Set the application status for job specified by its JobId.
         Internally calling the bulk method
         """
-        return cls.__setJobStatus(jobID, appStatus=appStatus, source=source)
+        return JobStatusUtility(cls.jobDB, cls.jobLoggingDB).setJobStatus(jobID, appStatus=appStatus, source=source)
 
     ###########################################################################
     types_setJobParameter = [[str, int], str, str]

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/JobStatusUtility.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/JobStatusUtility.py
@@ -1,0 +1,214 @@
+"""Utility to set the job status in the jobDB"""
+
+import datetime as dateTime
+
+from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC.Core.Utilities import TimeUtilities
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
+from DIRAC.WorkloadManagementSystem.Client import JobStatus
+from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
+from DIRAC.WorkloadManagementSystem.DB.JobLoggingDB import JobLoggingDB
+
+
+class JobStatusUtility:
+    def __init__(self, jobDB: JobDB = None, jobLoggingDB: JobLoggingDB = None) -> None:
+        """
+        :raises: RuntimeError, AttributeError
+        """
+
+        self.log = gLogger.getSubLogger(self.__class__.__name__)
+
+        if not jobDB:
+            try:
+                result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
+                if not result["OK"]:
+                    raise AttributeError(result["Message"])
+                jobDB = result["Value"](parentLogger=self.log)
+            except RuntimeError:
+                self.log.error("Can't connect to the jobDB")
+                raise
+        self.jobDB = jobDB
+
+        if not jobLoggingDB:
+            try:
+                result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobLoggingDB", "JobLoggingDB")
+                if not result["OK"]:
+                    raise AttributeError(result["Message"])
+                jobLoggingDB = result["Value"](parentLogger=self.log)
+            except RuntimeError:
+                self.log.error("Can't connect to the JobLoggingDB")
+                raise
+        self.jobLoggingDB = jobLoggingDB
+
+    def setJobStatus(
+        self, jobID: int, status=None, minorStatus=None, appStatus=None, source=None, datetime=None, force=False
+    ):
+        """
+        Update the job provided statuses (major, minor and application)
+        If sets also the source and the time stamp (or current time)
+        This method calls the bulk method internally
+        """
+        sDict = {}
+        if status:
+            sDict["Status"] = status
+        if minorStatus:
+            sDict["MinorStatus"] = minorStatus
+        if appStatus:
+            sDict["ApplicationStatus"] = appStatus
+        if sDict:
+            if source:
+                sDict["Source"] = source
+            if not datetime:
+                datetime = str(dateTime.datetime.utcnow())
+            return self.setJobStatusBulk(jobID, {datetime: sDict}, force=force)
+        return S_OK()
+
+    def setJobStatusBulk(self, jobID: int, statusDict: dict, force: bool = False):
+        """Set various status fields for job specified by its jobId.
+        Set only the last status in the JobDB, updating all the status
+        logging information in the JobLoggingDB. The statusDict has datetime
+        as a key and status information dictionary as values
+        """
+        jobID = int(jobID)
+        log = self.log.getLocalSubLogger("JobStatusBulk/Job-%d" % jobID)
+
+        result = self.jobDB.getJobAttributes(jobID, ["Status", "StartExecTime", "EndExecTime"])
+        if not result["OK"]:
+            return result
+        if not result["Value"]:
+            # if there is no matching Job it returns an empty dictionary
+            return S_ERROR("No Matching Job")
+
+        # If the current status is Stalled and we get an update, it should probably be "Running"
+        currentStatus = result["Value"]["Status"]
+        if currentStatus == JobStatus.STALLED:
+            currentStatus = JobStatus.RUNNING
+        startTime = result["Value"].get("StartExecTime")
+        endTime = result["Value"].get("EndExecTime")
+        # getJobAttributes only returns strings :(
+        if startTime == "None":
+            startTime = None
+        if endTime == "None":
+            endTime = None
+
+        # Remove useless items in order to make it simpler later, although there should not be any
+        for sDict in statusDict.values():
+            for item in sorted(sDict):
+                if not sDict[item]:
+                    sDict.pop(item, None)
+
+        # Get the latest time stamps of major status updates
+        result = self.jobLoggingDB.getWMSTimeStamps(int(jobID))
+        if not result["OK"]:
+            return result
+        if not result["Value"]:
+            return S_ERROR("No registered WMS timeStamps")
+        # This is more precise than "LastTime". timeStamps is a sorted list of tuples...
+        timeStamps = sorted((float(t), s) for s, t in result["Value"].items() if s != "LastTime")
+        lastTime = TimeUtilities.toString(TimeUtilities.fromEpoch(timeStamps[-1][0]))
+
+        # Get chronological order of new updates
+        updateTimes = sorted(statusDict)
+        log.debug("*** New call ***", "Last update time %s - Sorted new times %s" % (lastTime, updateTimes))
+        # Get the status (if any) at the time of the first update
+        newStat = ""
+        firstUpdate = TimeUtilities.toEpoch(TimeUtilities.fromString(updateTimes[0]))
+        for ts, st in timeStamps:
+            if firstUpdate >= ts:
+                newStat = st
+        # Pick up start and end times from all updates
+        for updTime in updateTimes:
+            sDict = statusDict[updTime]
+            newStat = sDict.get("Status", newStat)
+
+            if not startTime and newStat == JobStatus.RUNNING:
+                # Pick up the start date when the job starts running if not existing
+                startTime = updTime
+                log.debug("Set job start time", startTime)
+            elif not endTime and newStat in JobStatus.JOB_FINAL_STATES:
+                # Pick up the end time when the job is in a final status
+                endTime = updTime
+                log.debug("Set job end time", endTime)
+
+        # We should only update the status to the last one if its time stamp is more recent than the last update
+        attrNames = []
+        attrValues = []
+        if updateTimes[-1] >= lastTime:
+            minor = ""
+            application = ""
+            # Get the last status values looping on the most recent upupdateTimes in chronological order
+            for updTime in [dt for dt in updateTimes if dt >= lastTime]:
+                sDict = statusDict[updTime]
+                log.debug("\t", "Time %s - Statuses %s" % (updTime, str(sDict)))
+                status = sDict.get("Status", currentStatus)
+                # evaluate the state machine if the status is changing
+                if not force and status != currentStatus:
+                    res = JobStatus.JobsStateMachine(currentStatus).getNextState(status)
+                    if not res["OK"]:
+                        return res
+                    newStat = res["Value"]
+                    # If the JobsStateMachine does not accept the candidate, don't update
+                    if newStat != status:
+                        # keeping the same status
+                        log.error(
+                            "Job Status Error",
+                            "%s can't move from %s to %s: using %s" % (jobID, currentStatus, status, newStat),
+                        )
+                        status = newStat
+                        sDict["Status"] = newStat
+                        # Change the source to indicate this is not what was requested
+                        source = sDict.get("Source", "")
+                        sDict["Source"] = source + "(SM)"
+                    # at this stage status == newStat. Set currentStatus to this new status
+                    currentStatus = newStat
+
+                minor = sDict.get("MinorStatus", minor)
+                application = sDict.get("ApplicationStatus", application)
+
+            log.debug("Final statuses:", "status '%s', minor '%s', application '%s'" % (status, minor, application))
+            if status:
+                attrNames.append("Status")
+                attrValues.append(status)
+            if minor:
+                attrNames.append("MinorStatus")
+                attrValues.append(minor)
+            if application:
+                attrNames.append("ApplicationStatus")
+                attrValues.append(application)
+            # Here we are forcing the update as it's always updating to the last status
+            result = self.jobDB.setJobAttributes(jobID, attrNames, attrValues, update=True, force=True)
+            if not result["OK"]:
+                return result
+
+        # Update start and end time if needed
+        if endTime:
+            result = self.jobDB.setEndExecTime(jobID, endTime)
+            if not result["OK"]:
+                return result
+        if startTime:
+            result = self.jobDB.setStartExecTime(jobID, startTime)
+            if not result["OK"]:
+                return result
+
+        # Update the JobLoggingDB records
+        heartBeatTime = None
+        for updTime in updateTimes:
+            sDict = statusDict[updTime]
+            status = sDict.get("Status", "idem")
+            minor = sDict.get("MinorStatus", "idem")
+            application = sDict.get("ApplicationStatus", "idem")
+            source = sDict.get("Source", "Unknown")
+            result = self.jobLoggingDB.addLoggingRecord(
+                jobID, status=status, minorStatus=minor, applicationStatus=application, date=updTime, source=source
+            )
+            if not result["OK"]:
+                return result
+            # If the update comes from a job, update the heart beat time stamp with this item's stamp
+            if source.startswith("Job"):
+                heartBeatTime = updTime
+        if heartBeatTime is not None:
+            result = self.jobDB.setHeartBeatData(jobID, {"HeartBeatTime": heartBeatTime})
+            if not result["OK"]:
+                return result
+
+        return S_OK((attrNames, attrValues))

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_JobStatusUtility.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_JobStatusUtility.py
@@ -216,7 +216,11 @@ def test__setJobStatusBulk(
     jobLoggingDB_mock = MagicMock()
     jobLoggingDB_mock.getWMSTimeStamps.return_value = jobLoggingDB_getWMSTimeStamps_rv
 
-    jsu = JobStatusUtility(jobDB_mock, jobLoggingDB_mock)
+    esJobParameters_mock = MagicMock()
+    esJobParameters_mock.getJobAttributes.return_value = jobDB_getJobAttributes_rv
+    esJobParameters_mock.setJobAttributes.return_value = jobDB_setJobAttributes_rv
+
+    jsu = JobStatusUtility(jobDB_mock, jobLoggingDB_mock, esJobParameters_mock)
 
     # Act
     res = jsu.setJobStatusBulk(1, statusDict_in, force)

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_JobStatusUtility.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_JobStatusUtility.py
@@ -1,22 +1,17 @@
-""" unit test (pytest) of JobStateUpdate service
-"""
+# pylint: disable=missing-docstring, invalid-name
 
 from unittest.mock import MagicMock
 import pytest
 
 from DIRAC import gLogger
 
-gLogger.setLevel("DEBUG")
-
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
 from DIRAC.WorkloadManagementSystem.Client import JobMinorStatus
 
 # sut
-from DIRAC.WorkloadManagementSystem.Service.JobStateUpdateHandler import JobStateUpdateHandlerMixin
+from DIRAC.WorkloadManagementSystem.Utilities.JobStatusUtility import JobStatusUtility
 
-# mocks
-jobDB_mock = MagicMock()
-jobLoggingDB_mock = MagicMock()
+gLogger.setLevel("DEBUG")
 
 
 @pytest.mark.parametrize(
@@ -205,7 +200,6 @@ jobLoggingDB_mock = MagicMock()
     ],
 )
 def test__setJobStatusBulk(
-    mocker,
     statusDict_in,
     jobDB_getJobAttributes_rv,
     jobDB_setJobAttributes_rv,
@@ -214,18 +208,20 @@ def test__setJobStatusBulk(
     resExpected,
     resExpected_value,
 ):
-    JobStateUpdateHandlerMixin.jobDB = jobDB_mock
-    JobStateUpdateHandlerMixin.jobLoggingDB = jobLoggingDB_mock
-    JobStateUpdateHandlerMixin.log = gLogger
-    JobStateUpdateHandlerMixin.elasticJobParametersDB = None
-
+    # Arrange
+    jobDB_mock = MagicMock()
     jobDB_mock.getJobAttributes.return_value = jobDB_getJobAttributes_rv
     jobDB_mock.setJobAttributes.return_value = jobDB_setJobAttributes_rv
+
+    jobLoggingDB_mock = MagicMock()
     jobLoggingDB_mock.getWMSTimeStamps.return_value = jobLoggingDB_getWMSTimeStamps_rv
 
-    jsu = JobStateUpdateHandlerMixin()
+    jsu = JobStatusUtility(jobDB_mock, jobLoggingDB_mock)
 
-    res = jsu._setJobStatusBulk(1, statusDict_in, force)
+    # Act
+    res = jsu.setJobStatusBulk(1, statusDict_in, force)
+
+    # Assert
     assert res["OK"] is resExpected
     if res["OK"]:
         assert res["Value"] == resExpected_value


### PR DESCRIPTION
Making JobState use the setJobStatus method from JobStateUpdateHandler. This will allow to unify the way the job status is updated. I also removed useless code.