### PR TITLE
[v7r3] ReqProxy does not immediately forward to central service

### DIFF
--- a/src/DIRAC/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -186,10 +186,10 @@ class ReqProxyHandler(RequestHandler):
     types_putRequest = [six.string_types]
 
     def export_putRequest(self, requestJSON):
-        """forward request from local RequestDB to central RequestManager
+        """Dump the request in a local cache for later forwarding
 
         :param self: self reference
-        :param str requestType: request type
+        :param str requestJSON: json dump of the request
         """
 
         gMonitor.addMark("reqReceived", 1)
@@ -210,21 +210,13 @@ class ReqProxyHandler(RequestHandler):
         if not forwardable["OK"]:
             gLogger.warn("putRequest: %s" % forwardable["Message"])
 
-        setRequest = self.requestManager().putRequest(requestJSON)
-        if not setRequest["OK"]:
-            gLogger.error(
-                "setReqeuest: unable to set request '%s' @ RequestManager: %s" % (requestName, setRequest["Message"])
-            )
-            # # put request to the request file cache
-            save = self.__saveRequest(requestName, requestJSON)
-            if not save["OK"]:
-                gLogger.error("setRequest: unable to save request to the cache: %s" % save["Message"])
-                return save
-            gLogger.info("setRequest: %s is saved to %s file" % (requestName, save["Value"]))
-            return S_OK({"set": False, "saved": True})
-
-        gLogger.info("setRequest: request '%s' has been set to the ReqManager" % (requestName))
-        return S_OK({"set": True, "saved": False})
+        # # put request to the request file cache
+        save = self.__saveRequest(requestName, requestJSON)
+        if not save["OK"]:
+            gLogger.error("setRequest: unable to save request to the cache: %s" % save["Message"])
+            return save
+        gLogger.info("setRequest: %s is saved to %s file" % (requestName, save["Value"]))
+        return S_OK({"set": False, "saved": True})
 
     @staticmethod
     def __forwardable(requestDict):


### PR DESCRIPTION
Up to now, the ReqProxy was attempting a direct forward to the central ReqManager. If it wasn't working, it would dump the request to a file, and forward it later.

We had a DB outage, which means the central service was hanging. It would accept connections, but hang....
So a job would try to upload a request to the central service, timeout. Then it would go to a ReqProxy. The ReqProxy would attempt a forward to the central service. Meanwhile, the Client is fed up of waiting for the ReqProxy to answer, times out, cut the connection, and goes to the next ReqProxy. But the first ReqProxy was still trying to talk to the central service. Once it gives up, it dumps the Request to a file and sweeps it later. But the second proxy did the same. And the third. Etc

And that's how we end up with 1 job having many time the same request.

One bullet proof protection could be to have JobID a unique key in the DB. But it would cause problem for Requests not related to a job. Moreover, it would block the possibility of a job actually sending multiple requests, and I have the gut feeling that it's not an unreasonable use case. 

So instead, the ReqProxy just always dumps the request in a file, without trying to forward.

I target v7r3 just out of friendship for my ILC,GridPP and Belle II colleagues, because I already know the the sweeper is going to fail because of formatting.....

BEGINRELEASENOTES
*RMS
CHANGE: ReqProxy does not attempt a direct forward to central ReqManager

ENDRELEASENOTES
