### PR TITLE
[v7r3] Better handle requests exceptions in AREXCE + minor fix in an error message in ConfigHelper

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -125,12 +125,64 @@ class AREXComputingElement(ARCComputingElement):
         self.log.warn("Identifier already in REST format?", diracJobID)
         return diracJobID
 
+    #############################################################################
+
     def _urlJoin(self, command):
         """Add the command to the base URL.
 
         :param str command: command to execute
         """
         return os.path.join(self.base_url, command)
+
+    def _request(self, method, query, params=None, data=None, headers=None, timeout=None):
+        """Perform a request and properly handle the results/exceptions.
+
+        :param str method: "post", "get", "put"
+        :param str query: query to submit
+        :param dict/str params: parameters of the query
+        :param dict headers: headers of the query
+        :param int timeout: timeout value
+        :return: response
+        """
+        if not headers:
+            headers = self.headers
+        if not timeout:
+            timeout = self.arcRESTTimeout
+
+        if method.upper() not in ["GET", "POST", "PUT"]:
+            return S_ERROR("The request method is unknown")
+
+        try:
+            response = self.session.request(
+                method,
+                query,
+                headers=headers,
+                params=params,
+                data=data,
+                timeout=timeout,
+            )
+            if not response.ok:
+                return S_ERROR("Response: %s - %s" % (response.status_code, response.reason))
+            return S_OK(response)
+        except requests.Timeout as e:
+            return S_ERROR("Request timed out, consider increasing RESTARCTimeout: %s" % e)
+        except requests.ConnectionError as e:
+            return S_ERROR("Connection failed, consider checking the state of the CE: %s" % e)
+        except requests.RequestException as e:
+            return S_ERROR("Request exception: %s" % e)
+
+    def _checkSession(self):
+        """Check that the session exists and carries a valid proxy."""
+        if not self.session:
+            return S_ERROR("REST interface not initialised.")
+
+        # Get a proxy
+        result = self._prepareProxy()
+        if not result["OK"]:
+            self.log.error("Failed to set up proxy", result["Message"])
+            return result
+        self.session.cert = Locations.getProxyLocation()
+        return S_OK()
 
     #############################################################################
 
@@ -146,14 +198,11 @@ class AREXComputingElement(ARCComputingElement):
         query = self._urlJoin("delegations")
 
         # Submit a POST request
-        response = self.session.post(
-            query,
-            headers=self.headers,
-            params=params,
-            timeout=self.arcRESTTimeout,
-        )
-        if not response.ok:
-            return S_ERROR("Failed to get a delegation ID: %s %s" % (response.status_code, response.reason))
+        result = self._request("post", query, params=params)
+        if not result["OK"]:
+            self.log.error("Failed to get a delegation ID.", result["Message"])
+            return S_ERROR("Failed to get a delegation ID")
+        response = result["Value"]
 
         # Extract delegationID from response
         delegationURL = response.headers.get("location", "")
@@ -185,17 +234,10 @@ class AREXComputingElement(ARCComputingElement):
             return S_ERROR("Problem with the Certificate Signing Request")
 
         # Submit the certificate
-        response = self.session.put(
-            query,
-            data=result["Value"],
-            headers=headers,
-            timeout=self.arcRESTTimeout,
-        )
-        if not response.ok:
-            return S_ERROR(
-                "Issue while interacting with the delegation",
-                "%s - %s" % (response.status_code, response.reason),
-            )
+        result = self._request("put", query, data=result["Value"], headers=headers)
+        if not result["OK"]:
+            self.log.error("Issue while interacting with the delegation.", result["Message"])
+            return S_ERROR("Issue while interacting with the delegation")
 
         return S_OK()
 
@@ -237,19 +279,11 @@ class AREXComputingElement(ARCComputingElement):
 
         # Submit the POST request to get the delegation
         jobsJson = {"job": [{"id": arcJobID}]}
