### PR TITLE
[v8r0] fix (core): chainAsText not referenced before assignment

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -736,9 +736,12 @@ class BaseRequestHandler(RequestHandler):
             chainAsText = derCert.as_pem().decode("ascii")
             # Read all certificate chain
             chainAsText += "".join([cert.as_pem().decode("ascii") for cert in self.request.get_ssl_certificate_chain()])
-        elif balancer:
-            if self.request.headers.get("X-Ssl_client_verify") == "SUCCESS" and self.request.headers.get("X-SSL-CERT"):
-                chainAsText = unquote(self.request.headers.get("X-SSL-CERT"))
+        elif (
+            balancer
+            and self.request.headers.get("X-Ssl_client_verify") == "SUCCESS"
+            and self.request.headers.get("X-SSL-CERT")
+        ):
+            chainAsText = unquote(self.request.headers.get("X-SSL-CERT"))
         else:
             return S_ERROR(DErrno.ECERTFIND, "Valid certificate not found.")
 


### PR DESCRIPTION
Hackathon fix:

```bash
ERROR: local variable 'chainAsText' referenced before assignment
Traceback (most recent call last):
  File "/opt/dirac/versions/v8.1.0a3-1666850738/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 603, in __prepare
    self.credDict = self._gatherPeerCredentials()
  File "/opt/dirac/versions/v8.1.0a3-1666850738/Linux-x86_64/lib/python3.9/site-packages/WebAppDIRAC/Lib/WebHandler.py", line 235, in _gatherPeerCredentials
    credDict = super()._gatherPeerCredentials(grants=self.__authGrant)
  File "/opt/dirac/versions/v8.1.0a3-1666850738/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 709, in _gatherPeerCredentials
    result = grantFunc() if callable(grantFunc) else S_ERROR("%s authentication type is not supported." % grant)
  File "/opt/dirac/versions/v8.1.0a3-1666850738/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 747, in _authzSSL
    peerChain.loadChainFromString(chainAsText)
UnboundLocalError: local variable 'chainAsText' referenced before assignment
```
BEGINRELEASENOTES
*Core
FIX: chainAsText not referenced before assignmnet

ENDRELEASENOTES
