### PR TITLE
[8.0] fix(Resources): AREX should renew the delegation before submitting a payload

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -481,6 +481,11 @@ class AREXComputingElement(ARCComputingElement):
 
                 # If we are here, we have found the right delegationID to use
                 currentDelegationID = delegationID
+                # Renew the delegation just in case
+                if not self.token or self.alwaysIncludeProxy:
+                    result = self._renewDelegation(currentDelegationID)
+                    if not result["OK"]:
+                        self.log.warn("Could not renew the delegation", f"{currentDelegationID}: {result['Message']}")
                 break
 
             if not currentDelegationID:


### PR DESCRIPTION
As discussed with @marianne013 a few weeks ago

Otherwise, 
- if there is no pilot submission, there is no pilot monitoring, and
- if there is no pilot monitoring, there is no delegation renewal, and
- if there is no delegation renewal, then the delegation can expire (which happens in the certification instance)

I am not even sure it solves https://github.com/DIRACGrid/DIRAC/issues/7931 though

BEGINRELEASENOTES
*WorkloadManagement
FIX: renew delegation prior to submitting pilots
ENDRELEASENOTES
