### PR TITLE
[8.0] fix (Tornado): decode request name in the monitoring

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
+++ b/src/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py
@@ -703,7 +703,7 @@ class BaseRequestHandler(RequestHandler):
                 "Location": self.request.uri,
                 "ResponseTime": elapsedTime,
                 # Take the method name from the POST call
-                "MethodName": self.request.arguments.get("method", ["Unknown"])[0],
+                "MethodName": self.request.arguments.get("method", ["Unknown"])[0].decode(),
                 "Protocol": "https",
                 "Status": monitoringRetStatus,
             }


### PR DESCRIPTION
Stupid laziness and copy paste...

BEGINRELEASENOTES

*Core
FIX:  cast method names to string before sending monitoring

ENDRELEASENOTES