-        response = self.session.post(
-            query,
-            data=json.dumps(jobsJson),
-            headers=self.headers,
-            params=params,
-            timeout=self.arcRESTTimeout,
-        )
-
-        if not response.ok:
-            return S_ERROR(
-                "Issue while interacting with the delegation",
-                "%s - %s" % (response.status_code, response.reason),
-            )
+        result = self._request("post", query, params=params, data=json.dumps(jobsJson))
+        if not result["OK"]:
+            self.log.error("Issue while interacting with the delegation.", result["Message"])
+            return S_ERROR("Issue while interacting with the delegation")
+        response = result["Value"]
 
         responseDelegation = response.json()
         if "delegation_id" not in responseDelegation["job"]:
@@ -285,19 +319,11 @@ class AREXComputingElement(ARCComputingElement):
         self.log.debug("DIRAC stamp for job", "is %s" % diracStamp)
 
         # Submit the POST request
-        response = self.session.post(
-            query,
-            data=xrslString,
-            headers=self.headers,
-            params=params,
-            timeout=self.arcRESTTimeout,
-        )
-        if not response.ok:
-            self.log.warn(
-                "Failed to submit job",
-                "to CE %s with error - %s - and messages : %s" % (self.ceHost, response.status_code, response.reason),
-            )
+        result = self._request("post", query, params=params, data=xrslString)
+        if not result["OK"]:
+            self.log.error("Failed to submit job.", result["Message"])
             return S_ERROR("Failed to submit job")
+        response = result["Value"]
 
         responseJob = response.json()["job"]
         if responseJob["status-code"] > "400":
@@ -335,11 +361,9 @@ class AREXComputingElement(ARCComputingElement):
                 content = f.read()
 
             # Submit the PUT request
-            response = self.session.put(
-                queryExecutable, data=content, headers=self.headers, timeout=self.arcRESTTimeout
-            )
-            if not response.ok:
-                self.log.error("Input not uploaded:", fileToSubmit)
+            result = self._request("put", queryExecutable, data=content)
+            if not result["OK"]:
+                self.log.error("Input not uploaded", "%s: %s" % (fileToSubmit, result["Message"]))
                 return S_ERROR("Input not uploaded: %s" % fileToSubmit)
 
             self.log.verbose("Input correctly uploaded", fileToSubmit)
@@ -350,15 +374,10 @@ class AREXComputingElement(ARCComputingElement):
 
         :param list arcJobList: list of ARC Job IDs
         """
-        if not self.session:
-            return S_ERROR("REST interface not initialised. Cannot kill jobs.")
-
-        # Get a proxy
-        result = self._prepareProxy()
+        result = self._checkSession()
         if not result["OK"]:
-            self.log.error("Failed to set up proxy", result["Message"])
+            self.log.error("Cannot kill jobs", result["Message"])
             return result
-        self.session.cert = Locations.getProxyLocation()
 
         # List of jobs in json format for the REST query
         jobsJson = {"job": [{"id": job} for job in arcJobList]}
@@ -368,15 +387,10 @@ class AREXComputingElement(ARCComputingElement):
         query = self._urlJoin("jobs")
 
         # Killing jobs should be fast
-        response = self.session.post(
-            query,
-            data=json.dumps(jobsJson),
-            headers=self.headers,
-            params=params,
-            timeout=self.arcRESTTimeout,
-        )
-        if not response.ok:
-            return S_ERROR("Failed to kill all these jobs: %s %s" % (response.status_code, response.reason))
+        result = self._request("post", query, params=params, data=json.dumps(jobsJson))
+        if not result["OK"]:
+            self.log.error("Failed to kill all these jobs.", result["Message"])
+            return S_ERROR("Failed to kill all these jobs")
 
         self.log.debug("Successfully deleted jobs")
         return S_OK()
@@ -386,16 +400,12 @@ class AREXComputingElement(ARCComputingElement):
         Assume that the ARC queues are always of the format nordugrid-<batchSystem>-<queue>
         And none of our supported batch systems have a "-" in their name
         """
-        if not self.session:
-            return S_ERROR("REST interface not initialised. Cannot submit jobs.")
-        self.log.verbose("Executable file path: %s" % executableFile)
-
-        # Get a proxy
-        result = self._prepareProxy()
+        result = self._checkSession()
         if not result["OK"]:
-            self.log.error("Failed to set up proxy", result["Message"])
+            self.log.error("Cannot submit jobs", result["Message"])
             return result
