### PR TITLE
fix (FTS3Agent): fix wrong return type

### DIFF
--- a/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
+++ b/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
@@ -510,7 +510,7 @@ class FTS3Agent(AgentModule):
                                 scope=["fts"],
                             )
                             if not res["OK"]:
-                                return res
+                                return operation, res
 
                             fts_access_token = res["Value"]["access_token"]
 


### PR DESCRIPTION
BEGINRELEASENOTES
*DMS

FIX: fix wrong return type in the FTS3Agent, when using tokens

ENDRELEASENOTES
