### PR TITLE
[8.0] Use copy+remove in PilotSync agent to avoid SELinux problems

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/PilotSyncAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PilotSyncAgent.py
@@ -98,7 +98,9 @@ class PilotSyncAgent(AgentModule):
             self.log.info("Moving pilot files", f"to {self.saveDir}")
             for tf in allFiles:
                 # this overrides the destinations
-                shutil.move(tf, os.path.join(self.saveDir, os.path.basename(tf)))
+                # use copy & remove rather than move to reset SELinux context on files
+                shutil.copy(tf, os.path.join(self.saveDir, os.path.basename(tf)))
+                os.remove(tf)
 
         # Here, attempting upload somewhere, and somehow
         for server in self.uploadLocations:


### PR DESCRIPTION
Hi,

We've been switching to using an external webserver to serve the pilot files as things were getting overloaded, but ran into SELinux problems. This small tweak changes the deploying of the pilot files from move to copy and delete; this causes the SELinux context of the files to get reset to the correct values for the destination.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Use copy+remove in PilotSync agent to avoid SELinux problems
ENDRELEASENOTES
