### PR TITLE
[v7r3] fix(resources): drop "WholeNode" option in condor.py

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
@@ -85,25 +85,23 @@ class Condor(object):
         if not nJobs:
             nJobs = 1
         numberOfProcessors = kwargs.get("NumberOfProcessors")
-        wholeNode = kwargs.get("WholeNode")
         outputDir = kwargs["OutputDir"]
         executable = kwargs["Executable"]
         submitOptions = kwargs["SubmitOptions"]
         preamble = kwargs.get("Preamble")
-
-        if wholeNode:
-            requirements = (
-                '+RequiresWholeMachine=True\n Requirements = ( CAN_RUN_WHOLE_MACHINE ) && ( OpSys == "LINUX" )'
-            )
-        else:
-            requirements = 'Requirements = OpSys == "LINUX"'
+        if kwargs.get("WholeNode"):
+            resultDict["Status"] = -1
+            resultDict[
+                "Message"
+            ] = "The WholeNode option is deprecated and not applied anymore, please remove it from the CS to continue"
+            return resultDict
 
         jdlFile = tempfile.NamedTemporaryFile(dir=outputDir, suffix=".jdl")
         jdlFile.write(
             """
     Executable = %s
     Universe = vanilla
-    %s
+    Requirements = OpSys == "LINUX"
     Initialdir = %s
     Output = $(Cluster).$(Process).out
     Error = $(Cluster).$(Process).err
@@ -116,7 +114,7 @@ class Condor(object):
     Queue %s
 
     """
-            % (executable, requirements, outputDir, numberOfProcessors, nJobs)
+            % (executable, outputDir, numberOfProcessors, nJobs)
         )
 
         jdlFile.flush()


### PR DESCRIPTION
This PR aims at resolving this issue: https://github.com/DIRACGrid/DIRAC/issues/6598

The `WholeNode` option was passed as a string within `Condor.py`, not converted but used like a boolean (`if wholeNode:` -> `if "False":`).
The option seems buggy and not used anymore by the DIRAC community (and maybe even by the HTCondor users?).
The latest reference I found is from `HTCondor v7.4`: https://htcondor-wiki.cs.wisc.edu/index.cgi/wiki?p=WholeMachineSlots
Therefore, we have decided to delete it from DIRAC.
This will be discussed in the next BiLD-Dev meeting in case one disagrees with this decision. 

Also, it is worth noting that the DIRAC `WholeNode` option is not used anymore (well, only in the `CREAM` CE, which is deprecated).
Nevertheless, I have not deleted the mechanism to provide the option to the CEs, because we could add it to a few CEs/BatchSystems if required in the future (e.g. `slurm`, `ARC`).

I have not found (and not searched a lot I admit) any way to add this feature to recent versions of `HTCondor`.
I suggest that we just drop the option for now if nobody uses it.
We would make proper research in the future if it is needed. 

BEGINRELEASENOTES
*Resources
CHANGE: drop the WholeNode CE option from Condor
ENDRELEASENOTES
