### PR TITLE
[8.0] Depend on packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     importlib_metadata >=4.4
     importlib_resources
     M2Crypto >=0.36
+    packaging
     pexpect
     prompt-toolkit >=3
     psutil


### PR DESCRIPTION
https://github.com/DIRACGrid/DIRAC/pull/7499 added a dependency on packaging but didn't declare it in the setuptools metadata.

BEGINRELEASENOTES

*Core
FIX: Depend on packaging

ENDRELEASENOTES
