### PR TITLE
[v7r3] fix: return a specific error code in RemoteRunner in case of failure

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
@@ -13,6 +13,7 @@ import time
 
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
+from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Resources.Computing.ComputingElementFactory import ComputingElementFactory
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getQueue
@@ -63,7 +64,7 @@ class RemoteRunner(object):
         # Check whether CE parameters are set
         result = self._checkParameters()
         if not result["OK"]:
-            result["Value"] = (-1, "", result["Message"])
+            result["Errno"] = DErrno.ESECTION
             return result
         self.log.verbose(
             "The command will be sent to",
@@ -73,7 +74,7 @@ class RemoteRunner(object):
         # Set up Application Queue
         result = self._setUpWorkloadCE(numberOfProcessors)
         if not result["OK"]:
-            result["Value"] = (-1, "", result["Message"])
+            result["Errno"] = DErrno.ERESUNA
             return result
         workloadCE = result["Value"]
         self.log.debug("The CE interface has been set up")
@@ -93,7 +94,7 @@ class RemoteRunner(object):
         # Submit the command as a job
         result = workloadCE.submitJob(executable, workloadCE.proxy, inputs=inputs, outputs=outputs)
         if not result["OK"]:
-            result["Value"] = (-1, "", result["Message"])
+            result["Errno"] = DErrno.EWMSSUBM
             return result
         jobID = result["Value"][0]
         stamp = result["PilotStampDict"][jobID]
@@ -104,7 +105,7 @@ class RemoteRunner(object):
             time.sleep(120)
             result = workloadCE.getJobStatus([jobID])
             if not result["OK"]:
-                result["Value"] = (-1, "", result["Message"])
+                result["Errno"] = DErrno.EWMSSTATUS
                 return result
             jobStatus = result["Value"][jobID]
         self.log.verbose("The final status of the application/script is: ", jobStatus)
@@ -112,16 +113,15 @@ class RemoteRunner(object):
         # Get job outputs
         result = workloadCE.getJobOutput("%s:::%s" % (jobID, stamp), os.path.abspath("."))
         if not result["OK"]:
-            result["Value"] = (-1, "", result["Message"])
+            result["Errno"] = DErrno.EWMSJMAN
             return result
         output, error = result["Value"]
 
-        # Clean job on the remote resource
+        # Clean job in the remote resource
         if cleanRemoteJob:
             result = workloadCE.cleanJob(jobID)
             if not result["OK"]:
-                result["Value"] = (-1, "", result["Message"])
-                return result
+                self.log.warn("Failed to clean the output remotely", result["Message"])
 
         commandStatus = {"Done": 0, "Failed": -1, "Killed": -2}
         return S_OK((commandStatus[jobStatus], output, error))


### PR DESCRIPTION
This PR adds a specific exit code for the errors that can occur during the `RemoteRunner` execution.
If the output is not cleaned remotely, then it is still okay, a warning is simply displayed (the job execution remains correct and we have the outputs at this point).

BEGINRELEASENOTES
*WorkloadManagement
FIX: return specific exit code in RemoteRunner in case of failure
ENDRELEASENOTES
