### PR TITLE
[8.0] dmeta - Error message in case failure due to permission denied

### DIFF
--- a/src/DIRAC/Interfaces/scripts/dmeta.py
+++ b/src/DIRAC/Interfaces/scripts/dmeta.py
@@ -40,6 +40,9 @@ class DMetaAdd(DMetaCommand):
         result = self.fcClient.setMetadataBulk({lfn: metadict})
         if not result["OK"]:
             print("Error:", result["Message"])
+        if result["Value"]["Failed"]:
+            for ff in result["Value"]["Failed"]:
+                print("Error:", ff, result["Value"]["Failed"][ff])
 
 
 class DMetaRm(DMetaCommand):
@@ -50,6 +53,9 @@ class DMetaRm(DMetaCommand):
         result = self.fcClient.removeMetadata({lfn: metas})
         if not result["OK"]:
             print("Error:", result["Message"])
+        if result["Value"]["Failed"]:
+            for ff in result["Value"]["Failed"]:
+                print("Error:", ff, result["Value"]["Failed"][ff])
 
 
 class DMetaList(DMetaCommand):


### PR DESCRIPTION
  Make error message in case of metadata manipulation permission failre, e.g.:


```
$ dmeta add testfile Year="1997"
Error: /vo.formation.idgrilles.fr/user/a/atsareg/testmeta/testfile Permission denied ( 13 : Permission denied)
```

  Otherwise, no message at all

BEGINRELEASENOTES

*Interfaces
CHANGE: dfind - more explicit failure report

ENDRELEASENOTES
