### PR TITLE
fix (MQ): catch ConnectionError upon send

### DIFF
--- a/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
+++ b/src/DIRAC/Resources/MessageQueue/StompMQConnector.py
@@ -175,7 +175,7 @@ class StompMQConnector(MQConnector):
         try:
             try:
                 self.connection.send(body=json.dumps(message), destination=destination)
-            except stomp.exception.StompException:
+            except (stomp.exception.StompException, ConnectionError):
                 self.connect()
                 self.connection.send(body=json.dumps(message), destination=destination)
         except Exception as e:


### PR DESCRIPTION
Fixes 

```python
2025-03-10 08:09:51 UTC RequestManagement/RequestExecutingAgent/pid_862187/00276059_00000056/0/RemoveReplica INFO: Removing replicas at CERN-EOS-PILOT
error sending frame
Traceback (most recent call last):
  File "/opt/dirac/versions/v11.0.60-1741011990/Linux-x86_64/lib/python3.11/site-packages/stomp/transport.py", line 623, in send
    self.socket.sendall(encoded_frame)
BrokenPipeError: [Errno 32] Broken pipe
```

BEGINRELEASENOTES

*Resources
FIX: Catch ConnectionError when calling send on a MQ

ENDRELEASENOTES
