### PR TITLE
[v7r2] Increase VOMS command timeout

### DIFF
--- a/src/DIRAC/Core/Security/VOMS.py
+++ b/src/DIRAC/Core/Security/VOMS.py
@@ -24,12 +24,14 @@ from DIRAC.Core.Utilities import List, Time, Os
 
 
 class VOMS(BaseSecurity):
-    def __init__(self, timeout=40, *args, **kwargs):
+    def __init__(self, timeout=80, *args, **kwargs):
         """Create VOMS class, setting specific timeout for VOMS shell commands."""
-        # Per-server timeout for voms-proxy-init, should be at maximum timeout/n
+        # Per-server timeout for voms-proxy-init, should be at maximum timeout/2*n
         # where n as the number of voms servers to try.
+        # voms-proxy-init will try each server *twice* before moving to the next one
+        # once for new interface mode, once for legacy.
         self._servTimeout = 12
-        super(VOMS, self).__init__(timeout, *args, **kwargs)
+        super(VOMS, self).__init__(timeout=timeout, *args, **kwargs)
 
     def getVOMSAttributes(self, proxy, switch="all"):
         """


### PR DESCRIPTION
Hi,

We have one of our 3 VOMS servers in GridPP down for maintenance this week: We are seeing "Could not set-up proxy" errors due to a timeout on some of our jobs.

On investigating this I found 2 main problems:
 * The first parameter to the BaseSecurity constructor isn't timeout, so it actually uses the default (30) instead of the pre-set value for the VOMS class (initially 40).
 * The voms-proxy-init2 command actually tries each server twice, so the timeout needs to be doubled.

(voms-proxy-init2 can also be a bit slow to get going with a new pilot on a busy worker node, so it can still clip into the 30 second timeout even if the theoretical timeout for a single server down is 24 seconds, so giving it more leeway in general is probably a good idea).

Regards,
Simon

BEGINRELEASENOTES
*Core
FIX: Increase VOMS command timeout
ENDRELEASENOTES
