### PR TITLE
[9.0] Refactor VOMS for DiracX

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -18,6 +18,10 @@ DIRAC_DEPRECATED_FAIL
   If set, the use of functions or objects that are marked ``@deprecated`` will fail. Useful for example in continuous
   integration tests against future versions of DIRAC
 
+DIRAC_DISABLE_GCONFIG_REFRESH
+  If set, attempting to start the ``gConfig`` refresh thread will result in an exception.
+  This is used by DiracX to accidental use of vanilla DIRAC in contexts where it won't work.
+
 DIRAC_FEWER_CFG_LOCKS
   If ``true`` or ``yes`` or ``on`` or ``1`` or ``y`` or ``t``, DIRAC will reduce the number of locks used when accessing the CS for better performance (default, ``no``).
 

--- a/src/DIRAC/ConfigurationSystem/private/Refresher.py
+++ b/src/DIRAC/ConfigurationSystem/private/Refresher.py
@@ -58,6 +58,8 @@ class Refresher(RefresherBase, threading.Thread):
             except _thread.error:
                 pass
         # Launch the refresh
+        if os.environ.get("DIRAC_DISABLE_GCONFIG_REFRESH", "false").lower() in ("yes", "true"):
+            raise NotImplementedError("DIRAC_DISABLE_GCONFIG_REFRESH is set")
         thd = threading.Thread(target=self._refreshInThread)
         thd.daemon = True
         thd.start()

--- a/src/DIRAC/Core/Security/Locations.py
+++ b/src/DIRAC/Core/Security/Locations.py
@@ -5,6 +5,10 @@ import DIRAC
 from DIRAC import gConfig
 
 g_SecurityConfPath = "/DIRAC/Security"
+DEFAULT_VOMSES_LOCATION = f"{DIRAC.rootPath}/etc/grid-security/vomses"
+SYSTEM_VOMSES_LOCATION = "/etc/vomses"
+DEFAULT_VOMSDIR_LOCATION = f"{DIRAC.rootPath}/etc/grid-security/vomsdir"
+SYSTEM_VOMSDIR_LOCATION = "/etc/grid-security/vomsdir"
 
 
 def getProxyLocation():
@@ -172,3 +176,35 @@ def getDefaultProxyLocation():
     # /tmp/x509up_u<uid>
     proxyName = "x509up_u%d" % os.getuid()
     return f"/tmp/{proxyName}"
+
+
+def getVomsesLocation():
+    """Get the location of the directory containing the vomses files"""
+    if "X509_VOMSES" in os.environ:
+        return os.environ["X509_VOMSES"]
+    elif os.path.isdir(DEFAULT_VOMSES_LOCATION):
+        return DEFAULT_VOMSES_LOCATION
+    elif os.path.isdir(SYSTEM_VOMSES_LOCATION):
+        return SYSTEM_VOMSES_LOCATION
+    else:
+        raise Exception(
+            "The env variable X509_VOMSES is not set. "
+            "DIRAC does not know where to look for etc/grid-security/vomses. "
+            "Please set X509_VOMSES."
+        )
+
+
+def getVomsdirLocation():
+    """Get the location of the directory containing the vomsdir files"""
+    if "X509_VOMS_DIR" in os.environ:
+        return os.environ["X509_VOMS_DIR"]
+    elif os.path.isdir(DEFAULT_VOMSDIR_LOCATION):
+        return DEFAULT_VOMSDIR_LOCATION
+    elif os.path.isdir(SYSTEM_VOMSDIR_LOCATION):
+        return SYSTEM_VOMSDIR_LOCATION
+    else:
+        raise Exception(
+            "The env variable X509_VOMS_DIR is not set. "
+            "DIRAC does not know where to look for etc/grid-security/vomsdir. "
+            "Please set X509_VOMS_DIR."
+        )

--- a/src/DIRAC/Core/Security/Locations.py
+++ b/src/DIRAC/Core/Security/Locations.py
@@ -45,6 +45,12 @@ def getCAsLocation():
         casPath = retVal["Value"]
         if os.path.isdir(casPath):
             return casPath
+    # Other locations
+    return getCAsLocationNoConfig()
+
+
+def getCAsLocationNoConfig():
+    """Retrieve the CA's files location"""
     # Look up the X509_CERT_DIR environment variable
     if "X509_CERT_DIR" in os.environ:
         casPath = os.environ["X509_CERT_DIR"]

--- a/src/DIRAC/Core/Security/ProxyFile.py
+++ b/src/DIRAC/Core/Security/ProxyFile.py
@@ -135,6 +135,8 @@ def multiProxyArgument(proxy=False):
                 return S_ERROR(DErrno.EPROXYFIND)
         if isinstance(proxy, str):
             proxyLoc = proxy
+        else:
+            raise NotImplementedError(f"Unknown proxy type ({type(proxy)})")
         # Load proxy
         proxy = X509Chain()
         retVal = proxy.loadProxyFromFile(proxyLoc)

--- a/tests/Integration/Framework/Test_ProxyDB.py
+++ b/tests/Integration/Framework/Test_ProxyDB.py
@@ -631,10 +631,16 @@ class testDB(ProxyDBTestCase):
                 continue
             VOMS_PROXY_INIT_CMD = DIRAC.Core.Security.VOMS.VOMS_PROXY_INIT_CMD
             DIRAC.Core.Security.VOMS.VOMS_PROXY_INIT_CMD = "voms-proxy-fake"
+            clear_x509_env = False
+            if "X509_VOMS_DIR" not in os.environ:
+                os.environ["X509_VOMS_DIR"] = "/etc/grid-security/vomsdir"
+                clear_x509_env = True
             try:
                 result = db.getVOMSProxy(dn, group, time, role)
             finally:
                 DIRAC.Core.Security.VOMS.VOMS_PROXY_INIT_CMD = VOMS_PROXY_INIT_CMD
+                if clear_x509_env:
+                    del os.environ["X509_VOMS_DIR"]
 
             self.assertFalse(result["OK"], "Must be fail.")
             gLogger.info(f"Msg: {result['Message']}")


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: Adding VOMS extensions without having environment variables set
NEW: Add DIRAC_DISABLE_GCONFIG_REFRESH environment variable to prevent gConfig being accidentally used


ENDRELEASENOTES
