### PR TITLE
[8.0]: Fix issue when using secureWrite in binary mode

### DIFF
--- a/src/DIRAC/Core/Utilities/File.py
+++ b/src/DIRAC/Core/Utilities/File.py
@@ -273,7 +273,7 @@ def secureOpenForWrite(filename=None, *, text=True):
         )
     else:
         fd, filename = tempfile.mkstemp(text=text)
-    with open(fd, "w" if text else "wb", encoding="ascii") as fd:
+    with open(fd, "w" if text else "wb", encoding="ascii" if text else None) as fd:
         yield fd, filename
 
 


### PR DESCRIPTION
From the hackathon

BEGINRELEASENOTES

*Core

FIX: File.secureOpenForWrite: fix exception when opening in binary mode, fixes #7581


ENDRELEASENOTES
