### PR TITLE
[v7r3] Remove use of set-output in CI

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -38,7 +38,7 @@ jobs:
         # When v8 is released we can remove this check
         run: |
           if [[ "${{ github.event.ref }}" =~ ^refs/tags/v7r([2-9]|[0-9][0-9]+)(p[0-9]+)?(-pre[0-9]+)?$ ]]; then
-              echo ::set-output name=create-release::true
+              echo "create-release=true" >> $GITHUB_OUTPUT
           fi
       - name: Make PEP-440 style release on GitHub
         if: steps.check-tag.outputs.create-release == 'true'


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/