### PR TITLE
[v7r3] Fix exception in FileHelper.networkToString on Python 3

### DIFF
--- a/src/DIRAC/Core/DISET/private/FileHelper.py
+++ b/src/DIRAC/Core/DISET/private/FileHelper.py
@@ -12,7 +12,7 @@ import tempfile
 import threading
 
 import six
-from six import StringIO
+from six import StringIO, BytesIO
 
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
@@ -145,11 +145,11 @@ class FileHelper(object):
     def networkToString(self, maxFileSize=0):
         """Receive the input from a DISET client and return it as a string"""
 
-        stringIO = StringIO()
-        result = self.networkToDataSink(stringIO, maxFileSize=maxFileSize)
+        bytesIO = BytesIO()
+        result = self.networkToDataSink(bytesIO, maxFileSize=maxFileSize)
         if not result["OK"]:
             return result
-        return S_OK(stringIO.getvalue())
+        return S_OK(bytesIO.getvalue())
 
     def networkToFD(self, iFD, maxFileSize=0):
         dataSink = os.fdopen(iFD, "wb")


### PR DESCRIPTION
This PR fixes similar issue as #6720 but for FileHelper.networkToString, as discussed in #6724

BEGINRELEASENOTES

*Core
FIX: Fix exception in FileHelper.networkToString on Python3

ENDRELEASENOTES
