### PR TITLE
[v8.0] Add an SQL optimizer tracer

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -50,6 +50,9 @@ DIRAC_M2CRYPTO_SSL_CIPHERS
 DIRAC_M2CRYPTO_SSL_METHODS
   If set, overwrites the default SSL methods accepted. It should be a colon separated list. See :py:mod:`DIRAC.Core.DISET`
 
+DIRAC_MYSQL_OPTIMIZER_TRACES_PATH
+  If set, it should point to an existing directory, where MySQL Optimizer traces will be stored. See :py:func:`DIRAC.Core.Utilities.MySQL.captureOptimizerTraces`
+
 DIRAC_NO_CFG
   If set to anything, cfg files on the command line must be passed to the command using the --cfg option.
 

--- a/src/DIRAC/AccountingSystem/DB/AccountingDB.py
+++ b/src/DIRAC/AccountingSystem/DB/AccountingDB.py
@@ -510,10 +510,10 @@ class AccountingDB(DB):
             return retVal
         connection = retVal["Value"]
         self.log.info(f"Value {keyValue} for key {keyName} didn't exist, inserting")
-        retVal = self.insertFields(keyTable, ["id", "value"], [0, keyValue], connection)
+        retVal = self.insertFields(keyTable, ["id", "value"], [0, keyValue], conn=connection)
         if not retVal["OK"] and retVal["Message"].find("Duplicate key") == -1:
             return retVal
-        result = self.__getIdForKeyValue(typeName, keyName, keyValue, connection)
+        result = self.__getIdForKeyValue(typeName, keyName, keyValue, conn=connection)
         if not result["OK"]:
             return result
         keyCache[keyValue] = result["Value"]

--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -708,7 +708,7 @@ class MySQL:
         return S_OK()
 
     @captureOptimizerTraces
-    def _query(self, cmd, conn=None, debug=True):
+    def _query(self, cmd, *, conn=None, debug=True):
         """
         execute MySQL query command
 
@@ -756,7 +756,7 @@ class MySQL:
         return retDict
 
     @captureOptimizerTraces
-    def _update(self, cmd, conn=None, debug=True):
+    def _update(self, cmd, *, conn=None, debug=True):
         """execute MySQL update command
 
         :param debug: print or not the errors
@@ -1096,7 +1096,7 @@ class MySQL:
             return S_ERROR(DErrno.EMYSQL, x)
 
         cmd = f"SELECT COUNT(*) FROM {table} {cond}"
-        res = self._query(cmd, connection)
+        res = self._query(cmd, cconn=onnection)
         if not res["OK"]:
             return res
 
@@ -1139,7 +1139,7 @@ class MySQL:
             return S_ERROR(DErrno.EMYSQL, x)
 
         cmd = f"SELECT {attrNames}, COUNT(*) FROM {table} {cond} GROUP BY {attrNames} ORDER BY {attrNames}"
-        res = self._query(cmd, connection)
+        res = self._query(cmd, conn=connection)
         if not res["OK"]:
             return res
 
@@ -1188,7 +1188,7 @@ class MySQL:
             return S_ERROR(DErrno.EMYSQL, exc)
 
         cmd = f"SELECT DISTINCT( {attributeName} ) FROM {table} {cond} ORDER BY {attributeName}"
-        res = self._query(cmd, connection)
+        res = self._query(cmd, conn=connection)
         if not res["OK"]:
             return res
         attr_list = [x[0] for x in res["Value"]]
@@ -1421,7 +1421,7 @@ class MySQL:
         except Exception as x:
             return S_ERROR(DErrno.EMYSQL, x)
 
-        return self._query(f"SELECT {quotedOutFields} FROM {table} {condition}", conn)
+        return self._query(f"SELECT {quotedOutFields} FROM {table} {condition}", conn=conn)
 
     #############################################################################
     def deleteEntries(
@@ -1465,7 +1465,7 @@ class MySQL:
         except Exception as x:
             return S_ERROR(DErrno.EMYSQL, x)
 
-        return self._update(f"DELETE FROM {table} {condition}", conn)
+        return self._update(f"DELETE FROM {table} {condition}", conn=conn)
 
     #############################################################################
     def updateFields(
@@ -1551,7 +1551,7 @@ class MySQL:
             [f"{_quotedList([updateFields[k]])} = {updateValues[k]}" for k in range(len(updateFields))]
         )
 
-        return self._update(f"UPDATE {table} SET {updateString} {condition}", conn)
+        return self._update(f"UPDATE {table} SET {updateString} {condition}", conn=conn)
 
     #############################################################################
     def insertFields(self, tableName, inFields=None, inValues=None, conn=None, inDict=None):
@@ -1609,7 +1609,7 @@ class MySQL:
         return self._update(f"INSERT INTO {table} {inFieldString} VALUES {inValueString}", conn=conn)
 
     @captureOptimizerTraces
-    def executeStoredProcedure(self, packageName, parameters, outputIds, conn=None):
+    def executeStoredProcedure(self, packageName, parameters, outputIds, *, conn=None):
         if conn:
             connection = conn
         else:
@@ -1639,7 +1639,7 @@ class MySQL:
 
     # For the procedures that execute a select without storing the result
     @captureOptimizerTraces
-    def executeStoredProcedureWithCursor(self, packageName, parameters, conn=None):
+    def executeStoredProcedureWithCursor(self, packageName, parameters, *, conn=None):
         if conn:
             connection = conn
         else:

--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -1096,7 +1096,7 @@ class MySQL:
             return S_ERROR(DErrno.EMYSQL, x)
 
         cmd = f"SELECT COUNT(*) FROM {table} {cond}"
-        res = self._query(cmd, cconn=onnection)
+        res = self._query(cmd, conn=connection)
         if not res["OK"]:
             return res
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
@@ -168,13 +168,13 @@ class DatasetManager:
 
         resultDict = {"Successful": {}, "Failed": {}}
         if fullNames:
-            result = self.__findFullPathDatasets(fullNames, connection)
+            result = self.__findFullPathDatasets(fullNames, connection=connection)
             if not result["OK"]:
                 return result
             resultDict = result["Value"]
 
         if shortNames:
-            result = self.__findNoPathDatasets(shortNames, connection)
+            result = self.__findNoPathDatasets(shortNames, connection=connection)
             if not result["OK"]:
                 return result
             resultDict["Successful"].update(result["Value"]["Successful"])
@@ -209,7 +209,7 @@ class DatasetManager:
             wheres.append("( DirID=%d AND DatasetName IN (%s) )" % (dirID, stringListToString(dsNames)))
 
         req = "SELECT DatasetName,DirID,DatasetID FROM FC_MetaDatasets WHERE %s" % " OR ".join(wheres)
-        result = self.db._query(req, connection)
+        result = self.db._query(req, conn=connection)
         if not result["OK"]:
             return result
         for dsName, dirID, dsID in result["Value"]:
@@ -230,7 +230,7 @@ class DatasetManager:
         dsIDs = {}
         req = "SELECT COUNT(DatasetName),DatasetName,DatasetID FROM FC_MetaDatasets WHERE DatasetName in "
         req += "( %s ) GROUP BY DatasetName,DatasetID" % stringListToString(nodirDatasets)
-        result = self.db._query(req, connection)
+        result = self.db._query(req, conn=connection)
         if not result["OK"]:
             return result
         for dsCount, dsName, dsID in result["Value"]:
@@ -243,7 +243,7 @@ class DatasetManager:
             req = "SELECT DatasetName,DatasetID,DirID FROM FC_MetaDatasets WHERE DatasetID in (%s)" % ",".join(
                 dsIDs.values()
             )
-            result = self.db._query(req, connection)
+            result = self.db._query(req, conn=connection)
             if not result["OK"]:
                 return result
             for dsName, dsID, dirID in result["Value"]:
@@ -259,7 +259,7 @@ class DatasetManager:
         """Add annotation to the given dataset"""
         connection = self._getConnection()
         successful = {}
-        result = self._findDatasets(list(datasets), connection)
+        result = self._findDatasets(list(datasets), connection=connection)
         if not result["OK"]:
             return result
         failed = result["Value"]["Failed"]
@@ -270,7 +270,7 @@ class DatasetManager:
                     annotation,
                     datasetDict[dataset]["DatasetID"],
                 )
