### PR TITLE
[v7r3] Enable VirtualMachineMonitor halt call

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
@@ -237,6 +237,5 @@ class VirtualMachineMonitorAgent(AgentModule):
             if i < retries - 1:
                 self.log.info("Sleeping for %d seconds and retrying" % sleepTime)
                 time.sleep(sleepTime)
-
-        # self.log.info( "Executing system halt..." )
-        # os.system( "halt" )
+        self.log.info("Executing system halt...")
+        os.system("halt")


### PR DESCRIPTION
The call to halt at the end of VirtualMachineMonitor was mistakenly left commented out: It should be enabled so that VMs stop in a timely manner.


BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: Stop instance from VirtualMachineMonitor
ENDRELEASENOTES
