### PR TITLE
[v7r3] fix accounting JobsPerPilot plot

### DIFF
--- a/src/DIRAC/AccountingSystem/private/Plotters/PilotPlotter.py
+++ b/src/DIRAC/AccountingSystem/private/Plotters/PilotPlotter.py
@@ -190,8 +190,9 @@ class PilotPlotter(BaseReporter):
             "endtime": reportRequest["endTime"],
             "span": plotInfo["granularity"],
             "ylabel": "jobs/pilot",
-            "normalization": max(x for y in plotInfo["data"].values() for x in y.values()),
         }
+        if plotInfo["data"]:
+            metadata["normalization"] = max(x for y in plotInfo["data"].values() for x in y.values())
         return self._generateQualityPlot(filename, plotInfo["data"], metadata)
 
     def _reportTotalNumberOfPilots(self, reportRequest):


### PR DESCRIPTION
Very minor fix in the accounting system.
When we want to generate a plot `Pilot -> JobsPerPilot` grouped by a non-involved CE, we get the following exception:

```python
2023-01-17 09:57:33 UTC Accounting/ReportGenerator INFO: Plotting data for Pilot:JobsPerPilot
2023-01-17 09:57:33 UTC Accounting/ReportGenerator ERROR: Exception while generating plot
Traceback (most recent call last):
  File "/opt/dirac/versions/v11.0.0a14-1673942397/Linux-x86_64/lib/python3.9/site-packages/DIRAC/AccountingSystem/Service/ReportGeneratorHandler.py", line 208, in transfer_toClient
    result = self.__generatePlotFromFileId(fileId)
  File "/opt/dirac/versions/v11.0.0a14-1673942397/Linux-x86_64/lib/python3.9/site-packages/DIRAC/AccountingSystem/Service/ReportGeneratorHandler.py", line 183, in __generatePlotFromFileId
    result = self.export_generatePlot(plotRequest)
  File "/opt/dirac/versions/v11.0.0a14-1673942397/Linux-x86_64/lib/python3.9/site-packages/DIRAC/AccountingSystem/Service/ReportGeneratorHandler.py", line 120, in export_generatePlot
    return reporter.generate(reportRequest, self.getRemoteCredentials())
  File "/opt/dirac/versions/v11.0.0a14-1673942397/Linux-x86_64/lib/python3.9/site-packages/DIRAC/AccountingSystem/private/MainReporter.py", line 61, in generate
    return plotter.generate(reportRequest)
  File "/opt/dirac/versions/v11.0.0a14-1673942397/Linux-x86_64/lib/python3.9/site-packages/DIRAC/AccountingSystem/private/Plotters/BaseReporter.py", line 139, in generate
    retVal = self.__generatePlotForReport(reportRequest, reportHash, reportData)
  File "/opt/dirac/versions/v11.0.0a14-1673942397/Linux-x86_64/lib/python3.9/site-packages/DIRAC/AccountingSystem/private/Plotters/BaseReporter.py", line 175, in __generatePlotForReport
    return gDataCache.getReportPlot(reportRequest, reportHash, reportData, funcObj)
  File "/opt/dirac/versions/v11.0.0a14-1673942397/Linux-x86_64/lib/python3.9/site-packages/DIRAC/Core/Utilities/Plotting/DataCache.py", line 58, in getReportPlot
    retVal = plotFunc(reportRequest, reportData, basePlotFileName)
  File "/opt/dirac/versions/v11.0.0a14-1673942397/Linux-x86_64/lib/python3.9/site-packages/DIRAC/AccountingSystem/private/Plotters/PilotPlotter.py", line 189, in _plotJobsPerPilot
    "normalization": max(x for y in plotInfo["data"].values() for x in y.values()),
ValueError: max() arg is an empty sequence
```

This PR aims at fixing this issue.


BEGINRELEASENOTES
*Accounting
FIX: JobsPerPilot plot when no data available
ENDRELEASENOTES
