### PR TITLE
[v8.0] fix: AREX out and err need to exist before file integrity check

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -898,10 +898,8 @@ class AREXComputingElement(ARCComputingElement):
             if remoteOutput == f"{stamp}.out":
                 with open(localOutput) as f:
                     stdout = f.read()
-                os.unlink(localOutput)
             if remoteOutput == f"{stamp}.err":
                 with open(localOutput) as f:
                     stderr = f.read()
-                os.unlink(localOutput)
 
         return S_OK((stdout, stderr))

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
@@ -128,6 +128,8 @@ class RemoteRunner:
         self.log.info("The output has been retrieved and declared complete")
 
         # Clean up the job (local files not needed anymore)
+        os.remove(f"{stamp}.out")
+        os.remove(f"{stamp}.err")
         os.remove(self.checkSumOutput)
         os.remove(self.executable)
 


### PR DESCRIPTION
The Solution introduced in https://github.com/DIRACGrid/DIRAC/pull/7549 does not work: `RemoteRunner._checkOutputIntegrity()` checks the integrity of the output, but the `.out` and `.err` files are removed by the `AREXCE` before being checked. Therefore, the output is considered corrupted.

Here we remove the `.out` and `.err` in the `RemoteRunner` after the integrity check, following the `AREXCE` format. I don't think it is a problem because:
- the `RemoteRunner` works only with `AREX/ARC` CEs
- the `RemoteRunner` is going to disappear at some point.

BEGINRELEASENOTES
*WorkloadManagement
FIX: AREX "out" and "err" need to exist before file integrity check
ENDRELEASENOTES
