### PR TITLE
[v8.0] fix (Core): better report of error when importing Module

### DIFF
--- a/src/DIRAC/Core/Utilities/Extensions.py
+++ b/src/DIRAC/Core/Utilities/Extensions.py
@@ -146,7 +146,11 @@ def recurseImport(modName, parentModule=None, hideExceptions=False):
     try:
         return S_OK(importlib.import_module(modName))
     except ImportError as excp:
-        if str(excp).startswith("No module named"):
+        # name of the module reported as not found
+        notFoundModule = excp.name
+        # We make sure that the module not found is the one we are trying to import,
+        # and not for example a missing dependency in the handler we are trying to import
+        if isinstance(excp, ModuleNotFoundError) and modName.startswith(notFoundModule):
             return S_OK()
         errMsg = "Can't load %s" % modName
         if not hideExceptions:


### PR DESCRIPTION
If an import was buggy in an Agent or Handler, we would only see an error like 

```
ERROR: Error while loading agent module Could not find <system>/<agent>
```

This PR makes the distinction between not finding the module we look for, and a missing dependency in the module we are looking for

BEGINRELEASENOTES

*Core
FIX:  better report of error when importing Module

ENDRELEASENOTES
