### PR TITLE
[8.0] Use psutil.net_if_addrs for Network.discoverInterfaces

### DIFF
--- a/src/DIRAC/Core/Utilities/test/Test_Network.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Network.py
@@ -8,7 +8,8 @@ from DIRAC.Core.Utilities.Network import discoverInterfaces, getFQDN, getIPsForH
 def test_discoverInterfaces():
     interfaces = discoverInterfaces()
     assert len(interfaces) >= 1
-    assert "lo" in interfaces
+    assert "lo" in interfaces or "lo0" in interfaces
+    assert interfaces.get("lo", interfaces.get("lo0"))["ip"].startswith("127")
     for interfaceInfo in interfaces.values():
         assert "ip" in interfaceInfo
         assert "mac" in interfaceInfo


### PR DESCRIPTION
BEGINRELEASENOTES

*Core
CHANGE: Use psutil.net_if_addrs for Network.discoverInterfaces

ENDRELEASENOTES
