### PR TITLE
[8.0] remove stupid CS sync when getting MQ config

### DIFF
--- a/src/DIRAC/Resources/MessageQueue/Utilities.py
+++ b/src/DIRAC/Resources/MessageQueue/Utilities.py
@@ -2,7 +2,6 @@
 """
 import queue
 from DIRAC import S_OK, S_ERROR, gConfig
-from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 
 
 def getMQParamsFromCS(mqURI):
@@ -16,10 +15,6 @@ def getMQParamsFromCS(mqURI):
     Returns:
       S_OK(param_dicts) or S_ERROR
     """
-    # API initialization is required to get an up-to-date configuration from the CS
-    csAPI = CSAPI()
-    csAPI.initialize()
-
     try:
         mqService, mqType, mqName = mqURI.split("::")
     except ValueError:


### PR DESCRIPTION
This was blocking most of the agent !!! The reason we see it now is the increased usage of Monitoring, which uses MQ as fallback. 
I'll probably have another bigger PR cleaning up a bit all that mess... in the meantime, this helps a lot already

BEGINRELEASENOTES

*Resources
FIX:  remove stupid CS sync when getting MQ config

ENDRELEASENOTES
