### PR TITLE
[8.0]: TransformationCleaningAgentL fix two exceptions in CleanWithRMS

### DIFF
--- a/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -581,7 +581,7 @@ class TransformationCleaningAgent(AgentModule):
             return S_OK()
 
         if self.cleanWithRMS:
-            res = self.__submitRemovalRequests(fileToRemove, transID)
+            return self.__submitRemovalRequests(fileToRemove, transID)
         else:
             # Executing with shifter proxy
             gConfigurationData.setOptionInCFG("/DIRAC/Security/UseServerCertificate", "false")

--- a/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -723,7 +723,7 @@ class TransformationCleaningAgent(AgentModule):
         """
         for index, lfnList in enumerate(breakListIntoChunks(lfns, 300)):
             oRequest = Request()
-            requestName = "TCA_{transID}_{index}_{md5(repr(time.time())).hexdigest()[:5]}"
+            requestName = "TCA_{transID}_{index}_{md5(repr(time.time()).encode()).hexdigest()[:5]}"
             oRequest.RequestName = requestName
             oOperation = Operation()
             oOperation.Type = "RemoveFile"


### PR DESCRIPTION
I actually tested this now, and found some issues.

Also included in the swept PR #7239 already.

BEGINRELEASENOTES
*TS
FIX: TransformationCleaningAgent: fix two exceptions for CleanWithRMS: encoding before hashing, accessing res["Value"]["Failed"] when Value is None

ENDRELEASENOTES
