### PR TITLE
[8.1] feat: raising exception when a jdl does not contains brackets

### DIFF
--- a/src/DIRAC/Core/Utilities/ClassAd.py
+++ b/src/DIRAC/Core/Utilities/ClassAd.py
@@ -3,31 +3,30 @@
 """
 
 
-class ClassAd(object):
-    def __init__(self, jdl):
+from DIRAC import S_ERROR, S_OK
+
+
+class ClassAd:
+    def __init__(self, jdl: str = ""):
         """ClassAd constructor from a JDL string"""
         self.contents = {}
-        result = self.__analyse_jdl(jdl)
-        if result:
-            self.contents = result
+        if jdl:
+            result = self.__analyse_jdl(jdl)
+            if not result["OK"]:
+                raise Exception(result["Message"])
+            self.contents = result["Value"]
 
     def __analyse_jdl(self, jdl, index=0):
         """Analyse one [] jdl enclosure"""
 
-        jdl = jdl.strip()
-
-        # Strip all the blanks first
-        # temp = jdl.replace(' ','').replace('\n','')
-        temp = jdl
-
         result = {}
 
-        if temp[0] != "[" or temp[-1] != "]":
-            print("Invalid JDL: it should start with [ and end with ]")
-            return result
+        jdl = jdl.strip()
+        if not jdl.startswith("[") or not jdl.endswith("]"):
+            return S_ERROR("Invalid JDL: it should start with [ and end with ]")
 
         # Parse the jdl string now
-        body = temp[1:-1]
+        body = jdl[1:-1]
         index = 0
         namemode = 1
         valuemode = 0
@@ -51,7 +50,7 @@ class ClassAd(object):
                     newind = len(body)
                 else:
                     if index == ind2:
-                        return {}
+                        return S_OK({})
                     else:
                         value = body[index:ind2]
                         newind = ind2 + 1
@@ -61,7 +60,7 @@ class ClassAd(object):
                 valuemode = 0
                 namemode = 1
 
-        return result
+        return S_OK(result)
 
     def __find_subjdl(self, body, index):
         """Find a full [] enclosure starting from index"""
@@ -218,12 +217,9 @@ class ClassAd(object):
             return 1
         return 0
 
-    def isOK(self):
-        """Check the JDL validity - to be defined"""
-
-        if self.contents:
-            return 1
-        return 0
+    def isEmpty(self):
+        """Check if the class has content"""
+        return not bool(self.contents)
 
     def asJDL(self):
         """Convert the JDL description into a string"""

--- a/src/DIRAC/Core/Utilities/ClassAd/__init__.py
+++ b/src/DIRAC/Core/Utilities/ClassAd/__init__.py
@@ -1,3 +1,0 @@
-"""
-   DIRAC.Core.ClassAd package
-"""

--- a/src/DIRAC/Core/Utilities/test/Test_ClassAd.py
+++ b/src/DIRAC/Core/Utilities/test/Test_ClassAd.py
@@ -1,0 +1,85 @@
+import pytest
+
+from DIRAC.Core.Utilities.ClassAd import ClassAd
+
+
+@pytest.mark.parametrize(
+    "jdl, expected",
+    [
+        ("", True),
+        ("[]", True),
+        ('[Executable="dirac-jobexec";]', False),
+        ('[   Executable    =    "dirac-jobexec";   ]', False),
+    ],
+)
+def test_analyse_jdl(jdl, expected):
+
+    # Act
+    jobDescription = ClassAd(jdl)
+
+    # Assert
+    assert jobDescription.isEmpty() is expected
+
+
+def test_insertAttributeInt():
+
+    # Arrange
+    value = 1
+    jobDescription = ClassAd("")
+
+    # Act
+    jobDescription.insertAttributeInt("Test", value)
+
+    # Assert
+    assert jobDescription.isEmpty() is True
+    assert jobDescription.lookupAttribute("Test") is True
+    assert jobDescription.getAttributeInt("Test") == value
+    assert "".join(jobDescription.asJDL().split()) == f"[Test={value};]"
+
+
+def test_insertAttributeString():
+
+    # Arrange
+    value = "foo"
+    jobDescription = ClassAd("")
+
+    # Act
+    jobDescription.insertAttributeString("Test", value)
+
+    # Assert
+    assert jobDescription.isEmpty() is True
+    assert jobDescription.lookupAttribute("Test") is True
+    assert jobDescription.getAttributeString("Test") == value
+    assert "".join(jobDescription.asJDL().split()) == f'[Test="{value}";]'
+
+
+def test_insertAttributeVectorInt():
+
+    # Arrange
+    value = [1, 2, 3]
+    jobDescription = ClassAd("")
+
+    # Act
+    jobDescription.insertAttributeVectorInt("Test", value)
+
+    # Assert
+    assert jobDescription.isEmpty() is True
+    assert jobDescription.lookupAttribute("Test") is True
+    assert jobDescription.getListFromExpression("Test") == [str(x) for x in value]
+    assert "".join(jobDescription.asJDL().split()) == "[Test={1,2,3};]"
+
+
+def test_insertAttributeVectorString():
+
+    # Arrange
+    value = ["1", "2", "3"]
+    jobDescription = ClassAd("")
+
+    # Act
+    jobDescription.insertAttributeVectorString("Test", value)
+
+    # Assert
+    assert jobDescription.isEmpty() is True
+    assert jobDescription.lookupAttribute("Test") is True
+    assert jobDescription.getListFromExpression("Test") == [str(x) for x in value]
+    assert "".join(jobDescription.asJDL().split()) == '[Test={"1","2","3"};]'

--- a/src/DIRAC/Interfaces/API/Dirac.py
+++ b/src/DIRAC/Interfaces/API/Dirac.py
@@ -35,7 +35,7 @@ from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Utilities.SiteSEMapping import getSEsForSite
 from DIRAC.Core.Utilities.PrettyPrint import printTable, printDict
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.Core.Utilities.Subprocess import systemCall
 from DIRAC.Core.Utilities.ModuleFactory import ModuleFactory
 from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemSection, getServiceURL

--- a/src/DIRAC/Interfaces/API/Job.py
+++ b/src/DIRAC/Interfaces/API/Job.py
@@ -34,7 +34,7 @@ from DIRAC.Core.Base.API import API
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.Core.Workflow.Parameter import Parameter
 from DIRAC.Core.Workflow.Workflow import Workflow
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.Core.Utilities.Subprocess import systemCall
 from DIRAC.Core.Utilities.List import uniqueElements
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
@@ -1042,7 +1042,7 @@ class Job(API):
         :returns: JDL (str)
         """
         # Check if we have to do old bootstrap...
