### PR TITLE
[8.0] fix: interacting with CEs using tokens

### DIFF
--- a/src/DIRAC/Core/Utilities/Grid.py
+++ b/src/DIRAC/Core/Utilities/Grid.py
@@ -11,7 +11,7 @@ from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Subprocess import systemCall, shellCall
 
 
-def executeGridCommand(proxy, cmd, gridEnvScript=None, gridEnvDict=None):
+def executeGridCommand(cmd, gridEnvScript=None, gridEnvDict=None):
     """
     Execute cmd tuple after sourcing GridEnv
     """
@@ -36,22 +36,6 @@ def executeGridCommand(proxy, cmd, gridEnvScript=None, gridEnvDict=None):
             gridEnv["X509_CERT_DIR"] = currentEnv["X509_CERT_DIR"]
     else:
         gridEnv = currentEnv
-
-    if not proxy:
-        res = getProxyInfo()
-        if not res["OK"]:
-            return res
-        gridEnv["X509_USER_PROXY"] = res["Value"]["path"]
-    elif isinstance(proxy, str):
-        if os.path.exists(proxy):
-            gridEnv["X509_USER_PROXY"] = proxy
-        else:
-            return S_ERROR("Can not treat proxy passed as a string")
-    else:
-        ret = gProxyManager.dumpProxyToFile(proxy)
-        if not ret["OK"]:
-            return ret
-        gridEnv["X509_USER_PROXY"] = ret["Value"]
 
     if gridEnvDict:
         gridEnv.update(gridEnvDict)

--- a/src/DIRAC/FrameworkSystem/Client/TokenManagerClient.py
+++ b/src/DIRAC/FrameworkSystem/Client/TokenManagerClient.py
@@ -34,7 +34,7 @@ class TokenManagerClient(Client):
         self,
         username: str = None,
         userGroup: str = None,
-        scope: str = None,
+        scope: list[str] = None,
         audience: str = None,
         identityProvider: str = None,
         requiredTimeLeft: int = 0,
@@ -57,7 +57,7 @@ class TokenManagerClient(Client):
         idpObj = result["Value"]
 
         # Search for an existing token in tokensCache
-        cachedKey = getCachedKey(idpObj.name, username, userGroup, scope, audience)
+        cachedKey = getCachedKey(idpObj, username, userGroup, scope, audience)
         result = getCachedToken(self.__tokensCache, cachedKey, requiredTimeLeft)
         if result["OK"]:
             # A valid token has been found and is returned

--- a/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
@@ -61,6 +61,13 @@ class TokenManagerHandler(TornadoService):
 
         :return: S_OK()/S_ERROR()
         """
+        # Cache containing tokens from scope requested by the client
+        cls.__tokensCache = DictCache()
+
+        # The service plays an important OAuth 2.0 role, namely it is an Identity Provider client.
+        # This allows you to manage tokens without the involvement of their owners.
+        cls.idps = IdProviderFactory()
+
         # Let's try to connect to the database
         try:
             cls.__tokenDB = TokenDB(parentLogger=cls.log)
@@ -68,12 +75,6 @@ class TokenManagerHandler(TornadoService):
             cls.log.exception(e)
             return S_ERROR(f"Could not connect to the database {repr(e)}")
 
-        # Cache containing tokens from scope requested by the client
-        cls.__tokensCache = DictCache()
-
-        # The service plays an important OAuth 2.0 role, namely it is an Identity Provider client.
-        # This allows you to manage tokens without the involvement of their owners.
-        cls.idps = IdProviderFactory()
         return S_OK()
 
     def export_getUserTokensInfo(self):
@@ -185,7 +186,7 @@ class TokenManagerHandler(TornadoService):
         self,
         username: str = None,
         userGroup: str = None,
-        scope: str = None,
+        scope: list[str] = None,
         audience: str = None,
         identityProvider: str = None,
         requiredTimeLeft: int = 0,
@@ -213,7 +214,7 @@ class TokenManagerHandler(TornadoService):
         idpObj = result["Value"]
 
         # Search for an existing token in tokensCache
-        cachedKey = getCachedKey(idpObj.name, username, userGroup, scope, audience)
+        cachedKey = getCachedKey(idpObj, username, userGroup, scope, audience)
         result = getCachedToken(self.__tokensCache, cachedKey, requiredTimeLeft)
         if result["OK"]:
             # A valid token has been found and is returned

--- a/src/DIRAC/FrameworkSystem/Utilities/TokenManagementUtilities.py
+++ b/src/DIRAC/FrameworkSystem/Utilities/TokenManagementUtilities.py
@@ -30,7 +30,7 @@ def getCachedKey(
     idProviderClient,
     username: str = None,
     userGroup: str = None,
-    scope: str = None,
+    scope: list[str] = None,
     audience: str = None,
 ):
     """Build the key to potentially retrieve a cached token given the provided parameters.
