### PR TITLE
[8.0] jobID type discrepancies in PushJobAgent

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
@@ -187,7 +187,7 @@ class PushJobAgent(JobAgent):
                 # Check matcher information returned
                 matcherParams = ["JDL", "DN", "Group"]
                 matcherInfo = jobRequest["Value"]
-                jobID = matcherInfo["JobID"]
+                jobID = str(matcherInfo["JobID"])
                 self.jobs[jobID] = {}
                 self.jobs[jobID]["JobReport"] = JobReport(jobID, f"{self.__class__.__name__}@{self.siteName}")
                 result = self._checkMatcherInfo(jobID, matcherInfo, matcherParams)
@@ -222,7 +222,6 @@ class PushJobAgent(JobAgent):
                     self.failedQueues[queueName] += 1
                     break
                 submissionParams = result["Value"]
-                jobID = submissionParams["jobID"]
                 jobType = submissionParams["jobType"]
 
                 self.log.verbose("Job request successful: \n", jobRequest["Value"])


### PR DESCRIPTION
This was fixed in the `JobAgent` a week ago https://github.com/DIRACGrid/DIRAC/pull/7457

BEGINRELEASENOTES
*WorkloadManagement
FIX: JobID type in PushJobAgent
ENDRELEASENOTES
