### PR TITLE
[v8.0] test (JobParameters): restart Tornado after changing the configuration

### DIFF
--- a/tests/Integration/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py
@@ -62,6 +62,7 @@ def updateFlag():
 
     os.system("dirac-restart-component WorkloadManagement JobMonitoring")
     os.system("dirac-restart-component WorkloadManagement JobStateUpdate")
+    os.system("dirac-restart-component Tornado Tornado")
 
     time.sleep(5)
 


### PR DESCRIPTION
In LHCbDIRAC CI, we observer odd failures only for this very specific test. It is not systematically reproducible, but happens very often. This test is a bit odd since it runs in the server integration tests but is actually a client test. In any case, since the diset components were restarted, I restart Tornado too

```python
LocalRepo/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py::test_MySQLandES_jobParameters FAILED [100%]

=================================== FAILURES ===================================
________________________ test_MySQLandES_jobParameters _________________________

    def test_MySQLandES_jobParameters():
        """a basic put - remove test, changing the flag in between"""
    
        # First, create a job
        jobID = createJob()
    
        # Use the MySQL backend
    
        res = jobStateUpdateClient.setJobParameter(jobID, "ParName-fromMySQL", "ParValue-fromMySQL")
        assert res["OK"], res["Message"]
        _checkWithRetries(
            jobMonitoringClient.getJobParameter,
            (jobID, "ParName-fromMySQL"),
            {"ParName-fromMySQL": "ParValue-fromMySQL"},
        )
    
        res = jobMonitoringClient.getJobParameters(jobID)  # This will be looked up in MySQL only
        assert res["OK"], res["Message"]
        assert isinstance(res["Value"], dict), res["Value"]
        assert res["Value"] == {jobID: {"ParName-fromMySQL": "ParValue-fromMySQL"}}, res["Value"]
    
        res = jobMonitoringClient.getJobOwner(jobID)
        assert res["OK"], res["Message"]
        assert res["Value"] == "adminusername", res["Value"]
    
        res = jobStateUpdateClient.setJobsParameter({jobID: ["SomeStatus", "Waiting"]})
        assert res["OK"], res["Message"]
        _checkWithRetries(
            jobMonitoringClient.getJobParameters,
            (jobID,),
            {jobID: {"ParName-fromMySQL": "ParValue-fromMySQL", "SomeStatus": "Waiting"}},
        )
    
        res = jobMonitoringClient.getJobAttributes(jobID)
        assert res["OK"], res["Message"]
    
        # changing to use the ES flag
        updateFlag()
        # So now we are using the ES backend
    
        # This will still be in MySQL, but first it will look if it's in ES
        res = jobMonitoringClient.getJobParameter(jobID, "ParName-fromMySQL")
        assert res["OK"], res["Message"]
        assert res["Value"] == {"ParName-fromMySQL": "ParValue-fromMySQL"}, res["Value"]
    
        # Now we insert (in ES)
        res = jobStateUpdateClient.setJobParameter(jobID, "ParName-fromES", "ParValue-fromES")
        time.sleep(2)  # sleep to give time to ES to index
        assert res["OK"], res["Message"]
    
        res = jobMonitoringClient.getJobParameter(jobID, "ParName-fromES")  # This will be in ES
        assert res["OK"], res["Message"]
        assert res["Value"] == {"ParName-fromES": "ParValue-fromES"}, res["Value"]
    
        res = jobMonitoringClient.getJobOwner(jobID)
        assert res["OK"], res["Message"]
        assert res["Value"] == "adminusername", res["Value"]
    
        # These parameters will be looked up in MySQL and in ES, and combined
        res = jobMonitoringClient.getJobParameters(jobID)
        assert res["OK"], res["Message"]
        assert res["Value"] == {
            jobID: {"ParName-fromMySQL": "ParValue-fromMySQL", "SomeStatus": "Waiting", "ParName-fromES": "ParValue-fromES"}
        }, res["Value"]
    
        # Do it again
        res = jobMonitoringClient.getJobParameters(jobID)
        assert res["OK"], res["Message"]
        assert res["Value"] == {
            jobID: {"ParName-fromMySQL": "ParValue-fromMySQL", "SomeStatus": "Waiting", "ParName-fromES": "ParValue-fromES"}
        }, res["Value"]
    
        # this is updating an existing parameter, but in practice it will be in ES only,
        # while in MySQL the old status "Waiting" will stay
        res = jobStateUpdateClient.setJobsParameter({jobID: ["SomeStatus", "Matched"]})
        time.sleep(2)  # sleep to give time to ES to index
        assert res["OK"], res["Message"]
    
        res = jobMonitoringClient.getJobParameters(jobID)
>       assert res["OK"], res["Message"]
E       AssertionError: 500 Server Error: Internal Server Error for url: https://server:8443/WorkloadManagement/TornadoJobMonitoring: <html><title>500: Internal Server Error</title><body>500: Internal Server Error</body></html>
E       assert False

LocalRepo/TestCode/DIRAC/tests/Integration/WorkloadManagementSystem/Test_JobParameters_MySQLandES.py:158: AssertionError


```

