### PR TITLE
[sweep:integration] fix: removed option for python3 pilots

### DIFF
--- a/src/DIRAC/TransformationSystem/scripts/dirac_production_runjoblocal.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_production_runjoblocal.py
@@ -85,7 +85,7 @@ def __configurePilot(basepath, vo):
     os.system(
         "python "
         + basepath
-        + "dirac-pilot.py -S %s -l %s -C %s -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch --pythonVersion=3 -dd"
+        + "dirac-pilot.py -S %s -l %s -C %s -N ce.debug.ch -Q default -n DIRAC.JobDebugger.ch -dd"
         % (currentSetup, vo, masterCS)
     )
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -641,8 +641,6 @@ class SiteDirector(AgentModule):
         elif CVMFS_locations:
             pilotOptions.append(f"--CVMFS_locations={CVMFS_locations}")
 
-        pilotOptions.append("--pythonVersion=3")
-
         # DIRAC Extensions to be used in pilots
         pilotExtensionsList = opsHelper.getValue("Pilot/Extensions", [])
         extensionsList = []

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
@@ -251,7 +251,6 @@ def test_getPilotWrapper(mocker, sd, pilotWrapperDirectory):
     pilotOptions = sd._getPilotOptions("ce1.site1.com_condor")
     assert {
         "--preinstalledEnv=123",
-        "--pythonVersion=3",
         "--wnVO=dteam",
         "-n LCG.Site1.com",
         "-N ce1.site1.com",

--- a/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
@@ -51,7 +51,7 @@ time.sleep(1)
 from PilotWrapper import pilotWrapperScript  # pylint: disable=import-error
 
 res = pilotWrapperScript(
-    pilotOptions="--setup=CI -N ce.dirac.org -Q DIRACQUEUE -n DIRAC.CI.ORG --pythonVersion=3 --debug",
+    pilotOptions="--setup=CI -N ce.dirac.org -Q DIRACQUEUE -n DIRAC.CI.ORG --debug",
     location="diracproject.web.cern.ch/diracproject/tars/Pilot/DIRAC/" + pilotBranch + "/,wrong.cern.ch",
 )
 


### PR DESCRIPTION
Sweep #7531 `fix: removed option for python3 pilots` to `integration`.

Adding original author @fstagni as watcher.

BEGINRELEASENOTES

*WorkloadManagementSystem
FIX: Pilots submitted by SiteDirector won't add the pythonVersion flag

ENDRELEASENOTES
Closes #7533