### PR TITLE
[8.0] Log fixes for stdoutJson and MicrosecondjsonFormatter (MQ logs and stdoutjson)

### DIFF
--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/MicrosecondJsonFormatter.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/MicrosecondJsonFormatter.py
@@ -1,9 +1,25 @@
 import time
-from pythonjsonlogger.jsonlogger import JsonFormatter
+from pythonjsonlogger.jsonlogger import JsonFormatter, RESERVED_ATTRS
 
 
 class MicrosecondJsonFormatter(JsonFormatter):
     """Standard JSON formater with microsecond precision"""
+
+    def __init__(self, *args, **kwargs):
+        """
+        Add to the list of attributes we don't want to see
+        all the DIRAC spefic log formating instructions
+        """
+        if "reserved_attrs" not in kwargs:
+            kwargs["reserved_attrs"] = RESERVED_ATTRS + (
+                "spacer",
+                "headerIsShown",
+                "timeStampIsShown",
+                "contextIsShown",
+                "threadIDIsShown",
+                "color",
+            )
+        super().__init__(*args, **kwargs)
 
     def formatTime(self, record, datefmt=None):
         """:py:meth:`logging.Formatter.formatTime` with microsecond precision by default"""

--- a/src/DIRAC/Resources/LogBackends/StdoutJsonBackend.py
+++ b/src/DIRAC/Resources/LogBackends/StdoutJsonBackend.py
@@ -8,12 +8,24 @@ from DIRAC.Resources.LogBackends.AbstractBackend import AbstractBackend
 from DIRAC.FrameworkSystem.private.standardLogging.Formatter.MicrosecondJsonFormatter import MicrosecondJsonFormatter
 
 
+# These are the standard logging fields that we want to see
+# in the json. All the non default are printed anyway
+DEFAULT_FMT = "%(levelname)s %(message)s %(asctime)s"
+
+
 class StdoutJsonBackend(AbstractBackend):
     """
     This just spits out the log on stdout in a json format.
     """
 
     def __init__(self, backendParams=None, backendFilters=None):
+        # The `Format` parameter is passed as `fmt` to MicrosecondJsonFormatter
+        # which uses it to know which "standard" fields to keep in the
+        # json output. So we need these
+        if not backendParams:
+            backendParams = {}
+        backendParams.setdefault("Format", DEFAULT_FMT)
+
         super().__init__(logging.StreamHandler, MicrosecondJsonFormatter, backendParams, backendFilters)
 
     def _setHandlerParameters(self, backendParams=None):


### PR DESCRIPTION
This PR contains a fix for the stdoutJson which prints the missing info
but also a fix for the `MicrosecondjsonFormatter` which impacts the Centralized MQ logs.  I do not expect any issue with it though.

BEGINRELEASENOTES

*Framework
FIX: stdoutJson logger prints all the necessary fields
FIX: MicrosecondJsonFormatter does not dump DIRAC specific fields (`timeStampIsShown`, `colorIsShown`, etc)

ENDRELEASENOTES
