### PR TITLE
[v8r0] Close DISET selector when we no longer need it

### DIFF
--- a/src/DIRAC/Core/DISET/private/MessageBroker.py
+++ b/src/DIRAC/Core/DISET/private/MessageBroker.py
@@ -134,6 +134,7 @@ class MessageBroker:
                         continue
                     sel.register(mt["transport"].getSocket(), selectors.EVENT_READ, trid)
                 if not sel.get_map():
+                    sel.close()
                     self.__listeningForMessages = False
                     return
             finally:
@@ -148,6 +149,8 @@ class MessageBroker:
             except Exception as e:
                 gLogger.exception("Exception while selecting persistent connections", lException=e)
                 continue
+            finally:
+                sel.close()
 
             for key, event in events:
                 if event & selectors.EVENT_READ:


### PR DESCRIPTION
Hi,

We've noticed a case where the number of file descriptors used by DIRAC services & optimizer can slowly creep up: It seems this is caused by not explicitly closing the selector used by DISET (so we're relying on the garbage collector to delete the selector objects and close the eventpoll socket). We've seen nodes with >1000 FDs open for this, whereas with this patch the open FDs stays under 10.

Regards,
Simon

BEGINRELEASENOTES
FIX: Close DISET selector when we no longer need it
ENDRELEASENOTES
