### PR TITLE
[8.0] fix: support `file:/path/to/pilot_files` as a location for the pilot files

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -197,7 +197,7 @@ import random
 random.shuffle(location)
 
 # we try from the available locations
-locs = [os.path.join('https://', loc) for loc in location]
+locs = [os.path.join('https://', loc) if not loc.startswith(('file:', 'https:')) else loc for loc in location]
 locations = locs + [os.path.join(loc, 'pilot') for loc in locs]
 # adding also the cvmfs locations
 locations += %(CVMFS_locs)s


### PR DESCRIPTION
Aims at fixing this issue:

```
Trying https://file:/cvmfs/<repo>/dirac/pilot
2024-04-09 13:24:18 UTC ERROR    https://file:/cvmfs/<repo>/dirac/pilot unreacheable (this is normal!)
2024-04-09 13:24:18 UTC ERROR    <urlopen error [Errno -2] Name or service not known>
```

BEGINRELEASENOTES
*WorkloadManagement
FIX: support file:/... as a location for the pilot files
ENDRELEASENOTES
