### PR TITLE
[8.0] RSS fix: delete the occupancy cache only for older entries

### DIFF
--- a/src/DIRAC/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
+++ b/src/DIRAC/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
@@ -7,20 +7,19 @@
     For the moment, when you see "token" or "space token" here, just read "StorageElement".
 
 """
-import sys
 import errno
+import sys
+from datetime import datetime, timedelta, timezone
 
-from datetime import datetime
-
-from DIRAC import S_OK, S_ERROR
-from DIRAC.Core.Utilities.File import convertSizeUnits
+from DIRAC import S_ERROR, S_OK
 from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
 from DIRAC.AccountingSystem.Client.Types.StorageOccupancy import StorageOccupancy
+from DIRAC.Core.Utilities.File import convertSizeUnits
 from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
-from DIRAC.ResourceStatusSystem.Command.Command import Command
-from DIRAC.ResourceStatusSystem.Utilities import CSHelpers
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.ResourceStatusSystem.Client.ResourceManagementClient import ResourceManagementClient
+from DIRAC.ResourceStatusSystem.Command.Command import Command
+from DIRAC.ResourceStatusSystem.Utilities import CSHelpers
 
 
 class FreeDiskSpaceCommand(Command):
@@ -204,7 +203,9 @@ class FreeDiskSpaceCommand(Command):
         if not toDelete:
             toDelete = []
 
-            res = self.rmClient.selectSpaceTokenOccupancyCache()
+            res = self.rmClient.selectSpaceTokenOccupancyCache(
+                meta={"older": ["LastCheckTime", datetime.now(timezone.utc) - timedelta(hours=6)]}
+            )
             if not res["OK"]:
                 return res
             storedSEsSet = {(sse[0], sse[1]) for sse in res["Value"]}


### PR DESCRIPTION
The `FreeDiskSpaceCommand.doMaster()` method, which is invoked by `CacheFeederAgent` is rather quickly deleting all inserted entries. If re-updating such entries take time (and sometimes timeouts happen) then the RSS Policy System would declare the state to "Error", which is basically equivalent to "Banned". This should give more room before such event happens.

BEGINRELEASENOTES

*RSS
FIX: delete the Occupancy cache only for older entries

ENDRELEASENOTES
