### PR TITLE
[v7r3] Use safer mode for grid-security directories

### DIFF
--- a/src/DIRAC/Core/Utilities/File.py
+++ b/src/DIRAC/Core/Utilities/File.py
@@ -30,12 +30,19 @@ SIZE_UNIT_CONVERSION = {
 }
 
 
-def mkDir(path):
-    """Emulate 'mkdir -p path' (if path exists already, don't raise an exception)"""
+def mkDir(path, mode=None):
+    """Emulate 'mkdir -p path' (if path exists already, don't raise an exception)
+
+    :param str path: directory hierarchy to create
+    :param int mode: Use this mode as the mode for new directories, use python default if None.
+    """
     try:
         if os.path.isdir(path):
             return
-        os.makedirs(path)
+        if mode is None:
+            os.makedirs(path)
+        else:
+            os.makedirs(path, mode)
     except OSError as osError:
         if osError.errno == errno.EEXIST and os.path.isdir(path):
             pass

--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -454,7 +454,7 @@ def runDiracConfigure(params):
             Script.enableCS()
             try:
                 dirName = os.path.join(DIRAC.rootPath, "etc", "grid-security", "certificates")
-                mkDir(dirName)
+                mkDir(dirName, 0o755)
             except Exception:
                 DIRAC.gLogger.exception()
                 DIRAC.gLogger.fatal("Fail to create directory:", dirName)
@@ -577,7 +577,7 @@ def runDiracConfigure(params):
         vomsDirPath = os.path.join(DIRAC.rootPath, "etc", "grid-security", "vomsdir", voName)
         vomsesDirPath = os.path.join(DIRAC.rootPath, "etc", "grid-security", "vomses")
         for path in (vomsDirPath, vomsesDirPath):
-            mkDir(path)
+            mkDir(path, 0o755)
         vomsesLines = []
         for vomsHost in vomsDict[vo].get("Servers", {}):
             hostFilePath = os.path.join(vomsDirPath, "%s.lsc" % vomsHost)


### PR DESCRIPTION
Hi,

It turns out the xrootd library checks the permissions on the CA dir and possibly others when connecting to some (but bizarrely not all) SEs... If DIRAC is installed on a cluster with umask 0002, you get rwxrwxr-x permissions on the certificates, vomses & vomdir directories which result in the cryptic error message "Network dropped connection on reset" from GFAL when trying to to read from those SEs.

I believe a umask of 0002 is the default on clusters with older RHEL versions and newer ones where private groups are used (e.g. uid = default gid): I'm a little surprised we haven't run into this before.

I'm slightly of the opinion that the libraries shouldn't do checks on the permissions, but perhaps it's just easier to patch it here?

Regards,
Simon

BEGINRELEASENOTES
*Core
FIX: Use safer mode for grid-security directories
ENDRELEASENOTES
