### PR TITLE
[v7r2] Backport: Fix using HTTPS with Python 3.10+

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -32,15 +32,17 @@ DIRAC_GFAL_GRIDFTP_SESSION_REUSE
   If set to ``true`` or ``yes`` the GRIDFTP SESSION REUSE option will be set to True, should be set on server
   installations. See the information in the :ref:`resourcesStorageElement` page.
 
-DIRAC_USE_JSON_DECODE
-  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page (default=Yes since v7r2)
+DIRAC_HTTPS_SSL_CIPHERS
+  If set, overrides the default SSL ciphers accepted when using HTTPS. It should be a colon separated list.
+  This option is ignored if running with Python 2.
 
-DIRAC_USE_JSON_ENCODE
-  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page (default=No)
+DIRAC_HTTPS_SSL_METHOD_MAX
+  If set, overrides the highest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
+  This option is ignored if running with Python 2.
 
-DIRAC_USE_M2CRYPTO
-  If anything else than ``true`` or ``yes`` (default) DIRAC will revert back to using pyGSI instead of m2crypto for handling certificates, proxies, etc.
-  Unused since v7r2.
+DIRAC_HTTPS_SSL_METHOD_MIN
+  If set, overrides the lowest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
+  This option is ignored if running with Python 2.
 
 DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
   If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
@@ -51,20 +53,18 @@ DIRAC_M2CRYPTO_SSL_CIPHERS
 DIRAC_M2CRYPTO_SSL_METHODS
   If set, overwrites the default SSL methods accepted. It should be a colon separated list. See :py:mod:`DIRAC.Core.DISET`
 
-DIRAC_HTTPS_SSL_CIPHERS
-  If set, overrides the default SSL ciphers accepted when using HTTPS. It should be a colon separated list.
-  This option is ignored if running with Python 2.
-
-DIRAC_HTTPS_SSL_METHOD_MIN
-  If set, overrides the lowest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
-  This option is ignored if running with Python 2.
-
-DIRAC_HTTPS_SSL_METHOD_MAX
-  If set, overrides the highest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
-  This option is ignored if running with Python 2.
-
 DIRAC_NO_CFG
   If set to anything, cfg files on the command line must be passed to the command using the --cfg option.
+
+DIRAC_USE_JSON_DECODE
+  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page (default=Yes since v7r2)
+
+DIRAC_USE_JSON_ENCODE
+  Controls the transition to JSON serialization. See the information in :ref:`jsonSerialization` page (default=No)
+
+DIRAC_USE_M2CRYPTO
+  If anything else than ``true`` or ``yes`` (default) DIRAC will revert back to using pyGSI instead of m2crypto for handling certificates, proxies, etc.
+  Unused since v7r2.
 
 DIRAC_USE_NEWTHREADPOOL
   If this environment is set to ``true`` or ``yes``, the concurrent.futures.ThreadPoolExecutor will be used (default=Yes)

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -46,10 +46,19 @@ DIRAC_M2CRYPTO_SPLIT_HANDSHAKE
   If ``true`` or ``yes`` the SSL handshake is done in a new thread (default Yes)
 
 DIRAC_M2CRYPTO_SSL_CIPHERS
-  If set, overwrites the default SSL ciphers accepted. It should be a column separated list. See :py:mod:`DIRAC.Core.DISET`
+  If set, overwrites the default SSL ciphers accepted. It should be a colon separated list. See :py:mod:`DIRAC.Core.DISET`
 
 DIRAC_M2CRYPTO_SSL_METHODS
-  If set, overwrites the default SSL methods accepted. It should be a column separated list. See :py:mod:`DIRAC.Core.DISET`
+  If set, overwrites the default SSL methods accepted. It should be a colon separated list. See :py:mod:`DIRAC.Core.DISET`
+
+DIRAC_HTTPS_SSL_CIPHERS
+  If set, overrides the default SSL ciphers accepted when using HTTPS. It should be a colon separated list.
+
+DIRAC_HTTPS_SSL_METHOD_MIN
+  If set, overrides the lowest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
+
+DIRAC_HTTPS_SSL_METHOD_MAX
+  If set, overrides the highest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
 
 DIRAC_NO_CFG
   If set to anything, cfg files on the command line must be passed to the command using the --cfg option.

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -53,12 +53,15 @@ DIRAC_M2CRYPTO_SSL_METHODS
 
 DIRAC_HTTPS_SSL_CIPHERS
   If set, overrides the default SSL ciphers accepted when using HTTPS. It should be a colon separated list.
+  This option is ignored if running with Python 2.
 
 DIRAC_HTTPS_SSL_METHOD_MIN
   If set, overrides the lowest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