-                result = self.db._update(req, connection)
+                result = self.db._update(req, conn=connection)
                 if not result["OK"]:
                     failed[dataset] = "Failed to add annotation"
                 else:

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryClosure.py
@@ -197,7 +197,7 @@ class DirectoryClosure(DirectoryTreeBase):
     def getChildren(self, path, connection=False):
         """Get child directory IDs for the given directory"""
         if isinstance(path, str):
-            result = self.findDir(path, connection)
+            result = self.findDir(path, connection=connection)
             if not result["OK"]:
                 return result
             if not result["Value"]:

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
@@ -776,7 +776,7 @@ class DirectoryTreeBase:
             dirID = result["Value"]
             req = "SELECT SESize, SEFiles FROM FC_DirectoryUsage WHERE SEID=0 AND DirID=%d" % dirID
 
-            result = self.db._query(req, connection)
+            result = self.db._query(req, conn=connection)
             if not result["OK"]:
                 failed[path] = result["Message"]
             elif not result["Value"]:
@@ -835,7 +835,7 @@ class DirectoryTreeBase:
                     )
                     reqDir = dirString.replace("SELECT DirID FROM", "SELECT count(*) FROM")
 
-            result = self.db._query(req, connection)
+            result = self.db._query(req, conn=connection)
             if not result["OK"]:
                 failed[path] = result["Message"]
             elif not result["Value"]:
@@ -845,7 +845,7 @@ class DirectoryTreeBase:
                     "LogicalSize": int(result["Value"][0][0]),
                     "LogicalFiles": int(result["Value"][0][1]),
                 }
-                result = self.db._query(reqDir, connection)
+                result = self.db._query(reqDir, conn=connection)
                 if result["OK"] and result["Value"]:
                     successful[path]["LogicalDirectories"] = result["Value"][0][0] - 1
                 else:
@@ -879,7 +879,7 @@ class DirectoryTreeBase:
 
             req = "SELECT S.SEID, S.SEName, D.SESize, D.SEFiles FROM FC_DirectoryUsage as D, FC_StorageElements as S"
             req += "  WHERE S.SEID=D.SEID AND D.DirID=%d" % dirID
-            result = self.db._query(req, connection)
+            result = self.db._query(req, conn=connection)
             if not result["OK"]:
                 failed[path] = result["Message"]
             elif not result["Value"]:
@@ -932,7 +932,7 @@ class DirectoryTreeBase:
                 req += " JOIN (%s) AS F" % subDirString
                 req += " WHERE S.SEID=D.SEID AND D.DirID=F.DirID"
 
-            result = self.db._query(req, connection)
+            result = self.db._query(req, conn=connection)
             if not result["OK"]:
                 failed[path] = result["Message"]
             elif not result["Value"]:
@@ -993,7 +993,7 @@ class DirectoryTreeBase:
                     req += "WHERE R.SEID=S.SEID AND F.FileID=R.FileID AND F.DirID=T.DirID "
                     req += "GROUP BY S.SEID"
 
-            result = self.db._query(req, connection)
+            result = self.db._query(req, conn=connection)
             if not result["OK"]:
                 failed[path] = result["Message"]
             elif not result["Value"]:
@@ -1161,7 +1161,7 @@ class DirectoryTreeBase:
         conn = self._getConnection(connection)
         resultDict = {}
         req = "SELECT COUNT(*) from FC_DirectoryInfo"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         resultDict["Directories"] = res["Value"][0][0]
@@ -1170,26 +1170,26 @@ class DirectoryTreeBase:
 
         req = f"SELECT COUNT(DirID) FROM {treeTable} WHERE Parent NOT IN ( SELECT DirID from {treeTable} )"
         req += " AND DirID <> 1"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         resultDict["Orphan Directories"] = res["Value"][0][0]
 
         req = f"SELECT COUNT(DirID) FROM {treeTable} WHERE DirID NOT IN ( SELECT Parent from {treeTable} )"
         req += " AND DirID NOT IN ( SELECT DirID from FC_Files ) "
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         resultDict["Empty Directories"] = res["Value"][0][0]
 
         req = "SELECT COUNT(DirID) FROM %s WHERE DirID NOT IN ( SELECT DirID FROM FC_DirectoryInfo )" % treeTable
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         resultDict["DirTree w/o DirInfo"] = res["Value"][0][0]
 
         req = "SELECT COUNT(DirID) FROM FC_DirectoryInfo WHERE DirID NOT IN ( SELECT DirID FROM %s )" % treeTable
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         resultDict["DirInfo w/o DirTree"] = res["Value"][0][0]

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -36,39 +36,39 @@ class FileManagerBase:
 
         resultDict = {}
         req = "SELECT COUNT(*) FROM FC_Files;"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         resultDict["Files"] = res["Value"][0][0]
 
         req = "SELECT COUNT(FileID) FROM FC_Files WHERE FileID NOT IN ( SELECT FileID FROM FC_Replicas )"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         resultDict["Files w/o Replicas"] = res["Value"][0][0]
 
         req = "SELECT COUNT(RepID) FROM FC_Replicas WHERE FileID NOT IN ( SELECT FileID FROM FC_Files )"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         resultDict["Replicas w/o Files"] = res["Value"][0][0]
 
         treeTable = self.db.dtree.getTreeTable()
         req = "SELECT COUNT(FileID) FROM FC_Files WHERE DirID NOT IN ( SELECT DirID FROM %s)" % treeTable
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         resultDict["Orphan Files"] = res["Value"][0][0]
 
         req = "SELECT COUNT(FileID) FROM FC_Files WHERE FileID NOT IN ( SELECT FileID FROM FC_FileInfo)"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             resultDict["Files w/o FileInfo"] = 0
         else:
             resultDict["Files w/o FileInfo"] = res["Value"][0][0]
 
         req = "SELECT COUNT(FileID) FROM FC_FileInfo WHERE FileID NOT IN ( SELECT FileID FROM FC_Files)"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             resultDict["FileInfo w/o Files"] = 0
         else:
