### PR TITLE
[9.0] Remove system instances 

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/LocalConfiguration.py
+++ b/src/DIRAC/ConfigurationSystem/Client/LocalConfiguration.py
@@ -15,7 +15,6 @@ from DIRAC.ConfigurationSystem.Client.PathFinder import (
     getServiceSection,
     getAgentSection,
     getExecutorSection,
-    getSystemSection,
 )
 from DIRAC.Core.Utilities.Devloader import Devloader
 
@@ -507,7 +506,7 @@ class LocalConfiguration:
             if self.componentType == "service":
                 self.__setDefaultSection(getServiceSection(self.componentName))
             elif self.componentType == "tornado":
-                self.__setDefaultSection(getSystemSection("Tornado"))
+                self.__setDefaultSection("/Systems/Tornado")
             elif self.componentType == "agent":
                 self.__setDefaultSection(getAgentSection(self.componentName))
             elif self.componentType == "executor":

--- a/src/DIRAC/ConfigurationSystem/Client/Utilities.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Utilities.py
@@ -10,7 +10,6 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOs, getVOOptio
 from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getDIRACSiteName
 from DIRAC.ConfigurationSystem.Client.PathFinder import getDatabaseSection
 from DIRAC.Core.Utilities.Glue2 import getGlue2CEInfo
-from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemInstance
 
 
 def getGridVOs():
@@ -612,7 +611,7 @@ def getAuthAPI():
 
     :return: str
     """
-    return gConfig.getValue(f"/Systems/Framework/{getSystemInstance('Framework')}/URLs/AuthAPI")
+    return gConfig.getValue(f"/Systems/Framework/URLs/AuthAPI")
 
 
 def getAuthorizationServerMetadata(issuer=None, ignoreErrors=False):
@@ -651,5 +650,5 @@ def isDownloadProxyAllowed():
 
     :return: S_OK(bool)/S_ERROR()
     """
-    cs_path = f"/Systems/Framework/{getSystemInstance('Framework')}/APIs/Auth"
+    cs_path = f"/Systems/Framework/APIs/Auth"
     return gConfig.getValue(cs_path + "/allowProxyDownload", True)

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -63,11 +63,6 @@ def pathFinder(monkeypatch):
     return PathFinder
 
 
