### PR TITLE
[8.0] fix: Adapt AREXCE arc7 delegation new response

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -244,7 +244,7 @@ class AREXComputingElement(ARCComputingElement):
         if not delegationURL:
             return S_ERROR(f"Cannot extract delegation ID from the response: {response.headers}")
 
-        delegationID = delegationURL.split("new/")[-1]
+        delegationID = delegationURL.split("/")[-1]
         certificateSigningRequestData = response.text
         return S_OK((delegationID, certificateSigningRequestData))
 


### PR DESCRIPTION
Still using the `REST 1.0` (`REST 1.1` is available but we have not tried it yet)

BEGINRELEASENOTES
*Resources
FIX: adapt AREX to ARC7 delegation output
ENDRELEASENOTES
