### PR TITLE
[8.0]  Fix getting ES configuration

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/Utilities.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Utilities.py
@@ -472,9 +472,9 @@ def getElasticDBParameters(fullname):
             gLogger.debug("Failed to get the configuration parameter: CRT. Using False")
             certs = False
         else:
-            certs = result["Value"]
+            certs = result["Value"].lower() in ("true", "yes", "y", "1")
     else:
-        certs = result["Value"]
+        certs = result["Value"].lower() in ("true", "yes", "y", "1")
     parameters["CRT"] = certs
 
     # If connection is through certificates get the mandatory parameters: ca_certs, client_key, client_cert
@@ -579,9 +579,9 @@ def getElasticDBParameters(fullname):
             gLogger.debug("Failed to get the configuration parameter: SSL. Assuming SSL is needed")
             ssl = True
         else:
-            ssl = False if result["Value"].lower() in ("false", "no", "n") else True
+            ssl = result["Value"].lower() in ("true", "yes", "y", "1")
     else:
-        ssl = False if result["Value"].lower() in ("false", "no", "n") else True
+        ssl = result["Value"].lower() in ("true", "yes", "y", "1")
     parameters["SSL"] = ssl
 
     return S_OK(parameters)

--- a/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/ElasticJobParametersDB.py
@@ -17,6 +17,8 @@ from DIRAC import S_ERROR, S_OK
 from DIRAC.ConfigurationSystem.Client.Helpers import CSGlobals
 from DIRAC.Core.Base.ElasticDB import ElasticDB
 from DIRAC.Core.Utilities import TimeUtilities
+from DIRAC.ConfigurationSystem.Client.Config import gConfig
+from DIRAC.ConfigurationSystem.Client.PathFinder import getDatabaseSection
 
 try:
     from opensearchpy.exceptions import NotFoundError, RequestError
@@ -49,7 +51,8 @@ class ElasticJobParametersDB(ElasticDB):
         """Standard Constructor"""
 
         try:
-            indexPrefix = CSGlobals.getSetup().lower()
+            section = getDatabaseSection("WorkloadManagement/ElasticJobParametersDB")
+            indexPrefix = gConfig.getValue(f"{section}/IndexPrefix", CSGlobals.getSetup()).lower()
 
             # Connecting to the ES cluster
             super().__init__(name, "WorkloadManagement/ElasticJobParametersDB", indexPrefix, parentLogger=parentLogger)


### PR DESCRIPTION

BEGINRELEASENOTES

*WorkloadManagement

FIX: get ElasticJobParametersDB index prefix from the configuration

*Configuration

FIX: evaluate useCRT flag as boolean in Utilities.getElasticDBParameters()

ENDRELEASENOTES
