### PR TITLE
[v7r3] Handle missing Platform in SD

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -646,14 +646,20 @@ class SiteDirector(AgentModule):
             ceDict["OwnerGroup"] = self.voGroups
 
         if self.checkPlatform:
-            result = self.resourcesModule.getCompatiblePlatforms(self.queueDict[queue]["ParametersDict"]["Platform"])
-            if not result["OK"]:
+            platform = self.queueDict[queue]["ParametersDict"].get("Platform")
+            if not platform:
+                self.log.error("No platform set for CE %s, returning 'ANY'" % ce)
+                ceDict["Platform"] = "ANY"
+                return ce, ceDict
+            result = self.resourcesModule.getCompatiblePlatforms(platform)
+            if result["OK"]:
+                ceDict["Platform"] = result["Value"]
+            else:
                 self.log.error(
                     "Issue getting compatible platforms, returning 'ANY'",
                     "%s: %s" % (self.platforms, result["Message"]),
                 )
                 ceDict["Platform"] = "ANY"
-            ceDict["Platform"] = result["Value"]
 
         return ce, ceDict
 


### PR DESCRIPTION
Hi,

We still have occasions where we have a misconfigured CE missing a Platform for various reasons. If CheckPlatform = True this results in a KeyError and it isn't obvious which CE triggered it, so this just adds an error message for that state.

I also noticed that there was a return missing from the other error state: It'll still continue to use result["Value"] even if result["OK"] was False. I've never seen that happen, but I've fixed it at the same time anyway.

Regards,
Simon


BEGINRELEASENOTES
*WorkloadManagement
FIX: Log error if CE Platform is missing.
ENDRELEASENOTES
