### PR TITLE
[v8.0] fix (ReplicateAndRegister): better error reporting for files with no replicas

### DIFF
--- a/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
+++ b/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
@@ -430,10 +430,16 @@ class ReplicateAndRegister(DMSRequestOperationsBase):
                     )
                     opFile.Error = "Couldn't get metadata"
                 elif noReplicas:
-                    self.log.error(
-                        "Unable to schedule transfer",
-                        f"File {opFile.LFN} doesn't exist at {','.join(noReplicas)}",
-                    )
+                    if None in noReplicas:
+                        self.log.error(
+                            "Unable to schedule transfer",
+                            f"File {opFile.LFN} doesn't have any replicas, which should never happen",
+                        )
+                    else:
+                        self.log.error(
+                            "Unable to schedule transfer",
+                            f"File {opFile.LFN} doesn't exist at {','.join(noReplicas)}",
+                        )
                     opFile.Error = "No replicas found"
                     opFile.Status = "Failed"
                 elif badReplicas:

--- a/src/DIRAC/Interfaces/API/Dirac.py
+++ b/src/DIRAC/Interfaces/API/Dirac.py
@@ -917,7 +917,10 @@ class Dirac(API):
             for lfn in repsResult["Value"]["Failed"]:
                 records.append((lfn, "Unknown", str(repsResult["Value"]["Failed"][lfn])))
 
-            printTable(fields, records, numbering=False)
+            if records:
+                printTable(fields, records, numbering=False)
+            else:
+                self.log.info("No replicas found")
 
         return repsResult
 


### PR DESCRIPTION



BEGINRELEASENOTES

*DMS
FIX: better error reporting when an existing LFN has no replicas (at least it doesn't crash)

ENDRELEASENOTES
