### PR TITLE
[for minor release] feat: added foreign keys to PilotAgentsDB

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -194,19 +194,13 @@ class PilotAgentsDB(DB):
         if not isinstance(pilotIDs, list):
             return S_ERROR("Input argument is not a List")
 
-        failed = []
-
         result = self._escapeValues(pilotIDs)
         if not result["OK"]:
             return S_ERROR(f"Failed to remove pilot: {result['Value']}")
         stringIDs = ",".join(result["Value"])
-        for table in ["PilotOutput", "JobToPilotMapping", "PilotAgents"]:
-            result = self._update(f"DELETE FROM {table} WHERE PilotID in ({stringIDs})", conn=conn)
-            if not result["OK"]:
-                failed.append(table)
-
-        if failed:
-            return S_ERROR(f"Failed to remove pilot from {', '.join(failed)} tables")
+        result = self._update(f"DELETE FROM PilotAgents WHERE PilotID in ({stringIDs})", conn=conn)
+        if not result["OK"]:
+            return S_ERROR("Failed to remove pilots: ", result["Message"])
         return S_OK(pilotIDs)
 
     ##########################################################################################

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.sql
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.sql
@@ -55,8 +55,8 @@ CREATE TABLE `JobToPilotMapping` (
   `PilotID` INT(11) UNSIGNED NOT NULL,
   `JobID` INT(11) UNSIGNED NOT NULL,
   `StartTime` DATETIME NOT NULL,
-  KEY `JobID` (`JobID`),
-  KEY `PilotID` (`PilotID`)
+  PRIMARY KEY (`PilotID`, `JobID`),
+  FOREIGN KEY (`PilotID`) REFERENCES `PilotAgents`(`PilotID`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `PilotOutput`;
@@ -64,5 +64,6 @@ CREATE TABLE `PilotOutput` (
   `PilotID` INT(11) UNSIGNED NOT NULL,
   `StdOutput` MEDIUMTEXT,
   `StdError` MEDIUMTEXT,
-  PRIMARY KEY (`PilotID`)
+  PRIMARY KEY (`PilotID`),
+  FOREIGN KEY (`PilotID`) REFERENCES `PilotAgents`(`PilotID`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
For https://github.com/DIRACGrid/diracx/issues/414

- [ ] add to Wiki + update guide
```sql
use PilotAgentsDB;
ALTER TABLE `JobToPilotMapping` ADD CONSTRAINT `fk_JobToPilot_PilotID` FOREIGN KEY (`PilotID`) REFERENCES `PilotAgents`(`PilotID`) ON DELETE CASCADE;
ALTER TABLE `PilotOutput` ADD CONSTRAINT `fk_PilotOutput_PilotID` FOREIGN KEY (`PilotID`) REFERENCES `PilotAgents`(`PilotID`) ON DELETE CASCADE;

use SandboxMetadataDB;
ALTER TABLE `sb_EntityMapping` ADD CONSTRAINT `fk_EntityToSB_SBId` FOREIGN KEY (`SBId`) REFERENCES `sb_SandBoxes`(`SBId`) ON DELETE CASCADE;
ALTER TABLE `sb_EntityMapping` MODIFY COLUMN `Type` ENUM("Input", "Output") NOT NULL;

use TaskQueueDB;
ALTER TABLE `tq_TQToBannedSites` MODIFY CONSTRAINT `tq_TQToBannedSites_ibfk_1` FOREIGN KEY (`TQId`) REFERENCES `tq_TaskQueues` (`TQId`) ON DELETE CASCADE ON UPDATE RESTRICT;
ALTER TABLE `tq_TQToGridCEs` MODIFY CONSTRAINT `tq_TQToGridCEs_ibfk_1` FOREIGN KEY (`TQId`) REFERENCES `tq_TaskQueues` (`TQId`) ON DELETE CASCADE ON UPDATE RESTRICT;
ALTER TABLE `tq_TQToGridMiddlewares` MODIFY CONSTRAINT `tq_TQToGridMiddlewares_ibfk_1` FOREIGN KEY (`TQId`) REFERENCES `tq_TaskQueues` (`TQId`) ON DELETE CASCADE ON UPDATE RESTRICT;
ALTER TABLE `tq_TQToJobTypes` MODIFY CONSTRAINT `tq_TQToJobTypes_ibfk_1` FOREIGN KEY (`TQId`) REFERENCES `tq_TaskQueues` (`TQId`) ON DELETE CASCADE ON UPDATE RESTRICT;
ALTER TABLE `tq_TQToPilotTypes` MODIFY CONSTRAINT `tq_TQToPilotTypes_ibfk_1` FOREIGN KEY (`TQId`) REFERENCES `tq_TaskQueues` (`TQId`) ON DELETE CASCADE ON UPDATE RESTRICT;
ALTER TABLE `tq_TQToPlatforms` MODIFY CONSTRAINT `tq_TQToPlatforms_ibfk_1` FOREIGN KEY (`TQId`) REFERENCES `tq_TaskQueues` (`TQId`) ON DELETE CASCADE ON UPDATE RESTRICT;
ALTER TABLE `tq_TQToSites` MODIFY CONSTRAINT `tq_TQToSites_ibfk_1` FOREIGN KEY (`TQId`) REFERENCES `tq_TaskQueues` (`TQId`) ON DELETE CASCADE ON UPDATE RESTRICT;
ALTER TABLE `tq_TQToTags` MODIFY CONSTRAINT `tq_TQToTags_ibfk_1` FOREIGN KEY (`TQId`) REFERENCES `tq_TaskQueues` (`TQId`) ON DELETE CASCADE ON UPDATE RESTRICT;

ALTER TABLE `tq_Jobs` MODIFY CONSTRAINT `tq_Jobs_ibfk_1` FOREIGN KEY (`TQId`) REFERENCES `tq_TaskQueues` (`TQId`) ON DELETE CASCADE ON UPDATE RESTRICT;
```
- [ ] check for `tq_jobs` `ON DELETE CASCADE`
- [ ] port to DiracX

BEGINRELEASENOTES

*WMS
CHANGE: add foreign keys to PilotAgentsDB and SandboxMetadataDB

*Core
CHANGE: MySQL: use ON DELETE CASCADE for foreign keys by default

ENDRELEASENOTES

The issue with PilotWrapper should be fixed with https://github.com/DIRACGrid/Pilot/pull/251 (still to be merged to `master` branch...)
