### PR TITLE
fix(WMS): SandboxStore not able to assign a sandbox to a job

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -151,7 +151,7 @@ class SandboxStoreHandlerMixin:
             gLogger.info("Sandbox already exists. Skipping upload")
             if fileHelper:
                 fileHelper.markAsTransferred()
-            sbURL = f"SB:{self.__localSEName}|sbPath"
+            sbURL = f"SB:{self.__localSEName}|{sbPath}"
             assignTo = {key: [(sbURL, assignTo[key])] for key in assignTo}
             result = self.export_assignSandboxesToEntities(assignTo)
             if not result["OK"]:


### PR DESCRIPTION
Another issue observed during the latest hackathon.

BEGINRELEASENOTES

*WorkloadManagement
FIX: SandboxStore not able to assign a sandbox to a job
ENDRELEASENOTES
