### PR TITLE
[8.0] Change the updating logic of the TS FileStatus

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/scalingAndLimitations.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/scalingAndLimitations.rst
@@ -62,6 +62,15 @@ Databases
 
 Every now and then, it is interesting to look at the fragmentation status of your database. This is done by using the ``analyze table`` statement (https://dev.mysql.com/doc/refman/8.4/en/analyze-table.html) possibly followed by the ``optimize table`` statement (https://dev.mysql.com/doc/refman/8.4/en/optimize-table.html).
 
+To know whether your tables are fragmented::
+
+   select table_schema,table_name, sys.format_bytes(data_length) table_size, sys.format_bytes(data_free) empty_space from information_schema.tables where data_length >= (1024*1024*1024) order by data_length desc;
+
+
+The fragmented space should be very small with respect to the overall table size.
+
+
+
 
 Duplications
 ============

--- a/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
+++ b/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
@@ -106,6 +106,8 @@ class FTS3Agent(AgentModule):
         # lifetime of the proxy we download to delegate to FTS
         self.proxyLifetime = self.am_getOption("ProxyLifetime", PROXY_LIFETIME)
 
+        self.jobMonitoringBatchSize = self.am_getOption("JobMonitoringBatchSize", JOB_MONITORING_BATCH_SIZE)
+
         return S_OK()
 
     def initialize(self):
@@ -318,7 +320,7 @@ class FTS3Agent(AgentModule):
             log.info("Getting next batch of jobs to monitor", f"{loopId}/{nbOfLoops}")
             # get jobs from DB
             res = self.fts3db.getActiveJobs(
-                limit=JOB_MONITORING_BATCH_SIZE, lastMonitor=lastMonitor, jobAssignmentTag=self.assignmentTag
+                limit=self.jobMonitoringBatchSize, lastMonitor=lastMonitor, jobAssignmentTag=self.assignmentTag
             )
 
             if not res["OK"]:
@@ -353,7 +355,7 @@ class FTS3Agent(AgentModule):
 
             # If we got less to monitor than what we asked,
             # stop looping
-            if len(activeJobs) < JOB_MONITORING_BATCH_SIZE:
+            if len(activeJobs) < self.jobMonitoringBatchSize:
                 break
         # Commit records after each loop
         self.dataOpSender.concludeSending()

--- a/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
+++ b/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
@@ -207,6 +207,11 @@ class FTS3Job(JSerializable):
                 filesStatus[file_id]["ftsGUID"] = None
                 # TODO: update status to defunct if not recoverable here ?
 
+                # If the file is failed, check if it is recoverable
+                if file_state in FTS3File.FTS_FAILED_STATES:
+                    if not fileDict.get("Recoverable", True):
+                        filesStatus[file_id]["status"] = "Defunct"
+
             # If the file is not in a final state, but the job is, we return an error
             # FTS can have inconsistencies where the FTS Job is in a final state
             # but not all the files.

--- a/src/DIRAC/DataManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/DataManagementSystem/ConfigTemplate.cfg
@@ -143,6 +143,12 @@ Agents
     OperationBulkSize = 20
     # How many Job we will monitor in one loop
     JobBulkSize = 20
+    # split jobBulkSize in several chunks
+    # Bigger numbers (like 100) are efficient when there's a single agent
+    # When there are multiple agents, it may slow down the overall because
+    # of lock and race conditions
+    # (This number should of course be smaller or equal than JobBulkSize)
+    JobMonitoringBatchSize = 20
     # Max number of files to go in a single job
     MaxFilesPerJob = 100
     # Max number of attempt per file

--- a/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
@@ -311,6 +311,7 @@ class FTS3DB:
                 session.query(FTS3Job)
                 .join(FTS3Operation)
                 .filter(FTS3Job.status.in_(FTS3Job.NON_FINAL_STATES))
+                .filter(FTS3Operation.status == "Active")
                 .filter(FTS3Job.assignment.is_(None))
                 .filter(FTS3Operation.assignment.is_(None))
             )

--- a/src/DIRAC/DataManagementSystem/Utilities/ResolveSE.py
+++ b/src/DIRAC/DataManagementSystem/Utilities/ResolveSE.py
@@ -1,6 +1,7 @@
 """ This module allows to resolve output SEs for Job based
 on SE and site/country association
 """
