### PR TITLE
[v8.0] Replace ROOT_All with ROOT

### DIFF
--- a/src/DIRAC/Interfaces/API/Dirac.py
+++ b/src/DIRAC/Interfaces/API/Dirac.py
@@ -402,7 +402,7 @@ class Dirac(API):
         Example usage:
 
         >>> print(getInputDataCatalog('/lhcb/a/b/c/00001680_00000490_5.dst',None,'myCat.xml'))
-        {'Successful': {'<LFN>': {'pfntype': 'ROOT_All', 'protocol': 'SRM2',
+        {'Successful': {'<LFN>': {'pfntype': 'ROOT', 'protocol': 'SRM2',
          'pfn': '<PFN>', 'turl': '<TURL>', 'guid': '3E3E097D-0AC0-DB11-9C0A-00188B770645',
          'se': 'CERN-disk'}}, 'Failed': [], 'OK': True, 'Value': ''}
 

--- a/src/DIRAC/Resources/Catalog/PoolXMLCatalog.py
+++ b/src/DIRAC/Resources/Catalog/PoolXMLCatalog.py
@@ -85,7 +85,7 @@ class PoolFile:
         if pfntype:
             self.pfns.append((pfn, pfntype, sename))
         else:
-            self.pfns.append((pfn, "ROOT_All", sename))
+            self.pfns.append((pfn, "ROOT", sename))
 
     def toXML(self, metadata):
         """Output the contents as an XML string"""

--- a/src/DIRAC/Resources/Catalog/PoolXMLFile.py
+++ b/src/DIRAC/Resources/Catalog/PoolXMLFile.py
@@ -84,7 +84,7 @@ def getType(fileNames, directory=""):
     for fname in fileNames:
         typeFile = str(catalog.getTypeByPfn(fname))
         if not typeFile:
-            typeFile = "ROOT_All"
+            typeFile = "ROOT"
             generated.append(fname)
 
         pfnTypes[fname] = typeFile

--- a/src/DIRAC/WorkloadManagementSystem/Client/InputDataResolution.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/InputDataResolution.py
@@ -68,7 +68,7 @@ class InputDataResolution:
 
     #############################################################################
 
-    def _createCatalog(self, resolvedInputData, catalogName="pool_xml_catalog.xml", pfnType="ROOT_All"):
+    def _createCatalog(self, resolvedInputData, catalogName="pool_xml_catalog.xml", pfnType="ROOT"):
         """By default uses PoolXMLSlice, VO extensions can modify at will"""
 
         resolvedData = resolvedInputData["Successful"]


### PR DESCRIPTION
Apparently `ROOT_All` was to indicate the file was for use with POOL and apparently this only matters for LHCb. As we only need `ROOT` these days and the default causes problems the simplest thing is to just change it.

BEGINRELEASENOTES

*Core
CHANGE: Replace the default PFN type ROOT_All with ROOT

ENDRELEASENOTES
