### PR TITLE
[8.0] VOMSRole noVOMS prevents adding VOMS extension to a proxy

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -929,17 +929,20 @@ class ProxyDB(DB):
                         "Stored proxy has already a different VOMS attribute %s than requested %s"
                         % (attrs[0], vomsAttr)
                     )
-            else:
+            elif vomsAttr != "noVOMS":
                 retVal = vomsMgr.setVOMSAttributes(chain, vomsAttr, vo=vomsVO)
                 if not retVal["OK"]:
                     return retVal
                 chain = retVal["Value"]
 
-        # We have got the VOMS proxy, store it into the cache
-        result = self.__storeVOMSProxy(userDN, userGroup, vomsAttr, chain)
-        if not result["OK"]:
-            return result
-        return S_OK((chain, result["Value"]))
+        # If it is the VOMS proxy, store it into the cache
+        if vomsAttr != "noVOMS":
+            result = self.__storeVOMSProxy(userDN, userGroup, vomsAttr, chain)
+            if not result["OK"]:
+                return result
+            return S_OK((chain, result["Value"]))
+        else:
+            return S_OK((chain, _secsLeft))
 
     def __storeVOMSProxy(self, userDN, userGroup, vomsAttr, chain):
         """Store VOMS proxy


### PR DESCRIPTION
  In EGI there are multiple VOs that do not use grid storage. They need VOMS proxies only to access computing elements. So, only xxx_pilot groups need VOMS extension whereas xxx_user groups doesn't. This PR allows to configure this. As a result - considerably less load on multiple VOMS servers, faster responses from the ProxyManager.

BEGINRELEASENOTES

*Framework
CHANGE: ProxyDB - The VOMSRole in the group configuration set to noVOMS value prevents from adding VOMS extension

ENDRELEASENOTES