-        self.session.cert = Locations.getProxyLocation()
+
+        self.log.verbose("Executable file path: %s" % executableFile)
 
         # Get a "delegation" and use the same delegation for all the jobs
         delegation = ""
@@ -421,7 +431,6 @@ class AREXComputingElement(ARCComputingElement):
         for _ in range(numberOfJobs):
             result = self._getArcJobID(executableFile, inputs, outputs, executables, delegation)
             if not result["OK"]:
-                self.log.error(result["Message"])
                 break
             arcJobID, diracStamp = result["Value"]
 
@@ -429,7 +438,7 @@ class AREXComputingElement(ARCComputingElement):
             # Here we also upload the executable, other executable files and inputs.
             result = self._uploadJobDependencies(arcJobID, executableFile, inputs, executables)
             if not result["OK"]:
-                return result
+                break
 
             jobID = self._arcToDiracID(arcJobID)
             batchIDList.append(jobID)
@@ -470,15 +479,10 @@ class AREXComputingElement(ARCComputingElement):
         states and parameters. Hopefully this function weeds out everything except the relevant
         queue.
         """
-        if not self.session:
-            return S_ERROR("REST interface not initialised. Cannot get CE status.")
-
-        # Get a proxy
-        result = self._prepareProxy()
+        result = self._checkSession()
         if not result["OK"]:
-            self.log.error("Failed to set up proxy", result["Message"])
+            self.log.error("Cannot get CE Status", result["Message"])
             return result
-        self.session.cert = Locations.getProxyLocation()
 
         # Try to find out which VO we are running for.
         # Essential now for REST interface.
@@ -490,10 +494,11 @@ class AREXComputingElement(ARCComputingElement):
         query = self._urlJoin("info")
 
         # Submit the GET request
-        response = self.session.get(query, headers=self.headers, params=params, timeout=self.arcRESTTimeout)
-        if not response.ok:
-            res = S_ERROR("Unknown failure for CE %s. Is the CE down?" % self.ceHost)
-            return res
+        result = self._request("get", query, params=params)
+        if not result["OK"]:
+            self.log.error("Failed getting the status of the CE.", result["Message"])
+            return S_ERROR("Failed getting the status of the CE")
+        response = result["Value"]
         ceData = response.json()
 
         # Look only in the relevant section out of the headache
@@ -535,52 +540,55 @@ class AREXComputingElement(ARCComputingElement):
             query = self._urlJoin(os.path.join("delegations", delegationID))
 
             # Submit the POST request to get the proxy
-            response = self.session.post(query, headers=self.headers, params=params, timeout=self.arcRESTTimeout)
+            result = self._request("post", query, params=params)
+            if not result["OK"]:
+                self.log.debug("Could not get a proxy for", "job %s: %s" % (arcJob, result["Message"]))
+                continue
+            response = result["Value"]
+
             proxy = X509Chain()
-            res = proxy.loadChainFromString(response.text)
+            result = proxy.loadChainFromString(response.text)
+            if not result["OK"]:
+                continue
 
             # Now test and renew the proxy
-            if not res["OK"]:
+            result = proxy.getRemainingSecs()
+            if not result["OK"]:
+                continue
+            timeLeft = result["Value"]
+
+            if timeLeft >= self.proxyTimeLeftBeforeRenewal:
+                # No need to renew. Proxy is long enough
                 continue
 
-            timeLeftRes = proxy.getRemainingSecs()
-            if not timeLeftRes["OK"]:
-                continue
-            timeLeft = timeLeftRes["Value"]
-            if timeLeft < self.proxyTimeLeftBeforeRenewal:
+            self.log.debug(
+                "Renewing proxy for job",
+                "%s whose proxy expires at %s" % (arcJob, timeLeft),
+            )
+            # Proxy needs to be renewed - try to renew it
+            # First, get a new CSR from the delegation
+            params = {"action": "renew"}
+            query = self._urlJoin(os.path.join("delegations", delegationID))
+            result = self._request("post", query, params=params)
+
+            if not response.ok:
                 self.log.debug(
-                    "Renewing proxy for job",
-                    "%s whose proxy expires at %s" % (arcJob, timeLeft),
+                    "Proxy not renewed, failed to get CSR",
+                    "for job %s with delegation %s" % (arcJob, delegationID),
                 )
-                # Proxy needs to be renewed - try to renew it
-                # First, get a new CSR from the delegation
-                params = {"action": "renew"}
-                query = self._urlJoin(os.path.join("delegations", delegationID))
-
-                response = self.session.post(
-                    query,
-                    headers=self.headers,
-                    params=params,
-                    timeout=self.arcRESTTimeout,
-                )
-
-                if response.ok:
-                    # Then, sign and upload the certificate
-                    result = self.__uploadCertificate(delegationID, response.text)
-                    if result["OK"]:
-                        self.log.debug("Proxy successfully renewed", "for job %s" % arcJob)
-                    else:
-                        self.log.debug(
-                            "Proxy not renewed, failed to send renewed proxy",
-                            "for job %s with delegation %s: %s" % (arcJob, delegationID, result["Message"]),
-                        )
-                else:
-                    self.log.debug(
-                        "Proxy not renewed, failed to get CSR",
-                        "for job %s with delegation %s" % (arcJob, delegationID),
-                    )
-            else:  # No need to renew. Proxy is long enough
                 continue
+
+            # Then, sign and upload the certificate
+            result = self.__uploadCertificate(delegationID, response.text)
+            if not result["OK"]:
+                self.log.debug(
+                    "Proxy not renewed, failed to send renewed proxy",
+                    "for job %s with delegation %s: %s" % (arcJob, delegationID, result["Message"]),
+                )
+                continue
+
+            self.log.debug("Proxy successfully renewed", "for job %s" % arcJob)               
+                
         return S_OK()
 
     #############################################################################
@@ -590,15 +598,10 @@ class AREXComputingElement(ARCComputingElement):
 
         :param list jobIDList: list of DIRAC Job ID, followed by the DIRAC stamp.
         """
