### PR TITLE
[sweep:integration] HTCondorCE: fix HOME for useSSL

### DIFF
--- a/src/DIRAC/Core/Security/Locations.py
+++ b/src/DIRAC/Core/Security/Locations.py
@@ -150,9 +150,9 @@ def getCertificateAndKeyLocation():
     if "X509_USER_CERT" in os.environ:
         if os.path.exists(os.environ["X509_USER_CERT"]):
             certfile = os.environ["X509_USER_CERT"]
-    if not certfile:
-        if os.path.exists(os.environ["HOME"] + "/.globus/usercert.pem"):
-            certfile = os.environ["HOME"] + "/.globus/usercert.pem"
+    if not certfile and (home := os.environ.get("HOME")):
+        if os.path.exists(home + "/.globus/usercert.pem"):
+            certfile = home + "/.globus/usercert.pem"
 
     if not certfile:
         return False
@@ -161,9 +161,9 @@ def getCertificateAndKeyLocation():
     if "X509_USER_KEY" in os.environ:
         if os.path.exists(os.environ["X509_USER_KEY"]):
             keyfile = os.environ["X509_USER_KEY"]
-    if not keyfile:
-        if os.path.exists(os.environ["HOME"] + "/.globus/userkey.pem"):
-            keyfile = os.environ["HOME"] + "/.globus/userkey.pem"
+    if not keyfile and (home := os.environ.get("HOME")):
+        if os.path.exists(home + "/.globus/userkey.pem"):
+            keyfile = home + "/.globus/userkey.pem"
 
     if not keyfile:
         return False

--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -58,7 +58,7 @@ import threading
 import uuid
 
 from DIRAC import S_ERROR, S_OK, gConfig
-from DIRAC.Core.Security.Locations import getCAsLocation, getCertificateAndKeyLocation
+from DIRAC.Core.Security.Locations import getCAsLocation
 from DIRAC.Core.Utilities.File import mkDir
 from DIRAC.Core.Utilities.List import breakListIntoChunks
 from DIRAC.Core.Utilities.Subprocess import systemCall
@@ -247,14 +247,18 @@ class HTCondorCEComputingElement(ComputingElement):
         }
 
         if self.useSSLSubmission:
-            if not (certAndKey := getCertificateAndKeyLocation()):
-                return S_ERROR("You want to use SSL Submission, but no certificate and key are present")
+            certFile = "/home/dirac/.globus/usercert.pem"
+            keyFile = "/home/dirac/.globus/userkey.pem"
+            if not (os.path.exists(certFile) and os.path.exists(keyFile)):
+                return S_ERROR(
+                    "You want to use SSL Submission, but certificate and key are not present in /home/dirac/.globus/"
+                )
             if not (caFiles := getCAsLocation()):
                 return S_ERROR("You want to use SSL Submission, but no CA files are present")
             htcEnv = {
                 "_condor_SEC_CLIENT_AUTHENTICATION_METHODS": "SSL",
-                "_condor_AUTH_SSL_CLIENT_CERTFILE": certAndKey[0],
-                "_condor_AUTH_SSL_CLIENT_KEYFILE": certAndKey[1],
+                "_condor_AUTH_SSL_CLIENT_CERTFILE": certFile,
+                "_condor_AUTH_SSL_CLIENT_KEYFILE": keyFile,
                 "_condor_AUTH_SSL_CLIENT_CADIR": caFiles,
                 "_condor_AUTH_SSL_SERVER_CADIR": caFiles,
                 "_condor_AUTH_SSL_USE_CLIENT_PROXY_ENV_VAR": "false",


### PR DESCRIPTION
Sweep #7675 `HTCondorCE: fix HOME for useSSL` to `integration`.

Adding original author @andresailer as watcher.

BEGINRELEASENOTES
*Resources
FIX: HTCondorCE: fix exception when UseSSLSubmission is true. The SiteDirector environment does not have HOME. Always use /home/dirac/.globus to get userkey and usercert files.
*Core
FIX: Locations.getCertificateAndKeyLocation: fix exception when HOME is not set.

ENDRELEASENOTES
Closes #7676'