### PR TITLE
[v8r0] Improve getTransformationFiles performance

### DIFF
--- a/src/DIRAC/TransformationSystem/Client/TransformationClient.py
+++ b/src/DIRAC/TransformationSystem/Client/TransformationClient.py
@@ -179,12 +179,14 @@ class TransformationClient(Client):
             res = rpcClient.getTransformationFiles(
                 condDict, older, newer, timeStamp, orderAttribute, offset, maxfiles, columns
             )
+            # TransformationDB.getTransformationFiles includes a "Records"/"ParameterNames"
+            # that we don't want to return to the client so explicitly return S_OK with the value
             if not res["OK"]:
                 return res
             return S_OK(res["Value"])
 
-        # If LFNs requested continue to do the old behavior of requesting in small batches
-        # Probably not needed?
+        # If LFNs requested, request in small batches, because...
+        # Probably not needed? Because this should always be a list
         if isinstance(condDict["LFN"], str):
             lfnList = [condDict["LFN"]]
         else:

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -602,60 +602,49 @@ class TransformationDB(DB):
         limit=None,
         offset=None,
         connection=False,
+        columns=None,
     ):
         """Get files for the supplied transformations with support for the web standard structure"""
         connection = self.__getConnection(connection)
-        req = f"SELECT {intListToString(self.TRANSFILEPARAMS)} FROM TransformationFiles"
-        originalFileIDs = {}
-        if condDict is None:
-            condDict = {}
-        if condDict or older or newer:
-            lfns = condDict.pop("LFN", None)
-            if lfns:
-                if isinstance(lfns, str):
-                    lfns = [lfns]
-                res = self.__getFileIDsForLfns(lfns, connection=connection)
-                if not res["OK"]:
-                    return res
-                originalFileIDs = res["Value"][0]
-                condDict["FileID"] = list(originalFileIDs)
 
-            for val in condDict.values():
-                if not val:
-                    return S_OK([])
+        all_columns = ["LFN"] + self.TRANSFILEPARAMS
+        if columns is None:
+            columns = all_columns
+        elif not set(columns).issubset(all_columns):
+            return S_ERROR(f"Invalid columns requested, valid columns are: {all_columns}")
 
-            req = "{} {}".format(
-                req,
-                self.buildCondition(condDict, older, newer, timeStamp, orderAttribute, limit, offset=offset),
-            )
+        req = ", ".join(f"df.{x}" if x == "LFN" else f"tf.{x}" for x in columns)
+        req = f"SELECT {req} FROM TransformationFiles tf"
+        if "LFN" in columns or (condDict and "LFN" in condDict):
+            req = f"{req} JOIN DataFiles df ON tf.FileID = df.FileID"
+
+        fixedCondDict = {}
+        if condDict:
+            for key, value in condDict.items():
+                if key in self.TRANSFILEPARAMS:
+                    fixedCondDict[f"tf.{key}"] = value
+                elif key in ["LFN"]:
+                    fixedCondDict[f"df.{key}"] = value
+                else:
+                    return S_ERROR(f"Invalid key {key} in condDict")
+        if timeStamp:
+            timeStamp = f"t.{timeStamp}"
+        if fixedCondDict or older or newer:
+            cond = self.buildCondition(fixedCondDict, older, newer, timeStamp, orderAttribute, limit, offset=offset)
+            # When buildCondition tries to quote the column names, it will fail due to the table alias
+            # So we need to move the single quotes to the right place
+            req += f" {cond.replace('`tf.', 'tf.`').replace('`df.', 'df.`')}"
+
         res = self._query(req, conn=connection)
         if not res["OK"]:
             return res
 
