### PR TITLE
[v7r3] fix pylint errors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -30,20 +30,14 @@ load-plugins=
 # it should appear only once).
 
 #R0903 = Too few public methods (%s/%s)
-#C0326 = bad-whitespace
 #I0011 = locally-disabling
-disable=R0903,C0326,I0011,redefined-variable-type,c-extension-no-member
+disable=R0903,I0011,c-extension-no-member
 
 [REPORTS]
 
 # Set the output format. Available formats are text, parseable, colorized, msvs
 # (visual studio) and html
 output-format=colorized
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
 
 # Tells whether to display a full report or only the messages
 reports=no
@@ -56,9 +50,6 @@ reports=no
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
 [BASIC]
-
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,apply,input,raw_input,has_key
 
 # Regular expression which should only match correct module names
 # Added last option, to take into account script names
@@ -179,7 +170,7 @@ max-locals=20
 max-returns=8
 
 # Maximum number of branch for function / method body
-max-branchs=15
+max-branches=15
 
 # Maximum number of statements in function / method body
 max-statements=50

--- a/src/DIRAC/Core/Tornado/Server/TornadoServer.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoServer.py
@@ -18,7 +18,7 @@ import M2Crypto
 
 import tornado.iostream
 
-tornado.iostream.SSLIOStream.configure(
+tornado.iostream.SSLIOStream.configure(  # pylint: disable=no-member
     "tornado_m2crypto.m2iostream.M2IOStream"
 )  # pylint: disable=wrong-import-position
 

--- a/src/DIRAC/WorkloadManagementSystem/Client/DIRACbenchmark.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/DIRACbenchmark.py
@@ -50,6 +50,8 @@ def singleDiracBenchmark(iterations=1, measuredCopies=None):
     # Do one iteration extra to allow CPUs with variable speed (we ignore zeroth iteration)
     # Do one or more extra iterations to avoid tail effects when copies run in parallel
     i = 0
+    start = os.times()
+    end = os.times()
     while (i <= iterations) or (measuredCopies is not None and measuredCopies.value > 0):
         if i == 1:
             start = os.times()


### PR DESCRIPTION
PRs targeting `v7r3` cannot pass the CI because of a new version of `pylint`.
Here is the error:

```bash
************* Module ...DIRAC/.pylintrc
.pylintrc:1:0: E0015: Unrecognized option found: files-output, bad-functions, max-branchs (unrecognized-option)
.pylintrc:1:0: R0022: Useless option value for '--disable', 'C0326' was removed from pylint, see https://github.com/PyCQA/pylint/pull/3577. (useless-option-value)
.pylintrc:1:0: W0012: Unknown option value for '--disable', expected a valid pylint message and got 'redefined-variable-type' (unknown-option-value)
************* Module DIRAC.WorkloadManagementSystem.Client.DIRACbenchmark
src/DIRAC/WorkloadManagementSystem/Client/DIRACbenchmark.py:73:30: E0601: Using variable 'start' before assignment (used-before-assignment)
```

This PR aims at updating `pylint.rc` and adding some `pylint` tags within the code to fix the CI.

- `files-outputs`: does not seem to exist anymore
- `bad-functions`: does not seem to exist anymore
- `max-branchs`: renamed "max-branches"

- `C0326`: should be handled by Black now
- `redefined-variable-type`: became an optional plugin, not loaded by default

BEGINRELEASENOTES
FIX: pylint errors
ENDRELEASENOTES
