### PR TITLE
[8.1] Get tokens and sandboxes from DiracX

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -127,6 +127,15 @@ DIRAC
   }
 
 }
+# This part contains anything related to DiracX
+DiracX
+{
+  # The URL of the DIRAC Server
+  URL = https://diracx.invalid:8000
+  # A key used to have priviledged interactions with diracx. see
+  LegacyExchangeApiKey = diracx:legacy:InsecureChangeMe
+
+}
 ### Registry section:
 # Sections to register VOs, groups, users and hosts
 # https://dirac.readthedocs.org/en/latest/AdministratorGuide/UserManagement.html

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -350,6 +350,12 @@ def install_server():
 
     # This runs a continuous loop that exports the config in yaml
     # for the diracx container to use
+    # It needs to be started and running before the DIRAC server installation
+    # because after installing the databases, the install server script
+    # calls dirac-login.
+    # At this point we need the new CS to have been updated
+    # already else the token exchange fails.
+
     typer.secho("Starting configuration export loop for diracx", fg=c.GREEN)
     base_cmd = _build_docker_cmd("server", tty=False, daemon=True, use_root=True)
     subprocess.run(

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -348,19 +348,19 @@ def install_server():
     """Install DIRAC in the server container."""
     _check_containers_running()
 
+    # This runs a continuous loop that exports the config in yaml
+    # for the diracx container to use
+    typer.secho("Starting configuration export loop for diracx", fg=c.GREEN)
+    base_cmd = _build_docker_cmd("server", tty=False, daemon=True, use_root=True)
+    subprocess.run(
+        base_cmd + ["bash", "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/tests/CI/exportCSLoop.sh"],
+        check=True,
+    )
+
     typer.secho("Running server installation", fg=c.GREEN)
     base_cmd = _build_docker_cmd("server", tty=False)
     subprocess.run(
         base_cmd + ["bash", "/home/dirac/LocalRepo/TestCode/DIRAC/tests/CI/install_server.sh"],
-        check=True,
-    )
-
-    # This runs a continuous loop that exports the config in yaml
-    # for the diracx container to use
-    typer.secho("Starting configuration export loop for diracx", fg=c.GREEN)
-    base_cmd = _build_docker_cmd("server", tty=False, daemon=True)
-    subprocess.run(
-        base_cmd + ["bash", "/home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/tests/CI/exportCSLoop.sh"],
         check=True,
     )
 

--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -76,6 +76,7 @@ class Params:
         self.outputFile = ""
         self.skipVOMSDownload = False
         self.extensions = ""
+        self.legacyExchangeApiKey = ""
 
     def setGateway(self, optionValue):
         self.gatewayServer = optionValue
@@ -172,6 +173,12 @@ class Params:
             optionValue = f"{optionValue.rstrip('/')}/auth"
         self.issuer = optionValue
         DIRAC.gConfig.setOptionValue("/DIRAC/Security/Authorization/issuer", self.issuer)
+        return DIRAC.S_OK()
+
+    def setLegacyExchangeApiKey(self, optionValue):
+        self.legacyExchangeApiKey = optionValue
+        Script.localCfg.addDefaultEntry("/DiracX/LegacyExchangeApiKey", self.legacyExchangeApiKey)
+        DIRAC.gConfig.setOptionValue(cfgInstallPath("LegacyExchangeApiKey"), self.legacyExchangeApiKey)
         return DIRAC.S_OK()
 
 
@@ -361,6 +368,9 @@ def runDiracConfigure(params):
     Script.registerSwitch("n:", "SiteName=", "Set <sitename> as DIRAC Site Name", params.setSiteName)
     Script.registerSwitch("N:", "CEName=", "Set <cename> as Computing Element name", params.setCEName)
     Script.registerSwitch("V:", "VO=", "Set the VO name", params.setVO)
+    Script.registerSwitch(
+        "K:", "LegacyExchangeApiKey=", "Set the Api Key to talk to DiracX", params.setLegacyExchangeApiKey
+    )
 
     Script.registerSwitch("W:", "gateway=", "Configure <gateway> as DIRAC Gateway for the site", params.setGateway)
 

--- a/src/DIRAC/FrameworkSystem/Utilities/diracx.py
+++ b/src/DIRAC/FrameworkSystem/Utilities/diracx.py
@@ -1,0 +1,77 @@
+# pylint: disable=import-error
+
+import requests
+
+from cachetools import TTLCache, cached
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+from DIRAC import gConfig
+from DIRAC.ConfigurationSystem.Client.Helpers import Registry
+
+
+from diracx.core.preferences import DiracxPreferences
+
+from diracx.core.utils import write_credentials
+
+from diracx.core.models import TokenResponse
+from diracx.client import DiracClient
+
+# How long tokens are kept
+DEFAULT_TOKEN_CACHE_TTL = 5 * 60
+
+# Add a cache not to query the token all the time
+_token_cache = TTLCache(maxsize=100, ttl=DEFAULT_TOKEN_CACHE_TTL)
+
+
+@cached(_token_cache, key=lambda x, y: repr(x))
+def _get_token(credDict, diracxUrl, /) -> Path:
+    """
+    Write token to a temporary file and return the path to that file
+
+    """
+
+    apiKey = gConfig.getValue("/DiracX/LegacyExchangeApiKey")
+    if not apiKey:
+        raise ValueError("Missing mandatory /DiracX/LegacyExchangeApiKey configuration")
+
+    vo = Registry.getVOForGroup(credDict["group"])
+    dirac_properties = list(set(credDict.get("groupProperties", [])) | set(credDict.get("properties", [])))
+    group = credDict["group"]
+
+    scopes = [f"vo:{vo}", f"group:{group}"] + [f"property:{prop}" for prop in dirac_properties]
+
+    r = requests.get(
+        f"{diracxUrl}/auth/legacy-exchange",
+        params={
+            "preferred_username": credDict["username"],
+            "scope": " ".join(scopes),
+        },
+        headers={"Authorization": f"Bearer {apiKey}"},
+        timeout=10,
+    )
+
+    r.raise_for_status()
+
+    token_location = Path(NamedTemporaryFile().name)
+
+    write_credentials(TokenResponse(**r.json()), location=token_location)
+
+    return token_location
+
+
+def TheImpersonator(credDict: dict[str, Any]) -> DiracClient:
+    """
+    Client to be used by DIRAC server needing to impersonate
+    a user for diracx.
+    It queries a token, places it in a file, and returns the `DiracClient`
+    class
+
+    Use as a context manager
+    """
+
+    diracxUrl = gConfig.getValue("/DiracX/URL")
+    token_location = _get_token(credDict, diracxUrl)
+    pref = DiracxPreferences(url=diracxUrl, credentials_path=token_location)
+
+    return DiracClient(diracx_preferences=pref)

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
@@ -243,18 +243,27 @@ class ProxyInit:
         if os.getenv("DIRAC_ENABLE_DIRACX_LOGIN", "No").lower() in ("yes", "true"):
             from diracx.core.utils import write_credentials  # pylint: disable=import-error
             from diracx.core.models import TokenResponse  # pylint: disable=import-error
+            from diracx.core.preferences import DiracxPreferences  # pylint: disable=import-error
 
             res = Client(url="Framework/ProxyManager").exchangeProxyForToken()
             if not res["OK"]:
                 return res
+            from DIRAC import gConfig
+
+            diracxUrl = gConfig.getValue("/DiracX/URL")
+            if not diracxUrl:
+                return S_ERROR("Missing mandatory /DiracX/URL configuration")
+
             token_content = res["Value"]
+            preferences = DiracxPreferences(url=diracxUrl)
             write_credentials(
                 TokenResponse(
                     access_token=token_content["access_token"],
                     expires_in=token_content["expires_in"],
                     token_type=token_content.get("token_type"),
                     refresh_token=token_content.get("refresh_token"),
-                )
+                ),
+                location=preferences.credentials_path,
             )
 
         return S_OK()