```python
2022-05-16 15:50:22 UTC Tornado/Tornado/TornadoJobMonitoringHandler NOTICE: Returning response (172.20.0.6:54900)[prod:adminusername] WorkloadManagement/TornadoJobMonitoring (10.55 ms) OK
ERROR:tornado.application:Uncaught exception POST /WorkloadManagement/TornadoJobMonitoring (172.20.0.6)
HTTPServerRequest(protocol='https', host='server:8443', method='POST', uri='/WorkloadManagement/TornadoJobMonitoring', version='HTTP/1.1', remote_ip='172.20.0.6')
Traceback (most recent call last):
  File "/home/dirac/ServerInstallDIR/diracos/lib/python3.9/site-packages/tornado/web.py", line 1571, in _execute
    result = yield result
  File "/home/dirac/ServerInstallDIR/diracos/lib/python3.9/site-packages/tornado/gen.py", line 1133, in run
    value = future.result()
  File "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 571, in prepare
    await ioloop.run_in_executor(None, self.__prepare)
  File "/home/dirac/ServerInstallDIR/diracos/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 609, in __prepare
    authorized = self._authManager.authQuery(self.__methodName, self.credDict, self.__getMethodAuthProps())
  File "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/src/DIRAC/Core/DISET/AuthManager.py", line 50, in authQuery
    requiredProperties = self.getValidPropertiesForMethod(methodQuery, defaultProperties)
  File "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/src/DIRAC/Core/DISET/AuthManager.py", line 176, in getValidPropertiesForMethod
    authProps = gConfig.getValue("%s/%s" % (self.authSection, method), [])
  File "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/src/DIRAC/ConfigurationSystem/private/ConfigurationClient.py", line 123, in getValue
    retVal = self.getOption(optionPath, defaultValue)
  File "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/src/DIRAC/ConfigurationSystem/private/ConfigurationClient.py", line 134, in getOption
    gRefresher.refreshConfigurationIfNeeded()
  File "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/src/DIRAC/ConfigurationSystem/private/TornadoRefresher.py", line 34, in refreshConfigurationIfNeeded
    _IOLoop.current().run_in_executor(None, self._refresh)  # pylint: disable=no-member
  File "/home/dirac/ServerInstallDIR/diracos/lib/python3.9/site-packages/tornado/ioloop.py", line 282, in current
    loop = asyncio.get_event_loop()
  File "/home/dirac/ServerInstallDIR/diracos/lib/python3.9/asyncio/events.py", line 642, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'asyncio_2'.
ERROR:tornado.access:500 POST /WorkloadManagement/TornadoJobMonitoring (172.20.0.6) 16.47ms
2022-05-16 15:50:36 UTC Tornado/Tornado/TornadoJobMonitoringHandler NOTICE: Returning response (172.20.0.6:54902)[prod:anonymous] WorkloadManagement/TornadoJobMonitoring (16.61 ms) ERROR 500: Internal Server Error
```

BEGINRELEASENOTES
*Tests
FIX: restart Tornado after updating the configuration


ENDRELEASENOTES
