### PR TITLE
[v7r3] Return proper error if provider value missing in CloudCE

### DIFF
--- a/src/DIRAC/Resources/Computing/CloudComputingElement.py
+++ b/src/DIRAC/Resources/Computing/CloudComputingElement.py
@@ -233,11 +233,11 @@ class CloudComputingElement(ComputingElement):
         if self._cloudDriver and not refresh:
             return self._cloudDriver
 
-        provName = self.ceParameters.get(OPT_PROVIDER).upper()
+        provName = self.ceParameters.get(OPT_PROVIDER, "").upper()
         # check if provider (type of cloud) exists
-        if not hasattr(Provider, provName):
-            self.log.error("Provider %s not found in libcloud." % provName)
-            raise RuntimeError("Provider %s not found in libcloud." % provName)
+        if not provName or not hasattr(Provider, provName):
+            self.log.error("Provider '%s' not found in libcloud for CE %s." % (provName, self.ceName))
+            raise RuntimeError("Provider '%s' not found in libcloud for CE %s." % (provName, self.ceName))
         provIntName = getattr(Provider, provName)
         provCls = get_driver(provIntName)
         driverOpts = self._getDriverOptions()


### PR DESCRIPTION
Hi,

It's quite common for the CloudCE to be instantiated with missing config params as "CEType = Cloud" used to be a placeholder for all kinds of dynamic resources where the CEType isn't actually used (VMDIRAC, Vcycle, Vac) at least on GridPP instances. At the moment it just crashes with an exception on the ceParameters.get line which can make it hard to see which CE it is actually causing the problem, this patch changes it to a more useful error message.

Regards,
Simon

BEGINRELEASENOTES
*Resources
FIX: Return proper error if provider value missing in CloudCE
ENDRELEASENOTES
