### PR TITLE
[8.0] Remove dead code path in ReplicateAndRegister

### DIFF
--- a/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
+++ b/src/DIRAC/DataManagementSystem/Agent/RequestOperations/ReplicateAndRegister.py
@@ -605,13 +605,6 @@ class ReplicateAndRegister(DMSRequestOperationsBase):
                     # All source SEs are banned, delay execution by 1 hour
                     delayExecution = 60
                 continue
-            # # get the first one in the list
-            if sourceSE not in validReplicas:
-                if sourceSE:
-                    err = "File not at specified source"
-                    errors[err] += 1
-                    self.log.warn(f"{lfn} is not at specified sourceSE {sourceSE}, changed to {validReplicas[0]}")
-                sourceSE = validReplicas[0]
 
             # # loop over targetSE
             catalogs = self.operation.Catalog
@@ -623,6 +616,7 @@ class ReplicateAndRegister(DMSRequestOperationsBase):
                 if targetSE in validReplicas:
                     self.log.warn(f"Request to replicate {lfn} to an existing location: {targetSE}")
                     continue
+                sourceSE = self.operation.SourceSE if self.operation.SourceSE else None
                 res = self.dm.replicateAndRegister(lfn, targetSE, sourceSE=sourceSE, catalog=catalogs)
                 if res["OK"]:
                     if lfn in res["Value"]["Successful"]:


### PR DESCRIPTION
@chrisburr @andresailer I need a good review of that one :-) (not the RMS, that's just dead code) 
Oyr FTS agents had half a billion of proxy files left... not with this anymore I hope :)

BEGINRELEASENOTES

*Core
CHANGE: register the DictCache destructor as an atexit handler

ENDRELEASENOTES
