### PR TITLE
[8.0] fix: make sure CVMFS_locations is a list

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1106,7 +1106,8 @@ class SiteDirector(AgentModule):
             self.log.exception("Exception during pilot modules files compression", lException=be)
 
         location = Operations().getValue("Pilot/pilotFileServer", "")
-        CVMFS_locations = Operations().getValue("Pilot/CVMFS_locations")
+        CVMFS_locations = Operations().getValue("Pilot/CVMFS_locations", [])
+
         localPilot = pilotWrapperScript(
             pilotFilesCompressedEncodedDict=pilotFilesCompressedEncodedDict,
             pilotOptions=pilotOptions,


### PR DESCRIPTION
When `CVMFS_locations` contains a single value, it is currently interpreted as a string, whereas `pilotWrapperScript` expects a list of elements.
Then, this can potentially prevent the pilots from retrieving the pilot files.

```
2024-04-09 13:24:18 UTC ERROR    <urlopen error [Errno 2] No such file or directory: './lhcbdirac/pilot/checksums.sha512'>
 Traceback (most recent call last):
   File "<stdin>", line 106, in <module>
   File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
     return opener.open(url, data, timeout)
   File "/usr/lib64/python2.7/urllib2.py", line 431, in open
     response = self._open(req, data)
   File "/usr/lib64/python2.7/urllib2.py", line 449, in _open
     '_open', req)
   File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
     result = func(*args)
   File "/usr/lib64/python2.7/urllib2.py", line 1353, in file_open
     return self.open_local_file(req)
   File "/usr/lib64/python2.7/urllib2.py", line 1393, in open_local_file
     raise URLError(msg)
 URLError: <urlopen error [Errno 2] No such file or directory: './lhcbdirac/pilot/checksums.sha512'>
 Trying file:c/lhcbdirac/pilot
 2024-04-09 13:24:18 UTC ERROR    file:c/lhcbdirac/pilot unreacheable (this is normal!)
 2024-04-09 13:24:18 UTC ERROR    <urlopen error [Errno 2] No such file or directory: 'c/lhcbdirac/pilot/checksums.sha512'>
 Traceback (most recent call last):
   File "<stdin>", line 106, in <module>
   File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
     return opener.open(url, data, timeout)
   File "/usr/lib64/python2.7/urllib2.py", line 431, in open
     response = self._open(req, data)
   File "/usr/lib64/python2.7/urllib2.py", line 449, in _open
     '_open', req)
   File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
     result = func(*args)
   File "/usr/lib64/python2.7/urllib2.py", line 1353, in file_open
     return self.open_local_file(req)
   File "/usr/lib64/python2.7/urllib2.py", line 1393, in open_local_file
     raise URLError(msg)
 URLError: <urlopen error [Errno 2] No such file or directory: 'c/lhcbdirac/pilot/checksums.sha512'>
 Trying file:h/lhcbdirac/pilot
 2024-04-09 13:24:18 UTC ERROR    file:h/lhcbdirac/pilot unreacheable (this is normal!)
 2024-04-09 13:24:18 UTC ERROR    <urlopen error [Errno 2] No such file or directory: 'h/lhcbdirac/pilot/checksums.sha512'>
 Traceback (most recent call last):
   File "<stdin>", line 106, in <module>
   File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
     return opener.open(url, data, timeout)
   File "/usr/lib64/python2.7/urllib2.py", line 431, in open
     response = self._open(req, data)
   File "/usr/lib64/python2.7/urllib2.py", line 449, in _open
     '_open', req)
   File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
     result = func(*args)
   File "/usr/lib64/python2.7/urllib2.py", line 1353, in file_open
     return self.open_local_file(req)
   File "/usr/lib64/python2.7/urllib2.py", line 1393, in open_local_file
     raise URLError(msg)
 URLError: <urlopen error [Errno 2] No such file or directory: 'h/lhcbdirac/pilot/checksums.sha512'>
 2024-04-09 13:24:18 UTC ERROR    None of the locations of the pilot files is reachable
```

BEGINRELEASENOTES
*WorkloadManagement
FIX: make sure CVMFS_locations is a list
ENDRELEASENOTES