-        if not self.session:
-            return S_ERROR("REST interface not initialised. Cannot get job status.")
-
-        # Get a proxy
-        result = self._prepareProxy()
+        result = self._checkSession()
         if not result["OK"]:
-            self.log.error("AREXComputingElement: failed to set up proxy", result["Message"])
+            self.log.error("Cannot get status of the jobs", result["Message"])
             return result
-        self.session.cert = Locations.getProxyLocation()
 
         if not isinstance(jobIDList, list):
             jobIDList = [jobIDList]
@@ -617,19 +620,11 @@ class AREXComputingElement(ARCComputingElement):
         query = self._urlJoin("jobs")
 
         # Submit the POST request to get status of the jobs
-        response = self.session.post(
-            query,
-            data=json.dumps(arcJobsJson),
-            headers=self.headers,
-            params=params,
-            timeout=self.arcRESTTimeout,
-        )
-        if not response.ok:
-            self.log.info(
-                "Failed getting the status of the jobs",
-                "%s - %s" % (response.status_code, response.reason),
-            )
+        result = self._request("post", query, params=params, data=json.dumps(arcJobsJson))
+        if not result["OK"]:
+            self.log.error("Failed getting the status of the jobs.", result["Message"])
             return S_ERROR("Failed getting the status of the jobs")
+        response = result["Value"]
 
         resultDict = {}
         jobsToRenew = []
