### PR TITLE
[Integration] refactor: removing the load method from JobManifest

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/JobState/CachedJobState.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobState/CachedJobState.py
@@ -153,10 +153,10 @@ class CachedJobState:
         cjs.__jobLog = dataTuple[2]
         dt3 = dataTuple[3]
         if dataTuple[3]:
-            manifest = JobManifest()
-            result = manifest.loadCFG(dt3[0])
-            if not result["OK"]:
-                return result
+            try:
+                manifest = JobManifest(dt3[0])
+            except Exception as e:
+                return S_ERROR(e)
             if dt3[1]:
                 manifest.setDirty()
             else:
@@ -270,14 +270,12 @@ class CachedJobState:
 
     def setManifest(self, manifest):
         if not isinstance(manifest, JobManifest):
-            jobManifest = JobManifest()
-            result = jobManifest.load(str(manifest))
-            if not result["OK"]:
-                return result
-            manifest = jobManifest
+            try:
+                manifest = JobManifest(manifest)
+            except Exception as e:
+                return S_ERROR(e)
         manifest.setDirty()
         self.__manifest = manifest
-        # self.__manifest.clearDirty()
         return S_OK()
 
     # Attributes

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobManifest.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobManifest.py
@@ -7,12 +7,16 @@ from DIRAC.Core.Utilities.JDL import loadJDLAsCFG, dumpCFGAsJDL
 
 
 class JobManifest:
-    def __init__(self, manifest=""):
+    def __init__(self, manifest: str = ""):
         self.__manifest = CFG()
         self.__dirty = False
         self.__ops = False
         if manifest:
-            result = self.load(manifest)
+            manifest = manifest.strip()
+            if manifest.startswith("[") and manifest.endswith("]"):
+                result = self.__loadJDL(manifest)
+            else:
+                result = self.__loadCFG(manifest)
             if not result["OK"]:
                 raise Exception(result["Message"])
 
@@ -25,17 +29,7 @@ class JobManifest:
     def clearDirty(self):
         self.__dirty = False
 
-    def load(self, dataString):
-        """
-        Auto discover format type based on [ .. ] of JDL
-        """
-        dataString = dataString.strip()
-        if dataString[0] == "[" and dataString[-1] == "]":
-            return self.loadJDL(dataString)
-        else:
-            return self.loadCFG(dataString)
-
-    def loadJDL(self, jdlString):
+    def __loadJDL(self, jdlString):
         """
         Load job manifest from JDL format
         """
@@ -46,7 +40,7 @@ class JobManifest:
         self.__manifest = result["Value"][0]
         return S_OK()
 
-    def loadCFG(self, cfgString):
+    def __loadCFG(self, cfgString):
         """
         Load job manifest from CFG format
         """

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobState.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobState/JobState.py
@@ -52,19 +52,19 @@ class JobState:
             return result
         if not result["Value"]:
             return S_ERROR("No manifest for job %s" % self.__jid)
-        manifest = JobManifest()
-        result = manifest.loadJDL(result["Value"])
-        if not result["OK"]:
-            return result
+        try:
+            manifest = JobManifest(result["Value"])
+        except Exception as e:
+            return S_ERROR(e)
+
         return S_OK(manifest)
 
     def setManifest(self, manifest):
         if not isinstance(manifest, JobManifest):
-            manifestStr = manifest
-            manifest = JobManifest()
-            result = manifest.load(manifestStr)
-            if not result["OK"]:
-                return result
+            try:
+                manifest = JobManifest(manifest)
+            except Exception as e:
+                return S_ERROR(e)
         manifestJDL = manifest.dumpAsJDL()
         return self.__retryFunction(5, JobState.__db.jobDB.setJobJDL, (self.__jid, manifestJDL))
 

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -957,10 +957,11 @@ class JobDB(DB):
         :param str initialMinorStatus: optional initial minor job status
         :return: new job ID
         """
-        jobManifest = JobManifest()
-        result = jobManifest.load(jdl)
-        if not result["OK"]:
-            return result
+        try:
+            jobManifest = JobManifest(jdl)
+        except Exception as e:
+            return S_ERROR(e)
+
         jobManifest.setOptionsFromDict(
             {"OwnerName": owner, "OwnerDN": ownerDN, "OwnerGroup": ownerGroup, "DIRACSetup": diracSetup}
         )


### PR DESCRIPTION
This allows to ease the transition from JobManifest to ClassAd
