### PR TITLE
[8.0] Removed Google forum from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,8 @@ Important links
 - Official source code repo: https://github.com/DIRACGrid/DIRAC
 - HTML documentation (stable release): http://diracgrid.org (http://dirac.readthedocs.io/en/latest/index.html)
 - Issue tracker: https://github.com/DIRACGrid/DIRAC/issues
-- Support Mailing list: https://groups.google.com/forum/#!forum/diracgrid-forum
+- Discussions: https://github.com/DIRACGrid/DIRAC/discussions
+- [ARCHIVED] Support Mailing list: https://groups.google.com/forum/#!forum/diracgrid-forum
 
 Install
 =======

--- a/docs/source/AdministratorGuide/Systems/ResourceStatus/install.rst
+++ b/docs/source/AdministratorGuide/Systems/ResourceStatus/install.rst
@@ -8,8 +8,6 @@ This page describes the basic steps to install, configure, activate and start us
 
 *WARNING*: If you have doubts about the success of any step, DO NOT ACTIVATE RSS.
 
-*WARNING*: REPORT FIRST to the DIRAC FORUM !
-
 ----------------
 CS Configuration
 ----------------

--- a/docs/source/DeveloperGuide/index.rst
+++ b/docs/source/DeveloperGuide/index.rst
@@ -18,10 +18,8 @@ Detailed instructions on how to develop various types of DIRAC components are gi
 are discussed as well. More detailes on the available interfaces can be found in the
 :ref:`code_documentation` part.
 
-For every question, or comment, please open a `GitHub issue <https://github.com/DIRACGrid/DIRAC/issues>`_.
-For everything operational, instead, you can write on the `dirac-grid <https://groups.google.com/forum/#!forum/diracgrid-forum>`_
-group.
-
+For issues, please open a `GitHub issue <https://github.com/DIRACGrid/DIRAC/issues>`_.
+For questions, comments, or operational issues, use `GitHub discussions <https://github.com/DIRACGrid/DIRAC/discussions>`_.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION

BEGINRELEASENOTES

*Docs
FIX: Removed Google forum from docs

ENDRELEASENOTES
Closes #6781