### PR TITLE
[8.0] CloudCE: truncate long messages returned from create_node

### DIFF
--- a/src/DIRAC/Resources/Computing/CloudComputingElement.py
+++ b/src/DIRAC/Resources/Computing/CloudComputingElement.py
@@ -495,7 +495,12 @@ class CloudComputingElement(ComputingElement):
             try:
                 node = driver.create_node(**instParams)
             except Exception as err:
-                self.log.error("Failed to create_node", str(err))
+                errMsg = str(err)
+                # sometimes cloud returns complete user_data which is too long for
+                # a sensible log message
+                if len(errMsg) > 256:
+                    errMsg = f"{errMsg[:128]}...{errMsg[-128:]}"
+                self.log.error("Failed to create_node", errMsg)
                 continue
             instIDs.append(VM_ID_PREFIX + node.id)
             stampDict[instName] = instRandom


### PR DESCRIPTION
Hi,

We've found that sometimes create_node can return the entire user_data string (twice) which creates a log entry over 100K in length, so it makes sense to truncate that...

Regards,
Simon

BEGINRELEASENOTES
*Resources
FIX: CloudCE: truncate long messages returned from create_node
ENDRELEASENOTES
