### PR TITLE
[8.0] Simple  TornadoSandboxStore handler

### DIFF
--- a/src/DIRAC/Core/Tornado/Client/TornadoClient.py
+++ b/src/DIRAC/Core/Tornado/Client/TornadoClient.py
@@ -64,7 +64,7 @@ class TornadoClient(TornadoBaseClient):
         retVal["rpcStub"] = (self._getBaseStub(), method, list(args))
         return retVal
 
-    def receiveFile(self, destFile, fileId, token=""):
+    def receiveFile(self, destFile, *args):
         """
         Equivalent of :py:meth:`~DIRAC.Core.DISET.TransferClient.TransferClient.receiveFile`
 
@@ -74,15 +74,7 @@ class TornadoClient(TornadoBaseClient):
         :param args: list of arguments
         :returns: S_OK/S_ERROR
         """
-        rpcCall = {
-            "method": "streamToClient",
-            "args": encode(
-                (
-                    fileId,
-                    token,
-                )
-            ),
-        }
+        rpcCall = {"method": "streamToClient", "args": encode(args)}
         # Start request
         retVal = self._request(outputFile=destFile, **rpcCall)
         return retVal

--- a/src/DIRAC/Core/Tornado/Client/TornadoClient.py
+++ b/src/DIRAC/Core/Tornado/Client/TornadoClient.py
@@ -74,7 +74,15 @@ class TornadoClient(TornadoBaseClient):
         :param args: list of arguments
         :returns: S_OK/S_ERROR
         """
-        rpcCall = {"method": "streamToClient", "args": encode(args)}
+        rpcCall = {
+            "method": "streamToClient",
+            "args": encode(
+                (
+                    fileId,
+                    token,
+                )
+            ),
+        }
         # Start request
         retVal = self._request(outputFile=destFile, **rpcCall)
         return retVal

--- a/src/DIRAC/Core/Tornado/Client/TornadoClient.py
+++ b/src/DIRAC/Core/Tornado/Client/TornadoClient.py
@@ -24,6 +24,7 @@
 
 from DIRAC.Core.Tornado.Client.private.TornadoBaseClient import TornadoBaseClient
 from DIRAC.Core.Utilities.JEncode import encode
+from DIRAC.Core.Utilities.File import getGlobbedTotalSize
 
 
 class TornadoClient(TornadoBaseClient):
@@ -63,7 +64,7 @@ class TornadoClient(TornadoBaseClient):
         retVal["rpcStub"] = (self._getBaseStub(), method, list(args))
         return retVal
 
-    def receiveFile(self, destFile, *args):
+    def receiveFile(self, destFile, fileId, token=""):
         """
         Equivalent of :py:meth:`~DIRAC.Core.DISET.TransferClient.TransferClient.receiveFile`
 
@@ -77,6 +78,25 @@ class TornadoClient(TornadoBaseClient):
         # Start request
         retVal = self._request(outputFile=destFile, **rpcCall)
         return retVal
+
+    def sendFile(self, filename, fileID):
+        """
+        Equivalent of :py:meth:`~DIRAC.Core.DISET.TransferClient.TransferClient.sendFile`
+
+        In practice, it calls the remote method `streamFromClient` and transfers the file
+        as a string type value
+
+        :param str filename: file (or path) where to store the result
+        :param any fileID: tuple if file identifiers
+        :returns: S_OK/S_ERROR result of the remote RPC call
+        """
+        fileSize = getGlobbedTotalSize(filename)
+        token = ""
+
+        with open(filename, "br") as input:
+            result = self.executeRPC("streamFromClient", *[fileID, token, fileSize, input.read()])
+
+        return result
 
 
 def executeRPCStub(rpcStub):

--- a/src/DIRAC/FrameworkSystem/Client/TokenManagerClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/TokenManagerClient.py
@@ -57,7 +57,7 @@ class TokenManagerClient(Client):
         idpObj = result["Value"]
 
         # Search for an existing token in tokensCache
