### PR TITLE
[v7r3]fix (SE): free space can be negative, so set it to 0

### DIFF
--- a/src/DIRAC/Resources/Storage/StorageElement.py
+++ b/src/DIRAC/Resources/Storage/StorageElement.py
@@ -480,6 +480,12 @@ class StorageElementItem(object):
             log.error(msg)
             return S_ERROR(msg)
 
+        # It can happen that Used space > total space (quota enforcement on EOS are async)
+        # In that case, just set it to 0, and issue a warning
+        if occupancyDict["Free"] < 0:
+            log.warn("Negative free value in occupancy dict", str(occupancyDict["Free"]))
+            occupancyDict["Free"] = 0
+
         # Since plugins return Bytes, we do not need to convert if that's what we want
         if unit != "B":
             for space in ["Total", "Free"]:


### PR DESCRIPTION
We had problems recently of negative free space. This is due to the asynchronous nature of quota enforcement of some storage (EOS in that case) and the fact that we are very close to the limit.


BEGINRELEASENOTES
*Resources
CHANGE: negative free space value is transformed to 0

ENDRELEASENOTES
