### PR TITLE
[8.1] hacktathon fix: passing pilotDN instead of owner in getPilotProxyFromVOMSGroup()

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -6,7 +6,11 @@ import shutil
 
 from DIRAC import S_OK, S_ERROR, gLogger, gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getQueue
-from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getGroupOption, getUsernameForDN, getVOForGroup
+from DIRAC.ConfigurationSystem.Client.Helpers.Registry import (
+    getDNForUsername,
+    getGroupOption,
+    getVOForGroup,
+)
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.FrameworkSystem.Client.ProxyManagerClient import gProxyManager
 from DIRAC.FrameworkSystem.Client.TokenManagerClient import gTokenManager
@@ -56,13 +60,20 @@ def getPilotProxy(pilotDict):
     :param dict pilotDict: pilot parameters
     :return: S_OK/S_ERROR with proxy as Value
     """
-    ownerDN = pilotDict["OwnerDN"]
-    group = pilotDict["OwnerGroup"]
+    pilotGroup = pilotDict["OwnerGroup"]
 
-    groupVOMS = getGroupOption(group, "VOMSRole", group)
-    result = gProxyManager.getPilotProxyFromVOMSGroup(ownerDN, groupVOMS)
+    pilotDN = Operations(vo=getVOForGroup(pilotGroup)).getValue("Pilot/GenericPilotDN")
+    if not pilotDN:
+        owner = Operations(vo=getVOForGroup(pilotGroup)).getValue("Pilot/GenericPilotUser")
+        res = getDNForUsername(owner)
+        if not res["OK"]:
+            return S_ERROR(f"Cannot get the generic pilot DN: {res['Message']}")
+        pilotDN = res["Value"][0]
+
+    groupVOMS = getGroupOption(pilotGroup, "VOMSRole", pilotGroup)
+    result = gProxyManager.getPilotProxyFromVOMSGroup(pilotDN, groupVOMS)
     if not result["OK"]:
-        gLogger.error("Could not get proxy:", f"User \"{ownerDN}\" Group \"{groupVOMS}\" : {result['Message']}")
+        gLogger.error("Could not get proxy:", f"User \"{pilotDN}\" Group \"{groupVOMS}\" : {result['Message']}")
         return S_ERROR("Failed to get the pilot's owner proxy")
     return result
 
@@ -124,19 +135,20 @@ def killPilotsInQueues(pilotRefDict):
         ce = result["Value"]
 
         pilotDN = Operations(vo=getVOForGroup(pilotGroup)).getValue("Pilot/GenericPilotDN")
-
-        if pilotGroup and pilotDN:
-            res = getUsernameForDN(pilotDN)
+        if not pilotDN:
+            owner = Operations(vo=getVOForGroup(pilotGroup)).getValue("Pilot/GenericPilotUser")
+            res = getDNForUsername(owner)
             if not res["OK"]:
-                return res
-            owner = res["Value"]
-            group = getGroupOption(pilotGroup, "VOMSRole", pilotGroup)
-            ret = gProxyManager.getPilotProxyFromVOMSGroup(owner, group)
-            if not ret["OK"]:
-                gLogger.error("Could not get proxy:", f"User '{owner}' Group '{group}' : {ret['Message']}")
-                return S_ERROR("Failed to get the pilot's owner proxy")
-            proxy = ret["Value"]
-            ce.setProxy(proxy)
+                return S_ERROR(f"Cannot get the generic pilot DN: {res['Message']}")
+            pilotDN = res["Value"][0]
+
+        group = getGroupOption(pilotGroup, "VOMSRole", pilotGroup)
+        ret = gProxyManager.getPilotProxyFromVOMSGroup(pilotDN, group)
+        if not ret["OK"]:
+            gLogger.error("Could not get proxy:", f"User '{pilotDN}' Group '{group}' : {ret['Message']}")
+            return S_ERROR("Failed to get the pilot's owner proxy")
+        proxy = ret["Value"]
+        ce.setProxy(proxy)
 
         pilotList = pilotDict["PilotList"]
         result = ce.killJob(pilotList)


### PR DESCRIPTION
Aims at fixing errors while trying to get a pilot output.

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: passing pilotDN instead of owner in getPilotProxyFromVOMSGroup()
ENDRELEASENOTES
