### PR TITLE
[v7r3] test (CI): set a max number of files for the dirac containers in docker-compose

### DIFF
--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -47,6 +47,8 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
+    ulimits:
+      nofile: 8192
 
   dirac-client:
     image: ${CI_REGISTRY_IMAGE}/${HOST_OS}-dirac
@@ -55,3 +57,5 @@ services:
     user: "${DIRAC_UID}:${DIRAC_GID}"
     depends_on:
       - dirac-server
+    ulimits:
+      nofile: 8192


### PR DESCRIPTION
To make a very long story short, this just sets a maximum number of open files for the dirac container in the CI. 

If not, and using a recent version of docker, you get a huge number (1073741816) as a limit ([1]), and the `rpm` version in the `cc7` image will iterate on alllllll the `fd`, which can take very long ([2]). So if you do `yum install XYZ` in such a container, it will take half a day. 

[1] https://github.com/containerd/containerd/pull/4475  
[2] https://github.com/rpm-software-management/rpm/blob/rpm-4.11.3-release/lib/rpmscript.c#L116-L122


BEGINRELEASENOTES

*CI
NEW: max open files for dirac CI container to 8192

ENDRELEASENOTES