+  This option is ignored if running with Python 2.
 
 DIRAC_HTTPS_SSL_METHOD_MAX
   If set, overrides the highest supported TLS version when using HTTPS. It should be a valid value of :py:class:`ssl.TLSVersion`.
+  This option is ignored if running with Python 2.
 
 DIRAC_NO_CFG
   If set to anything, cfg files on the command line must be passed to the command using the --cfg option.

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -500,10 +500,12 @@ class TornadoBaseClient(object):
         # Getting CA file (or skip verification)
         verify = not self.kwargs.get(self.KW_SKIP_CA_CHECK)
         if verify:
-            cafile = Locations.getCAsLocation()
-            if not cafile:
-                gLogger.error("No CAs found!")
-                return S_ERROR("No CAs found!")
+            if not self.__ca_location:
+                self.__ca_location = Locations.getCAsLocation()
+                if not self.__ca_location:
+                    gLogger.error("No CAs found!")
+                    return S_ERROR("No CAs found!")
+
             verify = self.__ca_location
 
         # getting certificate

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -34,6 +34,7 @@ from io import open
 import errno
 import os
 import requests
+import ssl
 import six
 import tempfile
 from six.moves import http_client
@@ -42,6 +43,7 @@ from six.moves import http_client
 import DIRAC
 
 from DIRAC import S_OK, S_ERROR, gLogger
+from DIRAC.Core.Utilities.ReturnValues import convertToReturnValue
 
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.CSGlobals import skipCACheck
@@ -106,7 +108,7 @@ class TornadoBaseClient(object):
 
         self._destinationSrv = serviceName
         self._serviceName = serviceName
-        self.__ca_location = False
+        self.__session = None
 
         self.kwargs = kwargs
         self.__useCertificates = None
@@ -220,11 +222,13 @@ class TornadoBaseClient(object):
         else:
             self.__useCertificates = gConfig.useServerCertificate()
             self.kwargs[self.KW_USE_CERTIFICATES] = self.__useCertificates
-        if self.KW_SKIP_CA_CHECK not in self.kwargs:
-            if self.__useCertificates:
-                self.kwargs[self.KW_SKIP_CA_CHECK] = False
-            else:
-                self.kwargs[self.KW_SKIP_CA_CHECK] = skipCACheck()
+
+        # Prepare the session
+        skip_ca_check = self.kwargs.get(self.KW_SKIP_CA_CHECK, False if self.__useCertificates else skipCACheck())
+        retVal = _create_session(verified=not skip_ca_check)
+        if not retVal["OK"]:  # pylint: disable=unsubscriptable-object
+            return retVal
+        self.__session = retVal["Value"]  # pylint: disable=unsubscriptable-object
 
         # Rewrite a little bit from here: don't need the proxy string, we use the file
         if self.KW_PROXY_CHAIN in self.kwargs:
@@ -497,17 +501,6 @@ class TornadoBaseClient(object):
             return url
         url = url["Value"]
 
-        # Getting CA file (or skip verification)
-        verify = not self.kwargs.get(self.KW_SKIP_CA_CHECK)
-        if verify:
-            if not self.__ca_location:
-                self.__ca_location = Locations.getCAsLocation()
-                if not self.__ca_location:
-                    gLogger.error("No CAs found!")
-                    return S_ERROR("No CAs found!")
-
-            verify = self.__ca_location
-
         # getting certificate
         # Do we use the server certificate ?
         if self.kwargs[self.KW_USE_CERTIFICATES]:
@@ -537,7 +530,7 @@ class TornadoBaseClient(object):
 
                 # Default case, just return the result
                 if not outputFile:
-                    call = requests.post(url, data=kwargs, timeout=self.timeout, verify=verify, cert=cert)
+                    call = self.__session.post(url, data=kwargs, timeout=self.timeout, cert=cert)
                     # raising the exception for status here
                     # means essentialy that we are losing here the information of what is returned by the server
                     # as error message, since it is not passed to the exception
@@ -556,9 +549,7 @@ class TornadoBaseClient(object):
                     rawText = None
                     # Stream download
                     # https://requests.readthedocs.io/en/latest/user/advanced/#body-content-workflow
-                    with requests.post(
-                        url, data=kwargs, timeout=self.timeout, verify=verify, cert=cert, stream=True
-                    ) as r:
+                    with self.__session.post(url, data=kwargs, timeout=self.timeout, cert=cert, stream=True) as r:
                         rawText = r.text
                         r.raise_for_status()
 
