### PR TITLE
[8.0] fix (MonitoringDB): make a MonitoringDB singleton

### DIFF
--- a/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
+++ b/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
@@ -3,14 +3,14 @@ This module is used to create an appropriate object which can be used to insert 
 It always try to insert the records directly. In case of failure the monitoring client is used...
 """
 
-from DIRAC.Core.Utilities.ServerUtils import getDBOrClient
+from DIRAC.Core.Base.Client import Client
+from DIRAC.MonitoringSystem.DB.MonitoringDB import gMonitoringDB
 
 
 def getMonitoringDB():
-    serverName = "Monitoring/Monitoring"
-    MonitoringDB = None
     try:
-        from DIRAC.MonitoringSystem.DB.MonitoringDB import MonitoringDB
+        if gMonitoringDB and gMonitoringDB._connected:
+            return gMonitoringDB
     except Exception:
         pass
-    return getDBOrClient(MonitoringDB, serverName)
+    return Client(url="Monitoring/Monitoring")

--- a/src/DIRAC/MonitoringSystem/DB/MonitoringDB.py
+++ b/src/DIRAC/MonitoringSystem/DB/MonitoringDB.py
@@ -49,7 +49,6 @@ class MonitoringDB(ElasticDB):
         try:
             section = getDatabaseSection("Monitoring/MonitoringDB")
             indexPrefix = gConfig.getValue(f"{section}/IndexPrefix", CSGlobals.getSetup()).lower()
-
             # Connecting to the ES cluster
             super().__init__(dbname=name.split("/")[1], fullName=name, indexPrefix=indexPrefix)
         except RuntimeError as ex:
@@ -532,3 +531,9 @@ class MonitoringDB(ElasticDB):
             condDict["endTime"] = calendar.timegm(time.gmtime()) * 1000
 
         return self.__getRawData(typeName, condDict)
+
+
+try:
+    gMonitoringDB = MonitoringDB()
+except:
+    gMonitoringDB = None


### PR DESCRIPTION
Take this very simple script that does basically nothing

```python
from DIRAC.Core.Base.Script import parseCommandLine
parseCommandLine()
from DIRAC.DataManagementSystem.Client.FTS3Operation import FTS3Operation

for i in range(100):
    FTS3Operation()
```

It takes 45 seconds to execute on a server.
The reason is that each of these `FTS3Operation` will end up initializing a`MonitoringDB` instance, which will connect to `ElasticSeach`, list the indexes, and what not.... 

Unacceptable :unamused: 

So I just make a `MonitoringDB` singleton. With that, the script takes 2 seconds
I have full trust that the original author thought about thread safety.... (looks ok, from a quick glance)

BEGINRELEASENOTES
*Monitoring
CHANGE: introduce gMonitoringDB global instance

ENDRELEASENOTES
