### PR TITLE
[rel-v8r0] Fix deadlock when FTS3Agent._treatOperation fails

### DIFF
--- a/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
+++ b/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py
@@ -288,13 +288,15 @@ class FTS3Agent(AgentModule):
         :param returnedValue: value returned by the _monitorJob method
                               (ftsJob, standard dirac return struct)
         """
-
-        ftsJob, res = returnedValue
-        log = gLogger.getLocalSubLogger(f"_monitorJobCallback/{ftsJob.jobID}")
-        if not res["OK"]:
-            log.error("Error updating job status", res)
+        if not isinstance(returnedValue, tuple) or len(returnedValue) != 2:
+            ftsJob, res = returnedValue
+            log = gLogger.getLocalSubLogger(f"_monitorJobCallback/{ftsJob.jobID}")
+            if not res["OK"]:
+                log.error("Error updating job status", res)
+            else:
+                log.debug("Successfully updated job status")
         else:
-            log.debug("Successfully updated job status")
+            log.error("Invalid return value when monitoring job", f"{returnedValue!r}")
 
     def monitorJobsLoop(self):
         """* fetch the active FTSJobs from the DB
@@ -372,13 +374,15 @@ class FTS3Agent(AgentModule):
         :param returnedValue: value returned by the _treatOperation method
                               (ftsOperation, standard dirac return struct)
         """
-
-        operation, res = returnedValue
-        log = gLogger.getLocalSubLogger(f"_treatOperationCallback/{operation.operationID}")
-        if not res["OK"]:
-            log.error("Error treating operation", res)
+        if isinstance(returnedValue, tuple) and len(returnedValue) == 2:
+            operation, res = returnedValue
+            log = gLogger.getLocalSubLogger(f"_treatOperationCallback/{operation.operationID}")
+            if not res["OK"]:
+                log.error("Error treating operation", res)
+            else:
+                log.debug("Successfully treated operation")
         else:
-            log.debug("Successfully treated operation")
+            log.error("Invalid return value when treating operation", f"{returnedValue!r}")
 
     def _treatOperation(self, operation):
         """Treat one operation:
@@ -510,7 +514,7 @@ class FTS3Agent(AgentModule):
                                 scope=["fts"],
                             )
                             if not res["OK"]:
-                                return res
+                                return operation, res
 
                             fts_access_token = res["Value"]["access_token"]
 


### PR DESCRIPTION
```python
2024-10-22 08:24:02 UTC DataManagement/FTS3Agent/treatOperation/9186486 INFO: FTS3Operation 9186486: Submitted job for 10 transfers
Exception in thread Thread-132 (_handle_results):
Traceback (most recent call last):
  File "/opt/dirac/versions/v11.0.49-1729166531/Linux-x86_64/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/opt/dirac/versions/v11.0.49-1729166531/Linux-x86_64/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/dirac/versions/v11.0.49-1729166531/Linux-x86_64/lib/python3.11/multiprocessing/pool.py", line 595, in _handle_results
    cache[job]._set(i, obj)
  File "/opt/dirac/versions/v11.0.49-1729166531/Linux-x86_64/lib/python3.11/multiprocessing/pool.py", line 779, in _set
    self._callback(self._value)
  File "/opt/dirac/versions/v11.0.49-1729166531/Linux-x86_64/lib/python3.11/site-packages/DIRAC/DataManagementSystem/Agent/FTS3Agent.py", line 376, in _treatOperationCallback
    operation, res = returnedValue
    ^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```

There are two issues:

The traceback shown in the log (I've added some print out for next time). Actually it's probably https://github.com/DIRACGrid/DIRAC/blob/b5bc25cb2d04ac10e3998e7dd9055f38444f65cf/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py#L516

The fact it deadlocks in https://github.com/DIRACGrid/DIRAC/blob/b5bc25cb2d04ac10e3998e7dd9055f38444f65cf/src/DIRAC/DataManagementSystem/Agent/FTS3Agent.py#L573-L588 which can be reproduced with:

```python
In [1]: from multiprocessing.pool import ThreadPool
   ...: import time
   ...:
   ...: def my_op(should_fail):
   ...:     return should_fail
   ...:
   ...: def callback(should_fail):
   ...:     if should_fail:
   ...:         raise Exception()
   ...:
   ...: opsThreadPool = ThreadPool(4)
   ...: res_good = opsThreadPool.apply_async(my_op, (False,), callback=callback)
   ...: res_bad = opsThreadPool.apply_async(my_op, (True,), callback=callback)
   ...: time.sleep(1)
   ...: print(f"{res_good.ready()=} {res_bad.ready()=}")
Exception in thread Thread-7 (_handle_results):
Traceback (most recent call last):
  File "/home/cburr/miniconda3/envs/dirac-development-2/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/home/cburr/miniconda3/envs/dirac-development-2/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/home/cburr/miniconda3/envs/dirac-development-2/lib/python3.11/multiprocessing/pool.py", line 595, in _handle_results
    cache[job]._set(i, obj)
  File "/home/cburr/miniconda3/envs/dirac-development-2/lib/python3.11/multiprocessing/pool.py", line 779, in _set
    self._callback(self._value)
  File "<ipython-input-1-a027a5833145>", line 9, in callback
Exception
res_good.ready()=True res_bad.ready()=False
```

BEGINRELEASENOTES

*DataManagement
FIX: Fix deadlock when FTS3Agent._treatOperation fails

ENDRELEASENOTES
