### PR TITLE
[8.0] Add dirac-admin-add-pilot command

### DIFF
--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
@@ -168,7 +168,7 @@ If this is the case, then you need to:
 - provide a certificate, or a proxy, to start the pilot;
 - such certificate/proxy should have the `GenericPilot` property;
 - in case of multi-VO environment, the Pilot should set the `/Resources/Computing/CEDefaults/VirtualOrganization` (as done e.g. by `vm-pilot <https://github.com/DIRACGrid/DIRAC/blob/integration/src/DIRAC/WorkloadManagementSystem/Utilities/CloudBootstrap/vm-pilot#L122>`_);
-- find a way to start the pilots: VMDIRAC extension will make sure to create VirtualMachine contextualized to start Pilot3.
+- find a way to start the pilots: DIRAC will make sure to create VirtualMachine contextualized to start DIRAC Pilots.
 
 We have introduced a special command named "GetPilotVersion" that you should use,
 and possibly extend, in case you want to send/start pilots that don't know beforehand the (VO)DIRAC version they are going to install.
@@ -181,10 +181,8 @@ The main file in which you should look is dirac-pilot.py
 that also contains a good explanation on how the system works.
 
 You have to provide in this case a pilot wrapper script (which can be written in bash, for example) that will start your pilot script
-with the proper environment. If you are on a cloud site, often contextualization of your virtual machine is done by supplying
-a script like the following: https://github.com/DIRACGrid/Pilot/blob/master/Pilot/user_data_vm
-
-A simpler example using the LHCbPilot extension follows::
+with the proper environment.
+A simple example using the LHCbPilot extension follows::
 
   #!/bin/sh
   #

--- a/setup.cfg
+++ b/setup.cfg
@@ -305,6 +305,7 @@ console_scripts =
     dirac-transformation-verify-outputdata = DIRAC.TransformationSystem.scripts.dirac_transformation_verify_outputdata:main [admin]
     dirac-transformation-update-derived = DIRAC.TransformationSystem.scripts.dirac_transformation_update_derived:main [admin]
     # WorkloadManagementSystem
+    dirac-admin-add-pilot = DIRAC.WorkloadManagementSystem.scripts.dirac_admin_add_pilot:main [pilot]
     dirac-admin-kill-pilot = DIRAC.WorkloadManagementSystem.scripts.dirac_admin_kill_pilot:main [admin]
     dirac-admin-pilot-logging-info = DIRAC.WorkloadManagementSystem.scripts.dirac_admin_pilot_logging_info:main [admin]
     dirac-admin-show-task-queues = DIRAC.WorkloadManagementSystem.scripts.dirac_admin_show_task_queues:main [admin]

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -188,7 +188,7 @@ class ARCComputingElement(ComputingElement):
         :param list inputs: path of the dependencies to include along with the executable
         :param list outputs: path of the outputs that we want to get at the end of the execution
         """
-        diracStamp = makeGuid()[:8]
+        diracStamp = makeGuid()[:32]
         # Evaluate the number of processors to allocate
         nProcessors = self.ceParameters.get("NumberOfProcessors", 1)
 

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -48,11 +48,11 @@ XRSLMPExtraString:
 import os
 import stat
 import sys
+import uuid
 
 import arc  # Has to work if this module is called #pylint: disable=import-error
-from DIRAC import S_OK, S_ERROR, gConfig
+from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Subprocess import shellCall
-from DIRAC.Core.Utilities.File import makeGuid
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Security.ProxyInfo import getVOfromProxyGroup
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement
@@ -188,7 +188,7 @@ class ARCComputingElement(ComputingElement):
         :param list inputs: path of the dependencies to include along with the executable
         :param list outputs: path of the outputs that we want to get at the end of the execution
         """
-        diracStamp = makeGuid()[:32]
+        diracStamp = uuid.uuid4().hex
         # Evaluate the number of processors to allocate
         nProcessors = self.ceParameters.get("NumberOfProcessors", 1)
 

--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -302,7 +302,7 @@ Queue stamp in %(pilotStampList)s
         jobStamps = []
         commonJobStampPart = makeGuid()[:3]
         for _i in range(numberOfJobs):
-            jobStamp = commonJobStampPart + makeGuid()[:5]
+            jobStamp = commonJobStampPart + makeGuid()[:29]
             jobStamps.append(jobStamp)
 
         # We randomize the location of the pilot output and log, because there are just too many of them

--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -52,6 +52,7 @@ import datetime
 import errno
 import threading
 import textwrap
+import uuid
 
 from DIRAC import S_OK, S_ERROR, gConfig
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement
@@ -60,7 +61,6 @@ from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
-from DIRAC.Core.Utilities.File import makeGuid
 from DIRAC.FrameworkSystem.private.authorization.utils.Tokens import writeToTokenFile
 from DIRAC.Core.Security.Locations import getCAsLocation
 from DIRAC.Resources.Computing.BatchSystems.Condor import parseCondorStatus
