### PR TITLE
[8.0] fix: sets jobStatus=Failed/Payload failed iff the job was running

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -32,6 +32,7 @@ from DIRAC.RequestManagementSystem.private.RequestValidator import RequestValida
 from DIRAC.WorkloadManagementSystem.Client.MatcherClient import MatcherClient
 from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
 from DIRAC.WorkloadManagementSystem.Client.JobManagerClient import JobManagerClient
+from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
 from DIRAC.WorkloadManagementSystem.Client.JobStateUpdateClient import JobStateUpdateClient
 from DIRAC.WorkloadManagementSystem.Client.JobReport import JobReport
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
@@ -691,7 +692,7 @@ class JobAgent(AgentModule):
         payloadErrors = []
         originalJobID = self.jobReport.jobID
         for jobID, taskID in self.submissionDict.items():
-            if not taskID in self.computingElement.taskResults:
+            if taskID not in self.computingElement.taskResults:
                 continue
 
             result = self.computingElement.taskResults[taskID]
@@ -714,7 +715,12 @@ class JobAgent(AgentModule):
 
             # The payload failed (if result["Value"] is not 0)
             elif result["Value"]:
-                self.jobReport.setJobStatus(status=JobStatus.FAILED, minorStatus="Payload failed")
+                # In order to avoid overriding perfectly valid states, the status is updated iff the job was running
+                res = JobMonitoringClient().getJobsStatus(jobID)
+                if not res["OK"]:
+                    return res
+                if res["Value"][jobID]["Status"] == JobStatus.RUNNING:
+                    self.jobReport.setJobStatus(status=JobStatus.FAILED, minorStatus="Payload failed")
 
                 # Do not keep running and do not overwrite the Payload error
                 message = f"Payload execution failed with error code {result['Value']}"

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
@@ -3,6 +3,7 @@
 import os
 import pytest
 import time
+from unittest.mock import MagicMock
 
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Security.X509Chain import X509Chain  # pylint: disable=import-error
@@ -498,6 +499,7 @@ def test_submitAndCheckJob(mocker, localCE, job, expectedResult1, expectedResult
 
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.AgentModule.__init__")
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.JobAgent.am_stopExecution")
+    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.JobMonitoringClient", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.createJobWrapper", return_value=S_OK([jobName]))
     mocker.patch("DIRAC.Core.Security.X509Chain.X509Chain.dumpAllToString", return_value=S_OK())
 


### PR DESCRIPTION
This is a solution to https://lblogbook.cern.ch/Operations/37159

Since https://github.com/DIRACGrid/DIRAC/pull/6970 the result of (Inner) `ComputingElement.submit()` is correctly handled by the JobAgent. A job is set in "JobStatus=Failed/Payload failed" normally because of some catastrophic WN failure out of DIRAC control. All fine, but we might anyway incur in a race condition: it can happen that the job is rescheduled by the JobWrapper (https://github.com/DIRACGrid/DIRAC/blob/af7ab519cff701682afd50dbdad87e4e45cac312/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapperTemplate.py#L100) at time X. So, the job starts going again through the Optimizers. If at time X+Y the job is set to "JobStatus=Failed/Payload failed" then we can end up with the following job logging:

```
[...]
JobManager              Received     Job Rescheduled           Unknown                       2023-11-10 15:29:41
JobPath                 Checking     JobSanity                 Unknown                       2023-11-10 15:29:41
JobSanity               Checking     InputData                 Unknown                       2023-11-10 15:29:41
InputData               Checking     AncestorFiles             Unknown                       2023-11-10 15:29:41
AncestorFiles           Checking     AncestorFiles             Unknown                       2023-11-10 15:29:56
JobScheduling           Waiting      Pilot Agent Submission    Unknown                       2023-11-10 15:33:51
Matcher                 Matched      Assigned                  Unknown                       2023-11-10 15:36:11
JobAgent@LCG.RAL.uk     Matched      Job Received by Agent     Unknown                       2023-11-10 15:36:11
JobAgent@LCG.RAL.uk     Matched      Submitting To CE          Unknown                       2023-11-10 15:36:11
JobWrapper              Running      Job Initialization        Unknown                       2023-11-10 15:36:16
JobWrapper              Running      Downloading InputSandbox  Unknown                       2023-11-10 15:36:17
JobWrapper              Running      Input Data Resolution     Unknown                       2023-11-10 15:36:19
JobWrapper              Running      Input Data Resolution     Failed Input Data Resolution  2023-11-10 15:37:53
JobWrapper              Rescheduled  Input Data Resolution     Failed Input Data Resolution  2023-11-10 15:37:53
JobManager              Received     Job Rescheduled           Unknown                       2023-11-10 15:37:53
JobPath                 Checking     JobSanity                 Unknown                       2023-11-10 15:37:53
JobSanity               Checking     InputData                 Unknown                       2023-11-10 15:37:53
InputData               Checking     AncestorFiles             Unknown                       2023-11-10 15:37:53
AncestorFiles           Checking     AncestorFiles             Unknown                       2023-11-10 15:37:56
JobAgent@LCG.RAL.uk     Failed       Payload failed            Unknown                       2023-11-10 15:38:05
```

This PR changes the JobAgent: in order to avoid overriding perfectly valid states, the status is updated iff the job was running

BEGINRELEASENOTES

*WMS
FIX: JobAgents will set jobStatus=Failed/Payload failed if and only if the job was previously Running

ENDRELEASENOTES
