### PR TITLE
[v7r3] fix: ExtraPilotOptions can be a comma-separated list

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1022,7 +1022,8 @@ class SiteDirector(AgentModule):
             pilotOptions.append("-o '/LocalSite/SharedArea=%s'" % queueDict["SharedArea"])
 
         if "ExtraPilotOptions" in queueDict:
-            pilotOptions.append(queueDict["ExtraPilotOptions"])
+            for extraPilotOption in queueDict["ExtraPilotOptions"].split(","):
+                pilotOptions.append(extraPilotOption.strip())
 
         if "Modules" in queueDict:
             pilotOptions.append("--modules=%s" % queueDict["Modules"])


### PR DESCRIPTION
solves #6601

BEGINRELEASENOTES

*WMS
FIX: ExtraPilotOptions can be a comma-separated list

ENDRELEASENOTES
