### PR TITLE
[8.0] fix: get setup from gConfig in ComponentSupervisionAgent

### DIFF
--- a/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
@@ -121,7 +121,7 @@ class ComponentSupervisionAgent(AgentModule):
 
     def beginExecution(self):
         """Reload the configurations before every cycle."""
-        self.setup = self.am_getOption("Setup", self.setup)
+        self.setup = gConfig.getValue("/DIRAC/Setup", self.setup)
         self.enabled = self.am_getOption("EnableFlag", self.enabled)
         self.restartAgents = self.am_getOption("RestartAgents", self.restartAgents)
         self.restartExecutors = self.am_getOption("RestartExecutors", self.restartExecutors)

--- a/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
@@ -84,7 +84,6 @@ class TestComponentSupervisionAgent(unittest.TestCase):
         self.restartAgent.accounting["Junk"]["Funk"] = 1
         self.restartAgent.am_getOption = MagicMock()
         getOptionCalls = [
-            call("Setup", self.restartAgent.setup),
             call("EnableFlag", True),
             call("MailTo", self.restartAgent.addressTo),
             call("MailFrom", self.restartAgent.addressFrom),

--- a/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
@@ -208,8 +208,6 @@ Agents
     PollingTime = 600
     # Overall enable or disable
     EnableFlag = False
-    # Which setup to monitor
-    Setup = DIRAC-Production
     # Email addresses receiving notifications
     MailTo =
     # Sender email address


### PR DESCRIPTION
Solves https://github.com/DIRACGrid/DIRAC/issues/7235
Not entirely sure that this is the right fix.

BEGINRELEASENOTES
*Framework
CHANGE: ComponentSupervisionAgent: use gConfig to get the setup from /DIRAC/Setup
CHANGE: ComponentSupervisionAgent remove Setup option
ENDRELEASENOTES
