### PR TITLE
[v8.0] multiple hackaton fixes

### DIFF
--- a/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
@@ -17,7 +17,7 @@ from io import open
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
-from DIRAC.Core.Security.m2crypto import asn1_utils
+from DIRAC.Core.Security.m2crypto import asn1_utils, DEFAULT_PROXY_STRENGTH
 from DIRAC.Core.Utilities.Decorators import executeOnlyIf
 
 # Decorator to execute the method only of the certificate has been loaded
@@ -394,7 +394,7 @@ class X509Certificate(object):
             return S_ERROR(DErrno.EVOMS, "No VOMS data available")
 
     @executeOnlyIfCertLoaded
-    def generateProxyRequest(self, bitStrength=1024, limited=False):
+    def generateProxyRequest(self, bitStrength=DEFAULT_PROXY_STRENGTH, limited=False):
         """
         Generate a proxy request. See :py:class:`DIRAC.Core.Security.m2crypto.X509Request.X509Request`
 

--- a/src/DIRAC/Core/Security/m2crypto/X509Chain.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Chain.py
@@ -427,7 +427,7 @@ class X509Chain(object):
     @needCertList
     @needPKey
     def generateProxyToString(
-        self, lifetime, diracGroup=False, strength=DEFAULT_PROXY_STRENGTH, limited=False, proxyKey=False, rfc=True
+        self, lifetime, diracGroup=False, strength=DEFAULT_PROXY_STRENGTH, limited=False, proxyKey=False
     ):
         """
         Generate a proxy and get it as a string.
@@ -475,9 +475,7 @@ class X509Chain(object):
         return S_OK(proxyString)
 
     # pylint: disable=unused-argument
-    def generateProxyToFile(
-        self, filePath, lifetime, diracGroup=False, strength=DEFAULT_PROXY_STRENGTH, limited=False, rfc=True
-    ):
+    def generateProxyToFile(self, filePath, lifetime, diracGroup=False, strength=DEFAULT_PROXY_STRENGTH, limited=False):
         """
         Generate a proxy and put it into a file
 
@@ -810,7 +808,7 @@ class X509Chain(object):
 
     @needCertList
     @needPKey
-    def generateChainFromRequestString(self, pemData, lifetime=86400, requireLimited=False, diracGroup=False, rfc=True):
+    def generateChainFromRequestString(self, pemData, lifetime=86400, requireLimited=False, diracGroup=False):
         """
         Generate a x509 chain from a request.
 

--- a/src/DIRAC/Core/Security/m2crypto/X509Chain.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Chain.py
@@ -23,7 +23,7 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Utilities.Decorators import executeOnlyIf, deprecated
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
-from DIRAC.Core.Security.m2crypto import PROXY_OID, LIMITED_PROXY_OID, DIRAC_GROUP_OID
+from DIRAC.Core.Security.m2crypto import PROXY_OID, LIMITED_PROXY_OID, DIRAC_GROUP_OID, DEFAULT_PROXY_STRENGTH
 from DIRAC.Core.Security.m2crypto.X509Certificate import X509Certificate
 
 
@@ -426,7 +426,9 @@ class X509Chain(object):
     # pylint: disable=unused-argument
     @needCertList
     @needPKey
-    def generateProxyToString(self, lifetime, diracGroup=False, strength=1024, limited=False, proxyKey=False, rfc=True):
+    def generateProxyToString(
+        self, lifetime, diracGroup=False, strength=DEFAULT_PROXY_STRENGTH, limited=False, proxyKey=False, rfc=True
+    ):
         """
         Generate a proxy and get it as a string.
 
@@ -435,7 +437,7 @@ class X509Chain(object):
         Args:
             lifetime (int): expected lifetime in seconds of proxy
             diracGroup (str): diracGroup to add to the certificate
-            strength (int): length in bits of the pair if proxyKey not given (default 1024)
+            strength (int): length in bits of the pair if proxyKey not given (default 2048)
             limited (bool): Create a limited proxy (default False)
             proxyKey: M2Crypto.EVP.PKey instance with private and public key. If not given, generate one
             rfc: placeholder for backward compatibility and ignored
@@ -473,7 +475,9 @@ class X509Chain(object):
         return S_OK(proxyString)
 
     # pylint: disable=unused-argument
-    def generateProxyToFile(self, filePath, lifetime, diracGroup=False, strength=1024, limited=False, rfc=True):
+    def generateProxyToFile(
+        self, filePath, lifetime, diracGroup=False, strength=DEFAULT_PROXY_STRENGTH, limited=False, rfc=True
+    ):
         """
         Generate a proxy and put it into a file
 
