### PR TITLE
[v7r3] reduce the PollingTime of JobAgent to 20s

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -166,6 +166,7 @@ Agents
   ##END
   JobAgent
   {
+    PollingTime = 20
     FillingModeFlag = true
     StopOnApplicationFailure = true
     StopAfterFailedMatches = 10


### PR DESCRIPTION
Goes together with https://github.com/DIRACGrid/Pilot/pull/164

BEGINRELEASENOTES

*WMS
FIX: reduce the PollingTime of JobAgent to 20s

ENDRELEASENOTES

close https://github.com/DIRACGrid/DIRAC/issues/6116
