### PR TITLE
fix (Accounting): legend of graph use UTC

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/GraphData.py
+++ b/src/DIRAC/Core/Utilities/Graphs/GraphData.py
@@ -194,7 +194,9 @@ class GraphData:
                 self.all_num_keys.append(next)
                 next += 1
         elif self.key_type == "time":
-            self.all_num_keys = [date2num(datetime.datetime.fromtimestamp(to_timestamp(key))) for key in self.all_keys]
+            self.all_num_keys = [
+                date2num(datetime.datetime.utcfromtimestamp(to_timestamp(key))) for key in self.all_keys
+            ]
         elif self.key_type == "numeric":
             self.all_num_keys = [float(key) for key in self.all_keys]
 


### PR DESCRIPTION
From @phicharp 


> Is it please possible to finally fix the issues shown by this picture?
> 
> This  was generated at 17:36 CET, hence the time of update is correct (16:36:23 UTC) BUT the time on the plot and the scale are incorrect as they are in CET and the title says it is UTC. In addition as reported zillions of times the plot starts one hour late (I mean the first hour is not displayed)…
> 
> When reporting a problem e.g. to a site if we send the plot this will be really confusing for checking on their side… Local time is just something useless (as the person who gets the plot doesn’t necessarily know where you were) and ALL times should be UTC, please!
> 


Before and after the fix

![Screenshot from 2023-03-15 22-42-39](https://user-images.githubusercontent.com/3728211/225451182-7ee52f05-3725-4f4c-8a45-8f3ec744f406.png)

BEGINRELEASENOTES
Thank you for writing the text to appear in the release notes. It will show up
exactly as it appears between the two bold lines

Please follow the template:
*Subsystem
NEW/CHANGE/FIX: explanation

For examples look into release.notes

ENDRELEASENOTES
