### PR TITLE
[integration] replace pre-Python 2.5 ternary syntax

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -308,7 +308,7 @@ class ProxyDB(DB):
             result = Registry.getProxyProvidersForDN(userDN)
             if not result["OK"]:
                 return result
-            proxyProvider = result.get("Value") and result["Value"][0] or "Certificate"
+            proxyProvider = result["Value"][0] if result.get("Value") else "Certificate"
 
         # Get remaining secs
         retVal = chain.getRemainingSecs()

--- a/src/DIRAC/ResourceStatusSystem/Command/Command.py
+++ b/src/DIRAC/ResourceStatusSystem/Command/Command.py
@@ -12,13 +12,13 @@ class Command:
 
     def __init__(self, args=None, clients=None):
 
-        self.apis = (1 and clients) or {}
+        self.apis = clients if clients else {}
         self.masterMode = False
         self.onlyCache = False
         self.metrics = {"failed": []}
 
         self.args = {"onlyCache": False}
-        _args = (1 and args) or {}
+        _args = args if args else {}
         self.args.update(_args)
         self.log = gLogger.getSubLogger(self.__class__.__name__)
 

--- a/src/DIRAC/ResourceStatusSystem/Utilities/RSSCache.py
+++ b/src/DIRAC/ResourceStatusSystem/Utilities/RSSCache.py
@@ -24,7 +24,7 @@ class RSSCache:
 
         self.__lifeTime = lifeTime
         # lifetime of the history on hours
-        self.__cacheHistoryLifeTime = (1 and cacheHistoryLifeTime) or 24
+        self.__cacheHistoryLifeTime = cacheHistoryLifeTime if cacheHistoryLifeTime else 24
         self.__updateFunc = updateFunc
 
         # RSSCache


### PR DESCRIPTION
This PR replaces pre-Python 2.5 ternary syntax
```python
var = (condition and otherVar) or value
```
with modern equivalent:
```python
var = otherVar if condition else value
```

BTW: There are many small to large issues (~15k) in this code base, if you are happy with such contributions, please let me know. I will try to group the fixes.


BEGINRELEASENOTES

*FrameworkSystem

FIX: replace pre-Python 2.5 ternary syntax

*ResourceStatusSystem

FIX: replace pre-Python 2.5 ternary syntax

ENDRELEASENOTES
