### PR TITLE
[8.0] Allow TornadoREST methods to be prefixed with "get_"

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/TornadoREST.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoREST.py
@@ -173,8 +173,6 @@ class TornadoREST(BaseRequestHandler):  # pylint: disable=abstract-method
         # Look for methods that are exported
         for prefix in [cls.METHOD_PREFIX] if cls.METHOD_PREFIX else cls.SUPPORTED_METHODS:
             prefix = prefix.lower()
-            if prefix == "get":
-                raise NotImplementedError("This is fundamentally broken as tornado has methods named get_")
             for mName, mObj in inspect.getmembers(cls, lambda x: callable(x) and x.__name__.startswith(prefix)):
                 methodName = mName[len(prefix) :]
                 cls.log.debug(f"  Find {mName} method")


### PR DESCRIPTION
Returns `TornadoREST` to being functional for HTTP GET requests.

It's good enough for the `AuthHandler` class but we should plan more before using `TornadoREST` for any other handler.

Closes https://github.com/DIRACGrid/DIRAC/issues/6245
Superceeds https://github.com/DIRACGrid/DIRAC/pull/6249