### PR TITLE
[v7r3] FileHelper bytes

### DIFF
--- a/src/DIRAC/Core/DISET/private/FileHelper.py
+++ b/src/DIRAC/Core/DISET/private/FileHelper.py
@@ -152,7 +152,7 @@ class FileHelper(object):
         return S_OK(stringIO.getvalue())
 
     def networkToFD(self, iFD, maxFileSize=0):
-        dataSink = os.fdopen(iFD, "w")
+        dataSink = os.fdopen(iFD, "wb")
         try:
             return self.networkToDataSink(dataSink, maxFileSize=maxFileSize)
         finally:
@@ -326,7 +326,7 @@ class FileHelper(object):
         if "write" in dir(wPipe):
             filePipe = wPipe
         else:
-            filePipe = os.fdopen(wPipe, "w")
+            filePipe = os.fdopen(wPipe, "wb")
         tarMode = "w|"
         if compress:
             tarMode = "w|bz2"
@@ -370,7 +370,7 @@ class FileHelper(object):
             return response
 
     def __extractTar(self, destDir, rPipe, compress):
-        filePipe = os.fdopen(rPipe, "r")
+        filePipe = os.fdopen(rPipe, "rb")
         tarMode = "r|*"
         if compress:
             tarMode = "r|bz2"
@@ -402,7 +402,7 @@ class FileHelper(object):
         return retList[0]
 
     def bulkListToNetwork(self, iFD, compress=True):
-        filePipe = os.fdopen(iFD, "r")
+        filePipe = os.fdopen(iFD, "rb")
         try:
             tarMode = "r|"
             if compress:


### PR DESCRIPTION
When trying to get some files from a DIP StorageElement Handler (se.getDirectory), an exception is encountered.
```
  File "/Work/DIRAC/diracos/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/Work/DIRAC/diracos/lib/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "/Work/DIRAC/diracos/lib/python3.9/site-packages/DIRAC/Core/DISET/private/FileHelper.py", line 389, in __receiveToPipe
    retList.append(self.networkToFD(wPipe, maxFileSize=maxFileSize))
  File "/Work/DIRAC/diracos/lib/python3.9/site-packages/DIRAC/Core/DISET/private/FileHelper.py", line 157, in networkToFD
    return self.networkToDataSink(dataSink, maxFileSize=maxFileSize)
  File "/Work/DIRAC/diracos/lib/python3.9/site-packages/DIRAC/Core/DISET/private/FileHelper.py", line 186, in networkToDataSink
    dataSink.write(strBuffer)
TypeError: write() argument must be str, not bytes
```
Opening the files in "b" mode fixes that.
Not sure all of the changes are needed, I just changed all of them...
I am a bit lost about the python2/python3 implications, so comments welcome.

- [ ] I will also write a test to use the StorageElementHandler in the integration test that should trigger these code paths and convince myself things are fixed properly.

BEGINRELEASENOTES

*Core
FIX: Fix in FileHelper module writing to file, fixed exception "TypeError: write() argument must be str, not bytes, because file was opened in the wrong mode.

ENDRELEASENOTES
