### PR TITLE
[8.0] Fix using HTTPS with Python 3.10+ and suppress InsecureRequestWarning

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -32,11 +32,14 @@ DIRAC_GFAL_GRIDFTP_SESSION_REUSE
   If set to ``true`` or ``yes`` the GRIDFTP SESSION REUSE option will be set to True, should be set on server
   installations. See the information in the :ref:`resourcesStorageElement` page.
 
-DIRAC_USE_JSON_DECODE
-  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page (default=Yes since v7r2)
+DIRAC_HTTPS_SSL_CIPHERS
+  If set, overrides the default SSL ciphers accepted when using HTTPS. It should be a colon separated list.
 
-DIRAC_USE_JSON_ENCODE
-  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page (default=No)
+DIRAC_HTTPS_SSL_METHOD_MAX
+  If set, overrides the highest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
+
+DIRAC_HTTPS_SSL_METHOD_MIN
+  If set, overrides the lowest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
 
 DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
   If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
@@ -47,17 +50,14 @@ DIRAC_M2CRYPTO_SSL_CIPHERS
 DIRAC_M2CRYPTO_SSL_METHODS
   If set, overwrites the default SSL methods accepted. It should be a colon separated list. See :py:mod:`DIRAC.Core.DISET`
 
-DIRAC_HTTPS_SSL_CIPHERS
-  If set, overrides the default SSL ciphers accepted when using HTTPS. It should be a colon separated list.
-
-DIRAC_HTTPS_SSL_METHOD_MIN
-  If set, overrides the lowest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
-
-DIRAC_HTTPS_SSL_METHOD_MAX
-  If set, overrides the highest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
-
 DIRAC_NO_CFG
   If set to anything, cfg files on the command line must be passed to the command using the --cfg option.
+
+DIRAC_USE_JSON_DECODE
+  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page (default=Yes since v7r2)
+
+DIRAC_USE_JSON_ENCODE
+  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page (default=No)
 
 DIRAC_ROOT_PATH
   If set, overwrites the value of DIRAC.rootPath.

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -42,10 +42,19 @@ DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
   If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
 
 DIRAC_M2CRYPTO_SSL_CIPHERS
-  If set, overwrites the default SSL ciphers accepted. It should be a column separated list. See :py:mod:`DIRAC.Core.DISET`
+  If set, overwrites the default SSL ciphers accepted. It should be a colon separated list. See :py:mod:`DIRAC.Core.DISET`
 
 DIRAC_M2CRYPTO_SSL_METHODS
-  If set, overwrites the default SSL methods accepted. It should be a column separated list. See :py:mod:`DIRAC.Core.DISET`
+  If set, overwrites the default SSL methods accepted. It should be a colon separated list. See :py:mod:`DIRAC.Core.DISET`
+
+DIRAC_HTTPS_SSL_CIPHERS
+  If set, overrides the default SSL ciphers accepted when using HTTPS. It should be a colon separated list.
+
+DIRAC_HTTPS_SSL_METHOD_MIN
+  If set, overrides the lowest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
+
+DIRAC_HTTPS_SSL_METHOD_MAX
+  If set, overrides the highest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
 
 DIRAC_NO_CFG
   If set to anything, cfg files on the command line must be passed to the command using the --cfg option.

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -654,7 +654,11 @@ def _create_session(verified=True):
     # Python 3.10+ sets DEFAULT:@SECLEVEL=2 which prevents the use of 1024 bit RSA for proxies.
     # In DIRAC 8.0 the default proxy length has been increased to 2048 bits however we need to
     # downgrade to DEFAULT:@SECLEVEL=1 until all users have uploaded a new proxy.
-    ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
+    ctx.set_ciphers(os.environ.get("DIRAC_HTTPS_SSL_CIPHERS", "DEFAULT:@SECLEVEL=1"))
+    if minimum_tls_version := os.environ.get("DIRAC_HTTPS_SSL_METHOD_MIN"):
+        ctx.minimum_version = getattr(ssl.TLSVersion, minimum_tls_version)
+    if maximum_tls_version := os.environ.get("DIRAC_HTTPS_SSL_METHOD_MAX"):
+        ctx.maximum_version = getattr(ssl.TLSVersion, maximum_tls_version)
     session = requests.Session()
     session.mount("https://", _ContextAdapter(ssl_context=ctx))
     if verified:

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -28,11 +28,13 @@ from io import open
 import errno
 import os
 import requests
+import ssl
 import tempfile
 from http import HTTPStatus
 
 
 from DIRAC import S_OK, S_ERROR, gLogger
+from DIRAC.Core.Utilities.ReturnValues import convertToReturnValue
 
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import skipCACheck
@@ -98,7 +100,7 @@ class TornadoBaseClient(object):
 
         self._destinationSrv = serviceName
         self._serviceName = serviceName
-        self.__ca_location = False
+        self.__session = None
 
         self.kwargs = kwargs
         self.__idp = None
