### PR TITLE
[9.0] Support selecting legacy adaptor client

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -134,8 +134,8 @@ DiracX
   URL = https://diracx.invalid:8000
   # A key used to have priviledged interactions with diracx. see
   LegacyExchangeApiKey = diracx:legacy:InsecureChangeMe
-  # List of VOs which should use DiracX via the legacy compatibility mechanism
-  EnabledVOs = gridpp,cta
+  # List of VOs which should not use DiracX via the legacy compatibility mechanism
+  DisabledVOs = dteam,cta
 }
 ### Registry section:
 # Sections to register VOs, groups, users and hosts

--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -18,9 +18,6 @@ DIRAC_DEPRECATED_FAIL
   If set, the use of functions or objects that are marked ``@deprecated`` will fail. Useful for example in continuous
   integration tests against future versions of DIRAC
 
-DIRAC_ENABLE_DIRACX_JOB_MONITORING
-  If set, calls the diracx job monitoring service. Off by default.
-
 DIRAC_FEWER_CFG_LOCKS
   If ``true`` or ``yes`` or ``on`` or ``1`` or ``y`` or ``t``, DIRAC will reduce the number of locks used when accessing the CS for better performance (default, ``no``).
 

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -35,7 +35,7 @@ FEATURE_VARIABLES = {
     "DIRAC_USE_JSON_ENCODE": None,
     "INSTALLATION_BRANCH": "",
 }
-DIRACX_OPTIONS = ("DIRAC_ENABLE_DIRACX_JOB_MONITORING",)
+DIRACX_OPTIONS = ()
 DEFAULT_MODULES = {"DIRAC": Path(__file__).parent.absolute()}
 
 # Static configuration

--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -248,6 +248,19 @@ def getServiceURLs(system, service=None, setup=False, failover=False):
     return resList
 
 
