### PR TITLE
[8.0] fix SSHCE: clearer error message when output is not found

### DIFF
--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -513,12 +513,15 @@ class SSHComputingElement(ComputingElement):
         # Examine results of the job submission
         if sshStatus == 0:
             output = sshStdout.strip().replace("\r", "").strip()
+            if not output:
+                return S_ERROR("No output from remote command")
+
             try:
                 index = output.index("============= Start output ===============")
                 output = output[index + 42 :]
-            except Exception:
-                self.log.exception("Invalid output from remote command", output)
+            except ValueError:
                 return S_ERROR(f"Invalid output from remote command: {output}")
+
             try:
                 output = unquote(output)
                 result = json.loads(output)


### PR DESCRIPTION
Currently, when the `SSHCE` fails to get the output, we get the following error:

```bash
2024-06-06T11:44:40,902705Z WorkloadManagement/SiteDirectorDteam/ce.ce.ce ERROR: Invalid output from remote command
Traceback (most recent call last):
  File "/opt/dirac/versions/v9.0.0a29-1717652456/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Resources/Computing/SSHComputingElement.py", line 511, in __executeHostCommand
    index = output.index("============= Start output ===============")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: substring not found
```

The message is quite misleading.
- I added a condition where output is empty
- I removed the exception stack trace and the log when it is invalid

The `SiteDirector` is expected to print the `S_ERROR` message.

BEGINRELEASENOTES
*WorkloadManagement
FIX: remove exception log when output is not found
ENDRELEASENOTES
