### PR TITLE
[v8r0] fixes for rescheduling

### DIFF
--- a/src/DIRAC/Core/Utilities/TimeUtilities.py
+++ b/src/DIRAC/Core/Utilities/TimeUtilities.py
@@ -152,7 +152,12 @@ def fromString(myDate=None):
     The format of the string it is assume to be that returned by toString method.
     See notice on toString method
     On Error, return None
+
+    :param myDate: the date string to be converted
+    :type myDate: str or datetime.datetime
     """
+    if isinstance(myDate, datetime.datetime):
+        return myDate
     if isinstance(myDate, str):
         if myDate.find(" ") > 0:
             dateTimeTuple = myDate.split(" ")

--- a/src/DIRAC/WorkloadManagementSystem/Executor/JobScheduling.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/JobScheduling.py
@@ -60,7 +60,7 @@ class JobScheduling(OptimizerExecutor):
             return S_ERROR("RescheduleCounter has to be an integer")
         if reschedules != 0:
             delays = self.ex_getOption("RescheduleDelays", [60, 180, 300, 600])
-            delay = delays[min(reschedules, len(delays) - 1)]
+            delay = delays[min(reschedules - 1, len(delays) - 1)]
             waited = toEpoch() - toEpoch(fromString(attDict["RescheduleTime"]))
             if waited < delay:
                 return self.__holdJob(jobState, "On Hold: after rescheduling %s" % reschedules, delay)


### PR DESCRIPTION
During the hackathon test today: The "RescheduleTime" attribute is already a datetime.datetime, and then fromString was returning None.
If it is guaranteed that RescheduleTime is datetime.datetime, one could also drop the call to fromString and just use `toEpoch` directly in line 64 of JobScheduling

BEGINRELEASENOTES

*Core
FIX: TimeUtilities.fromString: when given a datetime.datetime, return the same object, instead of None. Also Fixes JobScheduling issue

*WMS:
FIX: JobScheduling: select the correct RescheduleDelay instead of 1 higher

ENDRELEASENOTES
