### PR TITLE
[v7r3] fix: ColorBar.draw_all() is replaced by figure.draw_without_rendering()

### DIFF
--- a/src/DIRAC/Core/Base/Client.py
+++ b/src/DIRAC/Core/Base/Client.py
@@ -167,10 +167,16 @@ def createClient(serviceName):
         attrDict = dict(clientCls.__dict__)
         for extension in extensionsByPriority():
             try:
-                path = importlib_resources.path(
-                    "%s.%sSystem.Service" % (extension, systemName),
-                    "%s.py" % handlerModuleName,
-                )
+                if six.PY3:
+                    path = importlib_resources.as_file(
+                        importlib_resources.files("%s.%sSystem.Service" % (extension, systemName)).joinpath(
+                            "%s.py" % handlerModuleName
+                        )
+                    )
+                else:
+                    path = importlib_resources.path(
+                        "%s.%sSystem.Service" % (extension, systemName), "%s.py" % handlerModuleName
+                    )  # pylint: disable=no-member
                 fullHandlerClassPath = "%s.%s" % (extension, handlerClassPath)
                 with path as fp:
                     handlerAst = ast.parse(fp.read_text(), str(path))

--- a/src/DIRAC/Core/Utilities/Graphs/QualityMapGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/QualityMapGraph.py
@@ -8,6 +8,7 @@ from __future__ import division
 from __future__ import print_function
 
 import datetime
+import six
 from pylab import setp
 from matplotlib.colors import Normalize
 import matplotlib.cm as cm
@@ -181,7 +182,10 @@ class QualityMapGraph(PlotBase):
         cb = ColorbarBase(
             cax, cmap=self.cmap, norm=self.norms, boundaries=self.cbBoundaries, values=self.cbValues, ticks=self.cbTicks
         )
-        cb.draw_all()
+        if six.PY2:
+            cb.draw_all()  # pylint: disable=no-member
+        else:
+            self.figure.draw_without_rendering()
         # cb = self.ax.colorbar( self.mapper, format="%d%%",
         #  orientation='horizontal', fraction=0.04, pad=0.1, aspect=40  )
         # setp( cb.outline, linewidth=.5 )


### PR DESCRIPTION
Aims at fixing the CI tests, broken by:
- a `matplotlib` update from 3.5 to 3.8

  ```bash
  ************* Module DIRAC.Core.Utilities.Graphs.QualityMapGraph
  src/DIRAC/Core/Utilities/Graphs/QualityMapGraph.py:174:8: E1101: Instance of 'Colorbar' has no 'draw_all' member; maybe '_draw_all'? (no-member)
  ```

  According to their documentation: https://github.com/matplotlib/matplotlib/blob/main/doc/api/prev_api_changes/api_changes_3.8.0/removals.rst

  ```
  The filled attribute and the draw_all method of .Colorbar (instead of draw_all, use figure.draw_without_rendering).
  ```

- `import_resources.read_text()/path()`

  ```bash
  ************* Module DIRAC.Core.Base.Client
  src/DIRAC/Core/Base/Client.py:170:23: E1101: Module 'importlib_resources' has no 'path' member (no-member)
  ************* Module DIRAC.FrameworkSystem.Client.ComponentInstaller
  src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py:848:34: E1101: Module 'importlib_resources' has no 'read_text' member (no-member)
  src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py:2198:16: E1101: Module 'importlib_resources' has no 'read_text' member (no-member)
  src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py:2298:28: E1101: Module 'importlib_resources' has no 'read_text' member (no-member)
  ```

  According to the documentation, they have been replaced such as:
  - https://docs.python.org/3/library/importlib.resources.html#importlib.resources.read_text
  - https://docs.python.org/3/library/importlib.resources.html#importlib.resources.path

BEGINRELEASENOTES
*Core
FIX: replace ColorBar.draw_all() with figure.draw_without_rendering()
FIX: replace import_resources deprecated functions
ENDRELEASENOTES