@@ -784,7 +788,7 @@ class X509Chain(object):
         return S_OK(notAfter)
 
     @needCertList
-    def generateProxyRequest(self, bitStrength=1024, limited=False):
+    def generateProxyRequest(self, bitStrength=DEFAULT_PROXY_STRENGTH, limited=False):
         """
         Generate a proxy request.
         See :py:meth:`DIRAC.Core.Security.m2crypto.X509Certificate.X509Certificate.generateProxyRequest`

--- a/src/DIRAC/Core/Security/m2crypto/X509Request.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Request.py
@@ -3,6 +3,7 @@ It's main use is for proxy delegation.
 """
 import M2Crypto
 from DIRAC import S_OK, S_ERROR
+from DIRAC.Core.Security.m2crypto import DEFAULT_PROXY_STRENGTH
 from DIRAC.Core.Utilities import DErrno
 
 # from DIRAC.Core.Security.m2crypto.X509Chain import X509Chain  # pylint: disable=import-error
@@ -30,11 +31,11 @@ class X509Request(object):
         if reqObj and pkeyObj:  # isn't it a bit too liberal?
             self.__valid = True
 
-    def generateProxyRequest(self, bitStrength=1024, limited=False):
+    def generateProxyRequest(self, bitStrength=DEFAULT_PROXY_STRENGTH, limited=False):
         """
         Initialize the Request object as well as the PKey.
 
-        :param bitStrength: (default 1024) length of the key generated
+        :param bitStrength: (default 2048) length of the key generated
         :param limited: (default False) If True, request is done for a limited proxy
         """
         # self.__pkeyObj is both the public and private key

--- a/src/DIRAC/Core/Security/m2crypto/__init__.py
+++ b/src/DIRAC/Core/Security/m2crypto/__init__.py
@@ -22,7 +22,6 @@ ORGANIZATIONAL_UNIT_NAME_OID = "2.5.4.11"
 TITLE_OID = "2.5.4.12"
 GIVEN_NAME_OID = "2.5.4.42"
 
-
 # See https://tools.ietf.org/html/rfc3820#appendix-A
 PROXY_OID = "1.3.6.1.5.5.7.21.1"
 LIMITED_PROXY_OID = "1.3.6.1.4.1.3536.1.1.1.9"
@@ -42,3 +41,7 @@ DN_MAPPING = {
     SURNAME_OID: "/SN=",
     TITLE_OID: "/T=",
 }
+
+
+#: Default strength of the proxy in bit
+DEFAULT_PROXY_STRENGTH = 2048

--- a/src/DIRAC/Core/Security/test/Test_X509Chain.py
+++ b/src/DIRAC/Core/Security/test/Test_X509Chain.py
@@ -438,7 +438,7 @@ def test_getCertInChain(get_proxy):
 
 
 @mark.slow
-@settings(max_examples=200, suppress_health_check=function_scoped)
+@settings(max_examples=200, suppress_health_check=function_scoped, deadline=None)
 @given(lifetime=integers(max_value=ONE_YEAR_IN_SECS, min_value=1))
 def test_proxyLifetime(get_proxy, lifetime):
     """ " Generate a proxy with various lifetime, smaller than the certificate length
@@ -459,7 +459,7 @@ def test_proxyLifetime(get_proxy, lifetime):
 
 
 @mark.slow
-@settings(max_examples=200, suppress_health_check=function_scoped)
+@settings(max_examples=200, suppress_health_check=function_scoped, deadline=None)
 @given(lifetime=integers(min_value=TWENTY_YEARS_IN_SEC, max_value=NO_LATER_THAN_2050_IN_SEC))
 def test_tooLong_proxyLifetime(get_proxy, lifetime):
     """ " Generate a proxy with various lifetime, longer than the certificate length
