### PR TITLE
fix(wms): pass args to SD.buildQueueDict() in the right order

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -168,7 +168,7 @@ class SiteDirector(AgentModule):
         self.log.always("MaxPilotsToSubmit:", self.maxPilotsToSubmit)
 
         # Build the dictionary of queues that are going to be used: self.queueDict
-        if not (result := self._buildQueueDict(siteNames, ceTypes, ces, tags))["OK"]:
+        if not (result := self._buildQueueDict(siteNames, ces, ceTypes, tags))["OK"]:
             return result
 
         # Stop the execution if there is no usable queue


### PR DESCRIPTION
Closes https://github.com/DIRACGrid/DIRAC/issues/8068

Thanks @natthan-pigoux for spotting the issue!

BEGINRELEASENOTES
*WorkloadManagement
FIX: pass args to buildQueueDict() in the right order
ENDRELEASENOTES
