### PR TITLE
[8.1] Resolve methods of the REST interface

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/TornadoREST.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoREST.py
@@ -171,10 +171,24 @@ class TornadoREST(BaseRequestHandler):  # pylint: disable=abstract-method
         """
         urls = []
         # Look for methods that are exported
-        for prefix in [cls.METHOD_PREFIX] if cls.METHOD_PREFIX else cls.SUPPORTED_METHODS:
-            prefix = prefix.lower()
-            for mName, mObj in inspect.getmembers(cls, lambda x: callable(x) and x.__name__.startswith(prefix)):
-                methodName = mName[len(prefix) :]
+        for mName in cls.__dict__:
+            mObj = cls.__dict__[mName]
+            if cls.METHOD_PREFIX and mName.startswith(cls.METHOD_PREFIX):
+                # Target methods begin with a prefix defined for all supported http methods,
+                # e.g.: def export_myMethod(self):
+                prefix = len(cls.METHOD_PREFIX)
+            elif _prefix := [
+                p for p in cls.SUPPORTED_METHODS if mName.startswith(f"{p.lower()}_")  # pylint: disable=no-member
+            ]:
+                # Target methods begin with the name of an http method,
+                # e.g.: def post_myMethod(self):
+                prefix = len(_prefix[-1]) + 1
+            else:
+                # The name of the target method must contain a special prefix
+                continue
+
+            # if the method exists we will continue
+            if callable(mObj) and (methodName := mName[prefix:]):
                 cls.log.debug(f"  Find {mName} method")
 
                 # Find target method URL

--- a/src/DIRAC/Core/Tornado/Server/TornadoREST.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoREST.py
@@ -4,13 +4,9 @@ It directly inherits from :py:class:`tornado.web.RequestHandler`
 """
 
 import os
-import inspect
 from tornado.escape import json_decode
 from tornado.web import url as TornadoURL
-from urllib.parse import unquote
-from functools import partial
 
-from DIRAC import gLogger
 from DIRAC.ConfigurationSystem.Client import PathFinder
 from DIRAC.Core.Tornado.Server.private.BaseRequestHandler import *
 
@@ -355,4 +351,4 @@ class TornadoREST(BaseRequestHandler):  # pylint: disable=abstract-method
                 # Wrap argument with annotated type
                 keywordArguments[name] = _type(value) if _type else value
 
-        return (positionalArguments, keywordArguments)
+        return positionalArguments, keywordArguments

--- a/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
+++ b/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
@@ -173,9 +173,7 @@ class OAuth2IdProvider(OAuth2Session):
         self._initialize()
         self.metadata_fetch_last = time.time() - self.METADATA_REFRESH_RATE
         self.log.debug(
-            f'"{self.name}" OAuth2 IdP initialization done:',
-            "\nclient_id: %s\nclient_secret: %s\nmetadata:\n%s"
-            % (self.client_id, self.client_secret, pprint.pformat(self.metadata)),
+            f'"{self.name}" OAuth2 IdP initialization done:', f"\nmetadata:\n{pprint.pformat(self.metadata)}"
         )
 
     def _initialize(self):


### PR DESCRIPTION

This PR avoids exposing methods from parent classes of the REST handler implementation class. 

BEGINRELEASENOTES

*Core
FIX: TornadoREST - resolve interface method names for standard HTTP access methods

ENDRELEASENOTES
