### PR TITLE
[sweep:integration] use pytest-reruns instead of flaky

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -65,11 +65,11 @@ dependencies:
   - pytest >=3.6
   - pytest-cov >=2.2.0
   - pytest-mock
+  - pytest-rerunfailures
   - setuptools-scm
   - shellcheck
   - typer
   - typer-cli
-  - flaky
   # docs
   - pygments >=1.5
   - sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,13 +85,13 @@ server =
     tornado-m2crypto
     importlib_resources
 testing =
-    flaky
     hypothesis
     mock
     parameterized
     pytest
     pytest-cov
     pytest-mock
+    pytest-rerunfailures
     pycodestyle
 
 [options.entry_points]

--- a/src/DIRAC/Core/Utilities/test/Test_Profiler.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Profiler.py
@@ -5,7 +5,6 @@ from os.path import dirname, join
 from subprocess import Popen
 
 import pytest
-from flaky import flaky
 
 import DIRAC
 from DIRAC.Core.Utilities.Profiler import Profiler
@@ -78,7 +77,7 @@ def test_base():
     assert resWC["Value"] >= res["Value"]
 
 
-@flaky(max_runs=10, min_passes=2)
+@pytest.mark.flaky(reruns=10)
 def test_cpuUsage():
     mainProcess = Popen(
         [

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_GetSubLogger.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_GetSubLogger.py
@@ -2,7 +2,6 @@
 Test SubLogger
 """
 import pytest
-from flaky import flaky
 from DIRAC.FrameworkSystem.private.standardLogging.LogLevels import LogLevels
 
 


### PR DESCRIPTION
Sweep #7499 `use pytest-reruns instead of flaky` to `integration`.

Adding original author @chaen as watcher.

BEGINRELEASENOTES
*Test
CHANGE: use pytest-rerun instead of flaky 

ENDRELEASENOTES
Closes #7501