### PR TITLE
[sweep:integration] updating the mysql version used in the tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,8 +33,8 @@ jobs:
         include:
           - TEST_NAME: "MariaDB 11.4"
             ARGS: MYSQL_VER=mariadb:11.4.3
-          - TEST_NAME: "HTTPS"
-            ARGS: TEST_HTTPS=Yes
+          - TEST_NAME: "HTTPS and MySQL8"
+            ARGS: TEST_HTTPS=Yes MYSQL_VER=mysql:8.0.40
           - TEST_NAME: "Force DEncode"
             ARGS: DIRAC_USE_JSON_ENCODE=NO
           - TEST_NAME: "Backward Compatibility"

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -23,7 +23,7 @@ from typer import colors as c
 
 # Editable configuration
 DEFAULT_HOST_OS = "el9"
-DEFAULT_MYSQL_VER = "mysql:8.0.40"
+DEFAULT_MYSQL_VER = "mysql:8.4.4"
 DEFAULT_ES_VER = "opensearchproject/opensearch:2.18.0"
 DEFAULT_IAM_VER = "indigoiam/iam-login-service:v1.10.2"
 FEATURE_VARIABLES = {

--- a/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.sql
+++ b/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.sql
@@ -23,7 +23,7 @@ CREATE TABLE Tasks(
   `CompleteTime` DATETIME,
   `CallBackMethod` VARCHAR(255),
   `SourceTaskID` VARCHAR(32),
-  PRIMARY KEY(`TaskID`,`Status`),
+  PRIMARY KEY(`TaskID`),
   INDEX(`TaskID`,`Status`)
 )ENGINE=INNODB;
 
@@ -41,7 +41,7 @@ CREATE TABLE CacheReplicas(
   `LastUpdate` DATETIME,
   `Reason` VARCHAR(255),
   `Links` INTEGER DEFAULT 0,
-  PRIMARY KEY (`ReplicaID`,`LFN`,`SE`),
+  PRIMARY KEY (`ReplicaID`),
   INDEX(`ReplicaID`,`Status`,`SE`)
 )ENGINE=INNODB;
 


### PR DESCRIPTION
Sweep #8039 `updating the mysql version used in the tests` to `integration`.

Adding original author @fstagni as watcher.

BEGINRELEASENOTES

*Subsystem
CHANGE: default MySQL version from 8.0 to 8.4

ENDRELEASENOTES
Closes #8043