### PR TITLE
[8.0] Replace subprocess32 with standard library module

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -142,7 +142,7 @@ generated-members=REQUEST,acl_users,aq_parent
 # List of ignored modules
 # (useful for classes with attributes dynamically set).
 # subprocess32 is disabled due to https://github.com/PyCQA/astroid/issues/911
-ignored-modules = MySQLdb,numpy,six.moves.urllib,subprocess32
+ignored-modules = MySQLdb,numpy,six.moves.urllib
 
 [VARIABLES]
 

--- a/docs/diracdoctools/Utilities.py
+++ b/docs/diracdoctools/Utilities.py
@@ -8,7 +8,7 @@ import re
 import sys
 import shlex
 import logging
-import subprocess32 as subprocess
+import subprocess
 
 
 LOG = logging.getLogger(__name__)

--- a/environment.yml
+++ b/environment.yml
@@ -48,7 +48,6 @@ dependencies:
   - python-gfal2
   - mysqlclient
   - diraccfg
-  - subprocess32
   - ldap3
   - importlib_resources
   # testing and development

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     setuptools
     six
     sqlalchemy
-    subprocess32
     Authlib >=1.0.0.a2
     pyjwt
     dominate

--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -31,7 +31,7 @@ import threading
 import time
 import os
 import sys
-import subprocess32 as subprocess
+import subprocess
 import signal
 import psutil
 

--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -62,7 +62,7 @@ from collections import defaultdict
 from importlib import metadata
 
 import importlib_resources
-import subprocess32 as subprocess
+import subprocess
 from diraccfg import CFG
 from prompt_toolkit import prompt
 

--- a/src/DIRAC/Resources/Computing/BatchSystems/Host.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Host.py
@@ -16,11 +16,7 @@ import os
 import glob
 import shutil
 import signal
-
-try:
-    import subprocess32 as subprocess
-except ImportError:
-    import subprocess
+import subprocess
 import stat
 import json
 import multiprocessing

--- a/src/DIRAC/Resources/Computing/test/Test_SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_SSHComputingElement.py
@@ -4,7 +4,7 @@ tests for SSHComputingElement module
 """
 import os
 import shutil
-import subprocess32 as subprocess
+import subprocess
 import shlex
 import pytest
 


### PR DESCRIPTION
For Python 2 we started using `subprocess32` in https://github.com/DIRACGrid/DIRAC/pull/4286 as it was significantly faster for the integration tests. Now DIRAC is Python 3-only we can remove it.