### PR TITLE
[8.0] fix: AREX get pilot logging info with a token

### DIFF
--- a/src/DIRAC/Resources/Computing/test/Test_AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/test/Test_AREXComputingElement.py
@@ -1,0 +1,94 @@
+import os
+import requests
+from unittest.mock import MagicMock, patch
+
+from DIRAC import S_ERROR, S_OK
+
+
+# Assuming 'arc' is imported at the module level of ARCComputingElement
+@patch.dict("sys.modules", {"arc": MagicMock()})
+def test__checkSession(mocker):
+    """Test checkSession"""
+    from DIRAC.Resources.Computing.AREXComputingElement import AREXComputingElement
+
+    arex = AREXComputingElement("test")
+
+    # 1. The session has not been initialized: it shoud return an error
+    result = arex._checkSession()
+
+    assert not result["OK"], result
+    assert not arex.session
+    assert "Authorization" not in arex.headers, arex.headers
+
+    # 2. This time the session is initialized but there is no proxy nor token
+    # It should return an error
+    arex.session = requests.Session()
+    result = arex._checkSession()
+
+    assert not result["OK"], result
+    assert arex.session
+    assert not arex.session.cert
+    assert "Authorization" not in arex.headers, arex.headers
+
+    # 3. We set a malformed proxy, but not a token: it should return an error
+    arex.proxy = "fake proxy"
+    mocker.patch(
+        "DIRAC.Resources.Computing.AREXComputingElement.AREXComputingElement._prepareProxy", return_value=S_ERROR()
+    )
+
+    result = arex._checkSession()
+    assert not result["OK"], result
+    assert arex.session
+    assert not arex.session.cert
+    assert "Authorization" not in arex.headers, arex.headers
+
+    # 4. We set a proxy, but not a token: the session should include the proxy, but not the token
+    arex.proxy = "fake proxy"
+
+    def side_effect():
+        os.environ["X509_USER_PROXY"] = arex.proxy
+        return S_OK()
+
+    mocker.patch(
+        "DIRAC.Resources.Computing.AREXComputingElement.AREXComputingElement._prepareProxy", side_effect=side_effect
+    )
+
+    result = arex._checkSession()
+    assert result["OK"], result
+    assert arex.session
+    assert arex.session.cert
+    assert "Authorization" not in arex.headers, arex.headers
+
+    # 5. We set a proxy and a token: the session should just include
+    # the token because the proxy is not mandatory
+    arex.proxy = "fake proxy"
+    arex.token = {"access_token": "fake token"}
+
+    result = arex._checkSession()
+    assert result["OK"], result
+    assert arex.session
+    assert not arex.session.cert
+    assert "Authorization" in arex.headers, arex.headers
+
+    # 6. We make the proxy mandatory: the session should include both the proxy and the token
+    result = arex._checkSession(mandatoryProxy=True)
+    assert result["OK"], result
+    assert arex.session
+    assert arex.session.cert
+    assert "Authorization" in arex.headers, arex.headers
+
+    # 7. Now we just include the token, the proxy is not mandatory:
+    # the session should only include the token
+    arex.proxy = None
+    result = arex._checkSession()
+    assert result["OK"], result
+    assert arex.session
+    assert not arex.session.cert
+    assert "Authorization" in arex.headers, arex.headers
+
+    # 8. Now we just include the token, but the proxy is mandatory: it should return an error
+    result = arex._checkSession(mandatoryProxy=True)
+    assert not result["OK"], result
+    assert arex.session
+    assert not arex.session.cert
+    assert "Authorization" not in arex.headers, arex.headers


### PR DESCRIPTION
We get an error "Proxy not set" when we try to get the pilot logging info in an AREX CE with a token.

BEGINRELEASENOTES
*WorkloadManagement
FIX: get pilot logging info with a token from an AREXCE
ENDRELEASENOTES
