### PR TITLE
[sweep:integration] Fix getting ES configuration

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/Utilities.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Utilities.py
@@ -467,9 +467,9 @@ def getElasticDBParameters(fullname):
             gLogger.debug("Failed to get the configuration parameter: CRT. Using False")
             certs = False
         else:
-            certs = result["Value"]
+            certs = result["Value"].lower() in ("true", "yes", "y", "1")
     else:
-        certs = result["Value"]
+        certs = result["Value"].lower() in ("true", "yes", "y", "1")
     parameters["CRT"] = certs
 
     # If connection is through certificates get the mandatory parameters: ca_certs, client_key, client_cert
@@ -574,9 +574,9 @@ def getElasticDBParameters(fullname):
             gLogger.debug("Failed to get the configuration parameter: SSL. Assuming SSL is needed")
             ssl = True
         else:
-            ssl = False if result["Value"].lower() in ("false", "no", "n") else True
+            ssl = result["Value"].lower() in ("true", "yes", "y", "1")
     else:
-        ssl = False if result["Value"].lower() in ("false", "no", "n") else True
+        ssl = result["Value"].lower() in ("true", "yes", "y", "1")
     parameters["SSL"] = ssl
 
     return S_OK(parameters)


### PR DESCRIPTION
Sweep #8037 `Fix getting ES configuration` to `integration`.

Adding original author @atsareg as watcher.

BEGINRELEASENOTES

*WorkloadManagement

FIX: get ElasticJobParametersDB index prefix from the configuration

*Configuration

FIX: evaluate useCRT flag as boolean in Utilities.getElasticDBParameters()

ENDRELEASENOTES
Closes #8038