### PR TITLE
[8.0] fix:  look also for DIRAC.rootPath/etc/dirac.cfg

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/LocalConfiguration.py
+++ b/src/DIRAC/ConfigurationSystem/Client/LocalConfiguration.py
@@ -61,8 +61,7 @@ class LocalConfiguration:
     def __getAbsolutePath(self, optionPath):
         if optionPath[0] == "/":
             return optionPath
-        else:
-            return f"{self.currentSectionPath}/{optionPath}"
+        return f"{self.currentSectionPath}/{optionPath}"
 
     def addMandatoryEntry(self, optionPath):
         """
@@ -446,8 +445,9 @@ class LocalConfiguration:
         Loads possibly several cfg files, in order:
         1. cfg files pointed by DIRACSYSCONFIG env variable (comma-separated)
         2. ~/.dirac.cfg
-        3. cfg files specified in addCFGFile calls
-        4. cfg files that come from the command line
+        3. DIRAC.rootPath/etc/dirac.cfg
+        4. cfg files specified in addCFGFile calls
+        5. cfg files that come from the command line
         """
         errorsList = []
         foundCFGFile = False
@@ -466,7 +466,11 @@ class LocalConfiguration:
             foundCFGFile = True
         gConfigurationData.loadFile(os.path.expanduser("~/.dirac.cfg"))
 
-        # 3. cfg files specified in addCFGFile calls
+        # 3. defaultCFGFile = os.path.join(DIRAC.rootPath, "etc", "dirac.cfg")
+        if os.path.isfile(os.path.join(DIRAC.rootPath, "etc", "dirac.cfg")):
+            foundCFGFile = True
+
+        # 4. cfg files specified in addCFGFile calls
         for fileName in self.additionalCFGFiles:
             if os.path.isfile(fileName):
                 foundCFGFile = True
@@ -476,7 +480,7 @@ class LocalConfiguration:
                 gLogger.debug(f"Could not load file {fileName}: {retVal['Message']}")
                 errorsList.append(retVal["Message"])
 
-        # 4. cfg files that come from the command line
+        # 5. cfg files that come from the command line
         for fileName in self.cliAdditionalCFGFiles:
             if os.path.isfile(fileName):
                 foundCFGFile = True


### PR DESCRIPTION
BEGINRELEASENOTES

*Core
FIX: look also for DIRAC.rootPath/etc/dirac.cfg before printing a warning of not found cfg

ENDRELEASENOTES

For https://github.com/DIRACGrid/DIRAC/issues/7088, on top of https://github.com/DIRACGrid/DIRAC/pull/6945