### PR TITLE
[8.0] fix: dirac-proxy-init should not print the group anymore

### DIFF
--- a/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
+++ b/src/DIRAC/FrameworkSystem/scripts/dirac_proxy_init.py
@@ -163,22 +163,19 @@ class ProxyInit:
         if self.__uploadedInfo:
             gLogger.notice("\nProxies uploaded:")
             maxDNLen = 0
-            maxGroupLen = 0
             for userDN in self.__uploadedInfo:
                 maxDNLen = max(maxDNLen, len(userDN))
-                for group in self.__uploadedInfo[userDN]:
-                    maxGroupLen = max(maxGroupLen, len(group))
-            gLogger.notice(f" {'DN'.ljust(maxDNLen)} | {'Group'.ljust(maxGroupLen)} | Until (GMT)")
+
+            gLogger.notice(f" {'DN'.ljust(maxDNLen)} | Until (GMT)")
             for userDN in self.__uploadedInfo:
-                for group in self.__uploadedInfo[userDN]:
-                    gLogger.notice(
-                        " %s | %s | %s"
-                        % (
-                            userDN.ljust(maxDNLen),
-                            group.ljust(maxGroupLen),
-                            self.__uploadedInfo[userDN][group].strftime("%Y/%m/%d %H:%M"),
-                        )
-                    )
+                # in v8.0, expirationTime is accessed from uploadedInfo[userDN][""]
+                if isinstance(self.__uploadedInfo[userDN], dict):
+                    expirationTime = self.__uploadedInfo[userDN][""]
+                # whereas in v9.0, expirationTime is accessed from uploadedInfo[userDN]
+                else:
+                    expirationTime = self.__uploadedInfo[userDN]
+
+                gLogger.notice(f" {userDN.ljust(maxDNLen)} | {expirationTime.strftime('%Y/%m/%d %H:%M')}")
 
     def checkCAs(self):
         caDir = getCAsLocation()


### PR DESCRIPTION
Similar to https://github.com/DIRACGrid/DIRAC/pull/7451

BEGINRELEASENOTES
*Framework
FIX: dirac-proxy-init printInfo without the dirac group
ENDRELEASENOTES
