### PR TITLE
fix (SandboxStore): LFN is needed for PhysicalRemoval

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -7,6 +7,7 @@
   :dedent: 2
   :caption: SandboxStore options
 """
+
 import os
 import time
 import threading
@@ -562,6 +563,7 @@ class SandboxStoreHandlerMixin:
                 physicalRemoval.TargetSE = SEName
                 fileToRemove = File()
                 fileToRemove.PFN = SEPFN
+                fileToRemove.LFN = SEPFN
                 physicalRemoval.addFile(fileToRemove)
                 request.addOperation(physicalRemoval)
                 return ReqClient().putRequest(request)


### PR DESCRIPTION
This fixes the following error. This could never have worked

```
2025-02-28 09:54:54 UTC WorkloadManagement/SandboxStore ERROR: Cannot delete sandbox from backend Operation #0 of type 'PhysicalRemoval' is missing LFN attribute for file.
2025-02-28 09:54:54 UTC WorkloadManagement/SandboxStore/RequestManagement/ReqClient/pid_766876 ERROR: putRequest: request not valid Operation #0 of type 'PhysicalRemoval' is missing LFN attribute for file.
```
BEGINRELEASENOTES

*WorkloadManagement

FIX: create valid request for delayed sandbox purging

ENDRELEASENOTES