@@ -81,7 +81,7 @@ class FileManagerBase:
 
         connection = self._getConnection(connection)
         req = "SELECT COUNT(*) FROM FC_Replicas;"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         return S_OK({"Replicas": res["Value"][0][0]})
@@ -446,7 +446,7 @@ class FileManagerBase:
         req = "INSERT INTO FC_FileAncestors (FileID, AncestorID, AncestorDepth) VALUES %s" % intListToString(
             ancestorTuples
         )
-        return self.db._update(req, connection)
+        return self.db._update(req, conn=connection)
 
     def _getFileAncestors(self, fileIDs, depths=[], connection=False):
         connection = self._getConnection(connection)
@@ -455,7 +455,7 @@ class FileManagerBase:
         )
         if depths:
             req = f"{req} AND AncestorDepth IN ({intListToString(depths)});"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         fileIDAncestors = {}
@@ -473,7 +473,7 @@ class FileManagerBase:
         )
         if depths:
             req = f"{req} AND AncestorDepth IN ({intListToString(depths)});"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         fileIDAncestors = {}
@@ -501,7 +501,7 @@ class FileManagerBase:
         for lfn in result["Value"]["Successful"]:
             lfns[lfn]["FileID"] = result["Value"]["Successful"][lfn]["FileID"]
 
-        result = self._populateFileAncestors(lfns, connection)
+        result = self._populateFileAncestors(lfns, connection=connection)
         if not result["OK"]:
             return result
         failed.update(result["Value"]["Failed"])
@@ -528,9 +528,9 @@ class FileManagerBase:
 
         inputIDs = list(inputIDDict)
         if relation == "ancestor":
-            result = self._getFileAncestors(inputIDs, depths, connection)
+            result = self._getFileAncestors(inputIDs, depths, connection=connection)
         else:
-            result = self._getFileDescendents(inputIDs, depths, connection)
+            result = self._getFileDescendents(inputIDs, depths, connection=connection)
 
         if not result["OK"]:
             return result
@@ -557,10 +557,10 @@ class FileManagerBase:
         return S_OK({"Successful": successful, "Failed": failed})
 
     def getFileAncestors(self, lfns, depths, connection=False):
-        return self._getFileRelatives(lfns, depths, "ancestor", connection)
+        return self._getFileRelatives(lfns, depths, "ancestor", connection=connection)
 
     def getFileDescendents(self, lfns, depths, connection=False):
-        return self._getFileRelatives(lfns, depths, "descendent", connection)
+        return self._getFileRelatives(lfns, depths, "descendent", connection=connection)
 
     def _getExistingMetadata(self, lfns, connection=False):
         connection = self._getConnection(connection)
@@ -868,7 +868,7 @@ class FileManagerBase:
             if guidList:
                 # A dict { guid: lfn to which it is supposed to be associated }
                 guidToGivenLfn = dict(zip(guidList, lfns))
-                res = self.getLFNForGUID(guidList, connection)
+                res = self.getLFNForGUID(guidList, connection=connection)
                 if not res["OK"]:
                     return res
                 guidLfns = res["Value"]["Successful"]
@@ -999,7 +999,7 @@ class FileManagerBase:
         for lfn, fileID in res["Value"]["Successful"].items():
             fileIDLFNs[fileID] = lfn
 
-        result = self.__getReplicasForIDs(fileIDLFNs, allStatus, connection)
+        result = self.__getReplicasForIDs(fileIDLFNs, allStatus, connection=connection)
         if not result["OK"]:
             return result
         replicas = result["Value"]
@@ -1017,7 +1017,7 @@ class FileManagerBase:
             return result
         idLfnDict = result["Value"]
 
-        result = self.__getReplicasForIDs(idLfnDict, allStatus, connection)
+        result = self.__getReplicasForIDs(idLfnDict, allStatus, connection=connection)
         if not result["OK"]:
             return result
         replicas = result["Value"]
@@ -1059,13 +1059,13 @@ class FileManagerBase:
     def _getStatusInt(self, status, connection=False):
         connection = self._getConnection(connection)
         req = "SELECT StatusID FROM FC_Statuses WHERE Status = '%s';" % status
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         if res["Value"]:
             return S_OK(res["Value"][0][0])
         req = "INSERT INTO FC_Statuses (Status) VALUES ('%s');" % status
-        res = self.db._update(req, connection)
+        res = self.db._update(req, conn=connection)
         if not res["OK"]:
             return res
         return S_OK(res["lastRowId"])
@@ -1075,7 +1075,7 @@ class FileManagerBase:
             return S_OK(self.statusDict[statusID])
         connection = self._getConnection(connection)
         req = "SELECT StatusID,Status FROM FC_Statuses"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         if res["Value"]:
