### PR TITLE
[v8.0] fix (wms): hackathon fix JobDB

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
@@ -315,10 +315,7 @@ class JobCleaningAgent(AgentModule):
         for jobID, outputSandboxLFNdict in osLFNDict.items():
             lfn = outputSandboxLFNdict["OutputSandboxLFN"]
             result = self.jobDB.getJobAttributes(jobID, ["OwnerDN", "OwnerGroup"])
-            if not result["OK"]:
-                failed[jobID] = lfn
-                continue
-            if not result["Value"]:
+            if not result["OK"] or not result["Value"]:
                 failed[jobID] = lfn
                 continue
 

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -279,7 +279,7 @@ class JobDB(DB):
         result = self.getJobsAttributes([jobID], attrList)
         if not result["OK"]:
             return result
-        return S_OK(result["Value"][jobID])
+        return S_OK(result["Value"].get(jobID, {}))
 
     #############################################################################
     def getJobAttribute(self, jobID, attribute):


### PR DESCRIPTION
This PR adds a check to `JobDB.getJobAttributes()`.
Currently, we assume the `jobID` passed in parameters always exist, which might not be true.

For instance:
```bash
dirac-wms-job-attributes <any ID that does not exist>
ERROR 2137335: 500 Server Error: Internal Server Error for url: https://lhcbvoboxcertif00.cern.ch:8443/WorkloadManagement/JobMonitoring: <html><title>500: Internal Server Error</title><body>500: Internal Server Error</body></html>
```

In this PR,  `JobDB.getJobAttributes()` returns an empty dictionary if the JobID does not exist:

```bash
dirac-wms-job-attributes <any ID that does not exist>
=================
 <any ID that does not exist>
{}

```

BEGINRELEASENOTES

* WorkloadManagementSystem 
FIX: JobDB.getJobAttributes() returns an empty dict if jobID does not exist

ENDRELEASENOTES
