### PR TITLE
[TBD][v7r3] test (CI): use github registry instead of docker

### DIFF
--- a/docs/source/DeveloperGuide/DIRACProjects/index.rst
+++ b/docs/source/DeveloperGuide/DIRACProjects/index.rst
@@ -52,7 +52,7 @@ The releases are created using the *dirac-distribution* docker image, which can 
 
 Pull it and run inside the dirac-distribution command::
 
-  docker pull diracgrid/dirac-distribution
+  docker pull ghcr.io/diracgrid/management/dirac-distribution
   python3 dirac-distribution.py -r v7r0p8
 
 The above works also for DIRAC extensions, in this case just remember to specify the project name, e.g.::

--- a/docs/source/DeveloperGuide/ReleaseProcedure/index.rst
+++ b/docs/source/DeveloperGuide/ReleaseProcedure/index.rst
@@ -239,7 +239,7 @@ The image is rebuilt once per week based on this `Dockerfile in <https://github.
 
 Pull it and run inside the dirac-distribution command::
 
-  $ docker pull diracgrid/dirac-distribution
+  $ docker pull ghcr.io/diracgrid/management/dirac-distribution
   $ python3 dirac-distribution.py -r v7r2p8
 
 The above works also for DIRAC extensions, in this case just remember to specify the project name, e.g.::
@@ -269,6 +269,6 @@ The image is rebuilt once per week based on this `Dockerfile <https://github.com
 
 Pull it and ... ::
 
-  $ docker pull diracgrid/dirac-cvmfs
+  $ docker pull ghcr.io/diracgrid/management/dirac-cvmfs
 
 --> to be expanded

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -606,7 +606,7 @@ def _make_env(flags):
     env["DIRAC_UID"] = str(os.getuid())
     env["DIRAC_GID"] = str(os.getgid())
     env["HOST_OS"] = flags.pop("HOST_OS", DEFAULT_HOST_OS)
-    env["CI_REGISTRY_IMAGE"] = flags.pop("CI_REGISTRY_IMAGE", "diracgrid")
+    env["CI_REGISTRY_IMAGE"] = flags.pop("CI_REGISTRY_IMAGE", "ghcr.io/diracgrid/management")
     env["MYSQL_VER"] = flags.pop("MYSQL_VER", DEFAULT_MYSQL_VER)
     env["ES_VER"] = flags.pop("ES_VER", DEFAULT_ES_VER)
     return env


### PR DESCRIPTION
Use github registry instead of docker
To be discussed, in the view of the new docker paid policy

BEGINRELEASENOTES
Thank you for writing the text to appear in the release notes. It will show up
exactly as it appears between the two bold lines

Please follow the template:
*Subsystem
NEW/CHANGE/FIX: explanation

For examples look into release.notes

ENDRELEASENOTES
