### PR TITLE
[8.1] Make TaskQueueDB VO aware for diracx transition

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -97,6 +97,7 @@ class TaskQueueDB(DB):
                 "Owner": "VARCHAR(255) NOT NULL",
                 "OwnerDN": "VARCHAR(255)",
                 "OwnerGroup": "VARCHAR(32) NOT NULL",
+                "VO": "VARCHAR(32) NOT NULL",
                 "CPUTime": "BIGINT(20) UNSIGNED NOT NULL",
                 "Priority": "FLOAT NOT NULL",
                 "Enabled": "TINYINT(1) NOT NULL DEFAULT 0",
@@ -251,6 +252,8 @@ class TaskQueueDB(DB):
         for field in singleValueDefFields:
             sqlSingleFields.append(field)
             sqlValues.append(tqDefDict[field])
+        sqlSingleFields.append("VO")
+        sqlValues.append(Registry.getVOForGroup(tqDefDict["OwnerGroup"]))
         # Insert the TQ Disabled
         sqlSingleFields.append("Enabled")
         sqlValues.append("0")


### PR DESCRIPTION
This will require DB changes.

- [x] Add to wiki - in https://github.com/DIRACGrid/DIRAC/wiki/DIRAC-8.1#wms

BEGINRELEASENOTES

*WMS
CHANGE: add VO info in TaskQueueDB

ENDRELEASENOTES

This PR was created for the purpose of getting some values from the Registry config (which is now VO specific in diracx) when deleting a TaskQueue to ajust the job shares correction.