### PR TITLE
[integration] simplify if-statements for readability and performance

### DIFF
--- a/src/DIRAC/ConfigurationSystem/private/ConfigurationData.py
+++ b/src/DIRAC/ConfigurationSystem/private/ConfigurationData.py
@@ -249,17 +249,11 @@ class ConfigurationData:
 
     def getAutoPublish(self):
         value = self.extractOptionFromCFG("%s/AutoPublish" % self.configurationPath, self.localCFG)
-        if value and value.lower() in ("no", "false", "n"):
-            return False
-        else:
-            return True
+        return not bool(value and value.lower() in ("no", "false", "n"))
 
     def getAutoSlaveSync(self):
         value = self.extractOptionFromCFG("%s/AutoSlaveSync" % self.configurationPath, self.localCFG)
-        if value and value.lower() in ("no", "false", "n"):
-            return False
-        else:
-            return True
+        return not bool(value and value.lower() in ("no", "false", "n"))
 
     def getServers(self):
         return list(self.remoteServerList)
@@ -288,10 +282,7 @@ class ConfigurationData:
 
     def isMaster(self):
         value = self.extractOptionFromCFG("%s/Master" % self.configurationPath, self.localCFG)
-        if value and value.lower() in ("yes", "true", "y"):
-            return True
-        else:
-            return False
+        return bool(value and value.lower() in ("yes", "true", "y"))
 
     def getServicesPath(self):
         return "/Services"
@@ -304,15 +295,11 @@ class ConfigurationData:
 
     def useServerCertificate(self):
         value = self.extractOptionFromCFG("/DIRAC/Security/UseServerCertificate")
-        if value and value.lower() in ("y", "yes", "true"):
-            return True
-        return False
+        return bool(value and value.lower() in ("yes", "true", "y"))
 
     def skipCACheck(self):
         value = self.extractOptionFromCFG("/DIRAC/Security/SkipCAChecks")
-        if value and value.lower() in ("y", "yes", "true"):
-            return True
-        return False
+        return bool(value and value.lower() in ("yes", "true", "y"))
 
     def dumpLocalCFGToFile(self, fileName):
         try:

--- a/src/DIRAC/DataManagementSystem/Client/CmdDirCompletion/DirectoryCompletion.py
+++ b/src/DIRAC/DataManagementSystem/Client/CmdDirCompletion/DirectoryCompletion.py
@@ -44,18 +44,13 @@ class DirectoryCompletion:
 
     # check absolute path
     def check_absolute(self, path):
-        if path.startswith(self.fs.seq):
-            return True
-        else:
-            return False
+        return path.startswith(self.fs.seq)
 
     # generate absolute path
     def generate_absolute(self, path, cwd):
         if self.check_absolute(path):
-            pass
-        else:
-            path = os.path.join(cwd, path)
-        return path
+            return path
+        return os.path.join(cwd, path)
 
     # get the parent directory or the current directory
     # Using the last char "/" to determine

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/SecurityManagerBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/SecurityManagerBase.py
@@ -69,7 +69,7 @@ class SecurityManagerBase:
 
         successful = {}
         failed = {}
-        if not opType.lower() in ["read", "write", "execute"]:
+        if opType.lower() not in ["read", "write", "execute"]:
             return S_ERROR("Operation type not known")
         if self.db.globalReadAccess and (opType.lower() == "read"):
             for path in paths:

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/VOMSSecurityManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/VOMSSecurityManager.py
@@ -79,11 +79,7 @@ class VOMSSecurityManager(SecurityManagerBase):
     def __isNotExistError(self, errorMsg):
         """Returns true if the errorMsg means that the file/directory does not exist"""
 
-        for possibleMsg in ["not exist", "not found", "No such file or directory"]:
-            if possibleMsg in errorMsg:
-                return True
-
-        return False
+        return any(possibleMsg in errorMsg for possibleMsg in ["not exist", "not found", "No such file or directory"])
 
     def __getFilePermission(self, path, credDict, noExistStrategy=None):
         """Checks POSIX permission for a file using the VOMS roles.

--- a/src/DIRAC/FrameworkSystem/Service/UserProfileManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/UserProfileManagerHandler.py
@@ -129,10 +129,7 @@ class UserProfileManagerHandler(RequestHandler):
         """
         credDict = self.getRemoteCredentials()
         requesterUserName = credDict["username"]
-        if Properties.SERVICE_ADMINISTRATOR in credDict["properties"]:
-            admin = True
-        else:
-            admin = False
+        admin = Properties.SERVICE_ADMINISTRATOR in credDict["properties"]
         for entry in userList:
             userName = entry
             if admin or userName == requesterUserName:

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_sys_sendmail.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_sys_sendmail.py
@@ -33,7 +33,7 @@ def main():
 
     arg = "".join(args)
 
-    if not len(arg) > 0:
+    if not arg:
         gLogger.error("Missing argument")
         DIRACexit(2)
 

--- a/src/DIRAC/Resources/Storage/RFIOStorage.py
+++ b/src/DIRAC/Resources/Storage/RFIOStorage.py
@@ -703,10 +703,7 @@ class RFIOStorage(StorageBase):
                 subDirsGot = False
 
         # Check whether all the operations were successful
-        if subDirsGot and gotFiles:
-            allGot = True
-        else:
-            allGot = False
+        allGot = bool(gotFiles and subDirsGot)
         resDict = {"AllGot": allGot, "Files": filesGot, "Size": sizeGot}
         return S_OK(resDict)
 

--- a/src/DIRAC/TransformationSystem/Agent/ValidateOutputDataAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/ValidateOutputDataAgent.py
@@ -68,7 +68,7 @@ class ValidateOutputDataAgent(AgentModule):
     def execute(self):
         """The VerifyOutputData execution method"""
         self.enableFlag = self.am_getOption("EnableFlag", "True")
-        if not self.enableFlag == "True":
+        if self.enableFlag != "True":
             self.log.info("VerifyOutputData is disabled by configuration option 'EnableFlag'")
             return S_OK("Disabled via CS flag")
 

--- a/src/DIRAC/TransformationSystem/Client/Transformation.py
+++ b/src/DIRAC/TransformationSystem/Client/Transformation.py
@@ -564,15 +564,13 @@ class Transformation(API):
             except Exception as x:
                 print("Exception %s " % str(x))
 
-        if not len(dictList) > 0:
+        if not dictList:
             gLogger.error("No found transformations satisfying input condition")
             return S_ERROR("No found transformations satisfying input condition")
-        else:
-            print(
-                self._printFormattedDictList(
-                    dictList, paramShowNamesShort, paramShowNamesShort[0], paramShowNamesShort[0]
-                )
-            )
+
+        print(
+            self._printFormattedDictList(dictList, paramShowNamesShort, paramShowNamesShort[0], paramShowNamesShort[0])
+        )
 
         return S_OK(dictList)
 


### PR DESCRIPTION
Tried to combine related "issues"  together.
This PR addresses readability and "performance" issues for `if` statements.


BEGINRELEASENOTES
*ConfigurationSystem
FIX: simplifying `if` statements for returning bools

*DataManagementSystem
FIX: simplifying `if` statements for returning bools
FIX: use `not in` instead of `not ... in`
FIX: simplify loop with `any` call

*FrameworkSystem
FIX: simplifying `if` statements for setting bools
FIX: simplified if statement for checking list/string len

*Resources
FIX: simplifying `if` statements for setting bools

*TransformationSystem
FIX: simplifying `if` statements [unneeded `not`]
FIX: simplified if statement for checking list/string len

ENDRELEASENOTES
