### PR TITLE
[Integration] fix: fix dirac-uninstall-component by using the new column name

### DIFF
--- a/src/DIRAC/FrameworkSystem/scripts/dirac_uninstall_component.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_uninstall_component.py
@@ -50,7 +50,10 @@ def main():
 
     monitoringClient = ComponentMonitoringClient()
     result = monitoringClient.getInstallations(
-        {"Instance": component, "UnInstallationTime": None}, {"System": system}, {"HostName": socket.getfqdn()}, True
+        {"Instance": component, "UnInstallationTime": None},
+        {"DIRACSystem": system},
+        {"HostName": socket.getfqdn()},
+        True,
     )
     if not result["OK"]:
         gLogger.error(result["Message"])


### PR DESCRIPTION
dirac-uninstall-component called the old "System" column name of InstalledComponentDB which is now called "DIRACSystem"
