### PR TITLE
[8.0] FileCatalog: add function to get user metadata for list of LFNs

### DIFF
--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogDB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogDB.py
@@ -769,6 +769,23 @@ class FileCatalogDB(DB):
         successful = res["Value"]["Successful"]
         return S_OK({"Successful": successful, "Failed": failed})
 
+    def getFileDetailsPublic(self, lfns, credDict):
+        """Return all the metadata, including user defined, for those lfns that exist.
+
+        :return: S_OK with a dictionary of LFNs to detailed information
+        """
+
+        res = self._checkPathPermissions("getFileDetailsPublic", lfns, credDict)
+        if not res["OK"]:
+            return res
+        failed = res["Value"]["Failed"]
+
+        # if no successful, just return empty dict
+        if not res["Value"]["Successful"]:
+            return S_OK({})
+
+        return self.getFileDetails(res["Value"]["Successful"], credDict)
+
     def getFileDetails(self, lfnList, credDict):
         """Get all the metadata for the given files"""
         connection = False

--- a/src/DIRAC/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/FileCatalogHandler.py
@@ -342,7 +342,7 @@ class FileCatalogHandlerMixin:
     types_getDirectoryMetadata = [[list, dict, str]]
 
     def export_getDirectoryMetadata(self, lfns):
-        """Get the size of the supplied directory"""
+        """Get the metadata of the supplied directory"""
         return self.fileCatalogDB.getDirectoryMetadata(lfns, self.getRemoteCredentials())
 
     types_getDirectorySize = [[list, dict, str]]

--- a/src/DIRAC/DataManagementSystem/Service/FileCatalogHandler.py
+++ b/src/DIRAC/DataManagementSystem/Service/FileCatalogHandler.py
@@ -261,6 +261,12 @@ class FileCatalogHandlerMixin:
         """Get the metadata associated to supplied lfns"""
         return self.fileCatalogDB.getFileMetadata(lfns, self.getRemoteCredentials())
 
+    types_getFileDetails = [[list, dict, str]]
+
+    def export_getFileDetails(self, lfns):
+        """Get all the metadata associated to supplied lfns, including user metadata"""
+        return self.fileCatalogDB.getFileDetailsPublic(lfns, self.getRemoteCredentials())
+
     types_getReplicas = [[list, dict, str], bool]
 
     def export_getReplicas(self, lfns, allStatus=False):

--- a/src/DIRAC/Resources/Catalog/FileCatalogClient.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalogClient.py
@@ -18,6 +18,7 @@ class FileCatalogClient(FileCatalogClientBase):
     READ_METHODS = FileCatalogClientBase.READ_METHODS + [
         "isFile",
         "getFileMetadata",
+        "getFileDetails",
         "getReplicas",
         "getReplicaStatus",
         "getFileSize",
@@ -471,6 +472,11 @@ class FileCatalogClient(FileCatalogClientBase):
     def getFileMetadata(self, lfns, timeout=120):
         """Get the metadata associated to supplied lfns"""
         return self._getRPC(timeout=timeout).getFileMetadata(lfns)
+
+    @checkCatalogArguments
+    def getFileDetails(self, lfns, timeout=120):
+        """Get the (user) metadata associated to supplied lfns"""
+        return self._getRPC(timeout=timeout).getFileDetails(lfns)
 
     @checkCatalogArguments
     def getReplicaStatus(self, lfns, timeout=120):


### PR DESCRIPTION
I need a function to get the user metadata for a list of LFNs. There are functions to get this information based on metadata, but I don't / can't do that, and for efficiency I need a bulk method. 

I am not sure I am missing some pieces, but this works for my purposes.

I added the getFileDetailsPublic to add a checkPathPermission before getting details, similar to getFileMetadata, but I am not sure if this is necessary or not.

Since I can hotfix this on my servers it is not urgent at all

BEGINRELEASENOTES

*DMS
NEW: FileCatalogHandler: add function export_getFileDetails to get the (user) metadata for a list of LFNs

ENDRELEASENOTES
