### PR TITLE
feat (DMS): DataManager.putAndRegister rejects too long filename

### DIFF
--- a/src/DIRAC/DataManagementSystem/Client/DataManager.py
+++ b/src/DIRAC/DataManagementSystem/Client/DataManager.py
@@ -434,7 +434,7 @@ class DataManager:
         'overwrite' removes file from the file catalogue and SE before attempting upload
         """
 
-        if len(os.path.basename(lfn)) >= MAX_FILENAME_LENGTH:
+        if len(os.path.basename(lfn)) > MAX_FILENAME_LENGTH:
             return S_ERROR(errno.ENAMETOOLONG, f"maximum {MAX_FILENAME_LENGTH} characters allowed")
 
         res = self.__hasAccess("addFile", lfn)

--- a/src/DIRAC/DataManagementSystem/Client/DataManager.py
+++ b/src/DIRAC/DataManagementSystem/Client/DataManager.py
@@ -8,6 +8,7 @@
 This module consists of DataManager and related classes.
 
 """
+
 # # imports
 from datetime import datetime, timedelta
 import fnmatch
@@ -25,6 +26,7 @@ from DIRAC.Core.Utilities.List import randomize, breakListIntoChunks
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC.DataManagementSystem.Client import MAX_FILENAME_LENGTH
 from DIRAC.MonitoringSystem.Client.DataOperationSender import DataOperationSender
 from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
@@ -431,6 +433,9 @@ class DataManager:
         'path' is the path on the storage where the file will be put (if not provided the LFN will be used)
         'overwrite' removes file from the file catalogue and SE before attempting upload
         """
+
+        if len(os.path.basename(lfn)) >= MAX_FILENAME_LENGTH:
+            return S_ERROR(errno.ENAMETOOLONG, f"maximum {MAX_FILENAME_LENGTH} characters allowed")
 
         res = self.__hasAccess("addFile", lfn)
         if not res["OK"]:

--- a/src/DIRAC/DataManagementSystem/Client/FailoverTransfer.py
+++ b/src/DIRAC/DataManagementSystem/Client/FailoverTransfer.py
@@ -16,6 +16,8 @@
     temporary replica.
 
 """
+
+import errno
 import time
 
 from DIRAC import S_OK, S_ERROR, gLogger
@@ -107,6 +109,9 @@ class FailoverTransfer:
                     break
                 elif cmpError(result, EFCERR):
                     self.log.debug("transferAndRegisterFile: FC unavailable, retry")
+                elif cmpError(result, errno.ENAMETOOLONG):
+                    self.log.debug(f"transferAndRegisterFile: this file won't be uploaded: {result}")
+                    return result
                 elif retryUpload and len(destinationSEList) == 1:
                     self.log.debug("transferAndRegisterFile: Failed uploading to the only SE, retry")
                 else:

--- a/src/DIRAC/DataManagementSystem/Client/__init__.py
+++ b/src/DIRAC/DataManagementSystem/Client/__init__.py
@@ -1,3 +1,6 @@
 """
    DIRAC.DataManagementSystem.Client package
 """
+
+# This should be the same as the FileName column of the DFC
+MAX_FILENAME_LENGTH = 128

--- a/src/DIRAC/DataManagementSystem/Client/__init__.py
+++ b/src/DIRAC/DataManagementSystem/Client/__init__.py
@@ -2,5 +2,5 @@
    DIRAC.DataManagementSystem.Client package
 """
 
-# This should be the same as the FileName column of the DFC
+#: Maximum number of characters for a filename, this should be the same as the FileName column of the DFC
 MAX_FILENAME_LENGTH = 128


### PR DESCRIPTION
closes https://github.com/DIRACGrid/DIRAC/issues/7602 (hopefully)


BEGINRELEASENOTES

*DMS
NEW: DataManager.putAndRegister rejects too long filename

ENDRELEASENOTES
