### PR TITLE
fix: solve errors with pydantic validators in github actions

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Utilities/JobModel.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/JobModel.py
@@ -83,7 +83,7 @@ class BaseJobDescriptionModel(BaseModel):
                     raise ValueError("Input data files must start with LFN:/")
         return v
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def checkNumberOfInputDataFiles(cls, values):
         if "inputData" in values and values["inputData"]:
             maxInputDataFiles = Operations().getValue("JobDescription/MaxInputData", 500)
@@ -126,14 +126,14 @@ class BaseJobDescriptionModel(BaseModel):
             )
         return v
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def checkThatMaxNumberOfProcessorsIsGreaterThanMinNumberOfProcessors(cls, values):
         if "maxNumberOfProcessors" in values and values["maxNumberOfProcessors"]:
             if values["maxNumberOfProcessors"] < values["minNumberOfProcessors"]:
                 raise ValueError("maxNumberOfProcessors must be greater than minNumberOfProcessors")
         return values
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def addTagsDependingOnNumberOfProcessors(cls, values):
         if "maxNumberOfProcessors" in values and values["minNumberOfProcessors"] == values["maxNumberOfProcessors"]:
             if values["tags"] is None:
@@ -157,7 +157,7 @@ class BaseJobDescriptionModel(BaseModel):
                 raise ValueError(f"Invalid sites: {' '.join(invalidSites)}")
         return v
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def checkThatSitesAndBannedSitesAreNotMutuallyExclusive(cls, values):
         if "sites" in values and values["sites"] and "bannedSites" in values and values["bannedSites"]:
             values["sites"] -= values["bannedSites"]
@@ -192,7 +192,7 @@ class JobDescriptionModel(BaseJobDescriptionModel):
     ownerGroup: str
     vo: str
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def checkLFNMatchesREGEX(cls, values):
         if "inputData" in values and values["inputData"]:
             for lfn in values["inputData"]:


### PR DESCRIPTION

BEGINRELEASENOTES

ENDRELEASENOTES

I couldn't reproduce the failing of the CI experienced in PRs #7132 and #7105 (one specific instance of the pipeline failing can be found [here](https://github.com/DIRACGrid/DIRAC/actions/runs/5670048239/job/15364076668?pr=7105)).

I found [this issue](https://github.com/nazrulworld/fhir.resources/issues/41) that seems to address a similar issue by setting allow_reuse=True to all the root_validators.