### PR TITLE
[9.0] fix: use UTC for plotting

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/BarGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/BarGraph.py
@@ -65,8 +65,8 @@ class BarGraph(PlotBase):
         start_plot = 0
         end_plot = 0
         if "starttime" in self.prefs and "endtime" in self.prefs:
-            start_plot = date2num(datetime.datetime.fromtimestamp(to_timestamp(self.prefs["starttime"])))
-            end_plot = date2num(datetime.datetime.fromtimestamp(to_timestamp(self.prefs["endtime"])))
+            start_plot = date2num(datetime.datetime.utcfromtimestamp(to_timestamp(self.prefs["starttime"])))
+            end_plot = date2num(datetime.datetime.utcfromtimestamp(to_timestamp(self.prefs["endtime"])))
 
         nKeys = self.gdata.getNumberOfKeys()
         tmp_b = []

--- a/src/DIRAC/Core/Utilities/Graphs/CurveGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/CurveGraph.py
@@ -35,8 +35,8 @@ class CurveGraph(PlotBase):
         start_plot = 0
         end_plot = 0
         if "starttime" in self.prefs and "endtime" in self.prefs:
-            start_plot = date2num(datetime.datetime.fromtimestamp(to_timestamp(self.prefs["starttime"])))
-            end_plot = date2num(datetime.datetime.fromtimestamp(to_timestamp(self.prefs["endtime"])))
+            start_plot = date2num(datetime.datetime.utcfromtimestamp(to_timestamp(self.prefs["starttime"])))
+            end_plot = date2num(datetime.datetime.utcfromtimestamp(to_timestamp(self.prefs["endtime"])))
 
         labels = self.gdata.getLabels()
         labels.reverse()

--- a/src/DIRAC/Core/Utilities/Graphs/GraphData.py
+++ b/src/DIRAC/Core/Utilities/Graphs/GraphData.py
@@ -194,7 +194,9 @@ class GraphData:
                 self.all_num_keys.append(next)
                 next += 1
         elif self.key_type == "time":
-            self.all_num_keys = [date2num(datetime.datetime.fromtimestamp(to_timestamp(key))) for key in self.all_keys]
+            self.all_num_keys = [
+                date2num(datetime.datetime.utcfromtimestamp(to_timestamp(key))) for key in self.all_keys
+            ]
         elif self.key_type == "numeric":
             self.all_num_keys = [float(key) for key in self.all_keys]
 

--- a/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
+++ b/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
@@ -70,7 +70,7 @@ def convert_to_datetime(dstring):
         else:
             results = eval(str(dstring), {"__builtins__": None, "time": time, "math": math}, {})
         if isinstance(results, (int, float)):
-            results = datetime.datetime.fromtimestamp(int(results))
+            results = datetime.datetime.utcfromtimestamp(int(results))
         elif isinstance(results, datetime.datetime):
             pass
         else:
@@ -81,7 +81,7 @@ def convert_to_datetime(dstring):
             try:
                 t = time.strptime(dstring, dateformat)
                 timestamp = calendar.timegm(t)  # -time.timezone
-                results = datetime.datetime.fromtimestamp(timestamp)
+                results = datetime.datetime.utcfromtimestamp(timestamp)
                 break
             except Exception:
                 pass
@@ -90,7 +90,7 @@ def convert_to_datetime(dstring):
                 dstring = dstring.split(".", 1)[0]
                 t = time.strptime(dstring, dateformat)
                 timestamp = time.mktime(t)  # -time.timezone
