### PR TITLE
[Integration] Feat: stop pylint invalid-name for test module and test function

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,7 @@ bad-functions=map,filter,apply,input,raw_input,has_key
 
 # Regular expression which should only match correct module names
 # Added last option, to take into account script names
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+)|([dirac_-][a-zA-Z_-]+))$
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+)|([dirac_-][a-zA-Z_-]+)|(Test_[a-zA-Z_-]+))$
 
 # Regular expression which should only match correct module level names
 #const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|(g[A-Z][a-zA-Z0-9]*))$
@@ -72,7 +72,7 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|(g[A-Z][a-zA-Z0-9]*)|[a-z_][A-Za-z0-9_]*)
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression which should only match correct function names
-function-rgx=[a-z_][A-Za-z0-9_]{2,30}$
+function-rgx=(([a-z_][A-Za-z0-9_]{2,30}$)|(test_[A-Za-z0-9_]{2,50}$))
 
 # Regular expression which should only match correct method names
 method-rgx=[a-z_][A-Za-z0-9_]{2,30}$

--- a/src/DIRAC/TransformationSystem/Agent/test/Test_Plugins.py
+++ b/src/DIRAC/TransformationSystem/Agent/test/Test_Plugins.py
@@ -1,9 +1,7 @@
 """ Test class for plugins
 """
-# pylint: disable=protected-access, missing-docstring, invalid-name,
-# line-too-long
+# pylint: disable=protected-access, missing-docstring
 
-# imports
 import pytest
 from mock import MagicMock
 
@@ -181,6 +179,6 @@ def test__Broadcast_Active_G1_NoSource(setup):
     # sort returned values by first lfn in LFNs
     sortedReturn = [(SE, lfns) for SE, lfns in sorted(res["Value"], key=lambda t: t[1][0])]
     # sort data by lfn
-    expected = [("SE2", [lfn]) for lfn, _SEs in sorted(data.items(), key=lambda t: t[0])]
+    expected = [("SE2", [lfn]) for lfn in sorted(data.keys())]
     assert res["OK"]
     assert sortedReturn == expected

--- a/src/DIRAC/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
+++ b/src/DIRAC/TransformationSystem/Client/test/Test_Client_TransformationSystem.py
@@ -1,11 +1,11 @@
 """ unit tests for Transformation Clients
 """
-# pylint: disable=protected-access,missing-docstring,invalid-name
+# pylint: disable=protected-access,missing-docstring
 
-import six
 import unittest
 import json
 import mock
+import six
 
 from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.TransformationSystem.Client.TaskManager import TaskBase

--- a/src/DIRAC/WorkloadManagementSystem/Client/test/Test_JobReport.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/test/Test_JobReport.py
@@ -1,5 +1,5 @@
 """Test for JobReport"""
-# pylint: disable=protected-access, missing-docstring, invalid-name
+# pylint: disable=missing-docstring
 
 from mock import MagicMock
 

--- a/src/DIRAC/WorkloadManagementSystem/Executor/test/Test_Executor.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/test/Test_Executor.py
@@ -1,6 +1,6 @@
 """ pytest(s) for Executors
 """
-# pylint: disable=protected-access, missing-docstring, invalid-name, line-too-long
+# pylint: disable=protected-access, missing-docstring
 
 import pytest
 from mock import MagicMock

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
@@ -1,6 +1,5 @@
 """ This is a test of the creation of the pilot wrapper
 """
-# pylint: disable=protected-access, invalid-name, no-self-use
 
 import os
 import base64

--- a/tests/Integration/AccountingSystem/Test_DataStoreClient.py
+++ b/tests/Integration/AccountingSystem/Test_DataStoreClient.py
@@ -5,7 +5,7 @@
 
     this is pytest!
 """
-# pylint: disable=invalid-name,wrong-import-position
+# pylint: disable=wrong-import-position, missing-docstring
 
 import DIRAC
 

--- a/tests/Workflow/Regression/Test_RegressionUserJobs.py
+++ b/tests/Workflow/Regression/Test_RegressionUserJobs.py
@@ -1,6 +1,6 @@
 """ This module will run some job descriptions defined with an older version of DIRAC
 """
-# pylint: disable=protected-access, wrong-import-position, invalid-name, missing-docstring
+# pylint: disable=protected-access, wrong-import-position, missing-docstring
 import unittest
 import os
 import sys


### PR DESCRIPTION

Adding specific regex to avoid pylint invalid-name warning for test module and too long test names