@@ -597,3 +588,35 @@ class TornadoBaseClient(object):
 # Rewrite this method if needed:
 #  /Core/DISET/private/BaseClient.py
 # __delegateCredentials
+
+
+class _ContextAdapter(requests.adapters.HTTPAdapter):
+    """Allows to override the default context."""
+
+    def __init__(self, *args, **kwargs):
+        self.ssl_context = kwargs.pop("ssl_context", None)
+        super(_ContextAdapter, self).__init__(*args, **kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs.setdefault("ssl_context", self.ssl_context)
+        return super(_ContextAdapter, self).init_poolmanager(*args, **kwargs)
+
+
+@convertToReturnValue
+def _create_session(verified=True):
+    ctx = ssl.create_default_context()
+    # Python 3.10+ sets DEFAULT:@SECLEVEL=2 which prevents the use of 1024 bit RSA for proxies.
+    # In DIRAC 8.0 the default proxy length has been increased to 2048 bits however we need to
+    # downgrade to DEFAULT:@SECLEVEL=1 until all users have uploaded a new proxy.
+    ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
+    session = requests.Session()
+    session.mount("https://", _ContextAdapter(ssl_context=ctx))
+    if verified:
+        ca_location = Locations.getCAsLocation()
+        if not ca_location:
+            raise ValueError("No CAs found!")
+        session.verify = ca_location
+    else:
+        ctx.check_hostname = False
+        session.verify = False
+    return session

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -608,11 +608,14 @@ def _create_session(verified=True):
     # Python 3.10+ sets DEFAULT:@SECLEVEL=2 which prevents the use of 1024 bit RSA for proxies.
     # In DIRAC 8.0 the default proxy length has been increased to 2048 bits however we need to
     # downgrade to DEFAULT:@SECLEVEL=1 until all users have uploaded a new proxy.
-    ctx.set_ciphers(os.environ.get("DIRAC_HTTPS_SSL_CIPHERS", "DEFAULT:@SECLEVEL=1"))
-    if minimum_tls_version := os.environ.get("DIRAC_HTTPS_SSL_METHOD_MIN"):
-        ctx.minimum_version = getattr(ssl.TLSVersion, minimum_tls_version)
-    if maximum_tls_version := os.environ.get("DIRAC_HTTPS_SSL_METHOD_MAX"):
-        ctx.maximum_version = getattr(ssl.TLSVersion, maximum_tls_version)
+    if six.PY3:
+        ctx.set_ciphers(os.environ.get("DIRAC_HTTPS_SSL_CIPHERS", "DEFAULT:@SECLEVEL=1"))
+        minimum_tls_version = os.environ.get("DIRAC_HTTPS_SSL_METHOD_MIN")
+        if minimum_tls_version:
+            ctx.minimum_version = getattr(ssl.TLSVersion, minimum_tls_version)  # pylint: disable=no-member
+        maximum_tls_version = os.environ.get("DIRAC_HTTPS_SSL_METHOD_MAX")
+        if maximum_tls_version:
+            ctx.maximum_version = getattr(ssl.TLSVersion, maximum_tls_version)  # pylint: disable=no-member
     session = requests.Session()
     session.mount("https://", _ContextAdapter(ssl_context=ctx))
     if verified:

--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -608,7 +608,11 @@ def _create_session(verified=True):
     # Python 3.10+ sets DEFAULT:@SECLEVEL=2 which prevents the use of 1024 bit RSA for proxies.
     # In DIRAC 8.0 the default proxy length has been increased to 2048 bits however we need to
     # downgrade to DEFAULT:@SECLEVEL=1 until all users have uploaded a new proxy.
-    ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
+    ctx.set_ciphers(os.environ.get("DIRAC_HTTPS_SSL_CIPHERS", "DEFAULT:@SECLEVEL=1"))
+    if minimum_tls_version := os.environ.get("DIRAC_HTTPS_SSL_METHOD_MIN"):
+        ctx.minimum_version = getattr(ssl.TLSVersion, minimum_tls_version)
+    if maximum_tls_version := os.environ.get("DIRAC_HTTPS_SSL_METHOD_MAX"):
+        ctx.maximum_version = getattr(ssl.TLSVersion, maximum_tls_version)
     session = requests.Session()
     session.mount("https://", _ContextAdapter(ssl_context=ctx))
     if verified:


### PR DESCRIPTION
Backport of https://github.com/DIRACGrid/DIRAC/pull/6299.

BEGINRELEASENOTES

*Core
CHANGE: Set OpenSSL ciphers to "DEFAULT:@SECLEVEL=1"
NEW: Experimental support for Python 3.10
FIX: Correct check of CA locations

ENDRELEASENOTES