### PR TITLE
[v8.0] Fix RMS monitoring with no object IDs

### DIFF
--- a/src/DIRAC/RequestManagementSystem/private/OperationHandlerBase.py
+++ b/src/DIRAC/RequestManagementSystem/private/OperationHandlerBase.py
@@ -282,7 +282,7 @@ class OperationHandlerBase(metaclass=DynamicProps):
             "operationType": self.operation.Type,
             "status": status,
             "nbObject": nbObject,
-            "parentID": self.operation.OperationID,
+            "parentID": getattr(self.operation, "OperationID", 0),
         }
 
         return record

--- a/src/DIRAC/RequestManagementSystem/private/RequestTask.py
+++ b/src/DIRAC/RequestManagementSystem/private/RequestTask.py
@@ -306,8 +306,8 @@ class RequestTask:
                                 "host": Network.getFQDN(),
                                 "objectType": "Operation",
                                 "operationType": pluginName,
-                                "objectID": operation.OperationID,
-                                "parentID": operation.RequestID,
+                                "objectID": getattr(operation, "OperationID", 0),
+                                "parentID": getattr(operation, "RequestID", 0),
                                 "status": "Attempted",
                                 "nbObject": 1,
                             }
@@ -328,8 +328,8 @@ class RequestTask:
                                     "host": Network.getFQDN(),
                                     "objectType": "Operation",
                                     "operationType": pluginName,
-                                    "objectID": operation.OperationID,
-                                    "parentID": operation.RequestID,
+                                    "objectID": getattr(operation, "OperationID", 0),
+                                    "parentID": getattr(operation, "RequestID", 0),
                                     "status": "Failed",
                                     "nbObject": 1,
                                 }
@@ -340,7 +340,7 @@ class RequestTask:
                                 "timestamp": int(TimeUtilities.toEpochMilliSeconds()),
                                 "host": Network.getFQDN(),
                                 "objectType": "Request",
-                                "objectID": operation.RequestID,
+                                "objectID": getattr(operation, "RequestID", 0),
                                 "status": "Failed",
                                 "nbObject": 1,
                             }
@@ -362,7 +362,10 @@ class RequestTask:
                             if operation.Status != "Failed":
                                 operation.Status = "Failed"
                             self.request.Error = "Job no longer exists"
-            except Exception as error:
+            except Exception as e:
+                # We can't do except Exception as error
+                # because it masks the local variable
+                error = repr(e)
                 self.log.exception("hit by exception:", error)
                 if pluginName:
                     if self.rmsMonitoring:
@@ -372,8 +375,8 @@ class RequestTask:
                                 "host": Network.getFQDN(),
                                 "objectType": "Operation",
                                 "operationType": pluginName,
-                                "objectID": operation.OperationID,
-                                "parentID": operation.RequestID,
+                                "objectID": getattr(operation, "OperationID", 0),
+                                "parentID": getattr(operation, "RequestID", 0),
                                 "status": "Failed",
                                 "nbObject": 1,
                             }
@@ -384,7 +387,7 @@ class RequestTask:
                             "timestamp": int(TimeUtilities.toEpochMilliSeconds()),
                             "host": Network.getFQDN(),
                             "objectType": "Request",
-                            "objectID": operation.RequestID,
+                            "objectID": getattr(operation, "RequestID", 0),
                             "status": "Failed",
                             "nbObject": 1,
                         }
@@ -403,8 +406,8 @@ class RequestTask:
                             "host": Network.getFQDN(),
                             "objectType": "Operation",
                             "operationType": pluginName,
-                            "objectID": operation.OperationID,
-                            "parentID": operation.RequestID,
+                            "objectID": getattr(operation, "OperationID", 0),
+                            "parentID": getattr(operation, "RequestID", 0),
                             "status": "Successful",
                             "nbObject": 1,
                         }
@@ -417,8 +420,8 @@ class RequestTask:
                             "host": Network.getFQDN(),
                             "objectType": "Operation",
                             "operationType": pluginName,
-                            "objectID": operation.OperationID,
-                            "parentID": operation.RequestID,
+                            "objectID": getattr(operation, "OperationID", 0),
+                            "parentID": getattr(operation, "RequestID", 0),
                             "status": "Failed",
                             "nbObject": 1,
                         }


### PR DESCRIPTION
The `RegisterReplica` operation has a weird edge case in which it would create a new `RegisterReplica` Operation, and it would be executed even before making it to the DB. As  a result, this new Operation has no `OperationID` nor `RequestID`. And thus the monitoring cannot work.
This PR just tries to dynamically get these values, otherwise uses 0.

And it also fixes another bug, illustrated by this

```python
In [1]: def f():
   ...:     error = None
   ...:     try:
   ...:         raise ValueError("Boom")
   ...:     except ValueError as error:
   ...:         print("There was an error")
   ...:     if error:
   ...:         print("Yes there was")
   ...: 

In [2]: f()
There was an error
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
Cell In[2], line 1
----> 1 f()

Cell In[1], line 7, in f()
      5 except ValueError as error:
      6     print("There was an error")
----> 7 if error:
      8     print("Yes there was")

UnboundLocalError: local variable 'error' referenced before assignment
```

BEGINRELEASENOTES
*RMS
FIX: fix the monitoring of Operations not yet entered into the DB

ENDRELEASENOTES
