### PR TITLE
[9.0] Move JobWrapperUtilities after Script.parseCommandLine()

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapperTemplate.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapperTemplate.py
@@ -15,16 +15,6 @@ import sys
 import json
 import os
 
-from DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapperUtilities import (
-    createAndEnterWorkingDirectory,
-    executePayload,
-    finalize,
-    getJobWrapper,
-    processJobOutputs,
-    resolveInputData,
-    transferInputSandbox,
-)
-
 sitePython = os.path.realpath("@SITEPYTHON@")
 if sitePython:
     sys.path.insert(0, sitePython)
@@ -35,6 +25,15 @@ Script.parseCommandLine()
 
 from DIRAC import gLogger
 from DIRAC.WorkloadManagementSystem.Client.JobReport import JobReport
+from DIRAC.WorkloadManagementSystem.JobWrapper.JobWrapperUtilities import (
+    createAndEnterWorkingDirectory,
+    executePayload,
+    finalize,
+    getJobWrapper,
+    processJobOutputs,
+    resolveInputData,
+    transferInputSandbox,
+)
 
 
 os.umask(0o22)


### PR DESCRIPTION
I've seen jobs getting stuck in Matched at some sites. I'm 90% sure this is caused by `JobWrapperUtilities` being imported in `JobWrapperTemplate` before the config is initialised. This makes the CS refresh latency dependent as it's a race for if the CS is loaded before it is used.

BEGINRELEASENOTES

*WorkloadManagement
FIX: Move JobWrapperUtilities after import Script.parseCommandLine()

ENDRELEASENOTES
