### PR TITLE
fix: disabledVOs not available when doing dirac-configure

### DIFF
--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
@@ -240,7 +240,7 @@ class ProxyInit:
 
         vo = Registry.getVOMSVOForGroup(self.__piParams.diracGroup)
         disabledVOs = gConfig.getValue("/DiracX/DisabledVOs", [])
-        if vo not in disabledVOs:
+        if vo and vo not in disabledVOs:
             from diracx.core.utils import write_credentials  # pylint: disable=import-error
             from diracx.core.models import TokenResponse  # pylint: disable=import-error
             from diracx.core.preferences import DiracxPreferences  # pylint: disable=import-error


### PR DESCRIPTION
"chicken and egg" situation here.
When doing `dirac-configure`, the CS is not yet available to the user, so we cannot get the VO and the `DisabledVOs` value.
Therefore, `DisabledVOs` is equal to `[]` and the condition is always `True`, which triggers calls to `diracx`, which is not available.

I proposed the following "hack" to perform the DIRAC hackathon.
The problem with that approach is that you would need to perform `dirac-proxy-init` again, after `dirac-configure`, to get a token along with a proxy.

BEGINRELEASENOTES
*Framework
FIX: disabledVOs not available when doing dirac-configure
ENDRELEASENOTES
