### PR TITLE
[8.1] Using JobManager instead of JobDB for rescheduling stalled jobs

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
@@ -27,6 +27,7 @@ def sja(mocker):
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobLoggingDB")
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getSystemInstance", side_effect=mockNone)
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobMonitoringClient", return_value=MagicMock())
+    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobManagerClient", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.PilotManagerClient", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.WMSClient", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getSystemInstance", return_value="/bof/bih")

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -1205,24 +1205,6 @@ class JobDB(DB):
 
         return result
 
-    #################################################################
-    def rescheduleJobs(self, jobIDs):
-        """Reschedule all the jobs in the given list"""
-
-        result = S_OK()
-
-        failedJobs = []
-        for jobID in jobIDs:
-            result = self.rescheduleJob(jobID)
-            if not result["OK"]:
-                failedJobs.append(jobID)
-
-        if failedJobs:
-            result = S_ERROR("JobDB.rescheduleJobs: Not all the jobs were rescheduled")
-            result["FailedJobs"] = failedJobs
-
-        return result
-
     #############################################################################
     def rescheduleJob(self, jobID):
         """Reschedule the given job to run again from scratch. Retain the already


### PR DESCRIPTION
BEGINRELEASENOTES

*WorkloadManagementSystem
CHANGE: Using JobManager instead of JobDB for rescheduling stalled jobs

ENDRELEASENOTES

When trying to add Celery, I noticed the StalledJobAgent used directly the JobDB instead of calling the JobManager. I think this PR would improve the separation of concerns and improve code quality.  
