### PR TITLE
[8.0] fix: support case where HTCondor kills the jobs

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
@@ -69,7 +69,7 @@ request_cpus = %(processors)s
 kill_sig=SIGTERM
 # By default, HTCondor marked jobs as completed regardless of its status
 # This option allows to mark jobs as Held if they don't finish successfully
-on_exit_hold = ExitCode != 0
+on_exit_hold = ExitCode =!= 0
 # A subcode of our choice to identify who put the job on hold
 on_exit_hold_subcode = %(holdReasonSubcode)s
 # Jobs are then deleted from the system after N days if they are not idle or running


### PR DESCRIPTION
Would solve the following issue happening when HTCondor kills the jobs:

```
The job attribute OnExitHold expression 'ExitCode != 0' evaluated to UNDEFINED
```

The `OnExitHold` parameter helps us to distinguish failures from the payload from failures from the batch system/node. 

Documentation about the `=!=` operator: https://htcondor.readthedocs.io/en/latest/classads/classad-mechanism.html#classad-operators

> In addition, the operators =?=, is, =!=, and isnt behave similar to == and !=, but are not strict. Semantically, the =?= and is test if their operands are “identical,” i.e., have the same type and the same value. For example, 10 == UNDEFINED and UNDEFINED == UNDEFINED both evaluate to UNDEFINED, but 10 =?= UNDEFINED and UNDEFINED is UNDEFINED evaluate to FALSE and TRUE respectively. The =!= and isnt operators test for the “is not identical to” condition.

> =?= and is have the same behavior as each other. And isnt and =!= behave the same as each other. The ClassAd unparser will always use =?= in preference to is and =!= in preference to isnt when printing out ClassAds.

BEGINRELEASENOTES
*Resources
FIX: support the case where HTCondor kills the jobs
ENDRELEASENOTES
