### PR TITLE
[8.0] updating the mysql version used in the tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,8 +31,8 @@ jobs:
       matrix:
         # TEST_NAME is a dummy variable used to make it easier to read the web interface
         include:
-          - TEST_NAME: "MySQL 5.7"
-            ARGS: MYSQL_VER=mysql:5.7
+          - TEST_NAME: "MySQL 8.0"
+            ARGS: MYSQL_VER=mysql:8.0.40
           - TEST_NAME: "MariaDB 10.6, opensearch:2.1.0"
             ARGS: MYSQL_VER=mariadb:10.6.3 ES_VER=opensearchproject/opensearch:2.1.0
           - TEST_NAME: "HTTPS"

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -22,7 +22,7 @@ from typer import colors as c
 
 # Editable configuration
 DEFAULT_HOST_OS = "cc7"
-DEFAULT_MYSQL_VER = "mysql:8.0"
+DEFAULT_MYSQL_VER = "mysql:8.4.4"
 DEFAULT_ES_VER = "elasticsearch:7.9.1"
 DEFAULT_IAM_VER = "indigoiam/iam-login-service:v1.10.2"
 

--- a/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.sql
+++ b/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.sql
@@ -23,7 +23,7 @@ CREATE TABLE Tasks(
   `CompleteTime` DATETIME,
   `CallBackMethod` VARCHAR(255),
   `SourceTaskID` VARCHAR(32),
-  PRIMARY KEY(`TaskID`,`Status`),
+  PRIMARY KEY(`TaskID`),
   INDEX(`TaskID`,`Status`)
 )ENGINE=INNODB;
 
@@ -41,7 +41,7 @@ CREATE TABLE CacheReplicas(
   `LastUpdate` DATETIME,
   `Reason` VARCHAR(255),
   `Links` INTEGER DEFAULT 0,
-  PRIMARY KEY (`ReplicaID`,`LFN`,`SE`),
+  PRIMARY KEY (`ReplicaID`),
   INDEX(`ReplicaID`,`Status`,`SE`)
 )ENGINE=INNODB;
 


### PR DESCRIPTION
From 8.0 to 8.4

From https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html :

> **Nonstandard foreign keys.**  The use of non-unique or partial keys as foreign keys is nonstandard, and is deprecated in MySQL. Beginning with MySQL 8.4.0, you must explicitly enable such keys by setting [restrict_fk_on_non_standard_key](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_restrict_fk_on_non_standard_key) to OFF, or by starting the server with --skip-restrict-fk-on-non-standard-key.

```
ALTER TABLE Tasks DROP PRIMARY KEY, ADD PRIMARY KEY (`TaskID`);
ALTER TABLE CacheReplicas DROP PRIMARY KEY, ADD PRIMARY KEY (`ReplicaID`);
```



BEGINRELEASENOTES

*Subsystem
CHANGE: default MySQL version from 8.0 to 8.4

ENDRELEASENOTES
