### PR TITLE
[sweep:integration] Change the updating logic of the TS FileStatus

### DIFF
--- a/docs/source/AdministratorGuide/ServerInstallations/scalingAndLimitations.rst
+++ b/docs/source/AdministratorGuide/ServerInstallations/scalingAndLimitations.rst
@@ -62,6 +62,15 @@ Databases
 
 Every now and then, it is interesting to look at the fragmentation status of your database. This is done by using the ``analyze table`` statement (https://dev.mysql.com/doc/refman/8.4/en/analyze-table.html) possibly followed by the ``optimize table`` statement (https://dev.mysql.com/doc/refman/8.4/en/optimize-table.html).
 
+To know whether your tables are fragmented::
+
+   select table_schema,table_name, sys.format_bytes(data_length) table_size, sys.format_bytes(data_free) empty_space from information_schema.tables where data_length >= (1024*1024*1024) order by data_length desc;
+
+
+The fragmented space should be very small with respect to the overall table size.
+
+
+
 
 Duplications
 ============

--- a/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
+++ b/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
@@ -104,6 +104,8 @@ class FTS3Agent(AgentModule):
         # lifetime of the proxy we download to delegate to FTS
         self.proxyLifetime = self.am_getOption("ProxyLifetime", PROXY_LIFETIME)
 
+        self.jobMonitoringBatchSize = self.am_getOption("JobMonitoringBatchSize", JOB_MONITORING_BATCH_SIZE)
+
         return S_OK()
 
     def initialize(self):
@@ -316,7 +318,7 @@ class FTS3Agent(AgentModule):
             log.info("Getting next batch of jobs to monitor", f"{loopId}/{nbOfLoops}")
             # get jobs from DB
             res = self.fts3db.getActiveJobs(
-                limit=JOB_MONITORING_BATCH_SIZE, lastMonitor=lastMonitor, jobAssignmentTag=self.assignmentTag
+                limit=self.jobMonitoringBatchSize, lastMonitor=lastMonitor, jobAssignmentTag=self.assignmentTag
             )
 
             if not res["OK"]:
@@ -351,7 +353,7 @@ class FTS3Agent(AgentModule):
 
             # If we got less to monitor than what we asked,
             # stop looping
-            if len(activeJobs) < JOB_MONITORING_BATCH_SIZE:
+            if len(activeJobs) < self.jobMonitoringBatchSize:
                 break
         # Commit records after each loop
         self.dataOpSender.concludeSending()

--- a/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
+++ b/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
@@ -207,6 +207,11 @@ class FTS3Job(JSerializable):
                 filesStatus[file_id]["ftsGUID"] = None
                 # TODO: update status to defunct if not recoverable here ?
 
+                # If the file is failed, check if it is recoverable
+                if file_state in FTS3File.FTS_FAILED_STATES:
+                    if not fileDict.get("Recoverable", True):
+                        filesStatus[file_id]["status"] = "Defunct"
+
             # If the file is not in a final state, but the job is, we return an error
             # FTS can have inconsistencies where the FTS Job is in a final state
             # but not all the files.

--- a/src/DIRAC/DataManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/DataManagementSystem/ConfigTemplate.cfg
@@ -132,6 +132,12 @@ Agents
     OperationBulkSize = 20
     # How many Job we will monitor in one loop
     JobBulkSize = 20
+    # split jobBulkSize in several chunks
+    # Bigger numbers (like 100) are efficient when there's a single agent
+    # When there are multiple agents, it may slow down the overall because
+    # of lock and race conditions
+    # (This number should of course be smaller or equal than JobBulkSize)
+    JobMonitoringBatchSize = 20
     # Max number of files to go in a single job
     MaxFilesPerJob = 100
     # Max number of attempt per file

--- a/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
@@ -311,6 +311,7 @@ class FTS3DB:
                 session.query(FTS3Job)
                 .join(FTS3Operation)
                 .filter(FTS3Job.status.in_(FTS3Job.NON_FINAL_STATES))
+                .filter(FTS3Operation.status == "Active")
                 .filter(FTS3Job.assignment.is_(None))
                 .filter(FTS3Operation.assignment.is_(None))
             )

