### PR TITLE
fix: JobMonitoring.getJobParameter(s)

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py
@@ -440,7 +440,7 @@ class JobMonitoringHandlerMixin:
         :param str/int jobID: one single Job ID
         :param str parName: one single parameter name
         """
-        res = cls.elasticJobParametersDB.getJobParameters(jobID, [parName])
+        res = cls.elasticJobParametersDB.getJobParameters(int(jobID), [parName])
         if not res["OK"]:
             return res
         return S_OK(res["Value"].get(int(jobID), {}))
@@ -464,6 +464,7 @@ class JobMonitoringHandlerMixin:
         """
         if not isinstance(jobIDs, list):
             jobIDs = [jobIDs]
+        jobIDs = [int(jobID) for jobID in jobIDs]
         parameters = {}
         for jobID in jobIDs:
             res = cls.elasticJobParametersDB.getJobParameters(jobID, parName)


### PR DESCRIPTION
`elasticJobParametersDB.getJobParameters()` expects `jobID` as an `int`. It aims at solving the following issue:

```python
2024-04-24T13:24:26,167397Z Tornado/Tornado/WorkloadManagementJobMonitoringHandler ERROR: Exception serving request unsupported operand type(s) for //: 'str' and 'float':TypeError("unsupported operand type(s) for //: 'str' and 'float'")
Traceback (most recent call last):
  File "/opt/dirac/versions/v9.0.0a28-1713361636/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Tornado/Server/private/BaseRequestHandler.py", line 644, in _executeMethod
    return self.methodObj(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v9.0.0a28-1713361636/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 90, in inner
    return meth(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v9.0.0a28-1713361636/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/Service/JobMonitoringHandler.py", line 469, in export_getJobParameters
    res = cls.elasticJobParametersDB.getJobParameters(jobID, parName)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v9.0.0a28-1713361636/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py", line 80, in getJobParameters
    res = self.getDoc(self._indexName(jobID), str(jobID))
                      ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v9.0.0a28-1713361636/Linux-x86_64/lib/python3.11/site-packages/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py", line 49, in _indexName
    indexSplit = int(jobID // 1e6)
                     ~~~~~~^^~~~~
TypeError: unsupported operand type(s) for //: 'str' and 'float'
```


BEGINRELEASENOTES
*WorkloadManagement
FIX: JobMonitoring.getJobParameters should pass jobID as an int to ElasticJobParametersDB
ENDRELEASENOTES
