### PR TITLE
[sweep:v8r0] Fix exception in FileHelper.networkToString on Python 3

### DIFF
--- a/src/DIRAC/Core/DISET/private/FileHelper.py
+++ b/src/DIRAC/Core/DISET/private/FileHelper.py
@@ -5,7 +5,7 @@ import tarfile
 import tempfile
 import threading
 
-from io import StringIO
+from io import StringIO, BytesIO
 
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
@@ -131,11 +131,11 @@ class FileHelper:
     def networkToString(self, maxFileSize=0):
         """Receive the input from a DISET client and return it as a string"""
 
-        stringIO = StringIO()
-        result = self.networkToDataSink(stringIO, maxFileSize=maxFileSize)
+        bytesIO = BytesIO()
+        result = self.networkToDataSink(bytesIO, maxFileSize=maxFileSize)
         if not result["OK"]:
             return result
-        return S_OK(stringIO.getvalue())
+        return S_OK(bytesIO.getvalue())
 
     def networkToFD(self, iFD, maxFileSize=0):
         dataSink = os.fdopen(iFD, "wb")


### PR DESCRIPTION
Sweep #6762 `Fix exception in FileHelper.networkToString on Python 3` to `rel-v8r0`.

Adding original author @hmiyake as watcher.

BEGINRELEASENOTES

*Core
FIX: Fix exception in FileHelper.networkToString on Python3

ENDRELEASENOTES
Closes #6789