### PR TITLE
[sweep:integration] test: extra_module default to empty list

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -196,6 +196,8 @@ def prepare_environment(
     release_var: Optional[str] = None,
 ):
     """Prepare the local environment for installing DIRAC."""
+    if extra_module is None:
+        extra_module = []
     _check_containers_running(is_up=False)
     if editable is None:
         editable = sys.stdout.isatty()


### PR DESCRIPTION
Sweep #7537 `test: extra_module default to empty list` to `integration`.

Adding original author @chaen as watcher.

BEGINRELEASENOTES

*Test
FIX: extra_module default to empty list
ENDRELEASENOTES
Closes #7538