### PR TITLE
[9.0] Include DiracX token in more places

### DIFF
--- a/src/DIRAC/Core/Security/DiracX.py
+++ b/src/DIRAC/Core/Security/DiracX.py
@@ -19,7 +19,7 @@ from diracx.core.models import TokenResponse
 from diracx.core.preferences import DiracxPreferences
 from diracx.core.utils import serialize_credentials
 
-from DIRAC import gConfig, S_ERROR
+from DIRAC import gConfig, gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.Core.Security.Locations import getDefaultProxyLocation
 from DIRAC.Core.Utilities.ReturnValues import convertToReturnValue, returnValueOrRaise
@@ -35,6 +35,8 @@ def addTokenToPEM(pemPath, group):
     from DIRAC.Core.Base.Client import Client
 
     vo = Registry.getVOMSVOForGroup(group)
+    if not vo:
+        gLogger.error(f"ERROR: Could not find VO for group {group}, DiracX will not work!")
     disabledVOs = gConfig.getValue("/DiracX/DisabledVOs", [])
     if vo and vo not in disabledVOs:
         token_content = returnValueOrRaise(

--- a/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -418,6 +418,7 @@ class ProxyManagerHandlerMixin:
             credDict["username"],
             credDict["group"],
             set(credDict.get("groupProperties", []) + credDict.get("properties", [])),
+            expires_minutes=credDict["secondsLeft"] // 60 + 1,
         )
 
 


### PR DESCRIPTION
BEGINRELEASENOTES

*Core
FIX: Use proxy lifetime for tokens from legacy proxy exchange (https://github.com/DIRACGrid/diracx/issues/130)

*WorkloadManagement
FIX: Add DiracX to payload proxies used by compute elements (#7402)

ENDRELEASENOTES

Closes #7402
Closes https://github.com/DIRACGrid/diracx/issues/130