### PR TITLE
[v7r2] fix (resources): a few fixes related to ARC

### DIFF
--- a/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
@@ -29,6 +29,19 @@ class ARC6ComputingElement(ARCComputingElement):
         # This should be reconstructed in getARCJob() to retrieve the outputs.
         self.restUrlPart = "rest/1.0/jobs/"
 
+        # Default ComputingInfo Endpoint, used to get details about the queues
+        self.computingInfoEndpoint = "org.nordugrid.ldapglue2"
+
+    def _reset(self):
+        super(ARC6ComputingElement, self)._reset()
+        # ComputingInfoEndpoint to get information about queues
+        # https://www.nordugrid.org/arc/arc6/users/client_tools.html?#arcinfo
+        # Expected values are: [
+        # org.nordugrid.ldapng, org.nordugrid.ldapglue2, org.nordugrid.arcrest, org.ogf.glue.emies.resourceinfo
+        # ]
+        self.computingInfoEndpoint = self.ceParameters.get("ComputingInfoEndpoint", self.computingInfoEndpoint)
+        return S_OK()
+
     def _getARCJob(self, jobID):
         """Create an ARC Job with all the needed / possible parameters defined.
         By the time we come here, the environment variable X509_USER_PROXY should already be set
@@ -88,7 +101,7 @@ class ARC6ComputingElement(ARCComputingElement):
         stampDict = {}
 
         # Creating an endpoint
-        endpoint = arc.Endpoint(self.ceHost, arc.Endpoint.COMPUTINGINFO, "org.nordugrid.ldapglue2")
+        endpoint = arc.Endpoint(self.ceHost, arc.Endpoint.COMPUTINGINFO, self.computingInfoEndpoint)
 
         # Get the ExecutionTargets of the ComputingElement (Can be REST, EMI-ES or GRIDFTP)
         retriever = arc.ComputingServiceRetriever(self.usercfg, [endpoint])
@@ -169,7 +182,7 @@ class ARC6ComputingElement(ARCComputingElement):
         self.usercfg.ProxyPath(os.environ["X509_USER_PROXY"])
 
         # Creating an endpoint
-        endpoint = arc.Endpoint(self.ceHost, arc.Endpoint.COMPUTINGINFO, "org.nordugrid.ldapglue2")
+        endpoint = arc.Endpoint(self.ceHost, arc.Endpoint.COMPUTINGINFO, self.computingInfoEndpoint)
 
         # Get the ExecutionTargets of the ComputingElement (Can be REST, EMI-ES or GRIDFTP)
         retriever = arc.ComputingServiceRetriever(self.usercfg, [endpoint])

--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -62,13 +62,12 @@ class AREXComputingElement(ARCComputingElement):
         Note : This is not run from __init__ as the design of DIRAC means that ceParameters is
         filled with CEDefaults only at the time this class is initialised for the given CE
         """
-        # super()._reset()
+        super(AREXComputingElement, self)._reset()
         self.log.debug("Testing if the REST interface is available", "for %s" % self.ceName)
 
         # Get options from the ceParameters dictionary
         self.port = self.ceParameters.get("Port", self.port)
         self.restVersion = self.ceParameters.get("RESTVersion", self.restVersion)
-        self.queue = self.ceParameters.get("Queue", self.queue)
 
         self.proxyTimeLeftBeforeRenewal = self.ceParameters.get(
             "proxyTimeLeftBeforeRenewal", self.proxyTimeLeftBeforeRenewal


### PR DESCRIPTION
This PR introduces the following features and fixes:
- `ARC`: add an option - `ARCLogLevel` - to enable/disable logs coming from the ARC library (they are independent from the standard `logging` library). It will help debugging issues coming from ARC instances if needed. 
- `ARC6`: add an option - `ComputingInfoEndpoint` - because the default one `ldapglue2` is not supported by new ARC instances. In the same way, the new one `rest` is not supported everywhere from what I observed.
- `AREX`: restore a line that was commented (I don't know why but I am pretty sure it would not work correctly without it).

Let me know if you think that this PR should be split and/or target another branch.
 
BEGINRELEASENOTES
*Resources
NEW: add the ARCLogLevel option in ARC
NEW: add the ComputingInfoEndpoint in ARC6
FIX: restore a commented line in AREX._reset()
ENDRELEASENOTES
