### PR TITLE
[8.0] Drop CloudCE proxy handling

### DIFF
--- a/src/DIRAC/Resources/Computing/cloudinit.template
+++ b/src/DIRAC/Resources/Computing/cloudinit.template
@@ -42,9 +42,6 @@ write_files:
      CVMFS_CACHE_BASE=/mnt/cvmfs
      CVMFS_HTTP_PROXY="auto;DIRECT"
      CVMFS_PAC_URLS="http://grid-wpad/wpad.dat;http://wpad/wpad.dat;http://cernvm-wpad.cern.ch/wpad.dat;http://cernvm-wpad.fnal.gov/wpad.dat"
- - path: /root/proxy.pem
-   permissions: '0600'
-   content: PROXY_STR
  - path: /root/run_pilot.sh
    permissions: '0755'
    content: EXECUTABLE_STR
@@ -53,7 +50,6 @@ write_files:
    content: |
      #!/bin/bash
      cd /mnt/dirac
-     export X509_USER_PROXY=/mnt/proxy.pem
      export PILOT_UUID="cloud://$(cat /var/lib/cloud/data/instance-id)"
      export DIRAC_PILOT_STAMP="STAMP_STR"
      bash /mnt/run_pilot.sh &> /mnt/dirac/startup.log
@@ -84,9 +80,6 @@ runcmd:
  - [ useradd, -m, -d, /mnt/dirac, dirac ]
  - [ passwd, -l, dirac ]
  - [ mkdir, -p, /mnt/dirac/etc/grid-security ]
- - [ cp, /root/proxy.pem, /mnt/proxy.pem ]
- - [ chmod, 600, /mnt/proxy.pem ]
- - [ chown, "dirac:dirac", /mnt/proxy.pem ]
  - [ chown, -R, "dirac:dirac", /mnt/dirac/etc ]
 # Start caching certificates directory from CVMFS
 # Workaround for when local Stratum-1 is slow


### PR DESCRIPTION
Hi,

Now that the pilot wrapper always includes a bundled proxy, we don't need to handle writing one specially in the cloud scripts, so this patch drops all of that functionality. This also fixes a recent v8 bug where CloudCE keeps self.proxy in a different format (string rather than proxy object) to other CEs resulting in a SiteDirector crash.

[Note: Users with a custom cloudinit.template will need to update it to match these changes].

Regards,
Simon

BEGINRELEASENOTES
*Resources
FIX: Drop CloudCE proxy handling
ENDRELEASENOTES
