### PR TITLE
[v8.0] fix (ElasticSearchDB): convert exception object to string representation and FTS3 lifetime changes

### DIFF
--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -503,7 +503,7 @@ class ElasticSearchDB:
             res = bulk(client=self.client, index=indexName, actions=generateDocs(data, withTimeStamp))
         except (BulkIndexError, RequestError) as e:
             sLog.exception()
-            return S_ERROR(e)
+            return S_ERROR(f"Failed to index by bulk {e!r}")
 
         if res[0] == len(data):
             # we have inserted all documents...

--- a/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
+++ b/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
@@ -48,7 +48,10 @@ from DIRAC.RequestManagementSystem.Client.ReqClient import ReqClient
 AGENT_NAME = "DataManagement/FTS3Agent"
 
 # Lifetime in seconds of the proxy we download for submission
-PROXY_LIFETIME = 43200  # 12 hours
+# Because we force the redelegation if only a third is left,
+# and we want to have a quiet night (~12h)
+# let's make the lifetime 12*3 hours
+PROXY_LIFETIME = 36 * 3600  # 36 hours
 
 # Instead of querying many jobs at once,
 # which maximizes the possibility of race condition

--- a/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
+++ b/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
@@ -763,15 +763,13 @@ class FTS3Job(JSerializable):
             # decides that there is not enough timeleft.
             # At the moment, this is 1 hour, which effectively means that if you do
             # not submit a job for more than 1h, you have no valid proxy in FTS servers
-            # anymore. In future release of FTS3, the delegation will be triggered when
+            # anymore, and all the jobs failed.So we force it when
             # one third of the lifetime will be left.
             # Also, the proxy given as parameter might have less than "lifetime" left
             # since it is cached, but it does not matter, because in the FTS3Agent
             # we make sure that we renew it often enough
-            # Finally, FTS3 has an issue with handling the lifetime of the proxy,
-            # because it does not check all the chain. This is under discussion
-            # https://its.cern.ch/jira/browse/FTS-1575
-            fts3.delegate(context, lifetime=datetime.timedelta(seconds=lifetime))
+            td_lifetime = datetime.timedelta(seconds=lifetime)
+            fts3.delegate(context, lifetime=td_lifetime, delegate_when_lifetime_lt=td_lifetime / 3)
 
             return S_OK(context)
         except FTS3ClientException as e:

--- a/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
+++ b/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
@@ -763,13 +763,13 @@ class FTS3Job(JSerializable):
             # decides that there is not enough timeleft.
             # At the moment, this is 1 hour, which effectively means that if you do
             # not submit a job for more than 1h, you have no valid proxy in FTS servers
-            # anymore, and all the jobs failed.So we force it when
+            # anymore, and all the jobs failed. So we force it when
             # one third of the lifetime will be left.
             # Also, the proxy given as parameter might have less than "lifetime" left
             # since it is cached, but it does not matter, because in the FTS3Agent
             # we make sure that we renew it often enough
             td_lifetime = datetime.timedelta(seconds=lifetime)
-            fts3.delegate(context, lifetime=td_lifetime, delegate_when_lifetime_lt=td_lifetime / 3)
+            fts3.delegate(context, lifetime=td_lifetime, delegate_when_lifetime_lt=td_lifetime // 3)
 
             return S_OK(context)
         except FTS3ClientException as e:

--- a/src/DIRAC/DataManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/DataManagementSystem/ConfigTemplate.cfg
@@ -155,8 +155,8 @@ Agents
     KickAssignedHours  = 1
     # Max number of kicks per cycle
     KickLimitPerCycle = 100
-    # Lifetime in sec of the Proxy we download to delegate to FTS3 (default 12h)
-    ProxyLifetime = 43200
+    # Lifetime in sec of the Proxy we download to delegate to FTS3 (default 36h)
+    ProxyLifetime = 129600
   }
   ##END FTS3Agent
 }


### PR DESCRIPTION
Otherwise a real error is hidden 

```python
2023-11-17 05:43:06 UTC Monitoring/Monitoring ERROR: Exception while executing handler action
Traceback (most recent call last):
  File "/opt/dirac/versions/v11.0.23-1699879020/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/DISET/private/Service.py", line 555, in _execu
teAction
    response = handlerObj._rh_executeAction(proposalTuple)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.23-1699879020/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/DISET/RequestHandler.py", line 144, in _rh_exe
cuteAction
    result = self.__trPool.send(self.__trid, retVal)  # this will delete the value from the S_OK(value)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.23-1699879020/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/DISET/private/TransportPool.py", line 109, in 
send
    return transport.sendData(msg)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.23-1699879020/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/DISET/private/Transports/BaseTransport.py", li
ne 164, in sendData
    sCodedData = MixedEncode.encode(uData)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.23-1699879020/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/MixedEncode.py", line 17, in encode
    return DEncode.encode(inData)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.23-1699879020/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 515, in encode
    g_dEncodeFunctions[type(uObject)](uObject, eList)
  File "/opt/dirac/versions/v11.0.23-1699879020/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 486, in encodeDict
    g_dEncodeFunctions[type(dValue[key])](dValue[key], eList)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
KeyError: <class 'opensearchpy.helpers.errors.BulkIndexError'>
```


BEGINRELEASENOTES

*Core
FIX: convert exception object to string representation in ElasticSearchDB

*DMS
CHANGE: default proxy lifetime for FTS is 36h and force the redelegation when 12h are left

ENDRELEASENOTES
