### PR TITLE
[v8.0] LHCbDIRAC Hackaton fixes

### DIFF
--- a/src/DIRAC/DataManagementSystem/Client/ConsistencyInspector.py
+++ b/src/DIRAC/DataManagementSystem/Client/ConsistencyInspector.py
@@ -712,7 +712,7 @@ class ConsistencyInspector:
     def _getCatalogReplicas(self, lfns):
         """Obtain the file replicas from the catalog while checking that there are replicas"""
         if not lfns:
-            return S_OK(([], []))
+            return S_OK(({}, []))
 
         gLogger.info("Obtaining the replicas for %s files" % len(lfns))
         zeroReplicaFiles = []

--- a/src/DIRAC/Resources/Storage/GFAL2_SRM2Storage.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_SRM2Storage.py
@@ -158,9 +158,9 @@ class GFAL2_SRM2Storage(GFAL2_StorageBase):
             extendedAttr = self._getExtendedAttributes(path, attributes=["user.replicas"])
             return S_OK(extendedAttr["user.replicas"])
         except gfal2.GError as e:
-            errMsg = "GFAL2_SRM2Storage.__getSingleTransportURL: Extended attribute tURL is not set"
+            errMsg = "GFAL2_SRM2Storage.__getSingleTransportURL: error getting user.replicas extended attribute"
             self.log.debug(errMsg, repr(e))
-            return S_ERROR(errMsg)
+            return S_ERROR(e.code, errMsg)
         finally:
             self.__setSRMOptionsToDefault()
 

--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -356,6 +356,7 @@ class GFAL2_StorageBase(StorageBase):
 
         # If we do a TPC, we want the file size to be specified
         else:
+            src_url = src_file
             if not sourceSize:
                 raise ValueError("sourceSize argument is mandatory for TPC copy")
 


### PR DESCRIPTION
The second commit fixes something long broken: interactive TPC replication to an SRM storage...

BEGINRELEASENOTES


*DMS
FIX:  fix a non initialized variable when doing a TPC with gfal2
FIX:  propagate error number when calling getTURL in SRM2
FIX : ConsistencyInspector default value should be a dict and not a list


ENDRELEASENOTES
