### PR TITLE
[8.0] create client get functions from HandlerMixins

### DIFF
--- a/src/DIRAC/Core/Base/Client.py
+++ b/src/DIRAC/Core/Base/Client.py
@@ -156,8 +156,8 @@ def createClient(serviceName):
 
             # loop over all the nodes (classes, functions, imports) in the handlerModule
             for node in ast.iter_child_nodes(handlerAst):
-                # find only a class with the name of the handlerClass
-                if not (isinstance(node, ast.ClassDef) and node.name == handlerClassName):
+                # find only a class that starts with the name of the handlerClass
+                if not (isinstance(node, ast.ClassDef) and node.name.startswith(handlerClassName)):
                     continue
                 for member in ast.iter_child_nodes(node):
                     # only look at functions


### PR DESCRIPTION

BEGINRELEASENOTES


*Core
FIX: createClient: also look at HandlerMixin classes to find `export_`ed functions. Fixes the client Documentation creation, fixes #7265 


ENDRELEASENOTES
