### PR TITLE
[v7r3] PushJobAgent: fixes and features

### DIFF
--- a/docs/source/AdministratorGuide/Resources/supercomputers.rst
+++ b/docs/source/AdministratorGuide/Resources/supercomputers.rst
@@ -133,7 +133,7 @@ One has also to authorize the machine hosting the :mod:`~DIRAC.WorkloadManagemen
    Properties += GenericPilot
    Properties += FileCatalogManagement
 
-One has to specify the concerned VO in the targeted CEs, such as::
+One has to specify the concerned VO, the platform and the CPU Power in the targeted CEs as well as , such as::
 
    <CE>
    {
@@ -141,6 +141,16 @@ One has to specify the concerned VO in the targeted CEs, such as::
          VO = <VO>
          # Required because we are on a host (not on a worker node)
          VirtualOrganization = <VO>
+         # To match compatible jobs
+         Platform = <platform>
+         Queues
+         {
+            <Queue>
+            {
+               CPUNormalizationFactor = <CPU Power value>
+            }
+         }
+
    }
 
 Finally, one has to make sure that job scheduling parameters are correctly fine-tuned. Further details in the :ref:`JobScheduling section <jobscheduling>`.

--- a/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
@@ -144,7 +144,7 @@ class ARC6ComputingElement(ARCComputingElement):
                 jobdescs = arc.JobDescriptionList()
 
                 # Get the job into the ARC way
-                xrslString, diracStamp = self._writeXRSL(executableFile)
+                xrslString, diracStamp = self._writeXRSL(executableFile, [], [])
                 self.log.debug("XRSL string submitted : %s" % xrslString)
                 self.log.debug("DIRAC stamp for job : %s" % diracStamp)
 

--- a/src/DIRAC/Workflow/Modules/Script.py
+++ b/src/DIRAC/Workflow/Modules/Script.py
@@ -13,7 +13,7 @@ import stat
 import shlex
 import distutils.spawn  # pylint: disable=no-name-in-module,no-member,import-error
 
-from DIRAC import gLogger
+from DIRAC import gLogger, gConfig
 from DIRAC.Core.Utilities.Subprocess import systemCall
 from DIRAC.WorkloadManagementSystem.Utilities.RemoteRunner import RemoteRunner
 from DIRAC.Workflow.Modules.ModuleBase import ModuleBase
@@ -88,8 +88,14 @@ class Script(ModuleBase):
         """execute the self.command (uses systemCall)"""
         failed = False
 
-        remoteRunner = RemoteRunner()
-        if remoteRunner.is_remote_execution():
+        # Check whether the execution should be done remotely
+        is_remote_execution = gConfig.getValue("/LocalSite/RemoteExecution", "false")
+        if is_remote_execution.lower() in ["true", "yes"]:
+            remoteRunner = RemoteRunner(
+                gConfig.getValue("/LocalSite/Site"),
+                gConfig.getValue("/LocalSite/GridCE"),
+                gConfig.getValue("/LocalSite/CEQueue"),
+            )
             retVal = remoteRunner.execute(self.command)
         else:
             retVal = systemCall(

--- a/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
@@ -373,18 +373,20 @@ class PushJobAgent(JobAgent):
 
     def _setCEDict(self, ceDict):
         """Set CEDict"""
-        # Matcher will check that ReleaseVersion match the pilot version
+        # Matcher will check that ReleaseVersion matches the pilot version
         # It is not needed in this configuration so we set ReleaseVersion as the pilot version
+        # Also, DIRACVersion should be equals to ReleaseVersion, so we modify it
         versions = self.opsHelper.getValue("Pilot/Version", [])
         if versions:
             if not isinstance(versions, list):
                 versions = [versions]
             ceDict["ReleaseVersion"] = versions[0]
+            ceDict["DIRACVersion"] = versions[0]
         project = self.opsHelper.getValue("Pilot/Project", "")
         if project:
             ceDict["ReleaseProject"] = project
 
-        # Add a remoteExecution tag, which can be used in the next stages
+        # Add a RemoteExecution entry, which can be used in the next stages
         ceDict["RemoteExecution"] = True
 
     def _checkMatchingIssues(self, jobRequest):

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_PushJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_PushJobAgent.py
@@ -53,10 +53,15 @@ def test__allowedToSubmit(mocker, queue, failedQueues, failedQueueCycleFactor, e
     "ceDict, pilotVersion, pilotProject, expected",
     [
         ({}, None, None, {"RemoteExecution": True}),
-        ({}, "8.0.0", None, {"ReleaseVersion": "8.0.0", "RemoteExecution": True}),
-        ({}, ["8.0.0", "7.3.7"], None, {"ReleaseVersion": "8.0.0", "RemoteExecution": True}),
+        ({}, "8.0.0", None, {"DIRACVersion": "8.0.0", "ReleaseVersion": "8.0.0", "RemoteExecution": True}),
+        ({}, ["8.0.0", "7.3.7"], None, {"DIRACVersion": "8.0.0", "ReleaseVersion": "8.0.0", "RemoteExecution": True}),
         ({}, None, "Project", {"ReleaseProject": "Project", "RemoteExecution": True}),
-        ({}, "8.0.0", "Project", {"ReleaseVersion": "8.0.0", "ReleaseProject": "Project", "RemoteExecution": True}),
+        (
+            {},
+            "8.0.0",
+            "Project",
+            {"DIRACVersion": "8.0.0", "ReleaseVersion": "8.0.0", "ReleaseProject": "Project", "RemoteExecution": True},
+        ),
     ],
 )
 def test__setCEDict(mocker, ceDict, pilotVersion, pilotProject, expected):

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
@@ -1,62 +1,99 @@
 """ RemoteRunner
 
+RemoteRunner has been designed to send scripts/applications and input files on remote worker nodes having
+no outbound connectivity (e.g. supercomputers)
+
 Mostly called by workflow modules, RemoteRunner is generally the last component to get through before
 the script/application execution on a remote machine.
-Depending on an environment variable WORKLOADEXECLOCATION, it decides whether it should take care of the execution.
-RemoteRunner has been designed to send script/application on remote worker nodes having no outbound connectivity
-(e.g. supercomputers)
 """
 import os
 import shlex
+from six.moves import shlex_quote
 import time
 
-from DIRAC import gLogger, gConfig, S_OK
+from DIRAC import gLogger, gConfig, S_OK, S_ERROR
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
+from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Resources.Computing.ComputingElementFactory import ComputingElementFactory
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getQueue
 from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 
 
 class RemoteRunner(object):
-    def __init__(self):
+    def __init__(self, siteName=None, ceName=None, queueName=None):
         self.log = gLogger.getSubLogger("RemoteRunner")
-        self.remoteExecution = gConfig.getValue("/LocalSite/RemoteExecution", "false")
+        self._workloadSite = siteName
+        if not self._workloadSite:
+            self.log.warn("You are expected to provide a siteName in parameters from v8.0")
+            self.log.warn("Trying to get workloadSite from /LocalSite/Site...")
+            self._workloadSite = gConfig.getValue("/LocalSite/Site")
+        self._workloadCE = ceName
+        if not self._workloadCE:
+            self.log.warn("You are expected to provide a ceName in parameters from v8.0")
+            self.log.warn("Trying to get workloadSite from /LocalSite/GridCE...")
+            self._workloadCE = gConfig.getValue("/LocalSite/GridCE")
+        self._workloadQueue = queueName
+        if not self._workloadQueue:
+            self.log.warn("You are expected to provide a queueName in parameters from v8.0")
+            self.log.warn("Trying to get workloadSite from /LocalSite/CEQueue...")
+            self._workloadQueue = gConfig.getValue("/LocalSite/CEQueue")
 
+    @deprecated('Use gConfig.getValue("/LocalSite/RemoteExecution") instead.')
     def is_remote_execution(self):
         """Main method: decides whether the execution will be done locally or remotely via a CE.
 
+        This method does not really make sense: if we use RemoteRunner, it means we want to perform a remote execution.
+        Therefore, this should be checked before calling RemoteRunner by checking /LocalSite/RemoteExecution for instance.
+
         :return: bool
         """
+        return gConfig.getValue("/LocalSite/RemoteExecution")
 
-        # if remoteExecution is true, this means the workload should be executed
-        # in a different remote location. This mainly happens when the remote Site has no
-        # external connectivity and can only execute the workload itself.
-        return self.remoteExecution.lower() in ["true", "yes"]
-
-    def execute(self, command):
+    def execute(self, command, workingDirectory=".", numberOfProcessors=1, cleanRemoteJob=True):
         """Execute the command remotely via a CE
 
         :param str command: command to execute remotely
+        :param str workingDirectory: directory containing the inputs required by the command
+        :param int numberOfProcessors: number of processors to allocate to the command
+        :param str cleanRemoteJob: clean the files related to the command on the remote host if True
+        :return: (status, output, error)
         """
-        # Set up Application Queue
-        self.log.verbose("Remote application execution on:", self.remoteExecution)
-        result = self._setUpworkloadCE()
+        self.log.verbose("Command to submit:", command)
+
+        # Check whether CE parameters are set
+        result = self._checkParameters()
         if not result["OK"]:
+            result["Value"] = (-1, "", result["Message"])
+            return result
+        self.log.verbose(
+            "The command will be sent to",
+            "site %s, CE %s, queue %s" % (self._workloadSite, self._workloadCE, self._workloadQueue),
+        )
+
+        # Set up Application Queue
+        result = self._setUpWorkloadCE(numberOfProcessors)
+        if not result["OK"]:
+            result["Value"] = (-1, "", result["Message"])
             return result
         workloadCE = result["Value"]
+        self.log.debug("The CE interface has been set up")
 
         # Add the command in an executable file
-        executable = self._wrapCommand(command)
-        # get inputs file from the current working directory
-        inputs = os.listdir(".")
+        executable = "workloadExec.sh"
+        self._wrapCommand(command, workingDirectory, executable)
+        self.log.debug("The command has been wrapped into an executable")
+
+        # Get inputs from the current working directory
+        inputs = os.listdir(workingDirectory)
         inputs.remove(os.path.basename(executable))
         self.log.verbose("The executable will be sent along with the following inputs:", ",".join(inputs))
-        # request the whole directory as output
+        # Request the whole directory as output
         outputs = ["/"]
 
         # Submit the command as a job
         result = workloadCE.submitJob(executable, workloadCE.proxy, inputs=inputs, outputs=outputs)
         if not result["OK"]:
+            result["Value"] = (-1, "", result["Message"])
             return result
         jobID = result["Value"][0]
         stamp = result["PilotStampDict"][jobID]
@@ -67,6 +104,7 @@ class RemoteRunner(object):
             time.sleep(120)
             result = workloadCE.getJobStatus([jobID])
             if not result["OK"]:
+                result["Value"] = (-1, "", result["Message"])
                 return result
             jobStatus = result["Value"][jobID]
         self.log.verbose("The final status of the application/script is: ", jobStatus)
@@ -74,24 +112,40 @@ class RemoteRunner(object):
         # Get job outputs
         result = workloadCE.getJobOutput("%s:::%s" % (jobID, stamp), os.path.abspath("."))
         if not result["OK"]:
+            result["Value"] = (-1, "", result["Message"])
             return result
+        output, error = result["Value"]
+
+        # Clean job on the remote resource
+        if cleanRemoteJob:
+            result = workloadCE.cleanJob(jobID)
+            if not result["OK"]:
+                result["Value"] = (-1, "", result["Message"])
+                return result
 
         commandStatus = {"Done": 0, "Failed": -1, "Killed": -2}
-        output, error = result["Value"]
-        outputDict = {"OK": True, "Value": [commandStatus[jobStatus], output, error]}
-        return outputDict
+        return S_OK((commandStatus[jobStatus], output, error))
 
-    def _setUpworkloadCE(self):
+    def _checkParameters(self):
+        """Initialize the remote runner using the parameters of the CS.
+        :return: S_OK, S_ERROR
+        """
+        if not self._workloadSite:
+            return S_ERROR("The remote site is not defined")
+        if not self._workloadCE:
+            return S_ERROR("The remote CE is not defined")
+        if not self._workloadQueue:
+            return S_ERROR("The remote queue is not defined")
+
+        return S_OK()
+
+    def _setUpWorkloadCE(self, numberOfProcessorsPayload=1):
         """Get application queue and configure it
 
         :return: a ComputingElement instance
         """
-        # Get CE parameters
-        workloadSite = gConfig.getValue("/LocalSite/Site")
-        workloadCE = gConfig.getValue("/LocalSite/GridCE")
-        workloadQueue = gConfig.getValue("/LocalSite/CEQueue")
-
-        result = getQueue(workloadSite, workloadCE, workloadQueue)
+        # Get CE Parameters
+        result = getQueue(self._workloadSite, self._workloadCE, self._workloadQueue)
         if not result["OK"]:
             return result
         ceType = result["Value"]["CEType"]
@@ -99,14 +153,34 @@ class RemoteRunner(object):
 
         # Build CE
         ceFactory = ComputingElementFactory()
-        result = ceFactory.getCE(ceName=workloadCE, ceType=ceType, ceParametersDict=ceParams)
+        result = ceFactory.getCE(ceName=self._workloadCE, ceType=ceType, ceParametersDict=ceParams)
         if not result["OK"]:
             return result
         workloadCE = result["Value"]
 
+        # Set the number of processors available according to the need of the payload
+        numberOfProcessorsCE = workloadCE.ceParameters.get("NumberOfProcessors", 1)
+        if numberOfProcessorsCE < 1 or numberOfProcessorsPayload < 1:
+            self.log.warn(
+                "Inappropriate values:",
+                "number of processors required for the payload %s - for the CE %s"
+                % (numberOfProcessorsPayload, numberOfProcessorsCE),
+            )
+            return S_ERROR("Inappropriate NumberOfProcessors value")
+
+        if numberOfProcessorsPayload > numberOfProcessorsCE:
+            self.log.warn(
+                "Not enough processors to execute the payload: ",
+                "number of processors required for the payload %s < %s the WN capacity"
+                % (numberOfProcessorsPayload, numberOfProcessorsCE),
+            )
+            return S_ERROR("Not enough processors to execute the command")
+
+        workloadCE.ceParameters["NumberOfProcessors"] = numberOfProcessorsPayload
+
         # Add a proxy to the CE
         result = getProxyInfo()
-        if not result["OK"] and not result["Value"]["chain"]:
+        if not result["OK"]:
             return result
         proxy = result["Value"]["chain"]
         result = proxy.getRemainingSecs()
@@ -117,13 +191,36 @@ class RemoteRunner(object):
 
         return S_OK(workloadCE)
 
-    def _wrapCommand(self, command):
+    def _wrapCommand(self, command, workingDirectory, executable):
         """Wrap the command in a file
 
         :param str command: command line to write in the executable
-        :return: name of the executable file
+        :param str workingDirectory: directory containing the inputs required by the command
+        :param str executable: path of the executable that should contain the command to submit
+        :return: path of the executable
         """
-        executable = "workloadExec.sh"
+        # Check whether the command contains any absolute path: there would be no way to access them remotely
+        # They need to be converted into relative path
+        argumentsProcessed = []
+        for argument in shlex.split(command):
+
+            argPath = os.path.dirname(argument)
+            # The argument does not contain any path, not concerned
+            if not argPath:
+                argumentsProcessed.append(argument)
+                continue
+
+            argPathAbsolutePath = os.path.abspath(argPath)
+            workingDirAbsolutePath = os.path.abspath(workingDirectory)
+            # The argument is not included in the workingDirectory, not concerned
+            if not argPathAbsolutePath.startswith(workingDirAbsolutePath):
+                argumentsProcessed.append(argument)
+                continue
+
+            # The argument is included in the workingDirectory and should be converted
+            argumentsProcessed.append(os.path.join(".", os.path.basename(argument)))
+
+        # Fro v8.0, use: shlex.join(argumentsProcessed)
+        command = " ".join(shlex_quote(arg) for arg in argumentsProcessed)
         with open(executable, "w") as f:
             f.write(command)
-        return executable

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_RemoteRunner.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_RemoteRunner.py
@@ -1,0 +1,110 @@
+""" Test class for Job Agent
+"""
+
+# imports
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+import pytest
+import os
+from diraccfg import CFG
+
+# DIRAC Components
+from DIRAC import gLogger, gConfig, S_OK
+from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
+from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-error
+from DIRAC.WorkloadManagementSystem.Utilities.RemoteRunner import RemoteRunner
+
+gLogger.setLevel("DEBUG")
+
+
+@pytest.mark.parametrize(
+    "command, workingDirectory, expectedContent",
+    [
+        ("/path/to/script.sh", "/path/to", "./script.sh"),
+        ("/path/to/script.sh", "/another/path/to", "/path/to/script.sh"),
+        ("/path/to/script.sh arg1", "/path/to", "./script.sh arg1"),
+        ("/path/to/script.sh /path/to/arg1", "/path/to", "./script.sh ./arg1"),
+        ("/path/to/script.sh /anotherpath/to/arg1", "/path/to", "./script.sh /anotherpath/to/arg1"),
+        ("/path/to/script.sh /another/path/to/arg1", "/path/to", "./script.sh /another/path/to/arg1"),
+        ("./script.sh", ".", "./script.sh"),
+        ("ls", "/path/to", "ls"),
+        ("echo 'Hello World'", "/path/to", "echo 'Hello World'"),
+        (
+            "lb-prod-run prodConf_Gauss_12345_12345.json --verbose",
+            ".",
+            "lb-prod-run prodConf_Gauss_12345_12345.json --verbose",
+        ),
+    ],
+)
+def test__wrapCommand(command, workingDirectory, expectedContent):
+    """Test RemoteRunner()._wrapCommand()"""
+    executable = "workloadExec.sh"
+
+    # Instantiate a RemoteRunner and wrap the command
+    remoteRunner = RemoteRunner("Site1", "CE1", "queue1")
+    remoteRunner._wrapCommand(command, workingDirectory, executable)
+
+    # Test the results
+    assert os.path.isfile(executable)
+    with open(executable, "r") as f:
+        content = f.read()
+    os.remove(executable)
+    assert content == expectedContent
+
+
+@pytest.mark.parametrize(
+    "payloadNumberOfProcessors, ceNumberOfProcessors, expectedResult, expectedNumberOfProcessors",
+    [
+        # CE has more processors than the payload requests
+        (1, 1, True, 1),
+        (2, 2, True, 2),
+        (1, 2, True, 1),
+        # CE has less processors than the payload requests
+        (2, 1, False, "Not enough processors to execute the command"),
+        # Specific case: we should not have 0
+        (0, 1, False, "Inappropriate NumberOfProcessors value"),
+        (1, 0, False, "Inappropriate NumberOfProcessors value"),
+        (-4, 1, False, "Inappropriate NumberOfProcessors value"),
+        (1, -4, False, "Inappropriate NumberOfProcessors value"),
+        (0, 0, False, "Inappropriate NumberOfProcessors value"),
+    ],
+)
+def test__setUpWorkloadCE(
+    mocker, payloadNumberOfProcessors, ceNumberOfProcessors, expectedResult, expectedNumberOfProcessors
+):
+    """Test RemoteRunner()._setUpWorkloadCE()"""
+    mocker.patch(
+        "DIRAC.WorkloadManagementSystem.Utilities.RemoteRunner.getProxyInfo", return_value=S_OK({"chain": X509Chain()})
+    )
+    mocker.patch("DIRAC.Core.Security.X509Chain.X509Chain.getRemainingSecs", return_value=S_OK(1000))
+
+    # Configure the CS with the number of available processors in the CE
+    siteName = "DIRAC.Site1.site"
+    ceName = "CE1"
+    queueName = "queue1"
+
+    config = {"Resources": {"Sites": {"DIRAC": {siteName: {"CEs": {ceName: {}}}}}}}
+    ceConfig = config["Resources"]["Sites"]["DIRAC"][siteName]["CEs"][ceName]
+    ceConfig["CEType"] = "HTCondorCE"
+    ceConfig["Queues"] = {}
+    ceConfig["Queues"][queueName] = {}
+    ceConfig["Queues"][queueName]["NumberOfProcessors"] = ceNumberOfProcessors
+
+    # Load the configuration
+    gConfigurationData.localCFG = CFG()
+    cfg = CFG()
+    cfg.loadFromDict(config)
+    gConfig.loadCFG(cfg)
+
+    # Instantiate a RemoteRunner and set up the CE
+    remoteRunner = RemoteRunner(siteName, ceName, queueName)
+    result = remoteRunner._setUpWorkloadCE(payloadNumberOfProcessors)
+
+    # Test the results
+    assert result["OK"] == expectedResult
+    if expectedResult:
+        workloadCE = result["Value"]
+        assert workloadCE.ceParameters["NumberOfProcessors"] == expectedNumberOfProcessors
+    else:
+        assert result["Message"] == expectedNumberOfProcessors


### PR DESCRIPTION
This PR is composed of 4 commits:
- 0c73abcf4a8e9c87cee1ba311a76d785af0fd934 adds a `cleanJob()` method to `AREX`. It allows to delete a job (id, inputs and outputs) on remote computing resources. This is useful to save some space.
- 8ad4e575e5a63d445396832757ff98710fe3e227 refactors the use of multiple executables in `ARC/AREX`. Basically, if an input file can be executed locally, then it should be added to the `executables` field of the XRSL to be executable from the remote computing resources.
- 373ca63e2931a9d97bfed0e08a5f00ae73ad693a adds some tests for `RemoteRunner`. Here are a list of the main changes:
  - `is_remote_execution()` is declared deprecated
  - Site, CE, queue parameters are passed to the constructor.
  - `execute` have additional parameters: `numberOfProcessors` to deal with MP applications, `cleanJob` to know whether the applications should be cleaned remotely, and `workingDirectory` to know where inputs should be retrieved. 
  - a few fixes
- 9c596b46bb2618e0b86790e9145b657bc76a2898 modifies the `DIRACVersion` key of the CE dictionary sent to the `Matcher` (`PushJobAgent`) and adds details to the documentation.

BEGINRELEASENOTES
*Resources
NEW: cleanJob() in AREX
CHANGE: executables from inputs are passed as executables in the XRSL in ARC and AREX
*WorkloadManagementSystem
NEW: tests for RemoteRunner
CHANGE: RemoteRunner can deal with MP applications, clean job outputs and process more applications
FIX: Modify the DIRACVersion in the PushJobAgent
*docs
CHANGE: more details in the "supercomputers" section
ENDRELEASENOTES
