### PR TITLE
fix: don't fail silently if directory not found

### DIFF
--- a/src/DIRAC/DataManagementSystem/Client/FileCatalogClientCLI.py
+++ b/src/DIRAC/DataManagementSystem/Client/FileCatalogClientCLI.py
@@ -1259,6 +1259,8 @@ class FileCatalogClientCLI(CLI):
                         dList.printListing(reverse, timeorder, sizeorder, humanread)
                     else:
                         dList.printOrdered()
+                else:
+                    print("Error:", result["Value"]["Failed"])
             else:
                 print("Error:", result["Message"])
         except Exception as x:


### PR DESCRIPTION
BEGINRELEASENOTES
*DataManagement
FIX:  FileCatalogCLI: ls command: Added a missing else to avoid failing silently if directory is not found as opposed to it just being an empty directory.
ENDRELEASENOTES
