### PR TITLE
[8.0] fix: delete parameters that are not needed

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
@@ -312,7 +312,7 @@ class JobCleaningAgent(AgentModule):
 
         self.log.verbose("Deleting oversized sandboxes", osLFNDict)
         # Schedule removal of the LFNs now
-        for jobID, outputSandboxLFNdict in osLFNDict.items():  # can be an iterator
+        for jobID, outputSandboxLFNdict in osLFNDict.items():
             lfn = outputSandboxLFNdict["OutputSandboxLFN"]
             result = self.jobDB.getJobAttributes(jobID, ["OwnerDN", "OwnerGroup"])
             if not result["OK"]:

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -17,6 +17,9 @@ from concurrent.futures import ThreadPoolExecutor
 
 import DIRAC
 from DIRAC import S_OK, S_ERROR, gConfig
+from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
+from DIRAC.AccountingSystem.Client.Types.Pilot import Pilot as PilotAccounting
+from DIRAC.AccountingSystem.Client.Types.PilotSubmission import PilotSubmission as PilotSubmissionAccounting
 from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals, Registry
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getCESiteMapping
@@ -24,10 +27,9 @@ from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Utilities.TimeUtilities import second, toEpochMilliSeconds
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
-from DIRAC.AccountingSystem.Client.Types.Pilot import Pilot as PilotAccounting
-from DIRAC.AccountingSystem.Client.Types.PilotSubmission import PilotSubmission as PilotSubmissionAccounting
 from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
-from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
+from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
+from DIRAC.ResourceStatusSystem.Client.SiteStatus import SiteStatus
 from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 from DIRAC.WorkloadManagementSystem.Client.MatcherClient import MatcherClient
 from DIRAC.WorkloadManagementSystem.Client.ServerUtils import pilotAgentsDB
@@ -39,8 +41,6 @@ from DIRAC.WorkloadManagementSystem.Utilities.PilotWrapper import (
     _writePilotWrapperFile,
     getPilotFilesCompressedEncodedDict,
 )
-from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
-from DIRAC.ResourceStatusSystem.Client.SiteStatus import SiteStatus
 
 MAX_PILOTS_TO_SUBMIT = 100
 

--- a/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
@@ -129,16 +129,14 @@ class ElasticJobParametersDB(ElasticDB):
         else:
             self.log.debug(f"The searched parameters with JobID {jobID} exists in the new index {self.indexName}")
             res = self.getDoc(self.indexName, str(jobID))
-            if res["OK"]:
-                if paramList:
-                    for par in paramList:
-                        try:
-                            resultDict[par] = res["Value"][par]
-                        except Exception as ex:
-                            self.log.error("Could not find the searched parameters")
-                else:
-                    # if parameters are not specified return all of them
-                    resultDict = res["Value"]
+            if not res["OK"]:
+                return res
+            resultDict = res["Value"]
+            if paramList:
+                for k in list(resultDict):
+                    if k not in paramList:
+                        resultDict.pop(k)
+
         return S_OK({jobID: resultDict})
 
     def setJobParameter(self, jobID: int, key: str, value: str) -> dict:


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: ElasticJobParametersDB: do not return parameters that are not needed

ENDRELEASENOTES
