### PR TITLE
[v7r2] feat (resources): introduce a new way to submit pilots from ARC

### DIFF
--- a/src/DIRAC/Core/scripts/dirac_agent.py
+++ b/src/DIRAC/Core/scripts/dirac_agent.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
+import os
 import sys
 
 from DIRAC import gLogger
@@ -48,6 +49,9 @@ def main():
     result = agentReactor.loadAgentModules(positionalArgs)
     if result["OK"]:
         agentReactor.go()
+        # dirac_agent might interact with ARC library which cannot be closed using a simple sys.exit(0)
+        # See https://bugzilla.nordugrid.org/show_bug.cgi?id=4022 for further details
+        os._exit(0)
     else:
         gLogger.error("Error while loading agent module", result["Message"])
         sys.exit(2)

--- a/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
@@ -1,0 +1,188 @@
+""" ARC6 Computing Element
+    Using the ARC API now
+
+    Temporary ARC Computing Element able to submit to gridftp and arex services
+    via the REST and EMI-ES interfaces.
+    Use it only if gridftp services are not supported anymore.
+    Arc6CE should be dropped once the AREXCE will be fully operational.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__RCSID__ = "$Id$"
+
+import os
+import stat
+
+import arc  # Has to work if this module is called #pylint: disable=import-error
+from DIRAC import S_OK, S_ERROR
+from DIRAC.Resources.Computing.ARCComputingElement import ARCComputingElement
+
+
+class ARCC6omputingElement(ARCComputingElement):
+    def __init__(self, ceUniqueID):
+        """Standard constructor."""
+        super(ARCC6omputingElement, self).__init__(ceUniqueID)
+
+    def __getARCJob(self, jobID):
+        """Create an ARC Job with all the needed / possible parameters defined.
+        By the time we come here, the environment variable X509_USER_PROXY should already be set
+        """
+        j = arc.Job()
+        j.JobID = str(jobID)
+        j.IDFromEndpoint = os.path.basename(j.JobID)
+
+        # Get the endpoint type (GridFTP or AREX)
+        endpointType = j.JobID.split(":")[0]
+        if endpointType == "gsiftp":
+            statURL = "ldap://%s:2135/Mds-Vo-Name=local,o=grid??sub?(nordugrid-job-globalid=%s)" % (self.ceHost, jobID)
+            j.JobStatusURL = arc.URL(str(statURL))
+            j.JobStatusInterfaceName = "org.nordugrid.ldapng"
+
+            mangURL = os.path.dirname(j.JobID)
+            j.JobManagementURL = arc.URL(str(mangURL))
+            j.JobManagementInterfaceName = "org.nordugrid.gridftpjob"
+
+            j.ServiceInformationURL = j.JobManagementURL
+            j.ServiceInformationInterfaceName = "org.nordugrid.ldapng"
+        else:
+            commonURL = "/".join(j.JobID.split("/")[0:4])
+            j.JobStatusURL = arc.URL(str(commonURL))
+            j.JobStatusInterfaceName = "org.nordugrid.arcrest"
+
+            j.JobManagementURL = arc.URL(str(commonURL))
+            j.JobManagementInterfaceName = "org.nordugrid.arcrest"
+
+            j.ServiceInformationURL = arc.URL(str(commonURL))
+            j.ServiceInformationInterfaceName = "org.nordugrid.arcrest"
+
+        j.PrepareHandler(self.usercfg)
+        return j
+
+    def submitJob(self, executableFile, proxy, numberOfJobs=1):
+        """Method to submit job"""
+
+        # Assume that the ARC queues are always of the format nordugrid-<batchSystem>-<queue>
+        # And none of our supported batch systems have a "-" in their name
+        self.arcQueue = self.queue.split("-", 2)[2]
+        result = self._prepareProxy()
+        if not result["OK"]:
+            self.log.error("ARCComputingElement: failed to set up proxy", result["Message"])
+            return result
+        self.usercfg.ProxyPath(os.environ["X509_USER_PROXY"])
+
+        self.log.verbose("Executable file path: %s" % executableFile)
+        if not os.access(executableFile, 5):
+            os.chmod(executableFile, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH + stat.S_IXOTH)
+
+        batchIDList = []
+        stampDict = {}
+
+        # Creating an endpoint
+        endpoint = arc.Endpoint(self.ceHost, arc.Endpoint.COMPUTINGINFO, "org.nordugrid.ldapglue2")
+
+        # Get the ExecutionTargets of the ComputingElement (Can be REST, EMI-ES or GRIDFTP)
+        retriever = arc.ComputingServiceRetriever(self.usercfg, [endpoint])
+        retriever.wait()
+        targetsWithQueues = list(retriever.GetExecutionTargets())
+
+        # Targets also include queues
+        # To avoid losing time trying to submit to queues we cannot interact with, we only keep the interesting ones
+        targets = []
+        for target in targetsWithQueues:
+            if target.ComputingShare.Name == self.arcQueue:
+                self.log.debug(
+                    "Adding target:",
+                    "%s (%s)" % (target.ComputingEndpoint.URLString, target.ComputingEndpoint.InterfaceName),
+                )
+                targets.append(target)
+
+        # At this point, we should have GRIDFTP and AREX (EMI-ES and REST) targets related to arcQueue
+        # We intend to submit to AREX first, if it does not work, GRIDFTP is used
+        submissionWorked = False
+        for target in targets:
+            # If the submission is already done, we stop
+            if submissionWorked:
+                break
+
+            for __i in range(numberOfJobs):
+
+                # The basic job description
+                jobdescs = arc.JobDescriptionList()
+
+                # Get the job into the ARC way
+                xrslString, diracStamp = self.__writeXRSL(executableFile)
+                self.log.debug("XRSL string submitted : %s" % xrslString)
+                self.log.debug("DIRAC stamp for job : %s" % diracStamp)
+
+                # The arc bindings don't accept unicode objects in Python 2 so xrslString must be explicitly cast
+                result = arc.JobDescription_Parse(str(xrslString), jobdescs)
+                if not result:
+                    self.log.error("Invalid job description", "%r, message=%s" % (xrslString, result.str()))
+                    break
+
+                # Submit the job
+                job = arc.Job()
+                result = target.Submit(self.usercfg, jobdescs[0], job)
+
+                # Save info or else ..else.
+                if result == arc.SubmissionStatus.NONE:
+                    # Job successfully submitted
+                    pilotJobReference = job.JobID
+                    batchIDList.append(pilotJobReference)
+                    stampDict[pilotJobReference] = diracStamp
+                    submissionWorked = True
+                    self.log.debug("Successfully submitted job %s to CE %s" % (pilotJobReference, self.ceHost))
+                else:
+                    self._analyzeSubmissionError(result)
+                    break  # Boo hoo *sniff*
+
+        if batchIDList:
+            result = S_OK(batchIDList)
+            result["PilotStampDict"] = stampDict
+        else:
+            result = S_ERROR("No pilot references obtained from the ARC job submission")
+        return result
+
+    def getCEStatus(self):
+        """Method to return information on running and pending jobs.
+        We hope to satisfy both instances that use robot proxies and those which use proper configurations.
+        """
+
+        result = self._prepareProxy()
+        if not result["OK"]:
+            self.log.error("ARCComputingElement: failed to set up proxy", result["Message"])
+            return result
+        self.usercfg.ProxyPath(os.environ["X509_USER_PROXY"])
+
+        # Creating an endpoint
+        endpoint = arc.Endpoint(self.ceHost, arc.Endpoint.COMPUTINGINFO, "org.nordugrid.ldapglue2")
+
+        # Get the ExecutionTargets of the ComputingElement (Can be REST, EMI-ES or GRIDFTP)
+        retriever = arc.ComputingServiceRetriever(self.usercfg, [endpoint])
+        retriever.wait()  # Takes a bit of time to get and parse the ldap information
+        targetsWithQueues = retriever.GetExecutionTargets()
+
+        # Targets also include queues
+        # Some of them might be used by different VOs
+        targets = []
+        for target in targetsWithQueues:
+            if target.ComputingShare.Name == self.arcQueue:
+                self.log.debug(
+                    "Adding target:",
+                    "%s (%s)" % (target.ComputingEndpoint.URLString, target.ComputingEndpoint.InterfaceName),
+                )
+                targets.append(target)
+
+        # We extract stat from the AREX service (targets[0])
+        ceStats = targets[0].ComputingShare
+        self.log.debug("Running jobs for CE %s : %s" % (self.ceHost, ceStats.RunningJobs))
+        self.log.debug("Waiting jobs for CE %s : %s" % (self.ceHost, ceStats.WaitingJobs))
+
+        result = S_OK()
+        result["SubmittedJobs"] = 0
+        result["RunningJobs"] = ceStats.RunningJobs
+        result["WaitingJobs"] = ceStats.WaitingJobs
+
+        return result

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -248,29 +248,7 @@ class ARCComputingElement(ComputingElement):
                 stampDict[pilotJobReference] = diracStamp
                 self.log.debug("Successfully submitted job %s to CE %s" % (pilotJobReference, self.ceHost))
             else:
-                message = "Failed to submit job because "
-                if result.isSet(arc.SubmissionStatus.NOT_IMPLEMENTED):  # pylint: disable=no-member
-                    self.log.warn("%s feature not implemented on CE? (weird I know - complain to site admins" % message)
-                if result.isSet(arc.SubmissionStatus.NO_SERVICES):  # pylint: disable=no-member
-                    self.log.warn("%s no services are running on CE? (open GGUS ticket to site admins" % message)
-                if result.isSet(arc.SubmissionStatus.ENDPOINT_NOT_QUERIED):  # pylint: disable=no-member
-                    self.log.warn("%s endpoint was not even queried. (network ..?)" % message)
-                if result.isSet(arc.SubmissionStatus.BROKER_PLUGIN_NOT_LOADED):  # pylint: disable=no-member
-                    self.log.warn("%s BROKER_PLUGIN_NOT_LOADED : ARC library installation problem?" % message)
-                if result.isSet(arc.SubmissionStatus.DESCRIPTION_NOT_SUBMITTED):  # pylint: disable=no-member
-                    self.log.warn(
-                        "%s Job not submitted - incorrect job description? (missing field in XRSL string?)" % message
-                    )
-                if result.isSet(arc.SubmissionStatus.SUBMITTER_PLUGIN_NOT_LOADED):  # pylint: disable=no-member
-                    self.log.warn("%s SUBMITTER_PLUGIN_NOT_LOADED : ARC library installation problem?" % message)
-                if result.isSet(arc.SubmissionStatus.AUTHENTICATION_ERROR):  # pylint: disable=no-member
-                    self.log.warn(
-                        "%s authentication error - screwed up / expired proxy? Renew / upload pilot proxy on machine?"
-                        % message
-                    )
-                if result.isSet(arc.SubmissionStatus.ERROR_FROM_ENDPOINT):  # pylint: disable=no-member
-                    self.log.warn("%s some error from the CE - possibly CE problems?" % message)
-                self.log.warn("%s ... maybe above messages will give a hint." % message)
+                self._analyzeSubmissionError(result)
                 break  # Boo hoo *sniff*
 
         if batchIDList:
@@ -279,6 +257,32 @@ class ARCComputingElement(ComputingElement):
         else:
             result = S_ERROR("No pilot references obtained from the ARC job submission")
         return result
+
+    def _analyzeSubmissionError(self, result):
+        """Provide further information about the submission error
+
+        :param arc.SubmissionStatus result: submission error
+        """
+        message = "Failed to submit job because "
+        if result.isSet(arc.SubmissionStatus.NOT_IMPLEMENTED):  # pylint: disable=no-member
+            self.log.warn("%s feature not implemented on CE? (weird I know - complain to site admins" % message)
+        if result.isSet(arc.SubmissionStatus.NO_SERVICES):  # pylint: disable=no-member
+            self.log.warn("%s no services are running on CE? (open GGUS ticket to site admins" % message)
+        if result.isSet(arc.SubmissionStatus.ENDPOINT_NOT_QUERIED):  # pylint: disable=no-member
+            self.log.warn("%s endpoint was not even queried. (network ..?)" % message)
+        if result.isSet(arc.SubmissionStatus.BROKER_PLUGIN_NOT_LOADED):  # pylint: disable=no-member
+            self.log.warn("%s BROKER_PLUGIN_NOT_LOADED : ARC library installation problem?" % message)
+        if result.isSet(arc.SubmissionStatus.DESCRIPTION_NOT_SUBMITTED):  # pylint: disable=no-member
+            self.log.warn("%s Job not submitted - incorrect job description? (missing field in XRSL string?)" % message)
+        if result.isSet(arc.SubmissionStatus.SUBMITTER_PLUGIN_NOT_LOADED):  # pylint: disable=no-member
+            self.log.warn("%s SUBMITTER_PLUGIN_NOT_LOADED : ARC library installation problem?" % message)
+        if result.isSet(arc.SubmissionStatus.AUTHENTICATION_ERROR):  # pylint: disable=no-member
+            self.log.warn(
+                "%s authentication error - screwed up / expired proxy? Renew / upload pilot proxy on machine?" % message
+            )
+        if result.isSet(arc.SubmissionStatus.ERROR_FROM_ENDPOINT):  # pylint: disable=no-member
+            self.log.warn("%s some error from the CE - possibly CE problems?" % message)
+        self.log.warn("%s ... maybe above messages will give a hint." % message)
 
     #############################################################################
     def killJob(self, jobIDList):


### PR DESCRIPTION
This PR aims to integrate a new method to submit ARC jobs:
- transfer the full proxies to the remote computing resources
- no need to specify the port (because it can be changed by the ARC admins)
- no need to specify the interface used (it will try to submit via the REST interface first, then EMI-ES, and finally GRIDFTP)

This can probably be a good way to transition from GRIDFTP to REST.

I tested the new method with ~45 ARC CEs from ~20 sites.
In most of the case, the Python interface was using the REST interface.

No big change in the submission duration, I did 3 submissions of 50 jobs with the new and the old method on a same CE and got the following results:
- new method: 30.5 seconds
- old method: 34.7 seconds


BEGINRELEASENOTES
*WorkloadManagementSystem
CHANGE: new method to submit pilots from ARC
ENDRELEASENOTES
