### PR TITLE
[v8.0] Annotate ReturnValues.py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -50,6 +50,7 @@ dependencies:
   - diraccfg
   - ldap3
   - importlib_resources
+  - typing_extensions >=4.3.0
   # testing and development
   - pre-commit
   - coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,12 @@ target-version = ['py39']
 [tool.pylint.typecheck]
 # List of decorators that change the signature of a decorated function.
 signature-mutators = []
+
+[tool.mypy]
+allow_redefinition = true
+strict = true
+check_untyped_defs = true
+ignore_missing_imports = true
+exclude = [
+    '/tests/'
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,7 @@ git_describe_command = "git describe --dirty --tags --long --match *[0-9].[0-9]*
 [tool.black]
 line-length = 120
 target-version = ['py39']
+
+[tool.pylint.typecheck]
+# List of decorators that change the signature of a decorated function.
+signature-mutators = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     setuptools
     six
     sqlalchemy
+    typing_extensions >=4.3.0
     Authlib >=1.0.0.a2
     pyjwt
     dominate

--- a/src/DIRAC/Core/Utilities/DErrno.py
+++ b/src/DIRAC/Core/Utilities/DErrno.py
@@ -297,7 +297,7 @@ dStrError = {  # Generic (10XX)
 }
 
 
-def strerror(code):
+def strerror(code: int) -> str:
     """This method wraps up os.strerror, and behave the same way.
     It completes it with the DIRAC specific errors.
     """

--- a/src/DIRAC/Core/Utilities/ReturnValues.py
+++ b/src/DIRAC/Core/Utilities/ReturnValues.py
@@ -240,10 +240,10 @@ def convertToReturnValue(func: Callable[P, T]) -> Callable[P, DReturnType[T]]:
         except Exception as e:
             retval = S_ERROR(repr(e))
             # Replace CallStack with the one from the exception
-            exc_type, exc_value, exc_tb = sys.exc_info()
-            if exc_type and exc_value and exc_tb:
-                retval["ExecInfo"] = exc_type, exc_value, exc_tb
-                retval["CallStack"] = traceback.format_tb(exc_tb)
+            # Use cast as mypy doesn't understand that sys.exc_info can't return None in an exception block
+            retval["ExecInfo"] = cast(tuple[Type[BaseException], BaseException, TracebackType], sys.exc_info())
+            exc_type, exc_value, exc_tb = retval["ExecInfo"]
+            retval["CallStack"] = traceback.format_tb(exc_tb)
             return retval
         else:
             return S_OK(value)

--- a/src/DIRAC/Core/Utilities/ReturnValues.py
+++ b/src/DIRAC/Core/Utilities/ReturnValues.py
@@ -8,7 +8,7 @@
 import functools
 import sys
 import traceback
-from typing import TypedDict, Any, Optional as Opt
+from typing import TypedDict, Any, Optional as Opt, Callable
 
 from DIRAC.Core.Utilities.DErrno import strerror
 
@@ -195,7 +195,7 @@ def returnValueOrRaise(result):
     return result["Value"]
 
 
-def convertToReturnValue(func):
+def convertToReturnValue(func: Callable[..., Any]) -> Callable[..., DReturnType]:
     """Decorate a function to convert return values to `S_OK`/`S_ERROR`
 
     If `func` returns, wrap the return value in `S_OK`.
@@ -220,4 +220,7 @@ def convertToReturnValue(func):
             retval["CallStack"] = traceback.format_tb(exc_tb)
             return retval
 
+    # functools will copy the annotations. Since we change the return type
+    # we have to update it
+    wrapped.__annotations__["return"] = DReturnType
     return wrapped

--- a/src/DIRAC/Core/Utilities/ReturnValues.py
+++ b/src/DIRAC/Core/Utilities/ReturnValues.py
@@ -34,9 +34,7 @@ class DErrorReturnType(TypedDict):
     OK: Literal[False]
     Message: str
     Errno: int
-    ExecInfo: NotRequired[
-        Union[tuple[None, None, None], tuple[Type[BaseException], BaseException, TracebackType]],
-    ]
+    ExecInfo: NotRequired[tuple[Type[BaseException], BaseException, TracebackType]]
     CallStack: NotRequired[list[str]]
 
 
@@ -215,7 +213,7 @@ def returnValueOrRaise(result: DReturnType[T]) -> T:
              If no exception is known an :exc:`SErrorException` is raised.
     """
     if not result["OK"]:
-        if "ExecInfo" in result and result["ExecInfo"][0]:
+        if "ExecInfo" in result:
             raise result["ExecInfo"][0]
         else:
             raise SErrorException(result)
@@ -242,9 +240,10 @@ def convertToReturnValue(func: Callable[P, T]) -> Callable[P, DReturnType[T]]:
         except Exception as e:
             retval = S_ERROR(repr(e))
             # Replace CallStack with the one from the exception
-            retval["ExecInfo"] = sys.exc_info()
-            exc_type, exc_value, exc_tb = retval["ExecInfo"]
-            retval["CallStack"] = traceback.format_tb(exc_tb)
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            if exc_type and exc_value and exc_tb:
+                retval["ExecInfo"] = exc_type, exc_value, exc_tb
+                retval["CallStack"] = traceback.format_tb(exc_tb)
             return retval
         else:
             return S_OK(value)

--- a/src/DIRAC/Core/Utilities/ReturnValues.py
+++ b/src/DIRAC/Core/Utilities/ReturnValues.py
@@ -8,8 +8,19 @@
 import functools
 import sys
 import traceback
+from typing import TypedDict, Any, Optional as Opt
 
 from DIRAC.Core.Utilities.DErrno import strerror
+
+
+class DReturnType(TypedDict):
+    """used for typing the DIRAC return structure"""
+
+    OK: bool
+    Value: Opt[Any]
+    Message: Opt[str]
+    ExecInfo: Opt[tuple]
+    CallStack: Opt[list[str]]
 
 
 def S_ERROR(*args, **kwargs):

--- a/src/DIRAC/Core/Utilities/ReturnValues.py
+++ b/src/DIRAC/Core/Utilities/ReturnValues.py
@@ -5,25 +5,45 @@
 
    keys are converted to string
 """
+from __future__ import annotations
+
 import functools
 import sys
 import traceback
-from typing import TypedDict, Any, Optional as Opt, Callable
+from types import TracebackType
+from typing import Any, Callable, cast, Generic, Literal, overload, Type, TypeVar, Union
+from typing_extensions import TypedDict, ParamSpec, NotRequired
 
 from DIRAC.Core.Utilities.DErrno import strerror
 
 
-class DReturnType(TypedDict):
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+class DOKReturnType(TypedDict, Generic[T]):
     """used for typing the DIRAC return structure"""
 
-    OK: bool
-    Value: Opt[Any]
-    Message: Opt[str]
-    ExecInfo: Opt[tuple]
-    CallStack: Opt[list[str]]
+    OK: Literal[True]
+    Value: T
 
 
-def S_ERROR(*args, **kwargs):
+class DErrorReturnType(TypedDict):
+    """used for typing the DIRAC return structure"""
+
+    OK: Literal[False]
+    Message: str
+    Errno: int
+    ExecInfo: NotRequired[
+        Union[tuple[None, None, None], tuple[Type[BaseException], BaseException, TracebackType]],
+    ]
+    CallStack: NotRequired[list[str]]
+
+
+DReturnType = Union[DOKReturnType[T], DErrorReturnType]
+
+
+def S_ERROR(*args: Any, **kwargs: Any) -> DErrorReturnType:
     """return value on error condition
 
     Arguments are either Errno and ErrorMessage or just ErrorMessage fro backward compatibility
@@ -34,7 +54,7 @@ def S_ERROR(*args, **kwargs):
     """
     callStack = kwargs.pop("callStack", None)
 
-    result = {"OK": False, "Errno": 0, "Message": ""}
+    result: DErrorReturnType = {"OK": False, "Errno": 0, "Message": ""}
 
     message = ""
     if args:
@@ -58,14 +78,21 @@ def S_ERROR(*args, **kwargs):
 
     result["CallStack"] = callStack
 
-    # print "AT >>> S_ERROR", result['OK'], result['Errno'], result['Message']
-    # for item in result['CallStack']:
-    #  print item
-
     return result
 
 
-def S_OK(value=None):
+# mypy doesn't understand default parameter values with generics so use overloads (python/mypy#3737)
+@overload
+def S_OK() -> DOKReturnType[None]:
+    ...
+
+
+@overload
+def S_OK(value: T) -> DOKReturnType[T]:
+    ...
+
+
+def S_OK(value=None):  # type: ignore
     """return value on success
 
     :param value: value of the 'Value'
@@ -74,7 +101,7 @@ def S_OK(value=None):
     return {"OK": True, "Value": value}
 
 
-def isReturnStructure(unk):
+def isReturnStructure(unk: Any) -> bool:
     """Check if value is an `S_OK`/`S_ERROR` object"""
     if not isinstance(unk, dict):
         return False
@@ -86,7 +113,7 @@ def isReturnStructure(unk):
         return "Message" in unk
 
 
-def isSError(value):
+def isSError(value: Any) -> bool:
     """Check if value is an `S_ERROR` object"""
     if not isinstance(value, dict):
         return False
@@ -95,7 +122,7 @@ def isSError(value):
     return "Message" in value
 
 
-def reprReturnErrorStructure(struct, full=False):
+def reprReturnErrorStructure(struct: DErrorReturnType, full: bool = False) -> str:
     errorNumber = struct.get("Errno", 0)
     message = struct.get("Message", "")
     if errorNumber:
@@ -111,7 +138,7 @@ def reprReturnErrorStructure(struct, full=False):
     return reprStr
 
 
-def returnSingleResult(dictRes):
+def returnSingleResult(dictRes: DReturnType[Any]) -> DReturnType[Any]:
     """Transform the S_OK{Successful/Failed} dictionary convention into
     an S_OK/S_ERROR return. To be used when a single returned entity
     is expected from a generally bulk call.
@@ -147,7 +174,7 @@ def returnSingleResult(dictRes):
         errorMessage = list(dictRes["Value"]["Failed"].values())[0]
         if isinstance(errorMessage, dict):
             if isReturnStructure(errorMessage):
-                return errorMessage
+                return cast(DErrorReturnType, errorMessage)
             else:
                 return S_ERROR(str(errorMessage))
         return S_ERROR(errorMessage)
@@ -161,7 +188,7 @@ def returnSingleResult(dictRes):
 class SErrorException(Exception):
     """Exception class for use with `convertToReturnValue`"""
 
-    def __init__(self, result):
+    def __init__(self, result: Union[DErrorReturnType, str]):
         """Create a new exception return value
 
         If `result` is a `S_ERROR` return it directly else convert it to an
@@ -171,10 +198,10 @@ class SErrorException(Exception):
         """
         if not isSError(result):
             result = S_ERROR(result)
-        self.result = result
+        self.result = cast(DErrorReturnType, result)
 
 
-def returnValueOrRaise(result):
+def returnValueOrRaise(result: DReturnType[T]) -> T:
     """Unwrap an S_OK/S_ERROR response into a value or Exception
 
     This method assists with using exceptions in DIRAC code by raising
@@ -188,14 +215,14 @@ def returnValueOrRaise(result):
              If no exception is known an :exc:`SErrorException` is raised.
     """
     if not result["OK"]:
-        if "ExecInfo" in result:
+        if "ExecInfo" in result and result["ExecInfo"][0]:
             raise result["ExecInfo"][0]
         else:
             raise SErrorException(result)
     return result["Value"]
 
 
-def convertToReturnValue(func: Callable[..., Any]) -> Callable[..., DReturnType]:
+def convertToReturnValue(func: Callable[P, T]) -> Callable[P, DReturnType[T]]:
     """Decorate a function to convert return values to `S_OK`/`S_ERROR`
 
     If `func` returns, wrap the return value in `S_OK`.
@@ -207,18 +234,20 @@ def convertToReturnValue(func: Callable[..., Any]) -> Callable[..., DReturnType]
     """
 
     @functools.wraps(func)
-    def wrapped(*args, **kwargs):
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> DReturnType[T]:
         try:
-            return S_OK(func(*args, **kwargs))
+            value = func(*args, **kwargs)
         except SErrorException as e:
             return e.result
         except Exception as e:
             retval = S_ERROR(repr(e))
             # Replace CallStack with the one from the exception
-            exc_type, exc_value, exc_tb = sys.exc_info()
-            retval["ExecInfo"] = exc_type, exc_value, exc_tb
+            retval["ExecInfo"] = sys.exc_info()
+            exc_type, exc_value, exc_tb = retval["ExecInfo"]
             retval["CallStack"] = traceback.format_tb(exc_tb)
             return retval
+        else:
+            return S_OK(value)
 
     # functools will copy the annotations. Since we change the return type
     # we have to update it


### PR DESCRIPTION
I originally just wanted to silent pylint for complaining about `unsubscriptable-object` when using `convertToReturnValue`. Turns out to be trickier than expected: https://github.com/PyCQA/pylint/issues/7292

Anyway, I added the type hints. Not sure whether we want to merge it already or wait for pylint to be fixed. I don't mind. 

Also, as of python 3.10, we will be able to forward the type hint through the elipse https://peps.python.org/pep-0612/

**Update from @cburr:** This now adds type hints to the entire `ReturnValues` module and can propogate the type of `retVal["Value"]` through `S_OK`/`convertToReturnValue`/`returnValueOrRaise`. We can't actually use mypy for checking this until https://github.com/python/mypy/pull/13389 is merged and releasd however I've tested locally with that branch and it works as expected and is able to catch a bunch of errors.

<details>
  <summary>Click me to see examples of errors than can now be caught with mypy</summary>

```python
from typing import Union

from DIRAC.Core.Utilities.ReturnValues import convertToReturnValue, DReturnType, DOKReturnType, S_OK, returnValueOrRaise


def do_thing0(x: int) -> DReturnType[int]:
    return S_OK(x * 2)


def do_thing1(x: int) -> DOKReturnType[int]:
    return S_OK(x * 2)


@convertToReturnValue
def do_thing2(x: int) -> int:
    return x * 2


@convertToReturnValue
def do_thing3(x: str) -> str:
    return x * 2


def do_thing4(x: int) -> DReturnType[int]:
    if x > 20:
        return S_OK(x)
    return S_OK()
    # ↑ error: Incompatible return value type (got "DOKReturnType[None]", expected "Union[DOKReturnType[int], DErrorReturnType]")


def do_thing5(x: int) -> Union[DReturnType[int], DReturnType[None]]:
    if x > 20:
        return S_OK(x)
    return S_OK()


retVal = do_thing0(5)
if retVal["OK"]:
    print(retVal["Value"] + 1)
    print(retVal["Value"] + "1")
    # ↑ error: Unsupported operand types for + ("int" and "str")
else:
    print(retVal["Message"])


retVal = do_thing0(5)
print(retVal["Value"] + 1)
# ↑ error: TypedDict "DErrorReturnType" has no key "Value"

retVal = do_thing1(5)
print(retVal["Value"] + 1)  # Allowed as do_thing1 can't return DErrorReturnType


retVal = do_thing2(5)
if retVal["OK"]:
    print(retVal["Value"] + 1)
    print(retVal["Value"] + "1")
    # ↑ error: Unsupported operand types for + ("int" and "str")
else:
    print(retVal["Message"])


xxx = do_thing0(5)
thing0 = returnValueOrRaise(xxx)
print(thing0 + 1)
print(thing0 + "1")
# ↑ error: Unsupported operand types for + ("int" and "str")


thing2: int = returnValueOrRaise(do_thing2(5))
print(thing2 + 1)
print(thing2 + "1")
# ↑ error: Unsupported operand types for + ("int" and "str")


retVal = do_thing3("2")
if retVal["OK"]:
    print(retVal["Value"] + "1")
    print(retVal["Value"] + 1)
    # ↑ error: Unsupported operand types for + ("str" and "int")
else:
    print(retVal["Message"])


print(retVal["Value"])
# ↑ error: TypedDict "DErrorReturnType" has no key "Value"
print(retVal["Message"])
# ↑ error: TypedDict "DOKReturnType[str]" has no key "Message"


x = do_thing5(5)
if x["OK"]:
    value = x["Value"]
    if value:
        print(value + 3)
    print(value + 3)
    # ↑ error: Unsupported operand types for + ("None" and "int")
    # ↑ note: Left operand is of type "Optional[int]"
```
</details>


BEGINRELEASENOTES
*Core
NEW: Introduce DReturnType/DOKReturnType/DErrorReturnType for DIRAC return structures

ENDRELEASENOTES
