### PR TITLE
[8.0] fix: added fromAddress for notification emails

### DIFF
--- a/src/DIRAC/DataManagementSystem/scripts/dirac_admin_allow_se.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_admin_allow_se.py
@@ -162,6 +162,7 @@ def main():
     subject = f"{len(totalAllowedSEs)} storage elements allowed for use"
     addressPath = "EMail/Production"
     address = Operations().getValue(addressPath, "")
+    fromAddress = Operations().getValue("ResourceStatus/Config/FromAddress", "")
 
     body = ""
     if read:
@@ -185,7 +186,7 @@ def main():
         gLogger.notice(f"'{addressPath}' not defined in Operations, can not send Mail\n", body)
         DIRAC.exit(0)
 
-    res = diracAdmin.sendMail(address, subject, body)
+    res = diracAdmin.sendMail(address, subject, body, fromAddress=fromAddress)
     gLogger.notice(f"Notifying {address}")
     if res["OK"]:
         gLogger.notice(res["Value"])

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_admin_ban_se.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_admin_ban_se.py
@@ -204,6 +204,7 @@ def main():
     subject = f"{len(writeBanned + readBanned + checkBanned + removeBanned)} storage elements banned for use"
     addressPath = "EMail/Production"
     address = Operations().getValue(addressPath, "")
+    fromAddress = Operations().getValue("ResourceStatus/Config/FromAddress", "")
 
     body = ""
     if read:
@@ -227,7 +228,7 @@ def main():
         gLogger.notice(f"'{addressPath}' not defined in Operations, can not send Mail\n", body)
         DIRAC.exit(0)
 
-    res = diracAdmin.sendMail(address, subject, body)
+    res = diracAdmin.sendMail(address, subject, body, fromAddress=fromAddress)
     gLogger.notice(f"Notifying {address}")
     if res["OK"]:
         gLogger.notice(res["Value"])

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_allow_site.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_allow_site.py
@@ -83,7 +83,8 @@ def main():
             if not address:
                 gLogger.notice(f"'{addressPath}' not defined in Operations, can not send Mail\n", body)
             else:
-                result = diracAdmin.sendMail(address, subject, body)
+                fromAddress = Operations().getValue("ResourceStatus/Config/FromAddress", "")
+                result = diracAdmin.sendMail(address, subject, body, fromAddress=fromAddress)
         else:
             print("Automatic email disabled by flag.")
 

--- a/src/DIRAC/Interfaces/scripts/dirac_admin_ban_site.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_admin_ban_site.py
@@ -85,7 +85,8 @@ def main():
             if not address:
                 gLogger.notice(f"'{addressPath}' not defined in Operations, can not send Mail\n", body)
             else:
-                result = diracAdmin.sendMail(address, subject, body)
+                fromAddress = Operations().getValue("ResourceStatus/Config/FromAddress", "")
+                result = diracAdmin.sendMail(address, subject, body, fromAddress=fromAddress)
         else:
             print("Automatic email disabled by flag.")
 

--- a/src/DIRAC/ResourceStatusSystem/Agent/TokenAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/TokenAgent.py
@@ -13,9 +13,11 @@ The following options can be set for the TokenAgent.
 from datetime import datetime, timedelta
 
 from DIRAC import S_OK, S_ERROR
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Interfaces.API.DiracAdmin import DiracAdmin
 from DIRAC.ResourceStatusSystem.Client.ResourceStatusClient import ResourceStatusClient
+
 
 AGENT_NAME = "ResourceStatus/TokenAgent"
 
@@ -209,7 +211,8 @@ class TokenAgent(AgentModule):
         mail += " Or you can use the dirac-rss-set-token script\n\n"
         mail += "Through the same interfaces you can release the token any time\n"
 
-        resEmail = self.diracAdmin.sendMail(tokenOwner, subject, mail)
+        fromAddress = Operations().getValue("ResourceStatus/Config/FromAddress", "")
+        resEmail = self.diracAdmin.sendMail(tokenOwner, subject, mail, fromAddress=fromAddress)
         if not resEmail["OK"]:
             return S_ERROR(f'Cannot send email to user "{tokenOwner}"')
 


### PR DESCRIPTION
BEGINRELEASENOTES

*RSS
FIX: use always a from address (from Operations ResourceStatus/Config/FromAddress ) when sending email notifications, to avoid "spoofing" domains restrictions

ENDRELEASENOTES
