### PR TITLE
[v7r3] fix(StalledJobAgent): after a job was Killed, we have to force the Fa…

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -249,7 +249,7 @@ class StalledJobAgent(AgentModule):
                 if site in self.stalledJobsToRescheduleSites:
                     return self._updateJobStatus(jobID, JobStatus.RESCHEDULED, minorStatus=setFailed, force=True)
 
-            return self._updateJobStatus(jobID, JobStatus.FAILED, minorStatus=setFailed)
+            return self._updateJobStatus(jobID, JobStatus.FAILED, minorStatus=setFailed, force=True)
 
         return S_OK()
 


### PR DESCRIPTION
…iled status

a few lines above the job is killed (sendKillCommand), which sets the status to Killed, and then we cannot update to Failed again, because of the JobStateMachine.

BEGINRELEASENOTES
*WMS
FIX:fix(StalledJobAgent): after a job was Killed, we have to force the Failed.

ENDRELEASENOTES
