### PR TITLE
[v7r3] Don't notify users with expired proxies

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -1417,6 +1417,8 @@ class ProxyDB(DB):
             gLogger.error("Could not discover user email", userName)
             return False
         daysLeft = int(lTime / 86400)
+        if daysLeft <= 0:
+            return True  # Don't annoy users with -1 messages
         msgSubject = "Your proxy uploaded to DIRAC will expire in %d days" % daysLeft
         msgBody = """\
 Dear %s,


### PR DESCRIPTION
Hi,

We're still seeing issues where users manage to upload proxies with groups occasionally: I haven't tracked that down yet, the checks in ProxyDB should prevent it happening but somehow they don't always. These proxies have either 0 or -1 days of lifetime causing the user to get a notification e-mail every day.

We've been hotpatching this extra check in for quite a while now (possibly more than a year?), so I thought I'd commit it properly.

Regards,
Simon


BEGINRELEASENOTES
*Framework
FIX: Don't notify users with expired proxies
ENDRELEASENOTES
