### PR TITLE
[8.0] fix AREXCE: `executables` definition not removed correctly within the code

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -399,9 +399,8 @@ class AREXComputingElement(ARCComputingElement):
             outputs = []
 
         # If there is a preamble, then we bundle it in an executable file
-        executables = []
         if self.preamble:
-            executables = [executableFile]
+            inputs.append(executableFile)
             executableFile = self._bundlePreamble(executableFile)
 
         # Submit multiple jobs sequentially.


### PR DESCRIPTION
I overlooked a specific block of code that was not replaced correctly when https://github.com/DIRACGrid/DIRAC/pull/6969 was swept from `v7r3` to `v8.0`.

BEGINRELEASENOTES
*Resources
FIX: remove executables definition from AREXCE.submitJob()
ENDRELEASENOTES
