### PR TITLE
[8.0] fix: actually using CVMFS for creating the pilot wrapper

### DIFF
--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
@@ -88,7 +88,7 @@ Inside this section, you should define the following options, and give them a me
    Installation = mycfg.cfg # For an optional configuration file, used by the installation script.
    PreInstalledEnv = /cvmfs/some/where/specific/bashrc # A specific rc file to source for setting up DIRAC
    PreInstalledEnvPrefix = /cvmfs/some/where/ # Location where DIRAC installations can be found. The Pilot will then try and find the following: /cvmfs/some/where/{Version/}{platform}/diracosrc
-   CVMFS_locations = /cvmfs/some/ # Comma-separated list of locations where DIRAC installations, CAs and CRLs can be found. The Pilot will then try and find the following: /cvmfs/some/{releaseProject}dirac/{Version/}{platform}/diracosrc and /cvmfs/some/etc/grid-security/certificates
+   CVMFS_locations = /cvmfs/some/ # Comma-separated list of locations where DIRAC installations, CAs and CRLs can be found. The Pilot will then try and find the following: /cvmfs/some/{releaseProject}dirac/{Version/}{platform}/diracosrc and /cvmfs/some/etc/grid-security/certificates. Those same locations will also be used by the Pilot Wrapper to try and find the pilot files in /cvmfs/some/{releaseProject}dirac/pilot/.
    # For the Matcher
    CheckVersion = False # True by default, if false any version would be accepted at matching level (this is a check done by the WorkloadManagementSystem/Matcher service).
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1108,12 +1108,14 @@ class SiteDirector(AgentModule):
             self.log.exception("Exception during pilot modules files compression", lException=be)
 
         location = Operations().getValue("Pilot/pilotFileServer", "")
+        CVMFS_locations = Operations().getValue("Pilot/CVMFS_locations")
         localPilot = pilotWrapperScript(
             pilotFilesCompressedEncodedDict=pilotFilesCompressedEncodedDict,
             pilotOptions=pilotOptions,
             pilotExecDir=pilotExecDir,
             envVariables=envVariables,
             location=location,
+            CVMFS_locations=CVMFS_locations,
         )
 
         return _writePilotWrapperFile(workingDirectory=workingDirectory, localPilot=localPilot)


### PR DESCRIPTION
Following from https://github.com/DIRACGrid/DIRAC/pull/7371