@@ -220,11 +222,13 @@ class TornadoBaseClient(object):
         else:
             self.__useCertificates = gConfig.useServerCertificate()
             self.kwargs[self.KW_USE_CERTIFICATES] = self.__useCertificates
-        if self.KW_SKIP_CA_CHECK not in self.kwargs:
-            if self.__useCertificates:
-                self.kwargs[self.KW_SKIP_CA_CHECK] = False
-            else:
-                self.kwargs[self.KW_SKIP_CA_CHECK] = skipCACheck()
+
+        # Prepare the session
+        skip_ca_check = self.kwargs.get(self.KW_SKIP_CA_CHECK, False if self.__useCertificates else skipCACheck())
+        retVal = _create_session(verified=not skip_ca_check)
+        if not retVal["OK"]:  # pylint: disable=unsubscriptable-object
+            return retVal
+        self.__session = retVal["Value"]  # pylint: disable=unsubscriptable-object
 
         # Use tokens?
         if self.KW_USE_ACCESS_TOKEN in self.kwargs:
@@ -506,17 +510,6 @@ class TornadoBaseClient(object):
             return url
         url = url["Value"]
 
-        # Getting CA file (or skip verification)
-        verify = not self.kwargs.get(self.KW_SKIP_CA_CHECK)
-        if verify:
-            if not self.__ca_location:
-                self.__ca_location = Locations.getCAsLocation()
-                if not self.__ca_location:
-                    gLogger.error("No CAs found!")
-                    return S_ERROR("No CAs found!")
-
-            verify = self.__ca_location
-
         # getting certificate
         # Do we use the server certificate ?
         if self.kwargs[self.KW_USE_CERTIFICATES]:
@@ -576,7 +569,7 @@ class TornadoBaseClient(object):
 
                 # Default case, just return the result
                 if not outputFile:
-                    call = requests.post(url, data=kwargs, timeout=self.timeout, verify=verify, **auth)
+                    call = self.__session.post(url, data=kwargs, timeout=self.timeout, **auth)
                     # raising the exception for status here
                     # means essentialy that we are losing here the information of what is returned by the server
                     # as error message, since it is not passed to the exception
@@ -595,7 +588,7 @@ class TornadoBaseClient(object):
                     rawText = None
                     # Stream download
                     # https://requests.readthedocs.io/en/latest/user/advanced/#body-content-workflow
-                    with requests.post(url, data=kwargs, timeout=self.timeout, verify=verify, stream=True, **auth) as r:
+                    with self.__session.post(url, data=kwargs, timeout=self.timeout, stream=True, **auth) as r:
                         rawText = r.text
                         r.raise_for_status()
 
@@ -641,3 +634,35 @@ class TornadoBaseClient(object):
 # Rewrite this method if needed:
 #  /Core/DISET/private/BaseClient.py
 # __delegateCredentials
+
+
+class _ContextAdapter(requests.adapters.HTTPAdapter):
+    """Allows to override the default context."""
+
+    def __init__(self, *args, **kwargs):
+        self.ssl_context = kwargs.pop("ssl_context", None)
+        super().__init__(*args, **kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs.setdefault("ssl_context", self.ssl_context)
+        return super().init_poolmanager(*args, **kwargs)
+
+
+@convertToReturnValue
+def _create_session(verified=True):
+    ctx = ssl.create_default_context()
+    # Python 3.10+ sets DEFAULT:@SECLEVEL=2 which prevents the use of 1024 bit RSA for proxies.
+    # In DIRAC 8.0 the default proxy length has been increased to 2048 bits however we need to
+    # downgrade to DEFAULT:@SECLEVEL=1 until all users have uploaded a new proxy.
+    ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
+    session = requests.Session()
+    session.mount("https://", _ContextAdapter(ssl_context=ctx))
+    if verified:
+        ca_location = Locations.getCAsLocation()
+        if not ca_location:
+            raise ValueError("No CAs found!")
+        session.verify = ca_location
+    else:
+        ctx.check_hostname = False
+        session.verify = False
+    return session


### PR DESCRIPTION
In Python 3.10 the default [OpenSSL security level](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html#DEFAULT-CALLBACK-BEHAVIOUR) is increased to 2 (see https://github.com/python/cpython/issues/88164). This results in 1024-bit RSA no longer being allowed. For DISET this isn't a problem however HTTPS requests fail due to the standard library being used. This pull request just modifies TornadoBaseClient to always set the OpenSSL ciphers to get consistency across Python versions.

See also https://github.com/DIRACGrid/DIRAC/issues/6269.

BEGINRELEASENOTES

*Core
CHANGE: Set OpenSSL ciphers to "DEFAULT:@SECLEVEL=1"
NEW: Experimental support for Python 3.10
NEW: Suppress InsecureRequestWarning when using dirac-configure with HTTPS servers
NEW: Support overriding ciphers and methods with environment variables when using HTTPS

ENDRELEASENOTES
