### PR TITLE
[8.1] feat: mark ARC/ARC6CE interfaces as deprecated

### DIFF
--- a/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
@@ -22,9 +22,11 @@ import stat
 
 import arc  # Has to work if this module is called #pylint: disable=import-error
 from DIRAC import S_OK, S_ERROR
+from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Resources.Computing.ARCComputingElement import ARCComputingElement, prepareProxyToken
 
 
+@deprecated("Use AREXComputingElement instead", onlyOnce=True)
 class ARC6ComputingElement(ARCComputingElement):
     def __init__(self, ceUniqueID):
         """Standard constructor."""

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -55,6 +55,7 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Subprocess import shellCall
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Security.ProxyInfo import getVOfromProxyGroup
+from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement
 from DIRAC.Resources.Computing.PilotBundle import writeScript
 from DIRAC.WorkloadManagementSystem.Client import PilotStatus
@@ -110,6 +111,7 @@ def prepareProxyToken(func):
     return wrapper
 
 
+@deprecated("Use AREXComputingElement instead", onlyOnce=True)
 class ARCComputingElement(ComputingElement):
     _arcLevels = ["DEBUG", "VERBOSE", "INFO", "WARNING", "ERROR", "FATAL"]
 


### PR DESCRIPTION
`AREX` aims at replacing `ARC` and `ARC6` from v8.1.


BEGINRELEASENOTES
*Resources
CHANGE: ARC and ARC6 are now deprecated
ENDRELEASENOTES
