### PR TITLE
[8.0] Remove remaining uses of six

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -39,8 +39,7 @@ jobs:
               pytz \
               readme_renderer \
               requests \
-              setuptools_scm \
-              six
+              setuptools_scm
       - name: Validate README for PyPI
         run: |
           python -m readme_renderer README.rst -o /tmp/README.html

--- a/.pylintrc
+++ b/.pylintrc
@@ -141,8 +141,7 @@ generated-members=REQUEST,acl_users,aq_parent
 
 # List of ignored modules
 # (useful for classes with attributes dynamically set).
-# subprocess32 is disabled due to https://github.com/PyCQA/astroid/issues/911
-ignored-modules = MySQLdb,numpy,six.moves.urllib
+ignored-modules = MySQLdb,numpy
 
 [VARIABLES]
 

--- a/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
+++ b/docs/diracdoctools/scripts/dirac-docs-get-release-notes.py
@@ -34,7 +34,6 @@ import logging
 import textwrap
 import requests
 from distutils.version import LooseVersion
-import six
 from configparser import ConfigParser
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,6 @@ dependencies:
   - pyyaml
   - recommonmark
   - requests >=2.9.1
-  - six >=1.10
   - sqlalchemy
   - stomp.py
   - suds >=0.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ install_requires =
     requests
     rucio-clients
     setuptools
-    six
     sqlalchemy
     typing_extensions >=4.3.0
     Authlib >=1.0.0.a2

--- a/src/DIRAC/Core/DISET/private/Transports/BaseTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/BaseTransport.py
@@ -18,7 +18,6 @@ Client <- RequestHandler : Response
 Client <- Service        : Close
 """
 import time
-import six
 from io import BytesIO
 from hashlib import md5
 

--- a/src/DIRAC/Core/DISET/private/Transports/SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/SSLTransport.py
@@ -1,4 +1,3 @@
-import six
 import os
 
 from DIRAC import gLogger

--- a/src/DIRAC/Core/Utilities/DEncode.py
+++ b/src/DIRAC/Core/Utilities/DEncode.py
@@ -11,7 +11,6 @@ Encoding and decoding for dirac, Ids:
  t -> tuple
  d -> dictionary
 """
-import six
 import datetime
 import os
 

--- a/src/DIRAC/DataManagementSystem/Client/ConsistencyInspector.py
+++ b/src/DIRAC/DataManagementSystem/Client/ConsistencyInspector.py
@@ -4,7 +4,6 @@
 
     Should be extended to include the Storage (in DIRAC)
 """
-import six
 import os
 import time
 import sys

--- a/src/DIRAC/DataManagementSystem/Client/DataIntegrityClient.py
+++ b/src/DIRAC/DataManagementSystem/Client/DataIntegrityClient.py
@@ -3,7 +3,6 @@ This is the Data Integrity Client which allows the simple reporting of
 problematic file and replicas to the IntegrityDB and their status
 correctly updated in the FileCatalog.
 """
-import six
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.DataManagementSystem.Client.DataManager import DataManager
 from DIRAC.Resources.Storage.StorageElement import StorageElement

--- a/src/DIRAC/DataManagementSystem/Client/DataManager.py
+++ b/src/DIRAC/DataManagementSystem/Client/DataManager.py
@@ -14,7 +14,6 @@ import fnmatch
 import os
 import time
 import errno
-import six
 
 # # from DIRAC
 import DIRAC

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
@@ -7,7 +7,6 @@
                      you do it several times within 1 second, then there will be no changed, and affected = 0
 
 """
-import six
 import os
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryFlatTree.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryFlatTree.py
@@ -1,7 +1,6 @@
 """ DIRAC FileCatalog component representing a flat directory tree
 """
 # pylint: disable=protected-access
-import six
 import os
 import stat
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
@@ -1,7 +1,6 @@
 """ DIRAC FileCatalog component representing a directory tree with enumerated paths
 """
 # pylint: disable=protected-access
-import six
 import os
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
@@ -1,5 +1,4 @@
 """ DIRAC DirectoryTree base class """
-import six
 import time
 import threading
 import os

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/DirectoryMetadata.py
@@ -1,7 +1,6 @@
 """ DIRAC FileCatalog mix-in class to manage directory metadata
 """
 # pylint: disable=protected-access
-import six
 import os
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManager.py
@@ -1,7 +1,6 @@
 """ FileManager (add doc here)
 """
 import os
-import six
 
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.DataManagementSystem.DB.FileCatalogComponents.FileManager.FileManagerBase import FileManagerBase

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -2,7 +2,6 @@
 """
 # pylint: disable=protected-access
 
