### PR TITLE
[8.0] better place to document token toggle

### DIFF
--- a/src/DIRAC/Resources/Computing/ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ComputingElement.py
@@ -30,6 +30,12 @@
         (the submission of a job is blocking the execution until its completion). It deals with one job at a time.
       - Inner Pool ComputingElement: includes methods to locally interact with Inner ComputingElements asynchronously.
         It can manage a pool of jobs running simultaneously.
+
+     To configure the use of Tokens for CEs:
+
+     * the CE is able to receive any token. Validation: 'Tag = Token' should be included in the CE parameters.
+     * the CE is able to receive VO-specifc tokens. Validation: 'Tag = Token:<VO>' should be included in the CE parameters.
+
 """
 
 import os

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -469,11 +469,7 @@ class SiteDirector(AgentModule):
         return S_OK()
 
     def __supportToken(self, ce: ComputingElement) -> bool:
-        """Check whether the SiteDirector is able to submit pilots with tokens.
-
-        * the CE is able to receive any token. Validation: Tag = Token should be included in the CE parameters.
-        * the CE is able to receive VO-specifc tokens. Validation: Tag = Token:<VO> should be included in the CE parameters.
-        """
+        """Check whether the SiteDirector is able to submit pilots with tokens."""
         return "Token" in ce.ceParameters.get("Tag", []) or f"Token:{self.vo}" in ce.ceParameters.get("Tag", [])
 
     def __getPilotToken(self, audience: str, scope: list[str] = None):


### PR DESCRIPTION

BEGINRELEASENOTES

*Doc
FIX: Move the explanation how to enable tokens to a place that is shown in ReadTheDocs in the end.


ENDRELEASENOTES