-        classadJob = ClassAd("[]")
+        classadJob = ClassAd()
 
         paramsDict = {}
         params = self.workflow.parameters  # ParameterCollection object

--- a/src/DIRAC/Interfaces/API/test/Test_JobAPI.py
+++ b/src/DIRAC/Interfaces/API/test/Test_JobAPI.py
@@ -6,7 +6,7 @@ import pytest
 from io import StringIO
 
 from DIRAC.Interfaces.API.Job import Job
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 
 
 def test_basicJob():

--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -19,7 +19,7 @@ from diraccfg import CFG
 
 from DIRAC import S_OK, S_ERROR, gConfig, rootPath, siteName
 from DIRAC.Core.Utilities.ModuleFactory import ModuleFactory
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.Core.Security import Properties

--- a/src/DIRAC/WorkloadManagementSystem/Agent/OptimizerModule.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/OptimizerModule.py
@@ -8,7 +8,7 @@ from DIRAC import S_OK, S_ERROR, exit as dExit
 
 from DIRAC.AccountingSystem.Client.Types.Job import Job as AccountingJob
 from DIRAC.Core.Base.AgentModule import AgentModule
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
@@ -144,7 +144,7 @@ class OptimizerModule(AgentModule):
             except Exception:
                 self.log.debug("Cannot load JDL")
                 return S_ERROR(JobMinorStatus.ILLEGAL_JOB_JDL)
-            if not classad.isOK():
+            if classad.isEmpty():
                 self.log.debug("Warning: illegal JDL for job %s, will be marked problematic" % (job))
                 return S_ERROR(JobMinorStatus.ILLEGAL_JOB_JDL)
             jobDef["classad"] = classad

--- a/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -18,7 +18,7 @@ from DIRAC.AccountingSystem.Client.Types.Job import Job
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Utilities.TimeUtilities import fromString, toEpoch, second
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.ConfigurationSystem.Client.Helpers import cfgPath
 from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemInstance
 from DIRAC.WorkloadManagementSystem.Client.WMSClient import WMSClient
@@ -359,7 +359,12 @@ class StalledJobAgent(AgentModule):
         result = self.jobDB.getJobJDL(jobID, original=True)
         if not result["OK"]:
             return processingType
-        classAdJob = ClassAd(result["Value"])
+
+        try:
+            classAdJob = ClassAd(result["Value"])
+        except Exception:
+            return processingType
+
         if classAdJob.lookupAttribute("ProcessingType"):
             processingType = classAdJob.getAttributeString("ProcessingType")
         return processingType

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobState/CachedJobState.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobState/CachedJobState.py
@@ -153,10 +153,10 @@ class CachedJobState:
         cjs.__jobLog = dataTuple[2]
         dt3 = dataTuple[3]
         if dataTuple[3]:
-            manifest = JobManifest()
-            result = manifest.loadCFG(dt3[0])
-            if not result["OK"]:
-                return result
+            try:
+                manifest = JobManifest(dt3[0])
+            except Exception as e:
+                return S_ERROR(e)
             if dt3[1]:
                 manifest.setDirty()
             else:

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobState.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobState.py
@@ -53,7 +53,7 @@ class JobState:
         if not result["Value"]:
             return S_ERROR("No manifest for job %s" % self.__jid)
         manifest = JobManifest()
-        result = manifest.loadJDL(result["Value"])
+        result = manifest.load(result["Value"])
         if not result["OK"]:
             return result
         return S_OK(manifest)

