### PR TITLE
[v8r0] Fix running tests with Python 3.11

### DIFF
--- a/src/DIRAC/RequestManagementSystem/private/test/Test_OperationHandlerBase.py
+++ b/src/DIRAC/RequestManagementSystem/private/test/Test_OperationHandlerBase.py
@@ -1,52 +1,42 @@
 """ tests for Graph OperationHandlerBase module
 """
-import unittest
+import sys
 
-# # SUT
+import pytest
+
 from DIRAC.RequestManagementSystem.private.OperationHandlerBase import DynamicProps
 
 
-class DynamicPropTests(unittest.TestCase):
+class TestClass(metaclass=DynamicProps):
     """
-    ..  class:: DynamicPropTests
+    .. class:: TestClass
+
+    dummy class
     """
 
-    def testDynamicProps(self):
-        """test dynamic props"""
-
-        class TestClass(metaclass=DynamicProps):
-            """
-            .. class:: TestClass
-
-            dummy class
-            """
-
-            pass
-
-        # # dummy instance
-        testObj = TestClass()
-        # # makeProperty in
-        self.assertEqual(hasattr(testObj, "makeProperty"), True)
-        self.assertEqual(callable(getattr(testObj, "makeProperty")), True)
-        # # .. and works  for rw properties
-        testObj.makeProperty("rwTestProp", 10)  # pylint: disable=no-member
-        self.assertEqual(hasattr(testObj, "rwTestProp"), True)
-        self.assertEqual(getattr(testObj, "rwTestProp"), 10)
-        testObj.rwTestProp += 1  # pylint: disable=no-member
-        self.assertEqual(getattr(testObj, "rwTestProp"), 11)
-        # # .. and ro as well
-        testObj.makeProperty("roTestProp", "I'm read only", True)  # pylint: disable=no-member
-        self.assertEqual(hasattr(testObj, "roTestProp"), True)
-        self.assertEqual(getattr(testObj, "roTestProp"), "I'm read only")
-        # # AttributeError for read only property setattr
-        try:
-            testObj.roTestProp = 11
-        except AttributeError as error:
-            self.assertEqual(str(error), "can't set attribute")
+    pass
 
 
-# # test execution
-if __name__ == "__main__":
-    testLoader = unittest.TestLoader()
-    tests = testLoader.loadTestsFromTestCase(DynamicPropTests)
-    unittest.TextTestRunner(verbosity=3).run(tests)
+def test_DynamicProps():
+    # # dummy instance
+    testObj = TestClass()
+    # # makeProperty in
+    assert hasattr(testObj, "makeProperty")
+    assert callable(getattr(testObj, "makeProperty"))
+    # # .. and works  for rw properties
+    testObj.makeProperty("rwTestProp", 10)  # pylint: disable=no-member
+    assert hasattr(testObj, "rwTestProp")
+    assert getattr(testObj, "rwTestProp") == 10
+    testObj.rwTestProp += 1  # pylint: disable=no-member
+    assert getattr(testObj, "rwTestProp") == 11
+    # # .. and ro as well
+    testObj.makeProperty("roTestProp", "I'm read only", True)  # pylint: disable=no-member
+    assert hasattr(testObj, "roTestProp")
+    assert getattr(testObj, "roTestProp") == "I'm read only"
+    # # AttributeError for read only property setattr
+    with pytest.raises(AttributeError) as exc_info:
+        testObj.roTestProp = 11
+    if sys.hexversion >= 0x03_0B_00_00:
+        assert str(exc_info.value) == "property of 'TestClass' object has no setter"
+    else:
+        assert str(exc_info.value) == "can't set attribute"

--- a/src/DIRAC/RequestManagementSystem/private/test/Test_RequestTask.py
+++ b/src/DIRAC/RequestManagementSystem/private/test/Test_RequestTask.py
@@ -6,19 +6,13 @@
 
     test cases for RequestTask class
 """
-
 import unittest
 import importlib
 from unittest.mock import Mock, MagicMock
 
-# # SUT
 from DIRAC.RequestManagementSystem.private.RequestTask import RequestTask
-
-# # request client
 from DIRAC.RequestManagementSystem.Client.ReqClient import ReqClient
 
-ReqClient = Mock(spec=ReqClient)
-# # from DIRAC
 from DIRAC.RequestManagementSystem.Client.Request import Request
 from DIRAC.RequestManagementSystem.Client.Operation import Operation
 


### PR DESCRIPTION
Two minor things:

* https://github.com/python/cpython/issues/87644 (seems like it was a bug to ever have the double mock)
* The `AttributeError` has a better error message for read-only properties (though I modernised the entire test file as part of this)