### PR TITLE
[v7r3] Still report AREX statuses if renew/cancel fails

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -643,13 +643,15 @@ class AREXComputingElement(ARCComputingElement):
         if jobsToRenew:
             result = self._renewJobs(jobsToRenew)
             if not result["OK"]:
-                return result
+                # Only log here as we still want to return statuses
+                self.log.warn("Failed to renew job proxies:", result["Message"])
 
         # Kill jobs to be killed
         if jobsToCancel:
             result = self._killJob(jobsToCancel)
             if not result["OK"]:
-                return result
+                # Only log here as we still want to return statuses
+                self.log.warn("Failed to kill held jobs:", result["Message"])
 
         return S_OK(resultDict)
 


### PR DESCRIPTION
Hi,

Another small suggestion... If the renew or cancel of jobs fails, it'd still be good to return the job statuses e.g. return S_OK from getJobStatus. Any comments?

Regards,
Simon

BEGINRELEASENOTES
*Resources
FIX: Still report AREX statuses if renew/cancel fails
ENDRELEASENOTES
