### PR TITLE
[v7r3] Hackathon fix: missing account parameter in SSHBatchCE

### DIFF
--- a/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHBatchComputingElement.py
@@ -45,6 +45,7 @@ class SSHBatchComputingElement(SSHComputingElement):
 
         self.submitOptions = self.ceParameters.get("SubmitOptions", "")
         self.preamble = self.ceParameters.get("Preamble", "")
+        self.account = self.ceParameters.get("Account", "")
 
         # Prepare all the hosts
         for hPar in self.ceParameters["SSHHost"].strip().split(","):


### PR DESCRIPTION
Oopsi, in a previous commit, I deleted the `account` parameter from `SSHBatchComputingElement`.


BEGINRELEASENOTES
*Resources
FIX: fix account parameter in SSHBatchCE
ENDRELEASENOTES
