### PR TITLE
[8.0] IAM2CS: ForceNickname, fix duplicate accounts for users

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -342,23 +342,26 @@ class VOMS2CSSynchronizer:
 
                 # We have a real new user
                 if not diracName:
-                    if nickName:
-                        newDiracName = nickName.strip()
-                    else:
-                        newDiracName = self.getUserName(dn)
-
                     # Do not consider users with Suspended status in VOMS
                     if self.vomsUserDict[dn]["suspended"] or self.vomsUserDict[dn]["certSuspended"]:
                         resultDict["SuspendedUsers"].append(newDiracName)
                         continue
 
-                    # If the chosen user name exists already, append a distinguishing suffix
-                    ind = 1
-                    trialName = newDiracName
-                    while newDiracName in allDiracUsers:
-                        # We have a user with the same name but with a different DN
-                        newDiracName = "%s_%d" % (trialName, ind)
-                        ind += 1
+                    # if we have a nickname, we use the nickname no
+                    # matter what so we can have users from different
+                    # VOs with the same nickname / username
+                    if nickName:
+                        newDiracName = nickName.strip()
+                    else:
+                        newDiracName = self.getUserName(dn)
+
+                        # If the chosen user name exists already, append a distinguishing suffix
+                        ind = 1
+                        trialName = newDiracName
+                        while newDiracName in allDiracUsers:
+                            # We have a user with the same name but with a different DN
+                            newDiracName = "%s_%d" % (trialName, ind)
+                            ind += 1
 
                     # We now have everything to add the new user
                     userDict = {"DN": dn, "CA": self.vomsUserDict[dn]["CA"], "Email": self.vomsUserDict[dn]["mail"]}

--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -132,6 +132,7 @@ class VOMS2CSSynchronizer:
         compareWithIAM=False,
         useIAM=False,
         accessToken=None,