@@ -489,7 +489,7 @@ def test_tooLong_proxyLifetime(get_proxy, lifetime):
 
 
 @mark.slow
-@settings(max_examples=200, suppress_health_check=function_scoped)
+@settings(max_examples=200, suppress_health_check=function_scoped, deadline=None)
 @given(diracGroup=text(ascii_letters + "-_" + digits, min_size=1))
 def test_diracGroup(get_proxy, diracGroup):
     """Generate a proxy with a given group and check that we can retrieve it"""

--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -568,17 +568,18 @@ class ElasticSearchDB:
         if period.lower() not in ["day", "week", "month", "year", "null"]:
             sLog.error("Period is not correct: ", period)
             return indexName
-        elif period.lower() == "day":
-            today = datetime.today().strftime("%Y-%m-%d")
-            return "%s-%s" % (indexName, today)
+
+        # Do NOT use datetime.today() because it is not UTC
+        todayUTC = datetime.utcnow().date()
+
+        if period.lower() == "day":
+            suffix = todayUTC.strftime("%Y-%m-%d")
         elif period.lower() == "week":
-            week = datetime.today().isocalendar()[1]
-            return "%s-%s" % (indexName, week)
+            suffix = todayUTC.isocalendar()[1]
         elif period.lower() == "month":
-            month = datetime.today().strftime("%Y-%m")
-            return "%s-%s" % (indexName, month)
+            suffix = todayUTC.strftime("%Y-%m")
         elif period.lower() == "year":
-            year = datetime.today().strftime("%Y")
-            return "%s-%s" % (indexName, year)
+            suffix = todayUTC.strftime("%Y")
         elif period.lower() == "null":
             return indexName
+        return f"{indexName}-{suffix}"

--- a/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
+++ b/src/DIRAC/FrameworkSystem/Client/ProxyGeneration.py
@@ -7,13 +7,14 @@ from prompt_toolkit import prompt
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Base.Script import Script
 from DIRAC.Core.Utilities.NTP import getClockDeviation
+from DIRAC.Core.Security.m2crypto import DEFAULT_PROXY_STRENGTH
 
 
 class CLIParams:
 
     proxyLifeTime = 86400
     diracGroup = False
-    proxyStrength = 1024
+    proxyStrength = DEFAULT_PROXY_STRENGTH
     limitedProxy = False
     strict = False
     summary = False

--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -595,9 +595,7 @@ class ProxyDB(DB):
                 if not result["OK"]:
                     return result
                 strength = result["Value"]
-                result = chain.generateProxyToString(
-                    secondsRemaining, diracGroup=userGroup, strength=strength, rfc=True
-                )
+                result = chain.generateProxyToString(secondsRemaining, diracGroup=userGroup, strength=strength)
                 if not result["OK"]:
                     return result
                 return S_OK((result["Value"], secondsRemaining))
@@ -801,7 +799,7 @@ class ProxyDB(DB):
                 if result["OK"]:
                     chain = result["Value"]["chain"]
                     remainingSecs = result["Value"]["remainingSecs"]
-                    result = chain.generateProxyToString(remainingSecs, diracGroup=userGroup, rfc=True)
+                    result = chain.generateProxyToString(remainingSecs, diracGroup=userGroup)
                     if result["OK"]:
                         return S_OK((result["Value"], remainingSecs))
                 errMsgs.append('"%s": %s' % (proxyProvider, result["Message"]))

--- a/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
+++ b/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
@@ -27,16 +27,75 @@ class DataOperationSender:
     # Initialize the object so that the Reporters are created only once
     def __init__(self):
         monitoringType = "DataOperation"
