### PR TITLE
[v7r3] Kill sweep jobs that take more than 30 minutes

### DIFF
--- a/.github/workflows/pr-sweep.yml
+++ b/.github/workflows/pr-sweep.yml
@@ -7,6 +7,7 @@ jobs:
   pr-sweep:
     runs-on: ubuntu-latest
     concurrency: pr-sweep
+    timeout-minutes: 30
     if: github.repository == 'DIRACGrid/DIRAC'
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Occasionally the sweeper gets stuck (probably due to a network glitch) and then waits for 6 hours before it gets killed. As we limit the concurrency of the job to 1 this prevents any sweeping for the full time.

I think it's preferable to set a shorter limit to avoid confusion from this.

Also we don't need to worry about lost jobs as the sweeper is designed to be eventually consistent rather than requiring a specific PR's merge CI to pick it up.