### PR TITLE
[8.0] AREX fixes: proxy renewal logic + submission with tokens + correctly report aborted pilots

### DIFF
--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -63,6 +63,7 @@ from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 MANDATORY_PARAMETERS = ["Queue"]  # Mandatory for ARC CEs in GLUE2?
 # See https://www.nordugrid.org/arc/arc6/tech/rest/rest.html#rest-interface-job-states
 # We let "Deleted, Hold, Undefined" for the moment as we are not sure whether they are still used
+# "None" is a special case: it is returned when the job ID is not found in the system
 STATES_MAP = {
     "Accepting": PilotStatus.WAITING,
     "Accepted": PilotStatus.WAITING,
@@ -83,6 +84,7 @@ STATES_MAP = {
     "Wiped": PilotStatus.ABORTED,
     "Deleted": PilotStatus.ABORTED,
     "Hold": PilotStatus.FAILED,
+    "None": PilotStatus.ABORTED,
     "Undefined": PilotStatus.UNKNOWN,
 }
 


### PR DESCRIPTION
This PR modifies and fixes the proxy renewal mechanism in AREX.
Basically, a set of jobs submitted within a same `submitJob()` call share a common delegation ID, which is used to renew the proxies of the jobs.

The previous logic was going through each `WAITING` and `RUNNING` jobs to extract and try to renew their delegations.
Instead of that, here we just get the list of our current delegations and we try to renew them.

Plus, the previous logic was not working at all, there were a few bugs introduced in the past (most probably by me :upside_down_face:).

EDIT: see the following [comment below](https://github.com/DIRACGrid/DIRAC/pull/7048#issuecomment-1611279046)

BEGINRELEASENOTES
*Resources
CHANGE/FIX: proxy renewal logic in AREX
FIX: submitting tokens with AREX
FIX: correctly report aborted pilots with AREX
ENDRELEASENOTES
