### PR TITLE
[v7r3] Set HOME in SingularityCE to avoid tmpfs

### DIFF
--- a/src/DIRAC/Resources/Computing/SingularityComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SingularityComputingElement.py
@@ -416,6 +416,7 @@ class SingularityComputingElement(ComputingElement):
         cmd.extend(["--contain"])  # use minimal /dev and empty other directories (e.g. /tmp and $HOME)
         cmd.extend(["--ipc", "--pid"])  # run container in new IPC and PID namespaces
         cmd.extend(["--workdir", baseDir])  # working directory to be used for /tmp, /var/tmp and $HOME
+        cmd.extend(["--home", "/tmp"])  # Avoid using small tmpfs for default $HOME and use scratch /tmp instead
         if self.__hasUserNS():
             cmd.append("--userns")
         if withCVMFS:


### PR DESCRIPTION
Hi,

The newer version of singularity in DIRACOS2 has an extra quirk that I haven't seen before: With the --contain option it makes the rootfs of the container a small tmpfs (which is fine, as it used to be), but it doesn't touch $HOME. Generally this results in $HOME pointing into /home or /mnt (on a cloud), whatever it was outside of the container and writing to a 16MiB tmpfs. Most user jobs don't even notice this, but some use pip and other tools that write to $HOME/.cache by default and can quite quickly run out of space. This new patch just adds the option to SingularityCE to set home to be /tmp inside the container (which is the usual scratch area) so that all the space is available and things don't trip-up.

Regards,
Simon

BEGINRELEASENOTES
*Resources
FIX: Set HOME in SingularityCE
ENDRELEASENOTES
