### PR TITLE
[8.0] Proper handling of waiting jobs when set to be killed

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobStatus.py
@@ -6,6 +6,8 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.StateMachine import State, StateMachine
 from DIRAC.Core.Utilities.Decorators import deprecated
 
+from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
+
 
 #:
 SUBMITTING = "Submitting"
@@ -129,7 +131,7 @@ def checkJobStateTransition(jobID, candidateState, currentStatus=None, jobMonito
     return S_OK()
 
 
-def filterJobStateTransition(jobIDs, candidateState, jobMonitoringClient=None):
+def filterJobStateTransition(jobIDs, candidateState):
     """Given a list of jobIDs, return a list that are allowed to transition
     to the given candidate state.
     """
@@ -138,12 +140,7 @@ def filterJobStateTransition(jobIDs, candidateState, jobMonitoringClient=None):
     if not isinstance(jobIDs, list):
         jobIDs = [jobIDs]
 
-    if not jobMonitoringClient:
-        from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
-
-        jobMonitoringClient = JobMonitoringClient()
-
-    res = jobMonitoringClient.getJobsStatus(jobIDs)
+    res = JobMonitoringClient().getJobsStatus(jobIDs)
     if not res["OK"]:
         return res
 

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -512,16 +512,16 @@ class JobManagerHandlerMixin:
             deleteJobList = []
             # Get the jobs allowed to transition to the Killed state
             filterRes = JobStatus.filterJobStateTransition(validJobList, JobStatus.KILLED)
-            if not filterRes['OK']:
+            if not filterRes["OK"]:
                 return filterRes
-            killJobList.extend(filterRes['Value'])
+            killJobList.extend(filterRes["Value"])
 
             if not right == RIGHT_KILL:
                 # Get the jobs allowed to transition to the Deleted state
                 filterRes = JobStatus.filterJobStateTransition(validJobList, JobStatus.DELETED)
-                if not filterRes['OK']:
+                if not filterRes["OK"]:
                     return filterRes
-                deleteJobList.extend(filterRes['Value'])
+                deleteJobList.extend(filterRes["Value"])
 
             # Look for jobs that are in the Staging state to send kill signal to the stager
             result = self.jobDB.getJobsAttributes(killJobList, ["Status"])

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -531,8 +531,8 @@ class JobManagerHandlerMixin:
                 ):
                     if not right == RIGHT_KILL:
                         deleteJobList.append(jobID)
-                else:
-                    markKilledJobList.append(jobID)
+                    else:
+                        markKilledJobList.append(jobID)
                 if sDict["Status"] in [JobStatus.STAGING]:
                     stagingJobList.append(jobID)
 

--- a/src/DIRAC/WorkloadManagementSystem/Service/tests/Test_JobManager.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/tests/Test_JobManager.py
@@ -1,0 +1,58 @@
+""" unit test (pytest) of JobManager service
+"""
+
+from unittest.mock import MagicMock
+import pytest
+
+from DIRAC import gLogger
+
+gLogger.setLevel("DEBUG")
+
+from DIRAC.WorkloadManagementSystem.Service.JobPolicy import (
+    RIGHT_DELETE,
+    RIGHT_KILL,
+)
+
+# sut
+from DIRAC.WorkloadManagementSystem.Service.JobManagerHandler import JobManagerHandlerMixin
+
+# mocks
+jobPolicy_mock = MagicMock()
+jobDB_mock = MagicMock()
+jobDB_mock.getJobsAttributes.return_value = {"OK": True, "Value": {}}
+
+
+@pytest.mark.parametrize(
+    "jobIDs_list, right, lists, filteredJobsList, expected_res, expected_value",
+    [
+        ([], RIGHT_KILL, ([], [], [], []), [], True, []),
+        ([], RIGHT_DELETE, ([], [], [], []), [], True, []),
+        (1, RIGHT_KILL, ([], [], [], []), [], True, []),
+        (1, RIGHT_KILL, ([1], [], [], []), [], True, []),
+        ([1, 2], RIGHT_KILL, ([], [], [], []), [], True, []),
+        ([1, 2], RIGHT_KILL, ([1], [], [], []), [], True, []),
+        (1, RIGHT_KILL, ([1], [], [], []), [1], True, [1]),
+        ([1, 2], RIGHT_KILL, ([1], [], [], []), [1], True, [1]),
+        ([1, 2], RIGHT_KILL, ([1], [2], [], []), [1], True, [1]),
+        ([1, 2], RIGHT_KILL, ([1], [2], [], []), [], True, []),
+        ([1, 2], RIGHT_KILL, ([1, 2], [], [], []), [1, 2], True, [1, 2]),
+    ],
+)
+def test___kill_delete_jobs(mocker, jobIDs_list, right, lists, filteredJobsList, expected_res, expected_value):
+    mocker.patch(
+        "DIRAC.WorkloadManagementSystem.Service.JobManagerHandler.filterJobStateTransition",
+        return_value={"OK": True, "Value": filteredJobsList},
+    )
+
+    JobManagerHandlerMixin.log = gLogger
+    JobManagerHandlerMixin.jobPolicy = jobPolicy_mock
+    JobManagerHandlerMixin.jobDB = jobDB_mock
+    JobManagerHandlerMixin.taskQueueDB = MagicMock()
+
+    jobPolicy_mock.evaluateJobRights.return_value = lists
+
+    jm = JobManagerHandlerMixin()
+
+    res = jm._kill_delete_jobs(jobIDs_list, right)
+    assert res["OK"] == expected_res
+    assert res["Value"] == expected_value


### PR DESCRIPTION
When jobs are in status SUBMITTING, WAITING, etc, and they are set to be killed, they are not added to the list `markKilledJobList`. This pull request fix the identation when `kill` instead of `delete` is used.


BEGINRELEASENOTES

*WMS
FIX: Proper killing of jobs when not matched, running or stalled

ENDRELEASENOTES
