### PR TITLE
[v8r0] Stop using PID namespaces with SingularityCE

### DIFF
--- a/src/DIRAC/Resources/Computing/SingularityComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SingularityComputingElement.py
@@ -398,7 +398,7 @@ class SingularityComputingElement(ComputingElement):
         innerCmd = os.path.join(self.__innerdir, "dirac_container.sh")
         cmd = [self.__singularityBin, "exec"]
         cmd.extend(["--contain"])  # use minimal /dev and empty other directories (e.g. /tmp and $HOME)
-        cmd.extend(["--ipc", "--pid"])  # run container in new IPC and PID namespaces
+        cmd.extend(["--ipc"])  # run container in a new IPC namespace
         cmd.extend(["--workdir", baseDir])  # working directory to be used for /tmp, /var/tmp and $HOME
         cmd.extend(["--home", "/tmp"])  # Avoid using small tmpfs for default $HOME and use scratch /tmp instead
         if self.__hasUserNS():


### PR DESCRIPTION
When sites use docker to isolate the pilot it's not possible to use both PID namespaces and mount /proc inside the container created by SingularityCE without the site starting the docker container with --privileged. See https://github.com/apptainer/singularity/issues/1768 for details.

I'm not convinced we gain much by passing --pid so I propose removing it.


BEGINRELEASENOTES

*WorkloadManagement
CHANGE: Stop using PID namespaces with SingularityCE

ENDRELEASENOTES