-        # Will use the `MonitoringBackends/Default` value as monitoring backend unless a flag for `MonitoringBackends/DataOperation` is set.
+        # Will use the `MonitoringBackends/Default` value
+        # as monitoring backend unless a flag for `MonitoringBackends/DataOperation` is set.
         self.monitoringOptions = Operations().getMonitoringBackends(monitoringType)
         if "Monitoring" in self.monitoringOptions:
             self.dataOperationReporter = MonitoringReporter(monitoringType)
         if "Accounting" in self.monitoringOptions:
             self.dataOp = DataOperation()
 
+        self._sendDataMethods = []
+        self._commitMethods = []
+        for backend in self.monitoringOptions:
+            self._sendDataMethods.append(getattr(self, f"_sendData{backend}"))
+            self._commitMethods.append(getattr(self, f"_commit{backend}"))
+
+    def _sendDataMonitoring(self, baseDict, commitFlag=False, delayedCommit=False, startTime=False, endTime=False):
+        """Send the data to the monitoring system"""
+        # Some fields added here are not known to the Accounting, so we have to make a copy
+        monitoringDict = copy.deepcopy(baseDict)
+
+        monitoringDict["Channel"] = monitoringDict["Source"] + "->" + monitoringDict["Destination"]
+        # Add timestamp if not already added
+        if "timestamp" not in monitoringDict:
+            monitoringDict["timestamp"] = int(toEpoch())
+        self.dataOperationReporter.addRecord(monitoringDict)
+        if commitFlag:
+            result = self.dataOperationReporter.commit()
+            sLog.debug("Committing data operation to monitoring")
+            if not result["OK"]:
+                sLog.error("Could not commit data operation to monitoring", result["Message"])
+            else:
+                sLog.debug("Done committing to monitoring")
+            return result
+        return S_OK()
+
+    @convertToReturnValue
+    def _sendDataAccounting(self, baseDict, commitFlag=False, delayedCommit=False, startTime=False, endTime=False):
+        """Send the data to the accounting system"""
+        returnValueOrRaise(self.dataOp.setValuesFromDict(baseDict))
+
+        if startTime:
+            self.dataOp.setStartTime(startTime)
+            self.dataOp.setEndTime(endTime)
+        else:
+            self.dataOp.setStartTime()
+            self.dataOp.setEndTime()
+        # Adding only to register
+        if not commitFlag and not delayedCommit:
+            return gDataStoreClient.addRegister(self.dataOp)
+
+        # Adding to register and committing
+        if commitFlag and not delayedCommit:
+            gDataStoreClient.addRegister(self.dataOp)
+            sLog.debug("Committing data operation to accounting")
+            result = gDataStoreClient.commit()
+
+            if not result["OK"]:
+                sLog.error("Could not commit data operation to accounting", result["Message"])
+                return result
+            sLog.debug("Done committing to accounting")
+        # Only late committing
+        else:
+            result = self.dataOp.delayedCommit()
+            if not result["OK"]:
+                sLog.error("Could not delay-commit data operation to accounting")
+        return result
+
     def sendData(self, baseDict, commitFlag=False, delayedCommit=False, startTime=False, endTime=False):
         """
-        Sends the input to Monitoring or Acconting based on the monitoringOptions
+        Sends the input to Monitoring or Accounting based on the monitoringOptions
 
         :param dict baseDict: contains a key/value pair
         :param bool commitFlag: decides whether to commit the record or not.
@@ -47,85 +106,49 @@ class DataOperationSender:
 
         baseDict["ExecutionSite"] = DIRAC.siteName()
 
-        def _sendMonitoring():
-            monitoringDict = copy.deepcopy(baseDict)
-
-            monitoringDict["Channel"] = monitoringDict["Source"] + "->" + monitoringDict["Destination"]
-            # Add timestamp if not already added
-            if "timestamp" not in monitoringDict:
-                monitoringDict["timestamp"] = int(toEpoch())
-            self.dataOperationReporter.addRecord(monitoringDict)
-            if commitFlag:
-                result = self.dataOperationReporter.commit()
-                sLog.debug("Committing data operation to monitoring")
-                if not result["OK"]:
-                    sLog.error("Could not commit data operation to monitoring", result["Message"])
-                else:
-                    sLog.debug("Done committing to monitoring")
-                return result
-            return S_OK()
-
-        @convertToReturnValue
-        def _sendAccounting():
-            returnValueOrRaise(self.dataOp.setValuesFromDict(baseDict))
-
-            if startTime:
-                self.dataOp.setStartTime(startTime)
-                self.dataOp.setEndTime(endTime)
-            else:
-                self.dataOp.setStartTime()
-                self.dataOp.setEndTime()
-            # Adding only to register
-            if not commitFlag and not delayedCommit:
-                return gDataStoreClient.addRegister(self.dataOp)
-
-            # Adding to register and committing
-            if commitFlag and not delayedCommit:
-                gDataStoreClient.addRegister(self.dataOp)
-                result = gDataStoreClient.commit()
-                sLog.debug("Committing data operation to accounting")
-                if not result["OK"]:
-                    sLog.error("Could not commit data operation to accounting", result["Message"])
-                    return result
-                sLog.debug("Done committing to accounting")
-            # Only late committing
-            else:
-                result = self.dataOp.delayedCommit()
-                if not result["OK"]:
-                    sLog.error("Could not delay-commit data operation to accounting")
-            return result
-
         # Send data and commit prioritizing the first monitoring option in the list
-        for backend in self.monitoringOptions:
-            func = locals()[f"_send{backend}"]
-            res = func()
+        for methId, _sendDataMeth in enumerate(self._sendDataMethods):
+            res = _sendDataMeth(
+                baseDict, commitFlag=commitFlag, delayedCommit=delayedCommit, startTime=startTime, endTime=endTime
+            )
             if not res["OK"]:
-                sLog.error("Could not send or commit data", f"Backend: {backend}, {res}")
+                sLog.error("DataOperationSender.sendData: could not send data", f"{res}")
+                # If this is the first backend, we stop
+                if methId == 0:
+                    sLog.error(
+                        "DataOperationSender.sendData: failure of the master accounting system, not trying the others"
+                    )
+                    return res
 
         return S_OK()
 
+    def _commitAccounting(self):
+        result = gDataStoreClient.commit()
+        sLog.debug("Concluding the sending and committing data operation to accounting")
+        if not result["OK"]:
+            sLog.error("Could not commit data operation to accounting", result["Message"])
+        sLog.debug("Committing to accounting concluded")
+        return result
+
+    def _commitMonitoring(self):
+        result = self.dataOperationReporter.commit()
+        sLog.debug("Committing data operation to monitoring")
+        if not result["OK"]:
+            sLog.error("Could not commit data operation to monitoring", result["Message"])
+        sLog.debug("Committing to monitoring concluded")
+        return result
+
     # Call this method in order to commit all records added but not yet committed to Accounting and Monitoring
     def concludeSending(self):
-        def _commitAccounting():
-            result = gDataStoreClient.commit()
-            sLog.debug("Concluding the sending and committing data operation to accounting")
-            if not result["OK"]:
-                sLog.error("Could not commit data operation to accounting", result["Message"])
-            sLog.debug("Committing to accounting concluded")
-            return result
-
-        def _commitMonitoring():
-            result = self.dataOperationReporter.commit()
-            sLog.debug("Committing data operation to monitoring")
-            if not result["OK"]:
-                sLog.error("Could not commit data operation to monitoring", result["Message"])
-            sLog.debug("Committing to monitoring concluded")
-            return result
-
-        # Commit data prioritizing first monitoring option in the list
-        for backend in self.monitoringOptions:
-            func = locals()[f"_commit{backend}"]
-            res = func()
+        """Flush to the services what is still queued"""
+        for methId, _commitMeth in enumerate(self._commitMethods):
+            res = _commitMeth()
             if not res["OK"]:
-                return res
+                sLog.error("DataOperationSender.concludeSending: could not commit data", f"{res}")
+                # If this is the first backend, we stop
+                if methId == 0:
+                    sLog.error(
+                        "DataOperationSender.sendData: failure of the master accounting system, not trying the others"
+                    )
+                    return res
         return S_OK()

--- a/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
+++ b/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
@@ -4,6 +4,7 @@ Created as replacement, or rather semplification, of the MonitoringReporter/gDat
 
 """
 
