### PR TITLE
[8.0] Update dirac_cert_convert.py;  Add guidance error message for user if unsupported crypto

### DIFF
--- a/src/DIRAC/Core/scripts/dirac_cert_convert.py
+++ b/src/DIRAC/Core/scripts/dirac_cert_convert.py
@@ -21,20 +21,21 @@ def main():
     # Allow legacy pcks12 certificates (as for some providers)
     # Only use long option, to show that this is not recommended,
     # and may be deprecated later (if providers gets their acts together)
-    Script.registerSwitch("", "legacy", "Allow legacy crypto pcks12 certificates (may be deprecated in future)")
+    Script.registerSwitch("", "legacy", "Allow legacy crypto pcks12 certificates "
+                          "(may be deprecated in future)")
 
     switches, args = Script.parseCommandLine(ignoreErrors=True)
-    
+
     # Handle legacy option
     legacy = ''
     for switch in switches:
-        # Check only for "legacy", not for "l" 
+        # Check only for "legacy", not for "l"
         # (otherwise would have "or switch[0].lower() == 'l'")
         if switch[0].lower() == "legacy":
             legacy = "-legacy"
 
     if len(legacy)>0:
-        gLogger.warn("Warning: using legacy crypto option: "+legacy
+        gLogger.warn("Warning: using legacy crypto option: -"+legacy
                      +" ... May be deprecated in future")
 
     p12 = args[0]
@@ -74,12 +75,16 @@ def main():
             if os.path.isfile(old + nowPrefix):
                 gLogger.notice(f"Restore {old} file from the {old + nowPrefix}")
                 shutil.move(old + nowPrefix, old)
+        # Provide guidance if crypto error
+        if "unsupported:crypto" in res.stdout:
+            gLogger.notice("Unsupported crypto; try with '--legacy' command-line option")
         sys.exit(1)
 
     os.chmod(key, 0o400)
     os.chmod(cert, 0o644)
 
-    gLogger.notice(f"{os.path.basename(cert)} and {os.path.basename(key)} was created in the {globus}")
+    gLogger.notice(f"{os.path.basename(cert)} and {os.path.basename(key)}"
+                   f" were created in the directory {globus}")
 
 
 if __name__ == "__main__":

--- a/src/DIRAC/Core/scripts/dirac_cert_convert.py
+++ b/src/DIRAC/Core/scripts/dirac_cert_convert.py
@@ -18,7 +18,24 @@ from DIRAC.Core.Base.Script import Script
 @Script()
 def main():
     Script.registerArgument("P12: user certificate in the p12")
-    _, args = Script.parseCommandLine(ignoreErrors=True)
+    # Allow legacy pcks12 certificates (as for some providers)
+    # Only use long option, to show that this is not recommended,
+    # and may be deprecated later (if providers gets their acts together)
+    Script.registerSwitch("", "legacy", "Allow legacy crypto pcks12 certificates (may be deprecated in future)")
+
+    switches, args = Script.parseCommandLine(ignoreErrors=True)
+    
+    # Handle legacy option
+    legacy = ''
+    for switch in switches:
+        # Check only for "legacy", not for "l" 
+        # (otherwise would have "or switch[0].lower() == 'l'")
+        if switch[0].lower() == "legacy":
+            legacy = "-legacy"
+
+    if len(legacy)>0:
+        gLogger.warn("Warning: using legacy crypto option: "+legacy
+                     +" ... May be deprecated in future")
 
     p12 = args[0]
     if not os.path.isfile(p12):
@@ -43,12 +60,12 @@ def main():
     with TemporaryDirectory() as tmpdir:
         env = os.environ | {"OPENSSL_CONF": tmpdir}
         gLogger.notice("Converting p12 key to pem format")
-        cmd = ["openssl", "pkcs12", "-nocerts", "-in", p12, "-out", key]
+        cmd = ["openssl", "pkcs12", "-nocerts", "-in", p12, "-out", key, legacy]
         res = run(cmd, env=env, check=False, timeout=900, text=True, stdout=PIPE, stderr=STDOUT)
         # The last command was successful
         if res.returncode == 0:
             gLogger.notice("Converting p12 certificate to pem format")
-            cmd = ["openssl", "pkcs12", "-clcerts", "-nokeys", "-in", p12, "-out", cert]
+            cmd = ["openssl", "pkcs12", "-clcerts", "-nokeys", "-in", p12, "-out", cert, legacy]
             res = run(cmd, env=env, check=False, timeout=900, text=True, stdout=PIPE, stderr=STDOUT)
     # Something went wrong
     if res.returncode != 0:


### PR DESCRIPTION
Tell user to try "--legacy" option if the pcks12 file has old crypto (addition or replacement for my previous pull request).
    
Also, corrected trailing white-space, long lines, and other clean-ups after pylint.