### PR TITLE
[8.0 ] Implement actual service monitoring

### DIFF
--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -555,7 +555,15 @@ class Service:
             response = handlerObj._rh_executeAction(proposalTuple)
             if not response["OK"]:
                 return response
+            retVal = response["Value"][0]
             if self.activityMonitoring:
+                _actionType, actionName = proposalTuple[1]
+                retStatus = "Unknown"
+                if isReturnStructure(retVal):
+                    if retVal["OK"]:
+                        retStatus = "OK"
+                    else:
+                        retStatus = "ERROR"
                 self.activityMonitoringReporter.addRecord(
                     {
                         "timestamp": int(TimeUtilities.toEpochMilliSeconds()),
@@ -563,9 +571,12 @@ class Service:
                         "ServiceName": "_".join(self._name.split("/")),
                         "Location": self._cfg.getURL(),
                         "ResponseTime": response["Value"][1],
+                        "MethodName": actionName,
+                        "Protocol": "dips",
+                        "Status": retStatus,
                     }
                 )
-            return response["Value"][0]
+            return retVal
         except Exception as e:
             gLogger.exception("Exception while executing handler action")
             return S_ERROR(f"Server error while executing action: {str(e)}")

--- a/src/DIRAC/Core/Tornado/Server/TornadoServer.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoServer.py
@@ -176,6 +176,12 @@ class TornadoServer:
         Starts the tornado server when ready.
         This method never returns.
         """
+
+        # If we are running with python3, Tornado will use asyncio,
+        # and we have to convince it to let us run in a different thread
+        # This statement must be placed before setting PeriodicCallback
+        asyncio.set_event_loop_policy(tornado.platform.asyncio.AnyThreadEventLoopPolicy())
+
         # If there is no services loaded:
         if not self.__calculateAppSettings():
             raise Exception("There is no services loaded, please check your configuration")
@@ -208,10 +214,6 @@ class TornadoServer:
             tornado.ioloop.PeriodicCallback(
                 self.__reportToMonitoring(self.__elapsedTime), self.__monitoringLoopDelay * 1000
             ).start()
-
-        # If we are running with python3, Tornado will use asyncio,
-        # and we have to convince it to let us run in a different thread
-        asyncio.set_event_loop_policy(tornado.platform.asyncio.AnyThreadEventLoopPolicy())
 
         for port, app in self.__appsSettings.items():
             sLog.debug(" - %s" % "\n - ".join([f"{k} = {ssl_options[k]}" for k in ssl_options]))


### PR DESCRIPTION
This PR contains bug fix and features

The main feature is that the activity monitoring now reports information that are actually useful (method name, status, duration), for both `dips` and `https`

It ACTUALLY does what was requested in https://github.com/DIRACGrid/DIRAC/issues/2138

```json
{
    "timestamp": 1678119467614,
    "Host": "lbvobox300.cern.ch",
    "ServiceName": "Bookkeeping_BookkeepingManager",
    "Location": "dips://lbvobox300.cern.ch:9200/Bookkeeping/BookkeepingManager",
    "ResponseTime": 0.3284897804260254,
    "MethodName": "getProductionProducedEvents",
    "Protocol": "dips",
    "Status": "OK"
  }
```

BEGINRELEASENOTES

*Core
FIX: Tornado PeriodicCallbacks are actually called
FEAT: Tornado Handlers report to ActivityMonitor
FEAT: Activity Monitoring reports useful information



ENDRELEASENOTES
