### PR TITLE
[v7r3] Make GOCDB2CSAgent functionMap less private

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Agent/GOCDB2CSAgent.py
+++ b/src/DIRAC/ConfigurationSystem/Agent/GOCDB2CSAgent.py
@@ -55,8 +55,8 @@ class GOCDB2CSAgent(AgentModule):
         and user request (options in configuration).
         """
 
-        # __functionMap is at the end of the class definition
-        for option, functionCall in GOCDB2CSAgent.__functionMap.items():
+        # _functionMap is at the end of the class definition
+        for option, functionCall in GOCDB2CSAgent._functionMap.items():
             optionValue = self.am_getOption(option, True)
             if optionValue:
                 result = functionCall(self)
@@ -289,6 +289,6 @@ class GOCDB2CSAgent(AgentModule):
         return S_OK()
 
     # define mapping between an agent option in the configuration and a function call
-    __functionMap = {
+    _functionMap = {
         "UpdatePerfSONARS": updatePerfSONARConfiguration,
     }


### PR DESCRIPTION
Hi,

We'd like to make the `__functionMap` variable in the GOCDB2CSAgent slightly less private so that we can easily add functions to it from the GridPP extension module.

Regards,
Simon

BEGINRELEASENOTES
*ConfigurationSystem
CHANGE: Make GOCDB2CSAgent functionMap less private
ENDRELEASENOTES
