### PR TITLE
[v8.0] Optimise ASN1 decoding in X509Certificate

### DIFF
--- a/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Certificate.py
@@ -10,6 +10,8 @@ import os
 import random
 import time
 
+import M2Crypto.m2
+import M2Crypto.ASN1
 import M2Crypto.X509
 
 
@@ -211,8 +213,10 @@ class X509Certificate:
 
         :returns: S_OK( datetime )/S_ERROR
         """
-
-        notAfter = self.__certObj.get_not_after().get_datetime()
+        # Here we use the M2Crypto low level API, as the high level API is notably
+        # slower due to the conversion to a string and then back to an ASN1_TIME.
+        rawNotAfter = M2Crypto.m2.x509_get_not_after(self.__certObj.x509)  # pylint: disable=no-member
+        notAfter = M2Crypto.ASN1.ASN1_TIME(rawNotAfter).get_datetime()
 
         # M2Crypto does things correctly by setting a timezone info in the datetime
         # However, we do not in DIRAC, and so we can't compare the dates.
@@ -242,7 +246,10 @@ class X509Certificate:
         :returns: S_OK( datetime )/S_ERROR
 
         """
-        return S_OK(self.__certObj.get_not_before().get_datetime())
+        # Here we use the M2Crypto low level API, as the high level API is notably
+        # slower due to the conversion to a string and then back to an ASN1_TIME.
+        rawNotBefore = M2Crypto.m2.x509_get_not_before(self.__certObj.x509)  # pylint: disable=no-member
+        return S_OK(M2Crypto.ASN1.ASN1_TIME(rawNotBefore).get_datetime())
 
     # @executeOnlyIfCertLoaded
     # def setNotBefore(self, notbefore):


### PR DESCRIPTION
This pull request includes changes to the `X509Certificate` class in the `src/DIRAC/Core/Security/m2crypto` directory. The changes primarily focus on updating the methods for retrieving certificate validity dates to use lower-level M2Crypto functions. These are considerably faster as they avoid dumping/loading the datetime to a string as an intermediate step.

```python
In [5]: %timeit ASN1.ASN1_TIME(m2.x509_get_not_before(certObj.x509)).get_datetime()
10.8 μs ± 24.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [6]: %timeit certObj.get_not_after().get_datetime()
73.3 μs ± 181 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```


BEGINRELEASENOTES

*Core
CHANGE: Optimise ASN1 decoding in X509Certificate

ENDRELEASENOTES