+def useLegacyAdapter(system, service=None) -> bool:
+    """Should DiracX be used for this service via the legacy adapter mechanism
+
+    :param str system: system name or full name e.g.: Framework/ProxyManager
+    :param str service: service name, like 'ProxyManager'.
+
+    :return: bool -- True if DiracX should be used
+    """
+    system, service = divideFullName(system, service)
+    value = gConfigurationData.extractOptionFromCFG(f"/DiracX/LegacyClientEnabled/{system}/{service}")
+    return (value or "no").lower() in ("y", "yes", "true", "1")
+
+
 def getServiceURL(system, service=None, setup=False):
     """Generate url.
 
@@ -297,3 +310,9 @@ def getGatewayURLs(system="", service=None):
         return False
     gateways = List.randomize(List.fromChar(gateways, ","))
     return [checkComponentURL(u, system, service) for u in gateways if u] if system and service else gateways
+
+
+def getDisabledDiracxVOs() -> list[str]:
+    """Get the list of VOs for which DiracX is enabled"""
+    vos = gConfigurationData.extractOptionFromCFG("/DiracX/DisabledVOs")
+    return List.fromChar(vos or "", ",")

--- a/src/DIRAC/Core/Base/Client.py
+++ b/src/DIRAC/Core/Base/Client.py
@@ -109,7 +109,10 @@ class Client:
                 timeout = self.timeout
 
             self.__kwargs["timeout"] = timeout
-            rpc = RPCClientSelector(url, httpsClient=self.httpsClient, **self.__kwargs)
+
+            rpc = RPCClientSelector(
+                url, httpsClient=self.httpsClient, diracxClient=getattr(self, "diracxClient", None), **self.__kwargs
+            )
         return rpc
 
 

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_login.py
@@ -315,8 +315,8 @@ class Params:
 
             # Get a token for use with diracx
             vo = getVOMSVOForGroup(self.group)
-            enabledVOs = gConfig.getValue("/DiracX/EnabledVOs", [])
-            if vo in enabledVOs:
+            disabledVOs = gConfig.getValue("/DiracX/DisabledVOs", [])
+            if vo not in disabledVOs:
                 from diracx.core.utils import write_credentials  # pylint: disable=import-error
                 from diracx.core.models import TokenResponse  # pylint: disable=import-error
                 from diracx.core.preferences import DiracxPreferences  # pylint: disable=import-error

--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
@@ -239,8 +239,8 @@ class ProxyInit:
                     return resultProxyUpload
 
         vo = Registry.getVOMSVOForGroup(self.__piParams.diracGroup)
-        enabledVOs = gConfig.getValue("/DiracX/EnabledVOs", [])
-        if vo in enabledVOs:
+        disabledVOs = gConfig.getValue("/DiracX/DisabledVOs", [])
+        if vo not in disabledVOs:
             from diracx.core.utils import write_credentials  # pylint: disable=import-error
             from diracx.core.models import TokenResponse  # pylint: disable=import-error
             from diracx.core.preferences import DiracxPreferences  # pylint: disable=import-error

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobMonitoringClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobMonitoringClient.py
@@ -5,6 +5,13 @@ from DIRAC.Core.Base.Client import Client, createClient
 from DIRAC.Core.Utilities.DEncode import ignoreEncodeWarning
 from DIRAC.Core.Utilities.JEncode import strToIntDict
 
+try:
+    from DIRAC.WorkloadManagementSystem.FutureClient.JobMonitoringClient import (
+        JobMonitoringClient as futureJobMonitoringClient,
+    )
+except ImportError:
+    futureJobMonitoringClient = None
+
 
 @createClient("WorkloadManagement/JobMonitoring")
 class JobMonitoringClient(Client):
@@ -12,12 +19,7 @@ class JobMonitoringClient(Client):
         super().__init__(**kwargs)
         self.setServer("WorkloadManagement/JobMonitoring")
 
-    if os.getenv("DIRAC_ENABLE_DIRACX_JOB_MONITORING", "No").lower() in ("yes", "true"):
-        from DIRAC.WorkloadManagementSystem.FutureClient.JobMonitoringClient import (
-            JobMonitoringClient as futureJobMonitoringClient,
-        )
-
-        httpsClient = futureJobMonitoringClient
+    diracxClient = futureJobMonitoringClient
 
     @ignoreEncodeWarning
     def getJobsStatus(self, jobIDs):

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -111,8 +111,8 @@ class SandboxStoreHandlerMixin:
         credDict = self.getRemoteCredentials()
         vo = Registry.getVOForGroup(credDict["group"])
 
-        enabledVOs = gConfig.getValue("/DiracX/EnabledVOs", [])
-        if self._useDiracXBackend and vo in enabledVOs:
+        disabledVOs = gConfig.getValue("/DiracX/DisabledVOs", [])
+        if self._useDiracXBackend and vo not in disabledVOs:
             from DIRAC.FrameworkSystem.Utilities.diracx import TheImpersonator
             from diracx.client.models import SandboxInfo  # pylint: disable=import-error
 

--- a/tests/Jenkins/dirac-cfg-setup-diracx.py
+++ b/tests/Jenkins/dirac-cfg-setup-diracx.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import argparse
+import os
+
+import DIRAC
+from DIRAC.Core.Utilities.ReturnValues import returnValueOrRaise
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Setup DIRAC CS for running integration tests with DiracX")
+    parser.add_argument("--disable-vo", nargs="+", help="Disable a VO", default=[])
+    parser.add_argument("--url", help="URL of the DiracX services")
+    parser.add_argument("--credentials-dir", help="Directory where hostcert.pem/hostkey.pem can be found")
+    args = parser.parse_args()
+
+    DIRAC.initialize(
+        host_credentials=(
+            f"{args.credentials_dir}/hostcert.pem",
+            f"{args.credentials_dir}/hostkey.pem",
+        )
+    )
+
+    main(args.url, args.disable_vo)
+
+
+def main(url: str, disabled_vos: list[str]):
+    from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
+
+    csAPI = CSAPI()
+
+    returnValueOrRaise(csAPI.createSection("DiracX"))
+
+    if url:
+        returnValueOrRaise(csAPI.setOption("DiracX/URL", url))
+
+    if disabled_vos:
+        returnValueOrRaise(csAPI.setOption("DiracX/DisabledVOs", ",".join(disabled_vos)))
+
+    returnValueOrRaise(csAPI.commit())
+
+
+if __name__ == "__main__":
+    parse_args()

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -614,7 +614,7 @@ diracProxies() {
   # And make sure it was synced
   if [[ -n $TEST_DIRACX ]]; then
     echo "Waiting for for DiracX to be available" >&2
-    for i in {1..100}; do
+    for i in {1..10}; do
       if dirac-login -C "${SERVERINSTALLDIR}/user/client.pem" -K "${SERVERINSTALLDIR}/user/client.key" -T 72 "${DEBUG}"; then
         break
       fi


### PR DESCRIPTION
This PR adds the ability to enable the DiracX backend for RPC calls in a specific client by setting `/DiracX/LegacyClientEnabled/SYSTEM_NAME/SERVICE_NAME` in the CS. The existing DIPS/Tornado client selector logic is then used to conditionally redirect RPC calls to the `diracxClient` class property of the client.

This PR also modified the CS to switch from an EnabledVOs list to a DisabledVOs list for specifying which Virtual Organizations (VOs) should not use DiracX via the legacy compatibility mechanism. This better reflects how having DiracX enabled is a temporary thing during the deployment of DIRAC v9.

Closes #7188
Closes https://github.com/DIRACGrid/diracx/issues/154


BEGINRELEASENOTES

*Core
NEW: Support using DiracX as a backend for RPC calls

ENDRELEASENOTES
