### PR TITLE
[8.0] docs: clarify how to install TokenManager in v8

### DIFF
--- a/docs/source/AdministratorGuide/HowTo/pilotsWithTokens.rst
+++ b/docs/source/AdministratorGuide/HowTo/pilotsWithTokens.rst
@@ -67,18 +67,9 @@ Setting up an ``IdProvider``
 Launching the ``TokenManagerHandler``
 -------------------------------------
 
-Run the following commands from a DIRAC client to install the ``Framework/TokenManager`` Tornado service:
+Install the ``Framework/TokenManager`` Tornado service, following :ref:`these instructions <httpsTornadoInstall>`
 
-.. code-block:: console
-
-   $ dirac-proxy-init -g dirac_admin
-
-   $ dirac-admin-sysadmin-cli --host <dirac host>
-
-   > install service Framework TokenManager
-
-.. note:: ``Tornado`` and then ``TokenManager`` might need to be restarted.
-.. note:: Get more details about the system administrator interface from the :ref:`System Administrator Interface <system-admin-console>` section.
+.. note:: the ``Tornado/Tornado`` service might need to be restarted.
 
 Marking computing resources and VOs as token-ready
 --------------------------------------------------

--- a/docs/source/DeveloperGuide/TornadoServices/index.rst
+++ b/docs/source/DeveloperGuide/TornadoServices/index.rst
@@ -318,10 +318,11 @@ Connections and certificates
 - ``_connect()``, ``_disconnect()`` and ``_purposeAction()`` are removed, ``_connect``/``_disconnect`` are now managed by `requests <http://docs.python-requests.org/>`_ and ``_purposeAction`` is no longer used is in HTTPS protocol.
 
 
+.. _httpsTornadoInstall:
+
 **********************
 How to install Tornado
 **********************
-
 
 Requirements
 ************


### PR DESCRIPTION
closes #7274 

BEGINRELEASENOTES

*docs
FIX: clarify how to install TokenManager in v8

ENDRELEASENOTES
