### PR TITLE
[sweep:integration] Fix CVMFS deployment script's path

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -152,7 +152,7 @@ jobs:
           export PATH=/usr/share/miniconda3/bin:/opt/conda/bin/:/opt/conda/condabin:$PATH
           mkdir -p ~/.ssh/ && touch ~/.ssh/known_hosts
           ssh-keyscan cvmfs-upload01.gridpp.rl.ac.uk >> ~/.ssh/known_hosts
-          gsissh -p 1975 -t cvmfs-upload01.gridpp.rl.ac.uk /home/diracsgm/cvmfs_repo/admin/sync_packages.sh -v
+          gsissh -p 1975 -t cvmfs-upload01.gridpp.rl.ac.uk /home/diracsgm/admin/sync_packages.sh
       - name: setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
Sweep #7626 `Fix CVMFS deployment script's path` to `integration`.

Adding original author @atsareg as watcher.

BEGINRELEASENOTES

*Deployment
FIX: fix the path of the CVMFS sync_packages.sh script

ENDRELEASENOTES
Closes #7627