### PR TITLE
[v7r3] Fix AREX ARCRESTTimeout

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -75,7 +75,7 @@ class AREXComputingElement(ARCComputingElement):
         self.proxyTimeLeftBeforeRenewal = self.ceParameters.get(
             "ProxyTimeLeftBeforeRenewal", self.proxyTimeLeftBeforeRenewal
         )
-        self.arcRESTTimeout = self.ceParameters.get("ARCRESTTimeout", self.arcRESTTimeout)
+        self.arcRESTTimeout = float(self.ceParameters.get("ARCRESTTimeout", self.arcRESTTimeout))
 
         # Build the URL based on the CEName, the port and the REST version
         service_url = os.path.join("https://", "%s:%s" % (self.ceName, self.port))


### PR DESCRIPTION
Hi,

The ARCRESTTimeout is used directly with requests, but if you've set it in the CS, it'll be a string and fails.
(As an aside, in my opinion the 5 second default for this value feels a bit low to me... When the number of jobs waiting at a CE goes up, you can start to see timeouts if you haven't raised this to something larger).

Regards,
Simon

```
Traceback (most recent call last):
  File "/opt/dirac/diracos/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/dirac/DIRAC/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 1215, in _updatePilotStatusPerQueue
    result = ce.getJobStatus(stampedPilotRefs)
  File "/opt/dirac/DIRAC/src/DIRAC/Resources/Computing/AREXComputingElement.py", line 574, in getJobStatus
    response = self.session.post(
  File "/opt/dirac/diracos/lib/python3.9/site-packages/requests/sessions.py", line 577, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/opt/dirac/diracos/lib/python3.9/site-packages/requests/sessions.py", line 529, in request
    resp = self.send(prep, **send_kwargs)
  File "/opt/dirac/diracos/lib/python3.9/site-packages/requests/sessions.py", line 645, in send
    r = adapter.send(request, **kwargs)
  File "/opt/dirac/diracos/lib/python3.9/site-packages/requests/adapters.py", line 436, in send
    timeout = TimeoutSauce(connect=timeout, read=timeout)
  File "/opt/dirac/diracos/lib/python3.9/site-packages/urllib3/util/timeout.py", line 103, in __init__
    self._connect = self._validate_timeout(connect, "connect")
  File "/opt/dirac/diracos/lib/python3.9/site-packages/urllib3/util/timeout.py", line 158, in _validate_timeout
    raise ValueError(
ValueError: Timeout value connect was 30, but it must be an int, float or None.
```

BEGINRELEASENOTES
*Resources
FIX: Fix AREX ARCRESTTimeout
ENDRELEASENOTES
