### PR TITLE
[8.0] Transformation InputDataAgent with MultiVOMetadata

### DIFF
--- a/src/DIRAC/TransformationSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/TransformationSystem/ConfigTemplate.cfg
@@ -25,6 +25,8 @@ Agents
     PollingTime = 120
     FullUpdatePeriod = 86400
     RefreshOnly = False
+    # If True, query the FileCatalog as the owner of the transformation, needed for MultiVO*MetaData filecatalogs
+    MultiVO = False
   }
   ##END
   ##BEGIN MCExtensionAgent


### PR DESCRIPTION

This is needed for MultiVO*Metadata file catalog configurations

BEGINRELEASENOTES

*TS
NEW: InputDataAgent: new Option MultiVO, which makes the FileCatalog Query use the author of the DN, rather than the Host, to resolve MultiVO metadata correctly. Fixes #7681 

ENDRELEASENOTES

@marianne013 Please test? But mind the other issue with dirac-dms-find-lfns and metadata that might cause way too many files to be found?
