### PR TITLE
[sweep:integration] fix: show status SysAdminCLI

### DIFF
--- a/src/DIRAC/Core/Base/Client.py
+++ b/src/DIRAC/Core/Base/Client.py
@@ -159,8 +159,8 @@ def createClient(serviceName):
 
             # loop over all the nodes (classes, functions, imports) in the handlerModule
             for node in ast.iter_child_nodes(handlerAst):
-                # find only a class with the name of the handlerClass
-                if not (isinstance(node, ast.ClassDef) and node.name == handlerClassName):
+                # find only a class that starts with the name of the handlerClass
+                if not (isinstance(node, ast.ClassDef) and node.name.startswith(handlerClassName)):
                     continue
                 for member in ast.iter_child_nodes(node):
                     # only look at functions

--- a/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -20,9 +20,15 @@ from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.Core.Utilities.PrettyPrint import printTable
 from DIRAC.Core.Utilities.PromptUser import promptUser
 from DIRAC.FrameworkSystem.Client.ComponentInstaller import gComponentInstaller
-from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient import ComponentMonitoringClient
-from DIRAC.FrameworkSystem.Client.SystemAdministratorClient import SystemAdministratorClient
-from DIRAC.FrameworkSystem.Client.SystemAdministratorIntegrator import SystemAdministratorIntegrator
+from DIRAC.FrameworkSystem.Client.ComponentMonitoringClient import (
+    ComponentMonitoringClient,
+)
+from DIRAC.FrameworkSystem.Client.SystemAdministratorClient import (
+    SystemAdministratorClient,
+)
+from DIRAC.FrameworkSystem.Client.SystemAdministratorIntegrator import (
+    SystemAdministratorIntegrator,
+)
 from DIRAC.FrameworkSystem.Utilities import MonitoringUtilities
 from DIRAC.MonitoringSystem.Client.MonitoringClient import MonitoringClient
 
@@ -199,7 +205,7 @@ class SystemAdministratorClientCLI(CLI):
                         for component in components:
                             record = []
                             if rDict[compType][system][component]["Installed"]:
-                                module = str(rDict[compType][system][component]["DIRACModule"])
+                                module = str(rDict[compType][system][component]["Module"])
                                 record += [system, component, module, compType.lower()[:-1]]
                                 if rDict[compType][system][component]["Setup"]:
                                     record += ["Setup"]


### PR DESCRIPTION
Sweep #7277 `fix: show status SysAdminCLI` to `integration`.

Adding original author @fstagni as watcher.

BEGINRELEASENOTES

*Framework
FIX: show status SysAdminCLI KeyError

ENDRELEASENOTES
Closes #7278