### PR TITLE
[9.0] fix: return if there's no token_content

### DIFF
--- a/src/DIRAC/Core/Security/DiracX.py
+++ b/src/DIRAC/Core/Security/DiracX.py
@@ -40,6 +40,8 @@ def addTokenToPEM(pemPath, group):
         token_content = returnValueOrRaise(
             Client(url="Framework/ProxyManager", proxyLocation=pemPath).exchangeProxyForToken()
         )
+        if not token_content:
+            return
 
         token = TokenResponse(
             access_token=token_content["access_token"],


### PR DESCRIPTION

BEGINRELEASENOTES

*DiracX
FIX: Just return if token_content is None

ENDRELEASENOTES
