### PR TITLE
[integration] fix: modify echo in function installDIRACX() where error occurs

### DIFF
--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -290,7 +290,7 @@ function installDIRACX() {
     if [[ -n "${DIRACX_CUSTOM_SOURCE_PREFIXES:-}" ]]; then
       wheels=( $(find "${DIRACX_CUSTOM_SOURCE_PREFIXES}" -name "diracx_${wheel_name}-*.whl") )
       if [[ ! ${#wheels[@]} -eq 1 ]]; then
-          echo "ERROR: Multiple wheels found for ${package_name} in ${dir}"
+          echo "ERROR: Multiple or no wheels found for ${wheel_name} in ${DIRACX_CUSTOM_SOURCE_PREFIXES}"
           exit 1
       fi
       pip install "${wheels[0]}"


### PR DESCRIPTION
Function` installDIRACX()` in `utilities.sh` had a malformed `echo` statement which referred to undefined variables.

*Tests
 FIX: print a correct package name and a source directory.

The error would normally not pop up in CI since the GitHub workflow created necessary wheels:
```
pip install build
for pkg_dir in $PWD/diracx-* .; do
echo "Building $pkg_dir"
python -m build --outdir "${GITHUB_WORKSPACE}/dist" $pkg_dir
```

And when trying to run tests locally I naively issued a command:

`./integration_tests.py prepare-environment "TEST_DIRACX=Yes"  --diracx-dist-dir  <my_diracX_source_tree>"`

without building the wheels first.