-def test_getDIRACSetup(pathFinder):
-    """Test getDIRACSetup"""
-    assert pathFinder.getDIRACSetup() == "TestSetup"
-
-
 @pytest.mark.parametrize(
     "system, componentName, setup, componentType, result",
     [

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -56,13 +56,13 @@ def pathFinder(monkeypatch):
             "WorkloadManagement/SandboxStoreHandler",
             False,
             "Services",
-            "/Systems/WorkloadManagement/MyWM/Services/SandboxStoreHandler",
+            "/Systems/WorkloadManagement/Services/SandboxStoreHandler",
         ),
         (
             "WorkloadManagement",
             "SandboxStoreHandler",
             "Services",
-            "/Systems/WorkloadManagement/MyWM/Services/SandboxStoreHandler",
+            "/Systems/WorkloadManagement/Services/SandboxStoreHandler",
         ),
         # tricky case one could expect that if entity string is wrong
         # than some kind of error will be returned, but it is not the case
@@ -70,7 +70,7 @@ def pathFinder(monkeypatch):
             "WorkloadManagement/SimpleLogConsumer",
             False,
             "NonRonsumersNon",
-            "/Systems/WorkloadManagement/MyWM/NonRonsumersNon/SimpleLogConsumer",
+            "/Systems/WorkloadManagement/NonRonsumersNon/SimpleLogConsumer",
         ),
     ],
 )

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -12,33 +12,19 @@ localCFGData = ConfigurationData(False)
 mergedCFG = CFG()
 mergedCFG.loadFromBuffer(
     """
-DIRAC
-{
-  Setup=TestSetup
-  Setups
-  {
-    TestSetup
-    {
-      WorkloadManagement=MyWM
-    }
-  }
-}
 Systems
 {
   WorkloadManagement
   {
-    MyWM
+    URLs
     {
-      URLs
-      {
-        Service1 = dips://server1:1234/WorkloadManagement/Service1
-        Service2 = dips://$MAINSERVERS$:5678/WorkloadManagement/Service2
-      }
-      FailoverURLs
-      {
-        Service2 = dips://failover1:5678/WorkloadManagement/Service2
-        Service2 += dips://failover2:5678/WorkloadManagement/Service2
-      }
+      Service1 = dips://server1:1234/WorkloadManagement/Service1
+      Service2 = dips://$MAINSERVERS$:5678/WorkloadManagement/Service2
+    }
+    FailoverURLs
+    {
+      Service2 = dips://failover1:5678/WorkloadManagement/Service2
+      Service2 += dips://failover2:5678/WorkloadManagement/Service2
     }
   }
 }

--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_PathFinder.py
@@ -64,11 +64,10 @@ def pathFinder(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "system, componentName, setup, componentType, result",
+    "system, componentName, componentType, result",
     [
         (
             "WorkloadManagement/SandboxStoreHandler",
-            False,
             False,
             "Services",
             "/Systems/WorkloadManagement/MyWM/Services/SandboxStoreHandler",
@@ -76,7 +75,6 @@ def pathFinder(monkeypatch):
         (
             "WorkloadManagement",
             "SandboxStoreHandler",
-            False,
             "Services",
             "/Systems/WorkloadManagement/MyWM/Services/SandboxStoreHandler",
         ),
@@ -85,26 +83,24 @@ def pathFinder(monkeypatch):
         (
             "WorkloadManagement/SimpleLogConsumer",
             False,
-            False,
             "NonRonsumersNon",
             "/Systems/WorkloadManagement/MyWM/NonRonsumersNon/SimpleLogConsumer",
         ),
     ],
 )
-def test_getComponentSection(pathFinder, system, componentName, setup, componentType, result):
+def test_getComponentSection(pathFinder, system, componentName, componentType, result):
     """Test getComponentSection"""
-    assert pathFinder.getComponentSection(system, componentName, setup, componentType) == result
+    assert pathFinder.getComponentSection(system, componentName, componentType) == result
 
 
 @pytest.mark.parametrize(
-    "system, setup, result",
+    "system, result",
     [
-        ("WorkloadManagement", False, "/Systems/WorkloadManagement/MyWM/URLs"),
-        ("WorkloadManagement", "TestSetup", "/Systems/WorkloadManagement/MyWM/URLs"),
+        ("WorkloadManagement", "/Systems/WorkloadManagement/MyWM/URLs"),
     ],
 )
-def test_getSystemURLSection(pathFinder, system, setup, result):
-    assert pathFinder.getSystemURLs(system, setup)
+def test_getSystemURLSection(pathFinder, system, result):
+    assert pathFinder.getSystemURLs(system)
 
 
 @pytest.mark.parametrize(
@@ -200,11 +196,10 @@ def test_getServiceURLs(pathFinder, serviceName, service, failover, result):
 
 
 @pytest.mark.parametrize(
-    "system, setup, failover, result",
+    "system, failover, result",
     [
         (
             "WorkloadManagement",
-            None,
             False,
             {
                 "Service1": {"dips://server1:1234/WorkloadManagement/Service1"},
@@ -216,7 +211,6 @@ def test_getServiceURLs(pathFinder, serviceName, service, failover, result):
         ),
         (
             "WorkloadManagement",
-            None,
             True,
             {
                 "Service1": {"dips://server1:1234/WorkloadManagement/Service1"},
@@ -230,8 +224,8 @@ def test_getServiceURLs(pathFinder, serviceName, service, failover, result):
         ),
     ],
 )
-def test_getSystemURLs(pathFinder, system, setup, failover, result):
-    sysDict = pathFinder.getSystemURLs(system, setup=setup, failover=failover)
+def test_getSystemURLs(pathFinder, system, failover, result):
+    sysDict = pathFinder.getSystemURLs(system, failover=failover)
     for service in sysDict:
         assert set(sysDict[service]) == result[service]
 

--- a/src/DIRAC/Core/Base/private/ModuleLoader.py
+++ b/src/DIRAC/Core/Base/private/ModuleLoader.py
@@ -3,7 +3,6 @@
 import os
 from DIRAC.Core.Utilities import List
 from DIRAC import gConfig, S_ERROR, S_OK, gLogger
-from DIRAC.ConfigurationSystem.Client import PathFinder
 from DIRAC.Core.Utilities.Extensions import extensionsByPriority, recurseImport
 
 
@@ -44,8 +43,7 @@ class ModuleLoader:
             # Check if it's a system name
             # Look in the CS
             system = modName
-            # Can this be generated with sectionFinder?
-            csPath = f"{PathFinder.getSystemSection(system)}/Executors"
+            csPath = f"/Systems/{system}/Executors"
             gLogger.verbose(f"Exploring {csPath} to discover modules")
             result = gConfig.getSections(csPath)
             if result["OK"]:

--- a/src/DIRAC/Core/Tornado/Server/HandlerManager.py
+++ b/src/DIRAC/Core/Tornado/Server/HandlerManager.py
@@ -54,22 +54,17 @@ class HandlerManager:
         if diracSystems["OK"]:
             for system in diracSystems["Value"]:
                 try:
-                    sysInstance = PathFinder.getSystemInstance(system)
-                    result = gConfig.getSections(f"/Systems/{system}/{sysInstance}/{handlerInstance}")
+                    result = gConfig.getSections(f"/Systems/{system}/{handlerInstance}")
                     if result["OK"]:
                         for instName in result["Value"]:
                             newInst = f"{system}/{instName}"
-                            port = gConfig.getValue(
-                                f"/Systems/{system}/{sysInstance}/{handlerInstance}/{instName}/Port"
-                            )
+                            port = gConfig.getValue(f"/Systems/{system}/{handlerInstance}/{instName}/Port")
                             if port:
                                 newInst += f":{port}"
 
                             if handlerInstance == "Services":
                                 # We search in the CS all handlers which used HTTPS as protocol
-                                isHTTPS = gConfig.getValue(
-                                    f"/Systems/{system}/{sysInstance}/{handlerInstance}/{instName}/Protocol"
-                                )
+                                isHTTPS = gConfig.getValue(f"/Systems/{system}/{handlerInstance}/{instName}/Protocol")
                                 if isHTTPS and isHTTPS.lower() == "https":
                                     urls.append(newInst)
                             else:

--- a/src/DIRAC/Core/Tornado/Server/TornadoServer.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoServer.py
@@ -25,7 +25,6 @@ from DIRAC import gConfig, gLogger, S_OK
 from DIRAC.Core.Security import Locations
 from DIRAC.Core.Utilities import Network, TimeUtilities
 from DIRAC.Core.Tornado.Server.HandlerManager import HandlerManager
-from DIRAC.ConfigurationSystem.Client import PathFinder
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 
 sLog = gLogger.getSubLogger(__name__)
@@ -91,7 +90,7 @@ class TornadoServer:
         self.__appsSettings = {}
         # Default port, if enother is not discover
         if port is None:
-            port = gConfig.getValue(f"/Systems/Tornado/{PathFinder.getSystemInstance('Tornado')}/Port", 8443)
+            port = gConfig.getValue(f"/Systems/Tornado/Port", 8443)
         self.port = port
 
         # Handler manager initialization with default settings

--- a/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
+++ b/src/DIRAC/Core/Tornado/scripts/tornado_start_all.py
@@ -47,7 +47,7 @@ def main():
     # We check if there is no configuration server started as master
     # If you want to start a master CS you should use Configuration_Server.cfg and
     # use tornado-start-CS.py
-    key = f"/Systems/Configuration/{PathFinder.getSystemInstance('Configuration')}/Services/Server/Protocol"
+    key = f"/Systems/Configuration/Services/Server/Protocol"
     if gConfigurationData.isMaster() and gConfig.getValue(key, "dips").lower() == "https":
         gLogger.fatal("You can't run the CS and services in the same server!")
         sys.exit(0)

--- a/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
@@ -525,9 +525,8 @@ class ComponentSupervisionAgent(AgentModule):
 
         # get port used for https based services
         try:
-            tornadoSystemInstance = PathFinder.getSystemInstance(system="Tornado")
             self._tornadoPort = gConfig.getValue(
-                Path.cfgPath("/System/Tornado/", tornadoSystemInstance, "Port"),
+                Path.cfgPath("/System/Tornado/", "Port"),
                 self._tornadoPort,
             )
         except RuntimeError:

--- a/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
@@ -672,8 +672,8 @@ class TestComponentSupervisionAgent(unittest.TestCase):
         self.assertTrue(res["OK"])
         self.restartAgent.csAPI.modifyValue.assert_has_calls(
             [
-                call("/Systems/Sys/Production/URLs/Serv", ",".join(tempurls)),
-                call("/Systems/Sys/Production/URLs/Serv", ",".join(newurls)),
+                call("/Systems/Sys/URLs/Serv", ",".join(tempurls)),
+                call("/Systems/Sys/URLs/Serv", ",".join(newurls)),
             ],
             any_order=False,
         )

--- a/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
@@ -681,9 +681,6 @@ class TestComponentSupervisionAgent(unittest.TestCase):
         with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig", new=gConfigMock), patch(
             "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.socket.gethostname", return_value=host
         ), patch(
-            "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getSystemInstance",
-            return_value="Decertification",
-        ), patch(
             "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getComponentSection",
             side_effect=mockComponentSection,
         ), patch(
@@ -711,9 +708,6 @@ class TestComponentSupervisionAgent(unittest.TestCase):
 
         self.restartAgent.csAPI.commit = MagicMock(return_value=S_ERROR("Nope"))
         with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig", new=MagicMock()), patch(
-            "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getSystemInstance",
-            return_value="Decertification",
-        ), patch(
             "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getComponentSection",
             side_effect=mockComponentSection,
         ):
@@ -724,9 +718,6 @@ class TestComponentSupervisionAgent(unittest.TestCase):
 
         self.restartAgent.csAPI.commit = MagicMock(return_value=S_OK())
         with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig", new=MagicMock()), patch(
-            "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getSystemInstance",
-            return_value="Decertification",
-        ), patch(
             "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getComponentSection",
             side_effect=mockComponentSection,
         ):

--- a/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
@@ -22,19 +22,6 @@ def clientMock(ret):
     return clientModuleMock
 
 
-def mockComponentSection(*_args, **kwargs):
-    """Mock the PathFinder.getComponentSection to return individual componentSections."""
-    system = kwargs.get("system")
-    component = kwargs.get("component")
-    return f"/Systems/{system}/Production/Services/{component}"
-
-
-def mockURLSection(*_args, **kwargs):
-    """Mock the PathFinder.getSystemURLSection to return individual componentSections."""
-    system = kwargs.get("system")
-    return f"/Systems/{system}/Production/URLs/"
-
-
 class TestComponentSupervisionAgent(unittest.TestCase):
     """TestComponentSupervisionAgent class."""
 
@@ -680,12 +667,6 @@ class TestComponentSupervisionAgent(unittest.TestCase):
 
         with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig", new=gConfigMock), patch(
             "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.socket.gethostname", return_value=host
-        ), patch(
-            "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getComponentSection",
-            side_effect=mockComponentSection,
-        ), patch(
-            "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getSystemURLSection",
-            side_effect=mockURLSection,
         ):
             res = self.restartAgent.checkURLs()
         self.assertTrue(res["OK"])
@@ -707,20 +688,14 @@ class TestComponentSupervisionAgent(unittest.TestCase):
         self.restartAgent.sysAdminClient.getOverallStatus.return_value = S_OK(dict(Services={}))
 
         self.restartAgent.csAPI.commit = MagicMock(return_value=S_ERROR("Nope"))
-        with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig", new=MagicMock()), patch(
-            "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getComponentSection",
-            side_effect=mockComponentSection,
-        ):
+        with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig", new=MagicMock()):
             res = self.restartAgent.checkURLs()
         self.assertFalse(res["OK"])
         self.assertIn("Failed to commit", res["Message"])
         self.assertIn("Commit to CS failed", self.restartAgent.errors[0])
 
         self.restartAgent.csAPI.commit = MagicMock(return_value=S_OK())
-        with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig", new=MagicMock()), patch(
-            "DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.PathFinder.getComponentSection",
-            side_effect=mockComponentSection,
-        ):
+        with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.gConfig", new=MagicMock()):
             res = self.restartAgent.checkURLs()
         self.assertTrue(res["OK"])
 

--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -402,6 +402,9 @@ class ComponentInstaller:
         if extensions:
             centralCfg["DIRAC"].addKey("Extensions", ",".join(extensions), "")  # pylint: disable=no-member
 
+        # No Setups will be used
+        centralCfg["DIRAC"].addKey("NoSetup", "True", "")
+
         vo = self.localCfg.getOption(cfgInstallPath("VirtualOrganization"), "")
         if vo:
             centralCfg["DIRAC"].addKey("VirtualOrganization", vo, "")  # pylint: disable=no-member

--- a/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
+++ b/src/DIRAC/FrameworkSystem/Client/ComponentInstaller.py
@@ -403,7 +403,7 @@ class ComponentInstaller:
             centralCfg["DIRAC"].addKey("Extensions", ",".join(extensions), "")  # pylint: disable=no-member
 
         # No Setups will be used
-        centralCfg["DIRAC"].addKey("NoSetup", "True", "")
+        centralCfg["DIRAC"].addKey("NoSetup", "True", "")  # pylint: disable=no-member
 
         vo = self.localCfg.getOption(cfgInstallPath("VirtualOrganization"), "")
         if vo:

--- a/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -1100,44 +1100,6 @@ class SystemAdministratorClientCLI(CLI):
         else:
             gLogger.notice("Software reverted to", result["Value"])
 
-    def do_add(self, args):
-        """
-        Add new entity to the Configuration Service
-
-        usage:
-
-          add system <system> <instance>
-        """
-        if not args:
-            gLogger.notice(self.do_add.__doc__)
-            return
-
-        argss = args.split()
-        option = argss[0]
-        del argss[0]
-        if option == "instance" or option == "system":
-            system = argss[0]
-            instance = argss[1]
-            client = SystemAdministratorClient(self.host, self.port)
-            result = client.getInfo()
-            if not result["OK"]:
-                self._errMsg(result["Message"])
-            hostSetup = CSGlobals.getSetup()
-            instanceName = gConfig.getValue(f"/DIRAC/Setups/{hostSetup}/{system}", "")
-            if instanceName:
-                if instanceName == instance:
-                    gLogger.notice(f"System {system} already has instance {instance}")
-                else:
-                    self._errMsg(f"System {system} already has instance {instance}")
-                return
-            result = gComponentInstaller.addSystemInstance(system, instance, hostSetup)
-            if not result["OK"]:
-                self._errMsg(result["Message"])
-            else:
-                gLogger.notice(f"{system} system instance {instance} added successfully")
-        else:
-            gLogger.notice("Unknown option:", option)
-
     def do_exec(self, args):
         """
         Execute a shell command on the remote host and get back the output

--- a/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
+++ b/src/DIRAC/FrameworkSystem/Client/SystemAdministratorClientCLI.py
@@ -649,12 +649,6 @@ class SystemAdministratorClientCLI(CLI):
                 return
             system = result["Value"][database]["System"]
             dbType = result["Value"][database]["Type"]
-            setup = CSGlobals.getSetup()
-            instance = gConfig.getValue(f"/DIRAC/Setups/{setup}/{system}", "")
-            if not instance:
-                self._errMsg(f"No instance defined for system {system}")
-                self._errMsg(f"\tAdd new instance with 'add instance {system} <instance_name>'")
-                return
 
             if dbType == "MySQL":
                 if not gComponentInstaller.mysqlPassword:
@@ -1083,7 +1077,7 @@ class SystemAdministratorClientCLI(CLI):
         else:
             gLogger.notice("Software successfully updated.")
             gLogger.notice("You should restart the services to use the new software version.")
-            gLogger.notice("Think of updating /Operations/<vo>/<setup>/Pilot/Versions section in the CS")
+            gLogger.notice("Think of updating /Operations/<vo>/Pilot/Versions section in the CS")
 
     def do_revert(self, args):
         """

--- a/src/DIRAC/Interfaces/API/Dirac.py
+++ b/src/DIRAC/Interfaces/API/Dirac.py
@@ -29,7 +29,7 @@ from urllib.parse import unquote
 import DIRAC
 from DIRAC import S_ERROR, S_OK, gConfig
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
-from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURL, getSystemSection
+from DIRAC.ConfigurationSystem.Client.PathFinder import getServiceURL
 from DIRAC.Core.Base.API import API
 from DIRAC.Core.Base.Client import Client
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
@@ -1210,7 +1210,7 @@ class Dirac(API):
 
         Example Usage:
 
-        >>> print(dirac.getPhysicalFileMetadata('srm://srm.grid.sara.nl/pnfs/grid.sara.nl/data)
+        >>> print(dirac.getPhysicalFileMetadata('srm://srm.grid.sara.nl/pnfs/grid.sara.nl/data')
         /lhcb/data/CCRC08/RAW/LHCb/CCRC/23341/023341_0000039571.raw','NIKHEF-RAW')
         {'OK': True, 'Value': {'Successful': {'srm://...': {'SRM2': 'rfio://...'}}, 'Failed': {}}}
 
@@ -2207,7 +2207,7 @@ class Dirac(API):
         result = S_ERROR()
         try:
             if not url:
-                systemSection = getSystemSection(system + "/")
+                systemSection = f"/Systems/{system}"
                 self.log.verbose(f"System section is: {systemSection}")
                 section = f"{systemSection}/{service}"
                 self.log.verbose(f"Requested service should have CS path: {section}")

--- a/src/DIRAC/RequestManagementSystem/private/test/Test_RequestValidator.py
+++ b/src/DIRAC/RequestManagementSystem/private/test/Test_RequestValidator.py
@@ -32,7 +32,6 @@ def setup():
 
 def test_Validator(mocker, setup):
     """validator test"""
-    mocker.patch("DIRAC.ConfigurationSystem.Client.PathFinder.getSystemInstance", new=MagicMock())
 
     request = Request()
     operation = Operation()
@@ -117,7 +116,6 @@ def test_Validator(mocker, setup):
 
 def test_Validator_backward_compatibility(mocker, setup):
     """validator test"""
-    mocker.patch("DIRAC.ConfigurationSystem.Client.PathFinder.getSystemInstance", new=MagicMock())
 
     request = Request()
     operation = Operation()

--- a/src/DIRAC/TransformationSystem/test/Test_DRA.py
+++ b/src/DIRAC/TransformationSystem/test/Test_DRA.py
@@ -22,7 +22,6 @@ class TestDRA(unittest.TestCase):
     dra = None
 
     @patch("DIRAC.Core.Base.AgentModule.PathFinder", new=Mock())
-    @patch("DIRAC.ConfigurationSystem.Client.PathFinder.getSystemInstance", new=Mock())
     @patch(f"{MODULE_NAME}.ReqClient", new=Mock())
     def setUp(self):
         self.dra = DataRecoveryAgent(agentName="ILCTransformationSystem/DataRecoveryAgent", loadName="TestDRA")
@@ -66,7 +65,6 @@ class TestDRA(unittest.TestCase):
         return testJob
 
     @patch("DIRAC.Core.Base.AgentModule.PathFinder", new=Mock())
-    @patch("DIRAC.ConfigurationSystem.Client.PathFinder.getSystemInstance", new=Mock())
     @patch(f"{MODULE_NAME}.ReqClient", new=Mock())
     def test_init(self):
         """test for DataRecoveryAgent initialisation...................................................."""

--- a/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -15,7 +15,6 @@ from DIRAC import S_ERROR, S_OK, gConfig
 from DIRAC.AccountingSystem.Client.Types.Job import Job
 from DIRAC.ConfigurationSystem.Client.Helpers import cfgPath
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getDNForUsername
-from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemInstance
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
@@ -60,9 +59,6 @@ class StalledJobAgent(AgentModule):
         if not self.am_getOption("Enable", True):
             self.log.info("Stalled Job Agent running in disabled mode")
 
-        wmsInstance = getSystemInstance("WorkloadManagement")
-        if not wmsInstance:
-            return S_ERROR("Can not get the WorkloadManagement system instance")
         self.stalledJobsTolerantSites = self.am_getOption("StalledJobsTolerantSites", self.stalledJobsTolerantSites)
         self.stalledJobsToleranceTime = self.am_getOption("StalledJobsToleranceTime", self.stalledJobsToleranceTime)
 
@@ -74,7 +70,7 @@ class StalledJobAgent(AgentModule):
         self.matchedTime = self.am_getOption("MatchedTime", self.matchedTime)
         self.rescheduledTime = self.am_getOption("RescheduledTime", self.rescheduledTime)
 
-        wrapperSection = cfgPath("Systems", "WorkloadManagement", wmsInstance, "JobWrapper")
+        wrapperSection = cfgPath("Systems", "WorkloadManagement", "JobWrapper")
 
         failedTime = self.am_getOption("FailedTimeHours", 6)
         watchdogCycle = gConfig.getValue(cfgPath(wrapperSection, "CheckingTime"), 30 * 60)

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_PushJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_PushJobAgent.py
@@ -186,7 +186,6 @@ def test_submitJobWrapper(mocker, jobID):
         side_effect=lambda x, y=None: y,
         create=True,
     )
-    mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", return_value="Value")
 
     # Initialize PJA
     jobAgent = PushJobAgent("Test", "Test1")

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
@@ -25,12 +25,10 @@ def sja(mocker):
     )
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobDB")
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobLoggingDB")
-    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getSystemInstance", side_effect=mockNone)
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobMonitoringClient", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobManagerClient", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.PilotManagerClient", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.WMSClient", return_value=MagicMock())
-    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getSystemInstance", return_value="/bof/bih")
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getDNForUsername", return_value=MagicMock())
 
     stalledJobAgent = StalledJobAgent()

--- a/src/DIRAC/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -6,7 +6,6 @@ import random
 import tempfile
 
 from DIRAC import S_ERROR, S_OK, gConfig, gLogger
-from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemSection
 from DIRAC.Core.Utilities.Os import getDiskSpace
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
@@ -229,7 +228,7 @@ class DownloadInputData:
         diskSpace = getDiskSpace(self.__getDownloadDir(False))  # MB
         availableBytes = diskSpace * 1024 * 1024  # bytes
         bufferGBs = gConfig.getValue(
-            os.path.join(getSystemSection("WorkloadManagement/JobWrapper"), "JobWrapper", "MinOutputDataBufferGB"), 5.0
+            os.path.join("/Systems/WorkloadManagement/JobWrapper", "JobWrapper", "MinOutputDataBufferGB"), 5.0
         )
         data = bufferGBs * 1024 * 1024 * 1024  # bufferGBs in bytes
         if (data + totalSize) < availableBytes:

--- a/src/DIRAC/WorkloadManagementSystem/Client/test/Test_Client_DownloadInputData.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/test/Test_Client_DownloadInputData.py
@@ -114,7 +114,6 @@ def test_DLIDownloadFromBestSE_Fail(dli, mockSE, osPathExists):
 
 
 def test_DLI_execute(mocker, dli, mockSE):
-    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.getSystemSection", return_value="pippo")
     mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
     dli._downloadFromSE = MagicMock(return_value=S_OK({"path": "/local/path/1.txt"}))
     res = dli.execute(dataToResolve=["/a/lfn/1.txt"])
@@ -125,7 +124,6 @@ def test_DLI_execute(mocker, dli, mockSE):
 
 def test_DLI_execute_getFileMetadata_Fails(mocker, dli, mockSE):
     """When getFileMetadata fails for the first SE, we should fall back to the second."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.getSystemSection", return_value="pippo")
     mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
     mockObjectSE = mockSE.return_value
     mockObjectSE.getFileMetadata.return_value = S_OK(
@@ -143,7 +141,6 @@ def test_DLI_execute_getFileMetadata_Fails(mocker, dli, mockSE):
 
 def test_DLI_execute_getFileMetadata_Lost(mocker, dli, mockSE):
     """When getFileMetadata fails for the first SE, we should fall back to the second."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.getSystemSection", return_value="pippo")
     mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
     mockObjectSE = mockSE.return_value
     mockObjectSE.getFileMetadata.return_value = S_OK(
@@ -169,7 +166,6 @@ def test_DLI_execute_getFileMetadata_Lost(mocker, dli, mockSE):
 
 def test_DLI_execute_getFileMetadata_Unavailable(mocker, dli, mockSE):
     """When getFileMetadata fails for the first SE, we should fall back to the second."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.getSystemSection", return_value="pippo")
     mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
     mockObjectSE = mockSE.return_value
     mockObjectSE.getFileMetadata.return_value = S_OK(
@@ -195,7 +191,6 @@ def test_DLI_execute_getFileMetadata_Unavailable(mocker, dli, mockSE):
 
 def test_DLI_execute_getFileMetadata_Cached(mocker, dli, mockSE):
     """When getFileMetadata fails for the first SE, we should fall back to the second."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.getSystemSection", return_value="pippo")
     mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
     mockObjectSE = mockSE.return_value
     mockObjectSE.getFileMetadata.return_value = S_OK(
@@ -221,7 +216,6 @@ def test_DLI_execute_getFileMetadata_Cached(mocker, dli, mockSE):
 
 def test_DLI_execute_FirstDownFailed(mocker, dli, mockSE):
     """When getFileMetadata fails for the first SE, we should fall back to the second."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.getSystemSection", return_value="pippo")
     mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
     mockObjectSE = mockSE.return_value
     mockObjectSE.getFileMetadata.return_value = S_OK(
@@ -238,7 +232,6 @@ def test_DLI_execute_FirstDownFailed(mocker, dli, mockSE):
 
 def test_DLI_execute_AllDownFailed(mocker, dli, mockSE):
     """When getFileMetadata fails for the first SE, we should fall back to the second."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.getSystemSection", return_value="pippo")
     mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
     mockObjectSE = mockSE.return_value
     mockObjectSE.getFileMetadata.return_value = S_OK(
@@ -255,7 +248,6 @@ def test_DLI_execute_AllDownFailed(mocker, dli, mockSE):
 
 def test_DLI_execute_NoLocal(mocker, dli, mockSE):
     """Data only at the remote SE."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.getSystemSection", return_value="pippo")
     mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
     dli = DownloadInputData(
         {

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -31,7 +31,6 @@ from DIRAC.AccountingSystem.Client.Types.Job import Job as AccountingJob
 
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getVOForGroup
-from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemSection
 from DIRAC.Core.Utilities import DEncode, DErrno, List
 from DIRAC.Core.Utilities.Adler import fileAdler
 from DIRAC.Core.Utilities.File import getGlobbedFiles, getGlobbedTotalSize
@@ -63,7 +62,7 @@ class JobWrapper:
     def __init__(self, jobID: int | None = None, jobReport: JobReport | None = None):
         """Standard constructor"""
         self.initialTiming = os.times()
-        self.section = os.path.join(getSystemSection("WorkloadManagement/JobWrapper"), "JobWrapper")
+        self.section = "/Systems/WorkloadManagement/JobWrapper"
         # Create the accounting report
         self.accountingReport = AccountingJob()
         # Initialize for accounting

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -25,7 +25,6 @@ import psutil
 
 from DIRAC import S_ERROR, S_OK, gLogger
 from DIRAC.ConfigurationSystem.Client.Config import gConfig
-from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemInstance
 from DIRAC.Core.Utilities.Os import getDiskSpace
 from DIRAC.Core.Utilities.Profiler import Profiler
 from DIRAC.Resources.Computing.BatchSystems.TimeLeft.TimeLeft import TimeLeft
@@ -124,10 +123,7 @@ class Watchdog:
         else:
             self.initialized = True
 
-        wms_instance = getSystemInstance("WorkloadManagement")
-        if not wms_instance:
-            return S_ERROR("Can not get the WorkloadManagement system instance")
-        self.section = f"/Systems/WorkloadManagement/{wms_instance}/JobWrapper"
+        self.section = f"/Systems/WorkloadManagement/JobWrapper"
 
         self.log.verbose("Watchdog initialization")
         # Test control flags

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -19,8 +19,6 @@ from DIRAC.WorkloadManagementSystem.Client import JobMinorStatus, JobStatus
 from DIRAC.WorkloadManagementSystem.JobWrapper.JobExecutionCoordinator import JobExecutionCoordinator
 from DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper import JobWrapper
 
-getSystemSectionMock = MagicMock()
-getSystemSectionMock.return_value = "aValue"
 
 gLogger.setLevel("DEBUG")
 
@@ -30,9 +28,6 @@ gLogger.setLevel("DEBUG")
 @pytest.fixture
 def setup_job_wrapper(mocker):
     """Fixture to create a JobWrapper instance with a JobExecutionCoordinator."""
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
 
     def _setup(jobArgs=None, ceArgs=None):
         jw = JobWrapper()
@@ -196,10 +191,6 @@ def test_preProcess_dirac_jobexec_with_args(setup_job_wrapper):
 @pytest.mark.slow
 def test_processSuccessfulCommand(mocker):
     """Test the process method of the JobWrapper class: most common scenario."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemInstance", return_value="Value")
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
     jw = JobWrapper()
     jw.jobArgs = {"CPUTime": 100, "Memory": 1}
 
@@ -227,10 +218,6 @@ def test_processSuccessfulCommand(mocker):
 @pytest.mark.slow
 def test_processSuccessfulDiracJobExec(mocker):
     """Test the process method of the JobWrapper class: most common scenario with dirac-jobexec."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemInstance", return_value="Value")
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
     jw = JobWrapper()
     jw.jobArgs = {"CPUTime": 100, "Memory": 1}
 
@@ -255,10 +242,6 @@ def test_processSuccessfulDiracJobExec(mocker):
 @pytest.mark.slow
 def test_processFailedCommand(mocker):
     """Test the process method of the JobWrapper class: the command fails."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemInstance", return_value="Value")
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
     jw = JobWrapper()
     jw.jobArgs = {"CPUTime": 100, "Memory": 1}
 
@@ -289,10 +272,6 @@ def test_processFailedCommand(mocker):
 @pytest.mark.slow
 def test_processFailedSubprocess(mocker):
     """Test the process method of the JobWrapper class: the subprocess fails."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemInstance", return_value="Value")
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
     mock_system_call = mocker.patch("DIRAC.Core.Utilities.Subprocess.Subprocess.systemCall")
     mock_system_call.return_value = S_ERROR("Any problem")
     mock_system_call = mocker.patch("DIRAC.Core.Utilities.Subprocess.Subprocess.getChildPID")
