### PR TITLE
[v8.0] hackaton fix: dirac_login HTML error hiding the actual error

### DIFF
--- a/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
@@ -385,7 +385,8 @@ def main():
         result = userParams.getAuthStatus()
 
     if not result["OK"]:
-        print(HTML(f"<red>{result['Message']}</red>"))
+        # Format the message as it can contain special characters that would be interpreted as HTML
+        print(HTML("<red>{error}</red>").format(error=result["Message"]))
         sys.exit(1)
 
     userParams.howToSwitch()


### PR DESCRIPTION
`result["Message"]` may contain special characters such as `<>`.
The `prompt_toolkit` package tries to interpret them and fail, which return an error hiding the real error.


BEGINRELEASENOTES
*FrameworkSystem
FIX: dirac_login HTML error hiding the actual error
ENDRELEASENOTES
