### PR TITLE
[8.0] Use plain proxy for pilot bundle

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -109,6 +109,9 @@ class SiteDirector(AgentModule):
         self.maxQueueLength = 86400 * 3
         # Maximum number of times the Site Director is going to try to get a pilot output before stopping
         self.maxRetryGetPilotOutput = 3
+        # Bundle proxy lifetime factor: Job bundled proxy lifetime will be this multiplied by the queue runtime length,
+        # should be high enough to accommodate the queuing time of the job.
+        self.bundleProxyLifetimeFactor = 1.5
 
         self.pilotWaitingFlag = True
         self.pilotLogLevel = "INFO"
@@ -734,7 +737,16 @@ class SiteDirector(AgentModule):
         jobExecDir = self.queueDict[queue]["ParametersDict"].get("JobExecDir", "")
         envVariables = self.queueDict[queue]["ParametersDict"].get("EnvironmentVariables", None)
 
-        executable = self.getExecutable(queue, proxy=ce.proxy, jobExecDir=jobExecDir, envVariables=envVariables)
+        # We don't want to use the submission/"pilot" proxy for the job in the bundle:
+        # Instead we use a non-VOMS proxy which is then not limited in lifetime by the VOMS extension
+        proxyTimeSec = int(self.maxQueueLength * self.bundleProxyLifetimeFactor)
+        result = gProxyManager.downloadProxy(self.pilotDN, self.pilotGroup, limited=True, requiredTimeLeft=proxyTimeSec)
+        if not result["OK"]:
+            self.log.error("Failed to get job proxy", f"Queue {queue}:\n{result['Message']}")
+            return result
+        jobProxy = result["Value"]
+
+        executable = self.getExecutable(queue, proxy=jobProxy, jobExecDir=jobExecDir, envVariables=envVariables)
 
         submitResult = ce.submitJob(executable, "", pilotsToSubmit)
         # In case the CE does not need the executable after the submission, we delete it

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
@@ -28,6 +28,10 @@ mockPM = MagicMock()
 mockPM.requestToken.return_value = {"OK": True, "Value": ("token", 1)}
 mockPMReply = MagicMock()
 mockPMReply.return_value = {"OK": True, "Value": ("token", 1)}
+mockPMProxy = MagicMock()
+mockPMProxy.dumpAllToString.return_value = {"OK": True, "Value": "fakeProxy"}
+mockPMProxyReply = MagicMock()
+mockPMProxyReply.return_value = {"OK": True, "Value": mockPMProxy}
 
 mockCSGlobalReply = MagicMock()
 mockCSGlobalReply.return_value = "TestSetup"
@@ -48,6 +52,9 @@ def sd(mocker):
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.SiteDirector.Operations", side_effect=mockOPS)
     mocker.patch(
         "DIRAC.WorkloadManagementSystem.Agent.SiteDirector.gProxyManager.requestToken", side_effect=mockPMReply
+    )
+    mocker.patch(
+        "DIRAC.WorkloadManagementSystem.Agent.SiteDirector.gProxyManager.downloadProxy", side_effect=mockPMProxyReply
     )
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.SiteDirector.AgentModule", side_effect=mockAM)
     sd = SiteDirector()


### PR DESCRIPTION
Hi,

As discussed at the last BiLD meeting, I've been looking at the problem of the bundled proxy expiring in the middle of the pilot job, causing various failures (as this is no longer renewed like the proxy delegated via the CE).

Here is an implementation of my proposed fix: Instead of using the proxy that's used to submit the job to the CE (which is capped by the VO's maximum VOMS lifetime), we generate a new vanilla proxy (with the lifetime set to a multiple of the expected maximum runtime) to send in the bundle. The pilot then uses this new proxy to report back to DIRAC which doesn't need VOMS. This is the same approach we were previously using in the CloudCE (where pilot runtime could easily be 2+ weeks for efficiency reasons).

I've done basic testing and it seems to fix the problems I was initially seeing, seemingly without creating any new issues.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
CHANGE: Use plain proxy for the pilot bundle
ENDRELEASENOTES
