### PR TITLE
Install diracdoctools directly from environment.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,12 +6,6 @@ build:
 sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
-python:
-  install:
-  - method: pip
-    path: docs/
-    extra_requirements:
-    - diracdoctools
 conda:
   environment: environment.yml
 formats: []

--- a/environment.yml
+++ b/environment.yml
@@ -102,4 +102,6 @@ dependencies:
     # This is an extension of Tornado to use M2Crypto
     # It should eventually be part of DIRACGrid
     - git+https://github.com/DIRACGrid/tornado_m2crypto
-    - -e .
+    - -e .[server]
+    # Add diracdoctools
+    - -e docs/


### PR DESCRIPTION
I don't think it deserves release notes.
This is just to have everything needed for Readthedoc builds for extension to work out of the box