### PR TITLE
[8.0] Support M2Crypto 0.40.0+

### DIFF
--- a/src/DIRAC/Core/Security/m2crypto/X509CRL.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509CRL.py
@@ -4,7 +4,7 @@ This class is used to manage the revoked certificates....
 import re
 import datetime
 
-import M2Crypto
+import M2Crypto.X509
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Utilities.File import secureOpenForWrite

--- a/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
@@ -10,7 +10,7 @@ import os
 import random
 import time
 
-import M2Crypto
+import M2Crypto.X509
 
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/Core/Security/m2crypto/X509Chain.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Chain.py
@@ -12,7 +12,7 @@ import hashlib
 
 import re
 
-import M2Crypto
+import M2Crypto.X509
 
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/Core/Security/m2crypto/X509Request.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Request.py
@@ -1,7 +1,7 @@
 """ X509Request is a class for managing X509 requests with their Pkeys.
 It's main use is for proxy delegation.
 """
-import M2Crypto
+import M2Crypto.X509
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security.m2crypto import DEFAULT_PROXY_STRENGTH
 from DIRAC.Core.Utilities import DErrno

--- a/src/DIRAC/Core/Tornado/Server/TornadoServer.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoServer.py
@@ -8,7 +8,7 @@ import os
 import asyncio
 import psutil
 
-import M2Crypto
+import M2Crypto.SSL
 
 import tornado.iostream
 


### PR DESCRIPTION
In M2Crypto 0.40.0 it's __init__ file was modified to no longer export it's various submodules:

https://gitlab.com/m2crypto/m2crypto/-/commit/ce75069d20053ad7bd558166eeb7c9ec8c7d77da#a316cb2948e657263203704c0d90d450799ab975_26_24

This has the effect of meaning that you must now explicitly import submodules:

```python
>>> import M2Crypto
>>> M2Crypto.X509
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'M2Crypto' has no attribute 'X509'
```

```python
>>> import M2Crypto.X509
>>> M2Crypto.X509
<module 'M2Crypto.X509' from '.../site-packages/M2Crypto/X509.py'>
```


BEGINRELEASENOTES

*Core
FIX: Support M2Crypto 0.40.0+

ENDRELEASENOTES
