### PR TITLE
[v7r3] fix (resources): SSHCE getJobOutput

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
@@ -384,12 +384,22 @@ srun -l -k %(wrapper)s
         nodes = {}
         for line in outputLines:
             node, line_content = line.split(":", 1)
-            if node not in nodes:
-                nodes[node] = []
-            nodes[node].append(line_content)
+
+            # if node is not a number, then it is a general information (e.g. timeout)
+            # else, it is related to a specific node
+            if not node.isdigit():
+                key = "General Information"
+                line_content = line
+            else:
+                key = "Node %s" % node
+
+            if key not in nodes:
+                nodes[key] = []
+            nodes[key].append(line_content)
+            print(nodes)
 
         content = ""
         for node, lines in nodes.items():
-            content += "# On node %s\n\n" % node
+            content += "# %s\n\n" % node
             content += "\n".join(lines) + "\n"
         return content

--- a/src/DIRAC/Resources/Computing/BatchSystems/test/Test_SLURM.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/test/Test_SLURM.py
@@ -44,8 +44,9 @@ srunOutput = """
 
 """
 
+
 srunExpected1 = """
-# On node 1
+# Node 1
 
  line1
  line2
@@ -54,7 +55,7 @@ srunExpected1 = """
 
 
 srunExpected2 = """
-# On node 3
+# Node 3
 
  line1
  line2
@@ -63,7 +64,7 @@ srunExpected2 = """
 
 
 srunExpected3 = """
-# On node 2
+# Node 2
 
  line1
  line2
@@ -72,6 +73,47 @@ srunExpected3 = """
 
 
 srunExpected = [srunExpected1, srunExpected2, srunExpected3]
+
+
+killedSrunOutput = """
+1: line1
+1: line2
+2: line1
+1: line3
+2: line2
+srun: Job step aborted: Waiting up to 32 seconds for job step to finish.
+slurmstepd: error: *** JOB 9999 ON hpc CANCELLED DUE TO TIME LIMIT ***
+1: slurmstepd: error: *** STEP 9999 ON hpc CANCELLED DUE TO TIME LIMIT ***
+
+"""
+
+
+killedSrunExpected1 = """
+# Node 1
+
+ line1
+ line2
+ line3
+ slurmstepd: error: *** STEP 9999 ON hpc CANCELLED DUE TO TIME LIMIT ***
+"""
+
+
+killedSrunExpected2 = """
+# Node 2
+
+ line1
+ line2
+"""
+
+killedSrunExpectedGI = """
+# General Information
+
+srun: Job step aborted: Waiting up to 32 seconds for job step to finish.
+slurmstepd: error: *** JOB 9999 ON hpc CANCELLED DUE TO TIME LIMIT ***
+"""
+
+
+killedSrunExpected = [killedSrunExpected1, killedSrunExpected2, killedSrunExpectedGI]
 
 
 normalOutput = """
@@ -118,6 +160,7 @@ def test_generateWrapper(mocker, expectedContent):
     "numberOfNodes, outputContent, expectedContent",
     [
         ("3-5", srunOutput, srunExpected),
+        ("3-5", killedSrunOutput, killedSrunExpected),
         ("1", normalOutput, normalExpected),
     ],
 )


### PR DESCRIPTION
This PR aims at fixing `SSHCE.getJobOutput()`.
So far, we have been unable to get pilot outputs because of : `invalid output from remote command`.

Fixes:
- get the hostname from the jobID if available, else it will be retrieved automatically from the CE parameters (`SSHHost`).
- return stdout and stderr instead of stderr twice.
- if we have a multi-node allocation in SLURM and that the job is killed, some logs appear as general information and are not bound to a specific node, this is now handled. 


BEGINRELEASENOTES
*Resources
FIX: SSHCE getJobOutput()
FIX: SLURM getJobOutput() when multi-node allocation and that the job is killed
ENDRELEASENOTES
