### PR TITLE
[9.0] fix getMonitoringDB, getPilotAgentsDB returning None

### DIFF
--- a/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
+++ b/src/DIRAC/MonitoringSystem/Client/ServerUtils.py
@@ -11,6 +11,8 @@ def getMonitoringDB():
         if gMonitoringDB and gMonitoringDB._connected:
             return gMonitoringDB
     except Exception:
-        from DIRAC.Core.Base.Client import Client
+        pass
 
-        return Client(url="Monitoring/Monitoring")
+    from DIRAC.Core.Base.Client import Client
+
+    return Client(url="Monitoring/Monitoring")

--- a/src/DIRAC/WorkloadManagementSystem/Client/ServerUtils.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/ServerUtils.py
@@ -13,4 +13,6 @@ def getPilotAgentsDB():
         if gPilotAgentsDB and gPilotAgentsDB._connected:
             return gPilotAgentsDB
     except Exception:
-        return Client(url="WorkloadManagement/PilotManager")
+        pass
+
+    return Client(url="WorkloadManagement/PilotManager")


### PR DESCRIPTION
[8.0] fix getMonitoringDB returning None

(cherry picked from commit 749ce65eb7971088eb1bcbeb9e40f63dea493eaa)

Swept: #7578
Fixes: #7582


VirtualMachineDB was removed in 9.0

BEGINRELEASENOTES

*Monitoring

FIX: ServerUtils: prevent getMonitoringDB from returning None

*WMS
FIX: ServerUtils: prevent getPilotAgentsDB from returning None

ENDRELEASENOTES