### PR TITLE
[8.0] Fix running with OpenSSL 3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - opensearch-dsl
   - fts3
   - gitpython >=2.1.0
-  - m2crypto >=0.36,!=0.38.0
+  - m2crypto >=0.38.0
   - matplotlib
   - numpy
   - pexpect >=4.0.1

--- a/src/DIRAC/Core/Security/VOMS.py
+++ b/src/DIRAC/Core/Security/VOMS.py
@@ -15,6 +15,9 @@ from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-er
 from DIRAC.Core.Utilities.Subprocess import shellCall
 from DIRAC.Core.Utilities import List
 
+# This is a variable so it can be monkeypatched in tests
+VOMS_PROXY_INIT_CMD = "voms-proxy-init"
+
 
 class VOMS(BaseSecurity):
     def __init__(self, timeout=80, *args, **kwargs):
@@ -266,7 +269,7 @@ class VOMS(BaseSecurity):
             return retVal
         newProxyLocation = retVal["Value"]
 
-        cmd = ["voms-proxy-init"]
+        cmd = [VOMS_PROXY_INIT_CMD]
         if chain.isLimitedProxy()["Value"]:
             cmd.append("-limited")
         cmd += ["-cert", proxyLocation]

--- a/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
@@ -99,7 +99,7 @@ class X509Certificate:
         issuerSubjectObj = x509Issuer.__certObj.get_subject()
         issuerSubjectParts = issuerSubjectObj.as_text().split(", ")
 
-        for isPart in issuerSubjectParts:
+        for isPart in [y for x in issuerSubjectParts for y in x.split("/")]:
             nid, val = isPart.split("=", 1)
             proxySubject.add_entry_by_txt(field=nid, type=M2Crypto.ASN1.MBSTRING_ASC, entry=val, len=-1, loc=-1, set=0)
 

--- a/src/DIRAC/Core/Security/m2crypto/X509Chain.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Chain.py
@@ -447,11 +447,12 @@ class X509Chain:
 
         issuerCert = self._certList[0]
 
+        # Generating key is a two step process: create key object and then assign RSA key.
+        # This contains both the private and public key
+        newKey = M2Crypto.EVP.PKey()
+        newKey.assign_rsa(M2Crypto.RSA.gen_key(strength, 65537, callback=M2Crypto.util.quiet_genparam_callback))
         if not proxyKey:
-            # Generating key is a two step process: create key object and then assign RSA key.
-            # This contains both the private and public key
-            proxyKey = M2Crypto.EVP.PKey()
-            proxyKey.assign_rsa(M2Crypto.RSA.gen_key(strength, 65537, callback=M2Crypto.util.quiet_genparam_callback))
+            proxyKey = newKey
 
         # Generate a new X509Certificate object
         proxyExtensions = self.__getProxyExtensionList(diracGroup, limited)
@@ -466,7 +467,7 @@ class X509Chain:
         # Generate the proxy string
         proxyString = "{}{}".format(
             proxyCert.asPem(),
-            proxyKey.as_pem(cipher=None, callback=M2Crypto.util.no_passphrase_callback).decode("ascii"),
+            newKey.as_pem(cipher=None, callback=M2Crypto.util.no_passphrase_callback).decode("ascii"),
         )
         for i in range(len(self._certList)):
             crt = self._certList[i]
@@ -831,7 +832,7 @@ class X509Chain:
         # You can't request a limit proxy if you are yourself not limited ?!
         # I think it should be a "or" instead of "and"
         limited = requireLimited and self.isLimitedProxy().get("Value", False)
-        return self.generateProxyToString(lifetime, diracGroup, None, limited, req.get_pubkey())
+        return self.generateProxyToString(lifetime, diracGroup, DEFAULT_PROXY_STRENGTH, limited, req.get_pubkey())
 
     @needCertList
     def getRemainingSecs(self):

--- a/tests/Integration/Framework/Test_ProxyDB.py
+++ b/tests/Integration/Framework/Test_ProxyDB.py
@@ -632,7 +632,13 @@ class testDB(ProxyDBTestCase):
                     "voms-proxy-fake command not working as expected, proxy have no VOMS extention, go to the next.."
                 )
                 continue
-            result = db.getVOMSProxy(dn, group, time, role)
+            VOMS_PROXY_INIT_CMD = DIRAC.Core.Security.VOMS.VOMS_PROXY_INIT_CMD
+            DIRAC.Core.Security.VOMS.VOMS_PROXY_INIT_CMD = "voms-proxy-fake"
+            try:
+                result = db.getVOMSProxy(dn, group, time, role)
+            finally:
+                DIRAC.Core.Security.VOMS.VOMS_PROXY_INIT_CMD = VOMS_PROXY_INIT_CMD
+
             self.assertFalse(result["OK"], "Must be fail.")
             gLogger.info("Msg: %s" % result["Message"])
         # Check stored proxies


### PR DESCRIPTION
There were a couple of places DIRAC was exploiting bugs in OpenSSL that have been fixed in OpenSSL 3.0.0 and therefore no longer work. The bugs are:

* certificate signing requests don't include a private key so trying to use it is nonsensical
* `add_entry_by_txt` now escapes `/` characters causing DNs like `CN=MrUser\\/emailAddress=good@mail.com`

I also:

* make the tests use `voms-proxy-fake` which shaves ~4 minutes of the proxy DB tests
* re-enable m2crypto 0.38.0 as it's been patched in conda-forge

This is targetting v8 as it might make sense to test on Monday's LHCbDIRAC hackathon but it will then need to be backported.

BEGINRELEASENOTES

*Core
FIX: Support OpenSSL 3.0.x

ENDRELEASENOTES
