### PR TITLE
[sweep:integration] Preinstalled env pilot options in SiteDirector

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1022,6 +1022,14 @@ class SiteDirector(AgentModule):
         else:
             self.log.info("DIRAC project will be installed by pilots")
 
+        # Preinstalled environment defined ?
+        preinstalledEnv = opsHelper.getValue("Pilot/PreinstalledEnv", "")
+        preinstalledEnvPrefix = opsHelper.getValue("Pilot/PreinstalledEnvPrefix", "")
+        if preinstalledEnv:
+            pilotOptions.append(f"--preinstalledEnv={preinstalledEnv}")
+        elif preinstalledEnvPrefix:
+            pilotOptions.append(f"--preinstalledEnvPrefix={preinstalledEnvPrefix}")
+
         pilotOptions.append("--pythonVersion=3")
 
         # DIRAC Extensions to be used in pilots


### PR DESCRIPTION
Sweep #7266 `Preinstalled env pilot options in SiteDirector` to `integration`.

Adding original author @atsareg as watcher.

BEGINRELEASENOTES

*WorkloadManagement
NEW: SiteDirector - added preinstalledEnv and preinstalledEnvPrefix pilot options

ENDRELEASENOTES
Closes #7270