### PR TITLE
[v7r3] feat (logging): add an stdout Backend with json formatting

### DIFF
--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/MicrosecondJsonFormatter.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/MicrosecondJsonFormatter.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import time
+from pythonjsonlogger.jsonlogger import JsonFormatter
+
+
+class MicrosecondJsonFormatter(JsonFormatter):
+    """Standard JSON formater with microsecond precision"""
+
+    def formatTime(self, record, datefmt=None):
+        """:py:meth:`logging.Formatter.formatTime` with microsecond precision by default"""
+        ct = self.converter(record.created)
+        if datefmt:
+            s = time.strftime(datefmt, ct)
+        else:
+            t = time.strftime("%Y-%m-%d %H:%M:%S", ct)
+            s = "%s,%06d" % (t, (record.created - int(record.created)) * 1e6)
+        return s

--- a/src/DIRAC/Resources/LogBackends/MessageQueueBackend.py
+++ b/src/DIRAC/Resources/LogBackends/MessageQueueBackend.py
@@ -7,29 +7,16 @@ from __future__ import print_function
 
 __RCSID__ = "$Id$"
 
-import time
-from pythonjsonlogger.jsonlogger import JsonFormatter
-
 from DIRAC.FrameworkSystem.private.standardLogging.Handler.MessageQueueHandler import MessageQueueHandler
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
+from DIRAC.FrameworkSystem.private.standardLogging.Formatter.MicrosecondJsonFormatter import MicrosecondJsonFormatter
 from DIRAC.Resources.LogBackends.AbstractBackend import AbstractBackend
+
 
 DEFAULT_MQ_LEVEL = "verbose"
 # These are the standard logging fields that we want to see
 # in the json. All the non default are printed anyway
 DEFAULT_FMT = "%(levelname)s %(message)s %(asctime)s"
-
-
-class MicrosecondJsonFormatter(JsonFormatter):
-    def formatTime(self, record, datefmt=None):
-        """:py:meth:`logging.Formatter.formatTime` with microsecond precision by default"""
-        ct = self.converter(record.created)
-        if datefmt:
-            s = time.strftime(datefmt, ct)
-        else:
-            t = time.strftime("%Y-%m-%d %H:%M:%S", ct)
-            s = "%s,%06d" % (t, (record.created - int(record.created)) * 1e6)
-        return s
 
 
 class MessageQueueBackend(AbstractBackend):

--- a/src/DIRAC/Resources/LogBackends/StdoutJsonBackend.py
+++ b/src/DIRAC/Resources/LogBackends/StdoutJsonBackend.py
@@ -1,0 +1,24 @@
+"""
+JSON output on stdout
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import sys
+
+from DIRAC.Resources.LogBackends.AbstractBackend import AbstractBackend
+from DIRAC.FrameworkSystem.private.standardLogging.Formatter.MicrosecondJsonFormatter import MicrosecondJsonFormatter
+
+
+class StdoutJsonBackend(AbstractBackend):
+    """
+    This just spits out the log on stdout in a json format.
+    """
+
+    def __init__(self, backendParams=None):
+        super(StdoutJsonBackend, self).__init__(logging.StreamHandler, MicrosecondJsonFormatter, backendParams)
+
+    def _setHandlerParameters(self, backendParams=None):
+        self._handlerParams["stream"] = sys.stdout


### PR DESCRIPTION
This is useful for orchestrators like K8 which often comes with fluentd or the like

BEGINRELEASENOTES

*Framework
NEW: Add StdoutJsonBackend 

ENDRELEASENOTES