--- a/src/DIRAC/Resources/Storage/StorageBase.py
+++ b/src/DIRAC/Resources/Storage/StorageBase.py
@@ -336,9 +336,7 @@ class StorageBase:
         # 2. VO name must not appear as any subdirectory or file name
         lfnSplitList = lfn.split("/")
         voLFN = lfnSplitList[1]
-        # TODO comparison to Sandbox below is for backward compatibility, should
-        # be removed in the next release
-        if voLFN != self.se.vo and voLFN != "SandBox" and voLFN != "Sandbox":
+        if voLFN != self.se.vo and voLFN != "SandBox" and voLFN != "S3":
             return S_ERROR(f"LFN ({lfn}) path must start with VO name ({self.se.vo})")
 
         urlDict = dict(self.protocolParameters)

--- a/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -142,6 +142,8 @@ Services
     SandboxPrefix = Sandbox
     BasePath = /opt/dirac/storage/sandboxes
     DelayedExternalDeletion = True
+    # If true, uploads the sandbox via diracx on an S3 storage
+    UseDiracXBackend = False
     Authorization
     {
       Default = authenticated

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -9,6 +9,7 @@
 """
 import hashlib
 import os
+import requests
 import tempfile
 import threading
 import time
@@ -49,6 +50,7 @@ class SandboxStoreHandlerMixin:
     def initializeRequest(self):
         self.__backend = self.getCSOption("Backend", "local")
         self.__localSEName = self.getCSOption("LocalSE", "SandboxSE")
+        self._useDiracXBackend = self.getCSOption("UseDiracXBackend", False)
         self._maxUploadBytes = self.getCSOption("MaxSandboxSizeMiB", 10) * 1048576
         if self.__backend.lower() == "local" or self.__backend == self.__localSEName:
             self.__useLocalStorage = True
@@ -106,6 +108,51 @@ class SandboxStoreHandlerMixin:
         gLogger.info("Upload requested", f"for {aHash} [{extension}]")
 
         credDict = self.getRemoteCredentials()
+
+        if self._useDiracXBackend:
+            from DIRAC.FrameworkSystem.Utilities.diracx import TheImpersonator
+            from diracx.client.models import SandboxInfo  # pylint: disable=import-error
+
+            gLogger.info("Forwarding to DiracX")
+            with tempfile.TemporaryFile(mode="w+b") as tar_fh:
+                result = fileHelper.networkToDataSink(tar_fh, maxFileSize=self._maxUploadBytes)
+                if not result["OK"]:
+                    return result
+                tar_fh.seek(0)
+
+                hasher = hashlib.sha256()
+                while data := tar_fh.read(512 * 1024):
+                    hasher.update(data)
+                checksum = hasher.hexdigest()
+                tar_fh.seek(0)
+                gLogger.debug("Sandbox checksum is", checksum)
+
+                sandbox_info = SandboxInfo(
+                    checksum_algorithm="sha256",
+                    checksum=checksum,
+                    size=os.stat(tar_fh.fileno()).st_size,
+                    format=extension,
+                )
+
+                with TheImpersonator(credDict) as client:
+                    res = client.jobs.initiate_sandbox_upload(sandbox_info)
+
+                if res.url:
+                    gLogger.debug("Uploading sandbox for", res.pfn)
+                    files = {"file": ("file", tar_fh)}
+
+                    response = requests.post(res.url, data=res.fields, files=files, timeout=300)
+
+                    gLogger.debug("Sandbox uploaded", f"for {res.pfn} with status code {response.status_code}")
+                    # TODO: Handle this error better
+                    try:
+                        response.raise_for_status()
+                    except Exception as e:
+                        return S_ERROR("Error uploading sandbox", repr(e))
+                else:
+                    gLogger.debug("Sandbox already exists in storage backend", res.pfn)
+                return S_OK(res.pfn)
+
         sbPath = self.__getSandboxPath(f"{aHash}.{extension}")
         # Generate the location
         result = self.__generateLocation(sbPath)
@@ -431,6 +478,27 @@ class SandboxStoreHandlerMixin:
         credDict = self.getRemoteCredentials()
         serviceURL = self.serviceInfoDict["URL"]
         filePath = fileID.replace(serviceURL, "")
+
+        # If the PFN starts with S3, we know it has been uploaded to the
+        # S3 sandbox store, so download it from there before sending it
+        if filePath.startswith("/S3"):
+            from DIRAC.FrameworkSystem.Utilities.diracx import TheImpersonator
+
+            with TheImpersonator(credDict) as client:
+                res = client.jobs.get_sandbox_file(pfn=filePath)
+                r = requests.get(res.url)
+                r.raise_for_status()
+                sbData = r.content
+                if fileHelper:
+                    from io import BytesIO
+
+                    result = fileHelper.DataSourceToNetwork(BytesIO(sbData))
+                    # fileHelper.oFile.close()
+                    return result
+                if raw:
+                    return sbData
+                return S_OK(sbData)
+
         result = self.sandboxDB.getSandboxId(self.__localSEName, filePath, credDict["username"], credDict["group"])
         if not result["OK"]:
             return result

--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -65,7 +65,6 @@ services:
     pull_policy: always
 
   diracx-wait-for-db:
-
     image: ${MYSQL_VER}
     container_name: diracx-wait-for-db
     depends_on:
@@ -73,7 +72,6 @@ services:
         condition: service_healthy
     command: /home/dirac/LocalRepo/ALTERNATIVE_MODULES/DIRAC/tests/CI/check_db_initialized.sh
     pull_policy: always
-
 
   dirac-server:
     image: ${CI_REGISTRY_IMAGE}/${HOST_OS}-dirac
@@ -91,7 +89,7 @@ services:
       iam-login-service:
         condition: service_started
       diracx-init-key:
-        condition: service_completed_successfully # Let the init container create the cs
+        condition: service_completed_successfully # Let the init container create the singing key
       diracx-init-cs:
         condition: service_completed_successfully # Let the init container create the cs
     ulimits:
@@ -114,8 +112,6 @@ services:
     ulimits:
       nofile: 8192
     pull_policy: always
-
-
 
   diracx-init-key:
     image: ghcr.io/diracgrid/diracx/server
@@ -140,7 +136,19 @@ services:
       - diracx-cs-store:/cs_store/
       - diracx-key-store:/signing-key/
     entrypoint: |
-      /dockerMicroMambaEntrypoint.sh dirac internal generate-cs /cs_store/initialRepo --vo=diracAdmin --user-group=admin --idp-url=http://dsdsd.csds/a/b
+      /dockerMicroMambaEntrypoint.sh bash -xc 'dirac internal generate-cs /cs_store/initialRepo --vo=vo --user-group=dirac_user --idp-url=http://dsdsd.csds/a/b'
+    pull_policy: always
+
+  diracx-init-db:
+    image: ghcr.io/diracgrid/diracx/server
+    container_name: diracx-init-db
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      - DIRACX_DB_URL_AUTHDB=mysql+aiomysql://Dirac:Dirac@mysql/DiracXAuthDB
+    entrypoint: |
+      /dockerMicroMambaEntrypoint.sh bash -xc 'micromamba install --yes -c conda-forge mysql-client && mysql -h mysql -u root --password=password -e "CREATE DATABASE DiracXAuthDB" && mysql -h mysql -u root --password=password -e "GRANT SELECT,INSERT,LOCK TABLES,UPDATE,DELETE,CREATE,DROP,ALTER,REFERENCES,CREATE VIEW,SHOW VIEW,INDEX,TRIGGER,ALTER ROUTINE,CREATE ROUTINE ON DiracXAuthDB.* TO Dirac@'"'"'%'"'"'" && python -m diracx.db init-sql'
     pull_policy: always
 
   diracx:
@@ -148,8 +156,10 @@ services:
     container_name: diracx
     environment:
       - DIRACX_CONFIG_BACKEND_URL=git+file:///cs_store/initialRepo
-      - "DIRACX_DB_URL_AUTHDB=sqlite+aiosqlite:///:memory:"
+      - DIRACX_DB_URL_AUTHDB=mysql+aiomysql://Dirac:Dirac@mysql/DiracXAuthDB
       - DIRACX_DB_URL_JOBDB=mysql+aiomysql://Dirac:Dirac@mysql/JobDB
+      - DIRACX_DB_URL_JOBLOGGINGDB=mysql+aiomysql://Dirac:Dirac@mysql/JobLoggingDB
+      - DIRACX_DB_URL_SANDBOXMETADATADB=mysql+aiomysql://Dirac:Dirac@mysql/SandboxMetadataDB
       - DIRACX_SERVICE_AUTH_TOKEN_KEY=file:///signing-key/rs256.key
       - DIRACX_SERVICE_AUTH_ALLOWED_REDIRECTS=["http://diracx:8000/docs/oauth2-redirect"]
       # Obtained with echo 'InsecureChangeMe' | base64 -d | openssl sha256
@@ -157,6 +167,8 @@ services:
     ports:
       - 8000:8000
     depends_on:
+      diracx-init-db:
+        condition: service_completed_successfully
       diracx-wait-for-db:
         condition: service_completed_successfully
     volumes:

--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -152,6 +152,8 @@ services:
       - DIRACX_DB_URL_JOBDB=mysql+aiomysql://Dirac:Dirac@mysql/JobDB
       - DIRACX_SERVICE_AUTH_TOKEN_KEY=file:///signing-key/rs256.key
       - DIRACX_SERVICE_AUTH_ALLOWED_REDIRECTS=["http://diracx:8000/docs/oauth2-redirect"]
+      # Obtained with echo 'InsecureChangeMe' | base64 -d | openssl sha256
+      - DIRACX_LEGACY_EXCHANGE_HASHED_API_KEY=07cddf6948d316ac9d186544dc3120c4c6697d8f994619665985c0a5bf76265a
     ports:
       - 8000:8000
     depends_on:

--- a/tests/CI/exportCSLoop.sh
+++ b/tests/CI/exportCSLoop.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 # This script will export to the `Production.cfg` file to the
 # yaml format for diracx every 5 seconds
+set -x
+exec >>/tmp/cs-loop.log 2>&1
 
+while [[ ! -f /home/dirac/ServerInstallDIR/bashrc ]]; do
+    sleep 1;
+done
+sleep 1;
 source /home/dirac/ServerInstallDIR/bashrc
+
 git config --global user.name "DIRAC Server CI"
 git config --global user.email "dirac-server-ci@invalid"
 
-while true;
-do
-    curl -L https://gitlab.cern.ch/chaen/chris-hackaton-cs/-/raw/master/convert-from-legacy.py |DIRAC_COMPAT_ENABLE_CS_CONVERSION=True  ~/ServerInstallDIR/diracos/bin/python - ~/ServerInstallDIR/etc/Production.cfg /cs_store/initialRepo/
-    git -C /cs_store/initialRepo/ commit -am "export $(date)"
+while true; do
+    curl -L https://gitlab.cern.ch/chaen/chris-hackaton-cs/-/raw/integration-tests/convert-from-legacy.py |DIRAC_COMPAT_ENABLE_CS_CONVERSION=True  /home/dirac/ServerInstallDIR/diracos/bin/python - /home/dirac/ServerInstallDIR/etc/Production.cfg /cs_store/initialRepo/
+    git --git-dir=.git -C /cs_store/initialRepo/ commit -am "export $(date)"
+    if [[ "${1}" == "--once" ]]; then
+        break
+    fi
     sleep 5;
 done

--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -135,7 +135,7 @@ installSite() {
 
   echo "==> Done installing, now configuring"
   source "${SERVERINSTALLDIR}/bashrc"
-  if ! dirac-configure --cfg "${SERVERINSTALLDIR}/install.cfg" "${DEBUG}"; then
+  if ! dirac-configure --cfg "${SERVERINSTALLDIR}/install.cfg" --LegacyExchangeApiKey='diracx:legacy:InsecureChangeMe' "${DEBUG}"; then
     echo "ERROR: dirac-configure failed" >&2
     exit 1
   fi

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -612,7 +612,7 @@ diracProxies() {
 
   # Make sure DiracX is running
   # And make sure it was synced
-  if [[ -n $DIRACX_URL ]]; then
+  if [[ -n $TEST_DIRACX ]]; then
     echo "Waiting for for DiracX to be available" >&2
     for i in {1..100}; do
       if dirac-login -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" -T 72 "${DEBUG}"; then

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -609,6 +609,19 @@ diracUserAndGroup() {
 
 diracProxies() {
   echo '==> [diracProxies]'
+
+  # Make sure DiracX is running
+  # And make sure it was synced
+  if [[ -n $DIRACX_URL ]]; then
+    echo "Waiting for for DiracX to be available" >&2
+    for i in {1..100}; do
+      if dirac-login -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" -T 72 "${DEBUG}"; then
+        break
+      fi
+      sleep 5
+    done
+  fi
+
   # User proxy
   if ! dirac-login -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" -T 72 "${DEBUG}"; then
     echo 'ERROR: dirac-login failed' >&2


### PR DESCRIPTION
This PR does two main things:

* Adapt the ProxyManager to get an access+refresh token from DiracX. This is needed as the refresh tokens are stored in the AuthDB so either DIRAC would need to talk to the new AuthDB or DIRAC needs to be able to talk to DiracX. We decided the latter was the simplest option and is implemented by giving the DIRAC services a secret key (`diracx:legacy:xxxxxx`) which can be used to request tokens from DiracX. This is a purely internal mechanism for the migration that should be used for no other purpose.

* Adapt the SandboxStoreHandler to get proxies from DiracX. This is basically explained in https://github.com/DIRACGrid/diracx/issues/13 so I refer to there.

This new functionality is all hidden behind CS options and environment variables. I don't think we should document these too well for now as we'll modify exactly how this works as the 8.1 release gets closer and the content of the release is better understood.

There are also a few minor CI changes to make the token exchange work correctly for the integration tests. See the individual commits for details.

In line with https://github.com/DIRACGrid/diracx/pull/112

BEGINRELEASENOTES

*DiracX
CHANGE: Get a access/refresh token pair when generating a proxy
NEW: Support using diracx as backend for the SandboxStoreHandler

ENDRELEASENOTES
