### PR TITLE
[8.0] fix(Workflow): prevent circular import in WorkflowReader

### DIFF
--- a/src/DIRAC/Core/Workflow/Workflow.py
+++ b/src/DIRAC/Core/Workflow/Workflow.py
@@ -396,10 +396,10 @@ class Workflow(AttributeCollection):
         return S_OK(step_result)
 
 
-from DIRAC.Core.Workflow.WorkflowReader import WorkflowXMLHandler
-
-
 def fromXMLString(xml_string, obj=None):
+    # prevent circular import in WorkflowReader
+    from DIRAC.Core.Workflow.WorkflowReader import WorkflowXMLHandler
+
     # KGG !!! We need to reset Workflow if it exists
     handler = WorkflowXMLHandler(obj)
     xml.sax.parseString(xml_string, handler)
@@ -407,6 +407,9 @@ def fromXMLString(xml_string, obj=None):
 
 
 def fromXMLFile(xml_file, obj=None):
+    # prevent circular import in WorkflowReader
+    from DIRAC.Core.Workflow.WorkflowReader import WorkflowXMLHandler
+
     # KGG !!! We need to reset Workflow if it exists
     handler = WorkflowXMLHandler(obj)
     xml.sax.parse(xml_file, handler)


### PR DESCRIPTION
I am not sure why I never tried this before...
```bash
python -c "from DIRAC.Core.Workflow.WorkflowReader import WorkflowXMLHandler"
```
fails all by itself.

I think in readthedocs we hit some race condition, because that treats source files in parallel.
Because this works

```
python -c "from DIRAC.Core.Workflow import Workflow; from DIRAC.Core.Workflow.WorkflowReader import WorkflowXMLHandler"
```

BEGINRELEASENOTES

*WMS
FIX: Fix potential circular import in WorkflowReader. Mostly seen in the creation of the documentation.

ENDRELEASENOTES
