### PR TITLE
[v8.0] Repect paramList in ElasticJobParametersDB.getJobParameters

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
@@ -131,6 +131,8 @@ class ElasticJobParametersDB(ElasticDB):
                 self.log.error("Could not retrieve the data from the new index!", res["Message"])
             else:
                 for key in res["Value"]:
+                    if paramList and key not in paramList:
+                        continue
                     # Add new parameters or overwrite the old ones
                     resultDict[key] = res["Value"][key]
 


### PR DESCRIPTION
Currently passing the `paramList` to `ElasticJobParametersDB.getJobParameters` results in all parameters being returned if they're in both the old and new index.

```python
In [3]: db = ElasticJobParametersDB().getJobParameters(710009702, ["OutputSandboxLFN"])
Out [3]:
{'OK': True,
 'Value': {710009702: {'JobID': 710009702,
   'Status': 'Done',
   'timestamp': 1674722152807,
   'PilotAgent': '11.0.2',
```


BEGINRELEASENOTES

*WorkloadManagement
FIX: Repect paramList argument in ElasticJobParametersDB.getJobParameters

ENDRELEASENOTES
