### PR TITLE
[8.1] Setting timeout when adding VOMS extension

### DIFF
--- a/src/DIRAC/Core/Security/VOMS.py
+++ b/src/DIRAC/Core/Security/VOMS.py
@@ -280,7 +280,7 @@ class VOMS:
 
         if chain.isRFC().get("Value"):
             cmd += ["-r"]
-        cmd += ["-timeout 12"]
+        cmd += ["-timeout", "12"]
 
         result = shellCall(self._secCmdTimeout, shlex.join(cmd))
         if tmpDir:


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: Setting timeout when adding VOMS extension

ENDRELEASENOTES