@@ -1155,7 +1155,7 @@ class FileManagerBase:
                             If False, take the visibleFileStatus and visibleReplicaStatus values from the configuration
         """
         connection = self._getConnection(connection)
-        result = self._getDirectoryReplicas(dirID, allStatus, connection)
+        result = self._getDirectoryReplicas(dirID, allStatus, connection=connection)
         if not result["OK"]:
             return result
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
@@ -54,7 +54,7 @@ class FileManagerFlat(FileManagerBase):
                 req = f"{req} AND Status IN ({intListToString(statusIDs)})"
         if fileNames:
             req = f"{req} AND FileName IN ({stringListToString(fileNames)})"
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         files = {}
@@ -96,7 +96,7 @@ class FileManagerFlat(FileManagerBase):
             )
         fields = "DirID,Size,UID,GID,Status,FileName,GUID,Checksum,ChecksumType,CreationDate,ModificationDate,Mode"
         req = "INSERT INTO FC_Files ({}) VALUES {}".format(fields, ",".join(insertTuples))
-        res = self.db._update(req, connection)
+        res = self.db._update(req, conn=connection)
         if not res["OK"]:
             return res
         # Get the fileIDs for the inserted files
@@ -118,7 +118,7 @@ class FileManagerFlat(FileManagerBase):
         if not isinstance(guid, (list, tuple)):
             guid = [guid]
         req = "SELECT FileID,GUID FROM FC_Files WHERE GUID IN (%s)" % stringListToString(guid)
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         guidDict = {}
@@ -146,14 +146,14 @@ class FileManagerFlat(FileManagerBase):
         if not fileIDs:
             return S_OK()
         req = "DELETE FROM FC_Replicas WHERE FileID in (%s)" % (intListToString(fileIDs))
-        return self.db._update(req, connection)
+        return self.db._update(req, conn=connection)
 
     def __deleteFiles(self, fileIDs, connection=False):
         connection = self._getConnection(connection)
         if not fileIDs:
             return S_OK()
         req = "DELETE FROM FC_Files WHERE FileID in (%s)" % (intListToString(fileIDs))
-        return self.db._update(req, connection)
+        return self.db._update(req, conn=connection)
 
     ######################################################
     #
@@ -209,7 +209,7 @@ class FileManagerFlat(FileManagerBase):
         if insertTuples:
             fields = "FileID,SEID,Status,RepType,CreationDate,ModificationDate,PFN"
             req = "INSERT INTO FC_Replicas ({}) VALUES {}".format(fields, ",".join(insertTuples.values()))
-            res = self.db._update(req, connection)
+            res = self.db._update(req, conn=connection)
             if not res["OK"]:
                 self.__deleteReplicas(deleteTuples, connection=connection)
                 for lfn in insertTuples.keys():
@@ -231,7 +231,7 @@ class FileManagerFlat(FileManagerBase):
                 return res
             seID = res["Value"]
         req = "SELECT FileID FROM FC_Replicas WHERE FileID=%d AND SEID=%d" % (fileID, seID)
-        result = self.db._query(req, connection)
+        result = self.db._query(req, conn=connection)
         if not result["OK"]:
             return result
         if not result["Value"]:
@@ -289,7 +289,7 @@ class FileManagerFlat(FileManagerBase):
                 seID = res["Value"]
             deleteTuples.append("(%d,%d)" % (fileID, seID))
         req = "DELETE FROM FC_Replicas WHERE (FileID,SEID) IN (%s)" % intListToString(deleteTuples)
-        return self.db._update(req, connection)
+        return self.db._update(req, conn=connection)
 
     ######################################################
     #
@@ -326,7 +326,7 @@ class FileManagerFlat(FileManagerBase):
             fileID,
             seID,
         )
-        return self.db._update(req, connection)
+        return self.db._update(req, conn=connection)
 
     def _setFileParameter(self, fileID, paramName, paramValue, connection=False):
         connection = self._getConnection(connection)
@@ -337,7 +337,7 @@ class FileManagerFlat(FileManagerBase):
             paramValue,
             intListToString(fileID),
         )
-        return self.db._update(req, connection)
+        return self.db._update(req, conn=connection)
 
     ######################################################
     #
@@ -352,7 +352,7 @@ class FileManagerFlat(FileManagerBase):
             intListToString(fields),
             intListToString(fileIDs),
         )
-        res = self.db._query(req, connection)
+        res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
         replicas = {}

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
@@ -761,7 +761,7 @@ class FileManagerPs(FileManagerBase):
                 paramValue,
                 intListToString(fileID),
             )
-            return self.db._update(req, connection)
+            return self.db._update(req, conn=connection)
 
         return S_OK()
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
@@ -58,7 +58,7 @@ class SEManagerDB(SEManagerBase):
             self.lock.release()
             return S_OK(seid)
         connection = self.db._getConnection()
-        res = self.db.insertFields("FC_StorageElements", ["SEName"], [seName], connection)
+        res = self.db.insertFields("FC_StorageElements", ["SEName"], [seName], conn=connection)
         if not res["OK"]:
             gLogger.debug(f"SEManager AddSE lock released. Used {time.time() - waitTime:.3f} seconds. {seName}")
             self.lock.release()
@@ -85,7 +85,7 @@ class SEManagerDB(SEManagerBase):
         gLogger.debug(f"SEManager RemoveSE lock created. Waited {waitTime - startTime:.3f} seconds. {seName}")
         seid = self.db.seNames.get(seName, "Missing")
         req = "DELETE FROM FC_StorageElements WHERE SEName='%s'" % seName
-        res = self.db._update(req, connection)
+        res = self.db._update(req, conn=connection)
         if not res["OK"]:
             gLogger.debug(f"SEManager RemoveSE lock released. Used {time.time() - waitTime:.3f} seconds. {seName}")
             self.lock.release()

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SEManager/SEManagerDB.py
@@ -47,6 +47,15 @@ class SEManagerDB(SEManagerBase):
         self.lock.release()
         return S_OK()
 
+    def _getConnection(self, connection):
+        if connection:
+            return connection
+        res = self.db._getConnection()
+        if res["OK"]:
+            return res["Value"]
+        gLogger.warn("Failed to get MySQL connection", res["Message"])
+        return connection
+
     def __addSE(self, seName, connection=False):
         startTime = time.time()
         self.lock.acquire()
@@ -57,7 +66,7 @@ class SEManagerDB(SEManagerBase):
             gLogger.debug(f"SEManager AddSE lock released. Used {time.time() - waitTime:.3f} seconds. {seName}")
             self.lock.release()
             return S_OK(seid)
-        connection = self.db._getConnection()
+        connection = self._getConnection(connection)
         res = self.db.insertFields("FC_StorageElements", ["SEName"], [seName], conn=connection)
         if not res["OK"]:
             gLogger.debug(f"SEManager AddSE lock released. Used {time.time() - waitTime:.3f} seconds. {seName}")
@@ -78,7 +87,7 @@ class SEManagerDB(SEManagerBase):
         return S_OK(seid)
 
     def __removeSE(self, seName, connection=False):
-        connection = self.db._getConnection()
+        connection = self._getConnection(connection)
         startTime = time.time()
         self.lock.acquire()
         waitTime = time.time()

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogDB.py
@@ -445,7 +445,7 @@ class FileCatalogDB(DB):
         if not res["Value"]["Successful"]:
             return S_OK({"Successful": {}, "Failed": failed})
 
-        res = self.fileManager.setFileStatus(res["Value"]["Successful"], credDict)
+        res = self.fileManager.setFileStatus(res["Value"]["Successful"])
         if not res["OK"]:
             return res
         failed.update(res["Value"]["Failed"])

--- a/src/DIRAC/ProductionSystem/DB/ProductionDB.py
+++ b/src/DIRAC/ProductionSystem/DB/ProductionDB.py
@@ -100,7 +100,7 @@ class ProductionDB(DB):
             % (prodName, prodDescription, authorDN, authorGroup)
         )
 
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             self.lock.release()
             return res
@@ -138,7 +138,7 @@ class ProductionDB(DB):
             intListToString(self.PRODPARAMS),
             self.buildCondition(condDict, older, newer, timeStamp, orderAttribute, limit, offset=offset),
         )
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
 
@@ -208,7 +208,7 @@ class ProductionDB(DB):
         """
         connection = self.__getConnection(connection)
         req = f"SELECT {intListToString(self.PRODSTEPSPARAMS)} FROM ProductionSteps WHERE StepID = {str(stepID)}"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
         if not res["Value"]:
