### PR TITLE
[8.0] Drop the system instance level in the CS

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -43,8 +43,8 @@ def getSystemInstance(system, setup=False):
        an empty string is returned
     """
 
-    # If Setup is None, it means that we have the case of configuration without Setup
-    setupToUse = setup or getDIRACSetup()
+    # If Setup is "None", it means that we have the case of configuration without Setup
+    setupToUse = setup or gConfigurationData.remoteCFG.getOption("/DIRAC/Setup")
     if setupToUse == "None":
         return ""
 

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -43,10 +43,16 @@ def getSystemInstance(system, setup=False):
        an empty string is returned
     """
 
-    # If Setup is "None", it means that we have the case of configuration without Setup
-    setupToUse = setup or gConfigurationData.remoteCFG.getOption("/DIRAC/Setup")
-    if setupToUse == "None":
+    # If noSetupFlag is set to True, we do not have system instances
+    try:
+        noSetupFlag = gConfigurationData.extractOptionFromCFG("/DIRAC/NoSetup")
+        if noSetupFlag == "True":
+            return ""
+    except:
         return ""
+
+    # If Setup is "None", it means that we have the case of configuration without Setup
+    setupToUse = setup or getDIRACSetup()
 
     optionPath = Path.cfgPath("/DIRAC/Setups", setupToUse, system)
     instance = gConfigurationData.extractOptionFromCFG(optionPath)

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -33,21 +33,22 @@ def divideFullName(entityName, componentName=None):
 
 
 def getSystemInstance(system, setup=False):
-    """Find system instance name
+    """Find system instance name.
 
     :param str system: system name
     :param str setup: setup name
 
-    :return: str
+    :return: str: instance name. If the system option is present
+       in the /DIRAC/Setups/<setup> section but is not given a value,
+       an empty string is returned
     """
-    if "Setups" in gConfigurationData.getSectionsFromCFG("/DIRAC"):
-        optionPath = Path.cfgPath("/DIRAC/Setups", setup or getDIRACSetup(), system)
-        instance = gConfigurationData.extractOptionFromCFG(optionPath)
-        if not instance:
-            raise RuntimeError(f"Option {optionPath} is not defined")
-        return instance
-    # If /DIRAC/Setups is not present in the CS return empty instance string
-    return ""
+
+    setupPath = Path.cfgPath("/DIRAC/Setups", setup or getDIRACSetup())
+    optionPath = Path.cfgPath(setupPath, system)
+    instance = gConfigurationData.extractOptionFromCFG(optionPath)
+    if not instance and system not in gConfigurationData.getOptionsFromCFG(setupPath):
+        raise RuntimeError(f"Option {optionPath} is not defined")
+    return instance
 
 
 def getSystemSection(system, instance=False, setup=False):

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -40,11 +40,14 @@ def getSystemInstance(system, setup=False):
 
     :return: str
     """
-    optionPath = Path.cfgPath("/DIRAC/Setups", setup or getDIRACSetup(), system)
-    instance = gConfigurationData.extractOptionFromCFG(optionPath)
-    if not instance:
-        raise RuntimeError(f"Option {optionPath} is not defined")
-    return instance
+    if "Setups" in gConfigurationData.getSectionsFromCFG("/DIRAC"):
+        optionPath = Path.cfgPath("/DIRAC/Setups", setup or getDIRACSetup(), system)
+        instance = gConfigurationData.extractOptionFromCFG(optionPath)
+        if not instance:
+            raise RuntimeError(f"Option {optionPath} is not defined")
+        return instance
+    # If /DIRAC/Setups is not present in the CS return empty instance string
+    return ""
 
 
 def getSystemSection(system, instance=False, setup=False):

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -43,10 +43,14 @@ def getSystemInstance(system, setup=False):
        an empty string is returned
     """
 
-    setupPath = Path.cfgPath("/DIRAC/Setups", setup or getDIRACSetup())
-    optionPath = Path.cfgPath(setupPath, system)
+    # If Setup is None, it means that we have the case of configuration without Setup
+    setupToUse = setup or getDIRACSetup()
+    if setupToUse == "None":
+        return ""
+
+    optionPath = Path.cfgPath("/DIRAC/Setups", setupToUse, system)
     instance = gConfigurationData.extractOptionFromCFG(optionPath)
-    if not instance and system not in gConfigurationData.getOptionsFromCFG(setupPath):
+    if not instance:
         raise RuntimeError(f"Option {optionPath} is not defined")
     return instance
 

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -43,17 +43,12 @@ def getSystemInstance(system, setup=False):
        an empty string is returned
     """
 
-    # If noSetupFlag is set to True, we do not have system instances
-    try:
-        noSetupFlag = gConfigurationData.extractOptionFromCFG("/DIRAC/NoSetup")
-        if noSetupFlag == "True":
-            return ""
-    except:
+    # If noSetupFlag is set to True, we do not have system instances in the configuration
+    noSetupFlag = gConfigurationData.extractOptionFromCFG("/DIRAC/NoSetup")
+    if noSetupFlag == "True":
         return ""
 
