### PR TITLE
[v7r3] Ensure all entrypoints are importable

### DIFF
--- a/src/DIRAC/Core/Utilities/test/Test_entrypoints.py
+++ b/src/DIRAC/Core/Utilities/test/Test_entrypoints.py
@@ -1,0 +1,16 @@
+import importlib_metadata as metadata
+import pytest
+import six
+
+
+@pytest.mark.skipif(six.PY2, reason="Only makes sense for Python 3 installs")
+def test_entrypoints():
+    """Make sure all console_scripts defined by DIRAC are importable."""
+    errors = []
+    for ep in metadata.entry_points(group="console_scripts"):  # pylint: disable=unexpected-keyword-arg
+        if ep.module.startswith("DIRAC"):
+            try:
+                ep.load()
+            except ModuleNotFoundError as e:  # pylint: disable=undefined-variable
+                errors.append(str(e))
+    assert not errors, errors


### PR DESCRIPTION
Adds a test which we've found was useful in LHCb to make sure that all of the scripts are importable.