### PR TITLE
[8.0] Correctly collect platform list from queues

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -251,13 +251,13 @@ class SiteDirector(AgentModule):
             return result
 
         self.queueDict = result["Value"]
+        self.platforms = []
         for __queueName, queueDict in self.queueDict.items():
             # Update self.sites
             if queueDict["Site"] not in self.sites:
                 self.sites.append(queueDict["Site"])
 
             # Update self.platforms, keeping entries unique and squashing lists
-            self.platforms = []
             if "Platform" in queueDict["ParametersDict"]:
                 platform = queueDict["ParametersDict"]["Platform"]
                 oldPlatforms = set(self.platforms)


### PR DESCRIPTION
Hi,

I think the platform matching logic in the 8.0 site director isn't quite right: The self.platforms list is initialised in the queue loop, so it only ever gets set to the platform of the last queue considered. This patch moves it out of the loop so that all of the platforms for all queues supporting the VO are collected.

(Please can you add a no sweep label to this: I think the 9.0 sitedirector has had all of the platform code removed?)

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagementSystem
FIX: Correctly collect platform list from queues
ENDRELEASENOTES
