### PR TITLE
[sweep:integration] fix (core): chainAsText not referenced before assignment

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -736,11 +736,12 @@ class BaseRequestHandler(RequestHandler):
             chainAsText = derCert.as_pem().decode("ascii")
             # Read all certificate chain
             chainAsText += "".join([cert.as_pem().decode("ascii") for cert in self.request.get_ssl_certificate_chain()])
-        elif balancer:
-            if self.request.headers.get("X-Ssl_client_verify") == "SUCCESS" and self.request.headers.get("X-SSL-CERT"):
-                chainAsText = unquote(self.request.headers.get("X-SSL-CERT"))
-            else:
-                return S_ERROR(DErrno.ECERTFIND, "Valid certificate not found.")
+        elif (
+            balancer
+            and self.request.headers.get("X-Ssl_client_verify") == "SUCCESS"
+            and self.request.headers.get("X-SSL-CERT")
+        ):
+            chainAsText = unquote(self.request.headers.get("X-SSL-CERT"))
         else:
             return S_ERROR(DErrno.ECERTFIND, "Valid certificate not found.")
 


### PR DESCRIPTION
Sweep #6537 `fix (core): chainAsText not referenced before assignment` to `integration`.

Adding original author @aldbr as watcher.

BEGINRELEASENOTES
*Core
FIX: chainAsText not referenced before assignmnet

ENDRELEASENOTES
Closes #6540