### PR TITLE
[9.0] fix(integration tests): mount diracx-services in init-db container

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -673,9 +673,12 @@ def _gen_docker_compose(modules, *, diracx_dist_dir=None):
             "dirac-server",
             "diracx-init-cs",
             "diracx-wait-for-db",
+            "diracx-init-db",
             "diracx",
         ]:
-            docker_compose["services"][container_name]["volumes"].append(f"{diracx_dist_dir}:/diracx_sources")
+            docker_compose["services"][container_name].setdefault("volumes", []).append(
+                f"{diracx_dist_dir}:/diracx_sources"
+            )
             docker_compose["services"][container_name].setdefault("environment", []).append(
                 "DIRACX_CUSTOM_SOURCE_PREFIXES=/diracx_sources"
             )


### PR DESCRIPTION
Fix https://github.com/DIRACGrid/diracx/pull/334

I ran my branch against the `diracx` repo to test it: https://github.com/DIRACGrid/diracx/actions/runs/12429503751/job/34703126233?pr=334

BEGINRELEASENOTES

*Integration tests
FIX: mount diracx in init-db container

ENDRELEASENOTES
