### PR TITLE
[9.0] fix: JobAgent.setupProxy takes owner instead of ownerDN

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -265,8 +265,7 @@ class JobAgent(AgentModule):
                 )
 
         self.jobs[jobID]["JobReport"].setJobStatus(minorStatus="Job Received by Agent", sendFlag=False)
-        ownerDN = getDNForUsername(owner)["Value"][0]
-        result_setupProxy = self._setupProxy(ownerDN, jobGroup)
+        result_setupProxy = self._setupProxy(owner, jobGroup)
         if not result_setupProxy["OK"]:
             result = self._rescheduleFailedJob(jobID, result_setupProxy["Message"])
             return self._finish(result["Message"], self.stopOnApplicationFailure)
@@ -465,10 +464,11 @@ class JobAgent(AgentModule):
         localCfg.writeToFile(localConfigFile)
 
     #############################################################################
-    def _setupProxy(self, ownerDN, ownerGroup):
+    def _setupProxy(self, owner, ownerGroup):
         """
         Retrieve a proxy for the execution of the job
         """
+        ownerDN = getDNForUsername(owner)["Value"][0]
         if gConfig.getValue("/DIRAC/Security/UseServerCertificate", False):
             proxyResult = self._requestProxyFromProxyManager(ownerDN, ownerGroup)
             if not proxyResult["OK"]:

--- a/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PushJobAgent.py
@@ -154,11 +154,7 @@ class PushJobAgent(JobAgent):
             if not result["OK"]:
                 return result
             proxy = result["Value"]
-            result = proxy.getRemainingSecs()  # pylint: disable=no-member
-            if not result["OK"]:
-                return result
-            lifetime_secs = result["Value"]
-            ce.setProxy(proxy, lifetime_secs)
+            ce.setProxy(proxy)
 
             # Check that there is enough slots in the remote CE to match a job
             result = self._checkCEAvailability(ce)
@@ -232,8 +228,7 @@ class PushJobAgent(JobAgent):
                 )
 
                 # Setup proxy
-                ownerDN = getDNForUsername(owner)["Value"]
-                result_setupProxy = self._setupProxy(ownerDN, jobGroup)
+                result_setupProxy = self._setupProxy(owner, jobGroup)
                 if not result_setupProxy["OK"]:
                     result = self._rescheduleFailedJob(jobID, result_setupProxy["Message"])
                     self.failedQueues[queueName] += 1

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
@@ -282,6 +282,7 @@ def test__setupProxy(mocker, mockGCReply, mockPMReply, expected):
     """Testing JobAgent()._setupProxy()"""
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.AgentModule.__init__")
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.AgentModule")
+    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.getDNForUsername", return_value=S_OK(["mockedDN"]))
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.gConfig.getValue", return_value=mockGCReply)
     module_str = "DIRAC.WorkloadManagementSystem.Agent.JobAgent.gProxyManager.getPayloadProxyFromDIRACGroup"
     mocker.patch(module_str, return_value=mockPMReply)


### PR DESCRIPTION
A few fixes for the PushJobAgent.

BEGINRELEASENOTES
*WorkloadManagement
FIX: JobAgent.setupProxy takes owner instead of ownerDN
ENDRELEASENOTES
