### PR TITLE
[8.0] fix (GraphUtilities): stop using matplotlib deprecated methods

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
+++ b/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
@@ -366,8 +366,8 @@ class PrettyDateLocator(AutoDateLocator):
         locator = RRuleLocator(rrule, self.tz)
         locator.set_axis(self.axis)
 
-        locator.set_view_interval(*self.axis.get_view_interval())
-        locator.set_data_interval(*self.axis.get_data_interval())
+        locator.axis.set_view_interval(*self.axis.get_view_interval())
+        locator.axis.set_data_interval(*self.axis.get_data_interval())
         return locator
 
 


### PR DESCRIPTION
Follow
https://matplotlib.org/3.5.3/api/dates_api.html#matplotlib.dates.MicrosecondLocator.set_data_interval

I hope the fix is correct... :-) 

BEGINRELEASENOTES
*Core
FIX: don't use matplotlib deprecated methods

ENDRELEASENOTES
