### PR TITLE
Fix race condition in the JobLoggingDB 

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -71,7 +71,10 @@ class JobLoggingDB(DB):
         except Exception:
             self.log.exception("Exception while date evaluation")
             _date = datetime.datetime.utcnow()
-        epoc = time.mktime(_date.timetuple()) + _date.microsecond / 1000000.0 - MAGIC_EPOC_NUMBER
+
+        # We need to specify that timezone is UTC because otherwise timestamp
+        # assumes local time while we mean UTC.
+        epoc = _date.replace(tzinfo=datetime.timezone.utc).timestamp() - MAGIC_EPOC_NUMBER
 
         cmd = (
             "INSERT INTO LoggingInfo (JobId, Status, MinorStatus, ApplicationStatus, "

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobLoggingDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobLoggingDB.py
@@ -141,7 +141,7 @@ class JobLoggingDB(DB):
         # self.log.debug('getWMSTimeStamps: Retrieving Timestamps for Job %d' % int(jobID))
 
         result = {}
-        cmd = "SELECT Status,StatusTimeOrder FROM LoggingInfo WHERE JobID=%d" % int(jobID)
+        cmd = "SELECT Status,StatusTimeOrder FROM LoggingInfo WHERE JobID=%d ORDER BY StatusTimeOrder" % int(jobID)
         resCmd = self._query(cmd)
         if not resCmd["OK"]:
             return resCmd


### PR DESCRIPTION
Quite a complex problem. 

The source of this PR is that we had jobs that went `Completed` with `ForwardDISET` request for status update. And these jobs ended up with a seemingly impossible status `Completed;Outpupt Sandbox Uploaded` while before they were `Completed;Pending Requests`

The issue comes from a UTC/Local time problem in the time stamps of the logging information: the time stamp of the status change (`StatusTime`) is in UTC, while the most precise time stamp (`StatusTimeOrder`) is UTC-1. This is due to problems  with UTC time handling that is not properly handled by the Dirac code*

As a consequence when executing the failover request (that b.t.w. is useless as the status change has already been successful), it is believed that the status is _after_ the last status, and hence the actual status in the jobs's attributes should be updated while it should not, but the item is  wrong by 1 hour! 

Hence the new minor status is `Output Sandbox Uploaded` while it should have remained `Pending Request` and then the request cannot be finalized...


* Details: we everywhere use `utcnow`, but it is a so called *naive datetime*, that means it does not have a timezone associated with it. So when this `datetime` is sent to a server/client, it may be assumed to be in local time by some tools (like `mktime`). 

cc @phicharp 


BEGINRELEASENOTES

*WorkloadManagementSystem

FIX: correctly handle UTC in JobLoggingDB float timestamp

ENDRELEASENOTES
