### PR TITLE
[8.0] test: adding a test for _getSiteCandidates

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Executor/InputData.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/InputData.py
@@ -385,8 +385,6 @@ class InputData(OptimizerExecutor):
                     if seStatus["DiskSE"]:
                         # Sets contain only unique elements, no need to check if it's there
                         diskLFNs.add(lfn)
-                        if lfn in tapeLFNs:
-                            tapeLFNs.remove(lfn)
                     if seStatus["TapeSE"]:
                         if lfn not in diskLFNs:
                             tapeLFNs.add(lfn)

--- a/src/DIRAC/WorkloadManagementSystem/Executor/InputData.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/InputData.py
@@ -23,6 +23,12 @@ class InputData(OptimizerExecutor):
       - optimizeJob() - the main method called for each job
     """
 
+    def __init__(self) -> None:
+
+        self.__lastCacheUpdate = 0
+        self.__cacheLifeTime = 600
+        super().__init__()
+
     @classmethod
     def initializeOptimizer(cls):
         """Initialize specific parameters for InputData executor."""
@@ -218,7 +224,7 @@ class InputData(OptimizerExecutor):
             return result
         okReplicas = result["Value"]
 
-        result = self.__getSiteCandidates(okReplicas, vo)
+        result = self._getSiteCandidates(okReplicas, vo)
         if not result["OK"]:
             self.jobLog.error("Failed to check SiteCandidates", result["Message"])
             return result
@@ -313,7 +319,7 @@ class InputData(OptimizerExecutor):
         return S_OK(self.__SEToSiteMap[seName])
 
     #############################################################################
-    def __getSiteCandidates(self, okReplicas, vo):
+    def _getSiteCandidates(self, okReplicas, vo):
         """This method returns a list of possible site candidates based on the job input data requirement.
 
         For each site candidate, the number of files on disk and tape is resolved.

--- a/src/DIRAC/WorkloadManagementSystem/Executor/InputData.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/InputData.py
@@ -386,12 +386,11 @@ class InputData(OptimizerExecutor):
                         # Sets contain only unique elements, no need to check if it's there
                         diskLFNs.add(lfn)
                     if seStatus["TapeSE"]:
-                        if lfn not in diskLFNs:
-                            tapeLFNs.add(lfn)
+                        tapeLFNs.add(lfn)
 
-        for siteName in sitesData:
-            sitesData[siteName]["disk"] = len(sitesData[siteName]["disk"])
-            sitesData[siteName]["tape"] = len(sitesData[siteName]["tape"])
+        for _, siteData in sitesData.items():
+            siteData["disk"] = len(siteData["disk"])
+            siteData["tape"] = len(siteData["tape"])
         return S_OK(sitesData)
 
     @executeWithUserProxy

--- a/src/DIRAC/WorkloadManagementSystem/Executor/test/Test_Executor.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/test/Test_Executor.py
@@ -163,6 +163,13 @@ def test__getInputSandbox(mocker, manifestOptions, expected):
             True,
             {"Site_1": {"disk": 2, "tape": 1}, "Site_2": {"disk": 2, "tape": 1}},
         ),
+        (
+            {"lfn_1": ["SE_1"], "lfn_2": ["SE_1", "SE_2"]},
+            {"OK": True, "Value": ["Site_1", "Site_2"]},
+            {"OK": True, "Value": {"DiskSE": True, "TapeSE": False}},
+            True,
+            {"Site_1": {"disk": 2, "tape": 1}, "Site_2": {"disk": 2, "tape": 1}},
+        ),
     ],
 )
 def test__getSiteCandidates(mocker, okReplicas, getSitesForSE_RV, storageGetStatus_RV, expectedRes, expectedValue):

--- a/src/DIRAC/WorkloadManagementSystem/Executor/test/Test_Executor.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/test/Test_Executor.py
@@ -5,6 +5,8 @@
 from unittest.mock import MagicMock
 import pytest
 
+from DIRAC import gLogger
+
 from DIRAC.WorkloadManagementSystem.Client.JobState.CachedJobState import CachedJobState
 from DIRAC.WorkloadManagementSystem.Client.JobState.JobManifest import JobManifest
 
@@ -14,6 +16,9 @@ from DIRAC.WorkloadManagementSystem.Executor.InputData import InputData
 
 mockNone = MagicMock()
 mockNone.return_value = None
