### PR TITLE
[v7r3] Backport: Replace deprecated threading.activeCount with active_count

### DIFF
--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -318,7 +318,7 @@ class Service(object):
 
         self._monitor.addMark("PendingQueries", pendingQueries)
         self._monitor.addMark("ActiveQueries", activeQuereies)
-        self._monitor.addMark("RunningThreads", threading.activeCount())
+        self._monitor.addMark("RunningThreads", threading.active_count())
         self._monitor.addMark("MaxFD", self.__maxFD)
         self.__maxFD = 0
 


### PR DESCRIPTION
Backport https://github.com/DIRACGrid/DIRAC/pull/6151