### PR TITLE
[integration] Explicitly import importlib.metadata instead of just importlib

### DIFF
--- a/src/DIRAC/Core/Base/AgentModule.py
+++ b/src/DIRAC/Core/Base/AgentModule.py
@@ -5,7 +5,7 @@ import os
 import threading
 import time
 import signal
-import importlib
+import importlib.metadata
 import inspect
 import datetime
 import psutil


### PR DESCRIPTION
Fixes this error I noticed:

```pylint
Traceback (most recent call last):
  File "/home/dirac/ServerInstallDIR/diracos/lib/python3.9/site-packages/DIRAC/Core/Base/AgentModule.py", line 152, in __getCodeInfo
    self.__codeProperties["version"] = importlib.metadata.version(
AttributeError: module 'importlib' has no attribute 'metadata'
```

Apparently pylint isn't able to notice this error as even this reproducer is okay:

```python
$ cat test.py
import importlib
importlib.metadata

$ pylint test.py
************* Module test
test.py:1:0: C0114: Missing module docstring (missing-module-docstring)
test.py:2:0: W0104: Statement seems to have no effect (pointless-statement)

------------------------------------------------------------------
Your code has been rated at 0.00/10 (previous run: 0.00/10, +0.00)

$ python test.py
Traceback (most recent call last):
  File "/Users/cburr/Development/DIRAC-dev/DIRAC/test.py", line 2, in <module>
    importlib.metadata
AttributeError: module 'importlib' has no attribute 'metadata'
```


BEGINRELEASENOTES

*Core
FIX: Setting codeProperties["version"] in AgentModule

ENDRELEASENOTES
