### PR TITLE
[8.1] hackathon fixes

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -254,7 +254,7 @@ class JobAgent(AgentModule):
                 )
 
         self.jobReport.setJobStatus(minorStatus="Job Received by Agent", sendFlag=False)
-        ownerDN = getDNForUsername(owner)["Value"]
+        ownerDN = getDNForUsername(owner)["Value"][0]
         result_setupProxy = self._setupProxy(ownerDN, jobGroup)
         if not result_setupProxy["OK"]:
             result = self._rescheduleFailedJob(jobID, result_setupProxy["Message"])

--- a/src/DIRAC/WorkloadManagementSystem/Agent/PilotStatusAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PilotStatusAgent.py
@@ -190,16 +190,7 @@ class PilotStatusAgent(AgentModule):
             pA = PilotAccounting()
             pA.setEndTime(pData["LastUpdateTime"])
             pA.setStartTime(pData["SubmissionTime"])
-            retVal = Registry.getUsernameForDN(pData["OwnerDN"])
-            if not retVal["OK"]:
-                userName = "unknown"
-                self.log.error(
-                    "Can't determine username for dn",
-                    f": {pData['OwnerDN']} : {retVal['Message']}",
-                )
-            else:
-                userName = retVal["Value"]
-            pA.setValueByKey("User", userName)
+            pA.setValueByKey("User", "unknown")
             pA.setValueByKey("UserGroup", pData["OwnerGroup"])
             result = getCESiteMapping(pData["DestinationSite"])
             if result["OK"] and pData["DestinationSite"] in result["Value"]:

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1338,7 +1338,7 @@ class SiteDirector(AgentModule):
             pA = PilotAccounting()
             pA.setEndTime(pilotDict[pRef]["LastUpdateTime"])
             pA.setStartTime(pilotDict[pRef]["SubmissionTime"])
-            retVal = Registry.getUsernameForDN(pilotDict[pRef]["OwnerDN"])
+            retVal = Registry.getUsernameForDN(self.pilotDN)
             if not retVal["OK"]:
                 username = "unknown"
                 self.log.error("Can't determine username for dn", pilotDict[pRef]["OwnerDN"])


### PR DESCRIPTION
Hackathon fixes:

- fix: remove OwnerDN from SiteDirector & PilotStatus. Very conservative approach.
- fix: process result of `getDNForUsername()` as a list in `JobAgent`. Very surprise we have not spotted this issue earlier.  


BEGINRELEASENOTES
*WorkloadManagement
FIX: emove OwnerDN from SiteDirector & PilotStatus
ENDRELEASENOTES
