### PR TITLE
[8.0] fix: `jobID` type discrepancies in JobAgent

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -213,7 +213,7 @@ class JobAgent(AgentModule):
         # Check matcher information returned
         matcherParams = ["JDL", "DN", "Group"]
         matcherInfo = jobRequest["Value"]
-        jobID = matcherInfo["JobID"]
+        jobID = str(matcherInfo["JobID"])
 
         self.jobs[jobID] = {}
         self.jobs[jobID]["JobReport"] = JobReport(jobID, f"{self.__class__.__name__}@{self.siteName}")
@@ -253,7 +253,6 @@ class JobAgent(AgentModule):
             self.jobs[jobID]["JobReport"].setJobStatus(status=JobStatus.FAILED, minorStatus=result["Message"])
             return self._finish(result["Value"], self.stopOnApplicationFailure)
         submissionParams = result["Value"]
-        jobID = submissionParams["jobID"]
         jobType = submissionParams["jobType"]
 
         self.log.verbose("Job request successful: \n", jobRequest["Value"])


### PR DESCRIPTION
Closes https://github.com/DIRACGrid/DIRAC/issues/7456

Basically, `jobID` is defined twice in `JobAgent`. I suppose it is first defined as a `int`, and later on as a `str`.

BEGINRELEASENOTES
*WorkloadManagement
FIX: jobID type issue in JobAgent
ENDRELEASENOTES