@@ -681,15 +676,10 @@ class AREXComputingElement(ARCComputingElement):
         :param str jobID: DIRAC JobID followed by the DIRAC stamp.
         :return: string representing the logging info of a given jobID
         """
-        if not self.session:
-            return S_ERROR("REST interface not initialised. Cannot get job output.")
-
-        # Get a proxy
-        result = self._prepareProxy()
+        result = self._checkSession()
         if not result["OK"]:
-            self.log.error("AREXComputingElement: failed to set up proxy", result["Message"])
+            self.log.error("Cannot get job logging info", result["Message"])
             return result
-        self.session.cert = Locations.getProxyLocation()
 
         # Extract stamp from the Job ID
         if ":::" in jobID:
@@ -701,12 +691,11 @@ class AREXComputingElement(ARCComputingElement):
 
         # Submit the GET request to retrieve outputs
         self.log.debug("Retrieving logging info for %s" % jobID)
-        response = self.session.get(query, headers=self.headers, timeout=self.arcRESTTimeout)
-        if not response.ok:
-            self.log.error(
-                "Error downloading logging info", "for %s: %s %s" % (arcJob, response.status_code, response.reason)
-            )
+        result = self._request("get", query)
+        if not result["OK"]:
+            self.log.error("Failed to retrieve logging info for", "%s: %s" % (jobID, result["Message"]))
             return S_ERROR("Failed to retrieve logging info for %s" % jobID)
+        response = result["Value"]
         loggingInfo = response.text
 
         return S_OK(loggingInfo)
@@ -724,13 +713,11 @@ class AREXComputingElement(ARCComputingElement):
 
         # Submit the GET request to retrieve the names of the outputs
         self.log.debug("Retrieving the names of the outputs for %s" % jobID)
-        response = self.session.get(query, headers=self.headers, timeout=self.arcRESTTimeout)
-
-        if not response.ok:
-            self.log.error(
-                "Error getting available outputs", "for %s: %s %s" % (jobID, response.status_code, response.reason)
-            )
+        result = self._request("get", query)
+        if not result["OK"]:
+            self.log.error("Failed to retrieve at least some outputs", "for %s: %s" % (jobID, result["Message"]))
             return S_ERROR("Failed to retrieve at least some outputs for %s" % jobID)
+        response = result["Value"]
 
         if not response.text:
             return S_ERROR("There is no output for job %s" % jobID)
@@ -746,15 +733,10 @@ class AREXComputingElement(ARCComputingElement):
         :param str workingDirectory: name of the directory containing the retrieved outputs.
         :return: content of stdout and stderr
         """
-        if not self.session:
-            return S_ERROR("REST interface not initialised. Cannot get job output.")
-
-        # Get a proxy
-        result = self._prepareProxy()
+        result = self._checkSession()
         if not result["OK"]:
-            self.log.error("AREXComputingElement: failed to set up proxy", result["Message"])
+            self.log.error("Cannot get job outputs", result["Message"])
             return result
-        self.session.cert = Locations.getProxyLocation()
 
         # Extract stamp from the Job ID
         if ":::" in jobID:
@@ -785,12 +767,12 @@ class AREXComputingElement(ARCComputingElement):
             query = self._urlJoin(os.path.join("jobs", job, "session", remoteOutput))
 
             # Submit the GET request to retrieve outputs
-            response = self.session.get(query, headers=self.headers, timeout=self.arcRESTTimeout)
-            if not response.ok:
-                self.log.error(
-                    "Error downloading", "%s for %s: %s %s" % (remoteOutput, job, response.status_code, response.reason)
-                )
-                return S_ERROR("Failed to retrieve at least some output for %s" % jobID)
+            result = self._request("get", query)
+            if not result["OK"]:
+                self.log.error("Error downloading", "%s for %s: %s" % (remoteOutput, job, result["Message"]))
+                return S_ERROR("Error downloading %s for %s" % (remoteOutput, jobID))
+            response = result["Value"]
+
             outputContent = response.text
 
             if remoteOutput == "%s.out" % stamp:

