### PR TITLE
[8.0] JobDB: update LastUpdateTime when the job is matched

### DIFF
--- a/src/DIRAC/Core/Utilities/TimeUtilities.py
+++ b/src/DIRAC/Core/Utilities/TimeUtilities.py
@@ -19,13 +19,11 @@ An timeInterval class provides a method to check
 if a give datetime is in the defined interval.
 
 """
-import calendar
-import time
 import datetime
 import sys
+import time
 
 from DIRAC import gLogger
-
 
 # Some useful constants for time operations
 microsecond = datetime.timedelta(microseconds=1)

--- a/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -13,20 +13,20 @@
 import concurrent.futures
 import datetime
 
-from DIRAC import S_OK, S_ERROR, gConfig
+from DIRAC import S_ERROR, S_OK, gConfig
 from DIRAC.AccountingSystem.Client.Types.Job import Job
-from DIRAC.Core.Base.AgentModule import AgentModule
-from DIRAC.Core.Utilities import DErrno
-from DIRAC.Core.Utilities.TimeUtilities import fromString, toEpoch, second
-from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
 from DIRAC.ConfigurationSystem.Client.Helpers import cfgPath
 from DIRAC.ConfigurationSystem.Client.PathFinder import getSystemInstance
-from DIRAC.WorkloadManagementSystem.Client.WMSClient import WMSClient
+from DIRAC.Core.Base.AgentModule import AgentModule
+from DIRAC.Core.Utilities import DErrno
+from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.TimeUtilities import fromString, second, toEpoch
+from DIRAC.WorkloadManagementSystem.Client import JobMinorStatus, JobStatus
 from DIRAC.WorkloadManagementSystem.Client.JobMonitoringClient import JobMonitoringClient
 from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
+from DIRAC.WorkloadManagementSystem.Client.WMSClient import WMSClient
 from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 from DIRAC.WorkloadManagementSystem.DB.JobLoggingDB import JobLoggingDB
-from DIRAC.WorkloadManagementSystem.Client import JobStatus, JobMinorStatus
 
 
 class StalledJobAgent(AgentModule):

--- a/src/DIRAC/WorkloadManagementSystem/Client/Matcher.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/Matcher.py
@@ -250,7 +250,7 @@ class Matcher:
         """
         attNames = ["Status", "MinorStatus", "ApplicationStatus", "Site"]
         attValues = ["Matched", "Assigned", "Unknown", resourceDict["Site"]]
-        result = self.jobDB.setJobAttributes(jobID, attNames, attValues)
+        result = self.jobDB.setJobAttributes(jobID, attNames, attValues, update=True)
         if not result["OK"]:
             self.log.error("Problem reporting job status", f"setJobAttributes, jobID = {jobID}: {result['Message']}")
         else:


### PR DESCRIPTION
This (commit https://github.com/DIRACGrid/DIRAC/commit/9125b4bcd86a5cbc695c144bbfd3d422e35d9300)  fixes an obscure bug that was unfolding like the following:

1. Job X went to status "Waiting" at time T
2. Job X was finally matched at time T + Y (with Y more than 2 hours)
    -  no update of LastUpdateTime field in JobDB, which was staying at time T
    - the job normally stays in status Matched only few seconds, before going to "Running"
3. StalledJobAgent looks, among other tasks, at jobs possibly stuck in status "Matched" for more than 2 hours, rescheduling them
    - if that happens in those few seconds when the status was "Matched" but the LastUpdateTime still T, those jobs were rescheduled.


BEGINRELEASENOTES

*WMS
FIX:  JobDB: update LastUpdateTime when the job is matched

ENDRELEASENOTES
