### PR TITLE
[v7r3] jobstatus: add staging to checking transition

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
@@ -92,7 +92,7 @@ class JobsStateMachine(StateMachine):
             RESCHEDULED: State(6, [WAITING, RECEIVED, DELETED, FAILED], defState=RESCHEDULED),
             MATCHED: State(5, [RUNNING, FAILED, RESCHEDULED, KILLED], defState=MATCHED),
             WAITING: State(4, [MATCHED, RESCHEDULED, DELETED], defState=WAITING),
-            STAGING: State(3, [WAITING, FAILED, KILLED], defState=STAGING),
+            STAGING: State(3, [CHECKING, WAITING, FAILED, KILLED], defState=STAGING),
             CHECKING: State(2, [STAGING, WAITING, RESCHEDULED, FAILED, DELETED], defState=CHECKING),
             RECEIVED: State(1, [CHECKING, WAITING, FAILED, DELETED], defState=RECEIVED),
             SUBMITTING: State(0, [RECEIVED, CHECKING, DELETED], defState=SUBMITTING),  # initial state


### PR DESCRIPTION
Given that the JobStateUpdateHandler will always go to checking from staging

https://github.com/DIRACGrid/DIRAC/blob/b65cb3d12cacf879ed0a1e33a2225b3c2b9d95d0/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py#L69

I think this has to be added.


BEGINRELEASENOTES

*WMS
FIX: JobStatus: add staging to checking transition, needed by StorageManagementSystem (Stager)

ENDRELEASENOTES
