### PR TITLE
[8.0] fix: change location for BatchSystemInfo

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
@@ -132,7 +132,7 @@ class TimeLeft:
 
     def _getBatchSystemPlugin(self):
         """Using the name of the batch system plugin, will return an instance of the plugin class."""
-        batchSystemInfo = gConfig.getSections("/LocalSite/BatchSystem")
+        batchSystemInfo = gConfig.getSections("/LocalSite/BatchSystemInfo")
         type = batchSystemInfo.get("Type")
         jobID = batchSystemInfo.get("JobID")
         parameters = batchSystemInfo.get("Parameters")

--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -297,7 +297,7 @@ class JobAgent(AgentModule):
         if queue:
             self.jobs[jobID]["JobReport"].setJobParameter(par_name="CEQueue", par_value=queue, sendFlag=False)
 
-        if batchSystem := gConfig.getValue("/LocalSite/BatchSystem/Type", ""):
+        if batchSystem := gConfig.getValue("/LocalSite/BatchSystemInfo/Type", ""):
             self.jobs[jobID]["JobReport"].setJobParameter(par_name="BatchSystem", par_value=batchSystem, sendFlag=False)
 
         self.log.debug(f"Before self._submitJob() ({self.ceName}CE)")


### PR DESCRIPTION
"BatchSystem" is a reserved keyword.

This is to avoid this Pilots issue:

```
024-02-12T17:39:04.091119Z INFO [ConfigureSite] Command ConfigureSite instantiated from pilotCommands
2024-02-12T17:39:04.091220Z INFO [ConfigureSite] Executing command dirac-configure -o /LocalSite/GridMiddleware=SSHSLURM -o /LocalSite/BatchSystem/Type=SLURM -o /LocalSite/BatchSystem/JobID=690412 -o /LocalSite/BatchSystem/Parameters/Queue=Unknown -o /LocalSite/BatchSystem/Parameters/BinaryPath=Unknown -o /LocalSite/BatchSystem/Parameters/Host=Unknown -o /LocalSite/BatchSystem/Parameters/InfoPath=Unknown -n "DIRAC.JINR-LHEP.ru" -S "JINR-Production" -N "ncxbmn.jinr.ru" -o /LocalSite/GridCE=ncxbmn.jinr.ru -o /LocalSite/CEQueue=nica -o "/LocalSite/SharedArea=/lhep/users/diracbmn/dirac_ce" -o /LocalSite/PilotReference=sshslurm://ncxbmn.jinr.ru/690412 -FDMH -O pilot.cfg --cfg pilot.cfg

Traceback (most recent call last):
  File "/cvmfs/dirac.egi.eu/dirac/v8.0.36/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ConfigurationSystem/Client/LocalConfiguration.py", line 338, in loadUserData
    retVal = self.__addUserDataToConfiguration()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/dirac.egi.eu/dirac/v8.0.36/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ConfigurationSystem/Client/LocalConfiguration.py", line 533, in __addUserDataToConfiguration
    retVal = func(optionValue)
             ^^^^^^^^^^^^^^^^^
  File "/cvmfs/dirac.egi.eu/dirac/v8.0.36/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ConfigurationSystem/Client/LocalConfiguration.py", line 653, in __setOptionByCmd
    self.__setOptionValue(valueList[0], "=".join(valueList[1:]))
  File "/cvmfs/dirac.egi.eu/dirac/v8.0.36/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ConfigurationSystem/Client/LocalConfiguration.py", line 118, in __setOptionValue
    gConfigurationData.setOptionInCFG(self.__getAbsolutePath(optionPath), str(value))
  File "/cvmfs/dirac.egi.eu/dirac/v8.0.36/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ConfigurationSystem/private/ConfigurationData.py", line 179, in setOptionInCFG
    cfg.createNewSection(section)
  File "/cvmfs/dirac.egi.eu/dirac/v8.0.36/Linux-x86_64/lib/python3.11/site-packages/diraccfg/cfg.py", line 65, in lockedFunc
    return funcToCall(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/dirac.egi.eu/dirac/v8.0.36/Linux-x86_64/lib/python3.11/site-packages/diraccfg/cfg.py", line 125, in createNewSection
    raise KeyError("%s key already exists" % sectionName)
KeyError: 'BatchSystem key already exists'
```

I will now make the equivalent PIlot PR.

