### PR TITLE
[8.0] feat: `RemoteRunner` can take a container image in parameter

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
@@ -53,13 +53,14 @@ class RemoteRunner:
         """
         return gConfig.getValue("/LocalSite/RemoteExecution", False)
 
-    def execute(self, command, workingDirectory=".", numberOfProcessors=1, cleanRemoteJob=True):
+    def execute(self, command, workingDirectory=".", numberOfProcessors=1, cleanRemoteJob=True, containerImage=None):
         """Execute the command remotely via a CE
 
         :param str command: command to execute remotely
         :param str workingDirectory: directory containing the inputs required by the command
         :param int numberOfProcessors: number of processors to allocate to the command
         :param str cleanRemoteJob: clean the files related to the command on the remote host if True
+        :param str containerImage: container image to use to execute the command
         :return: (status, output, error)
         """
         self.log.verbose("Command to submit:", command)
@@ -74,7 +75,7 @@ class RemoteRunner:
         )
 
         # Set up Application Queue
-        if not (result := self._setUpWorkloadCE(numberOfProcessors))["OK"]:
+        if not (result := self._setUpWorkloadCE(numberOfProcessors, containerImage))["OK"]:
             result["Errno"] = DErrno.ERESUNA
             return result
         workloadCE = result["Value"]
@@ -149,7 +150,7 @@ class RemoteRunner:
 
         return S_OK()
 
-    def _setUpWorkloadCE(self, numberOfProcessorsPayload=1):
+    def _setUpWorkloadCE(self, numberOfProcessorsPayload=1, containerImage=None):
         """Get application queue and configure it
 
         :return: a ComputingElement instance
@@ -160,6 +161,10 @@ class RemoteRunner:
             return result
         ceType = result["Value"]["CEType"]
         ceParams = result["Value"]
+
+        # Set the container image if needed
+        if containerImage:
+            ceParams["ContainerImage"] = containerImage
 
         # Build CE
         ceFactory = ComputingElementFactory()


### PR DESCRIPTION
In the LHCb context, applications have traditionally operated within a uniform container environment. This setup relied on specifying a singular container image via the `XRSLExtraString` parameter within the ARC/AREXCE configuration. This approach ensured simplicity and consistency across our computing tasks but also imposed limitations on flexibility for specific application requirements.

LHCb applications may now require tailored container environments to run properly. Applications are capable of autonomously selecting the most suitable container image from CVMFS before running. However, in environments lacking CVMFS support, applications would need to initiate a container within another container, a practice that may conflict with the policies enforced by system administrators I guess.

The goal of the PR is to integrate the possibility to dynamically select the appropriate container image best suited for each application's unique requirements.


BEGINRELEASENOTES
*WorkloadManagement
CHANGE: RemoteRunner can take a container image in parameters
*Resources
NEW: The ARC CE now has two new parameters, ContainerImage and ApptainerBinary, to configure which container image to run how
ENDRELEASENOTES
