### PR TITLE
[v8.0] fix: cannot get time left because of a wrong method used

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
@@ -132,15 +132,21 @@ class TimeLeft:
 
     def _getBatchSystemPlugin(self):
         """Using the name of the batch system plugin, will return an instance of the plugin class."""
-        batchSystemInfo = gConfig.getSections("/LocalSite/BatchSystemInfo")
-        type = batchSystemInfo.get("Type")
-        jobID = batchSystemInfo.get("JobID")
-        parameters = batchSystemInfo.get("Parameters")
+        result = gConfig.getOptionsDictRecursively("/LocalSite/BatchSystemInfo")
+        missingConfig = False
+        if not result["OK"]:
+            missingConfig = True
+
+        if not missingConfig:
+            batchSystemInfo = result["Value"]
+            type = batchSystemInfo.get("Type")
+            jobID = batchSystemInfo.get("JobID")
+            parameters = batchSystemInfo.get("Parameters")
 
         ###########################################################################################
         # TODO: remove the following block in v9.0
         # This is a temporary fix for the case where the batch system is not set in the configuration
-        if not type:
+        else:
             self.log.warn(
                 "Batch system info not set in local configuration: trying to guess from environment variables."
             )


### PR DESCRIPTION
I was not using `gConfig` properly, the issue was not fixed.

BEGINRELEASENOTES
*Resources
FIX: TimeLeft utility was unable to get values from the cfg
ENDRELEASENOTES
