### PR TITLE
[v7r3] Reorder pilot downloads to minimise race condition

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -193,7 +193,7 @@ for loc in locations:
       from urllib.request import urlopen as url_library_urlopen
       from urllib.error import URLError as url_library_URLError
 
-    for fileName in ['pilot.json', 'pilot.tar', 'checksums.sha512']:
+    for fileName in ['checksums.sha512', 'pilot.json', 'pilot.tar']:
       # needs to distinguish whether urlopen method contains the 'context' param
       # in theory, it should be available from python 2.7.9
       # in practice, some prior versions may be composed of recent urllib version containing the param


### PR DESCRIPTION
Hi,

Here's a slightly obscure one for you... We see batches of pilot checksum failures at some sites that are far away but almost never at nearer sites. My theory is that the sites have a large number of jobs start at the same time, possibly have a firewall and are a long way away: Their downloads are slow. While it's downloading the pilot.tar, the various files are occasionally updated by the PilotSyncAgent, this doesn't interrupt the pilot.tar download, but then they get a new checksums.sha512 file and it doesn't match the pilot.json or pilot.tar they've already downloaded.

By getting the files in increasing size order, the race condition is minimised: They'll already have the "old" version of the checksum file if pilot.tar takes a while to download. (Yes, pilot.tar is only 190K so it would have to be very slow, but we see this happening nevertheless!).

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Reorder pilot downloads to minimise race condition
ENDRELEASENOTES
