### PR TITLE
[8.0] SSHCE, Try python3 before unversioned python

### DIFF
--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -495,7 +495,7 @@ class SSHComputingElement(ComputingElement):
         options = quote(options)
 
         cmd = (
-            "bash --login -c 'python %s/execute_batch %s || python3 %s/execute_batch %s || python2 %s/execute_batch %s'"
+            "bash --login -c 'python3 %s/execute_batch %s || python %s/execute_batch %s || python2 %s/execute_batch %s'"
             % (self.sharedArea, options, self.sharedArea, options, self.sharedArea, options)
         )
 


### PR DESCRIPTION
Hi,

I think "python3" is more common than the unversioned "python" command on most nodes now, so I'm suggesting swapping the ordering around to cut down on the logs generated...

Regards,
Simon


BEGINRELEASENOTES
FIX: SSHCE, Try python3 before unversioned python
ENDRELEASENOTES