-        cachedKey = getCachedKey(idpObj.name, username, userGroup, scope, audience)
+        cachedKey = getCachedKey(idpObj, username, userGroup, scope, audience)
         result = getCachedToken(self.__tokensCache, cachedKey, requiredTimeLeft)
         if result["OK"]:
             # A valid token has been found and is returned

--- a/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
@@ -213,7 +213,7 @@ class TokenManagerHandler(TornadoService):
         idpObj = result["Value"]
 
         # Search for an existing token in tokensCache
-        cachedKey = getCachedKey(idpObj.name, username, userGroup, scope, audience)
+        cachedKey = getCachedKey(idpObj, username, userGroup, scope, audience)
         result = getCachedToken(self.__tokensCache, cachedKey, requiredTimeLeft)
         if result["OK"]:
             # A valid token has been found and is returned

--- a/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
@@ -259,7 +259,7 @@ class TokenManagerHandler(TornadoService):
                     result = self.__checkProperties(dn, userGroup)
                     if result["OK"]:
                         # refresh token with requested scope
-                        result = idpObj.refreshToken(tokens.get("refresh_token"))
+                        result = idpObj.refreshToken(tokens.get("refresh_token"), group=userGroup, scope=scope)
                         if result["OK"]:
                             # caching new tokens
                             self.__tokensCache.add(

--- a/src/DIRAC/Resources/IdProvider/Utilities.py
+++ b/src/DIRAC/Resources/IdProvider/Utilities.py
@@ -39,7 +39,8 @@ def getIdProviderIdentifierFromIssuerAndClientID(issuer, clientID):
 
     for identifier in result["Value"]:
         testedClientID = gConfig.getValue(f"/Resources/IdProviders/{identifier}/client_id")
-        if testedClientID and testedClientID == clientID:
+        # clientID is not always available, e.g. in case of a token of particular user
+        if not clientID or (testedClientID and testedClientID == clientID):
             # Found the client ID but need to check the issuer
             # 2 different issuers could theoretically have a same client ID
             testedIssuer = gConfig.getValue(f"/Resources/IdProviders/{identifier}/issuer")

--- a/src/DIRAC/Resources/Storage/DIPStorage.py
+++ b/src/DIRAC/Resources/Storage/DIPStorage.py
@@ -160,7 +160,7 @@ class DIPStorage(StorageBase):
 
     def __getFile(self, src_url, dest_file):
         transferClient = TransferClient(self.url)
-        res = transferClient.receiveFile(dest_file, src_url, token=self.checkSum)
+        res = transferClient.receiveFile(dest_file, src_url, self.checkSum)
         if not res["OK"]:
             return res
         if not os.path.exists(dest_file):

--- a/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -152,7 +152,7 @@ Services
   ##BEGIN TornadoSandboxStore
   TornadoSandboxStore
   {
-    Port = 9196
+    Protocol = https
     LocalSE = ProductionSandboxSE
     MaxThreads = 200
     toClientMaxThreads = 100

--- a/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -149,6 +149,28 @@ Services
     }
   }
   ##END
