### PR TITLE
[8.0] Support https URLs with dirac-framework-ping-service

### DIFF
--- a/src/DIRAC/Interfaces/scripts/dirac_framework_ping_service.py
+++ b/src/DIRAC/Interfaces/scripts/dirac_framework_ping_service.py
@@ -51,7 +51,7 @@ def main():
     url = None
     if len(args) == 1:
         # it is a URL
-        if args[0].startswith("dips://"):
+        if args[0].startswith(("dips://", "https://")):
             url = args[0]
         # It is System/Service
         else:


### PR DESCRIPTION

BEGINRELEASENOTES

*Framework
FIX: Support https URLs with dirac-framework-ping-service

ENDRELEASENOTES
