### PR TITLE
[8.0] Support receiving proxies from clients running v7.3.x

### DIFF
--- a/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -105,6 +105,9 @@ class ProxyManagerHandlerMixin:
 
         :return: S_OK(dict)/S_ERROR() -- dict contain proxies
         """
+        if isinstance(pemChain, bytes):
+            # The client is running v7.3.x and we need to decode for backwards compatibility
+            pemChain = pemChain.decode("ascii")
         credDict = self.getRemoteCredentials()
         userId = f'{credDict["username"]}:{credDict["group"]}'
         retVal = self.__proxyDB.completeDelegation(requestId, credDict["DN"], pemChain)


### PR DESCRIPTION
In the hackathon I noticed clients running 7.3 cause an exception in the proxy manager when proxies are uploaded which is then shown to the client like:

```
2022-06-23 09:28:49 UTC dirac-proxy-init [140503643989824] ERROR: Can't read certificate ( 1104 : TypeError('cannot use a string pattern on a bytes-like object'))
```

This is because the we've changed the type of X509 data from `bytes` to `str` for v8.0.

I suggest adding a workaround to the proxy manager in v8.0 and removing it in v8.1.