### PR TITLE
[8.0] Deprecate ARC and ARC6

### DIFF
--- a/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARC6ComputingElement.py
@@ -25,9 +25,11 @@ import stat
 
 import arc  # Has to work if this module is called #pylint: disable=import-error
 from DIRAC import S_OK, S_ERROR
+from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Resources.Computing.ARCComputingElement import ARCComputingElement, prepareProxyToken
 
 
+@deprecated("ARC6 is deprecated and will be removed from v9.0. Please, use AREXComputingElement instead", onlyOnce=True)
 class ARC6ComputingElement(ARCComputingElement):
     def __init__(self, ceUniqueID):
         """Standard constructor."""

--- a/src/DIRAC/Resources/Computing/ARCComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ARCComputingElement.py
@@ -55,6 +55,7 @@ from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Utilities.Subprocess import shellCall
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Security.ProxyInfo import getVOfromProxyGroup
+from DIRAC.Core.Utilities.Decorators import deprecated
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement
 from DIRAC.Resources.Computing.PilotBundle import writeScript
 from DIRAC.WorkloadManagementSystem.Client import PilotStatus
@@ -112,6 +113,7 @@ def prepareProxyToken(func):
     return wrapper
 
 
+@deprecated("ARC is deprecated and will be removed from v9.0. Please, use AREXComputingElement instead", onlyOnce=True)
 class ARCComputingElement(ComputingElement):
     _arcLevels = ["DEBUG", "VERBOSE", "INFO", "WARNING", "ERROR", "FATAL"]
 


### PR DESCRIPTION
Based on the following discussion: https://github.com/DIRACGrid/DIRAC/discussions/7551

BEGINRELEASENOTES
*Resources
CHANGE: mark ARC and ARC6 as deprecated
ENDRELEASENOTES
