### PR TITLE
[sweep:integration] dmeta - Error message in case failure due to permission denied

### DIFF
--- a/src/DIRAC/Interfaces/scripts/dmeta.py
+++ b/src/DIRAC/Interfaces/scripts/dmeta.py
@@ -40,6 +40,9 @@ class DMetaAdd(DMetaCommand):
         result = self.fcClient.setMetadataBulk({lfn: metadict})
         if not result["OK"]:
             gLogger.error(result["Message"])
+        if result["Value"]["Failed"]:
+            for ff in result["Value"]["Failed"]:
+                print("Error:", ff, result["Value"]["Failed"][ff])
 
 
 class DMetaRm(DMetaCommand):
@@ -50,6 +53,9 @@ class DMetaRm(DMetaCommand):
         result = self.fcClient.removeMetadata({lfn: metas})
         if not result["OK"]:
             gLogger.error(result["Message"])
+        if result["Value"]["Failed"]:
+            for ff in result["Value"]["Failed"]:
+                print("Error:", ff, result["Value"]["Failed"][ff])
 
 
 class DMetaList(DMetaCommand):


### PR DESCRIPTION
Sweep #7465 `dmeta - Error message in case failure due to permission denied` to `integration`.

Adding original author @atsareg as watcher.

BEGINRELEASENOTES

*Interfaces
CHANGE: dfind - more explicit failure report

ENDRELEASENOTES
Closes #7469