-                results = datetime.datetime.fromtimestamp(timestamp)
+                results = datetime.datetime.utcfromtimestamp(timestamp)
             except Exception:
                 raise ValueError(
                     "Unable to create time from string!\nExpecting "
@@ -108,8 +108,8 @@ def to_timestamp(val):
         pass
 
     val = convert_to_datetime(val)
-    # return calendar.timegm( val.timetuple() )
-    return time.mktime(val.timetuple())
+    return calendar.timegm(val.timetuple())
+    # return time.mktime(val.timetuple())
 
 
 # If the graph has more than `hour_switch` minutes, we print
@@ -179,8 +179,8 @@ def add_time_to_title(begin, end, metadata={}):
         format_name = "Seconds"
         time_slice = 1
 
-    begin_tuple = time.localtime(begin)
-    end_tuple = time.localtime(end)
+    begin_tuple = time.gmtime(begin)
+    end_tuple = time.gmtime(end)
     added_title = "%i %s from " % (int((end - begin) / time_slice), format_name)
     added_title += time.strftime(f"{format_str} to", begin_tuple)
     if time_slice < 86400:

--- a/src/DIRAC/Core/Utilities/Graphs/LineGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/LineGraph.py
@@ -49,8 +49,8 @@ class LineGraph(PlotBase):
         start_plot = 0
         end_plot = 0
         if "starttime" in self.prefs and "endtime" in self.prefs:
-            start_plot = date2num(datetime.datetime.fromtimestamp(to_timestamp(self.prefs["starttime"])))
-            end_plot = date2num(datetime.datetime.fromtimestamp(to_timestamp(self.prefs["endtime"])))
+            start_plot = date2num(datetime.datetime.utcfromtimestamp(to_timestamp(self.prefs["starttime"])))
+            end_plot = date2num(datetime.datetime.utcfromtimestamp(to_timestamp(self.prefs["endtime"])))
 
         self.polygons = []
         seq_b = [(self.gdata.max_num_key, 0.0), (self.gdata.min_num_key, 0.0)]

--- a/src/DIRAC/Core/Utilities/Graphs/QualityMapGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/QualityMapGraph.py
@@ -113,8 +113,8 @@ class QualityMapGraph(PlotBase):
         start_plot = 0
         end_plot = 0
         if "starttime" in self.prefs and "endtime" in self.prefs:
-            start_plot = date2num(datetime.datetime.fromtimestamp(to_timestamp(self.prefs["starttime"])))
-            end_plot = date2num(datetime.datetime.fromtimestamp(to_timestamp(self.prefs["endtime"])))
+            start_plot = date2num(datetime.datetime.utcfromtimestamp(to_timestamp(self.prefs["starttime"])))
+            end_plot = date2num(datetime.datetime.utcfromtimestamp(to_timestamp(self.prefs["endtime"])))
 
         labels = self.gdata.getLabels()
         nKeys = self.gdata.getNumberOfKeys()

--- a/tests/Integration/AccountingSystem/Test_Plots.py
+++ b/tests/Integration/AccountingSystem/Test_Plots.py
@@ -6,16 +6,11 @@ import os
 
 # sut
 from DIRAC.Core.Utilities.Plotting.Plots import (
-    generateHistogram,
-    generateStackedLinePlot,
-    generatePiePlot,
-    generateCumulativePlot,
-    generateQualityPlot,
-    generateTimedStackedBarPlot,
-    generateNoDataPlot,
     generateErrorMessagePlot,
+    generateHistogram,
+    generateNoDataPlot,
+    generatePiePlot,
 )
-
 from DIRAC.tests.Utilities.plots import compare
 
 plots_directory = os.path.join(os.path.dirname(__file__), "plots")
@@ -48,62 +43,6 @@ def test_histogram():
     assert res == 0.0
 
 
-def test_stackedlineplots():
-    """
-    test stacked line plot
-    """
-
-    res = generateStackedLinePlot(
-        filename,
-        {
-            "LCG.Zoltan.hu": {
-                1584460800: 1.0,
-                1584489600: 2.0,
-                1584511200: 1.0,
-                1584464400: 1.0,
-                1584540000: 0.022222222222222223,
-                1584500400: 2.2,
-                1584529200: 1.2,
-                1584468000: 0.0,
-                1584486000: 1.1,
-                1584518400: 0.2,
-                1584471600: 1.0,
-                1584532800: 0.0022222222222222222,
-                1584507600: 0.3,
-                1584475200: 1.2,
-                1584482400: 0.4,
-                1584496800: 5.0,
-                1584525600: 0.5,
-                1584536400: 0.012777777777777779,
-                1584514800: 2.0,
-                1584453600: 3.0,
-                1584478800: 0.09,
-                1584504000: 1.0,
-                1584457200: 3.0,
-                1584493200: 1.0,
-                1584522000: 1.8,
-            },
-            "LCG.CERN.cern": {
-                1584460800: 1.6,
-                1584489600: 2.8,
-                1584511200: 3.0,
-                1584464400: 4.0,
-                1584540000: 1.022222222222222223,
-                1584500400: 3.2,
-                1584529200: 0.2,
-                1584468000: 1.0,
-                1584486000: 1.1,
-            },
-        },
-        {},
-    )
-
-    assert res["OK"] is True
-
-    res = compare(filename, os.path.join(plots_directory, "stackedline.png"))
-    assert res == 0.0
-
-
 def test_piechartplot():
     """
     test pie chart plots
@@ -112,160 +51,6 @@ def test_piechartplot():
     assert res["OK"] is True
 
     res = compare(filename, os.path.join(plots_directory, "piechart.png"))
-    assert res == 0.0
-
-
-def test_cumulativeplot():
-    """
-    test cumulative stracked line plot
-    """
-
-    res = generateCumulativePlot(
-        filename,
-        {
-            "User": {
-                1584460800: 0.0,
-                1584489600: 0.0,
-                1584511200: 0.0,
-                1584464400: 0.0,
-                1584540000: 16.0,
-                1584500400: 0.0,
-                1584529200: 0.0,
-                1584468000: 0.0,
-                1584457200: 0.0,
-                1584518400: 0.0,
-                1584471600: 0.0,
-                1584507600: 0.0,
-                1584475200: 0.0,
-                1584496800: 0.0,
-                1584525600: 0.0,
-                1584536400: 6.0,
-                1584486000: 0.0,
-                1584514800: 0.0,
-                1584482400: 0.0,
-                1584478800: 0.0,
-                1584504000: 0.0,
-                1584532800: 1.0,
-                1584543600: 21.0,
-                1584493200: 0.0,
-                1584522000: 0.0,
-            }
-        },
-        {
-            "span": 3600,
-            "title": "Cumulative Jobs by JobType",
-            "starttime": 1584457326,
-            "ylabel": "jobs",
-            "sort_labels": "max_value",
-            "endtime": 1584543726,
-        },
-    )
-
-    assert res["OK"] is True
-
-    res = compare(filename, os.path.join(plots_directory, "cumulativeplot.png"))
-    assert res == 0.0
-
-
-def test_qualityplot():
-    """
-    Test quality plot
-    """
-
-    res = generateQualityPlot(
-        filename,
-        {"User": {1584543600: 37.5, 1584547200: 37.5, 1584619200: 33.33333333333333, 1584601200: 36.53846153846153}},
-        {},
-    )
-    assert res["OK"] is True
-
-    res = compare(filename, os.path.join(plots_directory, "qualityplot1.png"))
-    assert res == 0.0
-
-    res = generateQualityPlot(
-        filename,
-        {"User": {1584543600: 37.5, 1584547200: 37.5, 1584619200: 33.33333333333333, 1584601200: 36.53846153846153}},
-        {"endtime": 1584627764, "span": 3600, "starttime": 1584541364, "title": "Job CPU efficiency by JobType"},
-    )
-    assert res["OK"] is True
-
-    res = compare(filename, os.path.join(plots_directory, "qualityplot2.png"))
-    assert res == 0.0
-
-
-def test_timestackedbarplot():
-    """
-    test timed stacked bar plot
-    """
-    res = generateTimedStackedBarPlot(
-        filename,
-        {
-            "LCG.Cern.cern": {
-                1584662400: 0.0,
-                1584691200: 0.0,
-                1584637200: 15.9593220339,
-                1584666000: 0.0,
-                1584694800: 0.0,
-                1584626400: 31.867945823900005,
-                1584669600: 0.0,
-                1584644400: 0.0,
-                1584615600: 0.0,
-                1584673200: 0.0,
-                1584633600: 14.0406779661,
-                1584676800: 0.0,
-                1584684000: 0.0,
-                1584651600: 0.0,
-                1584680400: 0.0,
-                1584612000: 0.0,
-                1584640800: 0.0,
-                1584655200: 0.0,
-                1584622800: 23.2293933044,
-                1584698400: 0.0,
-                1584630000: 9.5970654628,
-                1584658800: 0.0,
-                1584648000: 0.0,
-                1584687600: 12.0,
-                1584619200: 10.3055954089,
-            },
-            "LCG.NCBJ.pl": {
-                1584691200: 0.1,
-                1584662400: 2.0,
-                1584651600: 0.0,
-                1584637200: 0.0,
-                1584694800: 4.0,
-                1584626400: 0.0,
-                1584669600: 6.0,
-                1584655200: 0.0,
-                1584644400: 0.0,
-                1584615600: 0.0,
-                1584673200: 0.0,
-                1584633600: 9.0,
-                1584676800: 0.0,
-                1584698400: 0.0,
-                1584622800: 0.0,
-                1584680400: 0.0,
-                1584612000: 0.0,
-                1584640800: 0.0,
-                1584684000: 0.0,
-                1584666000: 0.0,
-                1584630000: 0.0,
-                1584658800: 0.0,
-                1584648000: 0.0,
-                1584687600: 0.0,
-                1584619200: 0.0,
-            },
-        },
-        {
-            "ylabel": "jobs / hour",
-            "endtime": 1584700844,
-            "span": 3600,
-            "starttime": 1584614444,
-            "title": "Jobs by Site",
-        },
-    )
-    assert res["OK"] is True
-
-    res = compare(filename, os.path.join(plots_directory, "timedstackedbarplot.png"))
     assert res == 0.0
 
 


### PR DESCRIPTION
Expand from https://github.com/DIRACGrid/DIRAC/pull/6916

- [x] add as patch to DIRAC certification box, and test
- [ ] backport to v8.0


BEGINRELEASENOTES

*Accounting
FIX: use UTC for plotting

ENDRELEASENOTES
