### PR TITLE
[v8] fail when command documentation does not build, fix for importlib_metadata v5

### DIFF
--- a/docs/diracdoctools/cmd/commandReference.py
+++ b/docs/diracdoctools/cmd/commandReference.py
@@ -181,6 +181,7 @@ class CommandReference:
         if not helpMessage:
             LOG.warning("NO DOC for %s", scriptName)
             helpMessage = "Oops, we couldn't generate a description for this command."
+            self.exitcode = 1
 
         # Script reference
         fileContent = textwrap.dedent(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,8 @@ if os.environ.get("READTHEDOCS") == "True":
     LOG.info("Building command reference")
     from diracdoctools.cmd.commandReference import run as buildCommandReference
 
-    buildCommandReference(configFile="../docs.conf")
+    if buildCommandReference(configFile="../docs.conf") != 0:
+        raise RuntimeError("Something went wrong with the documentation creation")
 
     # singlehtml build needs too much memory, so we need to create less code documentation
     buildType = "limited" if any("singlehtml" in arg for arg in sys.argv) else "full"

--- a/src/DIRAC/Core/Base/Script.py
+++ b/src/DIRAC/Core/Base/Script.py
@@ -51,7 +51,7 @@ class Script:
             return functools.wraps(func)(self)
 
         # Iterate through all known entry_points looking for self.scriptName
-        matches = [ep for ep in metadata.entry_points()["console_scripts"] if ep.name == self.scriptName]
+        matches = [ep for ep in metadata.entry_points(group="console_scripts") if ep.name == self.scriptName]
         if not matches:
             raise NotImplementedError("Something is very wrong")
 


### PR DESCRIPTION
For some reason the output for the commands is now just "oops..." Not sure where this comes from :/

```
  diracdoctools.Utilities:    ERROR: Error when runnning command python /home/docs/checkouts/readthedocs.org/user_builds/dirac/checkouts/rel-v8r0/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_check_config_options.py -h: 'Traceback (most recent call last):\n  File "/home/docs/checkouts/readthedocs.org/user_builds/dirac/conda/rel-v8r0/lib/python3.9/site-packages/importlib_metadata/__init__.py", line 287, in __getitem__\n    return next(iter(self.select(name=name)))\nStopIteration\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/docs/checkouts/readthedocs.org/user_builds/dirac/checkouts/rel-v8r0/src/DIRAC/ConfigurationSystem/scripts/dirac_admin_check_config_options.py", line 214, in <module>\n    main()\n  File "/home/docs/checkouts/readthedocs.org/user_builds/dirac/checkouts/rel-v8r0/src/DIRAC/Core/Base/Script.py", line 54, in __call__\n    matches = [ep for ep in metadata.entry_points()["console_scripts"] if ep.name == self.scriptName]\n  File "/home/docs/checkouts/readthedocs.org/user_builds/dirac/conda/rel-v8r0/lib/python3.9/site-packages/importlib_metadata/__init__.py", line 289, in __getitem__\n    raise KeyError(name)\nKeyError: \'console_scripts\'\n'
         CommandReference:  WARNING: NO DOC for dirac-admin-check-config-options
```

BEGINRELEASENOTES

*Core
FIX: Scripts: adapt to proper way of getting console_scripts entry_points, mandatory for importlib_metadata v5

*Docs
FIX: Fail if one the commands cannot be documented

ENDRELEASENOTES
