### PR TITLE
[v8.0] fix (RSS): do not use timezone datetime

### DIFF
--- a/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
+++ b/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
@@ -205,6 +205,7 @@ class FTS3Job(JSerializable):
             # monitoring calls
             if file_state in FTS3File.FTS_FINAL_STATES:
                 filesStatus[file_id]["ftsGUID"] = None
+                # TODO: update status to defunct if not recoverable here ?
 
             # If the file is not in a final state, but the job is, we return an error
             # FTS can have inconsistencies where the FTS Job is in a final state

--- a/src/DIRAC/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
+++ b/src/DIRAC/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py
@@ -9,7 +9,7 @@
 """
 import errno
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from DIRAC import S_ERROR, S_OK
 from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
@@ -204,7 +204,7 @@ class FreeDiskSpaceCommand(Command):
             toDelete = []
 
             res = self.rmClient.selectSpaceTokenOccupancyCache(
-                meta={"older": ["LastCheckTime", datetime.now(timezone.utc) - timedelta(hours=6)]}
+                meta={"older": ["LastCheckTime", datetime.utcnow() - timedelta(hours=6)]}
             )
             if not res["OK"]:
                 return res

--- a/src/DIRAC/Resources/Storage/StorageElement.py
+++ b/src/DIRAC/Resources/Storage/StorageElement.py
@@ -1,5 +1,6 @@
 """ This is the StorageElement module. It implements The StorageElementItem as well as the caching system
 """
+
 # # custom duty
 
 
@@ -257,11 +258,13 @@ class StorageElementItem:
             self.localStageProtocolList = (
                 stageProto
                 if stageProto
-                else accessProto
-                if accessProto
-                else globalStageProto
-                if globalStageProto
-                else self.localAccessProtocolList
+                else (
+                    accessProto
+                    if accessProto
+                    else globalStageProto
+                    if globalStageProto
+                    else self.localAccessProtocolList
+                )
             )
             self.log.debug(f"localStageProtocolList {self.localStageProtocolList}")
 
@@ -420,6 +423,13 @@ class StorageElementItem:
         :returns: S_OK with dict (keys: Total, Free, SpaceReservation)
         """
         log = self.log.getSubLogger("getOccupancy")
+
+        res = self.isValid(operation="getOccupancy")
+        if not res["OK"]:
+            return res
+        else:
+            if not self.valid:
+                return S_ERROR(self.errorReason)
 
         if "occupancyLFN" not in kwargs:
             occupancyLFN = self.options.get("OccupancyLFN")


### PR DESCRIPTION
As deprecated as it may be, `DIRAC` does not support timezone, and still needs `utcnow` 

```python
2024-08-25 19:13:47 UTC ResourceStatus/CacheFeederAgent/ResourceStatus/CacheFeederAgent ERROR: Failed to execute command, with exception: FreeDiskSpace
Traceback (most recent call last):
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ResourceStatusSystem/Agent/CacheFeederAgent.py", line 135, in execute
    results = commandObject.doCommand()
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ResourceStatusSystem/Command/Command.py", line 47, in doCommand
    return self.returnSObj(self.doMaster())
                           ^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py", line 195, in doMaster
    return self._cleanCommand()
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ResourceStatusSystem/Command/FreeDiskSpaceCommand.py", line 206, in _cleanCommand
    res = self.rmClient.selectSpaceTokenOccupancyCache(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/ResourceStatusSystem/Client/ResourceManagementClient.py", line 751, in selectSpaceTokenOccupancyCache
    return self._getRPC().select("SpaceTokenOccupancyCache", prepareDict(columnNames, columnValues))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/DISET/RPCClient.py", line 36, in __call__
    return self.__doRPCFunc(self.__remoteFuncName, args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/DISET/RPCClient.py", line 82, in __doRPC
    return self.__innerRPCClient.executeRPC(sFunctionName, args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/DISET/private/InnerRPCClient.py", line 63, in executeRPC
    retVal = transport.sendData(S_OK(list(args)))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/DISET/private/Transports/BaseTransport.py", line 164, in sendData
    sCodedData = MixedEncode.encode(uData)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/MixedEncode.py", line 17, in encode
    return DEncode.encode(inData)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 515, in encode
    g_dEncodeFunctions[type(uObject)](uObject, eList)
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 486, in encodeDict
    g_dEncodeFunctions[type(dValue[key])](dValue[key], eList)
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 430, in encodeList
    g_dEncodeFunctions[type(uObject)](uObject, eList)
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 486, in encodeDict
    g_dEncodeFunctions[type(dValue[key])](dValue[key], eList)
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 486, in encodeDict
    g_dEncodeFunctions[type(dValue[key])](dValue[key], eList)
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 430, in encodeList
    g_dEncodeFunctions[type(uObject)](uObject, eList)
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 370, in encodeDateTime
    g_dEncodeFunctions[type(tDateTime)](tDateTime, eList)
  File "/opt/dirac/versions/v11.0.46-1723623328/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Utilities/DEncode.py", line 457, in encodeTuple
    g_dEncodeFunctions[type(uObject)](uObject, eList)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: <class 'datetime.timezone'>
```

it would be easy to add timezone support in DEncode, but we would run into way more issues, so I think it's just not worth it


BEGINRELEASENOTES

*RSS
FIX: Do not use tinezone aware datetime

ENDRELEASENOTES
