### PR TITLE
[v7r2] fix: ARCCE.getARCJob() becomes protected

### DIFF
--- a/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
@@ -25,7 +25,7 @@ class ARC6ComputingElement(ARCComputingElement):
         """Standard constructor."""
         super(ARC6ComputingElement, self).__init__(ceUniqueID)
 
-    def __getARCJob(self, jobID):
+    def _getARCJob(self, jobID):
         """Create an ARC Job with all the needed / possible parameters defined.
         By the time we come here, the environment variable X509_USER_PROXY should already be set
         """

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -79,7 +79,7 @@ class ARCComputingElement(ComputingElement):
 
     #############################################################################
 
-    def __getARCJob(self, jobID):
+    def _getARCJob(self, jobID):
         """Create an ARC Job with all the needed / possible parameters defined.
         By the time we come here, the environment variable X509_USER_PROXY should already be set
         """
@@ -301,7 +301,7 @@ class ARCComputingElement(ComputingElement):
         self.log.debug("Killing jobs %s" % jobIDList)
         jobs = []
         for jobID in jobList:
-            jobs.append(self.__getARCJob(jobID))
+            jobs.append(self._getARCJob(jobID))
 
         # JobSupervisor is able to aggregate jobs to perform bulk operations and thus minimizes the communication overhead
         # We still need to create chunks to avoid timeout in the case there are too many jobs to supervise
@@ -407,7 +407,7 @@ class ARCComputingElement(ComputingElement):
 
         jobs = []
         for jobID in jobList:
-            jobs.append(self.__getARCJob(jobID))
+            jobs.append(self._getARCJob(jobID))
 
         # JobSupervisor is able to aggregate jobs to perform bulk operations and thus minimizes the communication overhead
         # We still need to create chunks to avoid timeout in the case there are too many jobs to supervise
@@ -487,7 +487,7 @@ class ARCComputingElement(ComputingElement):
         if not stamp:
             return S_ERROR("Pilot stamp not defined for %s" % pilotRef)
 
-        job = self.__getARCJob(pilotRef)
+        job = self._getARCJob(pilotRef)
 
         arcID = os.path.basename(pilotRef)
         self.log.debug("Retrieving pilot logs for %s" % pilotRef)


### PR DESCRIPTION
Sorry, I didn't spot the issue in my previous PR from this morning.

BEGINRELEASENOTES
*Resources
FIX: ARCCE.getARCJob() becomes protected
ENDRELEASENOTES
