### PR TITLE
[8.0] fix (Core): limit read to TLS payload size

### DIFF
--- a/src/DIRAC/Core/DISET/private/Transports/BaseTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/BaseTransport.py
@@ -17,6 +17,7 @@ Client <- RequestHandler : Response
 
 Client <- Service        : Close
 """
+
 import time
 from io import BytesIO
 from hashlib import md5
@@ -26,6 +27,9 @@ import selectors
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK
 from DIRAC.FrameworkSystem.Client.Logger import gLogger
 from DIRAC.Core.Utilities import MixedEncode
+
+# https://datatracker.ietf.org/doc/html/rfc8446#section-5.1
+TLS_PAYLOAD_SIZE = 16384
 
 
 class BaseTransport:
@@ -198,7 +202,7 @@ class BaseTransport:
             isKeepAlive = self.byteStream.find(BaseTransport.keepAliveMagic, 0, keepAliveMagicLen) == 0
             # While not found the message length or the ka, keep receiving
             while iSeparatorPosition == -1 and not isKeepAlive:
-                retVal = self._read(16384)
+                retVal = self._read(TLS_PAYLOAD_SIZE)
                 # If error return
                 if not retVal["OK"]:
                     return retVal
@@ -225,6 +229,7 @@ class BaseTransport:
             pkgSize = int(self.byteStream[:iSeparatorPosition])
             pkgData = self.byteStream[iSeparatorPosition + 1 :]
             readSize = len(pkgData)
+
             if readSize >= pkgSize:
                 # If we already have all the data we need
                 data = pkgData[:pkgSize]
@@ -235,7 +240,7 @@ class BaseTransport:
                 pkgMem.write(pkgData)
                 # Receive while there's still data to be received
                 while readSize < pkgSize:
-                    retVal = self._read(pkgSize - readSize, skipReadyCheck=True)
+                    retVal = self._read(min(TLS_PAYLOAD_SIZE, pkgSize - readSize), skipReadyCheck=True)
                     if not retVal["OK"]:
                         return retVal
                     if not retVal["Value"]:

--- a/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
@@ -493,7 +493,8 @@ class SSLTransport(BaseTransport):
             # And writting on a socket that received an RST packet
             # triggers a SIGPIPE.
             # In practice, this means that if the server replies to a
-            # dead client with less that 16384 bytes (see),
+            # dead client with less that 16384 bytes
+            # (see https://datatracker.ietf.org/doc/html/rfc8446#section-5.1),
             # we will never notice that we sent the answer to the vacuum.
             # And don't look for a fix, there just isn't.
             wrote = self.oSocket.write(buf)


### PR DESCRIPTION
```python
2025-02-03 21:04:46 UTC Framework ERROR: Network error while receiving data
Traceback (most recent call last):
  File "/home/chaen/dirac/DIRAC/src/DIRAC/Core/DISET/private/Transports/BaseTransport.py", line 238, in receiveData
    retVal = self._read(pkgSize - readSize, skipReadyCheck=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chaen/dirac/DIRAC/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py", line 465, in _read
    read = self.oSocket.read(bufSize)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chaen/miniforge3/envs/diracprod/lib/python3.11/site-packages/M2Crypto/SSL/Connection.py", line 420, in 
read
    return self._read_bio(size)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/chaen/miniforge3/envs/diracprod/lib/python3.11/site-packages/M2Crypto/SSL/Connection.py", line 362, in 
_read_bio
    return m2.ssl_read(self.ssl, size, self._timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OverflowError: in method 'ssl_read', argument 2 of type 'int'
```

BEGINRELEASENOTES

*Core
FIX: read at most 2^14 bytes at the same time


ENDRELEASENOTES
