### PR TITLE
[8.0] fix: removed option for python3 pilots

### DIFF
--- a/src/DIRAC/Resources/Cloud/cloudinit.template
+++ b/src/DIRAC/Resources/Cloud/cloudinit.template
@@ -97,7 +97,6 @@ write_files:
        curl -o pilot.json -k https://%(pilot-server)s/pilot/pilot.json
      fi
      python dirac-pilot.py \
-            --pythonVersion=3 \
             --setup %(setup)s \
             -r %(release-version)s \
             --MaxCycles %(max-cycles)s \

--- a/src/DIRAC/TransformationSystem/scripts/dirac_production_runjoblocal.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_production_runjoblocal.py
@@ -84,7 +84,7 @@ def __configurePilot(basepath, vo):
     os.system(
         "python "
         + basepath
-        + "dirac-pilot.py -S %s -l %s -C %s -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch --pythonVersion=3 -dd"
+        + "dirac-pilot.py -S %s -l %s -C %s -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -dd"
         % (currentSetup, vo, masterCS)
     )
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1039,8 +1039,6 @@ class SiteDirector(AgentModule):
         if opsHelper.getValue("/Services/JobMonitoring/usePilotsLoggingFlag", False):
             pilotOptions.append("-z ")
 
-        pilotOptions.append("--pythonVersion=3")
-
         # Debug
         if self.pilotLogLevel.lower() == "debug":
             pilotOptions.append("-ddd")

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -51,7 +51,7 @@ time.sleep(1)
 from PilotWrapper import pilotWrapperScript  # pylint: disable=import-error
 
 res = pilotWrapperScript(
-    pilotOptions="--setup=CI -N ce.dirac.org -Q DIRACQUEUE -n DIRAC.CI.ORG --pythonVersion=3 --debug",
+    pilotOptions="--setup=CI -N ce.dirac.org -Q DIRACQUEUE -n DIRAC.CI.ORG --debug",
     location="diracproject.web.cern.ch/diracproject/tars/Pilot/DIRAC/" + pilotBranch + "/,wrong.cern.ch",
 )
 


### PR DESCRIPTION
This is anyway already the default: https://github.com/DIRACGrid/Pilot/blob/master/Pilot/pilotTools.py#L880


BEGINRELEASENOTES

*WorkloadManagementSystem
FIX: Pilots submitted by SiteDirector won't add the pythonVersion flag

ENDRELEASENOTES
