### PR TITLE
[sweep:integration] Fix MySQL Optimizer and dont start JobAgent for integration tests

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -222,7 +222,7 @@ def captureOptimizerTraces(meth):
       cd ${DIRAC_MYSQL_OPTIMIZER_TRACES_PATH}
       c=0; for i in $(ls); do newFn=$(echo $i | sed -E "s/_trace_[0-9]+.[0-9]+_(.*)/_trace_${c}_\1/g"); mv $i $newFn; c=$(( c + 1 )); done
 
-    This tool is useful then to compare the files https://github.com/cosmicanant/recursive-diff
+    This tool is useful then to compare the files https://github.com/crusaderky/recursive_diff
 
     Note that this method is far from pretty:
 
@@ -251,8 +251,9 @@ def captureOptimizerTraces(meth):
     def innerMethod(self, *args, **kwargs):
 
         # First, get a connection to the DB, and enable the tracing
-        connection = self.__connectionPool.get(self.__dbName)
+        connection = self._MySQL__connectionPool.get(self._MySQL__dbName)["Value"]
         connection.cursor().execute('SET optimizer_trace="enabled=on";')
+
         # We also set some options that worked for my use case.
         # you may need to tune these parameters if you have huge traces
         # or more recursive calls.
@@ -312,7 +313,7 @@ def captureOptimizerTraces(meth):
                     {"Query": trace_query, "Trace": json.loads(trace_analysis) if trace_analysis else None}
                 )
 
-            json.dump(jsonTraces, f)
+            json.dump(jsonTraces, f, indent=True)
 
         return res
 

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -156,10 +156,12 @@ findAgents(){
     echo 'ERROR: cannot change to ' "${SERVERINSTALLDIR}" >&2
     exit 1
   fi
+
+  # Always remove the JobAgent, which is not a real agent
   if [[ -n "${AgentstoExclude}" ]]; then
-    python -m DIRAC.Core.Utilities.Extensions findAgents | grep -v "${AgentstoExclude}" > agents
+    python -m DIRAC.Core.Utilities.Extensions findAgents | grep -v "WorkloadManagementSystem JobAgent" | grep -v "${AgentstoExclude}" > agents
   else
-    python -m DIRAC.Core.Utilities.Extensions findAgents | grep "${AgentstoSearch}" > agents
+    python -m DIRAC.Core.Utilities.Extensions findAgents | grep -v "WorkloadManagementSystem JobAgent" | grep "${AgentstoSearch}" > agents
   fi
 
   echo "found $(wc -l agents)"


### PR DESCRIPTION
Sweep #6411 `Fix MySQL Optimizer and don't start JobAgent for integration tests` to `integration`.

Adding original author @chaen as watcher.

BEGINRELEASENOTES
*Test
FIX: server installation do not install JobAgent

*Core
FIX: MySQL tracer bugs

ENDRELEASENOTES
Closes #6413