### PR TITLE
[9.0] fix: make sure OwnerDN is defined before trying to access its value

### DIFF
--- a/src/DIRAC/RequestManagementSystem/private/RequestValidator.py
+++ b/src/DIRAC/RequestManagementSystem/private/RequestValidator.py
@@ -157,7 +157,7 @@ class RequestValidator(metaclass=DIRACSingleton):
     @staticmethod
     def _hasOwner(request):
         """required attributes Owner and OwnerGroup"""
-        if not (request.Owner or request.OwnerDN):
+        if not (request.Owner or getattr(request, "OwnerDN", None)):
             return S_ERROR(f"Request '{request.RequestName}' is missing both Owner and OwnerDN value")
         if not request.OwnerGroup:
             return S_ERROR(f"Request '{request.RequestName}' is missing OwnerGroup value")


### PR DESCRIPTION
I randomly found that `Test_RequestValidator` was failing when executed locally:

https://github.com/DIRACGrid/DIRAC/blob/7e60c052d41d050c9171c9516a78ccc2a6bb1dbc/src/DIRAC/RequestManagementSystem/private/test/Test_RequestValidator.py#L51

This is likely because a proxy is generated and found when all the tests are sequentially executed in Github Actions.
Anyway, it is probably safer to check the existence of the attribute before trying to access its value.

BEGINRELEASENOTES
*RequestManagement
FIX: make sure OwnerDN is defined before trying to access its value
ENDRELEASENOTES
