### PR TITLE
[8.0] Standard naming for TokenManager service classes

### DIFF
--- a/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
@@ -29,6 +29,20 @@ Services
   # Section to describe TokenManager system
   TokenManager
   {
+    Port = 9180
+    # Description of rules for access to methods
+    Authorization
+    {
+      # Settings by default:
+      Default = authenticated
+      getUsersTokensInfo = ProxyManagement
+    }
+  }
+  ##END
+  ##BEGIN TornadoTokenManager:
+  # Section to describe TokenManager system
+  TokenManager
+  {
     Protocol = https
     # Description of rules for access to methods
     Authorization

--- a/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
@@ -41,7 +41,7 @@ Services
   ##END
   ##BEGIN TornadoTokenManager:
   # Section to describe TokenManager system
-  TokenManager
+  TornadoTokenManager
   {
     Protocol = https
     # Description of rules for access to methods

--- a/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/FrameworkSystem/ConfigTemplate.cfg
@@ -29,7 +29,7 @@ Services
   # Section to describe TokenManager system
   TokenManager
   {
-    Port = 9180
+    Port = 9181
     # Description of rules for access to methods
     Authorization
     {

--- a/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TokenManagerHandler.py
@@ -1,7 +1,5 @@
-"""TokenManager service is a HTTPs-exposed service responsible for token management, namely storing, updating,
+"""TokenManager service is responsible for token management, namely storing, updating,
 requesting new tokens for DIRAC components that have the appropriate permissions.
-
-.. note:: As a newly created service, it will not support the old DIPS protocol, which is living to its age.
 
 .. literalinclude:: ../ConfigTemplate.cfg
     :start-after: ##BEGIN TokenManager:
@@ -32,7 +30,6 @@ import pprint
 
 from DIRAC import S_OK, S_ERROR
 from DIRAC.Core.Security import Properties
-from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.FrameworkSystem.DB.TokenDB import TokenDB
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.Resources.IdProvider.IdProviderFactory import IdProviderFactory
@@ -40,6 +37,7 @@ from DIRAC.FrameworkSystem.Utilities.TokenManagementUtilities import (
     getIdProviderClient,
     getCachedKey,
 )
+from DIRAC.Core.DISET.RequestHandler import RequestHandler
 
 
 class TokenManagerHandlerMixin:
@@ -284,5 +282,5 @@ class TokenManagerHandlerMixin:
         return self.__tokenDB.getTokensByUserID(userID)
 
 
-class TokenManagerHandler(TokenManagerHandlerMixin, TornadoService):
+class TokenManagerHandler(TokenManagerHandlerMixin, RequestHandler):
     pass

--- a/src/DIRAC/FrameworkSystem/Service/TornadoTokenManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TornadoTokenManagerHandler.py
@@ -1,5 +1,7 @@
-"""TokenManager service is responsible for token management, namely storing, updating,
+"""TokenManager service is a HTTPs-exposed service responsible for token management, namely storing, updating,
 requesting new tokens for DIRAC components that have the appropriate permissions.
+
+.. note:: As a newly created service, it will not support the old DIPS protocol, which is living to its age.
 
 .. literalinclude:: ../ConfigTemplate.cfg
     :start-after: ##BEGIN TokenManager:
@@ -26,9 +28,9 @@ The ``refresh token`` from :py:class:`TokenDB <DIRAC.FrameworkSystem.DB.TokenDB.
 is taken and the **exchange token** request to Identity Provider is made.
 """
 
-from DIRAC.Core.DISET.RequestHandler import RequestHandler
+from DIRAC.Core.Tornado.Server.TornadoService import TornadoService
 from DIRAC.FrameworkSystem.Service.TokenManagerHandler import TokenManagerHandlerMixin
 
 
-class DisetTokenManagerHandler(TokenManagerHandlerMixin, RequestHandler):
+class TornadoTokenManagerHandler(TokenManagerHandlerMixin, TornadoService):
     pass

--- a/src/DIRAC/FrameworkSystem/Service/TornadoTokenManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/TornadoTokenManagerHandler.py
@@ -1,7 +1,5 @@
-"""TokenManager service is a HTTPs-exposed service responsible for token management, namely storing, updating,
+"""TornadoTokenManager service is a HTTPs-exposed service responsible for token management, namely storing, updating,
 requesting new tokens for DIRAC components that have the appropriate permissions.
-
-.. note:: As a newly created service, it will not support the old DIPS protocol, which is living to its age.
 
 .. literalinclude:: ../ConfigTemplate.cfg
     :start-after: ##BEGIN TokenManager:
@@ -17,7 +15,7 @@ This is mainly about the :py:meth:`export_getToken` method.
     :alt: https://dirac.readthedocs.io/en/integration/_images/TokenManager_getToken.png (source https://github.com/TaykYoku/DIRACIMGS/raw/main/TokenManagerService_getToken.ai)
 
 The client has a mechanism for caching the received tokens.
-This helps reduce the number of requests to both the service and the Identity Provider (IdP).
+This helps reducing the number of requests to both the service and the Identity Provider (IdP).
 
 If the client has a valid **access token** in the cache, it is used until it expires.
 After that you need to update. The client can update it independently if on the server where it is in ``dirac.cfg``


### PR DESCRIPTION
  This PR is a follow-up of #7888 to make names for the service handlers following the standard convention. The PR propagated to integration replaces #7893. This also means that upon the update the DIRAC installations using already the Tornado TokenManager service will have to update the TokenManager service configuration by adding the HandlerPath option:

```
HandlerPath = DIRAC/FrameworkSystem/Service/TornadoTokenManagerHandler.py
``` 

This will be reflected in the release notes and instructions

BEGINRELEASENOTES

*Framework
CHANGE: Rename TokenManager service classes to follow standard convention for tornado and diset handlers

ENDRELEASENOTES
