### PR TITLE
[8.0] fix: AREX submission issue

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -381,6 +381,9 @@ class AREXComputingElement(ARCComputingElement):
         response = result["Value"]
 
         responseJob = response.json()["job"]
+        if isinstance(responseJob, list):
+            responseJob = responseJob[0]
+
         if responseJob["status-code"] > "400":
             self.log.warn(
                 "Failed to submit job",


### PR DESCRIPTION
The submission error response is either a dict or a list, it seems to be random:

- [{'status-code': '500', 'reason': '...'}] <class 'list'>
- {'status-code': '500', 'reason': '...'} <class 'dict'>

BEGINRELEASENOTES
*Resources
FIX: AREX submission issue not properly handled
ENDRELEASENOTES
