### PR TITLE
[v7r3] Fix Platform key error in SD when CheckPlatform=True

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -646,7 +646,7 @@ class SiteDirector(AgentModule):
             ceDict["OwnerGroup"] = self.voGroups
 
         if self.checkPlatform:
-            result = self.resourcesModule.getCompatiblePlatforms(self.queueDict[queue]["Platform"])
+            result = self.resourcesModule.getCompatiblePlatforms(self.queueDict[queue]["ParametersDict"]["Platform"])
             if not result["OK"]:
                 self.log.error(
                     "Issue getting compatible platforms, returning 'ANY'",


### PR DESCRIPTION
Hi,

We've noticed that the SiteDirector crashes when CheckPlatform=True due to a KeyError, it looks like the Platform is actually contained within "ParametersDict" now.

```
Traceback (most recent call last):
  File "DIRAC/Core/Base/AgentModule.py", line 359, in am_secureCall
    result = functor(*args)
  File "DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 332, in execute
    result = self.submitPilots()
  File "DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 385, in submitPilots
    ce, ceDict = self._getCE(queueName)
  File "DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 651, in _getCE
    result = self.resourcesModule.getCompatiblePlatforms(self.queueDict[queue]["Platform"])
KeyError: 'Platform'
```

Regards,
Simon


BEGINRELEASENOTES
*WorkloadManagement
FIX: Fix Platform key error in SD when CheckPlatform=True
ENDRELEASENOTES
