### PR TITLE
[8.0] fix: remove valid arg from setToken

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -96,13 +96,13 @@ class AREXComputingElement(ARCComputingElement):
 
     #############################################################################
 
-    def setToken(self, token, valid):
+    def setToken(self, token):
         """Set the token and update the headers
 
         :param token: OAuth2Token object or dictionary containing token structure
         :param int valid: validity period in seconds
         """
-        super().setToken(token, valid)
+        super().setToken(token)
         self.headers["Authorization"] = "Bearer " + self.token["access_token"]
 
     def _arcIDToJobReference(self, arcJobID):

--- a/src/DIRAC/Resources/Computing/ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ComputingElement.py
@@ -102,9 +102,8 @@ class ComputingElement:
         self.proxy = proxy
         self.valid = datetime.datetime.utcnow() + second * valid
 
-    def setToken(self, token, valid=0):
+    def setToken(self, token):
         self.token = token
-        self.valid = datetime.datetime.utcnow() + second * valid
 
     def _prepareProxy(self):
         """Set the environment variable X509_USER_PROXY"""

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -451,7 +451,7 @@ class SiteDirector(AgentModule):
                 result = self.__getPilotToken(audience=ce.audienceName)
                 if not result["OK"]:
                     return result
-                ce.setToken(result["Value"], 3500)
+                ce.setToken(result["Value"])
 
             # now really submitting
             res = self._submitPilotsToQueue(pilotsToSubmit, ce, queueName)
@@ -1267,7 +1267,7 @@ class SiteDirector(AgentModule):
             if not result["OK"]:
                 self.log.error("Failed to get token", f"{ceName}: {result['Message']}")
                 return
-            ce.setToken(result["Value"], 3500)
+            ce.setToken(result["Value"])
 
         result = ce.getJobStatus(stampedPilotRefs)
         if not result["OK"]:


### PR DESCRIPTION
Solves the following issue found in certification: 

```
Server error while serving getPilotOutput: AREXComputingElement.setToken() missing 1 required positional argument: 'valid'
```

We just remove the `valid` argument, which was actually not used.

BEGINRELEASENOTES
*Resources
FIX: remove valid argument from setToken
ENDRELEASENOTES
