### PR TITLE
[v7r3] fix: Typo in AREX error meesage

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -572,7 +572,7 @@ class AREXComputingElement(ARCComputingElement):
                     else:
                         self.log.debug(
                             "Proxy not renewed, failed to send renewed proxy",
-                            "for job %s with delegation %s: %s" % (arcJob, delegationID, res["Message"]),
+                            "for job %s with delegation %s: %s" % (arcJob, delegationID, result["Message"]),
                         )
                 else:
                     self.log.debug(


### PR DESCRIPTION
Bah, I noticed I had a typo while fixing the sweep failure for my previous patch... Is it possible to mark this one not to sweep? (I fixed the error in v8r0 at the same time as sorting out the previous sweep problem).

Regards,
Simon


BEGINRELEASENOTES
*Resources
FIX: Typo in AREX error meesage
ENDRELEASENOTES