@@ -53,7 +53,9 @@ def getCachedKey(
     if userGroup and (result := idProviderClient.getGroupScopes(userGroup)):
         # What scope correspond to the requested group?
         scope = list(set((scope or []) + result))
-    scope = " ".join(scope)
+
+    if scope:
+        scope = " ".join(sorted(scope))
 
     return (subject, scope, audience, idProviderClient.name, idProviderClient.issuer)
 

--- a/src/DIRAC/FrameworkSystem/Utilities/test/Test_TokenManagementUtilities.py
+++ b/src/DIRAC/FrameworkSystem/Utilities/test/Test_TokenManagementUtilities.py
@@ -1,0 +1,211 @@
+""" Test IdProvider Factory"""
+import pytest
+import time
+
+from DIRAC import S_ERROR, S_OK
+from DIRAC.Core.Utilities.DictCache import DictCache
+from DIRAC.FrameworkSystem.private.authorization.utils.Tokens import OAuth2Token
+from DIRAC.FrameworkSystem.Utilities.TokenManagementUtilities import getCachedKey, getCachedToken
+from DIRAC.Resources.IdProvider.OAuth2IdProvider import OAuth2IdProvider
+
+
+@pytest.mark.parametrize(
+    "idProviderType, idProviderName, issuer, username, group, scope, audience, expectedValue",
+    [
+        # Only a client name: this is mandatory
+        (OAuth2IdProvider, "IdPTest", "Issuer1", None, None, None, None, ("IdPTest", None, None, "IdPTest", "Issuer1")),
+        (
+            OAuth2IdProvider,
+            "IdPTest2",
+            "Issuer1",
+            None,
+            None,
+            None,
+            None,
+            ("IdPTest2", None, None, "IdPTest2", "Issuer1"),
+        ),
+        (
+            OAuth2IdProvider,
+            "IdPTest2",
+            "Issuer2",
+            None,
+            None,
+            None,
+            None,
+            ("IdPTest2", None, None, "IdPTest2", "Issuer2"),
+        ),
+        # Client name and username
+        (OAuth2IdProvider, "IdPTest", "Issuer1", "user", None, None, None, ("user", None, None, "IdPTest", "Issuer1")),
+        # Client name and group (should not add any permission in scope)
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            None,
+            "group",
+            None,
+            None,
+            ("IdPTest", None, None, "IdPTest", "Issuer1"),
+        ),
+        # Client name and scope
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            None,
+            None,
+            ["permission:1", "permission:2"],
+            None,
+            ("IdPTest", "permission:1 permission:2", None, "IdPTest", "Issuer1"),
+        ),
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            None,
+            None,
+            ["permission:2", "permission:1"],
+            None,
+            ("IdPTest", "permission:1 permission:2", None, "IdPTest", "Issuer1"),
+        ),
+        # Client name and audience
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            None,
+            None,
+            None,
+            "CE1",
+            ("IdPTest", None, "CE1", "IdPTest", "Issuer1"),
+        ),
+        # Client name, username, group
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            "user",
+            "group1",
+            None,
+            None,
+            ("user", None, None, "IdPTest", "Issuer1"),
+        ),
+        # Client name, username, scope
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            "user",
+            None,
+            ["permission:1", "permission:2"],
+            None,
+            ("user", "permission:1 permission:2", None, "IdPTest", "Issuer1"),
+        ),
+        # Client name, username, audience
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            "user",
+            None,
+            None,
+            "CE1",
+            ("user", None, "CE1", "IdPTest", "Issuer1"),
+        ),
+        # Client name, username, group, scope
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            "user",
+            "group1",
+            ["permission:1", "permission:2"],
+            None,
+            ("user", "permission:1 permission:2", None, "IdPTest", "Issuer1"),
+        ),
+        # Client name, username, group, audience
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            "user",
+            "group1",
+            None,
+            "CE1",
+            ("user", None, "CE1", "IdPTest", "Issuer1"),
+        ),
+        # Client name, usergroup, scope, audience
+        (
+            OAuth2IdProvider,
+            "IdPTest",
+            "Issuer1",
+            "user",
+            "group1",
+            ["permission:1", "permission:2"],
+            "CE1",
+            ("user", "permission:1 permission:2", "CE1", "IdPTest", "Issuer1"),
+        ),
+    ],
+)
+def test_getCachedKey(idProviderType, idProviderName, issuer, username, group, scope, audience, expectedValue):
+    """Test getCachedKey"""
+    # Prepare IdP
+    idProviderClient = idProviderType()
+    idProviderClient.name = idProviderName
+    idProviderClient.issuer = issuer
+
+    result = getCachedKey(idProviderClient, username, group, scope, audience)
+    assert result == expectedValue
+
+
+@pytest.mark.parametrize(
+    "cachedKey, requiredTimeLeft, expectedValue",
+    [
+        # Normal case
+        (("IdPTest", "permission:1 permission:2", "CE1", "IdPTest", "Issuer1"), 0, S_OK()),
+        # Empty cachedKey
+        ((), 0, S_ERROR("The key does not exist")),
+        # Wrong cachedKey
+        (("IdPTest", "permission:1", "CE1", "IdPTest", "Issuer1"), 0, S_ERROR("The key does not exist")),
+        # Expired token (650 > 150)
+        (
+            ("IdPTest", "permission:1 permission:2", "CE1", "IdPTest", "Issuer1"),
+            650,
+            S_ERROR("Token found but expired"),
+        ),
+        # Expired cachedKey (1500 > 1200)
+        (
+            ("IdPTest", "permission:1 permission:2", "CE1", "IdPTest", "Issuer1"),
+            1500,
+            S_ERROR("The key does not exist"),
+        ),
+    ],
+)
+def test_getCachedToken(cachedKey, requiredTimeLeft, expectedValue):
+    """Test getCachedToken"""
+    # Prepare cachedToken dictionary
+    cachedTokens = DictCache()
+    currentTime = time.time()
+    token = {
+        "sub": "0001234",
+        "aud": "CE1",
+        "nbf": currentTime - 150,
+        "scope": "permission:1 permission:2",
+        "iss": "Issuer1",
+        "exp": currentTime + 150,
+        "iat": currentTime - 150,
+        "jti": "000001234",
+        "client_id": "0001234",
+    }
+    tokenKey = ("IdPTest", "permission:1 permission:2", token["aud"], "IdPTest", token["iss"])
+    cachedTokens.add(tokenKey, 1200, OAuth2Token(token))
+
+    # Try to get the token from the cache
+    result = getCachedToken(cachedTokens, cachedKey, requiredTimeLeft)
+    assert result["OK"] == expectedValue["OK"]
+    if result["OK"]:
+        resultToken = result["Value"]
+        assert resultToken["sub"] == token["sub"]
+        assert resultToken["scope"] == token["scope"]
+    else:
+        assert result["Message"] == expectedValue["Message"]

