### PR TITLE
[8.0] TransformationCleaningAgent: add Clean With RMS option

### DIFF
--- a/src/DIRAC/TransformationSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/TransformationSystem/ConfigTemplate.cfg
@@ -109,6 +109,10 @@ Agents
     # using the transformation owner for cleanup
     shifterProxy=
 
+    # If enabled, remove files by submitting requests to the RequestManagementSystem
+    # instead of during the agent run
+    CleanWithRMS=False
+
     # Which transformation types to clean
     # If not filled, transformation types are taken from
     #   Operations/Transformations/DataManipulation


### PR DESCRIPTION
So this was implemented some time ago, when a transformation with >10k files had to be cleaned. I am not sure I exercise this logic too often...

It is completely optional, so I think OK for 8.0.

It might be a bit loose on the error handling side, which is probably why I kept it in my hot fixes branch...

It request submission is successful, the transformation is marked as cleaned.
It is not waiting for requests to succeed, if something fails one can always clean a transformation again.

So review away.

BEGINRELEASENOTES

*TS
NEW: TransformationCleaningAgent: add CleanWithRMS option to clean files via the RequestManagementSystem asynchronously rather than serially in the agent run itself

ENDRELEASENOTES
