### PR TITLE
[v7r3] fix ComponentSupervisionAgent issue with duplicate module name

### DIFF
--- a/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
@@ -209,23 +209,24 @@ class ComponentSupervisionAgent(AgentModule):
         runningComponents = defaultdict(dict)
         for system, components in val.items():
             for componentName, componentInfo in components.items():
+                fullName = "%s__%s" % (system, componentName)
                 if componentInfo["Setup"] and componentInfo["Installed"]:
                     if runitStatus != "All" and componentInfo["RunitStatus"] != runitStatus:
                         continue
                     for option, default in (("PollingTime", HOUR), ("Port", None), ("Protocol", None)):
-                        runningComponents[componentName][option] = self._getComponentOption(
+                        runningComponents[fullName][option] = self._getComponentOption(
                             instanceType, system, componentName, option, default
                         )
                         # remove empty values so we can use defaults in _getURL
-                        if not runningComponents[componentName][option]:
-                            runningComponents[componentName].pop(option)
-                    runningComponents[componentName]["LogFileLocation"] = os.path.join(
+                        if not runningComponents[fullName][option]:
+                            runningComponents[fullName].pop(option)
+                    runningComponents[fullName]["LogFileLocation"] = os.path.join(
                         self.diracLocation, "runit", system, componentName, "log", "current"
                     )
-                    runningComponents[componentName]["PID"] = componentInfo["PID"]
-                    runningComponents[componentName]["Module"] = componentInfo["Module"]
-                    runningComponents[componentName]["RunitStatus"] = componentInfo["RunitStatus"]
-                    runningComponents[componentName]["System"] = system
+                    runningComponents[fullName]["PID"] = componentInfo["PID"]
+                    runningComponents[fullName]["Module"] = componentInfo["Module"]
+                    runningComponents[fullName]["RunitStatus"] = componentInfo["RunitStatus"]
+                    runningComponents[fullName]["System"] = system
 
         return S_OK(runningComponents)
 
@@ -589,6 +590,7 @@ class ComponentSupervisionAgent(AgentModule):
 
     def _getURL(self, serviceName, options):
         """Return URL for the service."""
+        serviceName = serviceName.rsplit("__")[-1]
         system = options["System"]
         port = options.get("Port", self._tornadoPort)
         host = socket.getfqdn()

--- a/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
@@ -209,10 +209,10 @@ class TestComponentSupervisionAgent(unittest.TestCase):
         self.restartAgent.sysAdminClient.getOverallStatus.return_value = S_OK(agents)
         res = self.restartAgent.getRunningInstances(instanceType="Agents")
 
-        # only insalled agents with RunitStatus RUN should be returned
-        self.assertTrue("FTSAgent" not in res["Value"])
-        self.assertTrue("FTS3Agent" in res["Value"])
-        self.assertTrue("ErrorMessageMonitor" in res["Value"])
+        # only installed agents with RunitStatus RUN should be returned
+        self.assertTrue("DataManagement__FTSAgent" not in res["Value"])
+        self.assertTrue("DataManagement__FTS3Agent" in res["Value"])
+        self.assertTrue("Framework__ErrorMessageMonitor" in res["Value"])
         for agent in res["Value"]:
             self.assertTrue("PollingTime" in res["Value"][agent])
             self.assertTrue("LogFileLocation" in res["Value"][agent])


### PR DESCRIPTION
The Framework/Monitoring and Monitoring/Monitoring where both tried to be stored in the dictionary under Monitoring resulting in one of them not being treated correctly if both were present on a machine

BEGINRELEASENOTES

*Framework
FIX: ComponentSupervisionAgent: Fix problem if two instances in different systems but with the same name are present on the same machine (e.g., Framework/Monitoring and Monitoring/Monitoring)


ENDRELEASENOTES

TODO
- [x] Adapt tests
