### PR TITLE
[8.0] fix: check for the -l pilot option 

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py
@@ -122,7 +122,7 @@ def pilotWrapperScript(
         # - file:/cvmfs/somewhere/lhcbdirac/pilot
         # - file:/cvmfs/elsewhere/lhcbdirac/pilot
         project = "dirac"
-        if "-l" in pilotOptions:
+        if " -l " in pilotOptions:
             project = pilotOptions.split(" ")[pilotOptions.split(" ").index("-l") + 1].lower() + "dirac"
         CVMFS_locs = "[" + ",".join('"file:' + os.path.join(loc, project, 'pilot"') for loc in CVMFS_locations) + "]"
 


### PR DESCRIPTION
The check for the -l option was spotting also cases like -Q nordugrid-torque-long which is wrong.

BEGINRELEASENOTES

*WorkloadManagement
FIX: PilotWrapper - check for the presence of the -l pilot option

ENDRELEASENOTES
