### PR TITLE
[v7r2] fix: address issue 6092 where built-in metakeys were modified for MultiVO

### DIFF
--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
@@ -19,14 +19,14 @@ VO_SUFFIX_SEPARATOR = "___"
 def _getMetaName(meta, credDict):
     """
     Return a fully-qualified metadata name based on client-supplied metadata name and
-    client credentials. User VO is added to the metadata passed in.
+    client credentials. User VO is added to the metadata passed in. Built-in meta keys are not affected.
 
     :param meta: metadata name
     :param credDict: client credentials
-    :return: fully-qualified metadata name
+    :return: fully-qualified metadata name for user metadata and unmodified metadata name for built-in keys.
     """
 
-    return meta + _getMetaNameSuffix(credDict)
+    return meta + _getMetaNameSuffix(credDict) if meta not in MetaQuery.FILE_STANDARD_METAKEYS else meta
 
 
 def _getMetaNameDict(metaDict, credDict):
@@ -41,10 +41,7 @@ def _getMetaNameDict(metaDict, credDict):
 
     fMetaDict = {}
     for meta, value in metaDict.items():
-        if meta in MetaQuery.FILE_STANDARD_METAKEYS:
-            fMetaDict[meta] = value
-        else:
-            fMetaDict[_getMetaName(meta, credDict)] = value
+        fMetaDict[_getMetaName(meta, credDict)] = value
     return fMetaDict
 
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
@@ -9,6 +9,7 @@ __RCSID__ = "$Id$"
 from DIRAC import S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.DataManagementSystem.DB.FileCatalogComponents.DirectoryMetadata.DirectoryMetadata import DirectoryMetadata
+from DIRAC.DataManagementSystem.Client import MetaQuery
 
 VO_SUFFIX_SEPARATOR = "___"
 
@@ -31,7 +32,7 @@ def _getMetaName(meta, credDict):
 def _getMetaNameDict(metaDict, credDict):
     """
     Return a dictionary with fully-qualified metadata name keys based on client-supplied metadata name and
-    client credentials. User VO is added to the metadata passed in.
+    client credentials. User VO is added to the metadata passed in. Built-in meta keys are not affected.
 
     :param meta: metadata name
     :param credDict: client credentials
@@ -40,7 +41,10 @@ def _getMetaNameDict(metaDict, credDict):
 
     fMetaDict = {}
     for meta, value in metaDict.items():
-        fMetaDict[_getMetaName(meta, credDict)] = value
+        if meta in MetaQuery.FILE_STANDARD_METAKEYS:
+            fMetaDict[meta] = value
+        else:
+            fMetaDict[_getMetaName(meta, credDict)] = value
     return fMetaDict
 
 


### PR DESCRIPTION



BEGINRELEASENOTES

*DataManagementSystem
FIX: Built-in metakeys were incorrectly modified in a MultiVO environment. This fix keeps them intact while modifying user-supplied metadata names by append a VO suffix, as before.


ENDRELEASENOTES
