### PR TITLE
[sweep:integration] Monitoring type loader fixes for editable install

### DIFF
--- a/src/DIRAC/Core/Utilities/ObjectLoader.py
+++ b/src/DIRAC/Core/Utilities/ObjectLoader.py
@@ -169,6 +169,11 @@ class ObjectLoader(metaclass=DIRACSingleton):
 
 def loadObjects(path: str, reFilter=None, parentClass: object = None) -> dict[str, Any]:
     """
+
+    Note: this does not work for editable install because it hardcodes
+    DIRAC.__file__
+    It is better to use ObjectLoader().getObjects()
+
     :param str path: the path to the system for example: DIRAC/AccountingSystem
     :param object reFilter: regular expression used to found the class
     :param object parentClass: class instance
@@ -184,6 +189,7 @@ def loadObjects(path: str, reFilter=None, parentClass: object = None) -> dict[st
         objDir = os.path.join(os.path.dirname(os.path.dirname(DIRAC.__file__)), parentModule, *pathList)
         if not os.path.isdir(objDir):
             continue
+
         for objFile in os.listdir(objDir):
             if reFilter.match(objFile):
                 pythonClassName = objFile[:-3]

--- a/src/DIRAC/Core/Utilities/Plotting/TypeLoader.py
+++ b/src/DIRAC/Core/Utilities/Plotting/TypeLoader.py
@@ -1,9 +1,10 @@
 """ Utility for loading plotting types.
     Works both for Accounting and Monitoring.
 """
+
 import re
 
-from DIRAC.Core.Utilities.ObjectLoader import loadObjects
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 
 from DIRAC.AccountingSystem.Client.Types.BaseAccountingType import BaseAccountingType
 from DIRAC.MonitoringSystem.Client.Types.BaseType import BaseType
@@ -26,12 +27,11 @@ class TypeLoader:
         """c'tor"""
         self.__loaded = {}
         if plottingFamily == "Accounting":
-            self.__path = "AccountingSystem/Client/Types"
+            self.__path = "AccountingSystem.Client.Types"
             self.__parentCls = BaseAccountingType
         elif plottingFamily == "Monitoring":
-            self.__path = "MonitoringSystem/Client/Types"
+            self.__path = "MonitoringSystem.Client.Types"
             self.__parentCls = BaseType
-        self.__reFilter = re.compile(r".*[a-z1-9]\.py$")
 
     ########################################################################
     def getTypes(self):
@@ -39,5 +39,9 @@ class TypeLoader:
         It returns all monitoring classes
         """
         if not self.__loaded:
-            self.__loaded = loadObjects(self.__path, self.__reFilter, self.__parentCls)
+            allObjects = ObjectLoader().getObjects(self.__path, parentClass=self.__parentCls)["Value"]
+            for _objectModule, objectClass in allObjects.items():
+                if objectClass.__name__ not in self.__loaded and objectClass != self.__parentCls:
+                    self.__loaded[objectClass.__name__] = objectClass
+
         return self.__loaded


### PR DESCRIPTION
Sweep #7496 `Monitoring type loader fixes for editable install` to `integration`.

Adding original author @chaen as watcher.

BEGINRELEASENOTES
*Core
FIX: plotting TypeLoader works with editable installation

ENDRELEASENOTES
Closes #7503