--- a/src/DIRAC/WorkloadManagementSystem/Client/WMSClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/WMSClient.py
@@ -9,7 +9,7 @@ from DIRAC import S_OK, S_ERROR, gLogger
 
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Utilities import File
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.Core.Utilities.DErrno import EWMSJDL, EWMSSUBM
 from DIRAC.WorkloadManagementSystem.Client.JobManagerClient import JobManagerClient
 from DIRAC.WorkloadManagementSystem.Client.SandboxStoreClient import SandboxStoreClient
@@ -167,8 +167,13 @@ class WMSClient:
         # Check the validity of the input JDL
         if jdlString.find("[") != 0:
             jdlString = "[%s]" % jdlString
-        classAdJob = ClassAd(jdlString)
-        if not classAdJob.isOK():
+
+        try:
+            classAdJob = ClassAd(jdlString)
+        except Exception as e:
+            return S_ERROR(EWMSJDL, e)
+
+        if classAdJob.isEmpty():
             return S_ERROR(EWMSJDL, "Invalid job JDL")
 
         # Check the size and the contents of the input sandbox

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -22,7 +22,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getSiteTier
 from DIRAC.Core.Base.DB import DB
 from DIRAC.Core.Utilities import DErrno
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.Utilities.DErrno import EWMSSUBM, EWMSJMAN
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
@@ -1009,11 +1009,14 @@ class JobDB(DB):
         if jobJDL.find("%j") != -1:
             jobJDL = jobJDL.replace("%j", str(jobID))
 
-        classAdJob = ClassAd(jobJDL)
-        classAdReq = ClassAd("[]")
+        try:
+            classAdJob = ClassAd(jobJDL)
+        except Exception:
+            pass
+        classAdReq = ClassAd()
         retVal = S_OK(jobID)
         retVal["JobID"] = jobID
-        if not classAdJob.isOK():
+        if classAdJob.isEmpty():
             jobAttrNames.append("Status")
             jobAttrValues.append(JobStatus.FAILED)
 
@@ -1351,7 +1354,7 @@ class JobDB(DB):
         if jdl.strip()[0].find("[") != 0:
             jdl = "[" + jdl + "]"
         classAdJob = ClassAd(jdl)
-        classAdReq = ClassAd("[]")
+        classAdReq = ClassAd()
         retVal = S_OK(jobID)
         retVal["JobID"] = jobID
 

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -14,7 +14,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 from DIRAC.Core.DISET.MessageClient import MessageClient
 from DIRAC.Core.Utilities.DErrno import EWMSJDL, EWMSSUBM
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.Core.Utilities.JEncode import strToIntDict
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
@@ -151,7 +151,10 @@ class JobManagerHandlerMixin:
             jobDesc = "%s]" % jobDesc
 
         # Check if the job is a parametric one
-        jobClassAd = ClassAd(jobDesc)
+        try:
+            jobClassAd = ClassAd(jobDesc)
+        except Exception as e:
+            return S_ERROR(e)
         result = getParameterVectorLength(jobClassAd)
         if not result["OK"]:
             self.log.error("Issue with getParameterVectorLength", result["Message"])

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/ParametricJob.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/ParametricJob.py
@@ -6,7 +6,7 @@
 """
 import re
 
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.Utilities.DErrno import EWMSJDL
 
@@ -153,7 +153,10 @@ def generateParametricJobs(jobClassAd):
     for n in range(nParValues):
         newJobDesc = jobDesc
         newJobDesc = newJobDesc.replace("%n", str(n).zfill(zLength))
-        newClassAd = ClassAd(newJobDesc)
+        try:
+            newClassAd = ClassAd(newJobDesc)
+        except Exception as e:
+            return S_ERROR(e)
         for seqID in parameterLists:
             parameter = parameterLists[seqID][n]
             for attribute in newClassAd.getAttributes():

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/QueueUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/QueueUtilities.py
@@ -1,11 +1,10 @@
 """Utilities to help Computing Element Queues manipulation
 """
-import os
 import hashlib
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.List import fromChar
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getDIRACPlatform
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
@@ -164,8 +163,12 @@ def matchQueue(jobJDL, queueDict, fullMatch=False):
     """
 
     # Check the job description validity
-    job = ClassAd(jobJDL)
-    if not job.isOK():
+    try:
+        job = ClassAd(jobJDL)
+    except Exception as e:
+        return S_ERROR(e)
+
+    if job.isEmpty():
         return S_ERROR("Invalid job description")
 
     noMatchReasons = []

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_ParametricJob.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_ParametricJob.py
@@ -5,7 +5,7 @@
 import unittest
 
 from DIRAC.WorkloadManagementSystem.Utilities.ParametricJob import generateParametricJobs, getParameterVectorLength
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ClassAd import ClassAd
 
 TEST_JDL_NO_PARAMETERS = """
 [


### PR DESCRIPTION

Raising exception when a jdl does not contains brackets instead of just printing a message. This also allows to rename the isOK() method to isEmpty() (because it is what it do).
