### PR TITLE
[v7r2] fix: ARC6 CE issues

### DIFF
--- a/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
@@ -20,10 +20,10 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Resources.Computing.ARCComputingElement import ARCComputingElement
 
 
-class ARCC6omputingElement(ARCComputingElement):
+class ARC6ComputingElement(ARCComputingElement):
     def __init__(self, ceUniqueID):
         """Standard constructor."""
-        super(ARCC6omputingElement, self).__init__(ceUniqueID)
+        super(ARC6ComputingElement, self).__init__(ceUniqueID)
 
     def __getARCJob(self, jobID):
         """Create an ARC Job with all the needed / possible parameters defined.
@@ -112,7 +112,7 @@ class ARCC6omputingElement(ARCComputingElement):
                 jobdescs = arc.JobDescriptionList()
 
                 # Get the job into the ARC way
-                xrslString, diracStamp = self.__writeXRSL(executableFile)
+                xrslString, diracStamp = self._writeXRSL(executableFile)
                 self.log.debug("XRSL string submitted : %s" % xrslString)
                 self.log.debug("DIRAC stamp for job : %s" % diracStamp)
 

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -156,7 +156,7 @@ class ARCComputingElement(ComputingElement):
         ComputingElement._addCEConfigDefaults(self)
 
     #############################################################################
-    def __writeXRSL(self, executableFile):
+    def _writeXRSL(self, executableFile):
         """Create the JDL for submission"""
         diracStamp = makeGuid()[:8]
         # Evaluate the number of processors to allocate
@@ -228,7 +228,7 @@ class ARCComputingElement(ComputingElement):
             # The basic job description
             jobdescs = arc.JobDescriptionList()
             # Get the job into the ARC way
-            xrslString, diracStamp = self.__writeXRSL(executableFile)
+            xrslString, diracStamp = self._writeXRSL(executableFile)
             self.log.debug("XRSL string submitted : %s" % xrslString)
             self.log.debug("DIRAC stamp for job : %s" % diracStamp)
             # The arc bindings don't accept unicode objects in Python 2 so xrslString must be explicitly cast


### PR DESCRIPTION
This PR solves typo issues in `ARC6`.
Also, the `writeXRSL` private method from `ARC` becomes protected to be used in `ARC6`.


BEGINRELEASENOTES
*Resources
FIX: ARC6 typo issues
FIX: ARC writeXRSL becomes protected
ENDRELEASENOTES
