### PR TITLE
[7.3] convert ComputingElement to CE before searching in the configuration

### DIFF
--- a/src/DIRAC/ResourceStatusSystem/Service/PublisherHandler.py
+++ b/src/DIRAC/ResourceStatusSystem/Service/PublisherHandler.py
@@ -284,6 +284,8 @@ class PublisherHandler(RequestHandler):
 
         if elementType == "StorageElement":
             elementType = "SE"
+        if elementType == "ComputingElement":
+            elementType = "CE"
 
         result = gConfig.getSections("Resources/Sites")
         if not result["OK"]:


### PR DESCRIPTION
`PublisherHandler.getSite` changes the name of the request field to the corresponding parameter name in the configuration for **SE**, but not for **CE**. Therefore, queries with the `ComputingElement` parameter fail.

BEGINRELEASENOTES

*ResourceStatus
FIX: convert ComputingElement to CE before searching in the configuration

ENDRELEASENOTES