@@ -267,7 +267,7 @@ class ProductionDB(DB):
             )
         )
 
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             self.lock.release()
             return res
@@ -310,7 +310,7 @@ class ProductionDB(DB):
             intListToString(self.TRANSPARAMS),
             self.buildCondition(condDict, older, newer, timeStamp, orderAttribute, limit, offset=offset),
         )
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
 
@@ -334,7 +334,7 @@ class ProductionDB(DB):
         :param str status: the Production status
         """
         req = "UPDATE Productions SET Status='%s', LastUpdate=UTC_TIMESTAMP() WHERE ProductionID=%d" % (status, prodID)
-        return self._update(req, connection)
+        return self._update(req, conn=connection)
 
     # This is to be replaced by startProduction, stopProduction etc.
     def setProductionStatus(self, prodName, status, connection=False):
@@ -422,7 +422,7 @@ class ProductionDB(DB):
         :param int prodID: ProductionID
         """
         req = "DELETE FROM Productions WHERE ProductionID=%d;" % prodID
-        return self._update(req, connection)
+        return self._update(req, conn=connection)
 
     def __deleteProductionTransformations(self, prodID, connection=False):
         """Remove all the transformations of the specified production from the TS and from the PS
@@ -438,12 +438,12 @@ class ProductionDB(DB):
 
         # Remove transformations from the PS
         req = "DELETE FROM ProductionTransformationLinks WHERE ProductionID = %d;" % prodID
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             gLogger.error("Failed to delete production transformation links from the PS", res["Message"])
 
         req = "DELETE FROM ProductionTransformations WHERE ProductionID = %d;" % prodID
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             gLogger.error("Failed to delete production transformations from the PS", res["Message"])
 
@@ -585,7 +585,7 @@ class ProductionDB(DB):
 
         gLogger.notice(req)
         req = req.rstrip(",")
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             return res
 
@@ -603,7 +603,7 @@ class ProductionDB(DB):
             req = "%s (%d,%d,UTC_TIMESTAMP(),UTC_TIMESTAMP())," % (req, prodID, transID)
             gLogger.notice(req)
         req = req.rstrip(",")
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             return res
 
@@ -621,7 +621,7 @@ class ProductionDB(DB):
             if not isinstance(prodName, str):
                 return S_ERROR("Production should be ID or name")
             cmd = "SELECT ProductionID from Productions WHERE ProductionName='%s';" % prodName
-        res = self._query(cmd, connection)
+        res = self._query(cmd, conn=connection)
         if not res["OK"]:
             gLogger.error("Failed to obtain production ID for production", "{}: {}".format(prodName, res["Message"]))
             return res

--- a/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
@@ -112,7 +112,7 @@ class StorageManagementDB(DB):
             intListToString(toUpdate),
             newTaskStatus,
         )
-        resSelect = self._query(reqSelect, connection)
+        resSelect = self._query(reqSelect, conn=connection)
         if not resSelect["OK"]:
             gLogger.error(
                 "{}.{}_DB: problem retrieving record:".format(self._caller(), "__updateTaskStatus"),
@@ -124,7 +124,7 @@ class StorageManagementDB(DB):
             intListToString(toUpdate),
             newTaskStatus,
         )
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             return res
 
@@ -135,7 +135,7 @@ class StorageManagementDB(DB):
 
         if len(taskIDs) > 0:
             reqSelect1 = "SELECT * FROM Tasks WHERE TaskID IN (%s);" % intListToString(taskIDs)
-            resSelect1 = self._query(reqSelect1, connection)
+            resSelect1 = self._query(reqSelect1, conn=connection)
             if not resSelect1["OK"]:
                 gLogger.warn(
                     "%s.%s_DB: problem retrieving records: %s. %s"
@@ -177,7 +177,7 @@ class StorageManagementDB(DB):
                 stringListToString(oldTaskState),
                 intListToString(taskIDs),
             )
-            res = self._query(req, connection)
+            res = self._query(req, conn=connection)
             if not res["OK"]:
                 return res
             toUpdate = [row[0] for row in res["Value"]]
@@ -200,7 +200,7 @@ class StorageManagementDB(DB):
             intListToString(toUpdate),
             newReplicaStatus,
         )
-        resSelect = self._query(reqSelect, connection)
+        resSelect = self._query(reqSelect, conn=connection)
         if not resSelect["OK"]:
             gLogger.error(
                 "{}.{}_DB: problem retrieving record:".format(self._caller(), "updateReplicaStatus"),
@@ -211,7 +211,7 @@ class StorageManagementDB(DB):
             "UPDATE CacheReplicas SET Status='%s',LastUpdate=UTC_TIMESTAMP() WHERE ReplicaID IN (%s) AND Status != '%s';"
             % (newReplicaStatus, intListToString(toUpdate), newReplicaStatus)
         )
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             return res
 
@@ -223,7 +223,7 @@ class StorageManagementDB(DB):
             )
         if len(replicaIDs) > 0:
             reqSelect1 = "SELECT * FROM CacheReplicas WHERE ReplicaID IN (%s);" % intListToString(replicaIDs)
-            resSelect1 = self._query(reqSelect1, connection)
+            resSelect1 = self._query(reqSelect1, conn=connection)
             if not resSelect1["OK"]:
                 gLogger.warn(
                     "%s.%s_DB: problem retrieving records: %s. %s"
@@ -249,7 +249,7 @@ class StorageManagementDB(DB):
             "SELECT T.TaskID,T.Status FROM Tasks AS T, TaskReplicas AS R WHERE R.ReplicaID IN "
             "( %s ) AND R.TaskID = T.TaskID GROUP BY T.TaskID, T.Status;"
         ) % intListToString(replicaIDs)
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
 
@@ -258,7 +258,7 @@ class StorageManagementDB(DB):
                 "SELECT DISTINCT(C.Status) FROM TaskReplicas AS R, CacheReplicas AS C WHERE R.TaskID=%s AND R.ReplicaID = C.ReplicaID;"
                 % taskId
             )
-            subres = self._query(subreq, connection)
+            subres = self._query(subreq, conn=connection)
             if not subres["OK"]:
                 return subres
 
@@ -326,7 +326,7 @@ class StorageManagementDB(DB):
                 stringListToString(oldReplicaState),
                 intListToString(replicaIDs),
             )
-            res = self._query(req, connection)
+            res = self._query(req, conn=connection)
             if not res["OK"]:
                 return res
             toUpdate = [row[0] for row in res["Value"]]
@@ -351,7 +351,7 @@ class StorageManagementDB(DB):
             intListToString(toUpdate),
             newStageStatus,
         )
-        resSelect = self._query(reqSelect, connection)
+        resSelect = self._query(reqSelect, conn=connection)
         if not resSelect["OK"]:
             gLogger.warn(
                 "%s.%s_DB: problem retrieving record: %s. %s"
@@ -362,7 +362,7 @@ class StorageManagementDB(DB):
             "UPDATE CacheReplicas SET Status='%s',LastUpdate=UTC_TIMESTAMP() WHERE ReplicaID IN (%s) AND Status != '%s';"
             % (newStageStatus, intListToString(toUpdate), newStageStatus)
         )
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             return res
 
@@ -374,7 +374,7 @@ class StorageManagementDB(DB):
             )
 
         reqSelect1 = "SELECT * FROM CacheReplicas WHERE ReplicaID IN (%s);" % intListToString(replicaIDs)
-        resSelect1 = self._query(reqSelect1, connection)
+        resSelect1 = self._query(reqSelect1, conn=connection)
         if not resSelect1["OK"]:
             gLogger.warn(
                 "%s.%s_DB: problem retrieving records: %s. %s"
@@ -411,7 +411,7 @@ class StorageManagementDB(DB):
                 oldStageState,
                 intListToString(replicaIDs),
             )
-            res = self._query(req, connection)
+            res = self._query(req, conn=connection)
             if not res["OK"]:
                 return res
             toUpdate = [row[0] for row in res["Value"]]
@@ -446,7 +446,7 @@ class StorageManagementDB(DB):
             "SELECT TaskID,Status,Source,SubmitTime,CompleteTime,CallBackMethod,SourceTaskID from Tasks WHERE TaskID IN (%s);"
             % intListToString(taskID)
         )
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.getTaskInfo: Failed to get task information.", res["Message"])
             return res
@@ -497,7 +497,7 @@ class StorageManagementDB(DB):
             "SELECT R.LFN,R.SE,R.PFN,R.Size,R.Status,R.LastUpdate,R.Reason FROM CacheReplicas AS R, TaskReplicas AS TR WHERE TR.TaskID in (%s) AND TR.ReplicaID=R.ReplicaID;"
             % intListToString(taskID)
         )
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.getTaskSummary: Failed to get Replica summary for task.", res["Message"])
             return res
@@ -537,7 +537,7 @@ class StorageManagementDB(DB):
                     return res
                 condDict["TaskID"] = res["Value"]
             req = f"{req} {self.buildCondition(condDict, older, newer, timeStamp, orderAttribute, limit)}"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
         # Cast to list to be able to serialize
@@ -578,7 +578,7 @@ class StorageManagementDB(DB):
             # BUG: limit is ignored unless there is a nonempty condition dictionary OR
             # older OR newer is nonemtpy
             req = f"{req} {self.buildCondition(condDict, older, newer, timeStamp, orderAttribute, limit)}"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
         # Cast to list to be able to serialize
@@ -617,7 +617,7 @@ class StorageManagementDB(DB):
                 else:
                     condDict["ReplicaID"] = [-1]
             req = f"{req} {self.buildCondition(condDict, older, newer, timeStamp, orderAttribute, limit)}"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
         # Cast to list to be able to serialize
@@ -634,7 +634,7 @@ class StorageManagementDB(DB):
         if not taskIDs:
             return S_OK([])
         req = "SELECT DISTINCT(ReplicaID) FROM TaskReplicas WHERE TaskID IN (%s);" % intListToString(taskIDs)
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
         replicaIDs = [row[0] for row in res["Value"]]
@@ -644,7 +644,7 @@ class StorageManagementDB(DB):
         if not replicaIDs:
             return S_OK([])
         req = "SELECT DISTINCT(TaskID) FROM TaskReplicas WHERE ReplicaID IN (%s);" % intListToString(replicaIDs)
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
         taskIDs = [row[0] for row in res["Value"]]
@@ -731,14 +731,14 @@ class StorageManagementDB(DB):
             "INSERT INTO Tasks (Source,SubmitTime,CallBackMethod,SourceTaskID) VALUES ('%s',UTC_TIMESTAMP(),'%s','%s');"
             % (source, callbackMethod, sourceTaskID)
         )
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB._createTask: Failed to create task.", res["Message"])
             return res
         # gLogger.info( "%s_DB:%s" % ('_createTask',req))
         taskID = res["lastRowId"]
         reqSelect = "SELECT * FROM Tasks WHERE TaskID = %s;" % (taskID)
-        resSelect = self._query(reqSelect, connection)
+        resSelect = self._query(reqSelect, conn=connection)
         if not resSelect["OK"]:
             gLogger.info(
                 "%s.%s_DB: problem retrieving record: %s. %s"
@@ -759,7 +759,7 @@ class StorageManagementDB(DB):
             storageElement,
             stringListToString(lfns),
         )
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB._getExistingReplicas: Failed to get existing replicas.", res["Message"])
             return res
@@ -775,7 +775,7 @@ class StorageManagementDB(DB):
             "INSERT INTO CacheReplicas (Type,SE,LFN,PFN,Size,FileChecksum,GUID,SubmitTime,LastUpdate) VALUES ('%s','%s','%s','',0,'','',UTC_TIMESTAMP(),UTC_TIMESTAMP());"
             % (rType, storageElement, lfn)
         )
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             gLogger.error("_insertReplicaInformation: Failed to insert to CacheReplicas table.", res["Message"])
             return res
@@ -783,7 +783,7 @@ class StorageManagementDB(DB):
 
         replicaID = res["lastRowId"]
         reqSelect = "SELECT * FROM CacheReplicas WHERE ReplicaID = %s;" % (replicaID)
-        resSelect = self._query(reqSelect, connection)
+        resSelect = self._query(reqSelect, conn=connection)
         if not resSelect["OK"]:
             gLogger.warn(
                 "%s.%s_DB: problem retrieving record: %s. %s"
@@ -805,7 +805,7 @@ class StorageManagementDB(DB):
             replicaString = f"({taskID},{replicaID}),"
             req = f"{req} {replicaString}"
         req = req.rstrip(",")
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             gLogger.error(
                 "StorageManagementDB._insertTaskReplicaInformation: Failed to insert to TaskReplicas table.",
@@ -829,7 +829,7 @@ class StorageManagementDB(DB):
     def getStagedReplicas(self, connection=False):
         connection = self.__getConnection(connection)
         req = "SELECT TR.TaskID, R.Status, COUNT(*) from TaskReplicas as TR, CacheReplicas as R where TR.ReplicaID=R.ReplicaID GROUP BY TR.TaskID,R.Status;"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.getStagedReplicas: Failed to get eligible TaskReplicas", res["Message"])
             return res
@@ -844,7 +844,7 @@ class StorageManagementDB(DB):
     def getWaitingReplicas(self, connection=False):
         connection = self.__getConnection(connection)
         req = "SELECT TR.TaskID, R.Status, COUNT(*) from TaskReplicas as TR, CacheReplicas as R where TR.ReplicaID=R.ReplicaID GROUP BY TR.TaskID,R.Status;"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.getWaitingReplicas: Failed to get eligible TaskReplicas", res["Message"])
             return res
@@ -864,7 +864,7 @@ class StorageManagementDB(DB):
     def getOfflineReplicas(self, connection=False):
         connection = self.__getConnection(connection)
         req = "SELECT TR.TaskID, R.Status, COUNT(*) from TaskReplicas as TR, CacheReplicas as R where TR.ReplicaID=R.ReplicaID GROUP BY TR.TaskID,R.Status;"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.getOfflineReplicas: Failed to get eligible TaskReplicas", res["Message"])
             return res
@@ -1147,7 +1147,7 @@ class StorageManagementDB(DB):
                     "UPDATE CacheReplicas SET Status='New',LastUpdate = UTC_TIMESTAMP(), Reason = 'wakeupOldRequests' WHERE ReplicaID in (%s);"
                     % intListToString(old_replicaIDs)
                 )
-                res = self._update(req, connection)
+                res = self._update(req, conn=connection)
                 if not res["OK"]:
                     gLogger.error(
                         "StorageManagementDB.wakeupOldRequests: Failed to roll CacheReplicas back to Status=New.",
@@ -1156,7 +1156,7 @@ class StorageManagementDB(DB):
                     return res
 
                 req = "DELETE FROM StageRequests WHERE ReplicaID in (%s);" % intListToString(old_replicaIDs)
-                res = self._update(req, connection)
+                res = self._update(req, conn=connection)
                 if not res["OK"]:
                     gLogger.error("StorageManagementDB.wakeupOldRequests. Problem removing entries from StageRequests.")
                     return res
@@ -1260,7 +1260,7 @@ class StorageManagementDB(DB):
 
             if replicaIDs:
                 req = "DELETE FROM StageRequests WHERE ReplicaID IN (%s);" % intListToString(replicaIDs)
-                res = self._update(req, connection)
+                res = self._update(req, conn=connection)
                 if not res["OK"]:
                     gLogger.error(
                         "%s.%s_DB: problem removing records: %s. %s"
@@ -1268,7 +1268,7 @@ class StorageManagementDB(DB):
                     )
 
                 req = "DELETE FROM CacheReplicas WHERE ReplicaID in (%s) AND Links=1;" % intListToString(replicaIDs)
-                res = self._update(req, connection)
+                res = self._update(req, conn=connection)
                 if not res["OK"]:
                     gLogger.error(
                         "%s.%s_DB: problem removing records: %s. %s"
@@ -1276,13 +1276,13 @@ class StorageManagementDB(DB):
                     )
 
             # Finally, remove the Task and TaskReplicas entries.
-            res = self.removeTasks(taskIDs, connection)
+            res = self.removeTasks(taskIDs, connection=connection)
         return res
 
     def removeStageRequests(self, replicaIDs, connection=False):
         connection = self.__getConnection(connection)
         req = "DELETE FROM StageRequests WHERE ReplicaID in (%s);" % intListToString(replicaIDs)
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.removeStageRequests. Problem removing entries from StageRequests.")
             return res
@@ -1292,7 +1292,7 @@ class StorageManagementDB(DB):
         """This will delete the entries from the TaskReplicas for the provided taskIDs."""
         connection = self.__getConnection(connection)
         req = "DELETE FROM TaskReplicas WHERE TaskID IN (%s);" % intListToString(taskIDs)
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.removeTasks. Problem removing entries from TaskReplicas.")
             return res
@@ -1309,7 +1309,7 @@ class StorageManagementDB(DB):
                 gLogger.verbose("{}.{}_DB: to_delete Tasks =  {}".format(self._caller(), "removeTasks", record))
 
         req = "DELETE FROM Tasks WHERE TaskID in (%s);" % intListToString(taskIDs)
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.removeTasks. Problem removing entries from Tasks.")
         gLogger.verbose("{}.{}_DB: deleted Tasks".format(self._caller(), "removeTasks"))
@@ -1324,7 +1324,7 @@ class StorageManagementDB(DB):
         req = "UPDATE Tasks SET Status='Failed' WHERE DATE_ADD(SubmitTime, INTERVAL %s DAY ) < UTC_TIMESTAMP();" % (
             daysOld
         )
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.setOldTasksAsFailed. Problem setting old Tasks to Failed.")
             return res
@@ -1336,7 +1336,7 @@ class StorageManagementDB(DB):
         """
         connection = self.__getConnection(connection)
         req = "SELECT DISTINCT(Status),SE,COUNT(*),sum(size)/(1024*1024*1024) FROM CacheReplicas GROUP BY Status,SE;"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error("StorageManagementDB.getCacheReplicasSummary failed.")
             return res
