### PR TITLE
[8.1] fix: replace crate_access_token with create_token

### DIFF
--- a/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -414,7 +414,7 @@ class ProxyManagerHandlerMixin:
         try:
             from diracx.routers.auth import (  # pylint: disable=import-error
                 AuthSettings,
-                create_access_token,
+                create_token,
                 TokenResponse,
             )  # pylint: disable=import-error
 
@@ -438,7 +438,7 @@ class ProxyManagerHandlerMixin:
             }
             return S_OK(
                 TokenResponse(
-                    access_token=create_access_token(payload, authSettings),
+                    access_token=create_token(payload, authSettings),
                     expires_in=authSettings.access_token_expire_minutes * 60,
                     state="None",
                 ).dict()


### PR DESCRIPTION
Aims at solving integration tests in https://github.com/DIRACGrid/diracx/pull/45

In https://github.com/DIRACGrid/diracx/pull/45, `create_access_token` becomes `create_token`.
 
BEGINRELEASENOTES
*Framework
FIX: replace create_access_token with create_token
ENDRELEASENOTES
