### PR TITLE
[9.0] fix(getMonitoringDB): prevent returning None

### DIFF
--- a/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
+++ b/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
@@ -11,6 +11,6 @@ def getMonitoringDB():
         if gMonitoringDB and gMonitoringDB._connected:
             return gMonitoringDB
     except Exception:
-        from DIRAC.Core.Base.Client import Client
-
-        return Client(url="Monitoring/Monitoring")
+        pass
+    from DIRAC.Core.Base.Client import Client
+    return Client(url="Monitoring/Monitoring")


### PR DESCRIPTION
if we don't have an exception but didn't directly connect we would reach end of function and return None



BEGINRELEASENOTES
*Monitoring
FIX: prevent getMonitoringDB from returning None

ENDRELEASENOTES