--- a/src/DIRAC/WorkloadManagementSystem/private/ConfigHelper.py
+++ b/src/DIRAC/WorkloadManagementSystem/private/ConfigHelper.py
@@ -45,7 +45,7 @@ def findGenericPilotCredentials(vo=False, group=False, pilotDN="", pilotGroup=""
         gLogger.verbose("Pilot credentials: %s@%s" % (pilotDN, pilotGroup))
         result = gProxyManager.userHasProxy(pilotDN, pilotGroup, 86400)
         if not result["OK"]:
-            return S_ERROR("%s@%s has no proxy in ProxyManager")
+            return S_ERROR("%s@%s has no proxy in ProxyManager" % (pilotDN, pilotGroup))
         return S_OK((pilotDN, pilotGroup))
 
     if pilotDN:


### PR DESCRIPTION
Aims at fixing this issue: https://github.com/DIRACGrid/DIRAC/issues/6761
Below, you can find an example of the logs produced by `AREXCE.submitJob()` before/after the PR.

Before the PR:
```bash
2023-02-06 16:27:22 UTC Framework/<AREXCE> VERBOSE: Executable file path: workloadExec.sh
Traceback (most recent call last):
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/util/connection.py", line 95, in create_connection
    raise err
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/util/connection.py", line 85, in create_connection
    sock.connect(sa)
socket.timeout: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/connectionpool.py", line 703, in urlopen
    httplib_response = self._make_request(
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/connectionpool.py", line 386, in _make_request
    self._validate_conn(conn)
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/connectionpool.py", line 1040, in _validate_conn
    conn.connect()
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/connection.py", line 358, in connect
    conn = self._new_conn()
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/connection.py", line 179, in _new_conn
    raise ConnectTimeoutError(
urllib3.exceptions.ConnectTimeoutError: (<urllib3.connection.HTTPSConnection object at 0x7f180afa0dc0>, 'Connection to <AREXCE> timed out. (connect timeout=10.0)')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/requests/adapters.py", line 440, in send
    resp = conn.urlopen(
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/connectionpool.py", line 785, in urlopen
    retries = retries.increment(
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/urllib3/util/retry.py", line 592, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host=<AREXCE>, port=8443): Max retries exceeded with url: /arex/rest/1.0/delegations?action=new (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7f180afa0dc0>, 'Connection to <AREXCE> timed out. (connect timeout=10.0)'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/CC7py3/v11.0.2/AREXInteract.py", line 22, in <module>
    res = arc_ce.submitJob("workloadExec.sh", None)
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/DIRAC/Resources/Computing/AREXComputingElement.py", line 387, in submitJob
    result = self._prepareDelegation()
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/DIRAC/Resources/Computing/AREXComputingElement.py", line 207, in _prepareDelegation
    result = self.__generateDelegationID()
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/DIRAC/Resources/Computing/AREXComputingElement.py", line 143, in __generateDelegationID
    response = self.session.post(
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/requests/sessions.py", line 577, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/requests/sessions.py", line 529, in request
    resp = self.send(prep, **send_kwargs)
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/requests/sessions.py", line 645, in send
    r = adapter.send(request, **kwargs)
  File "/tmp/CC7py3/v11.0.2/diracos/lib/python3.9/site-packages/requests/adapters.py", line 507, in send
    raise ConnectTimeout(e, request=request)
requests.exceptions.ConnectTimeout: HTTPSConnectionPool(host=<AREXCE>, port=8443): Max retries exceeded with url: /arex/rest/1.0/delegations?action=new (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7f180afa0dc0>, 'Connection to <AREXCE> timed out. (connect timeout=10.0)'))
```

After the PR:

```bash
2023-02-06 15:46:42 UTC Framework/<AREXCE> VERBOSE: Executable file path: workloadExec.sh
2023-02-06 15:47:02 UTC Framework/<AREXCE> ERROR: Failed to get a delegation ID. Request timed out, consider increasing RESTARCTimeout: HTTPSConnectionPool(host=<AREXCE>, port=8443): Max retries exceeded with url: /arex/rest/1.0/delegations?action=new (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7f475f4758b0>, 'Connection to <AREXCE> timed out. (connect timeout=10.0)'))
2023-02-06 15:47:02 UTC Framework/<AREXCE> WARN: Could not get a delegation For CE <AREXCE>
2023-02-06 15:47:02 UTC Framework/<AREXCE> WARN: Continue without a delegation
2023-02-06 15:47:22 UTC Framework/<AREXCE> ERROR: Failed to submit job. Request timed out, consider increasing RESTARCTimeout: HTTPSConnectionPool(host=<AREXCE>, port=8443): Max retries exceeded with url: /arex/rest/1.0/jobs?action=new (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7f475ebe9280>, 'Connection to <AREXCE> timed out. (connect timeout=10.0)'))
```

The PR also includes a very minor fix in an error message in `ConfigHelper`.

BEGINRELEASENOTES
*Resources
FIX: better handle exceptions in AREXCE
*WorkloadManagementSystem
FIX: config helper error message
ENDRELEASENOTES
