### PR TITLE
fix(resources): AREXCE should return an error if queue is not found

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -657,6 +657,8 @@ class AREXComputingElement(ARCComputingElement):
                 result["RunningJobs"] = int(qi["RunningJobs"])
                 result["WaitingJobs"] = int(qi["WaitingJobs"])
                 break  # Pick the first (should be only ...) matching queue + VO
+        else:
+            return S_ERROR(f"Could not find the queue {self.queue} associated to VO {vo}")
 
         return result
 


### PR DESCRIPTION
Minimal fix, better than getting: `KeyError: 'RunningJobs'`



BEGINRELEASENOTES
*Resources
FIX: AREXCE returns an error if a queue is not found in the ARC instance configuration
ENDRELEASENOTES