-        transFiles = res["Value"]
-        fileIDs = [int(row[1]) for row in transFiles]
-        webList = []
-        resultList = []
-        if not fileIDs:
-            originalFileIDs = {}
-        else:
-            if not originalFileIDs:
-                res = self.__getLfnsForFileIDs(fileIDs, connection=connection)
-                if not res["OK"]:
-                    return res
-                originalFileIDs = res["Value"][1]
-            for row in transFiles:
-                lfn = originalFileIDs[row[1]]
-                # Prepare the structure for the web
-                fDict = {"LFN": lfn}
-                fDict.update(dict(zip(self.TRANSFILEPARAMS, row)))
-                # Note: the line below is returning "None" if the item is None... This seems to work but is ugly...
-                rList = [lfn] + [str(item) if not isinstance(item, int) else item for item in row]
-                webList.append(rList)
-                resultList.append(fDict)
+        resultList = [dict(zip(columns, row)) for row in res["Value"]]
+        webList = [[str(item) if not isinstance(item, int) else item for item in row] for row in res["Value"]]
+
         result = S_OK(resultList)
         result["Records"] = webList
-        result["ParameterNames"] = ["LFN"] + self.TRANSFILEPARAMS
+        result["ParameterNames"] = columns
         return result
 
     def getFileSummary(self, lfns, connection=False):

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -628,7 +628,7 @@ class TransformationDB(DB):
                 else:
                     return S_ERROR(f"Invalid key {key} in condDict")
         if timeStamp:
-            timeStamp = f"t.{timeStamp}"
+            timeStamp = f"tf.{timeStamp}"
         if fixedCondDict or older or newer:
             cond = self.buildCondition(fixedCondDict, older, newer, timeStamp, orderAttribute, limit, offset=offset)
             # When buildCondition tries to quote the column names, it will fail due to the table alias

--- a/src/DIRAC/TransformationSystem/Service/TransformationManagerHandler.py
+++ b/src/DIRAC/TransformationSystem/Service/TransformationManagerHandler.py
@@ -288,6 +288,7 @@ class TransformationManagerHandlerMixin:
         orderAttribute=None,
         limit=None,
         offset=None,
+        columns=None,
     ):
         if not condDict:
             condDict = {}
@@ -300,6 +301,7 @@ class TransformationManagerHandlerMixin:
             limit=limit,
             offset=offset,
             connection=False,
+            columns=columns,
         )
 
     ####################################################################

--- a/tests/Integration/TransformationSystem/Test_Client_Transformation.py
+++ b/tests/Integration/TransformationSystem/Test_Client_Transformation.py
@@ -114,6 +114,17 @@ class TransformationClientChain(TestClientTransformationTestCase):
         for f in res["Value"]:
             self.assertEqual(f["Status"], TransformationFilesStatus.ASSIGNED)
 
+        # make sure we can selectively select LFNs
+        res = self.transClient.getTransformationFiles({"TransformationID": transID, "LFN": ["/aa/lfn.1.txt"]})
+        assert res["OK"], res
+        assert len(res["Value"]) == 1, res
+        assert "TargetSE" in res["Value"][0].keys(), res
+
+        # make sure we can selectively select columns
+        res = self.transClient.getTransformationFiles({"TransformationID": transID}, columns=["LFN", "Status"])
+        assert res["OK"], res
+        assert sorted(res["Value"][0]) == ["LFN", "Status"], res
+
         # now adding a new Transformation with new tasks, and introducing a mix of insertion,
         # to test that the trigger works as it should
         res = self.transClient.addTransformation(


### PR DESCRIPTION
This significantly improves the performance of `getTransformationFiles` by:

* Using a `JOIN` instead of manually looking up the LFNs from file IDs
* Remove the batching that was needed due to the use of `__getFileIDsForLfns`
    * This is doubly helpful as the use of `OFFSET N LIMIT 10000` made the function O(N^2) due to the database having to rebuild and scan the results for every batch.
* Giving the option to only get the columns you need

For example in LHCb: this optimises a ~1200 second call to be ~20 seconds.


BEGINRELEASENOTES

*TransformationSystem
NEW: 
CHANGE: Improve getTransformationFiles performance

ENDRELEASENOTES
