### PR TITLE
[v7r3] Introduce job status 'Scouting' in WMS

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
@@ -21,6 +21,8 @@ CHECKING = "Checking"
 #:
 STAGING = "Staging"
 #:
+SCOUTING = "Scouting"
+#:
 WAITING = "Waiting"
 #:
 MATCHED = "Matched"
@@ -49,6 +51,7 @@ JOB_STATES = [
     SUBMITTING,
     RECEIVED,
     CHECKING,
+    SCOUTING,
     STAGING,
     WAITING,
     MATCHED,
@@ -92,9 +95,10 @@ class JobsStateMachine(StateMachine):
             RESCHEDULED: State(6, [WAITING, RECEIVED, DELETED, FAILED], defState=RESCHEDULED),
             MATCHED: State(5, [RUNNING, FAILED, RESCHEDULED, KILLED], defState=MATCHED),
             WAITING: State(4, [MATCHED, RESCHEDULED, DELETED], defState=WAITING),
-            STAGING: State(3, [CHECKING, WAITING, FAILED, KILLED], defState=STAGING),
-            CHECKING: State(2, [STAGING, WAITING, RESCHEDULED, FAILED, DELETED], defState=CHECKING),
-            RECEIVED: State(1, [CHECKING, WAITING, FAILED, DELETED], defState=RECEIVED),
+            STAGING: State(3, [WAITING, FAILED, KILLED], defState=STAGING),
+            SCOUTING: State(2, [CHECKING, FAILED, STALLED, KILLED], defState=SCOUTING),
+            CHECKING: State(2, [SCOUTING, STAGING, WAITING, RESCHEDULED, FAILED, DELETED], defState=CHECKING),
+            RECEIVED: State(1, [SCOUTING, CHECKING, WAITING, FAILED, DELETED], defState=RECEIVED),
             SUBMITTING: State(0, [RECEIVED, CHECKING, DELETED], defState=SUBMITTING),  # initial state
         }
 


### PR DESCRIPTION
 Scout jobs are a small subset of the primary jobs that run first, and the rest are executed only when scouting is done. Main jobs get the status ‘Scouting’ while waiting for the execution of the subset. This pull request defines the state “Scouting” at JOB_STATES and enables the transitions. Closes #7083 

BEGINRELEASENOTES

*WorkloadManagement
NEW: Introducing 'Scouting' status in job state transitions

ENDRELEASENOTES
