### PR TITLE
[sweep:integration] fix: use the JobMonitoringClient to check for job parameters (that ca…

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -17,7 +17,6 @@ import datetime
 
 import operator
 
-from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getSiteTier
@@ -31,6 +30,7 @@ from DIRAC.ResourceStatusSystem.Client.SiteStatus import SiteStatus
 from DIRAC.WorkloadManagementSystem.Client.JobState.JobManifest import JobManifest
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
 from DIRAC.WorkloadManagementSystem.Client import JobMinorStatus
+from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
 
 #############################################################################
 # utility functions
@@ -1319,7 +1319,7 @@ class JobDB(DB):
         jobAttrValues.append(rescheduleCounter)
 
         # Save the job parameters for later debugging
-        result = self.getJobParameters(jobID)
+        result = JobMonitoringClient().getJobParameters(jobID)
         if result["OK"]:
             parDict = result["Value"]
             for key, value in parDict.get(jobID, {}).items():


### PR DESCRIPTION
Sweep #6133 `fix: use the JobMonitoringClient to check for job parameters (that ca…` to `integration`.

Adding original author @fstagni as watcher.

BEGINRELEASENOTES

*WMS
FIX: use the JobMonitoringClient to check for job parameters (that can be in the ES backend)

ENDRELEASENOTES
Closes #6156