### PR TITLE
[v7r3] Stop using matplotlib deprecated methods

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
+++ b/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
@@ -373,8 +373,6 @@ class PrettyDateLocator(AutoDateLocator):
         locator = RRuleLocator(rrule, self.tz)
         locator.set_axis(self.axis)
 
-        locator.set_view_interval(*self.axis.get_view_interval())
-        locator.set_data_interval(*self.axis.get_data_interval())
         return locator
 
 


### PR DESCRIPTION
Follow
https://matplotlib.org/3.5.3/api/dates_api.html#matplotlib.dates.MicrosecondLocator.set_data_interval

BEGINRELEASENOTES
*Core
FIX: don't use matplotlib deprecated methods

ENDRELEASENOTES
