### PR TITLE
[v8r0] Fix Command Documentation Section Title

### DIFF
--- a/docs/diracdoctools/cmd/commandReference.py
+++ b/docs/diracdoctools/cmd/commandReference.py
@@ -146,9 +146,9 @@ class CommandReference:
                 f"""
                     .. _{system}_cmd:
 
-                    {"=" * len(system)}
+                    {"-" * len(system)}
                     {system}
-                    {"=" * len(system)}
+                    {"-" * len(system)}
 
                 """
             )
@@ -188,9 +188,8 @@ class CommandReference:
 
                 .. _{scriptName}:
 
-                {'-' * len(scriptName)}
                 {scriptName}
-                {'-' * len(scriptName)}
+                {'`' * len(scriptName)}
 
             """
         )

--- a/docs/diracdoctools/cmd/commandReference.py
+++ b/docs/diracdoctools/cmd/commandReference.py
@@ -116,7 +116,9 @@ class CommandReference:
 
                 .. _cmd:
 
+                =================
                 Command Reference
+                =================
 
                 In this subsection all commands are collected:
 


### PR DESCRIPTION

BEGINRELEASENOTES

*Docs
FIX: Fix the title for the Command Reference Page, fixes #6455 

ENDRELEASENOTES
