### PR TITLE
[8.0] fix: replaced deprecated importlib read_text function

### DIFF
--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -798,7 +798,9 @@ class ComponentInstaller:
             for ext in extensions:
                 cfgTemplateModule = f"{ext}.{system}System"
                 try:
-                    cfgTemplate = importlib_resources.read_text(cfgTemplateModule, "ConfigTemplate.cfg")
+                    cfgTemplate = (
+                        importlib_resources.files(cfgTemplateModule).joinpath("ConfigTemplate.cfg").read_text()
+                    )
                 except (ImportError, OSError):
                     continue
                 gLogger.notice("Loading configuration template from", cfgTemplateModule)
@@ -2128,7 +2130,7 @@ exec dirac-webapp-run -p < /dev/null
         systemName = databases[filename]
         moduleName = ".".join([extension, systemName, "DB"])
         gLogger.debug(f"Installing {filename} from {moduleName}")
-        dbSql = importlib_resources.read_text(moduleName, filename)
+        dbSql = importlib_resources.files(moduleName).joinpath(filename).read_text()
 
         # just check
         result = self.execMySQL("SHOW STATUS")
@@ -2228,7 +2230,7 @@ exec dirac-webapp-run -p < /dev/null
                 sourcedDBbFileName = line.split(" ")[1].replace("\n", "")
                 gLogger.info(f"Found file to source: {sourcedDBbFileName}")
                 module, filename = sourcedDBbFileName.rsplit("/", 1)
-                dbSourced = importlib_resources.read_text(module.replace("/", "."), filename)
+                dbSourced = importlib_resources.files(module.replace("/", ".")).joinpath(filename).read_text()
                 for lineSourced in dbSourced.split("\n"):
                     if lineSourced.strip():
                         cmdLines.append(lineSourced.strip())


### PR DESCRIPTION

BEGINRELEASENOTES

*Framework
FIX: replaced deprecated importlib read_text function to fix failure in CI tests

ENDRELEASENOTES
