### PR TITLE
[8.0] Fix CVMFS deployment script's path

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -155,4 +155,4 @@ jobs:
           mkdir -p ~/.ssh/ && touch ~/.ssh/known_hosts
           ssh-keyscan cvmfs-upload01.gridpp.rl.ac.uk >> ~/.ssh/known_hosts
 
-          gsissh -p 1975 -t cvmfs-upload01.gridpp.rl.ac.uk /home/diracsgm/cvmfs_repo/admin/sync_packages.sh
+          gsissh -p 1975 -t cvmfs-upload01.gridpp.rl.ac.uk /home/diracsgm/admin/sync_packages.sh


### PR DESCRIPTION

BEGINRELEASENOTES

*Deployment
FIX: fix the path of the CVMFS sync_packages.sh script

ENDRELEASENOTES
