### PR TITLE
[sweep:integration] fix: Getting token for a specific VO in WMSUtilities

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -84,7 +84,8 @@ def setPilotCredentials(ce, pilotDict):
     :param pilotDict: pilot parameter dictionary
     :return: S_OK/S_ERROR
     """
-    if "Token" in ce.ceParameters.get("Tag", []):
+    vo = getVOForGroup(pilotDict["OwnerGroup"])
+    if "Token" in ce.ceParameters.get("Tag", []) or f"Token:{vo}" in ce.ceParameters.get("Tag", []):
         result = gTokenManager.getToken(
             userGroup=pilotDict["OwnerGroup"],
             scope=PILOT_SCOPES,


### PR DESCRIPTION
Sweep #7285 `fix: Getting token for a specific VO in WMSUtilities` to `integration`.

Adding original author @aldbr as watcher.

BEGINRELEASENOTES
*WorkloadManagement
FIX: WMSUtilities supports VO-specific token tags
ENDRELEASENOTES
Closes #7287