+import copy
 import DIRAC
 from DIRAC import S_OK, gLogger
 
@@ -44,13 +45,16 @@ class DataOperationSender:
         :param int endTime: epoch time, end time of the plot
         """
 
+        baseDict["ExecutionSite"] = DIRAC.siteName()
+
         def _sendMonitoring():
-            baseDict["ExecutionSite"] = DIRAC.siteName()
-            baseDict["Channel"] = baseDict["Source"] + "->" + baseDict["Destination"]
+            monitoringDict = copy.deepcopy(baseDict)
+
+            monitoringDict["Channel"] = monitoringDict["Source"] + "->" + monitoringDict["Destination"]
             # Add timestamp if not already added
-            if not "timestamp" in baseDict:
-                baseDict["timestamp"] = int(toEpoch())
-            self.dataOperationReporter.addRecord(baseDict)
+            if "timestamp" not in monitoringDict:
+                monitoringDict["timestamp"] = int(toEpoch())
+            self.dataOperationReporter.addRecord(monitoringDict)
             if commitFlag:
                 result = self.dataOperationReporter.commit()
                 sLog.debug("Committing data operation to monitoring")

--- a/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
+++ b/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
@@ -10,7 +10,7 @@ from DIRAC import S_OK, gLogger
 
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Utilities.ReturnValues import convertToReturnValue, returnValueOrRaise
-from DIRAC.Core.Utilities.TimeUtilities import toEpoch
+from DIRAC.Core.Utilities.TimeUtilities import toEpochMilliSeconds
 from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
 from DIRAC.AccountingSystem.Client.Types.DataOperation import DataOperation
 from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
@@ -49,7 +49,7 @@ class DataOperationSender:
         monitoringDict["Channel"] = monitoringDict["Source"] + "->" + monitoringDict["Destination"]
         # Add timestamp if not already added
         if "timestamp" not in monitoringDict:
-            monitoringDict["timestamp"] = int(toEpoch())
+            monitoringDict["timestamp"] = int(toEpochMilliSeconds())
         self.dataOperationReporter.addRecord(monitoringDict)
         if commitFlag:
             result = self.dataOperationReporter.commit()

--- a/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
+++ b/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
@@ -93,7 +93,7 @@ class DataOperationSender:
             func = locals()[f"_send{backend}"]
             res = func()
             if not res["OK"]:
-                sLog.error(f"Could not send or commit data to {backend}")
+                sLog.error("Could not send or commit data", f"Backend: {backend}, {res}")
 
         return S_OK()
 

--- a/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
+++ b/src/DIRAC/MonitoringSystem/Client/DataOperationSender.py
@@ -8,6 +8,7 @@ import DIRAC
 from DIRAC import S_OK, gLogger
 
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC.Core.Utilities.ReturnValues import convertToReturnValue, returnValueOrRaise
 from DIRAC.Core.Utilities.TimeUtilities import toEpoch
 from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
 from DIRAC.AccountingSystem.Client.Types.DataOperation import DataOperation
@@ -60,8 +61,10 @@ class DataOperationSender:
                 return result
             return S_OK()
 
+        @convertToReturnValue
         def _sendAccounting():
-            self.dataOp.setValuesFromDict(baseDict)
+            returnValueOrRaise(self.dataOp.setValuesFromDict(baseDict))
+
             if startTime:
                 self.dataOp.setStartTime(startTime)
                 self.dataOp.setEndTime(endTime)

--- a/src/DIRAC/Resources/ProxyProvider/DIRACCAProxyProvider.py
+++ b/src/DIRAC/Resources/ProxyProvider/DIRACCAProxyProvider.py
@@ -208,7 +208,7 @@ class DIRACCAProxyProvider(ProxyProvider):
                 if result["OK"]:
                     result = chain.loadKeyFromString(keyStr)
                     if result["OK"]:
-                        result = chain.generateProxyToString(365 * 24 * 3600, rfc=True)
+                        result = chain.generateProxyToString(365 * 24 * 3600)
 
         return result
 
@@ -429,7 +429,7 @@ class DIRACCAProxyProvider(ProxyProvider):
             certStr, keyStr = result["Value"]
             chain = X509Chain()
             if chain.loadChainFromString(certStr)["OK"] and chain.loadKeyFromString(keyStr)["OK"]:
-                result = chain.generateProxyToString(time, rfc=True, diracGroup=group)
+                result = chain.generateProxyToString(time, diracGroup=group)
         if not result["OK"]:
             return result
         chain = X509Chain()

--- a/tests/Integration/Core/Test_ElasticsearchDB.py
+++ b/tests/Integration/Core/Test_ElasticsearchDB.py
@@ -157,19 +157,10 @@ def test_existingIndex():
 
 
 def test_generateFullIndexName():
+    """Whatever we give as input, the full index should start with the prefix"""
     indexName = "test"
-    today = datetime.datetime.today().strftime("%Y-%m-%d")
-    expected = "%s-%s" % (indexName, today)
-    result = elasticSearchDB.generateFullIndexName(indexName, "day")
-    assert result == expected
-
-
-def test_generateFullIndexName2():
-    indexName = "test"
-    month = datetime.datetime.today().strftime("%Y-%m")
-    expected = "%s-%s" % (indexName, month)
-    result = elasticSearchDB.generateFullIndexName(indexName, "month")
-    assert result == expected
+    for period in ["day", "week", "month", "year", "null", "notExpected"]:
+        assert elasticSearchDB.generateFullIndexName(indexName, period).startswith(indexName)
 
 
 def test_getUniqueValue():

--- a/tests/System/client_dms.sh
+++ b/tests/System/client_dms.sh
@@ -23,8 +23,8 @@ fi
 
 echo " "
 mv DMS_Scripts_Test_File.txt DMS_Scripts_Test_File.old
-echo "======  dirac-dms-replicate-lfn $userdir/Dirac_Scripts_Test_Directory/DMS_Scripts_Test_File.txt CESNET-SE RAL-SE"
-dirac-dms-replicate-lfn $userdir/Dirac_Scripts_Test_Directory/DMS_Scripts_Test_File.txt CESNET-SE RAL-SE
+echo "======  dirac-dms-replicate-lfn $userdir/Dirac_Scripts_Test_Directory/DMS_Scripts_Test_File.txt UKI-LT2-IC-HEP-disk RAL-SE"
+dirac-dms-replicate-lfn $userdir/Dirac_Scripts_Test_Directory/DMS_Scripts_Test_File.txt UKI-LT2-IC-HEP-disk RAL-SE
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi
@@ -81,8 +81,8 @@ if [[ "${?}" -ne 0 ]]; then
 fi
 
 echo " "
-echo "====== dirac-dms-remove-replicas $userdir/Dirac_Scripts_Test_Directory/DMS_Scripts_Test_File.txt CESNET-SE"
-dirac-dms-remove-replicas $userdir/Dirac_Scripts_Test_Directory/DMS_Scripts_Test_File.txt CESNET-SE
+echo "====== dirac-dms-remove-replicas $userdir/Dirac_Scripts_Test_Directory/DMS_Scripts_Test_File.txt UKI-LT2-IC-HEP-disk"
+dirac-dms-remove-replicas $userdir/Dirac_Scripts_Test_Directory/DMS_Scripts_Test_File.txt UKI-LT2-IC-HEP-disk
 if [[ "${?}" -ne 0 ]]; then
    exit 1
 fi


### PR DESCRIPTION


Besides the change of proxy length, this PR contains quite a few improvement of the DataOperationSender. There will most definitely be more work needed for the DataOperation monitoring, but at least something comes out of it ! 

I guess 9d7910f178bf3c02f0c0d03cd7a03c6bd06f374a may lead into more data being added to an index, or the other way around, but it is not really important



BEGINRELEASENOTES

* Core
CHANGE: Default proxy length is 2048 bits
CHANGE: remove RFC argument for proxy generation

* Monitoring
FIX: ElasticSearchDB generates full index names based on UTC
FIX: DataOperationSender works on a copy of the documents
CHANGE: DataOperationSender fails if the master accounting system fails


ENDRELEASENOTES
