### PR TITLE
[sweep:integration] IAM2CS: ForceNickname, fix duplicate accounts for users

### DIFF
--- a/src/DIRAC/ConfigurationSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/ConfigurationSystem/ConfigTemplate.cfg
@@ -98,6 +98,8 @@ Agents
     CompareWithIAM = False
     # If set to true, will only query IAM and return the list of users from there
     UseIAM = False
+    # If set to true only users with a nickname attribute defined in the IAM are created in DIRAC
+    ForceNickname = False
   }
   ##END
   ##BEGIN GOCDB2CSAgent

--- a/src/DIRAC/Core/Security/VOMSService.py
+++ b/src/DIRAC/Core/Security/VOMSService.py
@@ -59,7 +59,7 @@ class VOMSService:
     def getUsers(self):
         """Get all the users of the VOMS VO with their detailed information
 
-        :return: user dictionary keyed by the user DN
+        :return: dictionary of: "Users": user dictionary keyed by the user DN, "Errors": empty list
         """
         if not self.urls:
             return S_ERROR(DErrno.ENOAUTH, "No VOMS server defined")
@@ -126,4 +126,5 @@ class VOMSService:
                             resultDict[dn]["nickname"] = attribute.get("value")
 
         self.userDict = dict(resultDict)
-        return S_OK(resultDict)
+        # for consistency with IAM interface, we add Errors
+        return S_OK({"Users": resultDict, "Errors": []})


### PR DESCRIPTION
Sweep #7784 `IAM2CS: ForceNickname, fix duplicate accounts for users` to `integration`.

Adding original author @andresailer as watcher.

BEGINRELEASENOTES

*ConfigurationSystem
CHANGE: VOMS2CSAgent: if a nickname is set, this nickname will always be used and no new accounts are going to be created if a DN changes or a user is in multiple VOs
NEW: VOMS2CSAgent: New option "ForceNickname", if this option is enabled no dirac user is created if no nickname attribute is set for a user
CHANGE: IAMService: use logger and return errors for users so that the VOMS2CSAgent can notify admins about issues

ENDRELEASENOTES
Closes #7795