--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -65,6 +65,8 @@ class AREXComputingElement(ARCComputingElement):
 
         # Get options from the ceParameters dictionary
         self.port = self.ceParameters.get("Port", self.port)
+        self.audienceName = f"https://{self.ceName}:{self.port}"
+
         self.restVersion = self.ceParameters.get("RESTVersion", self.restVersion)
 
         self.proxyTimeLeftBeforeRenewal = self.ceParameters.get(

--- a/src/DIRAC/Resources/Computing/ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ComputingElement.py
@@ -60,15 +60,21 @@ class ComputingElement:
         self.log = gLogger.getSubLogger(ceName)
         self.ceName = ceName
         self.ceParameters = {}
-        self.proxy = ""
-        self.token = None
-        self.valid = None
         self.mandatoryParameters = []
-        self.batchSystem = None
-        self.taskResults = {}
+
+        # Token audience
+        # None by default, it needs to be redefined in subclasses
+        self.audienceName = None
+        self.token = None
+
+        self.proxy = ""
         self.minProxyTime = gConfig.getValue("/Registry/MinProxyLifeTime", 10800)  # secs
         self.defaultProxyTime = gConfig.getValue("/Registry/DefaultProxyLifeTime", 43200)  # secs
         self.proxyCheckPeriod = gConfig.getValue("/Registry/ProxyCheckingPeriod", 3600)  # secs
+        self.valid = None
+
+        self.batchSystem = None
+        self.taskResults = {}
 
         clsName = self.__class__.__name__
         if clsName.endswith("ComputingElement"):

--- a/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_HTCondorCEComputingElement.py
@@ -61,7 +61,7 @@ def test_parseCondorStatus():
 def test_getJobStatus(mocker):
     """Test HTCondorCE getJobStatus"""
     mocker.patch(
-        MODNAME + ".executeGridCommand",
+        MODNAME + ".HTCondorCEComputingElement._executeCondorCommand",
         side_effect=[
             S_OK((0, "\n".join(STATUS_LINES), "")),
             S_OK((0, "\n".join(HISTORY_LINES), "")),
@@ -170,7 +170,9 @@ def test_submitJob(setUp, mocker, localSchedd, expected):
     ceName = "condorce.cern.ch"
     htce.ceName = ceName
 
-    execMock = mocker.patch(MODNAME + ".executeGridCommand", return_value=S_OK((0, "123.0 - 123.0", "")))
+    execMock = mocker.patch(
+        MODNAME + ".HTCondorCEComputingElement._executeCondorCommand", return_value=S_OK((0, "123.0 - 123.0", ""))
+    )
     mocker.patch(
         MODNAME + ".HTCondorCEComputingElement._HTCondorCEComputingElement__writeSub", return_value="dirac_pilot"
     )
@@ -179,7 +181,7 @@ def test_submitJob(setUp, mocker, localSchedd, expected):
     result = htce.submitJob("pilot", "proxy", 1)
 
     assert result["OK"] is True
-    assert " ".join(execMock.call_args_list[0][0][1]) == expected
+    assert " ".join(execMock.call_args_list[0][0][0]) == expected
 
 
 @pytest.mark.parametrize(
@@ -202,10 +204,12 @@ def test_killJob(setUp, mocker, jobIDList, jobID, ret, success, local):
     htce.ceParameters = ceParameters
     htce._reset()
 
-    execMock = mocker.patch(MODNAME + ".executeGridCommand", return_value=S_OK((ret, "", "")))
+    execMock = mocker.patch(
+        MODNAME + ".HTCondorCEComputingElement._executeCondorCommand", return_value=S_OK((ret, "", ""))
+    )
 
     ret = htce.killJob(jobIDList=jobIDList)
     assert ret["OK"] == success
     if jobID:
         expected = f"condor_rm {htce.remoteScheddOptions.strip()} {jobID}"
-        assert " ".join(execMock.call_args_list[0][0][1]) == expected
+        assert " ".join(execMock.call_args_list[0][0][0]) == expected

--- a/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
+++ b/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
@@ -50,26 +50,25 @@ class IdProviderFactory:
         """
         if not name:
             return S_ERROR("Identity Provider client name must be not None.")
-        # Get Authorization Server metadata
-        try:
-            asMetaDict = collectMetadata(kwargs.get("issuer"), ignoreErrors=True)
-        except Exception as e:
-            return S_ERROR(str(e))
         self.log.debug("Search configuration for", name)
+
         clients = getDIRACClients()
         if name in clients:
             # If it is a DIRAC default pre-registered client
+            # Get Authorization Server metadata
+            try:
+                asMetaDict = collectMetadata(kwargs.get("issuer"), ignoreErrors=True)
+            except Exception as e:
+                return S_ERROR(str(e))
             pDict = asMetaDict
             pDict.update(clients[name])
         else:
-            # if it is external identity provider client
+            # If it is external identity provider client
             result = gConfig.getOptionsDict(f"/Resources/IdProviders/{name}")
             if not result["OK"]:
                 self.log.error("Failed to read configuration", f"{name}: {result['Message']}")
                 return result
             pDict = result["Value"]
-            # Set default redirect_uri
-            pDict["redirect_uri"] = pDict.get("redirect_uri", asMetaDict["redirect_uri"])
 
         pDict.update(kwargs)
         pDict["ProviderName"] = name

--- a/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
+++ b/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
@@ -429,6 +429,8 @@ class OAuth2IdProvider(OAuth2Session):
         """
         try:
             self.fetch_access_token(self.get_metadata("token_endpoint"), **kwargs)
+        except OAuthError as e:
+            return S_ERROR(f"Cannot fetch access token: {e}")
         except Exception as e:
             self.log.exception(e)
             return S_ERROR(repr(e))

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -445,7 +445,7 @@ class SiteDirector(AgentModule):
 
             # Get valid token if needed
             if "Token" in ce.ceParameters.get("Tag", []):
-                result = self.__getPilotToken()
+                result = self.__getPilotToken(audience=ce.audienceName)
                 if not result["OK"]:
                     return result
                 ce.setToken(result["Value"], 3500)
@@ -465,13 +465,20 @@ class SiteDirector(AgentModule):
 
         return S_OK()
 
-    def __getPilotToken(self):
+    def __getPilotToken(self, audience: str, scope: list[str] = None):
         """Get the token corresponding to the pilot user identity
 
+        :param audience: Token audience, targeting a single CE
+        :param scope: list of permissions needed to interact with a CE
         :return: S_OK/S_ERROR, Token object as Value
         """
-        result = gTokenManager.getToken(userGroup=self.pilotGroup, requiredTimeLeft=600)
-        return result
+        if not audience:
+            return S_ERROR("Audience is not defined")
+
+        if not scope:
+            scope = ["compute.cancel", "compute.create", "compute.read", "compute.cancel"]
+
+        return gTokenManager.getToken(userGroup=self.pilotGroup, requiredTimeLeft=600, scope=scope, audience=audience)
 
     def _ifAndWhereToSubmit(self):
         """Return a tuple that says if and where to submit pilots:
@@ -1234,9 +1241,10 @@ class SiteDirector(AgentModule):
 
         # Get valid token if needed
         if "Token" in ce.ceParameters.get("Tag", []):
-            result = self.__getPilotToken()
+            result = self.__getPilotToken(audience=ce.audienceName)
             if not result["OK"]:
-                return result
+                self.log.error("Failed to get token", f"{ceName}: {result['Message']}")
+                return
             ce.setToken(result["Value"], 3500)
 
         result = ce.getJobStatus(stampedPilotRefs)

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -32,6 +32,8 @@ from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
 from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
 from DIRAC.ResourceStatusSystem.Client.SiteStatus import SiteStatus
 from DIRAC.WorkloadManagementSystem.Client import PilotStatus
+from DIRAC.WorkloadManagementSystem.Client.PilotScopes import PILOT_SCOPES
+
 from DIRAC.WorkloadManagementSystem.Client.MatcherClient import MatcherClient
 from DIRAC.WorkloadManagementSystem.Client.ServerUtils import getPilotAgentsDB
 from DIRAC.WorkloadManagementSystem.private.ConfigHelper import findGenericPilotCredentials
@@ -476,7 +478,7 @@ class SiteDirector(AgentModule):
             return S_ERROR("Audience is not defined")
 
         if not scope:
-            scope = ["compute.cancel", "compute.create", "compute.read", "compute.cancel"]
+            scope = PILOT_SCOPES
 
         return gTokenManager.getToken(userGroup=self.pilotGroup, requiredTimeLeft=600, scope=scope, audience=audience)
 

--- a/src/DIRAC/WorkloadManagementSystem/Client/PilotScopes.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/PilotScopes.py
@@ -1,0 +1,17 @@
+"""
+This module contains constants and lists for the possible scopes to interact with pilots on CEs.
+"""
+
+# Based on: https://github.com/WLCG-AuthZ-WG/common-jwt-profile/blob/master/profile.md#capability-based-authorization-scope
+
+#: To submit pilots:
+CREATE = "compute.create"
+#: To cancel pilots:
+CANCEL = "compute.cancel"
+#: To modify attributes of submitted pilots:
+MODIFY = "compute.modify"
+#: To read information about submitted pilots:
+READ = "compute.read"
+
+#: Possible pilot scopes:
+PILOT_SCOPES = [CANCEL, CREATE, MODIFY, READ]

--- a/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -135,6 +135,7 @@ class PilotManagerHandler(RequestHandler):
         if not hasattr(ce, "getJobOutput"):
             return S_ERROR(f"Pilot output not available for {pilotDict['GridType']} CEs")
 
+        # Set proxy or token for the CE
         result = setPilotCredentials(ce, pilotDict)
         if not result["OK"]:
             return result

--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -10,6 +10,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getGroupOption, ge
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 from DIRAC.FrameworkSystem.Client.TokenManagerClient import gTokenManager
 from DIRAC.Resources.Computing.ComputingElementFactory import ComputingElementFactory
+from DIRAC.WorkloadManagementSystem.Client.PilotScopes import PILOT_SCOPES
 
 
 # List of files to be inserted/retrieved into/from pilot Output Sandbox
@@ -77,7 +78,7 @@ def setPilotCredentials(ce, pilotDict):
     if "Token" in ce.ceParameters.get("Tag", []):
         result = gTokenManager.getToken(
             userGroup=pilotDict["OwnerGroup"],
-            scope=["compute.cancel", "compute.create", "compute.modify", "compute.read"],
+            scope=PILOT_SCOPES,
             audience=ce.audienceName,
             requiredTimeLeft=150,
         )


### PR DESCRIPTION
This PR aims at enhancing/fixing the interactions with CEs using tokens.

Improvement: 
- support for the `aud` claim in the `SiteDirector`: an access token targets a specific CE (limit its impact if stolen).
  - add the `audienceName` attribute in `ComputingElement`.

Fix:
- `TokenManager(Client/Handler/Utilities)`: 
  - change the `scope` type (`str` -> `list[str]`)
  - pass the `IdProvider` object instead of its name to `getCachedKey()`
  - initialize `tokensCache` and `idps` before the database. Note: this is likely a ugly hack, but if we only use the `client_credentials` flow, we do not need the database: by moving `tokensCache` and `idps` before the initialization of the database, the service can work without it (it gets an error at the initialization but it works).
- `Grid`:
  - move the proxy initialization in `HTCondorCE`. By the way `Grid` is only used by `HTCondorCE` now.
- `WMSUtilities`:
  - make `setPilotCredentials()` compatible with the `client_credentials` flow.
- `IdProviderFactory`:
  - move a block of code related to the DIRAC AS in a condition branch so that it is not needed if we only work with external IdPs to interact with CEs.

Plus, I added a few tests (`OAuth2IdProvider.fetchToken()`, `TokenManagerUtilities`).   


BEGINRELEASENOTES
*Resources
NEW: audienceName attribute in CEs
*WorkloadManagementSystem
NEW: audience support in SiteDirector
*FrameworkSyste
FIX: fix TokenManager(Client/Handler/Utilities)
ENDRELEASENOTES
