### PR TITLE
[8.1] Drop support for python 3.9 and 3.10?

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -90,45 +90,6 @@ jobs:
       env:
         REFERENCE_BRANCH: ${{ github['base_ref'] || github['head_ref'] }}
 
-  check-py39:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push' || github.repository == 'DIRACGrid/DIRAC'
-    timeout-minutes: 30
-    defaults:
-      # Activate the conda environment automatically in each step
-      run:
-        shell: bash -l {0}
-
-    strategy:
-      fail-fast: False
-      matrix:
-        command:
-          # TODO These three tests fail on Python 3:
-          #   * `test_BaseType_Unicode` and `test_nestedStructure` fail due to
-          #     DISET's string and unicode types being poorly defined
-          - pytest --runslow -k 'not test_BaseType_Unicode and not test_nestedStructure'
-          - pylint -j 0 -E src/
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Fail-fast for outdated pipelines
-      run: .github/workflows/fail-fast.sh
-    - name: fix python3.9
-      run: |
-        sed -i "s/python =3.11/python =3.9/g" environment.yml
-    - uses: conda-incubator/setup-miniconda@master
-      with:
-        environment-file: environment.yml
-        miniforge-variant: Mambaforge
-        use-mamba: true
-    - name: Run tests
-      run: |
-        # FIXME: The unit tests currently only work with editable installs
-        pip install -e .[server,testing]
-        ${{ matrix.command }}
-      env:
-        REFERENCE_BRANCH: ${{ github['base_ref'] || github['head_ref'] }}
-
   pylint-py27:
     name: Pylint for Python 2.7 in Pilot files
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,14 +14,12 @@ classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
     Topic :: System :: Distributed Computing
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.11
 package_dir=
     =src
 packages = find:


### PR DESCRIPTION
Do we still want to support python 3.9?


BEGINRELEASENOTES
ENDRELEASENOTES
