### PR TITLE
[v7r2] Fix FC chgrp on multiple LFNs

### DIFF
--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -1234,9 +1234,9 @@ class FileManagerBase(object):
                 successful[lfn] = True
             else:
                 fileID = res["Value"]["Successful"][lfn]["FileID"]
-                res = self._setFileParameter(fileID, "GID", group)
-                if not res["OK"]:
-                    failed[lfn] = res["Message"]
+                setRes = self._setFileParameter(fileID, "GID", group)
+                if not setRes["OK"]:
+                    failed[lfn] = setRes["Message"]
                 else:
                     successful[lfn] = True
         return S_OK({"Successful": successful, "Failed": failed})
@@ -1264,9 +1264,9 @@ class FileManagerBase(object):
                 successful[lfn] = True
             else:
                 fileID = res["Value"]["Successful"][lfn]["FileID"]
-                res = self._setFileParameter(fileID, "UID", owner)
-                if not res["OK"]:
-                    failed[lfn] = res["Message"]
+                setRes = self._setFileParameter(fileID, "UID", owner)
+                if not setRes["OK"]:
+                    failed[lfn] = setRes["Message"]
                 else:
                     successful[lfn] = True
         return S_OK({"Successful": successful, "Failed": failed})
@@ -1289,9 +1289,9 @@ class FileManagerBase(object):
                 successful[lfn] = True
             else:
                 fileID = res["Value"]["Successful"][lfn]["FileID"]
-                res = self._setFileParameter(fileID, "Mode", mode)
-                if not res["OK"]:
-                    failed[lfn] = res["Message"]
+                setRes = self._setFileParameter(fileID, "Mode", mode)
+                if not setRes["OK"]:
+                    failed[lfn] = setRes["Message"]
                 else:
                     successful[lfn] = True
         return S_OK({"Successful": successful, "Failed": failed})


### PR DESCRIPTION
Hi,

I found that running the FC changePathGroup function only works if one LFN is given: If multiple are specified only the first is updated and the rest return an error as the loop variable "res" gets overwritten.

Regards,
Simon

BEGINRELEASENOTES
*DataManagement
FIX: Fix FC change{group,owner,mode} for multiple LFNs
ENDRELEASENOTES
