### PR TITLE
[8.0] Late binding of MonitoringReporter to the monitoringDB

### DIFF
--- a/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
+++ b/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
@@ -30,6 +30,3 @@ def getMonitoringDB():
     except Exception:
         pass
     return getDBOrClient(MonitoringDB, serverName)
-
-
-monitoringDB = getMonitoringDB()


### PR DESCRIPTION
  A simple import of MonitoringReporter which happens, for example, when importing Dirac interface class, results in an attempt to create and ping ES MonitoringDB. In CLI commands this creates unnecessary delays and confusing error printouts, e.g.:

    $ dls -L /
    Cannot ping ElasticsearchDB!
    Can't connect to MonitoringDB RuntimeError('Can not connect to ES cluster , exiting...')

where it is normal that direct access to ES is not available in the interactive environment and the MonitoringReporter is not actually invoked. 

BEGINRELEASENOTES

*Monitoring
FIX: MonitoringReporter - late binding to MonitoringDB

ENDRELEASENOTES
