### PR TITLE
[8.0] feat: remove files from the RemoteRunner execution

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -898,8 +898,10 @@ class AREXComputingElement(ARCComputingElement):
             if remoteOutput == f"{stamp}.out":
                 with open(localOutput) as f:
                     stdout = f.read()
+                os.unlink(localOutput)
             if remoteOutput == f"{stamp}.err":
                 with open(localOutput) as f:
                     stderr = f.read()
+                os.unlink(localOutput)
 
         return S_OK((stdout, stderr))

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
@@ -127,7 +127,11 @@ class RemoteRunner:
             return result
         self.log.info("The output has been retrieved and declared complete")
 
-        # Clean job in the remote resource
+        # Clean up the job (local files not needed anymore)
+        os.remove(self.checkSumOutput)
+        os.remove(self.executable)
+
+        # Remove the job from the CE
         if cleanRemoteJob:
             if not (result := workloadCE.cleanJob(jobID))["OK"]:
                 self.log.warn("Failed to clean the output remotely", result["Message"])


### PR DESCRIPTION
A few files are not needed once the remote execution is done and should be removed from the output files.
Otherwise, they might unnecessarily be stored (e.g. end up in the "log files" in LHCbDIRAC).

BEGINRELEASENOTES
*WorkloadManagement
CHANGE: Remove files from the RemoteRunner execution
ENDRELEASENOTES
