### PR TITLE
[8.0] Set CA directory location in HTCondorCE

### DIFF
--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -272,6 +272,7 @@ Queue stamp in %(pilotStampList)s
             htcEnv = {
                 "_CONDOR_SEC_CLIENT_AUTHENTICATION_METHODS": "SCITOKENS",
                 "_CONDOR_SCITOKENS_FILE": self.tokenFile.name,
+                "_CONDOR_AUTH_SSL_CLIENT_CADIR": os.environ.get("X509_CERT_DIR", "/etc/grid-security/certificates"),
             }
         else:
             htcEnv = {"_CONDOR_SEC_CLIENT_AUTHENTICATION_METHODS": "GSI"}

--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -62,7 +62,7 @@ from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
 from DIRAC.Core.Utilities.File import makeGuid
 from DIRAC.FrameworkSystem.private.authorization.utils.Tokens import writeToTokenFile
-
+from DIRAC.Core.Security.Locations import getCAsLocation
 from DIRAC.Resources.Computing.BatchSystems.Condor import parseCondorStatus
 
 MANDATORY_PARAMETERS = ["Queue"]
@@ -272,8 +272,9 @@ Queue stamp in %(pilotStampList)s
             htcEnv = {
                 "_CONDOR_SEC_CLIENT_AUTHENTICATION_METHODS": "SCITOKENS",
                 "_CONDOR_SCITOKENS_FILE": self.tokenFile.name,
-                "_CONDOR_AUTH_SSL_CLIENT_CADIR": os.environ.get("X509_CERT_DIR", "/etc/grid-security/certificates"),
             }
+            if cas := getCAsLocation():
+                htcEnv["_CONDOR_AUTH_SSL_CLIENT_CADIR"] = cas
         else:
             htcEnv = {"_CONDOR_SEC_CLIENT_AUTHENTICATION_METHODS": "GSI"}
 


### PR DESCRIPTION
Address #6893 issue

BEGINRELEASENOTES

*Resources
FIX: HTCondorCEComputingElement - set _CONDOR_AUTH_SSL_CLIENT_CADIR before executing condor commands

ENDRELEASENOTES
