### PR TITLE
[9.0] Run CE cleanup step at correct point

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -750,6 +750,11 @@ class SiteDirector(AgentModule):
         ceType = self.queueDict[queue]["CEType"]
         siteName = self.queueDict[queue]["Site"]
 
+        # Call cleanup before checking pilot statuses (so cleanup always runs)
+        # This is needed to delete things like old cloud instances after the pilots are done
+        if callable(getattr(ce, "cleanupPilots", None)):
+            ce.cleanupPilots()
+
         # Select pilots in a transient states
         result = self.pilotAgentsDB.selectPilots(
             {
@@ -798,10 +803,6 @@ class SiteDirector(AgentModule):
             self.failedQueues[queue] += 1
         # Update the status of the pilots in the DB
         self._updatePilotsInDB(updatedPilots)
-
-        # FIXME: seems like it is only used by the CloudCE? Couldn't it be called from CloudCE.getJobStatus()?
-        if callable(getattr(ce, "cleanupPilots", None)):
-            ce.cleanupPilots()
 
         # Check if the accounting is to be sent
         if self.sendAccounting:


### PR DESCRIPTION
Hi,

We discovered in the hackathon this morning that the CloudCE doesn't always delete old instances any more. This was tracked down to the point where the cleanup function was called: It used to be at the start of the monitoring block, but was moved to the end during a refactor about a year ago.

To answer the comment in the fixme comment: getJobStatus is only called while there are transient pilots for the CE, but the cleanup has to still run after the pilot has finished, which is why we added the extra function hook earlier in the process.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Run CE cleanup step at correct point
ENDRELEASENOTES