+
+
+# JobScheduling
 
 
 @pytest.mark.parametrize(
@@ -72,6 +77,9 @@ def test__getTagsFromManifest(manifestOptions, expected):
     assert set(tagList) == set(expected)
 
 
+# InputData
+
+
 @pytest.mark.parametrize(
     "manifestOptions, expected",
     [
@@ -107,3 +115,73 @@ def test__getInputSandbox(mocker, manifestOptions, expected):
     res = inputData._getInputSandbox(js)
     assert res["OK"] is True
     assert res["Value"] == expected
+
+
+@pytest.mark.parametrize(
+    "okReplicas, getSitesForSE_RV, storageGetStatus_RV, expectedRes, expectedValue",
+    [
+        ({}, None, None, False, None),
+        (
+            {"lfn_1": ["SE_1"]},
+            {"OK": True, "Value": ["Site_1"]},
+            {"OK": True, "Value": {"DiskSE": True, "TapeSE": False}},
+            True,
+            {"Site_1": {"disk": 1, "tape": 0}},
+        ),
+        (
+            {"lfn_1": ["SE_2"]},
+            {"OK": True, "Value": ["Site_1"]},
+            {"OK": True, "Value": {"DiskSE": False, "TapeSE": True}},
+            True,
+            {"Site_1": {"disk": 0, "tape": 1}},
+        ),
+        (
+            {"lfn_1": ["SE_1"]},
+            {"OK": True, "Value": ["Site_1", "Site_2"]},
+            {"OK": True, "Value": {"DiskSE": True, "TapeSE": False}},
+            True,
+            {"Site_1": {"disk": 1, "tape": 0}, "Site_2": {"disk": 1, "tape": 0}},
+        ),
+        (
+            {"lfn_1": ["SE_1"], "lfn_2": ["SE_1"]},
+            {"OK": True, "Value": ["Site_1", "Site_2"]},
+            {"OK": True, "Value": {"DiskSE": True, "TapeSE": False}},
+            True,
+            {"Site_1": {"disk": 2, "tape": 0}, "Site_2": {"disk": 2, "tape": 0}},
+        ),
+        (
+            {"lfn_1": ["SE_1"], "lfn_2": ["SE_2"]},
+            {"OK": True, "Value": ["Site_1", "Site_2"]},
+            {"OK": True, "Value": {"DiskSE": False, "TapeSE": True}},
+            True,
+            {"Site_1": {"disk": 1, "tape": 1}, "Site_2": {"disk": 1, "tape": 1}},
+        ),
+        (
+            {"lfn_1": ["SE_1"], "lfn_2": ["SE_2", "SE_3"]},
+            {"OK": True, "Value": ["Site_1", "Site_2"]},
+            {"OK": True, "Value": {"DiskSE": True, "TapeSE": False}},
+            True,
+            {"Site_1": {"disk": 2, "tape": 1}, "Site_2": {"disk": 2, "tape": 1}},
+        ),
+    ],
+)
+def test__getSiteCandidates(mocker, okReplicas, getSitesForSE_RV, storageGetStatus_RV, expectedRes, expectedValue):
+
+    mockSE = MagicMock()
+    mockSE.getStatus.return_value = storageGetStatus_RV
+
+    mocker.patch("DIRAC.WorkloadManagementSystem.Client.JobState.JobState.JobDB.__init__", side_effect=mockNone)
+    mocker.patch("DIRAC.WorkloadManagementSystem.Client.JobState.JobState.JobLoggingDB.__init__", side_effect=mockNone)
+    mocker.patch("DIRAC.WorkloadManagementSystem.Client.JobState.JobState.TaskQueueDB.__init__", side_effect=mockNone)
+    mocker.patch(
+        "DIRAC.DataManagementSystem.Utilities.DMSHelpers.DMSHelpers.getSitesForSE", return_value=getSitesForSE_RV
+    )
+    mocker.patch("DIRAC.Resources.Storage.StorageElement.StorageElementItem", return_value=mockSE)
+
+    inputData = InputData()
+    inputData.log = gLogger
+    # inputData.jobLog = gLogger
+    res = inputData._getSiteCandidates(okReplicas, "vo")
+    assert res["OK"] is expectedRes
+    if res["OK"]:
+        assert res["Value"] == expectedValue


### PR DESCRIPTION
Possibly fixing bug seen in https://trello.com/c/DBnpgreL/26-submit-user-jobs-client-and-server-same-version and jobs "jobWithInputDataAndAncestor", which fail with "Site candidates do not have all the input data". 
The case is this:

```bash
bash-4.2$ dirac-dms-lfn-replicas /lhcb/data/2010/SDST/00008375/0005/00008375_00053941_1.sdst
Successful : 
    /lhcb/data/2010/SDST/00008375/0005/00008375_00053941_1.sdst : 
        SARA-RDST : srm://srm.grid.sara.nl:8443/srm/managerv2?SFN=/pnfs/grid.sara.nl/data/lhcb/LHCb-Tape/lhcb/data/2010/SDST/00008375/0005/00008375_00053941_1.sdst
bash-4.2$ dirac-dms-lfn-replicas /lhcb/data/2010/RAW/FULL/LHCb/COLLISION10/81616/081616_0000000213.raw
Successful : 
    /lhcb/data/2010/RAW/FULL/LHCb/COLLISION10/81616/081616_0000000213.raw : 
        CERN-RAW : root://x509up_u49429@eosctalhcb.cern.ch//eos/ctalhcb/archive/grid/lhcb/data/2010/RAW/FULL/LHCb/COLLISION10/81616/081616_0000000213.raw
        SARA-RAW : srm://srm.grid.sara.nl:8443/srm/managerv2?SFN=/pnfs/grid.sara.nl/data/lhcb/LHCb-Tape/lhcb/data/2010/RAW/FULL/LHCb/COLLISION10/81616/081616_0000000213.raw
```

```ipython
In [10]: DMSHelpers().getSitesForSE('SARA-RAW')
Out[10]: {'OK': True, 'Value': ['LCG.NIKHEF.nl', 'LCG.SARA.nl']}

In [11]: DMSHelpers().getSitesForSE('SARA-RDST')
Out[11]: {'OK': True, 'Value': ['LCG.NIKHEF.nl', 'LCG.SARA.nl']}
```

BEGINRELEASENOTES

*WMS
FIX: InputData optimizer: keep the tape LFNs in

ENDRELEASENOTES

Let me know if you think it's wrong!