-import six
 import os
 import stat
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
@@ -1,4 +1,3 @@
-import six
 import os
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
@@ -1,6 +1,5 @@
 """ FileManager for ... ?
 """
-import six
 import os
 import datetime
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/FileMetadata.py
@@ -1,6 +1,5 @@
 """ DIRAC FileCatalog plugin class to manage file metadata
 """
-import six
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.TimeUtilities import queryTime
 from DIRAC.Core.Utilities.List import intListToString

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
@@ -1,5 +1,4 @@
 """ DIRAC FileCatalog Storage Element Manager mix-in class for SE definitions within the FC database"""
-import six
 import time
 import random
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/UserGroupManager/UserAndGroupManagerDB.py
@@ -1,6 +1,5 @@
 """ DIRAC FileCatalog mix-in class to manage users and groups within the FC database
 """
-import six
 import time
 import threading
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/Utilities.py
@@ -1,6 +1,5 @@
 """ DIRAC FileCatalog utilities
 """
-import six
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.List import intListToString
 

--- a/src/DIRAC/DataManagementSystem/Service/FileCatalogProxyHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/FileCatalogProxyHandler.py
@@ -8,7 +8,6 @@
 """
 # imports
 import os
-import six
 
 # from DIRAC
 from DIRAC import gLogger, S_OK, S_ERROR

--- a/src/DIRAC/DataManagementSystem/Service/StorageElementProxyHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/StorageElementProxyHandler.py
@@ -13,7 +13,6 @@ import socketserver
 import threading
 import socket
 import random
-import six
 
 # from DIRAC
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR

--- a/src/DIRAC/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/src/DIRAC/DataManagementSystem/Utilities/DMSHelpers.py
@@ -3,7 +3,6 @@
 
 """
 from collections import defaultdict
-import six
 from DIRAC import gConfig, gLogger, S_OK, S_ERROR
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations

--- a/src/DIRAC/FrameworkSystem/private/authorization/utils/Clients.py
+++ b/src/DIRAC/FrameworkSystem/private/authorization/utils/Clients.py
@@ -1,4 +1,3 @@
-import six
 import time
 
 from authlib.oauth2.rfc6749.util import scope_to_list, list_to_scope

--- a/src/DIRAC/ProductionSystem/Service/ProductionManagerHandler.py
+++ b/src/DIRAC/ProductionSystem/Service/ProductionManagerHandler.py
@@ -1,6 +1,5 @@
 """ DISET request handler base class for the ProductionDB.
 """
-import six
 
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.RequestHandler import RequestHandler

--- a/src/DIRAC/Resources/Catalog/FileCatalog.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalog.py
@@ -43,7 +43,6 @@
     the documentation of the respective FileCatalog plug-ins ( client classes )
 
 """
-import six
 import re
 
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR

--- a/src/DIRAC/Resources/Catalog/Utilities.py
+++ b/src/DIRAC/Resources/Catalog/Utilities.py
@@ -1,6 +1,5 @@
 """ DIRAC FileCatalog client utilities
 """
-import six
 import os
 import errno
 import functools

--- a/src/DIRAC/Resources/Cloud/Utilities.py
+++ b/src/DIRAC/Resources/Cloud/Utilities.py
@@ -3,7 +3,6 @@ Utility functions for cloud endpoints.
 """
 import sys
 import os
-import six
 
 from DIRAC import S_OK, S_ERROR
 from email.mime.text import MIMEText

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -35,7 +35,6 @@ Preamble:
 
 **Code Documentation**
 """
-import six
 import os
 import stat
 

--- a/src/DIRAC/Resources/Computing/CREAMComputingElement.py
+++ b/src/DIRAC/Resources/Computing/CREAMComputingElement.py
@@ -5,7 +5,6 @@
 
 """ CREAM Computing Element
 """
-import six
 import os
 import re
 import tempfile

--- a/src/DIRAC/Resources/Computing/ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ComputingElement.py
@@ -26,7 +26,6 @@
      ComputingElementFactory.
 """
 
-import six
 import os
 import datetime
 

--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -44,7 +44,6 @@ When using a local condor_schedd look at the HTCondor documenation for enabling 
 # created documentation, there should only be one slash when setting the option,
 # but "\n" gets rendered as a linebreak in sphinx
 
