### PR TITLE
[8.0] VOMS2CSSynchronizer: strip leading and trailing whitespaces from DN entries

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -64,6 +64,8 @@ def _getUserNameFromDN(dn, vo):
                 key, value = "CN", entry
             else:
                 key, value = entry.split("=")
+            key = key.strip()
+            value = value.strip()
             if key.upper() == "CN":
                 ind = value.find("(")
                 # Strip of possible words in parenthesis in the name


### PR DESCRIPTION

BEGINRELEASENOTES

*Configuration
FIX: VOMS2CSSynchronizer: strip leading and trailing whitespaces from DN entries

ENDRELEASENOTES
