### PR TITLE
[v7r2] Fix testing against S3Mock

### DIFF
--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -43,7 +43,8 @@ services:
       - 9090
       - 9191
     environment:
-      - initialBuckets=myFirstBucket
+      - initialBuckets=my-first-bucket
+      - debug=true
 
   dirac-server:
     image: ${CI_REGISTRY_IMAGE}/${HOST_OS}-dirac

--- a/tests/Jenkins/dirac-cfg-update-server.py
+++ b/tests/Jenkins/dirac-cfg-update-server.py
@@ -201,7 +201,7 @@ csAPI.setOption("Resources/StorageElements/SE-2/DIP/Access", "remote")
 #         Host = s3-direct
 #         Port = 9090
 #         Protocol = s3
-#         Path = myFirstBucket
+#         Path = my-first-bucket
 #         Access = remote
 #         SecureConnection = False
 #         Aws_access_key_id = fakeId #useless
@@ -226,7 +226,7 @@ csAPI.setOption("Resources/StorageElements/S3-DIRECT/WriteProtocols", "s3")
 csAPI.setOption("Resources/StorageElements/S3-DIRECT/S3/Host", "s3-direct")
 csAPI.setOption("Resources/StorageElements/S3-DIRECT/S3/Port", "9090")
 csAPI.setOption("Resources/StorageElements/S3-DIRECT/S3/Protocol", "s3")
-csAPI.setOption("Resources/StorageElements/S3-DIRECT/S3/Path", "myFirstBucket")
+csAPI.setOption("Resources/StorageElements/S3-DIRECT/S3/Path", "my-first-bucket")
 csAPI.setOption("Resources/StorageElements/S3-DIRECT/S3/Access", "remote")
 csAPI.setOption("Resources/StorageElements/S3-DIRECT/S3/SecureConnection", "False")
 csAPI.setOption("Resources/StorageElements/S3-DIRECT/S3/Aws_access_key_id", "FakeId")
@@ -249,7 +249,7 @@ csAPI.setOption("Resources/StorageElements/S3-DIRECT/S3/Aws_secret_access_key", 
 #         Host = s3-direct
 #         Port = 9090
 #         Protocol = s3
-#         Path = myFirstBucket
+#         Path = my-first-bucket
 #         Access = remote
 #         SecureConnection = False
 #       }
@@ -272,7 +272,7 @@ csAPI.setOption("Resources/StorageElements/S3-INDIRECT/WriteProtocols", "s3")
 csAPI.setOption("Resources/StorageElements/S3-INDIRECT/S3/Host", "s3-direct")
 csAPI.setOption("Resources/StorageElements/S3-INDIRECT/S3/Port", "9090")
 csAPI.setOption("Resources/StorageElements/S3-INDIRECT/S3/Protocol", "s3")
-csAPI.setOption("Resources/StorageElements/S3-INDIRECT/S3/Path", "myFirstBucket")
+csAPI.setOption("Resources/StorageElements/S3-INDIRECT/S3/Path", "my-first-bucket")
 csAPI.setOption("Resources/StorageElements/S3-INDIRECT/S3/Access", "remote")
 csAPI.setOption("Resources/StorageElements/S3-INDIRECT/S3/SecureConnection", "False")
 


### PR DESCRIPTION
The latest release of S3Mock has become stricter and now requires a valid bucket name (https://github.com/adobe/S3Mock/pull/743).