### PR TITLE
[8.0] fix: AREX delegation not found

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -293,8 +293,8 @@ class AREXComputingElement(ARCComputingElement):
         # Submit the POST request to get the delegation
         result = self._request("get", query)
         if not result["OK"]:
-            self.log.error("Issue while interacting with the delegations.", result["Message"])
-            return S_ERROR("Issue while interacting with the delegations")
+            self.log.warn("Issue while interacting with the delegations.", result["Message"])
+            return S_OK([])
         response = result["Value"]
 
         # If there is no delegation, response.json is expected to return an exception
@@ -328,7 +328,7 @@ class AREXComputingElement(ARCComputingElement):
         # Submit the POST request to get the delegation
         result = self._request("post", query, params=params)
         if not result["OK"]:
-            self.log.error("Issue while interacting with the delegations.", result["Message"])
+            self.log.error("Issue while interacting with delegation ", f"{delegationID}: {result['Message']}")
             return S_ERROR("Issue while interacting with the delegations")
         response = result["Value"]
 
@@ -422,7 +422,7 @@ class AREXComputingElement(ARCComputingElement):
 
         self.log.verbose(f"Executable file path: {executableFile}")
 
-        # Get a delegation and use the same delegation for all the jobs
+        # Get existing delegations
         result = self._getDelegationIDs()
         if not result["OK"]:
             self.log.error("Could not get delegation IDs.", result["Message"])
@@ -436,7 +436,7 @@ class AREXComputingElement(ARCComputingElement):
             # Get the proxy attached to the delegationID
             result = self._getProxyFromDelegationID(delegationID)
             if not result["OK"]:
-                return result
+                continue
             proxy = result["Value"]
 
             if proxy.getDIRACGroup() != proxyGroup:


### PR DESCRIPTION
Aims to solve https://github.com/DIRACGrid/DIRAC/discussions/7217

For an unknown reason, a few ARC instances from different sites got some discrepancies at some point. Here is an example:

```bash
GET https://<ce>:<port>/arex/rest/1.0/delegations -> {'delegation': [{'id': '02cfaf01c2ab'}]}
POST https://<ce>:<port>/arex/rest/1.0/delegations/02bvdf19c7at?action=get -> Error 404: No delegation found
```

CE admins are not able to find any detail about those buggy delegations on their side.
I submitted a ticket to inform the ARC developers, but as we don't know how to reproduce the issue, it is going to be hard for them to provide a fix: https://bugzilla.nordugrid.org/show_bug.cgi?id=4133

To avoid that, in this PR, we relax some constraints: if a delegation is not found, then instead of returning an error, we just continue so that a new delegation is generated.
I will monitor a few ARC instances for a few days to make sure it is not a recurrent issue and that it does not generate many delegations.

BEGINRELEASENOTES
*WorkloadManagement
FIX: AREX does not return an error if delegation not found
ENDRELEASENOTES
