### PR TITLE
[v8.1] [diracx] Get token and run integration tests

### DIFF
--- a/docs/diracdoctools/__init__.py
+++ b/docs/diracdoctools/__init__.py
@@ -9,6 +9,7 @@ DIRAC_DOC_MOCK_LIST = [
     "_arc",
     "arc",
     "cmreslogging",
+    "diracx",
     "fts3",
     "gfal2",
     "git",

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -21,6 +21,9 @@ DIRAC_DEPRECATED_FAIL
 DIRAC_ENABLE_DIRACX_JOB_MONITORING
   If set, calls the diracx job monitoring service. Off by default.
 
+DIRAC_ENABLE_DIRACX_LOGIN
+  If set, retrieve a DiracX token when calling dirac-proxy-init or dirac-login
+
 DIRAC_FEWER_CFG_LOCKS
   If ``true`` or ``yes`` or ``on`` or ``1`` or ``y`` or ``t``, DIRAC will reduce the number of locks used when accessing the CS for better performance (default, ``no``).
 

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -18,6 +18,9 @@ DIRAC_DEPRECATED_FAIL
   If set, the use of functions or objects that are marked ``@deprecated`` will fail. Useful for example in continuous
   integration tests against future versions of DIRAC
 
+DIRAC_ENABLE_DIRACX_JOB_MONITORING
+  If set, calls the diracx job monitoring service. Off by default.
+
 DIRAC_FEWER_CFG_LOCKS
   If ``true`` or ``yes`` or ``on`` or ``1`` or ``y`` or ``t``, DIRAC will reduce the number of locks used when accessing the CS for better performance (default, ``no``).
 

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -29,13 +29,16 @@ FEATURE_VARIABLES = {
     "DIRACOSVER": "master",
     "DIRACOS_TARBALL_PATH": None,
     "TEST_HTTPS": "Yes",
+    "TEST_DIRACX": "No",
     "DIRAC_FEWER_CFG_LOCKS": None,
     "DIRAC_USE_JSON_ENCODE": None,
     "INSTALLATION_BRANCH": "",
 }
-DEFAULT_MODULES = {
-    "DIRAC": Path(__file__).parent.absolute(),
-}
+DIRACX_OPTIONS = (
+    "DIRAC_ENABLE_DIRACX_LOGIN",
+    "DIRAC_ENABLE_DIRACX_JOB_MONITORING",
+)
+DEFAULT_MODULES = {"DIRAC": Path(__file__).parent.absolute()}
 
 # Static configuration
 DB_USER = "Dirac"
@@ -180,7 +183,7 @@ def destroy():
     with _gen_docker_compose(DEFAULT_MODULES) as docker_compose_fn:
         os.execvpe(
             "docker-compose",
-            ["docker-compose", "-f", docker_compose_fn, "down", "--remove-orphans", "-t", "0"],
+            ["docker-compose", "-f", docker_compose_fn, "down", "--remove-orphans", "-t", "0", "--volumes"],
             _make_env({}),
         )
 
@@ -193,7 +196,6 @@ def prepare_environment(
     release_var: Optional[str] = None,
 ):
     """Prepare the local environment for installing DIRAC."""
-
     _check_containers_running(is_up=False)
     if editable is None:
         editable = sys.stdout.isatty()
@@ -224,7 +226,7 @@ def prepare_environment(
     typer.secho("Running docker-compose to create containers", fg=c.GREEN)
     with _gen_docker_compose(modules) as docker_compose_fn:
         subprocess.run(
-            ["docker-compose", "-f", docker_compose_fn, "up", "-d"],
+            ["docker-compose", "-f", docker_compose_fn, "up", "-d", "dirac-server", "dirac-client"],
             check=True,
             env=docker_compose_env,
         )
@@ -313,6 +315,27 @@ def prepare_environment(
             )
             subprocess.run(command, check=True, shell=True)
 
+    docker_compose_fn_final = Path(tempfile.mkdtemp()) / "ci"
+    typer.secho("Running docker-compose to create DiracX containers", fg=c.GREEN)
+    typer.secho(f"Will eave a folder behind: {docker_compose_fn_final}", fg=c.YELLOW)
+
+    with _gen_docker_compose(modules) as docker_compose_fn:
+        # We cannot use the temporary directory created in the context manager because
+        # we don't stay in the contect manager (Popen)
+        # So we need something that outlives it.
+        shutil.copytree(docker_compose_fn.parent, docker_compose_fn_final, dirs_exist_ok=True)
+        # We use Popen because we don't want to wait for this command to finish.
+        # It is going to start all the diracx containers, including one which waits
+        # for the DIRAC installation to be over.
+        subprocess.Popen(
+            ["docker-compose", "-f", docker_compose_fn_final / "docker-compose.yml", "up", "-d", "diracx"],
+            env=docker_compose_env,
+            stdin=None,
+            stdout=None,
+            stderr=None,
+            close_fds=True,
+        )
+
 
 @app.command()
 def install_server():
@@ -323,6 +346,15 @@ def install_server():
     base_cmd = _build_docker_cmd("server", tty=False)
     subprocess.run(
         base_cmd + ["bash", "/home/dirac/LocalRepo/TestCode/DIRAC/tests/CI/install_server.sh"],
+        check=True,
+    )
+
+    # This runs a continuous loop that exports the config in yaml
+    # for the diracx container to use
+    typer.secho("Starting configuration export loop for diracx", fg=c.GREEN)
+    base_cmd = _build_docker_cmd("server", tty=False, daemon=True)
+    subprocess.run(
+        base_cmd + ["bash", "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/tests/CI/exportCSLoop.sh"],
         check=True,
     )
 
@@ -508,13 +540,24 @@ def _gen_docker_compose(modules):
     # Load the docker-compose configuration and mount the necessary volumes
     input_fn = Path(__file__).parent / "tests/CI/docker-compose.yml"
     docker_compose = yaml.safe_load(input_fn.read_text())
+    # diracx-wait-for-db needs the volume to be able to run the witing script
+    for ctn in ("dirac-server", "dirac-client", "diracx-wait-for-db"):
+        if "volumes" not in docker_compose["services"][ctn]:
+            docker_compose["services"][ctn]["volumes"] = []
     volumes = [f"{path}:/home/dirac/LocalRepo/ALTERNATIVE_MODULES/{name}" for name, path in modules.items()]
     volumes += [f"{path}:/home/dirac/LocalRepo/TestCode/{name}" for name, path in modules.items()]
-    docker_compose["services"]["dirac-server"]["volumes"] = volumes[:]
-    docker_compose["services"]["dirac-client"]["volumes"] = volumes[:]
+    docker_compose["services"]["dirac-server"]["volumes"].extend(volumes[:])
+    docker_compose["services"]["dirac-client"]["volumes"].extend(volumes[:])
+    docker_compose["services"]["diracx-wait-for-db"]["volumes"].extend(volumes[:])
+
+    module_configs = _load_module_configs(modules)
+    if "diracx" in module_configs:
+        docker_compose["services"]["diracx"]["volumes"].append(
+            f"{modules['diracx']}/src/diracx:{module_configs['diracx']['install-location']}"
+        )
 
     # Add any extension services
-    for module_name, module_configs in _load_module_configs(modules).items():
+    for module_name, module_configs in module_configs.items():
         for service_name, service_config in module_configs["extra-services"].items():
             typer.secho(f"Adding service {service_name} for {module_name}", err=True, fg=c.GREEN)
             docker_compose["services"][service_name] = service_config.copy()
@@ -981,6 +1024,8 @@ def _make_config(modules, flags, release_var, editable):
         "CLIENT_HOST": "client",
         # Test specific variables
         "WORKSPACE": "/home/dirac",
+        # DiracX variable
+        "DIRACX_URL": "http://diracx:8000",
     }
 
     if editable:
@@ -1006,6 +1051,12 @@ def _make_config(modules, flags, release_var, editable):
         except KeyError:
             typer.secho(f"Required feature variable {key!r} is missing", err=True, fg=c.RED)
             raise typer.Exit(code=1)
+
+    # If we test DiracX, enable all the options
+    if config["TEST_DIRACX"].lower() in ("yes", "true"):
+        for key in DIRACX_OPTIONS:
+            config[key] = "Yes"
+
     config["TESTREPO"] = [f"/home/dirac/LocalRepo/TestCode/{name}" for name in modules]
     config["ALTERNATIVE_MODULES"] = [f"/home/dirac/LocalRepo/ALTERNATIVE_MODULES/{name}" for name in modules]
 
@@ -1027,7 +1078,7 @@ def _load_module_configs(modules):
     return module_ci_configs
 
 
-def _build_docker_cmd(container_name, *, use_root=False, cwd="/home/dirac", tty=True):
+def _build_docker_cmd(container_name, *, use_root=False, cwd="/home/dirac", tty=True, daemon=False):
     if use_root or os.getuid() == 0:
         user = "root"
     else:
@@ -1042,6 +1093,8 @@ def _build_docker_cmd(container_name, *, use_root=False, cwd="/home/dirac", tty=
                 err=True,
                 fg=c.YELLOW,
             )
+    if daemon:
+        cmd += ["-d"]
     cmd += [
         "-e=TERM=xterm-color",
         "-e=INSTALLROOT=/home/dirac",

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -317,7 +317,7 @@ def prepare_environment(
 
     docker_compose_fn_final = Path(tempfile.mkdtemp()) / "ci"
     typer.secho("Running docker-compose to create DiracX containers", fg=c.GREEN)
-    typer.secho(f"Will eave a folder behind: {docker_compose_fn_final}", fg=c.YELLOW)
+    typer.secho(f"Will leave a folder behind: {docker_compose_fn_final}", fg=c.YELLOW)
 
     with _gen_docker_compose(modules) as docker_compose_fn:
         # We cannot use the temporary directory created in the context manager because

--- a/src/DIRAC/ConfigurationSystem/Client/CSAPI.py
+++ b/src/DIRAC/ConfigurationSystem/Client/CSAPI.py
@@ -612,25 +612,15 @@ class CSAPI:
             Where is the shifters section?
             """
             vo = CSGlobals.getVO()
-            setup = CSGlobals.getSetup()
 
             if vo:
-                res = gConfig.getSections(f"/Operations/{vo}/{setup}/Shifter")
+                res = gConfig.getSections(f"/Operations/{vo}/Shifter")
                 if res["OK"]:
-                    return S_OK(f"/Operations/{vo}/{setup}/Shifter")
+                    return S_OK(f"/Operations/{vo}/Shifter")
 
-                res = gConfig.getSections(f"/Operations/{vo}/Defaults/Shifter")
-                if res["OK"]:
-                    return S_OK(f"/Operations/{vo}/Defaults/Shifter")
-
-            else:
-                res = gConfig.getSections(f"/Operations/{setup}/Shifter")
-                if res["OK"]:
-                    return S_OK(f"/Operations/{setup}/Shifter")
-
-                res = gConfig.getSections("/Operations/Defaults/Shifter")
-                if res["OK"]:
-                    return S_OK("/Operations/Defaults/Shifter")
+            res = gConfig.getSections("/Operations/Defaults/Shifter")
+            if res["OK"]:
+                return S_OK("/Operations/Defaults/Shifter")
 
             return S_ERROR("No shifter section")
 
@@ -671,7 +661,7 @@ class CSAPI:
                 gLogger.info("Adding shifter section")
                 vo = CSGlobals.getVO()
                 if vo:
-                    section = f"/Operations/{vo}/Defaults/Shifter"
+                    section = f"/Operations/{vo}/Shifter"
                 else:
                     section = "/Operations/Defaults/Shifter"
                 res = self.__csMod.createSection(section)

--- a/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Helpers/Operations.py
@@ -6,56 +6,19 @@
 
       Operations/
           Defaults/
+                someOption = someValue
+                aSecondOption = aSecondValue
+          specificVo/
               someSection/
-                  someOption = someValue
-                  aSecondOption = aSecondValue
-          Production/
-              someSection/
-                  someOption = someValueInProduction
-                  aSecondOption = aSecondValueInProduction
-          Certification/
-              someSection/
-                  someOption = someValueInCertification
+                  someOption = someValueInVO
 
     The following calls would give different results based on the setup::
 
       Operations().getValue('someSection/someOption')
-        - someValueInProduction if we are in 'Production' setup
-        - someValueInCertification if we are in 'Certification' setup
+        - someValueInVO if we are in 'specificVo' vo
+        - someValue if we are in any other VO
 
-      Operations().getValue('someSection/aSecondOption')
-        - aSecondValueInProduction if we are in 'Production' setup
-        - aSecondValue if we are in 'Certification' setup    <- looking in Defaults
-                                                                since there's no Certification/someSection/aSecondOption
-
-
-    At the same time, for multi-VO installations, it is also possible to specify different options per-VO,
-    like the following::
-
-      Operations/
-          aVOName/
-              Defaults/
-                  someSection/
-                      someOption = someValue
-                      aSecondOption = aSecondValue
-              Production/
-                  someSection/
-                      someOption = someValueInProduction
-                      aSecondOption = aSecondValueInProduction
-              Certification/
-                  someSection/
-                      someOption = someValueInCertification
-          anotherVOName/
-              Defaults/
-                  someSectionName/
-                      someOptionX = someValueX
-                      aSecondOption = aSecondValue
-              setupName/
-                  someSection/
-                      someOption = someValueInProduction
-                      aSecondOption = aSecondValueInProduction
-
-    For this case it becomes then important for the Operations() objects to know the VO name
+    It becomes then important for the Operations() objects to know the VO name
     for which we want the information, and this can be done in the following ways.
 
     1. by specifying the VO name directly::
@@ -98,9 +61,7 @@ class Operations:
         """
         self.__uVO = vo
         self.__uGroup = group
-        self.__uSetup = setup
         self.__vo = False
-        self.__setup = False
         self.__discoverSettings()
 
     def __discoverSettings(self):
@@ -119,12 +80,6 @@ class Operations:
             result = getVOfromProxyGroup()
             if result["OK"]:
                 self.__vo = result["Value"]
-        # Set the setup
-        self.__setup = False
-        if self.__uSetup:
-            self.__setup = self.__uSetup
-        else:
-            self.__setup = CSGlobals.getSetup()
 
     def __getCache(self):
         Operations.__cacheLock.acquire()
@@ -134,7 +89,7 @@ class Operations:
                 Operations.__cache = {}
                 Operations.__cacheVersion = currentVersion
 
-            cacheKey = (self.__vo, self.__setup)
+            cacheKey = (self.__vo,)
             if cacheKey in Operations.__cache:
                 return Operations.__cache[cacheKey]
 
@@ -155,14 +110,13 @@ class Operations:
                 pass
 
     def __getSearchPaths(self):
-        paths = ["/Operations/Defaults", f"/Operations/{self.__setup}"]
+        paths = ["/Operations/Defaults"]
         if not self.__vo:
             globalVO = CSGlobals.getVO()
             if not globalVO:
                 return paths
             self.__vo = CSGlobals.getVO()
-        paths.append(f"/Operations/{self.__vo}/Defaults")
-        paths.append(f"/Operations/{self.__vo}/{self.__setup}")
+        paths.append(f"/Operations/{self.__vo}/")
         return paths
 
     def getValue(self, optionPath, defaultValue=None):
@@ -201,26 +155,6 @@ class Operations:
         for opName in sectionCFG.listOptions():
             data[opName] = sectionCFG[opName]
         return S_OK(data)
-
-    def getPath(self, option, vo=False, setup=False):
-        """
-        Generate the CS path for an option:
-
-          - if vo is not defined, the helper's vo will be used for multi VO installations
-          - if setup evaluates False (except None) -> The helpers setup will  be used
-          - if setup is defined -> whatever is defined will be used as setup
-          - if setup is None -> Defaults will be used
-
-        :param option: path with respect to the Operations standard path
-        :type option: string
-        """
-
-        for path in self.__getSearchPaths():
-            optionPath = os.path.join(path, option)
-            value = gConfig.getValue(optionPath, "NoValue")
-            if value != "NoValue":
-                return optionPath
-        return ""
 
     def getMonitoringBackends(self, monitoringType=None):
         """

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
@@ -16,6 +16,9 @@ Example:
 import os
 import sys
 import copy
+import datetime
+import json
+from pathlib import Path
 from prompt_toolkit import prompt, print_formatted_text as print, HTML
 
 import DIRAC
@@ -26,6 +29,13 @@ from DIRAC.Core.Security.ProxyFile import writeToProxyFile
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo, formatProxyInfoAsString
 from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-error
 from DIRAC.Core.Base.Script import Script
+from DIRAC.Core.Base.Client import Client
+
+
+# token location
+DIRAC_TOKEN_FILE = Path.home() / ".cache" / "diracx" / "credentials.json"
+EXPIRES_GRACE_SECONDS = 15
+
 
 # At this point, we disable CS synchronization so that an error related
 # to the lack of a proxy certificate does not occur when trying to synchronize.
@@ -304,7 +314,27 @@ class Params:
             # Upload proxy to the server if it longer that uploaded one
             if credentials["secondsLeft"] > uploadedProxyLifetime:
                 gLogger.notice("Upload proxy to server.")
-                return gProxyManager.uploadProxy(proxy)
+                res = gProxyManager.uploadProxy(proxy)
+                if not res["OK"]:
+                    return res
+
+            # Get a token for use with diracx
+            if os.getenv("DIRAC_ENABLE_DIRACX_LOGIN", "No").lower() in ("yes", "true"):
+                res = Client(url="Framework/ProxyManager").exchangeProxyForToken()
+                if not res["OK"]:
+                    return res
+                DIRAC_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+                expires = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
+                    seconds=res["Value"]["expires_in"] - EXPIRES_GRACE_SECONDS
+                )
+                credential_data = {
+                    "access_token": res["Value"]["access_token"],
+                    # TODO: "refresh_token":
+                    # TODO: "refresh_token_expires":
+                    "expires": expires.isoformat(),
+                }
+                DIRAC_TOKEN_FILE.write_text(json.dumps(credential_data))
+
         return S_OK()
 
     def __enableCS(self):

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
@@ -9,6 +9,7 @@ Example:
 import os
 import sys
 import glob
+import json
 import time
 import datetime
 
@@ -21,6 +22,12 @@ from DIRAC.Core.Security import X509Chain, ProxyInfo, VOMS
 from DIRAC.Core.Security.Locations import getCAsLocation
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.FrameworkSystem.Client.BundleDeliveryClient import BundleDeliveryClient
+from DIRAC.Core.Base.Client import Client
+from pathlib import Path
+
+
+DIRAC_TOKEN_FILE = Path.home() / ".cache" / "diracx" / "credentials.json"
+EXPIRES_GRACE_SECONDS = 15
 
 
 class Params(ProxyGeneration.CLIParams):
@@ -236,6 +243,22 @@ class ProxyInit:
             if not resultProxyUpload["OK"]:
                 if self.__piParams.strict:
                     return resultProxyUpload
+
+        if os.getenv("DIRAC_ENABLE_DIRACX_LOGIN", "No").lower() in ("yes", "true"):
+            res = Client(url="Framework/ProxyManager").exchangeProxyForToken()
+            if not res["OK"]:
+                return res
+            DIRAC_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+            expires = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
+                seconds=res["Value"]["expires_in"] - EXPIRES_GRACE_SECONDS
+            )
+            credential_data = {
+                "access_token": res["Value"]["access_token"],
+                # TODO: "refresh_token":
+                # TODO: "refresh_token_expires":
+                "expires": expires.isoformat(),
+            }
+            DIRAC_TOKEN_FILE.write_text(json.dumps(credential_data))
 
         return S_OK()
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
@@ -26,10 +26,6 @@ from DIRAC.Core.Base.Client import Client
 from pathlib import Path
 
 
-DIRAC_TOKEN_FILE = Path.home() / ".cache" / "diracx" / "credentials.json"
-EXPIRES_GRACE_SECONDS = 15
-
-
 class Params(ProxyGeneration.CLIParams):
     addVOMSExt = False
     uploadProxy = True
@@ -245,10 +241,13 @@ class ProxyInit:
                     return resultProxyUpload
 
         if os.getenv("DIRAC_ENABLE_DIRACX_LOGIN", "No").lower() in ("yes", "true"):
+            from diracx.cli import EXPIRES_GRACE_SECONDS  # pylint: disable=import-error
+            from diracx.cli.utils import CREDENTIALS_PATH  # pylint: disable=import-error
+
             res = Client(url="Framework/ProxyManager").exchangeProxyForToken()
             if not res["OK"]:
                 return res
-            DIRAC_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+            CREDENTIALS_PATH.parent.mkdir(parents=True, exist_ok=True)
             expires = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
                 seconds=res["Value"]["expires_in"] - EXPIRES_GRACE_SECONDS
             )
@@ -258,7 +257,7 @@ class ProxyInit:
                 # TODO: "refresh_token_expires":
                 "expires": expires.isoformat(),
             }
-            DIRAC_TOKEN_FILE.write_text(json.dumps(credential_data))
+            CREDENTIALS_PATH.write_text(json.dumps(credential_data))
 
         return S_OK()
 

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobMonitoringClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobMonitoringClient.py
@@ -1,5 +1,6 @@
 """ Class that contains client access to the job monitoring handler. """
 
+import os
 from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
 from DIRAC.Core.Utilities.JEncode import strToIntDict
@@ -10,6 +11,13 @@ class JobMonitoringClient(Client):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.setServer("WorkloadManagement/JobMonitoring")
+
+    if os.getenv("DIRAC_ENABLE_DIRACX_JOB_MONITORING", "No").lower() in ("yes", "true"):
+        from DIRAC.WorkloadManagementSystem.FutureClient.JobMonitoringClient import (
+            JobMonitoringClient as futureJobMonitoringClient,
+        )
+
+        httpsClient = futureJobMonitoringClient
 
     @ignoreEncodeWarning
     def getJobsStatus(self, jobIDs):

--- a/src/DIRAC/WorkloadManagementSystem/FutureClient/JobMonitoringClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/FutureClient/JobMonitoringClient.py
@@ -1,36 +1,34 @@
 # pylint: disable=import-error
-import os
+from diracx.client import Dirac
+from diracx.client.models import JobSearchParams
 
-if os.getenv("DIRAC_ENABLE_DIRACX_JOB_MONITORING", "No").lower() in ("yes", "true"):
-    from diracx.client import Dirac
-    from diracx.client.models import JobSearchParams
+from diracx.cli.utils import get_auth_headers
+from diracx.core.preferences import DiracxPreferences
 
-    from diracx.cli.utils import get_auth_headers
-    from diracx.core.preferences import DiracxPreferences
+from DIRAC.Core.Utilities.ReturnValues import convertToReturnValue
 
-    from DIRAC.Core.Utilities.ReturnValues import convertToReturnValue
 
-    class JobMonitoringClient:
-        def __init__(self, *args, **kwargs):
-            self.endpoint = DiracxPreferences().url
+class JobMonitoringClient:
+    def __init__(self, *args, **kwargs):
+        self.endpoint = DiracxPreferences().url
 
-        def fetch(self, parameters, jobIDs):
-            with Dirac(endpoint=self.endpoint) as api:
-                jobs = api.jobs.search(
-                    parameters=["JobID"] + parameters,
-                    search=[{"parameter": "JobID", "operator": "in", "values": jobIDs}],
-                    headers=get_auth_headers(),
-                )
-                return {j["JobID"]: {param: j[param] for param in parameters} for j in jobs}
+    def fetch(self, parameters, jobIDs):
+        with Dirac(endpoint=self.endpoint) as api:
+            jobs = api.jobs.search(
+                parameters=["JobID"] + parameters,
+                search=[{"parameter": "JobID", "operator": "in", "values": jobIDs}],
+                headers=get_auth_headers(),
+            )
+            return {j["JobID"]: {param: j[param] for param in parameters} for j in jobs}
 
-        @convertToReturnValue
-        def getJobsMinorStatus(self, jobIDs):
-            return self.fetch(["MinorStatus"], jobIDs)
+    @convertToReturnValue
+    def getJobsMinorStatus(self, jobIDs):
+        return self.fetch(["MinorStatus"], jobIDs)
 
-        @convertToReturnValue
-        def getJobsStates(self, jobIDs):
-            return self.fetch(["Status", "MinorStatus", "ApplicationStatus"], jobIDs)
+    @convertToReturnValue
+    def getJobsStates(self, jobIDs):
+        return self.fetch(["Status", "MinorStatus", "ApplicationStatus"], jobIDs)
 
-        @convertToReturnValue
-        def getJobsSites(self, jobIDs):
-            return self.fetch(["Site"], jobIDs)
+    @convertToReturnValue
+    def getJobsSites(self, jobIDs):
+        return self.fetch(["Site"], jobIDs)

--- a/src/DIRAC/WorkloadManagementSystem/FutureClient/JobMonitoringClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/FutureClient/JobMonitoringClient.py
@@ -1,0 +1,36 @@
+# pylint: disable=import-error
+import os
+
+if os.getenv("DIRAC_ENABLE_DIRACX_JOB_MONITORING", "No").lower() in ("yes", "true"):
+    from diracx.client import Dirac
+    from diracx.client.models import JobSearchParams
+
+    from diracx.cli.utils import get_auth_headers
+    from diracx.core.preferences import DiracxPreferences
+
+    from DIRAC.Core.Utilities.ReturnValues import convertToReturnValue
+
+    class JobMonitoringClient:
+        def __init__(self, *args, **kwargs):
+            self.endpoint = DiracxPreferences().url
+
+        def fetch(self, parameters, jobIDs):
+            with Dirac(endpoint=self.endpoint) as api:
+                jobs = api.jobs.search(
+                    parameters=["JobID"] + parameters,
+                    search=[{"parameter": "JobID", "operator": "in", "values": jobIDs}],
+                    headers=get_auth_headers(),
+                )
+                return {j["JobID"]: {param: j[param] for param in parameters} for j in jobs}
+
+        @convertToReturnValue
+        def getJobsMinorStatus(self, jobIDs):
+            return self.fetch(["MinorStatus"], jobIDs)
+
+        @convertToReturnValue
+        def getJobsStates(self, jobIDs):
+            return self.fetch(["Status", "MinorStatus", "ApplicationStatus"], jobIDs)
+
+        @convertToReturnValue
+        def getJobsSites(self, jobIDs):
+            return self.fetch(["Site"], jobIDs)

--- a/tests/CI/check_db_initialized.sh
+++ b/tests/CI/check_db_initialized.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+dbMissing=true;
+allDBs=(JobDB FileCatalogDB)
+while ${dbMissing};
+do
+    dbMissing=false;
+    allExistingDBs=$(mysql -uDirac -pDirac -h mysql -P 3306 -e "show databases;");
+    for db in "${allDBs[@]}";
+    do
+        if grep -q "${db}" <<< "${allExistingDBs}";
+        then
+            echo "${db} OK";
+        else
+            echo "${db} not created";
+            dbMissing=true;
+        fi;
+    done;
+    if ${dbMissing};
+    then
+        sleep 1;
+    fi
+done

--- a/tests/CI/check_db_initialized.sh
+++ b/tests/CI/check_db_initialized.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 dbMissing=true;
-allDBs=(JobDB FileCatalogDB)
+allDBs=(AccountingDB FTS3DB JobDB JobLoggingDB PilotAgentsDB ProductionDB ProxyDB ReqDB ResourceManagementDB ResourceStatusDB SandboxMetadataDB StorageManagementDB TaskQueueDB TransformationDB)
 while ${dbMissing};
 do
     dbMissing=false;

--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -1,5 +1,11 @@
 version: '3.4'
 
+volumes:
+  # Volume used to store the config of diracx
+  diracx-cs-store:
+  # Volume used to store the pair of keys to sign the tokens
+  diracx-key-store:
+
 services:
   mysql:
     image: ${MYSQL_VER}
@@ -42,7 +48,6 @@ services:
       retries: 15
       start_period: 60s
 
-
   # Mock of an S3 storage
   s3-direct:
     image: adobe/s3mock
@@ -55,18 +60,45 @@ services:
       - initialBuckets=my-first-bucket
       - debug=true
 
+
+  diracx-wait-for-db:
+
+    image: ${MYSQL_VER}
+    container_name: diracx-wait-for-db
+    depends_on:
+      mysql:
+        condition: service_healthy
+    command: /home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/tests/CI/check_db_initialized.sh
+
+
+
   dirac-server:
     image: ${CI_REGISTRY_IMAGE}/${HOST_OS}-dirac
     container_name: server
     hostname: server
     user: "${DIRAC_UID}:${DIRAC_GID}"
+
     depends_on:
       mysql:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
+      s3-direct:
+        condition: service_started
+      iam-login-service:
+        condition: service_started
+      diracx-init-key:
+        condition: service_completed_successfully # Let the init container create the cs
+      diracx-init-cs:
+        condition: service_completed_successfully # Let the init container create the cs
     ulimits:
       nofile: 8192
+    volumes:
+      - diracx-cs-store:/cs_store
+      - diracx-key-store:/signing-key
+    environment:
+      - DIRACX_CONFIG_BACKEND_URL=git+file:///cs_store/initialRepo
+      - DIRACX_SERVICE_AUTH_TOKEN_KEY=file:///signing-key/rs256.key
 
   dirac-client:
     image: ${CI_REGISTRY_IMAGE}/${HOST_OS}-dirac
@@ -77,3 +109,54 @@ services:
       - dirac-server
     ulimits:
       nofile: 8192
+
+
+
+  diracx-init-key:
+    image: ghcr.io/diracgrid/diracx/server
+    container_name: diracx-init-key
+    environment:
+      - DIRACX_SERVICE_AUTH_TOKEN_KEY="file:///signing-key/rs256.key"
+    volumes:
+      - diracx-key-store:/signing-key/
+    # We need to allow everybody to read the private keys
+    # Because the users are different between the DIRAC and DiracX containers
+    entrypoint: |
+      /dockerMicroMambaEntrypoint.sh bash -c "ssh-keygen -P '' -trsa -b4096 -mPEM -f/signing-key/rs256.key && /dockerMicroMambaEntrypoint.sh chmod o+r /signing-key/rs256.*"
+
+  diracx-init-cs:
+    image: ghcr.io/diracgrid/diracx/server
+    container_name: diracx-init-cs
+    environment:
+      - DIRACX_CONFIG_BACKEND_URL=git+file:///cs_store/initialRepo
+      - DIRACX_SERVICE_AUTH_TOKEN_KEY=file:///signing-key/rs256.key
+    volumes:
+      - diracx-cs-store:/cs_store/
+      - diracx-key-store:/signing-key/
+    entrypoint: |
+      /dockerMicroMambaEntrypoint.sh dirac internal generate-cs /cs_store/initialRepo --vo=diracAdmin --user-group=admin --idp-url=http://dsdsd.csds/a/b
+
+  diracx:
+    image: ghcr.io/diracgrid/diracx/server
+    container_name: diracx
+    environment:
+      - DIRACX_CONFIG_BACKEND_URL=git+file:///cs_store/initialRepo
+      - "DIRACX_DB_URL_AUTHDB=sqlite+aiosqlite:///:memory:"
+      - DIRACX_DB_URL_JOBDB=mysql+aiomysql://Dirac:Dirac@mysql/JobDB
+      - DIRACX_SERVICE_AUTH_TOKEN_KEY=file:///signing-key/rs256.key
+      - DIRACX_SERVICE_AUTH_ALLOWED_REDIRECTS=["http://diracx:8000/docs/oauth2-redirect"]
+    ports:
+      - 8000:8000
+    depends_on:
+      diracx-wait-for-db:
+        condition: service_completed_successfully
+    volumes:
+      - diracx-cs-store:/cs_store/
+      - diracx-key-store:/signing-key/
+
+    healthcheck:
+      test: ["CMD", "/dockerMicroMambaEntrypoint.sh", "curl", "-f", "http://localhost:8000/.well-known/openid-configuration"]
+      interval: 5s
+      timeout: 2s
+      retries: 15
+      start_period: 60s

--- a/tests/CI/exportCSLoop.sh
+++ b/tests/CI/exportCSLoop.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# This script will export to the `Production.cfg` file to the
+# yaml format for diracx every 5 seconds
+
+source /home/dirac/ServerInstallDIR/bashrc
+git config --global user.name "DIRAC Server CI"
+git config --global user.email "dirac-server-ci@invalid"
+
+while true;
+do
+    curl -L https://gitlab.cern.ch/chaen/chris-hackaton-cs/-/raw/master/convert-from-legacy.py |DIRAC_COMPAT_ENABLE_CS_CONVERSION=True  ~/ServerInstallDIR/diracos/bin/python - ~/ServerInstallDIR/etc/Production.cfg /cs_store/initialRepo/
+    git -C /cs_store/initialRepo/ commit -am "export $(date)"
+    sleep 5;
+done


### PR DESCRIPTION
This should be transparent :-)
It starts integrating diracx by:
* enabling/disabling feature with env variables
* allow it to run in the `integration_tests`

One thing could be disruptive though:(@fstagni ) The CSApi does not look anymore in `Default`  or `<Setup>` for the shifter. 
What's your plan for that migration ? Tell the people to copy everything under `/Default` to the root of the `Operatons` section before upgrading ? 

BEGINRELEASENOTES
*CS
CHANGE: do not look for the shifter under the Default or <Setup> section

*Test
NEW: allow integration tests to run against DiracX

*Core

NEW: get a token for a proxy

*WMS
NEW: call the diracx Job Monitoring endpoint

ENDRELEASENOTES
