### PR TITLE
[sweep:integration] Don't notify users with expired proxies

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -1449,6 +1449,8 @@ class ProxyDB(DB):
             gLogger.error("Could not discover user email", userName)
             return False
         daysLeft = int(lTime / 86400)
+        if daysLeft <= 0:
+            return True  # Don't annoy users with -1 messages
         msgSubject = "Your proxy uploaded to DIRAC will expire in %d days" % daysLeft
         msgBody = """\
 Dear %s,


### PR DESCRIPTION
Sweep #6305 `Don'"'"'t notify users with expired proxies` to `integration'.

Not sure why this was a sweep failure, the patch applied cleanly, so I guess some kind of problem with the sweeper itself?
