### PR TITLE
[9.0] fix: DISET and proxy location

### DIFF
--- a/src/DIRAC/Core/DISET/private/Transports/SSL/M2Utils.py
+++ b/src/DIRAC/Core/DISET/private/Transports/SSL/M2Utils.py
@@ -116,7 +116,9 @@ def getM2SSLContext(ctx=None, **kwargs):
     # CHRIS: I think clientMode was just an internal of pyGSI implementation
     # if kwargs.get('clientMode', False) and not kwargs.get('useCertificates', False):
     # if not kwargs.get('useCertificates', False):
-    if kwargs.get("bServerMode", False) or kwargs.get("useCertificates", False):
+    if kwargs.get("bServerMode", False) or (
+        kwargs.get("useCertificates", False) and not kwargs.get("proxyLocation", False)
+    ):
         # Server mode always uses hostcert
         __loadM2SSLCTXHostcert(ctx)
 


### PR DESCRIPTION
**Context:**

- The Site Director downloads the proxy of a given user (or robot) to submit pilots to the grid: https://github.com/DIRACGrid/DIRAC/blob/c3f2274f59d8049f8e14198fbcf33e30c61f6e25/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py#L925
- The proxy is exchanged against a token from DiracX: 
https://github.com/DIRACGrid/DIRAC/blob/c3f2274f59d8049f8e14198fbcf33e30c61f6e25/src/DIRAC/FrameworkSystem/Client/ProxyManagerClient.py#L445
https://github.com/DIRACGrid/DIRAC/blob/c3f2274f59d8049f8e14198fbcf33e30c61f6e25/src/DIRAC/Core/Security/DiracX.py#L40-L65

This can fail with the following error (Client Site Director, Server Proxy Manager):

```bash
2025-03-04T10:21:45,631491Z WorkloadManagement/SiteDirector/WorkloadManagement/SiteDirector ERROR: Failed to set credentials: Unauthorized query ( 1111 : Unauthorized query)
```

```bash
2025-03-04T10:27:24,426363Z Framework/ProxyManager/Authorization WARN: User is invalid or does not belong to the group it's saying
2025-03-04T10:27:24,426452Z Framework/ProxyManager WARN: Unauthorized query to Framework/ProxyManager:RPC/exchangeProxyForToken by [anonymous:visitor](<DN of the host>) from ::...
```

How did we miss that? The problem only occurs with DISET, Tornado has no issue.

**Problem:**

As you can see, `DiracX.py` is performing the request with the `proxyLocation` kwarg, and is expected to submit its request with the proxy provided rather than the host credentials usually used.
While the approach works well with `Tornado`, in `DISET`, the `useCertificates` kwarg seems to take priority over `proxyLocation` and force the client to go to the server with the host credentials. 


**Solution:**

Probably imperfect as I am not an expert of that part of the code, but the fix seems to work (tested on the certification instance).
If you think that the fix should go elsewhere, please let me know.

Thanks @natthan-pigoux and @arrabito for spotting the issue!


BEGINRELEASENOTES
*Core
FIX: force M2Crypto to use the proxy instead of the host certificate if provided
ENDRELEASENOTES
