### PR TITLE
[v7r3] Add workaround for labeler ignoring hidden files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,8 @@
 alsoTargeting:integration:
 - '*'
 - '**/*'
+# Workaround as hidden files are ignored by the labeler action:
+# https://github.com/actions/labeler/issues/135
+- '.*'
+- '.*/*'
+- '.*/**/*'


### PR DESCRIPTION
Hopefully fixing the issue for https://github.com/DIRACGrid/DIRAC/pull/6198, I'll test in https://github.com/DIRACGrid/DIRAC/pull/6200 and manually apply to all branches if it works.