### PR TITLE
[8.0] test: extra_module default to empty list

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -193,7 +193,8 @@ def prepare_environment(
     release_var: Optional[str] = None,
 ):
     """Prepare the local environment for installing DIRAC."""
-
+    if extra_module is None:
+        extra_module = []
     _check_containers_running(is_up=False)
     if editable is None:
         editable = sys.stdout.isatty()


### PR DESCRIPTION
Typer 0.10.0 fixed the behavior of `list|None` paramaters which default to `None`. 
https://typer.tiangolo.com/release-notes/#fixes
https://github.com/tiangolo/typer/pull/664

Without this fix, our integration tests fail with

```python
Traceback (most recent call last):

  File "/tmp/DIRACRepo/./integration_tests.py", line 1[15](https://github.com/DIRACGrid/diracx/actions/runs/8410072574/job/23028073455?pr=225#step:6:16)4, in <module>
    app()

  File "/tmp/DIRACRepo/./integration_tests.py", line 208, in prepare_environment
    modules = DEFAULT_MODULES | dict(f.split("=", 1) for f in extra_module)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

BEGINRELEASENOTES

*Test
FIX: extra_module default to empty list
ENDRELEASENOTES