@@ -1357,7 +1357,7 @@ class StorageManagementDB(DB):
         # First, check if there is a StageRequest and PinExpiryTime has arrived
         req = "select SR.ReplicaID from CacheReplicas CR,StageRequests SR WHERE CR.Links = 0 and CR.ReplicaID=SR.ReplicaID group by SR.ReplicaID HAVING max(SR.PinExpiryTime) < UTC_TIMESTAMP();"
         # req = "SELECT ReplicaID from CacheReplicas WHERE Links = 0;"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error(
                 "StorageManagementDB.removeUnlinkedReplicas. Problem selecting entries from CacheReplicas where Links = 0."
@@ -1369,7 +1369,7 @@ class StorageManagementDB(DB):
         # as they were not staged successfully (for various reasons), even though
         # a staging request had been submitted
         req = "SELECT ReplicaID FROM CacheReplicas WHERE Links = 0 AND Status = 'Failed';"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error(
                 "StorageManagementDB.removeUnlinkedReplicas. Problem selecting entries from CacheReplicas where Links = 0 AND Status=Failed."
@@ -1395,7 +1395,7 @@ class StorageManagementDB(DB):
                     )
 
             req = "DELETE FROM StageRequests WHERE ReplicaID IN (%s);" % intListToString(replicaIDs)
