### PR TITLE
[8.0] FIX  Multi VO metadata double VO suffix issue fix (#7697)

### DIFF
--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryMetadata/MultiVODirectoryMetadata.py
@@ -158,17 +158,17 @@ class MultiVODirectoryMetadata(DirectoryMetadata):
 
     def getDirectoryMetadata(self, path, credDict, inherited=True, ownData=True):
         """
-    Get metadata for the given directory aggregating metadata for the directory itself
-    and for all the parent directories if inherited flag is True. Get also the non-indexed
-    metadata parameters.
+        Get metadata for the given directory aggregating metadata for the directory itself
+        and for all the parent directories if inherited flag is True. Get also the non-indexed
+        metadata parameters.
 
-    :param str path: directory path
-    :param dict credDict: client credential dictionary
-    :param bool inherited: include parent directories if True
-    :param bool ownData:
-    :return: standard Dirac result object + additional MetadataOwner \
-    and MetadataType dict entries if the operation is successful.
-    """
+        :param str path: directory path
+        :param dict credDict: client credential dictionary
+        :param bool inherited: include parent directories if True
+        :param bool ownData:
+        :return: standard Dirac result object + additional MetadataOwner \
+        and MetadataType dict entries if the operation is successful.
+        """
 
         result = super().getDirectoryMetadata(path, credDict, inherited, ownData)
         if not result["OK"]:
@@ -181,9 +181,16 @@ class MultiVODirectoryMetadata(DirectoryMetadata):
 
         return result
 
-    def findDirIDsByMetadata(self, metaDict, dPath, credDict):
-        """Find Directories satisfying the given metadata and being subdirectories of
-        the given path
+    def findDirectoriesByMetadata(self, queryDict, path, credDict):
         """
-        fMetaDict = _getMetaNameDict(metaDict, credDict)
-        return super().findDirIDsByMetadata(fMetaDict, dPath, credDict)
+        Find Directory names satisfying the given metadata and being subdirectories of
+        the given path.
+
+        :param dict queryDict: dictionary containing query data
+        :param str path: starting directory path
+        :param dict credDict: client credential dictionary
+        :return: S_OK/S_ERROR, Value list of selected directory paths
+        """
+
+        fMetaDict = _getMetaNameDict(queryDict, credDict)
+        return super().findDirectoriesByMetadata(fMetaDict, path, credDict)

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/MultiVOFileMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/MultiVOFileMetadata.py
@@ -120,7 +120,7 @@ class MultiVOFileMetadata(FileMetadata):
     def findFilesByMetadata(self, metaDict, path, credDict):
         """Find Files satisfying the given metadata
 
-        :param dict metaDict: dictionary with the metaquery parameters
+        :param dict metaDict: dictionary with the metaquery parameters                                                                                                                                                                                   :param dict metaDict: dictionary with the metaquery parameters
         :param str path: Path to search into
         :param dict credDict: Dictionary with the user credentials
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/MultiVOFileMetadata.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileMetadata/MultiVOFileMetadata.py
@@ -120,7 +120,7 @@ class MultiVOFileMetadata(FileMetadata):
     def findFilesByMetadata(self, metaDict, path, credDict):
         """Find Files satisfying the given metadata
 
-        :param dict metaDict: dictionary with the metaquery parameters                                                                                                                                                                                   :param dict metaDict: dictionary with the metaquery parameters
+        :param dict metaDict: dictionary with the metaquery parameters
         :param str path: Path to search into
         :param dict credDict: Dictionary with the user credentials
 

--- a/src/DIRAC/TransformationSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/TransformationSystem/ConfigTemplate.cfg
@@ -25,6 +25,8 @@ Agents
     PollingTime = 120
     FullUpdatePeriod = 86400
     RefreshOnly = False
+    # If True, query the FileCatalog as the owner of the transformation, needed for MultiVO*MetaData filecatalogs
+    MultiVO = False
   }
   ##END
   ##BEGIN MCExtensionAgent


### PR DESCRIPTION
BEGINRELEASENOTES

*DMS
FIX: Remove `def findDirIDsByMetadata(self, metaDict, dPath, credDict):` method from `MultiVODirectoryMetadata` (derived) class which caused an extra VO suffix added when searching. The method is meant to be used _internally_ only on keys which are already expanded in a MultiVO case. Add a user-level def `findDirectoriesByMetadata(self, queryDict, path, credDict)` to the derived class thus adding a VO suffix for a directory search. Fixes  #7687.

ENDRELEASENOTES
