### PR TITLE
[8.0] Change TS addFile logic for Deleted files

### DIFF
--- a/src/DIRAC/TransformationSystem/Client/TransformationFilesStatus.py
+++ b/src/DIRAC/TransformationSystem/Client/TransformationFilesStatus.py
@@ -17,6 +17,8 @@ MISSING_IN_FC = "MissingInFC"
 PROB_IN_FC = "ProbInFC"
 #:
 REMOVED = "Removed"
+#:
+DELETED = "Deleted"
 
 # below ones are for inherited transformations
 #:

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -1127,7 +1127,7 @@ class TransformationDB(DB):
 
         for parameterName in sorted(queryDict):
             parameterValue = queryDict[parameterName]
-            if not parameterValue:
+            if parameterValue is None:
                 continue
             parameterType = "String"
             if isinstance(parameterValue, (list, tuple)):

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -1636,11 +1636,7 @@ class TransformationDB(DB):
                             )
                             if not res["OK"]:
                                 return res
-                            if not (
-                                res := self.__setDataFileStatus(
-                                    list(fileIDs), "New", connection=connection
-                                )["OK"]
-                            ):
+                            if not (res := self.__setDataFileStatus(list(fileIDs), "New", connection=connection)["OK"]):
                                 return res
 
                     res = self.addFilesToTransformation(transID, lfns)

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -15,7 +15,7 @@ from errno import ENOENT
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Base.DB import DB
 from DIRAC.Core.Utilities.DErrno import cmpError
-from DIRAC.TransformationSystem.Client import TransformationStatus
+from DIRAC.TransformationSystem.Client import TransformationFilesStatus
 from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.Core.Utilities.List import stringListToString, intListToString, breakListIntoChunks
@@ -1630,15 +1630,15 @@ class TransformationDB(DB):
                     fileIDs = []
                     for fileDict in res["Value"]:
                         fileIDs.append(fileDict["FileID"])
-                        if fileDict["Status"] == TransformationStatus.DELETED:
+                        if fileDict["Status"] == TransformationFilesStatus.DELETED:
                             res = self.__setTransformationFileStatus(
-                                list(fileIDs), TransformationStatus.UNUSED, connection=connection
+                                list(fileIDs), TransformationFilesStatus.UNUSED, connection=connection
                             )
                             if not res["OK"]:
                                 return res
                             if not (
                                 res := self.__setDataFileStatus(
-                                    list(fileIDs), TransformationStatus.NEW, connection=connection
+                                    list(fileIDs), "New", connection=connection
                                 )["OK"]
                             ):
                                 return res
@@ -1782,13 +1782,13 @@ class TransformationDB(DB):
                 fileIDs = []
                 for fileDict in res["Value"]:
                     fileIDs.append(fileDict["FileID"])
-                    if fileDict["Status"] == TransformationStatus.DELETED:
+                    if fileDict["Status"] == TransformationFilesStatus.DELETED:
                         res = self.__setTransformationFileStatus(
-                            list(fileIDs), TransformationStatus.UNUSED, connection=connection
+                            list(fileIDs), TransformationFilesStatus.UNUSED, connection=connection
                         )
                         if not res["OK"]:
                             return res
-                        res = self.__setDataFileStatus(list(fileIDs), TransformationStatus.NEW, connection=connection)
+                        res = self.__setDataFileStatus(list(fileIDs), "New", connection=connection)
                         if not res["OK"]:
                             return res
 

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -1631,10 +1631,16 @@ class TransformationDB(DB):
                     for fileDict in res["Value"]:
                         fileIDs.append(fileDict["FileID"])
                         if fileDict["Status"] == TransformationStatus.DELETED:
-                            res = self.__setTransformationFileStatus(list(fileIDs), TransformationStatus.UNUSED, connection=connection)
+                            res = self.__setTransformationFileStatus(
+                                list(fileIDs), TransformationStatus.UNUSED, connection=connection
+                            )
                             if not res["OK"]:
                                 return res
-                            if not (res := self.__setDataFileStatus(list(fileIDs), TransformationStatus.NEW, connection=connection)["OK"]:
+                            if not (
+                                res := self.__setDataFileStatus(
+                                    list(fileIDs), TransformationStatus.NEW, connection=connection
+                                )["OK"]
+                            ):
                                 return res
 
                     res = self.addFilesToTransformation(transID, lfns)
@@ -1777,13 +1783,14 @@ class TransformationDB(DB):
                 for fileDict in res["Value"]:
                     fileIDs.append(fileDict["FileID"])
                     if fileDict["Status"] == TransformationStatus.DELETED:
-                        res = self.__setTransformationFileStatus(list(fileIDs), TransformationStatus.UNUSED, connection=connection)
+                        res = self.__setTransformationFileStatus(
+                            list(fileIDs), TransformationStatus.UNUSED, connection=connection
+                        )
                         if not res["OK"]:
                             return res
                         res = self.__setDataFileStatus(list(fileIDs), TransformationStatus.NEW, connection=connection)
                         if not res["OK"]:
                             return res
-
 
                 res = self.addFilesToTransformation(transID, lfns)
                 if not res["OK"]:

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -1627,16 +1627,18 @@ class TransformationDB(DB):
                     )
                     if not res["OK"]:
                         return res
-                    fileIDs = []
                     for fileDict in res["Value"]:
-                        fileIDs.append(fileDict["FileID"])
                         if fileDict["Status"] == TransformationFilesStatus.DELETED:
                             res = self.__setTransformationFileStatus(
-                                list(fileIDs), TransformationFilesStatus.UNUSED, connection=connection
+                                list([fileDict["FileID"]]), TransformationFilesStatus.UNUSED, connection=connection
                             )
                             if not res["OK"]:
                                 return res
