### PR TITLE
[8.0] fix(JobStateUpdate): for staging, make sure the jobID is an integer

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py
@@ -68,7 +68,7 @@ class JobStateUpdateHandlerMixin:
         infoStr = None
         trials = 10
         for i in range(trials):
-            result = cls.jobDB.getJobAttributes(jobID, ["Status"])
+            result = cls.jobDB.getJobAttributes(int(jobID), ["Status"])
             if not result["OK"]:
                 return result
             if not result["Value"]:


### PR DESCRIPTION


If jobID is not an integer, we never get a correct result, because the dictionary key is converted to an int, 

https://github.com/DIRACGrid/DIRAC/blob/255b146d06b99d9050d443f7b1fe8ab844c38bec/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py#L237

and then the string jobID is not found 

https://github.com/DIRACGrid/DIRAC/blob/255b146d06b99d9050d443f7b1fe8ab844c38bec/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py#L255

and we do not get the attribute value back
https://github.com/DIRACGrid/DIRAC/blob/255b146d06b99d9050d443f7b1fe8ab844c38bec/src/DIRAC/WorkloadManagementSystem/Service/JobStateUpdateHandler.py#L75

BEGINRELEASENOTES
* WMS
FIX: The callback for the Stager was failing, because of a type mismatch in the jobID used to retrieve the status. Jobs never came out of Staging.

ENDRELEASENOTES