+
 from random import shuffle
 
 from DIRAC import gLogger, gConfig
@@ -70,7 +71,6 @@ def getDestinationSEList(outputSE, site, outputmode="Any"):
         raise RuntimeError(localSEs["Message"])
     localSEs = localSEs["Value"]
     sLog.verbose("Local SE list is:", ", ".join(localSEs))
-
     # There is an alias defined for this Site
     associatedSEs = gConfig.getValue(f"/Resources/Sites/{prefix}/{site}/AssociatedSEs/{outputSE}", [])
     if associatedSEs:

--- a/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
+++ b/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
@@ -258,7 +258,7 @@ class ReqClient(Client):
         self.log.debug("getRequestStatus: attempting to get status for '%d' request." % requestID)
         requestStatus = self._getRPC().getRequestStatus(requestID)
         if not requestStatus["OK"]:
-            self.log.error(
+            self.log.verbose(
                 "getRequestStatus: unable to get status for request",
                 ": '%d' %s" % (requestID, requestStatus["Message"]),
             )

--- a/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
+++ b/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
@@ -5,6 +5,7 @@
   :synopsis: implementation of client for RequestDB using DISET framework
 
 """
+
 import os
 import time
 import random
@@ -469,6 +470,23 @@ class ReqClient(Client):
             req.NotBefore = datetime.datetime.utcnow().replace(microsecond=0)
             return self.putRequest(req)
         return S_OK("Not reset")
+
+    @ignoreEncodeWarning
+    def getBulkRequestStatus(self, requestIDs: list[int]):
+        """get the Status for the supplied request IDs.
+
+        :param self: self reference
+        :param list requestIDs: list of job IDs (integers)
+        :return: S_ERROR or S_OK( { reqID1:status, requID2:status2, ... })
+        """
+        res = self._getRPC().getBulkRequestStatus(requestIDs)
+        if not res["OK"]:
+            return res
+
+        # Cast the requestIDs back to int
+        statuses = strToIntDict(res["Value"])
+
+        return S_OK(statuses)
 
 
 # ============= Some useful functions to be shared ===========

--- a/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
+++ b/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
@@ -875,6 +875,9 @@ class RequestDB:
         try:
             statuses = session.query(Request.RequestID, Request._Status).filter(Request.RequestID.in_(requestIDs)).all()
             status_dict = {req_id: req_status for req_id, req_status in statuses}
+        except Exception as e:
+            # log as well?
+            return S_ERROR(f"Failed to getBulkRequestStatus {e!r}")
         finally:
             session.close()
         return S_OK(status_dict)

--- a/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
+++ b/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
@@ -869,6 +869,16 @@ class RequestDB:
             session.close()
         return S_OK(status[0])
 
+    def getBulkRequestStatus(self, requestIDs):
+        """get requests statuses for given request IDs"""
+        session = self.DBSession()
+        try:
+            statuses = session.query(Request.RequestID, Request._Status).filter(Request.RequestID.in_(requestIDs)).all()
+            status_dict = {req_id: req_status for req_id, req_status in statuses}
+        finally:
+            session.close()
+        return S_OK(status_dict)
+
     def getRequestFileStatus(self, requestID, lfnList):
         """get status for files in request given its id
 

--- a/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -340,6 +340,16 @@ class ReqManagerHandlerMixin:
             gLogger.error(f"getRequestStatus: {status['Message']}")
         return status
 
+    types_getBulkRequestStatus = [list]
+
+    @classmethod
+    def export_getBulkRequestStatus(cls, requestIDs):
+        """get requests statuses given their ids"""
+        res = cls.__requestDB.getBulkRequestStatus(requestIDs)
+        if not res["OK"]:
+            gLogger.error(f"getRequestStatus: {res['Message']}")
+        return res
+
     types_getRequestFileStatus = [int, [str, list]]
 
     @classmethod

--- a/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -347,7 +347,7 @@ class ReqManagerHandlerMixin:
         """get requests statuses given their ids"""
         res = cls.__requestDB.getBulkRequestStatus(requestIDs)
         if not res["OK"]:
-            gLogger.error(f"getRequestStatus: {res['Message']}")
+            gLogger.error("getBulkRequestStatus", res["Message"])
         return res
 
     types_getRequestFileStatus = [int, [str, list]]

--- a/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
@@ -8,6 +8,7 @@ The following options can be set for the TransformationAgent.
   :dedent: 2
   :caption: TransformationAgent options
 """
+
 import time
 import os
 import datetime
@@ -241,7 +242,7 @@ class TransformationAgent(AgentModule, TransformationAgentsUtilities):
         if transID not in self.replicaCache:
             self.__readCache(transID)
         transFiles = transFiles["Value"]
-        unusedLfns = [f["LFN"] for f in transFiles]
+        unusedLfns = {f["LFN"] for f in transFiles}
         unusedFiles = len(unusedLfns)
 
         plugin = transDict.get("Plugin", "Standard")
@@ -250,7 +251,7 @@ class TransformationAgent(AgentModule, TransformationAgentsUtilities):
             maxFiles = Operations().getValue(f"TransformationPlugins/{plugin}/MaxFilesToProcess", 0)
             # Get plugin-specific limit in number of files (0 means no limit)
             totLfns = len(unusedLfns)
-            lfnsToProcess = self.__applyReduction(unusedLfns, maxFiles=maxFiles)
+            lfnsToProcess = set(self.__applyReduction(unusedLfns, maxFiles=maxFiles))
             if len(lfnsToProcess) != totLfns:
                 self._logInfo(
                     "Reduced number of files from %d to %d" % (totLfns, len(lfnsToProcess)),
@@ -533,8 +534,10 @@ class TransformationAgent(AgentModule, TransformationAgentsUtilities):
             method=method,
             transID=transID,
         )
+        successful_set = set(replicas["Successful"])
+        failed_set = set(replicas["Failed"])
         # If files are neither Successful nor Failed, they are set problematic in the FC
-        problematicLfns = [lfn for lfn in lfns if lfn not in replicas["Successful"] and lfn not in replicas["Failed"]]
+        problematicLfns = [lfn for lfn in lfns if lfn not in successful_set and lfn not in failed_set]
         if problematicLfns:
             self._logInfo(f"{len(problematicLfns)} files found problematic in the catalog, set ProbInFC")
             res = clients["TransformationClient"].setFileStatusForTransformation(

--- a/src/DIRAC/TransformationSystem/Client/RequestTasks.py
+++ b/src/DIRAC/TransformationSystem/Client/RequestTasks.py
@@ -317,26 +317,48 @@ class RequestTasks(TaskBase):
         Check if tasks changed status, and return a list of tasks per new status
         """
         updateDict = {}
-        badRequestID = 0
+        externalIDs = [
+            int(taskDict["ExternalID"])
+            for taskDict in taskDicts
+            if taskDict["ExternalID"] and int(taskDict["ExternalID"])
+        ]
+        # Count how many tasks don't have an valid external ID
+        badRequestID = len(taskDicts) - len(externalIDs)
+
+        res = self.requestClient.getBulkRequestStatus(externalIDs)
+        if not res["OK"]:
+            # We need a transformationID for the log, and although we expect a single one,
+            # do things ~ properly
+            tids = list({taskDict["TransformationID"] for taskDict in taskDicts})
+            try:
+                tid = tids[0]
+            except IndexError:
+                tid = 0
+
+            self._logWarn(
+                "getSubmittedTaskStatus: Failed to get bulk requestIDs",
+                res["Message"],
+                transID=tid,
+            )
+            return S_OK({})
+        new_statuses = res["Value"]
+
         for taskDict in taskDicts:
             oldStatus = taskDict["ExternalStatus"]
             # ExternalID is normally a string
-            if taskDict["ExternalID"] and int(taskDict["ExternalID"]):
-                newStatus = self.requestClient.getRequestStatus(taskDict["ExternalID"])
-                if not newStatus["OK"]:
-                    log = self._logVerbose if "not exist" in newStatus["Message"] else self._logWarn
-                    log(
-                        "getSubmittedTaskStatus: Failed to get requestID for request",
-                        newStatus["Message"],
-                        transID=taskDict["TransformationID"],
-                    )
-                else:
-                    newStatus = newStatus["Value"]
-                    # We don't care updating the tasks to Assigned while the request is being processed
-                    if newStatus != oldStatus and newStatus != "Assigned":
-                        updateDict.setdefault(newStatus, []).append(taskDict["TaskID"])
+
+            newStatus = new_statuses.get(int(taskDict["ExternalID"]))
+            if not newStatus:
+                self._logVerbose(
+                    "getSubmittedTaskStatus: Failed to get requestID for request",
+                    f"No such RequestID {taskDict['ExternalID']}",
+                    transID=taskDict["TransformationID"],
+                )
             else:
-                badRequestID += 1
+                # We do not update the tasks status if the Request is Assigned, as it is a very temporary status
+                if newStatus != oldStatus and newStatus != "Assigned":
+                    updateDict.setdefault(newStatus, []).append(taskDict["TaskID"])
+
         if badRequestID:
             self._logWarn("%d requests have identifier 0" % badRequestID)
         return S_OK(updateDict)
@@ -363,26 +385,35 @@ class RequestTasks(TaskBase):
         requestFiles = {}
         for taskDict in res["Value"]:
             taskID = taskDict["TaskID"]
-            externalID = taskDict["ExternalID"]
+            externalID = int(taskDict["ExternalID"])
             # Only consider tasks that are submitted, ExternalID is a string
             if taskDict["ExternalStatus"] != "Created" and externalID and int(externalID):
                 requestFiles[externalID] = taskFiles[taskID]
+
+        res = self.requestClient.getBulkRequestStatus(list(requestFiles))
+        if not res["OK"]:
+            self._logWarn(
+                "Failed to get request status",
+                res["Message"],
+                transID=transID,
+                method="getSubmittedFileStatus",
+            )
+            return S_OK({})
+        reqStatuses = res["Value"]
 
         updateDict = {}
         for requestID, lfnList in requestFiles.items():
             # We only take request in final state to avoid race conditions
             # https://github.com/DIRACGrid/DIRAC/issues/7116#issuecomment-2188740414
-            reqStatus = self.requestClient.getRequestStatus(requestID)
-            if not reqStatus["OK"]:
-                log = self._logVerbose if "not exist" in reqStatus["Message"] else self._logWarn
-                log(
+            reqStatus = reqStatuses.get(requestID)
+            if not reqStatus:
+                self._logVerbose(
                     "Failed to get request status",
-                    reqStatus["Message"],
+                    f"Request {requestID} does not exist",
                     transID=transID,
                     method="getSubmittedFileStatus",
                 )
                 continue
-            reqStatus = reqStatus["Value"]
             if reqStatus not in Request.FINAL_STATES:
                 continue
 
@@ -398,7 +429,7 @@ class RequestTasks(TaskBase):
                 continue
 
             # If we are here, it means the Request is in a final state.
-            # In principle, you could expect everyfile also be in a final state
+            # In principle, you could expect every file also be in a final state
             # but this is only true for simple Request.
             # Hence, the file is marked as PROCESSED only if the file status is Done
             # In any other case, we mark it problematic


### PR DESCRIPTION
This aims at solving https://github.com/DIRACGrid/DIRAC/issues/7116
It is quite a big change of logic, but should not impact anybody but LHCb, as it mostly matters for complex body plugin

Also, it speeds up a lot the RequestTaskAgent. 
Hotfixed in LHCb, we observe a huge speedup on a transformation with 4M files:

```bash
# Before
2024-08-13 05:24:33 UTC Transformation/RequestTaskAgent/[231355] ._execute INFO: Processed transformation in 2134.9 seconds

# After
2024-08-13 09:29:19 UTC Transformation/RequestTaskAgent/[231355] ._execute INFO: Processed transformation in 62.4 seconds
```


BEGINRELEASENOTES
*TS
FIX: RequestTaskAgent only considers requests in final states, and consider files in intermediate state as problematic (https://github.com/DIRACGrid/DIRAC/issues/7116)
NEW: RequestTaskAgent uses getBulkRequestStatus instead of getRequestStatus

RMS:
NEW: implement getRequestStatus



ENDRELEASENOTES
