### PR TITLE
[v7r3] dirac-admin-add-host fix for long option names

### DIFF
--- a/src/DIRAC/Interfaces/scripts/dirac_admin_add_host.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_add_host.py
@@ -47,10 +47,10 @@ def main():
     global hostName
     global hostDN
     global hostProperties
-    Script.registerSwitch("H:", "HostName:", "Name of the Host (Mandatory)", setHostName)
-    Script.registerSwitch("D:", "HostDN:", "DN of the Host Certificate (Mandatory)", setHostDN)
+    Script.registerSwitch("H:", "HostName=", "Name of the Host (Mandatory)", setHostName)
+    Script.registerSwitch("D:", "HostDN=", "DN of the Host Certificate (Mandatory)", setHostDN)
     Script.registerSwitch(
-        "P:", "Property:", "Property to be added to the Host (Allow Multiple instances or None)", addProperty
+        "P:", "Property=", "Property to be added to the Host (Allow Multiple instances or None)", addProperty
     )
     # Registering arguments will automatically add their description to the help menu
     Script.registerArgument(


### PR DESCRIPTION

BEGINRELEASENOTES

*Interfaces
FIX: dirac-admin-add-host: fixed to allow use of long option names

ENDRELEASENOTES
