### PR TITLE
[8.0] Drop stalled Mysql connection reuse

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/environment_variable_configuration.rst
@@ -50,9 +50,6 @@ DIRAC_M2CRYPTO_SSL_CIPHERS
 DIRAC_M2CRYPTO_SSL_METHODS
   If set, overwrites the default SSL methods accepted. It should be a colon separated list. See :py:mod:`DIRAC.Core.DISET`
 
-DIRAC_MYSQL_CONNECTION_GRACE_TIME
-  If set to an integer, default of the grace time before the connection is reused. See :py:class:`DIRAC.Core.Utilities.MySQL.ConnectionPool`
-
 DIRAC_MYSQL_OPTIMIZER_TRACES_PATH
   If set, it should point to an existing directory, where MySQL Optimizer traces will be stored. See :py:func:`DIRAC.Core.Utilities.MySQL.captureOptimizerTraces`
 

--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -327,26 +327,11 @@ class ConnectionPool:
     Management of connections per thread
     """
 
-    # The idea of the grace time is that a given thread should not keep a connection object for too long
-    # However, in case of long running queries, this is unavoidable.
-    # If the DISET/HTTPs connection timeout is longer than the MySQL grace time,
-    # the connection will be reallocated to another thread, and that does not go down well
-    # From the mysqlclient doc ("threadsafety" of https://mysqlclient.readthedocs.io/user_guide.html#mysqldb)
-    # "The general upshot of this is: Don’t share connections between threads."
-    # The best thing to do, if we don't want to have a lock, is to set this value to 0
-    # so it is not used. LHCb will run in prod with the value 0 for a while, and if no issue arrises,
-    # it will become the default
-    try:
-        MYSQL_CONNECTION_GRACE_TIME = int(os.environ.get("DIRAC_MYSQL_CONNECTION_GRACE_TIME"))
-    except Exception:
-        MYSQL_CONNECTION_GRACE_TIME = 600
-
-    def __init__(self, host, user, passwd, port=3306, graceTime=MYSQL_CONNECTION_GRACE_TIME):
+    def __init__(self, host, user, passwd, port=3306):
         self.__host = host
         self.__user = user
         self.__passwd = passwd
         self.__port = port
-        self.__graceTime = graceTime
         self.__spares = collections.deque()
         self.__maxSpares = 10
         self.__lastClean = 0
@@ -455,12 +440,6 @@ class ConnectionPool:
         self.__lastClean = now
         for thid in list(self.__assigned):
             if not thid.is_alive():
-                self.__pop(thid)
-            try:
-                data = self.__assigned[thid]
-            except KeyError:
-                continue
-            if self.__graceTime and now - data[2] > self.__graceTime:
                 self.__pop(thid)
 
     def transactionStart(self, dbName):


### PR DESCRIPTION
Closes https://github.com/DIRACGrid/DIRAC/issues/7183 for good
LHCb has been running for 6 month with https://github.com/DIRACGrid/DIRAC/pull/7342 so remove the `grace` feature entirely. 



BEGINRELEASENOTES

*Core
CHANGE: drop DIRAC_MYSQL_CONNECTION_GRACE_TIME and stalled connections reuse


ENDRELEASENOTES
