### PR TITLE
[8.0] Intermediate replication uses all possible SE

### DIFF
--- a/src/DIRAC/DataManagementSystem/Client/DataManager.py
+++ b/src/DIRAC/DataManagementSystem/Client/DataManager.py
@@ -853,6 +853,10 @@ class DataManager:
             else:
                 log.debug("Catalog size and physical size match")
 
+            # The file at the SE seems healthy, so we could potentially use this SE
+            # for non TPC transfer in case everything else fails.
+            possibleIntermediateSEs.append(candidateSE)
+
             res = destStorageElement.negociateProtocolWithOtherSE(candidateSE, protocols=self.thirdPartyProtocols)
 
             if not res["OK"]:
@@ -862,7 +866,6 @@ class DataManager:
             replicationProtocols = res["Value"]
 
             if not replicationProtocols:
-                possibleIntermediateSEs.append(candidateSE)
                 log.debug("No protocol suitable for replication found")
                 continue
 


### PR DESCRIPTION
When replicating a file interactively with the `DataManager`, we first try TPC. If that does not work, we replicate locally before uploading. The sources used for that intermediate replication were only the SE for which no potential TPC protocol were found. Now we also take as sources the SE for which there were possible protocols, but the replication still failed.



BEGINRELEASENOTES

*DMS
CHANGE: take into account all possible sources for intermediate copy when replicating files

ENDRELEASENOTES
