### PR TITLE
[9.0] Move to pydantic 2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - psutil >=4.2.0
   - pyasn1 >0.4.1
   - pyasn1-modules
-  - pydantic <2
+  - pydantic >=2
   - python-json-logger >=0.1.8
   - pytz >=2015.7
   - pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     psutil
     pyasn1
     pyasn1-modules
+    pydantic
     pyparsing
     python-dateutil
     pytz

--- a/src/DIRAC/Workflow/Utilities/test/Test_Utilities.py
+++ b/src/DIRAC/Workflow/Utilities/test/Test_Utilities.py
@@ -48,7 +48,7 @@ from DIRAC.Workflow.Modules.<MODULE> import <MODULE>
 
         stepDef = getStepDefinition("App_Step", ["Script", "FailoverRequest"])
 
-        self.assertTrue(str(appDefn) == str(stepDef))
+        assert str(appDefn) == str(stepDef)
 
         self.job._addParameter(appDefn, "name", "type", "value", "desc")
         self.job._addParameter(appDefn, "name1", "type1", "value1", "desc1")
@@ -59,7 +59,7 @@ from DIRAC.Workflow.Modules.<MODULE> import <MODULE>
             parametersList=[["name", "type", "value", "desc"], ["name1", "type1", "value1", "desc1"]],
         )
 
-        self.assertTrue(str(appDefn) == str(stepDef))
+        assert str(appDefn) == str(stepDef)
 
     def test_getStepCPUTimes(self):
         execT, cpuT = getStepCPUTimes({})

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapperTemplate.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapperTemplate.py
@@ -5,6 +5,7 @@ We don't test the actual execution of the wrapper or its payload.
 """
 import json
 import os
+import re
 import shutil
 import sys
 
@@ -311,7 +312,7 @@ def test_createAndExecuteRelocatedJobWrapperTemplate_success(extraOptions):
 
     assert result.returncode == 127, result.stderr
     assert result.stdout == b"", result.stdout
-    assert f"{jobExecutableRelocatedPath}: not found".encode() in result.stderr, result.stderr
+    assert re.search(rf"{jobExecutableRelocatedPath}: (No such file or directory|not found)", result.stderr.decode())
 
     # 3. Now we relocate the files as a container bind mount would do and execute the relocated executable file in a subprocess
     # We expect it to work
@@ -424,7 +425,7 @@ def test_createAndExecuteJobWrapperOfflineTemplate_success(extraOptions):
 
     assert result.returncode == 127, result.stderr
     assert result.stdout == b"", result.stdout
-    assert f"{jobExecutableRelocatedPath}: not found".encode() in result.stderr, result.stderr
+    assert re.search(rf"{jobExecutableRelocatedPath}: (No such file or directory|not found)", result.stderr.decode())
 
     # 3. Now we relocate the files as if they were on a remote resource and execute the relocated executable file in a subprocess
     # We expect it to fail because the payload parameters are not available


### PR DESCRIPTION
This moves the pydantic models in the WMS to use pydantic 2. ~~Given this is only in integration I haven't bothered with supporting both pydantic 1 and 2.~~ Actually we should support both briefly as we have a chicken-and-egg problem with diracx.


BEGINRELEASENOTES

*WorkloadManagement
NEW: Support Pydantic 2

ENDRELEASENOTES
