### PR TITLE
[8.0] HTCondorCE: fix HOME for useSSL

### DIFF
--- a/src/DIRAC/Core/Security/Locations.py
+++ b/src/DIRAC/Core/Security/Locations.py
@@ -140,9 +140,9 @@ def getCertificateAndKeyLocation():
     if "X509_USER_CERT" in os.environ:
         if os.path.exists(os.environ["X509_USER_CERT"]):
             certfile = os.environ["X509_USER_CERT"]
-    if not certfile:
-        if os.path.exists(os.environ["HOME"] + "/.globus/usercert.pem"):
-            certfile = os.environ["HOME"] + "/.globus/usercert.pem"
+    if not certfile and (home := os.environ.get("HOME")):
+        if os.path.exists(home + "/.globus/usercert.pem"):
+            certfile = home + "/.globus/usercert.pem"
 
     if not certfile:
         return False
@@ -151,9 +151,9 @@ def getCertificateAndKeyLocation():
     if "X509_USER_KEY" in os.environ:
         if os.path.exists(os.environ["X509_USER_KEY"]):
             keyfile = os.environ["X509_USER_KEY"]
-    if not keyfile:
-        if os.path.exists(os.environ["HOME"] + "/.globus/userkey.pem"):
-            keyfile = os.environ["HOME"] + "/.globus/userkey.pem"
+    if not keyfile and (home := os.environ.get("HOME")):
+        if os.path.exists(home + "/.globus/userkey.pem"):
+            keyfile = home + "/.globus/userkey.pem"
 
     if not keyfile:
         return False


### PR DESCRIPTION

I managed to run some jobs at CERN with the UseSSLSubmission and the help of the CERN batch people.
But the two processes I checked don't have HOME in their environ on the dirac servers, mine or lbcertifdirac. So I propose to fix the location of the files here.

BEGINRELEASENOTES
*Resources
FIX: HTCondorCE: fix exception when UseSSLSubmission is true. The SiteDirector environment does not have HOME. Always use /home/dirac/.globus to get userkey and usercert files.
*Core
FIX: Locations.getCertificateAndKeyLocation: fix exception when HOME is not set.

ENDRELEASENOTES
