### PR TITLE
fix: Get ElasticJobParametersDB indexPrefix from config

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
@@ -11,10 +11,11 @@
       - deleteJobParameters()
 """
 from DIRAC import S_ERROR, S_OK
+from DIRAC.ConfigurationSystem.Client.Config import gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
+from DIRAC.ConfigurationSystem.Client.PathFinder import getDatabaseSection
 from DIRAC.Core.Base.ElasticDB import ElasticDB
 from DIRAC.Core.Utilities import TimeUtilities
-
 
 mapping = {
     "properties": {
@@ -38,11 +39,12 @@ class ElasticJobParametersDB(ElasticDB):
     def __init__(self, parentLogger=None):
         """Standard Constructor"""
 
+        db_name = "WorkloadManagement/ElasticJobParametersDB"
         try:
-            indexPrefix = CSGlobals.getSetup().lower()
-
-            # Connecting to the ES cluster
-            super().__init__("WorkloadManagement/ElasticJobParametersDB", indexPrefix, parentLogger=parentLogger)
+            section = getDatabaseSection(db_name)
+            indexPrefix = gConfig.getValue(f"{section}/IndexPrefix", CSGlobals.getSetup()).lower()
+            # Connecting to the ES cluster using ElasticJobParametersDB
+            super().__init__(db_name, indexPrefix, parentLogger=parentLogger)
         except Exception as ex:
             self.log.error("Can't connect to ElasticJobParametersDB", repr(ex))
             raise RuntimeError("Can't connect to ElasticJobParametersDB") from ex


### PR DESCRIPTION
Issues and questions:

- The ElasticParametersDB IndexPrefix was hard coded to be the setup name. That was a problem for us since we use a different Index Prefix. Is this wanted ? Is it preferable to read it from configuration (see changes)?
- If the Opensearch client configuration used for the Monitoring is already configured and is the same for the JobParametersDB, it should not be needed to add the section under `WMS.DB.ElasticJobParamatersDB`. Instead it should read the MonitoringDB Opensearch client configuration. Do you agree?
This is a bit more work since the path `WMS.DB.ElasticJobParamatersDB`  is hard coded in the related handlers.
 
Changes:

- Get the IndexPrefix from the indexPrefix Option in the configuration as it is for the MonitoringDB.

