### PR TITLE
[v7r3] fix (gfal2): specify new directory permissions in octal

### DIFF
--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -1167,7 +1167,7 @@ class GFAL2_StorageBase(StorageBase):
         log = self.log.getSubLogger("GFAL2_StorageBase._createSingleDirectory")
         try:
             log.debug("Creating %s" % path)
-            status = self.ctx.mkdir_rec(str(path), 755)
+            status = self.ctx.mkdir_rec(str(path), 0o755)
             if status >= 0:
                 log.debug("Successfully created directory")
                 return S_OK()


### PR DESCRIPTION
That goes to show how well posix permissions are supported on grid storage :-) 

BEGINRELEASENOTES

*Resources
FIX: new directory creation specifies the permission in octal mode


ENDRELEASENOTES
