### PR TITLE
[8.0] fix(Job): add SoftwareDistModule if it is set in the ConfigurationSystem

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDBUtils.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDBUtils.py
@@ -103,6 +103,10 @@ def checkAndPrepareJob(jobID, classAdJob, classAdReq, owner, ownerDN, ownerGroup
     if inputDataPolicy and not classAdJob.lookupAttribute("InputDataModule"):
         classAdJob.insertAttributeString("InputDataModule", inputDataPolicy)
 
+    softwareDistModule = Operations(vo=vo).getValue("SoftwareDistModule")
+    if softwareDistModule and not classAdJob.lookupAttribute("SoftwareDistModule"):
+        classAdJob.insertAttributeString("SoftwareDistModule", softwareDistModule)
+
     # priority
     priority = classAdJob.getAttributeInt("Priority")
     if priority is None:


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: If the SoftwareDistModule is set in the Operations Section, add it to the Job JDL to restore previous behaviour

ENDRELEASENOTES
