### PR TITLE
[8.0] Fix DISET calls with proxy to be used passed as an argument

### DIFF
--- a/src/DIRAC/Core/DISET/private/Transports/SSL/M2Utils.py
+++ b/src/DIRAC/Core/DISET/private/Transports/SSL/M2Utils.py
@@ -101,6 +101,7 @@ def getM2SSLContext(ctx=None, **kwargs):
             with tempfile.NamedTemporaryFile(mode="w") as tmpFile:
                 tmpFilePath = tmpFile.name
                 tmpFile.write(kwargs["proxyString"])
+                tmpFile.flush()
                 __loadM2SSLCTXProxy(ctx, proxyPath=tmpFilePath)
         else:
             # Use normal proxy

--- a/src/DIRAC/Core/DISET/private/Transports/SSL/M2Utils.py
+++ b/src/DIRAC/Core/DISET/private/Transports/SSL/M2Utils.py
@@ -101,6 +101,7 @@ def getM2SSLContext(ctx=None, **kwargs):
             with tempfile.NamedTemporaryFile(mode="w") as tmpFile:
                 tmpFilePath = tmpFile.name
                 tmpFile.write(kwargs["proxyString"])
+                # Flush, otherwise the file is empty in the subsequent call
                 tmpFile.flush()
                 __loadM2SSLCTXProxy(ctx, proxyPath=tmpFilePath)
         else:

--- a/src/DIRAC/Core/DISET/private/Transports/SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/SSLTransport.py
@@ -48,7 +48,7 @@ def checkSanity(urlTuple, kwargs):
         certFile = certTuple[0]
         useCerts = True
     elif "proxyString" in kwargs:
-        if not isinstance(kwargs["proxyString"], bytes):
+        if not isinstance(kwargs["proxyString"], str):
             gLogger.error("proxyString parameter is not a valid type", str(type(kwargs["proxyString"])))
             return S_ERROR("proxyString parameter is not a valid type")
     else:


### PR DESCRIPTION
In case the DISET Client is used with proxyChain argument (this is the case of the payload proxy renewal in the JobAgent), the proxy string was not properly passed to the ssl transport call. This fixes #7450   

BEGINRELEASENOTES

*Core
FIX: Fix DISET calls with proxy to be used passed as an argument

ENDRELEASENOTES
