### PR TITLE
[9.0] Require rucio-clients >=1.29.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     python-dateutil
     pytz
     requests
-    rucio-clients
+    rucio-clients >=1.29.10
     setuptools
     sqlalchemy
     typing_extensions >=4.3.0


### PR DESCRIPTION
The diracx CI gets unhappy due to rucio pinning dependencies to much. Forcing a recent version avoids it.