### PR TITLE
[sweep:integration] fix: py2/3 remnants : removed selectors2

### DIFF
--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -16,16 +16,11 @@
 """
 import time
 import datetime
-import socket
+import selectors
 import signal
 import os
 import sys
 import multiprocessing
-
-try:
-    import selectors
-except ImportError:
-    import selectors2 as selectors
 
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.private.Service import Service

--- a/src/DIRAC/Core/DISET/private/MessageBroker.py
+++ b/src/DIRAC/Core/DISET/private/MessageBroker.py
@@ -2,15 +2,9 @@
 """
 import threading
 import time
-import select
-import socket
+import selectors
 
 from concurrent.futures import ThreadPoolExecutor
-
-try:
-    import selectors
-except ImportError:
-    import selectors2 as selectors
 
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.DISET.private.TransportPool import getGlobalTransportPool

--- a/src/DIRAC/Core/DISET/private/Transports/PlainTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/PlainTransport.py
@@ -1,11 +1,7 @@
+import selectors
 import socket
 import time
 import os
-
-try:
-    import selectors
-except ImportError:
-    import selectors2 as selectors
 
 from DIRAC.Core.DISET.private.Transports.BaseTransport import BaseTransport
 from DIRAC.FrameworkSystem.Client.Logger import gLogger

--- a/src/DIRAC/Core/DISET/private/Transports/test/Test_SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/test/Test_SSLTransport.py
@@ -1,12 +1,7 @@
 """ Test the SSLTransport mechanism """
 import os
-import socket
+import selectors
 import threading
-
-try:
-    import selectors
-except ImportError:
-    import selectors2 as selectors
 
 from pytest import fixture
 


### PR DESCRIPTION
Sweep #6958 `fix: py2/3 remnants : removed selectors2` to `integration`.

Adding original author @fstagni as watcher.


Closes #6959