### PR TITLE
docs: add forgotten doc for DefaultLocalCEType

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -596,6 +596,10 @@ Resources
     #
     # Values are overwritten by the most specialized option.
 
+    # Default local CE to use on all CEs (Pool, Singularity, InProcess, etc)
+    # There is no default value
+    DefaultLocalCEType = Singularity
+
     # The options below can be valid for all computing element types
     CEDefaults
     {


### PR DESCRIPTION
Probably don't need release note, just an oversight when doing the origin PR I suppose