### PR TITLE
[8.0] fix bad error handling in removing file

### DIFF
--- a/src/DIRAC/Core/Utilities/ServerUtils.py
+++ b/src/DIRAC/Core/Utilities/ServerUtils.py
@@ -20,5 +20,5 @@ def getDBOrClient(DB, serverName):
     except Exception:
         pass
 
-    gLogger.info(f"Can not connect to DB will use {serverName}")
+    gLogger.debug(f"Can not connect to DB will use {serverName}")
     return Client(url=serverName)

--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -535,13 +535,7 @@ class GFAL2_StorageBase(StorageBase):
             return True
         except gfal2.GError as e:
             # file doesn't exist so operation was successful
-            # Explanations for ECOMM:
-            # Because of the way the new DPM DOME flavor works
-            # and the poor error handling of Globus works, we might
-            # encounter ECOMM when removing non existing file
-            # That should be for gsiftp only
-
-            if e.code in (errno.ENOENT, errno.ECOMM):
+            if e.code == errno.ENOENT:
                 log.debug("File does not exist.")
                 return True
             raise


### PR DESCRIPTION
Copy/paste is bad.... when refactoring gfal2 code, I mistakenly handled `ECOMM` when removing a file, while I shouldn't. This bug would trigger only in very rare occasions, so it is unlikely to have created a lot of dark data...

BEGINRELEASENOTES
*Resources
FIX: do not handle ECOMM when removing file

ENDRELEASENOTES
