### PR TITLE
[v7r3] fix: don't truncate first char in cli doc strings

### DIFF
--- a/src/DIRAC/Core/Base/CLI.py
+++ b/src/DIRAC/Core/Base/CLI.py
@@ -137,7 +137,7 @@ class CLI(cmd.Cmd):
             attrList = sorted(dir(self))
             for attribute in attrList:
                 if attribute.startswith("do_"):
-                    self.printPair(attribute[3:], getattr(self, attribute).__doc__[1:])
+                    self.printPair(attribute[3:], getattr(self, attribute).__doc__)
                     print("")
         else:
             command = args.split()[0].strip()


### PR DESCRIPTION
Currently the dirac-dms-filecatalog-cli displays its help along these lines:
`stats               : et the catalog statistics`
after fix:
`stats               : Get the catalog statistics`

BEGINRELEASENOTES

*Core
FIX: don't truncate first character in cli doc strings

ENDRELEASENOTES
