### PR TITLE
[8.1] Fix group to vo conversion in TaskQueueDB

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -170,6 +170,12 @@ class TaskQueueDB(DB):
         Check a task queue definition dict is valid
         """
 
+        if "OwnerGroup" in tqDefDict:
+            result = self._escapeString(Registry.getVOForGroup(tqDefDict["OwnerGroup"]))
+            if not result["OK"]:
+                return result
+            tqDefDict["VO"] = result["Value"]
+
         for field in singleValueDefFields:
             if field == "CPUTime":
                 if not isinstance(tqDefDict[field], int):
@@ -255,7 +261,7 @@ class TaskQueueDB(DB):
             sqlSingleFields.append(field)
             sqlValues.append(tqDefDict[field])
         sqlSingleFields.append("VO")
-        sqlValues.append(Registry.getVOForGroup(tqDefDict["OwnerGroup"]))
+        sqlValues.append(tqDefDict["VO"])
         # Insert the TQ Disabled
         sqlSingleFields.append("Enabled")
         sqlValues.append("0")


### PR DESCRIPTION
This failed because `tqDefDict` is already quotes so it never finds a group in the CS (i.e. `tqDefDict["OwnerGroup"].strip('"')` would be the hacky solution). Instead add the VO when generating `tqDefDict`.


BEGINRELEASENOTES

*WorkloadManagement
FIX: Group to vo conversion in TaskQueueDB

ENDRELEASENOTES
