### PR TITLE
[8.0] Remove use of set-output in CI

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -97,8 +97,8 @@ jobs:
                 git show
                 # Create the tag
                 git tag "$NEW_VERSION"
-                echo ::set-output name=create-release::true
-                echo ::set-output name=new-version::"$NEW_VERSION"
+                echo "create-release=true" >> $GITHUB_OUTPUT
+                echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
               fi
             fi
           fi


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/