### PR TITLE
[integration] Sort out whitespace in cvmfs.yml

### DIFF
--- a/.github/workflows/cvmfs.yml
+++ b/.github/workflows/cvmfs.yml
@@ -20,7 +20,6 @@ jobs:
           conda info
           conda info --envs
           conda list
-        
           conda install ca-policy-lcg openssl==3.0.7 gct
 
           echo "$CVMFS_PROXY_BASE64" | base64 --decode > cvmfs.proxy


### PR DESCRIPTION
Some rogue whitespace has made it into cvmfs.yml and is upsetting one of the basic formatting tests on other pull requests... Here is a thrilling patch for it.

BEGINRELEASENOTES
*Misc
FIX: Tidy up whitespace in cvmfs.yml
ENDRELEASENOTES
