### PR TITLE
fix(WMS): JobWrapper checks existence of executable in jobIDPath

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -307,7 +307,10 @@ class JobWrapper:
             executable = shutil.which(executable) or executable
 
         # Make the full path since . is not always in the PATH
-        executable = os.path.abspath(executable)
+        # self.jobIDPath is an absolute path, so we can use it directly
+        # if executable is an absolute path, self.jobIDPath is ignored
+        # Example: "/bin/ls" will be used as is
+        executable = str(self.jobIDPath / executable)
         if not os.path.exists(executable):
             self.__report(status=JobStatus.FAILED, minorStatus=JobMinorStatus.APP_NOT_FOUND, sendFlag=True)
             return S_ERROR(f"Path to executable {executable} not found")

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -134,9 +134,16 @@ def test_preProcess_nonexistent_executable(setup_job_wrapper):
     """Test the pre process method of the JobWrapper class: nonexistent executable."""
     jw = setup_job_wrapper({"Executable": "pippo"})
 
+    # Without a jobID
     result = jw.preProcess()
     assert not result["OK"]
     assert result["Message"] == f"Path to executable {os.getcwd()}/pippo not found"
+
+    # With a jobID
+    jw.jobIDPath = jw.jobIDPath / "123"
+    result = jw.preProcess()
+    assert not result["OK"]
+    assert result["Message"] == f"Path to executable {os.getcwd()}/123/pippo not found"
 
 
 def test_preProcess_dirac_jobexec(setup_job_wrapper):


### PR DESCRIPTION
Should solve an issue observed during the latest hackathon.

BEGINRELEASENOTES
*WorkloadManagement
FIX: JobWrapper checks existence of executable in jobIDPath
ENDRELEASENOTES
