### PR TITLE
[v8.0] fix (StompMQConnector): add a timeout for the StompConnector

### DIFF
--- a/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
+++ b/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
@@ -35,6 +35,7 @@ class StompMQConnector(MQConnector):
     RECONNECT_SLEEP_MAX = 120  # [s] The maximum delay that can be reached independent of increasing procedure.
     RECONNECT_SLEEP_JITTER = 0.1  # Random factor to add. 0.1 means a random number from 0 to 10% of the current time.
     RECONNECT_ATTEMPTS_MAX = 1e4  # Maximum attempts to reconnect.
+    STOMP_TIMEOUT = 60
 
     PORT = 61613
 
@@ -72,6 +73,8 @@ class StompMQConnector(MQConnector):
         reconnectSleepJitter = self.parameters.get("ReconnectSleepJitter", StompMQConnector.RECONNECT_SLEEP_JITTER)
         reconnectAttemptsMax = self.parameters.get("ReconnectAttemptsMax", StompMQConnector.RECONNECT_ATTEMPTS_MAX)
 
+        stompTimeout = self.parameters.get("Timeout", StompMQConnector.STOMP_TIMEOUT)
+
         host = self.parameters.get("Host")
         port = self.parameters.get("Port", StompMQConnector.PORT)
         vhost = self.parameters.get("VHost")
@@ -83,6 +86,7 @@ class StompMQConnector(MQConnector):
         connectionArgs = {
             "vhost": vhost,
             "keepalive": True,
+            "timeout": stompTimeout,
             "reconnect_sleep_initial": reconnectSleepInitial,
             "reconnect_sleep_increase": reconnectSleepIncrease,
             "reconnect_sleep_max": reconnectSleepMax,

--- a/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
+++ b/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
@@ -35,6 +35,9 @@ class StompMQConnector(MQConnector):
     RECONNECT_SLEEP_MAX = 120  # [s] The maximum delay that can be reached independent of increasing procedure.
     RECONNECT_SLEEP_JITTER = 0.1  # Random factor to add. 0.1 means a random number from 0 to 10% of the current time.
     RECONNECT_ATTEMPTS_MAX = 1e4  # Maximum attempts to reconnect.
+
+    OUTGOING_HEARTBEAT_MS = 15_000
+    INCOMING_HEARTBEAT_MS = 15_000
     STOMP_TIMEOUT = 60
 
     PORT = 61613
@@ -73,6 +76,9 @@ class StompMQConnector(MQConnector):
         reconnectSleepJitter = self.parameters.get("ReconnectSleepJitter", StompMQConnector.RECONNECT_SLEEP_JITTER)
         reconnectAttemptsMax = self.parameters.get("ReconnectAttemptsMax", StompMQConnector.RECONNECT_ATTEMPTS_MAX)
 
+        outgoingHeartbeatMs = self.parameters.get("OutgoingHeartbeatMs", StompMQConnector.OUTGOING_HEARTBEAT_MS)
+        incomingHeartbeatMs = self.parameters.get("IncomingHeartbeatMs", StompMQConnector.INCOMING_HEARTBEAT_MS)
+
         stompTimeout = self.parameters.get("Timeout", StompMQConnector.STOMP_TIMEOUT)
 
         host = self.parameters.get("Host")
@@ -87,6 +93,7 @@ class StompMQConnector(MQConnector):
             "vhost": vhost,
             "keepalive": True,
             "timeout": stompTimeout,
+            "heartbeats": (outgoingHeartbeatMs, incomingHeartbeatMs),
             "reconnect_sleep_initial": reconnectSleepInitial,
             "reconnect_sleep_increase": reconnectSleepIncrease,
             "reconnect_sleep_max": reconnectSleepMax,


### PR DESCRIPTION
cc @chrisburr 

for #7851 

BEGINRELEASENOTES

*StompMQConnector
FIX: add a timeout for the StompConnector to handle nonresponsive sockets which can cause logging to be blocked

ENDRELEASENOTES
