### PR TITLE
[8.0] Workflow tests need pilot.cfg to work

### DIFF
--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -214,6 +214,8 @@ def initialize(
     localCfg = LocalConfiguration()
 
     for config_file in extra_config_files or []:
+        if not os.path.exists(config_file):
+            continue
         cfg = CFG()
         cfg.loadFromFile(config_file)
         gConfigurationData.mergeWithLocal(cfg)

--- a/tests/Workflow/Integration/Test_UserJobs.py
+++ b/tests/Workflow/Integration/Test_UserJobs.py
@@ -10,7 +10,7 @@ import multiprocessing
 
 import DIRAC
 
-DIRAC.initialize()  # Initialize configuration
+DIRAC.initialize(extra_config_files=["pilot.cfg"])  # Initialize configuration
 
 from DIRAC import gLogger, rootPath
 from DIRAC.tests.Utilities.IntegrationTest import IntegrationTest

--- a/tests/Workflow/Regression/Test_RegressionUserJobs.py
+++ b/tests/Workflow/Regression/Test_RegressionUserJobs.py
@@ -8,7 +8,7 @@ import shutil
 
 import DIRAC
 
-DIRAC.initialize()  # Initialize configuration
+DIRAC.initialize(extra_config_files=["pilot.cfg"])  # Initialize configuration
 
 from DIRAC import gLogger, rootPath
 


### PR DESCRIPTION
BEGINRELEASENOTES

*test
FIX: Workflow tests need pilot.cfg to work

ENDRELEASENOTES
