### PR TITLE
[8.0] Replace suds-jurko with suds

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
   - six >=1.10
   - sqlalchemy
   - stomp.py
-  - suds-jurko >=0.6
+  - suds >=0.6
   - xmltodict
   - pycurl
   - voms

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ server =
     python-json-logger
     pyyaml
     stomp.py
-    suds-jurko
+    suds
     tornado ~=5.1.1
     tornado-m2crypto
     importlib_resources


### PR DESCRIPTION
`suds-jurko` was originally a fork since then `suds-community/suds` has taken over the `suds` name on PyPI and is the only maintained version.

This [should be a backwards compatible change](https://github.com/suds-community/suds/issues/81) and I'm inclined to suggest backporting it after I've done a few more checks.

See https://github.com/DIRACGrid/DIRAC/issues/6322 for details.

BEGINRELEASENOTES

*Core
CHANGE: Replace suds-jurko with suds

ENDRELEASENOTES
