### PR TITLE
[8.0] Preinstalled env pilot options in SiteDirector

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1024,6 +1024,14 @@ class SiteDirector(AgentModule):
         else:
             self.log.info("DIRAC project will be installed by pilots")
 
+        # Preinstalled environment defined ?
+        preinstalledEnv = opsHelper.getValue("Pilot/PreinstalledEnv", "")
+        preinstalledEnvPrefix = opsHelper.getValue("Pilot/PreinstalledEnvPrefix", "")
+        if preinstalledEnvPrefix:
+            pilotOptions.append(f"--preinstalledEnvPrefix={preinstalledEnvPrefix}")
+        elif preinstalledEnv:
+            pilotOptions.append(f"--preinstalledEnv={preinstalledEnv}")
+
         # Pilot Logging defined?
         if opsHelper.getValue("/Services/JobMonitoring/usePilotsLoggingFlag", False):
             pilotOptions.append("-z ")

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1027,10 +1027,10 @@ class SiteDirector(AgentModule):
         # Preinstalled environment defined ?
         preinstalledEnv = opsHelper.getValue("Pilot/PreinstalledEnv", "")
         preinstalledEnvPrefix = opsHelper.getValue("Pilot/PreinstalledEnvPrefix", "")
-        if preinstalledEnvPrefix:
-            pilotOptions.append(f"--preinstalledEnvPrefix={preinstalledEnvPrefix}")
-        elif preinstalledEnv:
+        if preinstalledEnv:
             pilotOptions.append(f"--preinstalledEnv={preinstalledEnv}")
+        elif preinstalledEnvPrefix:
+            pilotOptions.append(f"--preinstalledEnvPrefix={preinstalledEnvPrefix}")
 
         # Pilot Logging defined?
         if opsHelper.getValue("/Services/JobMonitoring/usePilotsLoggingFlag", False):


### PR DESCRIPTION
PR to add preinstalledEnv and preinstalledEnvPrefix pilot options in the SiteDirector as defined in https://github.com/DIRACGrid/Pilot/pull/205. 

If both PreinstalledEnv and PreinstalledEnvPrefix pilot options are defined, the PreinstalledEnv option is preferred.

BEGINRELEASENOTES

*WorkloadManagement
NEW: SiteDirector - added preinstalledEnv and preinstalledEnvPrefix pilot options

ENDRELEASENOTES
