### PR TITLE
[v7r2] Fix integration_tests.py for latest release of typer

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -77,4 +77,4 @@ dependencies:
     - git+https://github.com/DIRACGrid/tornado.git@iostreamConfigurable
     # This is an extension of Tornado to use M2Crypto
     - git+https://github.com/DIRACGrid/tornado_m2crypto
-    - rucio-clients >= 1.25.6
+    - rucio-clients==1.26.*

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -58,7 +58,7 @@ LOG_LEVEL_MAP = {
 LOG_PATTERN = re.compile(r"^[\d\-]{10} [\d:]{8} UTC [^\s]+ ([A-Z]+):")
 
 
-class NaturalOrderGroup(click.Group):
+class NaturalOrderGroup(typer.core.TyperGroup):
     """Group for showing subcommands in the correct order"""
 
     def list_commands(self, ctx):

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ pytz
 readline>=6.2.4
 recommonmark
 requests>=2.9.1
-rucio-clients >=1.25.6
+rucio-clients==1.26.*
 simplejson>=3.8.1
 six>=1.10
 # Freeze until all problems with 1.4 are solved


### PR DESCRIPTION
The latest release of `typer` changed slightly how the `NaturalOrderGroup` in `integration_tests.py` needed to be implemented.

Also includes https://github.com/DIRACGrid/DIRAC/pull/6253.