-            res = self._update(req, connection)
+            res = self._update(req, conn=connection)
             if not res["OK"]:
                 gLogger.error("StorageManagementDB.removeUnlinkedReplicas. Problem deleting from StageRequests.")
                 return res
@@ -1408,7 +1408,7 @@ class StorageManagementDB(DB):
 
         # Second look for CacheReplicas for which there is no entry in StageRequests
         req = "SELECT ReplicaID FROM CacheReplicas WHERE Links = 0 AND ReplicaID NOT IN ( SELECT DISTINCT( ReplicaID ) FROM StageRequests )"
-        res = self._query(req, connection)
+        res = self._query(req, conn=connection)
         if not res["OK"]:
             gLogger.error(
                 "StorageManagementDB.removeUnlinkedReplicas. Problem selecting entries from CacheReplicas where Links = 0."
@@ -1434,7 +1434,7 @@ class StorageManagementDB(DB):
                 )
 
         req = "DELETE FROM CacheReplicas WHERE ReplicaID IN (%s) AND Links= 0;" % intListToString(replicaIDs)
-        res = self._update(req, connection)
+        res = self._update(req, conn=connection)
         if res["OK"]:
             gLogger.verbose("{}.{}_DB: deleted CacheReplicas".format(self._caller(), "removeUnlinkedReplicas"))
             gLogger.debug(


### PR DESCRIPTION
The idea was to be able to compare what the `MySQL` optimizer does in version 5.7 and 8.0 when running the Integration tests of the DFC.
This PR adds an environment variable `DIRAC_MYSQL_OPTIMIZER_TRACES_PATH` that should point to an existing directory. Every call to a method of `MySQL` (`_query`, `_update`, `executeStoredProcedure`, `executeStoredProcedureWithCursor`) will then create a json file in that directory containing the optimizer traces (https://dev.mysql.com/doc/internals/en/optimizer-tracing.html).
The logic is in ff45676376323d7b60c344f42b0aea09053a48ab

This is a very advanced optimization tool, so the decorator itself may lead in crashes, but that's by design (see code doc). If the environment variable is NOT set, the decorator is not even applied. 


<details>
  <summary>Click me to see example of the json file</summary>

```json

[
  {
    "query": "call ps_get_lfns_from_guids(\"'1000'\")",
    "trace": {
      "steps": []
    }
  },
  {
    "query": "SET @sql = CONCAT('SELECT SQL_NO_CACHE GUID, CONCAT(d.Name, \"/\", f.FileName) FROM FC_Files f JOIN FC_DirectoryList d on f.DirID = d.DirID WHERE GUID IN (', guids, ')')",
    "trace": {
      "steps": []
    }
  },
  {
    "query": "SELECT SQL_NO_CACHE GUID, CONCAT(d.Name, \"/\", f.FileName) FROM FC_Files f JOIN FC_DirectoryList d on f.DirID = d.DirID WHERE GUID IN ('1000')",
    "trace": {
      "steps": [
        {
          "join_preparation": {
            "select#": 1,
            "steps": [
              {
                "expanded_query": "/* select#1 */ select `f`.`GUID` AS `GUID`,concat(`d`.`Name`,'/',`f`.`FileName`) AS `CONCAT(d.Name, \"/\", f.FileName)` from (`FC_Files` `f` join `FC_DirectoryList` `d` on((`f`.`DirID` = `d`.`DirID`))) where (`f`.`GUID` = '1000')"
              },
              {
                "transformations_to_nested_joins": {
                  "transformations": [
                    "JOIN_condition_to_WHERE",
                    "parenthesis_removal"
                  ],
                  "expanded_query": "/* select#1 */ select `f`.`GUID` AS `GUID`,concat(`d`.`Name`,'/',`f`.`FileName`) AS `CONCAT(d.Name, \"/\", f.FileName)` from `FC_Files` `f` join `FC_DirectoryList` `d` where ((`f`.`GUID` = '1000') and (`f`.`DirID` = `d`.`DirID`))"
                }
              }
            ]
          }
        }
      ]
    }
  },
  {
    "query": "SELECT SQL_NO_CACHE GUID, CONCAT(d.Name, \"/\", f.FileName) FROM FC_Files f JOIN FC_DirectoryList d on f.DirID = d.DirID WHERE GUID IN ('1000')",
    "trace": {
      "steps": [
        {
          "join_optimization": {
            "select#": 1,
            "steps": [
              {
                "condition_processing": {
                  "condition": "WHERE",
                  "original_condition": "((`f`.`GUID` = '1000') and (`f`.`DirID` = `d`.`DirID`))",
                  "steps": [
                    {
                      "transformation": "equality_propagation",
                      "resulting_condition": "(multiple equal('1000', `f`.`GUID`) and multiple equal(`f`.`DirID`, `d`.`DirID`))"
                    },
                    {
                      "transformation": "constant_propagation",
                      "resulting_condition": "(multiple equal('1000', `f`.`GUID`) and multiple equal(`f`.`DirID`, `d`.`DirID`))"
                    },
                    {
                      "transformation": "trivial_condition_removal",
                      "resulting_condition": "(multiple equal('1000', `f`.`GUID`) and multiple equal(`f`.`DirID`, `d`.`DirID`))"
                    }
                  ]
                }
              },
              {
                "substitute_generated_columns": {}
              },
              {
                "table_dependencies": [
                  {
                    "table": "`FC_Files` `f`",
                    "row_may_be_null": false,
                    "map_bit": 0,
                    "depends_on_map_bits": []
                  },
                  {
                    "table": "`FC_DirectoryList` `d`",
                    "row_may_be_null": false,
                    "map_bit": 1,
                    "depends_on_map_bits": []
                  }
                ]
              },
              {
                "ref_optimizer_key_uses": [
                  {
                    "table": "`FC_Files` `f`",
                    "field": "DirID",
                    "equals": "`d`.`DirID`",
                    "null_rejecting": true
                  },
                  {
                    "table": "`FC_Files` `f`",
                    "field": "GUID",
                    "equals": "'1000'",
                    "null_rejecting": true
                  },
                  {
                    "table": "`FC_DirectoryList` `d`",
                    "field": "DirID",
                    "equals": "`f`.`DirID`",
                    "null_rejecting": true
                  }
                ]
              },
              {
                "rows_estimation": [
                  {
                    "table": "`FC_Files` `f`",
                    "rows": 1,
                    "cost": 1,
                    "table_type": "const",
                    "empty": false
                  },
                  {
                    "table": "`FC_DirectoryList` `d`",
                    "rows": 1,
                    "cost": 1,
                    "table_type": "const",
                    "empty": false
                  }
                ]
              },
              {
                "condition_on_constant_tables": "true",
                "condition_value": true
              },
              {
                "attaching_conditions_to_tables": {
                  "original_condition": "true",
                  "attached_conditions_computation": [],
                  "attached_conditions_summary": []
                }
              },
              {
                "refine_plan": []
              }
            ]
          }
        },
        {
          "join_execution": {
            "select#": 1,
            "steps": []
          }
        }
      ]
    }
  }
]
```
</details>

One important change in that PR is a73ba156d75e8ea400f6668f47aa15e69de2bc34  As a consequence, the keyword parameter MUST be named if used. I think I got all of them fixed in 14531d1977fb9ee2a6e7d803b8b5ce50150b4ef5

BEGINRELEASENOTES
*Core
NEW: Introduce ``DIRAC_MYSQL_OPTIMIZER_TRACES_PATH`` environment variable for advance optimization of MySQL calls
CHANGE: calls to the MySQL class with keyword parameters MUST now be named

ENDRELEASENOTES
