### PR TITLE
feat (ConditionalFC): ProxyPlugin checks also ThreadConfig

### DIFF
--- a/src/DIRAC/Resources/Catalog/ConditionPlugins/ProxyPlugin.py
+++ b/src/DIRAC/Resources/Catalog/ConditionPlugins/ProxyPlugin.py
@@ -11,7 +11,9 @@ import re
 
 
 from DIRAC.Resources.Catalog.ConditionPlugins.FCConditionBasePlugin import FCConditionBasePlugin
+from DIRAC.Core.DISET.ThreadConfig import ThreadConfig
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
+from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 
 
 class ProxyPlugin(FCConditionBasePlugin):
@@ -60,6 +62,16 @@ class ProxyPlugin(FCConditionBasePlugin):
 
         self._checkCondition()
         self.proxyInfo = getProxyInfo().get("Value")
+
+        # We may not have a proxy, check the thread local
+        if not self.proxyInfo:
+            tc = ThreadConfig()
+            userDN = tc.getDN()
+            userGroup = tc.getGroup()
+            if userDN and userGroup:
+                userName = Registry.getUsernameForDN(userDN).get("Value")
+                if userName:
+                    self.proxyInfo = {"username": userName, "group": userGroup}
 
     def _checkCondition(self):
         """Checks that the actual condition makes sense


### PR DESCRIPTION
I just realized that the ProxyPlugin of the FCCondition parser was not taking ThreadConfig into account


BEGINRELEASENOTES

*Resources
FIX: Conditional FC ProxyPlugin checks the ThreadConfig

ENDRELEASENOTES
