### PR TITLE
[v7r3] fix userData format for creating VMs from Cloud resources

### DIFF
--- a/src/DIRAC/Resources/Cloud/Utilities.py
+++ b/src/DIRAC/Resources/Cloud/Utilities.py
@@ -32,13 +32,13 @@ def createMimeData(userDataTuple):
     userData = MIMEMultipart()
     for contents, mtype, fname in userDataTuple:
         try:
-            mimeText = MIMEText(contents, mtype, sys.getdefaultencoding())
+            mimeText = MIMEText(contents, mtype, "ascii")
             mimeText.add_header("Content-Disposition", 'attachment; filename="%s"' % fname)
             userData.attach(mimeText)
         except Exception as e:
             return S_ERROR(str(e))
 
-    return S_OK(userData)
+    return S_OK(userData.as_string())
 
 
 def createPilotDataScript(vmParameters, bootstrapParameters):


### PR DESCRIPTION

BEGINRELEASENOTES

*Resources/Cloud
FIX: userData need to be in "ascii" string format to meet the requirement of "create_node" when creating VMs from cloud resources

ENDRELEASENOTES
