### PR TITLE
[v8.0] ensure processProposal always returns "closeTransport" on error

### DIFF
--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -511,6 +511,7 @@ class Service:
         # Notify the client we're ready to execute the action
         retVal = self._transportPool.send(trid, S_OK())
         if not retVal["OK"]:
+            retVal["closeTransport"] = True
             return retVal
 
         messageConnection = False


### PR DESCRIPTION
cc @chrisburr 


BEGINRELEASENOTES

*Core
FIX: ensure processProposal always returns "closeTransport" on error

ENDRELEASENOTES
