### PR TITLE
[v7r3] VOMS2CSAgent: strip whitespaces from DN entries and nickname

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -70,6 +70,8 @@ def _getUserNameFromDN(dn, vo):
                 key, value = "CN", entry
             else:
                 key, value = entry.split("=")
+            key = key.strip()
+            value = value.strip()
             if key.upper() == "CN":
                 ind = value.find("(")
                 # Strip of possible words in parenthesis in the name

--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -281,7 +281,7 @@ class VOMS2CSSynchronizer(object):
                 # We have a real new user
                 if not diracName:
                     if nickName:
-                        newDiracName = nickName
+                        newDiracName = nickName.strip()
                     else:
                         newDiracName = self.getUserName(dn)
 


### PR DESCRIPTION
closes https://github.com/DIRACGrid/DIRAC/issues/6824


BEGINRELEASENOTES

*Configuration
FIX: VOMS2CSAgent: strip whitespaces from DN entried and nickname

ENDRELEASENOTES