@@ -300,9 +300,9 @@ Queue stamp in %(pilotStampList)s
         # The submitted pilots are going to have a common part of the stamp to construct a path to retrieve results
         # Then they also have an individual part to make them unique
         jobStamps = []
-        commonJobStampPart = makeGuid()[:3]
+        commonJobStampPart = uuid.uuid4().hex[:3]
         for _i in range(numberOfJobs):
-            jobStamp = commonJobStampPart + makeGuid()[:29]
+            jobStamp = commonJobStampPart + uuid.uuid4().hex[:29]
             jobStamps.append(jobStamp)
 
         # We randomize the location of the pilot output and log, because there are just too many of them

--- a/src/DIRAC/Resources/Computing/LocalComputingElement.py
+++ b/src/DIRAC/Resources/Computing/LocalComputingElement.py
@@ -37,15 +37,14 @@ import shutil
 import tempfile
 import getpass
 import errno
+import uuid
 from urllib.parse import urlparse
 
 from DIRAC import S_OK, S_ERROR
-from DIRAC import gConfig
 
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement
 from DIRAC.Resources.Computing.PilotBundle import bundleProxy, writeScript
 from DIRAC.Core.Utilities.List import uniqueElements
-from DIRAC.Core.Utilities.File import makeGuid
 from DIRAC.Core.Utilities.Subprocess import systemCall
 
 
@@ -170,7 +169,7 @@ class LocalComputingElement(ComputingElement):
 
         jobStamps = []
         for _i in range(numberOfJobs):
