### PR TITLE
[v7r3] Fix incorrect rendering of code block

### DIFF
--- a/docs/source/UserGuide/GettingStarted/UserJobs/DiracAPI/index.rst
+++ b/docs/source/UserGuide/GettingStarted/UserJobs/DiracAPI/index.rst
@@ -92,7 +92,7 @@ The script output is going to return the status, minor status and the site where
 Job Output
 ==========
 
-When the status of the job is done, the outputs can be retrieved using also a simple script::
+When the status of the job is done, the outputs can be retrieved using also a simple script:
 
 .. code-block:: python
 


### PR DESCRIPTION
In the documentation, the python code block was not rendered correctly due to an extra :