### PR TITLE
[8.0] Remove CPU(MHz) from CacheSize(kB) job parameters

### DIFF
--- a/src/DIRAC/Interfaces/scripts/dirac_wms_job_parameters.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_wms_job_parameters.py
@@ -8,9 +8,7 @@ Retrieve parameters associated to the given DIRAC job
 
 Example:
   $ dirac-wms-job-parameters 1
-  {'CPU(MHz)': '1596.479',
-   'CPUNormalizationFactor': '6.8',
-   'CacheSize(kB)': '4096KB',
+  {'CPUNormalizationFactor': '6.8',
    'GridCEQueue': 'ce.labmc.inf.utfsm.cl:2119/jobmanager-lcgpbs-prod',
    'HostName': 'wn05.labmc',
    'JobPath': 'JobPath,JobSanity,JobScheduling,TaskQueue',

--- a/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
@@ -47,7 +47,6 @@ mapping = {
         "CPUNormalizationFactor": {"type": "long"},
         "NormCPUTime(s)": {"type": "long"},
         "Memory(kB)": {"type": "long"},
-        "CPU(MHz)": {"type": "long"},
         "TotalCPUTime(s)": {"type": "long"},
         "MemoryUsed(kb)": {"type": "long"},
         "HostName": {"type": "keyword"},

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -964,10 +964,6 @@ class Watchdog:
         """Retrieves all static system information"""
         result = {}
         result["HostName"] = socket.gethostname()
-        try:
-            result["CPU(MHz)"] = psutil.cpu_freq()[0]
-        except Exception:
-            result["CPU(MHz)"] = 0
         result["Memory(kB)"] = int(psutil.virtual_memory()[1] / 1024)
         result["LocalAccount"] = getpass.getuser()
 
@@ -977,7 +973,6 @@ class Watchdog:
             raw_info = path.read_text().split("\n\n")[0]
             info = dict(map(str.strip, x.split(":", 1)) for x in raw_info.split("\n"))
             result["ModelName"] = info.get("model name", "Unknown")
-            result["CacheSize(kB)"] = info.get("cache size", "Unknown")
 
         return result
 


### PR DESCRIPTION
Closes #6332. See the issue for justification.

BEGINRELEASENOTES

*WorkloadManagement
CHANGE: Remove CPU(MHz) from CacheSize(kB) job parameters

ENDRELEASENOTES
