### PR TITLE
fix(Client): Fix typo Addler -> Adler in putAndRegister

### DIFF
--- a/src/DIRAC/DataManagementSystem/Client/DataManager.py
+++ b/src/DIRAC/DataManagementSystem/Client/DataManager.py
@@ -569,7 +569,7 @@ class DataManager:
             "Size": size,
             "TargetSE": destinationSE,
             "GUID": guid,
-            "Addler": checksum,
+            "Adler": checksum,
         }
         startTime = time.time()
         res = self.registerFile(fileTuple)


### PR DESCRIPTION
BEGINRELEASENOTES
Fix a typo in the key Addler -> Adler of the return dict of putAndRegister
ENDRELEASENOTES

Fixes  #7704
