### PR TITLE
[v7r3] Make tmpdir for local cache instead of using CWD when replicating

### DIFF
--- a/src/DIRAC/Interfaces/API/Dirac.py
+++ b/src/DIRAC/Interfaces/API/Dirac.py
@@ -1277,12 +1277,14 @@ class Dirac(API):
         :type destinationSE: string
         :param sourceSE: Optional source SE
         :type sourceSE: string
-        :param localCache: Optional path to local cache
+        :param localCache: Optional path to local cache, if not specified
+                           a temp dir will be created in CWD
         :type localCache: string
         :param printOutput: Optional flag to print result
         :type printOutput: boolean
         :returns: S_OK,S_ERROR
         """
+        tmpCache = False
         ret = self._checkFileArgument(lfn, "LFN", single=True)
         if not ret["OK"]:
             return ret
@@ -1291,7 +1293,8 @@ class Dirac(API):
         if not sourceSE:
             sourceSE = ""
         if not localCache:
-            localCache = ""
+            localCache = tempfile.mkdtemp(prefix=".DIRAC", suffix="rep", dir=".")
+            tmpCache = True
         if not isinstance(sourceSE, six.string_types):
             return self._errorReport("Expected string for source SE name")
         if not isinstance(localCache, six.string_types):
@@ -1310,6 +1313,8 @@ class Dirac(API):
 
         dm = DataManager()
         result = dm.replicateAndRegister(lfn, destinationSE, sourceSE, "", localCache)
+        if tmpCache:
+            shutil.rmtree(localCache, ignore_errors=True)
         if not result["OK"]:
             return self._errorReport("Problem during replicateFile call", result["Message"])
         if printOutput:


### PR DESCRIPTION
Hi,

We frequently run into this infamous error when trying to replicate an LFN with dirac-dms-replicate-lfn:
```
ERROR A local file "mytestfile" with the same name as the remote file exists. Cannot proceed with replication:
   Go to a different working directory
   Move it different directory or use a different localCache
   Delete the file yourself
```

While not a major issue, this is still a little annoying, particularly as it's most frequently encountered by users just starting to learn DIRAC (and long time sysadmins who always forget this restriction :-)  . I can't see any negative effects of creating a local tmpdir and using that instead of just CWD by default (you can always set localCache="." if you really want the old behaviour, e.g. actual caching between commands).

Regards,
Simon

BEGINRELEASENOTES
*Interfaces
CHANGE: Make tmpdir for local cache instead of using CWD directly when replicating
ENDRELEASENOTES
