### PR TITLE
[v7r3] Allow the default InputDataDirectory to be overridden in LocalSite

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/InputDataResolution.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/InputDataResolution.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 
 import six
 import DIRAC
-from DIRAC import S_OK, S_ERROR, gLogger
+from DIRAC import S_OK, S_ERROR, gLogger, gConfig
 from DIRAC.Core.Utilities.ModuleFactory import ModuleFactory
 from DIRAC.WorkloadManagementSystem.Client.PoolXMLSlice import PoolXMLSlice
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
@@ -42,7 +42,7 @@ class InputDataResolution(object):
         )
 
         # By default put input data into the current directory
-        self.arguments.setdefault("InputDataDirectory", "CWD")
+        self.arguments.setdefault("InputDataDirectory", gConfig.getValue("/LocalSite/InputDataDirectory", "CWD"))
 
     #############################################################################
     def execute(self):


### PR DESCRIPTION
When running some test jobs locally I've been wanting to use a shared local directory for downloading the input data rather than re-downloading it for every job. One option would be to keep passing the directory from `Job.runLocal` until `DownloadInputData` is initialised however this feels messy. The best idea I've had so far is to add a configuration option (`/LocalSite/InputDataDirectory`) but I'm open to others.

BEGINRELEASENOTES

*WMS
NEW: The default InputDataDirectory used by DownloadInputData can be overridden by setting /LocalSite/InputDataDirectory

ENDRELEASENOTES
