### PR TITLE
[8.0] fix: adapt HTCondorCE to latest htcondor version 

### DIFF
--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -172,7 +172,7 @@ class HTCondorCEComputingElement(ComputingElement):
 
         executable = os.path.join(self.workingDirectory, executable)
 
-        useCredentials = "use_x509userproxy = true"
+        useCredentials = ""
         # If tokenFile is present, then we transfer it to the worker node
         if tokenFile:
             useCredentials += textwrap.dedent(
@@ -245,10 +245,7 @@ class HTCondorCEComputingElement(ComputingElement):
         if not result["OK"]:
             return result
 
-        htcEnv = {
-            "_CONDOR_SEC_CLIENT_AUTHENTICATION_METHODS": "GSI",
-        }
-
+        htcEnv = {}
         if self.useSSLSubmission:
             # this is guaranteed by _prepareProxy above
             proxyFile = os.environ.get("X509_USER_PROXY")


### PR DESCRIPTION
Problem:

```bash
$ condor_submit -terse -pool <ce>:9619 -remote <ce> file.sub --debug
01/16/25 11:14:27 CREDMON: invoking /usr/bin/batch_krb5_credential
01/16/25 11:14:27 CREDMON: storing credential with CredD.
01/16/25 11:14:27 STORE_CRED: In mode 160 'add', user is ""
91264384.0 - 91264384.0
01/16/25 11:14:27 Not entering transfer queue because sandbox (12092) is too small (<= 104857600).
01/16/25 11:14:27 Delegation error: 4048566DC27F0000:error:05800091:x509 certificate routines:X509_REQ_verify_ex:unsupported version:crypto/x509/x_all.c:47:

01/16/25 11:14:27 Delegation error: 
01/16/25 11:14:27 ReliSock::put_x509_delegation(): delegation failed: X509Credential::Delegate() failed
01/16/25 11:14:27 DoUpload: SUBMIT at 188.185.129.0 failed to send file(s) to <137.138.149.107:9619>: |Error: sending file /tmp/x509up_u127430; SCHEDD at 137.138.149.107 - |Error: receiving file /var/lib/condor-ce/spool/4384/0/cluster91264384.proc0.subproc0.tmp/x509up_u127430
```

I don't really solve the problem here, I just remove a few options that trigger the issue, and that seem not needed anymore.


Still needs a proper test with:
- [x] tokens (I made a quick test with a client that works)
- [ ] SSL (@andresailer could you try please?)

BEGINRELEASENOTES
*Resources
FIX: adapt HTCondorCE to latest htcondor version
ENDRELEASENOTES
