### PR TITLE
[8.0] Workaround for HTTPs timeout

### DIFF
--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -473,7 +473,13 @@ class GFAL2_StorageBase(StorageBase):
         # gfal2 needs a protocol to copy local which is 'file:'
         if not dest_file.startswith("file://"):
             dest = f"file://{os.path.abspath(dest_file)}"
-        self.ctx.filecopy(params, src_url, dest)
+
+        # We can remove the context manager when https://its.cern.ch/jira/browse/DMC-1371
+        # is solved
+        # The problem is gfal2 not respecting the parameter timeout
+        with setGfalSetting(self.ctx, "HTTP PLUGIN", "OPERATION_TIMEOUT", params.timeout):
+            self.ctx.filecopy(params, src_url, dest)
+
         if useChecksum:
             # gfal2 did a checksum check, so we should be good
             return sourceSize


### PR DESCRIPTION

When downloading a file with https, the timeout is not respected.
This is a bug in gfal, being tracked in https://its.cern.ch/jira/browse/DMC-1371
This is a workaround


BEGINRELEASENOTES

*Resources
FIX: add workaround for https timeout when dowloading file

ENDRELEASENOTES