-    # If Setup is "None", it means that we have the case of configuration without Setup
     setupToUse = setup or getDIRACSetup()
-
     optionPath = Path.cfgPath("/DIRAC/Setups", setupToUse, system)
     instance = gConfigurationData.extractOptionFromCFG(optionPath)
     if not instance:

--- a/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -16,7 +16,7 @@ import datetime
 from DIRAC import S_ERROR, S_OK, gConfig
 from DIRAC.AccountingSystem.Client.Types.Job import Job
 from DIRAC.ConfigurationSystem.Client.Helpers import cfgPath
-from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemInstance
+from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemSection
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
@@ -55,9 +55,6 @@ class StalledJobAgent(AgentModule):
         if not self.am_getOption("Enable", True):
             self.log.info("Stalled Job Agent running in disabled mode")
 
-        wms_instance = getSystemInstance("WorkloadManagement")
-        if not wms_instance:
-            return S_ERROR("Can not get the WorkloadManagement system instance")
         self.stalledJobsTolerantSites = self.am_getOption("StalledJobsTolerantSites", [])
         self.stalledJobsToleranceTime = self.am_getOption("StalledJobsToleranceTime", 0)
 
@@ -67,7 +64,7 @@ class StalledJobAgent(AgentModule):
         self.matchedTime = self.am_getOption("MatchedTime", self.matchedTime)
         self.rescheduledTime = self.am_getOption("RescheduledTime", self.rescheduledTime)
 
-        wrapperSection = cfgPath("Systems", "WorkloadManagement", wms_instance, "JobWrapper")
+        wrapperSection = f"{getSystemSection('WorkloadManagement')}/JobWrapper"
 
         failedTime = self.am_getOption("FailedTimeHours", 6)
         watchdogCycle = gConfig.getValue(cfgPath(wrapperSection, "CheckingTime"), 30 * 60)

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
@@ -25,11 +25,11 @@ def sja(mocker):
     )
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobDB")
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobLoggingDB")
-    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getSystemInstance", side_effect=mockNone)
+    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getSystemSection", side_effect=mockNone)
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobMonitoringClient", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.PilotManagerClient", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.WMSClient", return_value=MagicMock())
-    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getSystemInstance", return_value="/bof/bih")
+    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getSystemSection", return_value="/bof/bih")
 
     stalledJobAgent = StalledJobAgent()
     stalledJobAgent._AgentModule__configDefaults = mockAM

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -25,7 +25,7 @@ import psutil
 
 from DIRAC import S_ERROR, S_OK, gLogger
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
-from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemInstance
+from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemSection
 from DIRAC.Core.Utilities import MJF
 from DIRAC.Core.Utilities.Os import getDiskSpace
 from DIRAC.Core.Utilities.Profiler import Profiler
@@ -107,10 +107,7 @@ class Watchdog:
         setup = gConfig.getValue("/DIRAC/Setup", "")
         if not setup:
             return S_ERROR("Can not get the DIRAC Setup value")
-        wms_instance = getSystemInstance("WorkloadManagement")
-        if not wms_instance:
-            return S_ERROR("Can not get the WorkloadManagement system instance")
-        self.section = f"/Systems/WorkloadManagement/{wms_instance}/JobWrapper"
+        self.section = f"{getSystemSection('WorkloadManagement')}/JobWrapper"
 
         self.log.verbose("Watchdog initialization")
         # Test control flags

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -104,9 +104,6 @@ class Watchdog:
         else:
             self.initialized = True
 
-        setup = gConfig.getValue("/DIRAC/Setup", "")
-        if not setup:
-            return S_ERROR("Can not get the DIRAC Setup value")
         self.section = f"{getSystemSection('WorkloadManagement')}/JobWrapper"
 
         self.log.verbose("Watchdog initialization")

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -92,7 +92,7 @@ def test_execute(mocker, executable, args, src, expectedResult):
         "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
     )
     mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemInstance", side_effect=getSystemSectionMock
+        "DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemSection", side_effect=getSystemSectionMock
     )
 
     if src:


### PR DESCRIPTION
  This PR allows to drop the System instance section level from the CS. The presence of the /DIRAC/NoSetup=True option in the CS suggests that the configuration is defined without Setups (to be introduced in 9.0 #7671). This forces the system section not to contain the instance level in the output of getSystemSection() and similar cases. This way it should be compatible with CS both with and without Setups defined. 

BEGINRELEASENOTES

*Configuration
CHANGE: PathFinder.getSystemInstance() returns empty string if Setups are dropped from the CS

*WorkloadManagement
CHANGE: StalledJobAgent, Watchdog - use getSystemSection() instead of getSystemInstance()

ENDRELEASENOTES
