### PR TITLE
[int] StorageBase: Fix typo  in docstring

### DIFF
--- a/src/DIRAC/Resources/Storage/StorageBase.py
+++ b/src/DIRAC/Resources/Storage/StorageBase.py
@@ -324,7 +324,7 @@ class StorageBase:
 
     def constructURLFromLFN(self, lfn, withWSUrl=False):
         """Construct URL from the given LFN according to the VO convention for the
-        primary protocol of the storage plagin
+        primary protocol of the storage plugin
 
         :param str lfn: file LFN
         :param boolean withWSUrl: flag to include the web service part into the resulting URL


### PR DESCRIPTION
BEGINRELEASENOTES
*Resources
FIX: StorageBase.constructURLFromLFN: Fix a typo in the docstring
ENDRELEASENOTES
