### PR TITLE
[9.0] Ignore -S option for dirac-configure

### DIFF
--- a/src/DIRAC/Core/scripts/dirac_configure.py
+++ b/src/DIRAC/Core/scripts/dirac_configure.py
@@ -99,9 +99,7 @@ class Params:
         self.includeAllServers = True
 
     def setSetup(self, optionValue):
-        self.setup = optionValue
-        DIRAC.gConfig.setOptionValue("/DIRAC/Setup", self.setup)
-        DIRAC.gConfig.setOptionValue(cfgInstallPath("Setup"), self.setup)
+        DIRAC.gLogger.warn("Ignoring Setup option as it is not used for DIRAC v9.0+")
         return DIRAC.S_OK()
 
     def setSiteName(self, optionValue):


### PR DESCRIPTION
I saw pilots failing with:

```
[LHCbConfigureBasics] Executing command dirac-configure -S "LHCb-Certification" ....
Executing: /pool_1/condor/dir_4078706/9aWKDm0HJH7nzEJDjqAzJLkqISAWgmABFKDmr1FKDm3jWLDmt6yQSm/DIRAC_p32k2a7cpilot/diracos/bin/dirac-configure -S LHCb-Certification ...
Checking DIRAC installation at "/pool_1/condor/dir_4078706/9aWKDm0HJH7nzEJDjqAzJLkqISAWgmABFKDmr1FKDm3jWLDmt6yQSm/DIRAC_p32k2a7cpilot/diracos"
Could not select DISET or Tornado client RuntimeError('Option /DIRAC/Setups/LHCb-Certification/Framework is not defined')
```

BEGINRELEASENOTES

*Core
NEW: -S option on dirac-configure is now ignored

ENDRELEASENOTES
