### PR TITLE
[8.0] dirac-configure warning about existing file

### DIFF
--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -593,6 +593,8 @@ def runDiracConfigure(params):
         mkDir(configDir)
         params.update = True
         DIRAC.gConfig.dumpLocalCFGToFile(params.outputFile)
+    elif not params.forceUpdate:
+        DIRAC.gLogger.notice(f"{params.outputFile} exists, not overwriting it. Or use the '--ForceUpdate' Flag")
 
     if params.includeAllServers:
         # We need user proxy or server certificate to continue in order to get all the CS URLs


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
New: dirac-configure warns you about existing config file

ENDRELEASENOTES
