### PR TITLE
[v7r3] fix (FTS3DB): distinct and order by need to have common columns

### DIFF
--- a/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
@@ -560,7 +560,7 @@ class FTS3DB(object):
             # We get the list of operations ID that have associated jobs assigned
             opIDsWithJobAssigned = session.query(FTS3Job.operationID).filter(~FTS3Job.assignment.is_(None)).subquery()
             operationIDsQuery = (
-                session.query(FTS3Operation.operationID)
+                session.query(FTS3Operation.operationID, FTS3Operation.lastUpdate)
                 .filter(FTS3Operation.status.in_(["Active", "Processed"]))
                 .filter(FTS3Operation.assignment.is_(None))
                 .filter(~FTS3Operation.operationID.in_(opIDsWithJobAssigned))


### PR DESCRIPTION
As of mysql 5.7 the column with which we order must be present in the `distinct` clause. 
`SQLAlchemy < 2.0` was doing that behind the scene,  now we do it ourselves.

I've checked, we have no other situation like this in DIRAC

This fixes the following exception

```
DataManagement/FTS3Agent/DataManagement/FTS3Agent WARN:  Cycle had an error: getAllProcessedOperations: unexpected exception : (MySQLdb._exceptions.Operation
alError) (3065, "Expression #1 of ORDER BY clause is not in SELECT list, references column 'FTS3DB.Operations.lastUpdate' which is not in SELECT list; this is incompatible with DISTINCT")
[SQL: SELECT DISTINCT `Operations`.`operationID` AS `Operations_operationID` 
FROM `Operations` 
WHERE `Operations`.status IN (%s, %s) AND `Operations`.assignment IS NULL AND (`Operations`.`operationID` NOT IN (SELECT `Jobs`.`operationID` 
FROM `Jobs` 
WHERE `Jobs`.assignment IS NOT NULL)) ORDER BY `Operations`.`lastUpdate` ASC 
 LIMIT %s FOR UPDATE]
[parameters: ('Active', 'Processed', 20)]
(Background on this error at: https://sqlalche.me/e/20/e3q8)
```
  
BEGINRELEASENOTES

*DMS

FIX: specify the same column in order_by and distinct in FTS3DB.getNonFinishedOperations

ENDRELEASENOTES
