### PR TITLE
[v7r3] fix stager wakeupOldRequests

### DIFF
--- a/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
@@ -140,7 +140,7 @@ class StorageManagementDB(DB):
             taskIDs.append(record[0])
             gLogger.verbose("%s.%s_DB: to_update Tasks =  %s" % (self._caller(), "__updateTaskStatus", record))
 
-        if len(taskIDs) > 0:
+        if taskIDs:
             reqSelect1 = "SELECT * FROM Tasks WHERE TaskID IN (%s);" % intListToString(taskIDs)
             resSelect1 = self._query(reqSelect1, connection)
             if not resSelect1["OK"]:
@@ -226,7 +226,7 @@ class StorageManagementDB(DB):
         for record in resSelect["Value"]:
             replicaIDs.append(record[0])
             gLogger.verbose("%s.%s_DB: to_update CacheReplicas =  %s" % (self._caller(), "updateReplicaStatus", record))
-        if len(replicaIDs) > 0:
+        if replicaIDs:
             reqSelect1 = "SELECT * FROM CacheReplicas WHERE ReplicaID IN (%s);" % intListToString(replicaIDs)
             resSelect1 = self._query(reqSelect1, connection)
             if not resSelect1["OK"]:
@@ -1127,7 +1127,7 @@ class StorageManagementDB(DB):
             errorString = "Wrong argument type"
             gLogger.exception(errorString)
             return S_ERROR(errorString)
-        if (replicaIDs) > 0:
+        if replicaIDs:
             req = (
                 "SELECT ReplicaID FROM StageRequests WHERE ReplicaID IN (%s) AND StageStatus='StageSubmitted' AND DATE_ADD( StageRequestSubmitTime, INTERVAL %s HOUR ) < UTC_TIMESTAMP();"
                 % (intListToString(replicaIDs), retryInterval)
@@ -1141,7 +1141,7 @@ class StorageManagementDB(DB):
 
             old_replicaIDs = [row[0] for row in res["Value"]]
 
-            if len(old_replicaIDs) > 0:
+            if old_replicaIDs:
                 req = (
                     "UPDATE CacheReplicas SET Status='New',LastUpdate = UTC_TIMESTAMP(), Reason = 'wakeupOldRequests' WHERE ReplicaID in (%s);"
                     % intListToString(old_replicaIDs)


### PR DESCRIPTION
Fixes the following exception, due to a python2 only construct

```python
Traceback (most recent call last):
  File "/opt/dirac/versions/v10.4.23-1669726292/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/DISET/RequestHandler.py", line 302, in __RPCCallFunction
    uReturnValue = oMethod(*args)
  File "/opt/dirac/versions/v10.4.23-1669726292/Linux-x86_64/lib/python3.9/site-packages/DIRAC/StorageManagementSystem/Service/StorageManagerHandler.py", line 352, in export_wakeupOldRequests
    res = cls.storageManagementDB.wakeupOldRequests(oldRequests, retryInterval)
  File "/opt/dirac/versions/v10.4.23-1669726292/Linux-x86_64/lib/python3.9/site-packages/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py", line 1130, in wakeupOldRequests
    if (replicaIDs) > 0:
TypeError: '>' not supported between instances of 'list' and 'int'
```

BEGINRELEASENOTES
*SMS
FIX: fix py3 incompatibility in wakeupOldRequests

ENDRELEASENOTES