--- a/src/DIRAC/DataManagementSystem/Utilities/ResolveSE.py
+++ b/src/DIRAC/DataManagementSystem/Utilities/ResolveSE.py
@@ -1,6 +1,7 @@
 """ This module allows to resolve output SEs for Job based
 on SE and site/country association
 """
+
 from random import shuffle
 
 from DIRAC import gLogger, gConfig
@@ -70,7 +71,6 @@ def getDestinationSEList(outputSE, site, outputmode="Any"):
         raise RuntimeError(localSEs["Message"])
     localSEs = localSEs["Value"]
     sLog.verbose("Local SE list is:", ", ".join(localSEs))
-
     # There is an alias defined for this Site
     associatedSEs = gConfig.getValue(f"/Resources/Sites/{prefix}/{site}/AssociatedSEs/{outputSE}", [])
     if associatedSEs:

--- a/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
+++ b/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
@@ -5,6 +5,7 @@
   :synopsis: implementation of client for RequestDB using DISET framework
 
 """
+
 import os
 import time
 import random
@@ -258,7 +259,7 @@ class ReqClient(Client):
         self.log.debug("getRequestStatus: attempting to get status for '%d' request." % requestID)
         requestStatus = self._getRPC().getRequestStatus(requestID)
         if not requestStatus["OK"]:
-            self.log.error(
+            self.log.verbose(
                 "getRequestStatus: unable to get status for request",
                 ": '%d' %s" % (requestID, requestStatus["Message"]),
             )
@@ -469,6 +470,23 @@ class ReqClient(Client):
             req.NotBefore = datetime.datetime.utcnow().replace(microsecond=0)
             return self.putRequest(req)
         return S_OK("Not reset")
+
+    @ignoreEncodeWarning
+    def getBulkRequestStatus(self, requestIDs: list[int]):
+        """get the Status for the supplied request IDs.
+
+        :param self: self reference
+        :param list requestIDs: list of job IDs (integers)
+        :return: S_ERROR or S_OK( { reqID1:status, requID2:status2, ... })
+        """
+        res = self._getRPC().getBulkRequestStatus(requestIDs)
+        if not res["OK"]:
+            return res
+
+        # Cast the requestIDs back to int
+        statuses = strToIntDict(res["Value"])
+
+        return S_OK(statuses)
 
 
 # ============= Some useful functions to be shared ===========

--- a/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
+++ b/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
@@ -918,6 +918,19 @@ class RequestDB:
             session.close()
         return S_OK(status[0])
 
+    def getBulkRequestStatus(self, requestIDs):
+        """get requests statuses for given request IDs"""
+        session = self.DBSession()
+        try:
+            statuses = session.query(Request.RequestID, Request._Status).filter(Request.RequestID.in_(requestIDs)).all()
+            status_dict = {req_id: req_status for req_id, req_status in statuses}
+        except Exception as e:
+            # log as well?
+            return S_ERROR(f"Failed to getBulkRequestStatus {e!r}")
+        finally:
+            session.close()
+        return S_OK(status_dict)
+
     def getRequestFileStatus(self, requestID, lfnList):
         """get status for files in request given its id
 

--- a/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/ReqManagerHandler.py
@@ -337,6 +337,16 @@ class ReqManagerHandlerMixin:
             gLogger.error("getRequestStatus", status["Message"])
         return status
 
+    types_getBulkRequestStatus = [list]
+
+    @classmethod
+    def export_getBulkRequestStatus(cls, requestIDs):
+        """get requests statuses given their ids"""
+        res = cls.__requestDB.getBulkRequestStatus(requestIDs)
+        if not res["OK"]:
+            gLogger.error("getBulkRequestStatus", res["Message"])
+        return res
+
     types_getRequestFileStatus = [int, [str, list]]
 
     @classmethod


### PR DESCRIPTION
Sweep #7741 `Change the updating logic of the TS FileStatus` to `integration`.

Adding original author @chaen as watcher.

BEGINRELEASENOTES
*TS
FIX: RequestTaskAgent only considers requests in final states, and consider files in intermediate state as problematic (https://github.com/DIRACGrid/DIRAC/issues/7116)
NEW: RequestTaskAgent uses getBulkRequestStatus instead of getRequestStatus

RMS:
NEW: implement getRequestStatus



ENDRELEASENOTES
Closes #7804