### PR TITLE
[7.3] Matcher fix tag is empty string (backport)

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/Matcher.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/Matcher.py
@@ -187,7 +187,8 @@ class Matcher(object):
             if name in resourceDescription:
                 resourceDict[name] = resourceDescription[name]
 
-        if resourceDescription.get("Tag"):
+        # resourceDescription["Tag"] can be ''
+        if "Tag" in resourceDescription:
             tags = resourceDescription["Tag"]
             resourceDict["Tag"] = (
                 tags if isinstance(tags, list) else list({tag.strip("\"' ") for tag in tags.strip("[]").split(",")})


### PR DESCRIPTION
Backport from #6701 
BEGINRELEASENOTES

*WMS
FIX: Matcher handles cases of empty Tag in resource description

ENDRELEASENOTES
