### PR TITLE
fix (DiracX Sandboxstore): assign output SB

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -151,6 +151,11 @@ class SandboxStoreHandlerMixin:
                         return S_ERROR("Error uploading sandbox", repr(e))
                 else:
                     gLogger.debug("Sandbox already exists in storage backend", res.pfn)
+
+                assignTo = {key: [(res.pfn, assignTo[key])] for key in assignTo}
+                result = self.export_assignSandboxesToEntities(assignTo)
+                if not result["OK"]:
+                    return result
                 return S_OK(res.pfn)
 
         sbPath = self.__getSandboxPath(f"{aHash}.{extension}")


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: Output sandbox are assigned when using DiracX



ENDRELEASENOTES
