### PR TITLE
[v8r0] doc: replace sphinx panels with sphinx design (its successor)

### DIFF
--- a/docs/setup.py
+++ b/docs/setup.py
@@ -29,5 +29,5 @@ setup(
     package_dir=PACKAGE_DIR,
     packages=ALL_PACKAGES,
     scripts=SCRIPTS,
-    install_requires=["sphinx_rtd_theme", "sphinx_panels"],
+    install_requires=["sphinx_rtd_theme", "sphinx_design"],
 )

--- a/docs/source/AdministratorGuide/index.rst
+++ b/docs/source/AdministratorGuide/index.rst
@@ -1,3 +1,5 @@
+.. _administrator_guide:
+
 ===================
 Administrator Guide
 ===================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -104,7 +104,7 @@ extensions = [
     "sphinx.ext.graphviz",
     "recommonmark",
     "sphinx_rtd_theme",
-    "sphinx_panels",
+    "sphinx_design",
 ]
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,43 +34,64 @@ An alternative description of the DIRAC system can be found in this `presentatio
 Documentation
 =============
 
-.. panels::
-  :card: shadow + text-center
-  :img-top-cls: p-5
+.. grid:: 2
+   :padding: 3
+   :gutter: 3
 
-  :img-top: _static/dirac_user.png
-  .. link-button:: UserGuide/index
-      :type: ref
-      :text: User Guide
-      :classes: btn-link stretched-link font-weight-bold
+   .. grid-item-card::
+      :shadow: lg
+      :text-align: center
+      :link-type: ref
+      :class-body: btn-link stretched-link font-weight-bold
+      :class-img-top: p-5
+      :img-top: _static/dirac_user.png
+      :link: user-guide
+      :link-alt: User Guide
 
-  including client installation
+      User Guide
 
-  ---
-  :img-top: _static/dirac_dev.png
-  .. link-button:: DeveloperGuide/index
-      :type: ref
-      :text: Developer Guide
-      :classes: btn-link stretched-link font-weight-bold
+      including client installation
 
-  adding new functionality to DIRAC
+   .. grid-item-card::
+      :shadow: lg
+      :text-align: center
+      :link-type: ref
+      :class-body: btn-link stretched-link font-weight-bold
+      :class-img-top: p-5
+      :img-top: _static/dirac_dev.png
+      :link: developer_guide
+      :link-alt: Developer Guide
 
-  ---
-  :img-top: _static/dirac_admin.png
-  .. link-button:: AdministratorGuide/index
-      :type: ref
-      :text: Administrator Guide
-      :classes: btn-link stretched-link font-weight-bold
+      Developer Guide
 
-  services administration, server installation
+      adding new functionality to DIRAC
 
-  ---
-  :img-top: _static/dirac_code.png
-  .. link-button:: CodeDocumentation/index
-      :type: ref
-      :text: Code Documentation
-      :classes: btn-link stretched-link font-weight-bold
 
-  code reference
+   .. grid-item-card::
+      :shadow: lg
+      :text-align: center
+      :link-type: ref
+      :class-body: btn-link stretched-link font-weight-bold
+      :class-img-top: p-5
+      :img-top: _static/dirac_admin.png
+      :link: administrator_guide
+      :link-alt: Administrator Guide
+
+      Administrator Guide
+
+      services administration, server installation
+
+
+   .. grid-item-card::
+      :shadow: lg
+      :text-align: center
+      :link-type: ref
+      :class-body: btn-link stretched-link font-weight-bold
+      :class-img-top: p-5
+      :img-top: _static/dirac_code.png
+      :link: code_documentation
+      :link-alt: Code Reference
+
+      code reference
 
 :ref:`genindex`

--- a/environment.yml
+++ b/environment.yml
@@ -75,7 +75,7 @@ dependencies:
   # RTD Sphinx theme
   - sphinx_rtd_theme
   # Bootstrap and new elements fo Sphinx
-  - sphinx-panels
+  - sphinx-design
   # unused
   - funcsigs
   - jinja2


### PR DESCRIPTION
This unblocks the sphinx < 5 version constraint from sphinx panels

https://sphinx-design.readthedocs.io/en/furo-theme/get_started.html#migrating-from-sphinx-panels

BEGINRELEASENOTES

*docs:
change: Replace the use of sphinx-panels with sphinx-design, this unblocks the use of latest sphinx versions (panels was requiring sphinx < 5)

ENDRELEASENOTES

- [x] Still need to replace panels somewhere!?!