-import six
 import os
 import tempfile
 

--- a/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
@@ -6,7 +6,6 @@
 """ SSH (Virtual) Computing Element: For a given list of ip/cores pair it will send jobs
     directly through ssh
 """
-import six
 import os
 import socket
 import stat

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -58,7 +58,6 @@ SSHType:
 **Code Documentation**
 
 """
-import six
 import os
 import json
 import stat

--- a/src/DIRAC/Resources/Storage/test/FIXME_Test_StorageElement.py
+++ b/src/DIRAC/Resources/Storage/test/FIXME_Test_StorageElement.py
@@ -7,7 +7,6 @@ import time
 import os
 import shutil
 import sys
-import six
 
 from DIRAC.Core.Base.Script import parseCommandLine, getPositionalArgs
 

--- a/src/DIRAC/Resources/Storage/test/FIXME_Test_StoragePlugIn.py
+++ b/src/DIRAC/Resources/Storage/test/FIXME_Test_StoragePlugIn.py
@@ -8,7 +8,6 @@ import time
 import os
 import shutil
 import sys
-import six
 
 from DIRAC.Core.Base.Script import parseCommandLine, getPositionalArgs
 

--- a/src/DIRAC/StorageManagementSystem/Client/StorageManagerClient.py
+++ b/src/DIRAC/StorageManagementSystem/Client/StorageManagerClient.py
@@ -1,6 +1,5 @@
 """ Class that contains client access to the StorageManagerDB handler.
 """
-import six
 import random
 import errno
 

--- a/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
@@ -9,7 +9,6 @@
     The TaskReplicas table maps the TaskIDs from the Tasks table to the ReplicaID from the CacheReplicas table.
     The StageRequests table contains each of the prestage request IDs for each of the replicas.
 """
-import six
 import inspect
 import threading
 

--- a/src/DIRAC/StorageManagementSystem/Service/StorageManagerHandler.py
+++ b/src/DIRAC/StorageManagementSystem/Service/StorageManagerHandler.py
@@ -1,6 +1,5 @@
 """ StorageManagerHandler is the implementation of the StorageManagementDB in the DISET framework """
 
-import six
 
 from DIRAC import gLogger, S_OK
 from DIRAC.Core.DISET.RequestHandler import RequestHandler

--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -6,7 +6,6 @@
 """
 
 # ## This agent might potentially still need to be run in python2, so leave this
-import six
 
 # #############################
 

--- a/src/DIRAC/WorkloadManagementSystem/Client/InputDataByProtocol.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/InputDataByProtocol.py
@@ -7,7 +7,6 @@
     components to provide access to datasets by available site protocols as
     defined in the CS for the VO.
 """
-import six
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.WorkloadManagementSystem.Client.JobStateUpdateClient import JobStateUpdateClient

--- a/src/DIRAC/WorkloadManagementSystem/Client/InputDataResolution.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/InputDataResolution.py
@@ -6,7 +6,6 @@
     result and in principle has all the necessary information to resolve input data
     for applications.
 """
-import six
 import DIRAC
 from DIRAC import S_OK, S_ERROR, gLogger
 from DIRAC.Core.Utilities.ModuleFactory import ModuleFactory

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -21,7 +21,6 @@ import threading
 import tarfile
 import glob
 import json
-import six
 
 from urllib.parse import unquote
 

--- a/src/DIRAC/tests/Utilities/assertingUtils.py
+++ b/src/DIRAC/tests/Utilities/assertingUtils.py
@@ -3,7 +3,6 @@
 The AgentOptionsTest can be used to check consistency of options for Agents.
 
 """
-import six
 import inspect
 import importlib
 import logging

--- a/tests/Integration/RequestManagementSystem/Test_Client_Req.py
+++ b/tests/Integration/RequestManagementSystem/Test_Client_Req.py
@@ -8,7 +8,6 @@
 import copy
 import unittest
 import sys
-import six
 
 import DIRAC
 

--- a/tests/Integration/TornadoServices/Services/UserDiracHandler.py
+++ b/tests/Integration/TornadoServices/Services/UserDiracHandler.py
@@ -1,8 +1,6 @@
 """ Dummy Service is a service for testing new dirac protocol
   This file must be copied in FrameworkSystem/Service to run tests
 """
-import six
-
 from DIRAC import S_OK
 from DIRAC.Core.DISET.RequestHandler import RequestHandler
 


### PR DESCRIPTION
The only remaining cases were unused imports 🥳 