### PR TITLE
[8.0] fix: dirac-rss-sync: flip the default status to Active

### DIFF
--- a/docs/source/AdministratorGuide/Systems/ResourceStatus/install.rst
+++ b/docs/source/AdministratorGuide/Systems/ResourceStatus/install.rst
@@ -85,26 +85,17 @@ Copy over the values that we had on the CS for the StorageElements::
 
     $ dirac-rss-sync --init -o LogLevel=VERBOSE
 
-*WARNING*: If the StorageElement does not have a particular StatusType declared
+*WARNING*: If the StorageElement does not have a particular StatusType declared, on the CS, this script will set it to Active.
 
-*WARNING*: on the CS, this script will set it to Banned. If that happens, you will
+You can check the status of the resources with the following command::
 
-*WARNING*: have to issue the dirac-rss-status script over the elements that need
-
-*WARNING*: to be fixed.
-
+    $ dirac-rss-list-status --element Resource --elementType StorageElement
 
 --------------------
 Set statuses by HAND
 --------------------
 
-In case you entered the WARNING ! on point 4, you may need to identify the
-status of your StorageElements. Try to detect the Banned SEs using the
-following::
-
-    $ dirac-rss-list-status --element Resource --elementType StorageElement --status Banned
-
-If is there any SE to be modified, you can do it as follows::
+If there is any SE status to be modified, you can do it as follows::
 
     $ dirac-rss-set-status --element Resource --name CERN-USER --statusType ReadAccess --status Active --reason "Why not?"
     # This matches all StatusTypes

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_sync.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_sync.py
@@ -4,7 +4,7 @@ Script that synchronizes the resources described on the CS with the RSS.
 By default, it sets their Status to `Unknown`, StatusType to `all` and
 reason to `Synchronized`. However, it can copy over the status on the CS to
 the RSS. Important: If the StatusType is not defined on the CS, it will set
-it to Banned !
+it to Active !
 """
 from DIRAC import S_OK
 from DIRAC import exit as DIRACExit
@@ -44,7 +44,7 @@ def parseSwitches():
 
     # Default values
     switches.setdefault("element", None)
-    switches.setdefault("defaultStatus", "Banned")
+    switches.setdefault("defaultStatus", "Active")
     if not switches["element"] in ("all", "Site", "Resource", "Node", None):
         gLogger.error(f"Found {switches['element']} as element switch")
         gLogger.error("Please, check documentation below")
@@ -242,7 +242,7 @@ def main():
 
     registerSwitches()
     switchDict = parseSwitches()
-    DEFAULT_STATUS = switchDict.get("defaultStatus", "Banned")
+    DEFAULT_STATUS = switchDict.get("defaultStatus", "Active")
 
     # Run script
     run()

--- a/tests/Jenkins/dirac_ci.sh
+++ b/tests/Jenkins/dirac_ci.sh
@@ -311,11 +311,11 @@ fullInstallDIRAC() {
 
   # populate RSS
   echo "==> Populating RSS DB"
-  dirac-rss-sync --element Site -o LogLevel=VERBOSE
-  dirac-rss-sync --element Resource -o LogLevel=VERBOSE
+  dirac-rss-sync --element Site --defaultStatus Banned -o LogLevel=VERBOSE
+  dirac-rss-sync --element Resource --defaultStatus Banned -o LogLevel=VERBOSE
   # init RSS
   echo "==> Initializing status of sites and resources in RSS"
-  dirac-rss-sync --init -o LogLevel=VERBOSE
+  dirac-rss-sync --init --defaultStatus Banned -o LogLevel=VERBOSE
   # Setting by hand
   dirac-rss-set-status --element Resource --name ProductionSandboxSE --status Active --reason "Why not?"
   dirac-rss-set-status --element Resource --name jenkins.cern.ch --status Active --reason "Why not?"


### PR DESCRIPTION

BEGINRELEASENOTES

*RSS
CHANGE: dirac-rss-sync: flip the default status to Active

ENDRELEASENOTES
