### PR TITLE
[v8.0] Fix exceptions in StalledJobAgent

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -339,7 +339,7 @@ class StalledJobAgent(AgentModule):
 
         if not minorStatus:  # Retain last minor status for stalled jobs
             result = self.jobDB.getJobAttributes(job, ["MinorStatus"])
-            if result["OK"]:
+            if result["OK"] and "MinorStatus" in result["Value"]:
                 minorStatus = result["Value"]["MinorStatus"]
             else:
                 self.log.error("Failed getting MinorStatus", "for job %d: %s" % (job, result["Message"]))
@@ -474,6 +474,8 @@ class StalledJobAgent(AgentModule):
                             lastWallTime = value
                     except ValueError:
                         pass
+                if isinstance(heartBeatTime, str):
+                    heartBeatTime = datetime.datetime.strptime(heartBeatTime, "%Y-%m-%d %H:%M:%S")
                 if heartBeatTime > lastHeartBeatTime:
                     lastHeartBeatTime = heartBeatTime
 


### PR DESCRIPTION
Triggered by seeing a lot of errors in the StalledJobAgent mostly:

```
2023-07-03 15:56:11 UTC WorkloadManagement/StalledJobAgent/WorkloadManagement/StalledJobAgent ERROR: Exception in _sendAccounting for job=761471346: endTime=2023-06-29 22:24:12, lastHBTime=Unknown
Traceback (most recent call last):
  File "/opt/dirac/versions/v11.0.13-1688390107/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py", line 384, in _sendAccounting
    lastCPUTime, lastWallTime, lastHeartBeatTime = self._checkHeartBeat(jobID, jobDict)
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.13-1688390107/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py", line 478, in _checkHeartBeat
    if heartBeatTime > lastHeartBeatTime:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'datetime.datetime'
```

but also:

```
2023-07-03 15:39:59 UTC WorkloadManagement/StalledJobAgent/WorkloadManagement/StalledJobAgent ERROR: Agent exception while calling method <bound method StalledJobAgent.execute of <DIRAC.WorkloadManagementSystem.Age
nt.StalledJobAgent.StalledJobAgent object at 0x7f2f2aa4e7d0>>
Traceback (most recent call last):
  File "/opt/dirac/versions/v11.0.13-1688390107/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Base/AgentModule.py", line 310, in am_secureCall
    result = functor(*args)
             ^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.13-1688390107/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py", line 151, in execute
    result = self._failSubmittingJobs()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.13-1688390107/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py", line 566, in _failSubmittingJobs
    result = self._updateJobStatus(jobID, JobStatus.FAILED, force=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.13-1688390107/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py", line 343, in _updateJobStatus
    minorStatus = result["Value"]["MinorStatus"]
                  ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'MinorStatus'
```

BEGINRELEASENOTES

*WMS
FIX: Exceptions in StalledJobAgent

ENDRELEASENOTES
