### PR TITLE
[8.0] fix getMonitoringDB returning None

### DIFF
--- a/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
+++ b/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
@@ -11,6 +11,8 @@ def getMonitoringDB():
         if gMonitoringDB and gMonitoringDB._connected:
             return gMonitoringDB
     except Exception:
-        from DIRAC.Core.Base.Client import Client
+        pass
 
-        return Client(url="Monitoring/Monitoring")
+    from DIRAC.Core.Base.Client import Client
+
+    return Client(url="Monitoring/Monitoring")

--- a/src/DIRAC/WorkloadManagementSystem/Client/ServerUtils.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/ServerUtils.py
@@ -13,7 +13,9 @@ def getPilotAgentsDB():
         if gPilotAgentsDB and gPilotAgentsDB._connected:
             return gPilotAgentsDB
     except Exception:
-        return Client(url="WorkloadManagement/PilotManager")
+        pass
+
+    return Client(url="WorkloadManagement/PilotManager")
 
 
 def getVirtualMachineDB():
@@ -23,4 +25,6 @@ def getVirtualMachineDB():
         if gVirtualMachineDB and gVirtualMachineDB._connected:
             return gVirtualMachineDB
     except Exception:
-        return Client(url="WorkloadManagement/VirtualMachineManager")
+        pass
+
+    return Client(url="WorkloadManagement/VirtualMachineManager")


### PR DESCRIPTION
BEGINRELEASENOTES

*Monitoring

FIX: ServerUtils: prevent getMonitoringDB from returning None

*WMS
FIX: ServerUtils: prevent getPilotAgentsDB, getVirtualMachineDB from returning None

ENDRELEASENOTES
