### PR TITLE
[8.1] Integration test fixes for DiracX

### DIFF
--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -181,6 +181,12 @@ class Params:
         DIRAC.gConfig.setOptionValue(cfgInstallPath("LegacyExchangeApiKey"), self.legacyExchangeApiKey)
         return DIRAC.S_OK()
 
+    def setDiracxUrl(self, optionValue):
+        self.diracxUrl = optionValue
+        Script.localCfg.addDefaultEntry("/DiracX/URL", self.diracxUrl)
+        DIRAC.gConfig.setOptionValue(cfgInstallPath("URL"), self.diracxUrl)
+        return DIRAC.S_OK()
+
 
 def _runConfigurationWizard(setups, defaultSetup):
     """The implementation of the configuration wizard"""
@@ -371,6 +377,7 @@ def runDiracConfigure(params):
     Script.registerSwitch(
         "K:", "LegacyExchangeApiKey=", "Set the Api Key to talk to DiracX", params.setLegacyExchangeApiKey
     )
+    Script.registerSwitch("", "DiracxUrl=", "Set the URL to talk to DiracX", params.setDiracxUrl)
 
     Script.registerSwitch("W:", "gateway=", "Configure <gateway> as DIRAC Gateway for the site", params.setGateway)
 

--- a/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -430,7 +430,7 @@ class ProxyManagerHandlerMixin:
 
         try:
             r = requests.get(
-                f"{diracxUrl}/auth/legacy-exchange",
+                f"{diracxUrl}/api/auth/legacy-exchange",
                 params={
                     "preferred_username": credDict["username"],
                     "scope": " ".join(scopes),

--- a/src/DIRAC/FrameworkSystem/Utilities/diracx.py
+++ b/src/DIRAC/FrameworkSystem/Utilities/diracx.py
@@ -42,7 +42,7 @@ def _get_token(credDict, diracxUrl, /) -> Path:
     scopes = [f"vo:{vo}", f"group:{group}"] + [f"property:{prop}" for prop in dirac_properties]
 
     r = requests.get(
-        f"{diracxUrl}/auth/legacy-exchange",
+        f"{diracxUrl}/api/auth/legacy-exchange",
         params={
             "preferred_username": credDict["username"],
             "scope": " ".join(scopes),
@@ -71,6 +71,8 @@ def TheImpersonator(credDict: dict[str, Any]) -> DiracClient:
     """
 
     diracxUrl = gConfig.getValue("/DiracX/URL")
+    if not diracxUrl:
+        raise ValueError("Missing mandatory /DiracX/URL configuration")
     token_location = _get_token(credDict, diracxUrl)
     pref = DiracxPreferences(url=diracxUrl, credentials_path=token_location)
 

--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -164,6 +164,7 @@ services:
       - DIRACX_SERVICE_AUTH_ALLOWED_REDIRECTS=["http://diracx:8000/docs/oauth2-redirect"]
       # Obtained with echo 'InsecureChangeMe' | base64 -d | openssl sha256
       - DIRACX_LEGACY_EXCHANGE_HASHED_API_KEY=07cddf6948d316ac9d186544dc3120c4c6697d8f994619665985c0a5bf76265a
+      - DIRACX_SERVICE_JOBS_ENABLED=false
     ports:
       - 8000:8000
     depends_on:

--- a/tests/CI/exportCSLoop.sh
+++ b/tests/CI/exportCSLoop.sh
@@ -14,7 +14,10 @@ git config --global user.name "DIRAC Server CI"
 git config --global user.email "dirac-server-ci@invalid"
 
 while true; do
-    curl -L https://gitlab.cern.ch/chaen/chris-hackaton-cs/-/raw/integration-tests/convert-from-legacy.py |DIRAC_COMPAT_ENABLE_CS_CONVERSION=True  /home/dirac/ServerInstallDIR/diracos/bin/python - /home/dirac/ServerInstallDIR/etc/Production.cfg /cs_store/initialRepo/
+    DIRAC_COMPAT_ENABLE_CS_CONVERSION=x dirac internal legacy cs-sync \
+        "$DIRACOS/etc/Production.cfg" \
+        /home/dirac/TestCode/diracx/tests/cli/legacy/cs_sync/convert_integration_test.yaml \
+        /cs_store/initialRepo/default.yml
     git --git-dir=.git -C /cs_store/initialRepo/ commit -am "export $(date)"
     if [[ "${1}" == "--once" ]]; then
         break

--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -135,7 +135,12 @@ installSite() {
 
   echo "==> Done installing, now configuring"
   source "${SERVERINSTALLDIR}/bashrc"
-  if ! dirac-configure --cfg "${SERVERINSTALLDIR}/install.cfg" --LegacyExchangeApiKey='diracx:legacy:InsecureChangeMe' "${DEBUG}"; then
+  configureArgs=()
+  if [[ -n "${TEST_DIRACX:-}" ]]; then
+    configureArgs+=("--LegacyExchangeApiKey=diracx:legacy:InsecureChangeMe")
+    configureArgs+=("--DiracxUrl=${DIRACX_URL}")
+  fi
+  if ! dirac-configure --cfg "${SERVERINSTALLDIR}/install.cfg" "${configureArgs[@]}" "${DEBUG}"; then
     echo "ERROR: dirac-configure failed" >&2
     exit 1
   fi

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -562,17 +562,17 @@ diracUserAndGroup() {
     exit 1
   fi
 
-  if ! dirac-admin-add-group -G prod -U adminusername,ciuser,trialUser -P Operator,FullDelegation,ProxyManagement,ServiceAdministrator,JobAdministrator,CSAdministrator,AlarmsManagement,FileCatalogManagement,SiteManager,NormalUser,ProductionManagement "${DEBUG}"; then
+  if ! dirac-admin-add-group -G prod -U adminusername,ciuser,trialUser -P Operator,FullDelegation,ProxyManagement,ServiceAdministrator,JobAdministrator,CSAdministrator,AlarmsManagement,FileCatalogManagement,SiteManager,NormalUser,ProductionManagement VO=vo "${DEBUG}"; then
     echo 'ERROR: dirac-admin-add-group failed' >&2
     exit 1
   fi
 
-  if ! dirac-admin-add-group -G jenkins_fcadmin -U adminusername,ciuser,trialUser -P FileCatalogManagement,NormalUser "${DEBUG}"; then
+  if ! dirac-admin-add-group -G jenkins_fcadmin -U adminusername,ciuser,trialUser -P FileCatalogManagement,NormalUser VO=vo "${DEBUG}"; then
     echo 'ERROR: dirac-admin-add-group failed' >&2
     exit 1
   fi
 
-  if ! dirac-admin-add-group -G jenkins_user -U adminusername,ciuser,trialUser -P NormalUser "${DEBUG}"; then
+  if ! dirac-admin-add-group -G jenkins_user -U adminusername,ciuser,trialUser -P NormalUser VO=vo "${DEBUG}"; then
     echo 'ERROR: dirac-admin-add-group failed' >&2
     exit 1
   fi


### PR DESCRIPTION
This contains changes that are required for https://github.com/DIRACGrid/diracx/pull/127. In particular:

* Assign a VO to all groups in the CS when running the integration tests
* Use the DiracX CS conversion CLI instead of the script in @chaen's GitLab area
* Follow the change of API route naming (`/` -> `/api/`)
* Disable the `/api/jobs/` router for now as it isn't needed at the moment and requires S3-like storage to be configured