### PR TITLE
[v7r3] Backport: adapt mapper to sqlalchemy2.0

### DIFF
--- a/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
@@ -15,7 +15,7 @@ import errno
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql.expression import and_
-from sqlalchemy.orm import relationship, sessionmaker, mapper
+from sqlalchemy.orm import relationship, sessionmaker, registry
 from sqlalchemy.sql import update, delete
 from sqlalchemy import (
     create_engine,
@@ -45,6 +45,7 @@ __RCSID__ = "$Id$"
 
 
 metadata = MetaData()
+mapper_registry = registry()
 
 # Define the default utc_timestampfunction.
 # We overwrite it in the case of sqlite in the tests
@@ -69,7 +70,7 @@ fts3FileTable = Table(
     mysql_engine="InnoDB",
 )
 
-mapper(FTS3File, fts3FileTable)
+mapper_registry.map_imperatively(FTS3File, fts3FileTable)
 
 
 fts3JobTable = Table(
@@ -93,7 +94,7 @@ fts3JobTable = Table(
     mysql_engine="InnoDB",
 )
 
-mapper(FTS3Job, fts3JobTable)
+mapper_registry.map_imperatively(FTS3Job, fts3JobTable)
 
 
 fts3OperationTable = Table(
@@ -119,7 +120,7 @@ fts3OperationTable = Table(
 )
 
 
-fts3Operation_mapper = mapper(
+fts3Operation_mapper = mapper_registry.map_imperatively(
     FTS3Operation,
     fts3OperationTable,
     properties={
@@ -146,9 +147,13 @@ fts3Operation_mapper = mapper(
     polymorphic_identity="Abs",
 )
 
-mapper(FTS3TransferOperation, fts3OperationTable, inherits=fts3Operation_mapper, polymorphic_identity="Transfer")
+mapper_registry.map_imperatively(
+    FTS3TransferOperation, fts3OperationTable, inherits=fts3Operation_mapper, polymorphic_identity="Transfer"
+)
 
-mapper(FTS3StagingOperation, fts3OperationTable, inherits=fts3Operation_mapper, polymorphic_identity="Staging")
+mapper_registry.map_imperatively(
+    FTS3StagingOperation, fts3OperationTable, inherits=fts3Operation_mapper, polymorphic_identity="Staging"
+)
 
 
 # About synchronize_session:

--- a/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
+++ b/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
@@ -26,7 +26,7 @@ import random
 import datetime
 
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.orm import relationship, backref, sessionmaker, joinedload, mapper
+from sqlalchemy.orm import relationship, backref, sessionmaker, joinedload, registry
 from sqlalchemy.sql import update
 from sqlalchemy import (
     create_engine,
@@ -57,7 +57,7 @@ __RCSID__ = "$Id$"
 
 # Metadata instance that is used to bind the engine, Object and tables
 metadata = MetaData()
-
+mapper_registry = registry()
 
 # Description of the file table
 
@@ -80,7 +80,7 @@ fileTable = Table(
 
 # Map the File object to the fileTable, with a few special attributes
 
-mapper(
+mapper_registry.map_imperatively(
     File,
     fileTable,
     properties={
@@ -120,7 +120,7 @@ operationTable = Table(
 
 # Map the Operation object to the operationTable, with a few special attributes
 
-mapper(
+mapper_registry.map_imperatively(
     Operation,
     operationTable,
     properties={
@@ -164,7 +164,7 @@ requestTable = Table(
 )
 
 # Map the Request object to the requestTable, with a few special attributes
-mapper(
+mapper_registry.map_imperatively(
     Request,
     requestTable,
     properties={
@@ -402,7 +402,7 @@ class RequestDB(object):
             # the joinedload is to force the non-lazy loading of all the attributes, especially _parent
             request = (
                 session.query(Request)
-                .options(joinedload("__operations__").joinedload("__files__"))
+                .options(joinedload(Request.__operations__).joinedload(Operation.__files__))
                 .filter(Request.RequestID == requestID)
                 .one()
             )
@@ -467,7 +467,7 @@ class RequestDB(object):
 
                 requests = (
                     session.query(Request)
-                    .options(joinedload("__operations__").joinedload("__files__"))
+                    .options(joinedload(Request.__operations__).joinedload(Operation.__files__))
                     .filter(Request.RequestID.in_(requestIDs))
                     .all()
                 )
@@ -840,7 +840,7 @@ class RequestDB(object):
         try:
             ret = (
                 session.query(Request.JobID, Request)
-                .options(joinedload("__operations__").joinedload("__files__"))
+                .options(joinedload(Request.__operations__).joinedload(Operation.__files__))
                 .filter(Request.JobID.in_(jobIDs))
                 .all()
             )


### PR DESCRIPTION
Backport #6739 

BEGINRELEASENOTES

*DMS
CHANGE: adapt FTS3DB to sqlalchemy 2.0

*RMS
CHANGE: adapt ReqDB to sqlalchemy 2.0

ENDRELEASENOTES