@@ -321,10 +300,6 @@ def test_processFailedSubprocess(mocker):
 @pytest.mark.slow
 def test_processQuickExecutionNoWatchdog(mocker):
     """Test the process method of the JobWrapper class: the payload is too fast to start the watchdog."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemInstance", return_value="Value")
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
     jw = JobWrapper()
     jw.jobArgs = {"CPUTime": 100, "Memory": 1}
 
@@ -348,10 +323,6 @@ def test_processQuickExecutionNoWatchdog(mocker):
 @pytest.mark.slow
 def test_processSubprocessFailureNoPid(mocker):
     """Test the process method of the JobWrapper class: the subprocess fails and no PID is returned."""
-    mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemInstance", return_value="Value")
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
     # Test failure in starting the payload process
     jw = JobWrapper()
     jw.jobArgs = {}
@@ -612,10 +583,6 @@ def test_execute(mocker, executable, args, src, expectedResult):
     """Test the status of the job after JobWrapper.execute().
     The returned value of JobWrapper.execute() is not checked as it can apparently be wrong depending on the shell used.
     """
-    mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.getSystemInstance", return_value="Value")
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
 
     if src:
         shutil.copy(os.path.join(src, executable), executable)
@@ -684,9 +651,6 @@ def jobIDPath():
 @pytest.fixture
 def setup_another_job_wrapper(mocker, jobIDPath):
     """Fixture to create a JobWrapper instance with the jobIDPath."""
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
     jw = JobWrapper(jobIDPath)
     jw.jobIDPath = Path(str(jobIDPath))
     jw.failedFlag = False
@@ -887,9 +851,6 @@ def test_processJobOutputs_output_data_upload(mocker, setup_another_job_wrapper)
 
 def test_resolveInputData(mocker):
     mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.ObjectLoader", side_effect=MagicMock())
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
 
     jw = JobWrapper()
     jw.jobArgs["InputData"] = ""
@@ -975,9 +936,6 @@ def test_transferInputSandbox(mocker, setup_another_job_wrapper):
 )
 def test_finalize(mocker, failedFlag, expectedRes, finalStates):
     mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.ObjectLoader", side_effect=MagicMock())
-    mocker.patch(
-        "DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapper.getSystemSection", side_effect=getSystemSectionMock
-    )
 
     jw = JobWrapper()
     jw.jobArgs = {"Executable": "/bin/ls"}

--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       interval: 5s
       timeout: 2s
       retries: 15
-      start_period: 60s
+      start_period: 150s
     pull_policy: always
 
   iam-login-service:

--- a/tests/Jenkins/dirac-cfg-update-dbs.py
+++ b/tests/Jenkins/dirac-cfg-update-dbs.py
@@ -42,10 +42,9 @@ csAPI = CSAPI()
 
 for sct in [
     "Systems/DataManagement",
-    "Systems/DataManagement/Production",
-    "Systems/DataManagement/Production/Databases",
-    "Systems/DataManagement/Production/Databases/FileCatalogDB",
-    "Systems/DataManagement/Production/Databases/MultiVOFileCatalogDB",
+    "Systems/DataManagement/Databases",
+    "Systems/DataManagement/Databases/FileCatalogDB",
+    "Systems/DataManagement/Databases/MultiVOFileCatalogDB",
 ]:
     res = csAPI.createSection(sct)
     if not res["OK"]:
@@ -55,13 +54,13 @@ for sct in [
 dbHost = os.environ["DB_HOST"]
 dbPort = os.environ["DB_PORT"]
 
-csAPI.setOption("Systems/DataManagement/Production/Databases/FileCatalogDB/DBName", "FileCatalogDB")
-csAPI.setOption("Systems/DataManagement/Production/Databases/FileCatalogDB/Host", dbHost)
-csAPI.setOption("Systems/DataManagement/Production/Databases/FileCatalogDB/Port", dbPort)
+csAPI.setOption("Systems/DataManagement/Databases/FileCatalogDB/DBName", "FileCatalogDB")
+csAPI.setOption("Systems/DataManagement/Databases/FileCatalogDB/Host", dbHost)
+csAPI.setOption("Systems/DataManagement/Databases/FileCatalogDB/Port", dbPort)
 
-csAPI.setOption("Systems/DataManagement/Production/Databases/MultiVOFileCatalogDB/DBName", "MultiVOFileCatalogDB")
-csAPI.setOption("Systems/DataManagement/Production/Databases/MultiVOFileCatalogDB/Host", dbHost)
-csAPI.setOption("Systems/DataManagement/Production/Databases/MultiVOFileCatalogDB/Port", dbPort)
+csAPI.setOption("Systems/DataManagement/Databases/MultiVOFileCatalogDB/DBName", "MultiVOFileCatalogDB")
+csAPI.setOption("Systems/DataManagement/Databases/MultiVOFileCatalogDB/Host", dbHost)
+csAPI.setOption("Systems/DataManagement/Databases/MultiVOFileCatalogDB/Port", dbPort)
 
 # Setup other DBs (this is for LHCb - innocuous!)
 #
@@ -84,19 +83,18 @@ csAPI.setOption("Systems/DataManagement/Production/Databases/MultiVOFileCatalogD
 
 for sct in [
     "Systems/Bookkeeping",
-    "Systems/Bookkeeping/Production",
-    "Systems/Bookkeeping/Production/Databases",
-    "Systems/Bookkeeping/Production/Databases/BookkeepingDB",
+    "Systems/Bookkeeping/Databases",
+    "Systems/Bookkeeping/Databases/BookkeepingDB",
 ]:
     res = csAPI.createSection(sct)
     if not res["OK"]:
         print(res["Message"])
         exit(1)
 
-csAPI.setOption("Systems/Bookkeeping/Production/Databases/BookkeepingDB/LHCbDIRACBookkeepingTNS", "FILL_ME")
-csAPI.setOption("Systems/Bookkeeping/Production/Databases/BookkeepingDB/LHCbDIRACBookkeepingUser", "FILL_ME")
-csAPI.setOption("Systems/Bookkeeping/Production/Databases/BookkeepingDB/LHCbDIRACBookkeepingPassword", "FILL_ME")
-csAPI.setOption("Systems/Bookkeeping/Production/Databases/BookkeepingDB/LHCbDIRACBookkeepingServer", "FILL_ME")
+csAPI.setOption("Systems/Bookkeeping/Databases/BookkeepingDB/LHCbDIRACBookkeepingTNS", "FILL_ME")
+csAPI.setOption("Systems/Bookkeeping/Databases/BookkeepingDB/LHCbDIRACBookkeepingUser", "FILL_ME")
+csAPI.setOption("Systems/Bookkeeping/Databases/BookkeepingDB/LHCbDIRACBookkeepingPassword", "FILL_ME")
+csAPI.setOption("Systems/Bookkeeping/Databases/BookkeepingDB/LHCbDIRACBookkeepingServer", "FILL_ME")
 
 # Commit
 csAPI.commit()

--- a/tests/Jenkins/dirac-cfg-update-server.py
+++ b/tests/Jenkins/dirac-cfg-update-server.py
@@ -23,10 +23,10 @@ from DIRAC.ConfigurationSystem.Client.CSAPI import CSAPI
 
 csAPI = CSAPI()
 
-csAPI.setOption("Systems/WorkloadManagement/Production/Services/SandboxStore/BasePath", f"{setupName}/sandboxes")
-csAPI.setOption("Systems/WorkloadManagement/Production/Services/SandboxStore/LogLevel", "DEBUG")
-csAPI.setOption("Systems/WorkloadManagement/Production/Services/TornadoSandboxStore/BasePath", f"{setupName}/sandboxes")
-csAPI.setOption("Systems/WorkloadManagement/Production/Services/TornadoSandboxStore/LogLevel", "DEBUG")
+csAPI.setOption("Systems/WorkloadManagement/Services/SandboxStore/BasePath", f"{setupName}/sandboxes")
+csAPI.setOption("Systems/WorkloadManagement/Services/SandboxStore/LogLevel", "DEBUG")
+csAPI.setOption("Systems/WorkloadManagement/Services/TornadoSandboxStore/BasePath", f"{setupName}/sandboxes")
+csAPI.setOption("Systems/WorkloadManagement/Services/TornadoSandboxStore/LogLevel", "DEBUG")
 
 # Now setting a SandboxSE as the following:
 #     ProductionSandboxSE
@@ -552,9 +552,9 @@ csAPI.setOption(
     "TrustedHost,CSAdministrator,JobAdministrator,FullDelegation,ProxyManagement,Operator,ProductionManagement,GenericPilot",
 )
 
-# Setting Systems/WorkloadManagement/Production/Executors/Optimizers/JobScheduling/RescheduleDelays
+# Setting Systems/WorkloadManagement/Executors/Optimizers/JobScheduling/RescheduleDelays
 # to avoid having to wait while testing rescheduling
-csAPI.setOption("Systems/WorkloadManagement/Production/Executors/Optimizers/JobScheduling/RescheduleDelays", "0")
+csAPI.setOption("Systems/WorkloadManagement/Executors/Optimizers/JobScheduling/RescheduleDelays", "0")
 
 csAPI.createSection("Systems/WorkloadManagement/Production/JobWrapper/")
 csAPI.setOption("Systems/WorkloadManagement/Production/JobWrapper/MinOutputDataBufferGB", 1)

--- a/tests/Jenkins/dirac-cfg-update-services.py
+++ b/tests/Jenkins/dirac-cfg-update-services.py
@@ -59,33 +59,31 @@ if os.environ.get("TEST_HTTPS", "Yes") == "Yes":
     multiFC = f"Tornado{multiFC}"
 
 for sct in [
-    "Systems/DataManagement/Production/Services",
-    f"Systems/DataManagement/Production/Services/{fc}",
-    f"Systems/DataManagement/Production/Services/{multiFC}",
+    "Systems/DataManagement/Services",
+    f"Systems/DataManagement/Services/{fc}",
+    f"Systems/DataManagement/Services/{multiFC}",
 ]:
     res = csAPI.createSection(sct)
     if not res["OK"]:
         print(res["Message"])
         sys.exit(1)
 
-csAPI.setOption(f"Systems/DataManagement/Production/Services/{fc}/DirectoryManager", "DirectoryClosure")
-csAPI.setOption(f"Systems/DataManagement/Production/Services/{fc}/FileManager", "FileManagerPs")
-csAPI.setOption(f"Systems/DataManagement/Production/Services/{fc}/SecurityManager", "VOMSSecurityManager")
-csAPI.setOption(f"Systems/DataManagement/Production/Services/{fc}/UniqueGUID", True)
+csAPI.setOption(f"Systems/DataManagement/Services/{fc}/DirectoryManager", "DirectoryClosure")
+csAPI.setOption(f"Systems/DataManagement/Services/{fc}/FileManager", "FileManagerPs")
+csAPI.setOption(f"Systems/DataManagement/Services/{fc}/SecurityManager", "VOMSSecurityManager")
+csAPI.setOption(f"Systems/DataManagement/Services/{fc}/UniqueGUID", True)
 
-csAPI.setOption(f"Systems/DataManagement/Production/Services/{multiFC}/DirectoryManager", "DirectoryClosure")
-csAPI.setOption(f"Systems/DataManagement/Production/Services/{multiFC}/FileManager", "FileManagerPs")
-csAPI.setOption(f"Systems/DataManagement/Production/Services/{multiFC}/SecurityManager", "NoSecurityManager")
-csAPI.setOption(f"Systems/DataManagement/Production/Services/{multiFC}/UniqueGUID", True)
+csAPI.setOption(f"Systems/DataManagement/Services/{multiFC}/DirectoryManager", "DirectoryClosure")
+csAPI.setOption(f"Systems/DataManagement/Services/{multiFC}/FileManager", "FileManagerPs")
+csAPI.setOption(f"Systems/DataManagement/Services/{multiFC}/SecurityManager", "NoSecurityManager")
+csAPI.setOption(f"Systems/DataManagement/Services/{multiFC}/UniqueGUID", True)
 # configure MultiVO metadata related options:
-res = csAPI.setOption(f"Systems/DataManagement/Production/Services/{multiFC}/FileMetadata", "MultiVOFileMetadata")
+res = csAPI.setOption(f"Systems/DataManagement/Services/{multiFC}/FileMetadata", "MultiVOFileMetadata")
 if not res["OK"]:
     print(res["Message"])
     sys.exit(1)
 
-res = csAPI.setOption(
-    f"Systems/DataManagement/Production/Services/{multiFC}/DirectoryMetadata", "MultiVODirectoryMetadata"
-)
+res = csAPI.setOption(f"Systems/DataManagement/Services/{multiFC}/DirectoryMetadata", "MultiVODirectoryMetadata")
 if not res["OK"]:
     print(res["Message"])
     sys.exit(1)


### PR DESCRIPTION
  This PR removes the concept of system instances. The corresponding configuration options and sections are removed. 

  Requires #7186

BEGINRELEASENOTES

NEW: Remove the use of Setup and System Instances from the configuration and code

ENDRELEASENOTES
