### PR TITLE
[8.0] fix: JobAgent fails when checking status of the jobs using JobMonitoringClient

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -722,7 +722,7 @@ class JobAgent(AgentModule):
                 res = JobMonitoringClient().getJobsStatus(jobID)
                 if not res["OK"]:
                     return res
-                if res["Value"][jobID]["Status"] == JobStatus.RUNNING:
+                if res["Value"][int(jobID)]["Status"] == JobStatus.RUNNING:
                     self.jobReport.setJobStatus(status=JobStatus.FAILED, minorStatus="Payload failed")
 
                 # Do not keep running and do not overwrite the Payload error

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
@@ -11,6 +11,7 @@ from DIRAC.Resources.Computing.BatchSystems.TimeLeft.TimeLeft import TimeLeft
 from DIRAC.Resources.Computing.ComputingElementFactory import ComputingElementFactory
 from DIRAC.Resources.Computing.test.Test_PoolComputingElement import badJobScript, jobScript
 from DIRAC.WorkloadManagementSystem.Agent.JobAgent import JobAgent
+from DIRAC.WorkloadManagementSystem.Client import JobStatus
 from DIRAC.WorkloadManagementSystem.Client.JobReport import JobReport
 
 gLogger.setLevel("DEBUG")
@@ -497,13 +498,20 @@ def test_submitAndCheckJob(mocker, localCE, job, expectedResult1, expectedResult
         execFile.write(job)
     os.chmod(jobName, 0o755)
 
+    jobID = "123"
+
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.AgentModule.__init__")
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.JobAgent.am_stopExecution")
-    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.JobMonitoringClient", return_value=MagicMock())
+    mocker.patch(
+        "DIRAC.WorkloadManagementSystem.Agent.JobAgent.JobMonitoringClient.getJobsStatus",
+        return_value=S_OK({int(jobID): {"Status": JobStatus.RUNNING}}),
+    )
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.createJobWrapper", return_value=S_OK([jobName]))
     mocker.patch("DIRAC.Core.Security.X509Chain.X509Chain.dumpAllToString", return_value=S_OK())
-
-    jobID = 123
+    mocker.patch(
+        "DIRAC.Resources.Computing.SingularityComputingElement.SingularityComputingElement._SingularityComputingElement__hasSingularity",
+        return_value=False,
+    )
 
     jobAgent = JobAgent("JobAgent", "Test")
     jobAgent.log = gLogger.getSubLogger("JobAgent")


### PR DESCRIPTION
Pilots with failed jobs are failing with:

```
Traceback (most recent call last):
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v11.0.27-1702983535/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Base/AgentReactor.py", line 130, in __finalize
    self.__agentModules[agentName]["instanceObj"].finalize()
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v11.0.27-1702983535/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py", line 881, in finalize
    result = self._checkSubmittedJobs()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v11.0.27-1702983535/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py", line 725, in _checkSubmittedJobs
    if res["Value"][jobID]["Status"] == JobStatus.RUNNING:
       ~~~~~~~~~~~~^^^^^^^
KeyError: '827068098'

2023-12-21T07:59:07.609424Z INFO [LaunchAgent] DiskSpace (MB) = 6430006
``` 

The bug was introduced with https://github.com/DIRACGrid/DIRAC/commit/dab543056ae2fde308aa72738be0a5fa6af2fc70.

Cause of the issue: the `jobID` is processed as a `str` in `JobAgent`, whereas it is returned as a `int` by the `JobMonitoringClient` if I understand correctly (type hints would have been more than welcome here).


BEGINRELEASENOTES
*WorkloadManagement
FIX: JobAgent interaction with JobMonitoringClient
ENDRELEASENOTES
