### PR TITLE
[v8r0] Fix for FileCatalog DirectoryLevelTree

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -29,7 +29,7 @@
     Returns S_OK or S_ERROR.
 
 
-    _query( cmd, [conn] )
+    _query( cmd, [conn=conn] )
 
     Executes SQL command "cmd".
     Gets a connection from the Queue (or open a new one if none is available),
@@ -39,7 +39,7 @@
     Returns S_OK with fetchall() out in Value or S_ERROR upon failure.
 
 
-    _update( cmd, [conn] )
+    _update( cmd, [conn=conn] )
 
     Executes SQL command "cmd" and issue a commit
     Gets a connection from the Queue (or open a new one if none is available),

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryLevelTree.py
@@ -141,10 +141,10 @@ class DirectoryLevelTree(DirectoryTreeBase):
 
         result = self.db._getConnection()
         conn = result["Value"]
-        # result = self.db._query("LOCK TABLES FC_DirectoryLevelTree WRITE; ",conn)
-        result = self.db.insertFields("FC_DirectoryLevelTree", names, values, conn)
+        # result = self.db._query("LOCK TABLES FC_DirectoryLevelTree WRITE; ", conn=conn)
+        result = self.db.insertFields("FC_DirectoryLevelTree", names, values, conn=conn)
         if not result["OK"]:
-            # resUnlock = self.db._query("UNLOCK TABLES;",conn)
+            # resUnlock = self.db._query("UNLOCK TABLES;", conn=conn)
             if result["Message"].find("Duplicate") != -1:
                 # The directory is already added
                 resFind = self.findDir(path)
@@ -162,25 +162,25 @@ class DirectoryLevelTree(DirectoryTreeBase):
         if parentDirID:
             #       lPath = "LPATH%d" % (level)
             #       req = " SELECT @tmpvar:=max(%s)+1 FROM FC_DirectoryLevelTree WHERE Parent=%d; " % (lPath,parentDirID)
-            #       resultLock = self.db._query("LOCK TABLES FC_DirectoryLevelTree WRITE; ",conn)
-            #       result = self.db._query(req,conn)
+            #       resultLock = self.db._query("LOCK TABLES FC_DirectoryLevelTree WRITE; ", conn=conn)
+            #       result = self.db._query(req, conn=conn)
             #       req = "UPDATE FC_DirectoryLevelTree SET %s=@tmpvar WHERE DirID=%d; " % (lPath,dirID)
-            #       result = self.db._update(req,conn)
-            #       result = self.db._query("UNLOCK TABLES;",conn)
+            #       result = self.db._update(req, conn=conn)
+            #       result = self.db._query("UNLOCK TABLES;", conn=conn)
             lPath = "LPATH%d" % (level)
             req = " SELECT @tmpvar:=max(%s)+1 FROM FC_DirectoryLevelTree WHERE Parent=%d FOR UPDATE; " % (
                 lPath,
                 parentDirID,
             )
-            resultLock = self.db._query("START TRANSACTION; ", conn)
-            result = self.db._query(req, conn)
+            resultLock = self.db._query("START TRANSACTION; ", conn=conn)
+            result = self.db._query(req, conn=conn)
             req = "UPDATE FC_DirectoryLevelTree SET %s=@tmpvar WHERE DirID=%d; " % (lPath, dirID)
-            result = self.db._update(req, conn)
-            result = self.db._query("COMMIT;", conn)
+            result = self.db._update(req, conn=conn)
+            result = self.db._query("COMMIT;", conn=conn)
             if not result["OK"]:
                 return result
         else:
-            result = self.db._query("ROLLBACK;", conn)
+            result = self.db._query("ROLLBACK;", conn=conn)
 
         result = S_OK(dirID)
         result["NewDirectory"] = True

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -136,7 +136,7 @@ class PilotAgentsDB(DB):
     #       req = reqBase + ','.join("('%s', '%s', '%s')" % (pilotJobReference, status, statusReason))
     #       req += " ON DUPLICATE KEY UPDATE Status=VALUES(Status),StatusReason=VALUES(StatusReason)"
 
-    #     return self._update(req, conn)
+    #     return self._update(req, conn=conn)
 
     ##########################################################################################
     def selectPilots(


### PR DESCRIPTION

BEGINRELEASENOTES
*DMS
FIX: DirectoryLevelTree: fix missing keyword argument name causing failures to upload files for example

ENDRELEASENOTES

No more output for

```
git grep "_\(query\|update\)(.*conn"  | grep -v "conn *="
```