### PR TITLE
[8.0] Support testing v8r0 with EL9

### DIFF
--- a/docs/diracdoctools/cmd/codeReference.py
+++ b/docs/diracdoctools/cmd/codeReference.py
@@ -183,6 +183,9 @@ class CodeReference:
             if dire.lower() == "docs" or "/docs" in dire.lower():
                 LOG.debug("Skipping docs directory: %s/%s", abspath, dire)
                 continue
+            if any(f.lower() in abspath.lower() for f in self.config.code_ignoreFolders):
+                LOG.debug("Skipping subpackages: %s/%s", abspath, dire)
+                continue
             if os.path.exists(os.path.join(self.config.sourcePath, abspath, dire, "__init__.py")):
                 packages.append(os.path.join(dire))
         return packages

--- a/tests/CI/docker-compose.yml
+++ b/tests/CI/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       timeout: 20s
       retries: 10
       start_period: 60s
+    pull_policy: always
 
   elasticsearch:
     image: ${ES_VER}
@@ -25,6 +26,7 @@ services:
       timeout: 2s
       retries: 15
       start_period: 60s
+    pull_policy: always
 
   iam-login-service:
     image: ${IAM_VER}
@@ -39,7 +41,7 @@ services:
       timeout: 2s
       retries: 15
       start_period: 60s
-
+    pull_policy: always
 
   # Mock of an S3 storage
   s3-direct:
@@ -52,6 +54,7 @@ services:
     environment:
       - initialBuckets=my-first-bucket
       - debug=true
+    pull_policy: always
 
   dirac-server:
     image: ${CI_REGISTRY_IMAGE}/${HOST_OS}-dirac
@@ -65,6 +68,9 @@ services:
         condition: service_healthy
     ulimits:
       nofile: 8192
+    pull_policy: always
+    command: ["sleep", "infinity"] # This is necessary because of the issue described in https://github.com/moby/moby/issues/42275. What is added here is a hack/workaround.
+
 
   dirac-client:
     image: ${CI_REGISTRY_IMAGE}/${HOST_OS}-dirac
@@ -75,3 +81,5 @@ services:
       - dirac-server
     ulimits:
       nofile: 8192
+    pull_policy: always
+    command: ["sleep", "infinity"] # This is necessary because of the issue described in https://github.com/moby/moby/issues/42275. What is added here is a hack/workaround.

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -125,7 +125,7 @@ findServices(){
     ServicestoExclude='notExcluding'
   fi
 
-  if ! cd "${SERVERINSTALLDIR}" -ne 0; then
+  if ! cd "${SERVERINSTALLDIR}"; then
     echo 'ERROR: cannot change to ' "${SERVERINSTALLDIR}" >&2
     exit 1
   fi


### PR DESCRIPTION
Mostly a backport. Needed to be able to move the LHCbDIRAC CI to using EL9.