### PR TITLE
[8.0] Don't print client_secret in oauth2 debug

### DIFF
--- a/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
+++ b/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
@@ -165,8 +165,7 @@ class OAuth2IdProvider(OAuth2Session):
         self.metadata_fetch_last = time.time() - self.METADATA_REFRESH_RATE
         self.log.debug(
             f'"{self.name}" OAuth2 IdP initialization done:',
-            "\nclient_id: %s\nclient_secret: %s\nmetadata:\n%s"
-            % (self.client_id, self.client_secret, pprint.pformat(self.metadata)),
+            f"\nclient_id: {self.client_id}\nmetadata:\n{pprint.pformat(self.metadata)}",
         )
 
     def _initialize(self):


### PR DESCRIPTION
As discussed in #7128 .

BEGINRELEASENOTES
*Resources
FIX: Don't print client_secret in oauth2 debug
ENDRELEASENOTES
