### PR TITLE
[8.0] fix: condor and delegated proxies

### DIFF
--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -172,7 +172,9 @@ class HTCondorCEComputingElement(ComputingElement):
 
         executable = os.path.join(self.workingDirectory, executable)
 
-        useCredentials = ""
+        # For now, we still need to include a proxy in the submit file
+        # HTCondor extracts VOMS attribute from it for the sites
+        useCredentials = "use_x509userproxy = true"
         # If tokenFile is present, then we transfer it to the worker node
         if tokenFile:
             useCredentials += textwrap.dedent(
@@ -274,6 +276,10 @@ class HTCondorCEComputingElement(ComputingElement):
             htcEnv = {
                 "_CONDOR_SEC_CLIENT_AUTHENTICATION_METHODS": "SCITOKENS",
                 "_CONDOR_SCITOKENS_FILE": self.tokenFile.name,
+                # This options is needed because we are still passing the proxy in the JDL (see use_x509userproxy)
+                # In condor v24.4, there is a bug preventing us from delegating the proxy, so we have to set
+                # it to false: https://opensciencegrid.atlassian.net/browse/HTCONDOR-2904
+                "_CONDOR_DELEGATE_JOB_GSI_CREDENTIALS": "false",
             }
             if cas := getCAsLocation():
                 htcEnv["_CONDOR_AUTH_SSL_CLIENT_CADIR"] = cas


### PR DESCRIPTION
Coming back to https://github.com/DIRACGrid/DIRAC/pull/7993

I removed the `use_x509userproxy` too soon: X509 proxies are actually still needed along with the tokens, as they are used to extract VOMS attributes.

But there is a bug in condor `v24` that prevents proxies to be delegated: https://opensciencegrid.atlassian.net/browse/HTCONDOR-2904

The workaround is to set `DELEGATE_JOB_GSI_CREDENTIALS` to `False`:  https://htcondor.readthedocs.io/en/24.0/admin-manual/configuration-macros.html#DELEGATE_JOB_GSI_CREDENTIALS

BEGINRELEASENOTES
*Resources
FIX: htcondor x509 unsupported version
ENDRELEASENOTES