+  ##BEGIN TornadoSandboxStore
+  TornadoSandboxStore
+  {
+    Port = 9196
+    LocalSE = ProductionSandboxSE
+    MaxThreads = 200
+    toClientMaxThreads = 100
+    Backend = local
+    MaxSandboxSizeMiB = 10
+    SandboxPrefix = Sandbox
+    BasePath = /opt/dirac/storage/sandboxes
+    DelayedExternalDeletion = True
+    Authorization
+    {
+      Default = authenticated
+      FileTransfer
+      {
+        Default = authenticated
+      }
+    }
+  }
+  ##END
   OptimizationMind
   {
     Port = 9175

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -569,11 +569,6 @@ class SandboxStoreHandlerMixin:
                 gLogger.exception("RM raised an exception while trying to delete a remote sandbox")
                 return S_ERROR("RM raised an exception while trying to delete a remote sandbox")
 
-    def export_sendFile(self, filename, fileID, data=""):
-        print(filename, fileID, data)
-
-        return S_OK(filename)
-
 
 class SandboxStoreHandler(SandboxStoreHandlerMixin, RequestHandler):
     pass

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -197,7 +197,7 @@ class SandboxStoreHandlerMixin:
         Receive a file as a sandbox
         """
 
-        return self._getFromFile(fileId, token, fileSize, fileHelper=fileHelper)
+        return self._getFromClient(fileId, token, fileSize, fileHelper=fileHelper)
 
     def transfer_bulkFromClient(self, fileId, token, _fileSize, fileHelper):
         """Receive files packed into a tar archive by the fileHelper logic.

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -46,7 +46,7 @@ class SandboxStoreHandlerMixin:
             return S_ERROR(f"Can't connect to DB: {repr(excp)}")
         return S_OK()
 
-    def initializeRequest(self):
+    def initialize(self):
         self.__backend = self.getCSOption("Backend", "local")
         self.__localSEName = self.getCSOption("LocalSE", "SandboxSE")
         self._maxUploadBytes = self.getCSOption("MaxSandboxSizeMiB", 10) * 1048576
@@ -63,6 +63,9 @@ class SandboxStoreHandlerMixin:
             SandboxStoreHandler.__purgeCount = 0
         if SandboxStoreHandler.__purgeCount == 0:
             threading.Thread(target=self.purgeUnusedSandboxes).start()
+
+    def initializeRequest(self):
+        self.initialize()
 
     def __getSandboxPath(self, md5):
         """Generate the sandbox path"""
@@ -292,7 +295,7 @@ class SandboxStoreHandlerMixin:
                 fd = tfd
             else:
                 fd = open(destFileName, "wb")
-            result = fileHelper.networkToDataSink(fd, maxFileSize=self.__maxUploadBytes)
+            result = fileHelper.networkToDataSink(fd, maxFileSize=self._maxUploadBytes)
             fd.close()
         except Exception as e:
             gLogger.error("Cannot open to write destination file", f"{destFileName}: {repr(e).replace(',)', ')')}")

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -358,14 +358,16 @@ class SandboxStoreHandlerMixin:
 
     types_assignSandboxesToEntities = [dict]
 
-    def export_assignSandboxesToEntities(self, enDict, ownerName="", ownerGroup=""):
+    def export_assignSandboxesToEntities(self, enDict, ownerName="", ownerGroup="", entitySetup=False):
         """
         Assign sandboxes to jobs.
         Expects a dict of { entityId : [ ( SB, SBType ), ... ] }
         """
+        if not entitySetup:
+            entitySetup = self.serviceInfoDict["clientSetup"]
         credDict = self.getRemoteCredentials()
         return self.sandboxDB.assignSandboxesToEntities(
-            enDict, credDict["username"], credDict["group"], ownerName, ownerGroup
+            enDict, credDict["username"], credDict["group"], entitySetup, ownerName, ownerGroup
         )
 
     ##################
@@ -373,24 +375,30 @@ class SandboxStoreHandlerMixin:
 
     types_unassignEntities = [(list, tuple)]
 
-    def export_unassignEntities(self, entitiesList):
+    def export_unassignEntities(self, entitiesList, entitiesSetup=False):
         """
         Unassign a list of jobs
         """
+        if not entitiesSetup:
+            entitiesSetup = self.serviceInfoDict["clientSetup"]
         credDict = self.getRemoteCredentials()
-        return self.sandboxDB.unassignEntities(entitiesList, credDict["username"], credDict["group"])
+        return self.sandboxDB.unassignEntities({entitiesSetup: entitiesList}, credDict["username"], credDict["group"])
 
     ##################
     # Getting assigned sandboxes
 
     types_getSandboxesAssignedToEntity = [str]
 
-    def export_getSandboxesAssignedToEntity(self, entityId):
+    def export_getSandboxesAssignedToEntity(self, entityId, entitySetup=False):
         """
         Get the sandboxes associated to a job and the association type
         """
+        if not entitySetup:
+            entitySetup = self.serviceInfoDict["clientSetup"]
         credDict = self.getRemoteCredentials()
-        result = self.sandboxDB.getSandboxesAssignedToEntity(entityId, credDict["username"], credDict["group"])
+        result = self.sandboxDB.getSandboxesAssignedToEntity(
+            entityId, entitySetup, credDict["username"], credDict["group"]
+        )
         if not result["OK"]:
             return result
         sbDict = {}

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -456,7 +456,7 @@ class SandboxStoreHandlerMixin:
         if fileHelper:
             result = fileHelper.getFileDescriptor(hdPath, "rb")
             if not result["OK"]:
-                return S_ERROR(f"Failed to get file descriptor: {result['Message']}")
+                return result
             fd = result["Value"]
             result = fileHelper.FDToNetwork(fd)
             fileHelper.oFile.close()
@@ -465,8 +465,7 @@ class SandboxStoreHandlerMixin:
         with open(hdPath, "rb") as fd:
             if raw:
                 return fd.read()
-            else:
-                return S_OK(fd.read())
+            return S_OK(fd.read())
 
     ##################
     # Purge sandboxes

--- a/src/DIRAC/WorkloadManagementSystem/Service/TornadoSandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/TornadoSandboxStoreHandler.py
@@ -1,0 +1,23 @@
+""" Tornado-based HTTPs SandboxStore service.
+
+.. literalinclude:: ../ConfigTemplate.cfg
+  :start-after: ##BEGIN TornadoSandboxStore
+  :end-before: ##END
+  :dedent: 2
+  :caption: SandboxStore options
+
+"""
+from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
+from DIRAC.WorkloadManagementSystem.Service.SandboxStoreHandler import SandboxStoreHandlerMixin
+
+
+class TornadoSandboxStoreHandler(SandboxStoreHandlerMixin, TornadoService):
+    def initializeRequest(self):
+        return SandboxStoreHandlerMixin.initializeRequest(self)
+
+    def export_streamFromClient(self, fileId, token, fileSize, data):
+        return self._getFromClient(fileId, token, fileSize, data=data)
+
+    def export_streamToClient(self, fileId, token=""):
+        return self._sendToClient(fileId, token, raw=True)

--- a/src/DIRAC/WorkloadManagementSystem/Service/TornadoSandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/TornadoSandboxStoreHandler.py
@@ -14,6 +14,9 @@ from DIRAC.WorkloadManagementSystem.Service.SandboxStoreHandler import SandboxSt
 
 class TornadoSandboxStoreHandler(SandboxStoreHandlerMixin, TornadoService):
     def initializeRequest(self):
+        self.diracSetup = self.get_argument("clientSetup")
+        # Ugly, but makes DIPS and HTTPS handlers compatible, TBD properly
+        self.serviceInfoDict = self._serviceInfoDict
         return SandboxStoreHandlerMixin.initializeRequest(self)
 
     def export_streamFromClient(self, fileId, token, fileSize, data):

--- a/tests/Jenkins/dirac-cfg-update-server.py
+++ b/tests/Jenkins/dirac-cfg-update-server.py
@@ -25,6 +25,8 @@ csAPI = CSAPI()
 
 csAPI.setOption("Systems/WorkloadManagement/Production/Services/SandboxStore/BasePath", f"{setupName}/sandboxes")
 csAPI.setOption("Systems/WorkloadManagement/Production/Services/SandboxStore/LogLevel", "DEBUG")
+csAPI.setOption("Systems/WorkloadManagement/Production/Services/TornadoSandboxStore/BasePath", f"{setupName}/sandboxes")
+csAPI.setOption("Systems/WorkloadManagement/Production/Services/TornadoSandboxStore/LogLevel", "DEBUG")
 
 # Now setting a SandboxSE as the following:
 #     ProductionSandboxSE


### PR DESCRIPTION
This is a simple implementation of TornadoSandboxStoreHandler. The sandbox file transfers is done by putting it contents in a byte string inside a usual return structure. This can be only limited for relatively small files which are the sandboxes. The implementation is done in order to further experiment with token-only job management. 
The standard SandboxStore service behavior is not affected, neither TornadoClient's one

BEGINRELEASENOTES

*WorkloadManagent
NEW: New TornadoSandboxStoreHandler implementation

*Core
NEW: TornadoClient - added sendFile() method 

ENDRELEASENOTES
