### PR TITLE
[8.0] feat(BDII2CSAgent): allow using AREX or ARC6 CEs instead of ARC (fixes #6541)

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/Utilities.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Utilities.py
@@ -260,7 +260,13 @@ def getSiteUpdates(vo, bdiiInfo=None, log=None, onecore=False):
                 addToChangeSet((ceSection, "architecture", arch, newarch), changeSet)
                 addToChangeSet((ceSection, "OS", OS, newOS), changeSet)
                 addToChangeSet((ceSection, "SI00", si00, newsi00), changeSet)
-                addToChangeSet((ceSection, "CEType", ceType, newCEType), changeSet)
+
+                if (newCEType == "ARC6" and ceType in ("AREX",)) or (newCEType == "AREX" and ceType in ("ARC6",)):
+                    # preserve manually chosen AREX or ARC6 setting
+                    pass
+                else:
+                    addToChangeSet((ceSection, "CEType", ceType, newCEType), changeSet)
+
                 addToChangeSet((ceSection, "MaxRAM", ram, newRAM), changeSet)
 
                 for queue, queueInfo in ceInfo["Queues"].items():


### PR DESCRIPTION
If the ComputingShareEndpoints of an ARC like CE advertises an emies endpoint, we are going to use AREX as the CE, even if gridftpjob endpoint is also advertised. If only gridftpjob is advertised we stay with ARC6. If neither exists, we error out.

Also do not overwrite if we have already set AREX or ARC6 as the CE.

Not sure if this is the behaviour people want...

BEGINRELEASENOTES

*CS
NEW: BDII2CSAgent: allow using AREX or ARC6 Computing Elements instead of ARC, fixes #6541

ENDRELEASENOTES
