### PR TITLE
[8.0] feat: use client token instead of user token for submission

### DIFF
--- a/src/DIRAC/FrameworkSystem/Utilities/TokenManagementUtilities.py
+++ b/src/DIRAC/FrameworkSystem/Utilities/TokenManagementUtilities.py
@@ -1,0 +1,78 @@
+""" TokenManagementUtilties contains simple functions used by both TokenManagerClient and TokenManagerHandler."""
+
+from DIRAC import S_OK, S_ERROR
+from DIRAC.ConfigurationSystem.Client.Helpers import Registry
+from DIRAC.Core.Utilities.DictCache import DictCache
+from DIRAC.Resources.IdProvider.IdProviderFactory import IdProviderFactory
+
+
+DEFAULT_RT_EXPIRATION_TIME = 24 * 3600
+DEFAULT_AT_EXPIRATION_TIME = 1200
+
+
+def getIdProviderClient(userGroup: str, idProviderClientName: str = None):
+    """Get an IdProvider client
+
+    :param userGroup: group name
+    :param idProviderClientName: name of an identity provider in the DIRAC CS
+    """
+    # Get IdProvider credentials from CS
+    if not idProviderClientName and userGroup:
+        idProviderClientName = Registry.getIdPForGroup(userGroup)
+    if not idProviderClientName:
+        return S_ERROR(f"The {userGroup} group belongs to the VO that is not tied to any Identity Provider.")
+
+    # Prepare the client instance of the appropriate IdP
+    return IdProviderFactory().getIdProvider(idProviderClientName)
+
+
+def getCachedKey(
+    idProviderClient,
+    username: str = None,
+    userGroup: str = None,
+    scope: str = None,
+    audience: str = None,
+):
+    """Build the key to potentially retrieve a cached token given the provided parameters.
+
+    :param cachedTokens: dictionary of cached tokens
+    :param idProviderClient: name of an identity provider in the DIRAC CS
+    :param username: user name
+    :param userGroup: group name
+    :param scope: scope
+    :param audience: audience
+    """
+    # Get subject
+    # if username is not defined, then we aim at fetching a client token
+    # see https://www.rfc-editor.org/rfc/rfc6749#section-4.4 for further details
+    subject = username
+    if not subject:
+        subject = idProviderClient.name
+
+    # Get scope
+    if userGroup and (result := idProviderClient.getGroupScopes(userGroup)):
+        # What scope correspond to the requested group?
+        scope = list(set((scope or []) + result))
+    scope = " ".join(scope)
+
+    return (subject, scope, audience, idProviderClient.name, idProviderClient.issuer)
+
+
+def getCachedToken(cachedTokens: DictCache, cachedKey: str, requiredTimeLeft: int = 0):
+    """Check whether a token related to the information provided is present in cache.
+
+    :param cachedTokens: dictionary of cached tokens
+    :param cachedKey: use to retrieve a potential valid token from cachedTokens
+    :param requiredTimeLeft: required time
+    """
+    if not cachedTokens.exists(cachedKey, requiredTimeLeft):
+        return S_ERROR("The key does not exist")
+
+    # Well we have a fresh record containing a Token object
+    token = cachedTokens.get(cachedKey)
+
+    # Let's check if the access token is fresh
+    if token.is_expired(requiredTimeLeft):
+        return S_ERROR("Token found but expired")
+
+    return S_OK(token)

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -470,16 +470,7 @@ class SiteDirector(AgentModule):
 
         :return: S_OK/S_ERROR, Token object as Value
         """
-
-        result = Registry.getUsernameForDN(self.pilotDN)
-        if not result["OK"]:
-            return result
-        username = result["Value"]
-        result = gTokenManager.getToken(
-            username=username,
-            userGroup=self.pilotGroup,
-            requiredTimeLeft=3600,
-        )
+        result = gTokenManager.getToken(userGroup=self.pilotGroup, requiredTimeLeft=600)
         return result
 
     def _ifAndWhereToSubmit(self):


### PR DESCRIPTION
With this PR, DIRAC can support the OAuth2 `client_credentials` flow.

- if the `username` is provided to the `TokenManagerClient`, the `TokenManagerHandler` tries to retrieve a user access token.
- else, the `TokenManagerHandler` contacts the IdP to get a client access token.

What's new in this PR:
- The `username` parameter becomes optional in `TokenManager(Client/Handler).getToken()`
- The `SiteDirector` only passes the `group` to the `TokenManagerClient`
- The `TokenManagerHandler` fetches a client access token based on the `group` parameter (using the underlying IdP).
- Code that was common to the `TokenManager(Client/Handler)` has been moved to a new module named `TokenManagementUtilities`. 


BEGINRELEASENOTES
*WorkloadManagementSystem
CHANGE: TokenManagerHandler provides client access token if username is not provided.
ENDRELEASENOTES