+        forceNickname=False,
     ):
         """VOMS2CSSynchronizer class constructor
 
@@ -165,6 +166,7 @@ class VOMS2CSSynchronizer:
         self.compareWithIAM = compareWithIAM
         self.useIAM = useIAM
         self.accessToken = accessToken
+        self.forceNickname = forceNickname
 
         if syncPluginName:
             objLoader = ObjectLoader()
@@ -329,6 +331,10 @@ class VOMS2CSSynchronizer:
                 # Check the nickName in the same VO to see if the user is already registered
                 # with another DN
                 nickName = self.vomsUserDict[dn].get("nickname")
+                if not nickName and self.forceNickname:
+                    resultDict["NoNickname"].append(self.vomsUserDict[dn])
+                    self.log.error("No nickname defined for", self.vomsUserDict[dn])
+                    continue
                 if nickName in diracUserDict or nickName in newAddedUserDict:
                     diracName = nickName
                     # This is a flag for adding the new DN to an already existing user

--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -259,7 +259,8 @@ class VOMS2CSSynchronizer:
         if not result["OK"]:
             self.log.error("Could not retrieve user information", result["Message"])
             return result
-
+        if getUserErrors := result.get("Errors", []):
+            self.adminMsgs["Errors"].extend(getUserErrors)
         self.vomsUserDict = result["Value"]
         message = f"There are {len(self.vomsUserDict)} user entries in VOMS for VO {self.vomsVOName}"
         self.adminMsgs["Info"].append(message)

--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -232,7 +232,7 @@ class VOMS2CSSynchronizer:
         vomsSrv = VOMSService(self.vo)
         voms_users = returnValueOrRaise(vomsSrv.getUsers())
         if self.compareWithIAM:
-            self.compareUsers(voms_users, iam_users)
+            self.compareUsers(voms_users.get("Users", {}), iam_users.get("Users", {}))
         return voms_users
 
     def syncCSWithVOMS(self):
@@ -259,9 +259,9 @@ class VOMS2CSSynchronizer:
         if not result["OK"]:
             self.log.error("Could not retrieve user information", result["Message"])
             return result
-        if getUserErrors := result.get("Errors", []):
+        if getUserErrors := result["Value"]["Errors"]:
             self.adminMsgs["Errors"].extend(getUserErrors)
-        self.vomsUserDict = result["Value"]
+        self.vomsUserDict = result["Value"]["Users"]
         message = f"There are {len(self.vomsUserDict)} user entries in VOMS for VO {self.vomsVOName}"
         self.adminMsgs["Info"].append(message)
         self.log.info("VOMS user entries", message)

--- a/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
+++ b/src/DIRAC/ConfigurationSystem/Client/VOMS2CSSynchronizer.py
@@ -224,7 +224,7 @@ class VOMS2CSSynchronizer:
     @convertToReturnValue
     def _getUsers(self):
         if self.compareWithIAM or self.useIAM:
-            iamSrv = IAMService(self.accessToken, vo=self.vo)
+            iamSrv = IAMService(self.accessToken, vo=self.vo, forceNickname=self.forceNickname)
             iam_users = returnValueOrRaise(iamSrv.getUsers())
             if self.useIAM:
                 return iam_users

--- a/src/DIRAC/ConfigurationSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/ConfigurationSystem/ConfigTemplate.cfg
@@ -76,6 +76,8 @@ Agents
     CompareWithIAM = False
     # If set to true, will only query IAM and return the list of users from there
     UseIAM = False
+    # If set to true only users with a nickname attribute defined in the IAM are created in DIRAC
+    ForceNickname = False
   }
   ##END
   ##BEGIN GOCDB2CSAgent

--- a/src/DIRAC/Core/Security/IAMService.py
+++ b/src/DIRAC/Core/Security/IAMService.py
@@ -129,6 +129,10 @@ class IAMService:
         return converted_output
 
     def getUsers(self):
+        """Extract users from IAM user dump.
+
+        :return: dictionary of: "Users": user dictionary keyed by the user DN, "Errors": list of error messages
+        """
         self.iam_users_raw = self._getIamUserDump()
         users = {}
         errors = []
@@ -140,6 +144,5 @@ class IAMService:
                 self.log.error("Could not convert", f"{user['name']} {e!r}")
         self.log.error("There were in total", f"{len(errors)} errors")
         self.userDict = dict(users)
-        result = S_OK(users)
-        result["Errors"] = errors
+        result = S_OK({"Users": users, "Errors": errors})
         return result

--- a/src/DIRAC/Core/Security/IAMService.py
+++ b/src/DIRAC/Core/Security/IAMService.py
@@ -23,8 +23,8 @@ class IAMService:
     def __init__(self, access_token, vo=None, forceNickname=False):
         """c'tor
 
-        :param str vo: name of the virtual organization (community)
         :param str access_token: the token used to talk to IAM, with the scim:read property
+        :param str vo: name of the virtual organization (community)
         :param bool forceNickname: if enforce the presence of a nickname attribute and do not fall back to username in IAM
 
         """

--- a/src/DIRAC/Core/Security/VOMSService.py
+++ b/src/DIRAC/Core/Security/VOMSService.py
@@ -81,7 +81,7 @@ class VOMSService:
     def getUsers(self):
         """Get all the users of the VOMS VO with their detailed information
 
-        :return: user dictionary keyed by the user DN
+        :return: dictionary of: "Users": user dictionary keyed by the user DN, "Errors": empty list
         """
         if not self.urls:
             return S_ERROR(DErrno.ENOAUTH, "No VOMS server defined")
@@ -148,4 +148,5 @@ class VOMSService:
                             resultDict[dn]["nickname"] = attribute.get("value")
 
         self.userDict = dict(resultDict)
-        return S_OK(resultDict)
+        # for consistency with IAM interface, we add Errors
+        return S_OK({"Users": resultDict, "Errors": []})


### PR DESCRIPTION
BEGINRELEASENOTES

*ConfigurationSystem
CHANGE: VOMS2CSAgent: if a nickname is set, this nickname will always be used and no new accounts are going to be created if a DN changes or a user is in multiple VOs
NEW: VOMS2CSAgent: New option "ForceNickname", if this option is enabled no dirac user is created if no nickname attribute is set for a user
CHANGE: IAMService: use logger and return errors for users so that the VOMS2CSAgent can notify admins about issues

ENDRELEASENOTES
