### PR TITLE
[v7r3] Backport GFAL2 webdav/https timeout workaround

### DIFF
--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -558,7 +558,11 @@ class GFAL2_StorageBase(StorageBase):
             # gfal2 needs a protocol to copy local which is 'file:'
             if not dest_file.startswith("file://"):
                 dest = "file://%s" % os.path.abspath(dest_file)
-            self.ctx.filecopy(params, str(src_url), str(dest))
+            # We can remove the context manager when https://its.cern.ch/jira/browse/DMC-1371
+            # is solved
+            # The problem is gfal2 not respecting the parameter timeout
+            with setGfalSetting(self.ctx, "HTTP PLUGIN", "OPERATION_TIMEOUT", params.timeout):
+                self.ctx.filecopy(params, str(src_url), str(dest))
             if useChecksum:
                 # gfal2 did a checksum check, so we should be good
                 return S_OK(remoteSize)


### PR DESCRIPTION
Hi,

This is a simple cherry-pick backport of #6881 to v7r3 as we were seeing the same webdav timeouts for GridPP instance users.

Could someone with suitable permissions please add a no sweep label?

Regards,
Simon


BEGINRELEASENOTES
*Resources
FIX: add workaround for https timeout when dowloading file
ENDRELEASENOTES
