### PR TITLE
[v7r3] Support using ARC that was compiled against SWIG 4.1+

### DIFF
--- a/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
@@ -125,7 +125,7 @@ class ARC6ComputingElement(ARCComputingElement):
                 self.log.debug("DIRAC stamp for job : %s" % diracStamp)
 
                 # The arc bindings don't accept unicode objects in Python 2 so xrslString must be explicitly cast
-                result = arc.JobDescription_Parse(str(xrslString), jobdescs)
+                result = arc.JobDescription.Parse(str(xrslString), jobdescs)
                 if not result:
                     self.log.error("Invalid job description", "%r, message=%s" % (xrslString, result.str()))
                     break

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -296,7 +296,7 @@ class ARCComputingElement(ComputingElement):
             self.log.debug("XRSL string submitted : %s" % xrslString)
             self.log.debug("DIRAC stamp for job : %s" % diracStamp)
             # The arc bindings don't accept unicode objects in Python 2 so xrslString must be explicitly cast
-            result = arc.JobDescription_Parse(str(xrslString), jobdescs)
+            result = arc.JobDescription.Parse(str(xrslString), jobdescs)
             if not result:
                 self.log.error("Invalid job description", "%r, message=%s" % (xrslString, result.str()))
                 break


### PR DESCRIPTION
Looks like this has been available for a very long time so I propose we switch:

```bash
-bash-4.2$ tar xf /cvmfs/dirac.egi.eu/installSource/diracos-v1r15.tar.gz
-bash-4.2$ . diracos/diracosrc
-bash-4.2$ which python
/tmp/cburr/diracos/usr/bin/python
-bash-4.2$ python
Python 2.7.13 (default, Oct 26 2020, 22:59:14)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-23)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import arc
>>> arc
<module 'arc' from '/tmp/cburr/diracos/usr/lib64/python2.7/site-packages/arc/__init__.py'>
>>> arc.JobDescription.Parse
<built-in function JobDescription_Parse>
>>>
```

See https://bugzilla.nordugrid.org/show_bug.cgi?id=4092 for details.

BEGINRELEASENOTES

*Resources
FIX: Support using ARC that was compiled against SWIG 4.1+

ENDRELEASENOTES