-                            if not (res := self.__setDataFileStatus(list(fileIDs), "New", connection=connection)["OK"]):
+                            if not (
+                                res := self.__setDataFileStatus(
+                                    list([fileDict["FileID"]]), "New", connection=connection
+                                )["OK"]
+                            ):
                                 return res
 
                     res = self.addFilesToTransformation(transID, lfns)
@@ -1775,16 +1777,14 @@ class TransformationDB(DB):
                 )
                 if not res["OK"]:
                     return res
-                fileIDs = []
                 for fileDict in res["Value"]:
-                    fileIDs.append(fileDict["FileID"])
                     if fileDict["Status"] == TransformationFilesStatus.DELETED:
                         res = self.__setTransformationFileStatus(
-                            list(fileIDs), TransformationFilesStatus.UNUSED, connection=connection
+                            list([fileDict["FileID"]]), TransformationFilesStatus.UNUSED, connection=connection
                         )
                         if not res["OK"]:
                             return res
-                        res = self.__setDataFileStatus(list(fileIDs), "New", connection=connection)
+                        res = self.__setDataFileStatus(list([fileDict["FileID"]]), "New", connection=connection)
                         if not res["OK"]:
                             return res
 

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -1633,6 +1633,9 @@ class TransformationDB(DB):
                             res = self.__setTransformationFileStatus(list(fileIDs), "Unused", connection=connection)
                             if not res["OK"]:
                                 return res
+                            res = self.__setDataFileStatus(list(fileIDs), "New", connection=connection)
+                            if not res["OK"]:
+                                return res
 
                     res = self.addFilesToTransformation(transID, lfns)
                     if not res["OK"]:
@@ -1777,6 +1780,10 @@ class TransformationDB(DB):
                         res = self.__setTransformationFileStatus(list(fileIDs), "Unused", connection=connection)
                         if not res["OK"]:
                             return res
+                        res = self.__setDataFileStatus(list(fileIDs), "New", connection=connection)
+                        if not res["OK"]:
+                            return res
+
 
                 res = self.addFilesToTransformation(transID, lfns)
                 if not res["OK"]:

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -15,6 +15,7 @@ from errno import ENOENT
 from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Base.DB import DB
 from DIRAC.Core.Utilities.DErrno import cmpError
+from DIRAC.TransformationSystem.Client import TransformationStatus
 from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.Core.Utilities.List import stringListToString, intListToString, breakListIntoChunks
@@ -1629,12 +1630,11 @@ class TransformationDB(DB):
                     fileIDs = []
                     for fileDict in res["Value"]:
                         fileIDs.append(fileDict["FileID"])
-                        if fileDict["Status"] == "Deleted":
-                            res = self.__setTransformationFileStatus(list(fileIDs), "Unused", connection=connection)
+                        if fileDict["Status"] == TransformationStatus.DELETED:
+                            res = self.__setTransformationFileStatus(list(fileIDs), TransformationStatus.UNUSED, connection=connection)
                             if not res["OK"]:
                                 return res
-                            res = self.__setDataFileStatus(list(fileIDs), "New", connection=connection)
-                            if not res["OK"]:
+                            if not (res := self.__setDataFileStatus(list(fileIDs), TransformationStatus.NEW, connection=connection)["OK"]:
                                 return res
 
                     res = self.addFilesToTransformation(transID, lfns)
@@ -1776,11 +1776,11 @@ class TransformationDB(DB):
                 fileIDs = []
                 for fileDict in res["Value"]:
                     fileIDs.append(fileDict["FileID"])
-                    if fileDict["Status"] == "Deleted":
-                        res = self.__setTransformationFileStatus(list(fileIDs), "Unused", connection=connection)
+                    if fileDict["Status"] == TransformationStatus.DELETED:
+                        res = self.__setTransformationFileStatus(list(fileIDs), TransformationStatus.UNUSED, connection=connection)
                         if not res["OK"]:
                             return res
-                        res = self.__setDataFileStatus(list(fileIDs), "New", connection=connection)
+                        res = self.__setDataFileStatus(list(fileIDs), TransformationStatus.NEW, connection=connection)
                         if not res["OK"]:
                             return res
 

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -1706,7 +1706,7 @@ class TransformationDB(DB):
                 successful.append(lfn)
         return {"OK": True, "Value": len(res["Value"]["Successful"]), "Successful": successful, "Failed": failed}
 
-    def setMetadata(self, path, usermetadatadict):
+    def setMetadata(self, path, usermetadatadict, connection=False):
         """
         It can be applied to a file or to a directory (path).
         For a file, add the file to Transformations if the updated metadata dictionary passes the filter.


### PR DESCRIPTION
In the current 8.0 release when a file is removed from DFC, if the file was attached to a transformation it gets in 'Deleted' Status in the TransformationFile table. Now, if a new file with the same LFN of the one which has been removed is added again to the DFC and also to the TSCatalog, the current implementation of the addFile method of the TS does not update the Status of this file. As a consequence the new produced file will remain in 'Deleted' Status and will be never be processed by the transformation. The same is true for the setMetadata method of the TS. With this PR we add a check in the addFile and setMetadata methods on the 'Deleted' status of files already attached to the transformation and if the file must be attached to the transformations its Status is changed from 'Deleted' to 'Unused'. For coherence we also update the Status in the DataFile table from 'Deleted' to 'New'.

BEGINRELEASENOTES

*TransformationSystem
CHANGE: Check if file previously DELETED is back in DFC

ENDRELEASENOTES
