### PR TITLE
[8.0] Make TimeUtilities Module independent of timezone

### DIFF
--- a/src/DIRAC/Core/Utilities/TimeUtilities.py
+++ b/src/DIRAC/Core/Utilities/TimeUtilities.py
@@ -20,7 +20,7 @@ if a give datetime is in the defined interval.
 
 """
 import calendar
-import time as nativetime
+import time
 import datetime
 import sys
 
@@ -39,11 +39,11 @@ def timeThis(method):
 
     def timed(*args, **kw):
         """What actually times"""
-        ts = nativetime.time()
+        ts = time.time()
         result = method(*args, **kw)
         if sys.stdout.isatty():
             return result
-        te = nativetime.time()
+        te = time.time()
 
         pre = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC ")
 
@@ -236,10 +236,10 @@ def queryTime(f):
     """Decorator to measure the function call time"""
 
     def measureQueryTime(*args, **kwargs):
-        start = nativetime.time()
+        start = time.time()
         result = f(*args, **kwargs)
         if result["OK"] and "QueryTime" not in result:
-            result["QueryTime"] = nativetime.time() - start
+            result["QueryTime"] = time.time() - start
         return result
 
     return measureQueryTime

--- a/src/DIRAC/Core/Utilities/TimeUtilities.py
+++ b/src/DIRAC/Core/Utilities/TimeUtilities.py
@@ -19,6 +19,7 @@ An timeInterval class provides a method to check
 if a give datetime is in the defined interval.
 
 """
+import calendar
 import time as nativetime
 import datetime
 import sys
@@ -84,7 +85,7 @@ def toEpoch(dateTimeObject=None):
     """
     if not dateTimeObject:
         dateTimeObject = datetime.datetime.utcnow()
-    return nativetime.mktime(dateTimeObject.timetuple())
+    return calendar.timegm(dateTimeObject.utctimetuple())
 
 
 def toEpochMilliSeconds(dateTimeObject=None):
@@ -98,7 +99,7 @@ def fromEpoch(epoch):
     """
     Get datetime object from epoch
     """
-    return datetime.datetime.utcnow().fromtimestamp(epoch)
+    return datetime.datetime.utcfromtimestamp(epoch)
 
 
 def toString(myDate=None):

--- a/tests/Integration/Monitoring/Test_MonitoringSystem.py
+++ b/tests/Integration/Monitoring/Test_MonitoringSystem.py
@@ -123,8 +123,8 @@ def test_getReport(putAndDelete):
     params = (
         "WMSHistory",
         "NumberOfJobs",
-        datetime(2016, 3, 16, 12, 30, 0, 0),
-        datetime(2016, 3, 17, 19, 29, 0, 0),
+        datetime(2016, 3, 16, 10, 30, 0, 0),
+        datetime(2016, 3, 17, 17, 29, 0, 0),
         {"grouping": ["Site"]},
         "Site",
         {},


### PR DESCRIPTION
Resolves https://github.com/DIRACGrid/DIRAC/issues/5275.
To merge after #6076.

BEGINRELEASENOTES

*Core
FIX: Removing time dependence of TimeUtilities Module

ENDRELEASENOTES