### PR TITLE
[sweep:integration] Do not overwrite the tornado port if already set

### DIFF
--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -2432,7 +2432,13 @@ class ComponentInstaller:
             return S_ERROR(f"{instanceOption} not defined in {self.cfgFile}")
         tornadoSection = cfgPath("Systems", "Tornado", compInstance)
 
-        cfg = self.__getCfg(tornadoSection, "Port", 8443)
+        if gConfig_o:
+            tornadoPort = gConfig_o.getValue(cfgPath(tornadoSection, "Port"), "8443")
+        else:
+            tornadoPort = self.localCfg.getOption(cfgPath(tornadoSection, "Port"), "8443")
+
+        cfg = self.__getCfg(tornadoSection, "Port", tornadoPort)
+
         return self._addCfgToCS(cfg)
 
     def setupTornadoService(self, system, component):


### PR DESCRIPTION
Sweep #7130 `Do not overwrite the tornado port if already set` to `integration`.

Adding original author @fstagni as watcher.

BEGINRELEASENOTES

*Framework
FIX: Do not overwrite the tornado port if already set

ENDRELEASENOTES
Closes #7145