### PR TITLE
[integration] Replace deprecated threading.activeCount with active_count

### DIFF
--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -267,7 +267,7 @@ class Service(object):
                 "CpuPercentage": percentage,
                 "PendingQueries": pendingQueries,
                 "ActiveQueries": activeQuereies,
-                "RunningThreads": threading.activeCount(),
+                "RunningThreads": threading.active_count(),
                 "MaxFD": self.__maxFD,
             }
         )


### PR DESCRIPTION
`threading.activeCount` was deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023).

Replace with `threading.active_count`, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174


BEGINRELEASENOTES

*Core
FIX: Replace deprecated threading.activeCount with active_count

ENDRELEASENOTES