-            jobStamps.append(makeGuid()[:32])
+            jobStamps.append(uuid.uuid4().hex)
 
         batchDict = {
             "Executable": submitFile,

--- a/src/DIRAC/Resources/Computing/LocalComputingElement.py
+++ b/src/DIRAC/Resources/Computing/LocalComputingElement.py
@@ -170,7 +170,7 @@ class LocalComputingElement(ComputingElement):
 
         jobStamps = []
         for _i in range(numberOfJobs):
-            jobStamps.append(makeGuid()[:8])
+            jobStamps.append(makeGuid()[:32])
 
         batchDict = {
             "Executable": submitFile,

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -65,13 +65,15 @@ SSHType:
 import errno
 import json
 import os
-import pexpect
 import shutil
 import stat
+import uuid
 from urllib.parse import urlparse
 from urllib.parse import quote
 from urllib.parse import unquote
 from shlex import quote as shlex_quote
+
+import pexpect
 
 import DIRAC
 from DIRAC import S_OK, S_ERROR
@@ -81,7 +83,6 @@ from DIRAC.Resources.Computing.ComputingElement import ComputingElement
 from DIRAC.Resources.Computing.PilotBundle import bundleProxy, writeScript
 from DIRAC.Resources.Computing.BatchSystems.executeBatch import executeBatchContent
 from DIRAC.Core.Utilities.List import uniqueElements
-from DIRAC.Core.Utilities.File import makeGuid
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 
 
@@ -563,7 +564,7 @@ class SSHComputingElement(ComputingElement):
 
         jobStamps = []
         for _i in range(numberOfJobs):
-            jobStamps.append(makeGuid()[:32])
+            jobStamps.append(uuid.uuid4().hex)
 
         numberOfProcessors = self.ceParameters.get("NumberOfProcessors", 1)
         wholeNode = self.ceParameters.get("WholeNode", False)

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -563,7 +563,7 @@ class SSHComputingElement(ComputingElement):
 
         jobStamps = []
         for _i in range(numberOfJobs):
-            jobStamps.append(makeGuid()[:8])
+            jobStamps.append(makeGuid()[:32])
 
         numberOfProcessors = self.ceParameters.get("NumberOfProcessors", 1)
         wholeNode = self.ceParameters.get("WholeNode", False)

--- a/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -129,7 +129,7 @@ def test__writeSub(mocker, localSchedd, optionsNotExpected, optionsExpected):
     jobStamps = []
     commonJobStampPart = makeGuid()[:3]
     for _i in range(42):
-        jobStamp = commonJobStampPart + makeGuid()[:5]
+        jobStamp = commonJobStampPart + makeGuid()[:29]
         jobStamps.append(jobStamp)
 
     htce._HTCondorCEComputingElement__writeSub("dirac-install", 42, "", 1, jobStamps)  # pylint: disable=E1101

--- a/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -2,11 +2,11 @@
 """
 tests for HTCondorCEComputingElement module
 """
+import uuid
 import pytest
 
 from DIRAC.Resources.Computing import HTCondorCEComputingElement as HTCE
 from DIRAC.Resources.Computing.BatchSystems import Condor
-from DIRAC.Core.Utilities.File import makeGuid
 from DIRAC import S_OK
 
 MODNAME = "DIRAC.Resources.Computing.HTCondorCEComputingElement"
@@ -127,9 +127,9 @@ def test__writeSub(mocker, localSchedd, optionsNotExpected, optionsExpected):
     mocker.patch(MODNAME + ".mkDir")
 
     jobStamps = []
-    commonJobStampPart = makeGuid()[:3]
+    commonJobStampPart = uuid.uuid4().hex[:3]
     for _i in range(42):
-        jobStamp = commonJobStampPart + makeGuid()[:29]
+        jobStamp = commonJobStampPart + uuid.uuid4().hex[:29]
         jobStamps.append(jobStamp)
 
     htce._HTCondorCEComputingElement__writeSub("dirac-install", 42, "", 1, jobStamps)  # pylint: disable=E1101

--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_add_pilot.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_admin_add_pilot.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""
+This command is here mainly to be used by running Pilots.
+Its goal is to add a PilotReference in PilotAgentsDB, and to update its status.
+
+While SiteDirectors normally add pilots in PilotAgentsDB,
+the same can't be true for pilots started in the vacuum (i.e. without SiteDirectors involved).
+This script is here to solve specifically this issue, even though it can be used for other things too.
+
+Example:
+  $ dirac-admin-add-pilot htcondor:123456 user_DN user_group DIRAC A11D8D2E-60F8-17A6-5520-E2276F41 --Status=Running
+
+"""
+
+from DIRAC import S_OK, S_ERROR, gLogger, exit as DIRACExit
+from DIRAC.Core.Base.Script import Script
+
+
+class Params:
+    """
+    Class holding the parameters, and callbacks for their respective switches.
+    """
+
+    def __init__(self):
+        """C'or"""
+        self.status = False
+        self.taskQueueID = 0
+        self.switches = [
+            ("", "status=", "sets the pilot status", self.setStatus),
+            ("t:", "taskQueueID=", "sets the taskQueueID", self.setTaskQueueID),
+        ]
+
+    def setStatus(self, value):
+        """sets self.status
+
+        :param value: option argument
+
+        :return: S_OK()/S_ERROR()
+        """
+        from DIRAC.WorkloadManagementSystem.Client.PilotStatus import PILOT_STATES
+
+        if value not in PILOT_STATES:
+            return S_ERROR(f"{value} is not a valid pilot status")
+        self.status = value
+        return S_OK()
+
+    def setTaskQueueID(self, value):
+        """sets self.taskQueueID
+
+        :param value: option argument
+
+        :return: S_OK()/S_ERROR()
+        """
+        try:
+            self.taskQueueID = int(value)
+        except ValueError:
+            return S_ERROR("TaskQueueID has to be a number")
+        return S_OK()
+
+
+@Script()
+def main():
+    """
+    This is the script main method, which holds all the logic.
+    """
+    params = Params()
+
+    Script.registerSwitches(params.switches)
+    Script.registerArgument("pilotRef: pilot reference")
+    Script.registerArgument("ownerDN: pilot owner DN")
+    Script.registerArgument("ownerGroup: pilot owner group")
+    Script.registerArgument("gridType: grid type")
+    Script.registerArgument("pilotStamp: DIRAC pilot stamp")
+
+    Script.parseCommandLine(ignoreErrors=False)
+
+    # Get grouped positional arguments
+    pilotRef, ownerDN, ownerGroup, gridType, pilotStamp = Script.getPositionalArgs(group=True)
+
+    # Import the required DIRAC modules
+    from DIRAC.Core.Utilities import DErrno
+    from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
+
+    pmc = PilotManagerClient()
+
+    # Check if pilot is not already registered
+    res = pmc.getPilotInfo(pilotRef)
+    if not res["OK"]:
+        if not DErrno.cmpError(res, DErrno.EWMSNOPILOT):
+            gLogger.error(res["Message"])
+            DIRACExit(1)
+        res = pmc.addPilotTQReference(
+            [pilotRef], params.taskQueueID, ownerDN, ownerGroup, "Unknown", gridType, {pilotRef: pilotStamp}
+        )
+        if not res["OK"]:
+            gLogger.error(res["Message"])
+            DIRACExit(1)
+
+    if params.status:
+        res = pmc.setPilotStatus(pilotRef, params.status)
+        if not res["OK"]:
+            gLogger.error(res["Message"])
+            DIRACExit(1)
+
+    DIRACExit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a dirac-admin-add-pilot command, to be used primarily by Pilots (the Pilot PR will come soon). 

Addresses comment https://github.com/DIRACGrid/DIRAC/issues/6491#issuecomment-1303463270 . Basically this is for addressing the case of "pilots started in the vacuum", as it is the case for vac and "HLT farm" resources.

BEGINRELEASENOTES

*WMS
NEW: new script dirac-admin-add-pilot

ENDRELEASENOTES


Question part: at the moment, the component that changes the status of pilots from "Submitted" to "Running", IIUC, is the Matcher: basically, when a job is matched, the status of the Pilot changes to "Running". Can you confirm if this is true? 
If this is true, it feels rather wrong (what if there's no job matched?). The Pilot should declare itself as "Running".