### PR TITLE
[8.0] Avoid locking in MessageQueueHandler

### DIFF
--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Handler/MessageQueueHandler.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Handler/MessageQueueHandler.py
@@ -47,3 +47,15 @@ class MessageQueueHandler(logging.Handler):
         strRecord = self.format(record)
         if self.producer is not None:
             self.producer.put(json.loads(strRecord))
+
+    def handle(self, record):
+        """
+        Conditionally emit the specified logging record.
+
+        Override the handle method from logging.Handler as there is no need to
+        acquire the lock to emit the record.
+        """
+        rv = self.filter(record)
+        if rv:
+            self.emit(record)
+        return rv


### PR DESCRIPTION
In `logging.Handler` cpython suggests having a lock on the `handle` method to avoid multiple lines being emitted at the same time and corrupting the output.

For the `MessageQueueHandler` this isn't actually a concern and it actually just becomes a source of lock contention.

BEGINRELEASENOTES

*Core
FIX: Avoid locking in MessageQueueHandler

ENDRELEASENOTES
