### PR TITLE
[v7r3] Ensure CPUNormalization is float

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -221,7 +221,7 @@ class JobWrapper(object):
         self.jobClass = self.jobArgs.get("JobSplitType", self.jobClass)
 
         if not self.cpuNormalizationFactor:
-            self.cpuNormalizationFactor = self.ceArgs.get("CPUNormalizationFactor", self.cpuNormalizationFactor)
+            self.cpuNormalizationFactor = float(self.ceArgs.get("CPUNormalizationFactor", self.cpuNormalizationFactor))
         self.siteName = self.ceArgs.get("Site", self.siteName)
 
         # Prepare the working directory, cd to there, and copying eventual extra arguments in it


### PR DESCRIPTION
We've started seeing job failures in a nested Pool/Singularity use-cases for >= 7.3.29 as cpuNormalization is now picked up, but is a string. This causes the inner job to fail with error:
```
Job raised exception during execution phase
Traceback (most recent call last):
  File "/tmp/Wrapper_39861446", line 179, in execute
    result = job.execute()
  File "/tmp/diracos/lib/python3.9/site-packages/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py", line 510, in execute
    self.__sendFinalStdOut(exeThread)
  File "/tmp/diracos/lib/python3.9/site-packages/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py", line 548, in __sendFinalStdOut
    normCPU = cpuConsumed[0] * self.cpuNormalizationFactor
TypeError: can't multiply sequence by non-int of type 'float'
```

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Ensure cpuNormalizationFactor is a float
ENDRELEASENOTES
