### PR TITLE
[8.0] Fix AREX proxy pilotlog (alwaysIncludeProxy mode)

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -198,9 +198,6 @@ class AREXComputingElement(ARCComputingElement):
         if not (self.token or self.proxy):
             self.log.error("Proxy or token not set")
             return S_ERROR("Proxy or token not set")
-        if not self.proxy and self.alwaysIncludeProxy:
-            self.log.error("Proxy required but not set")
-            return S_ERROR("Proxy required but not set")
 
         # If a token is set, we use it
         if self.token:


### PR DESCRIPTION
Hi,

We've found that we can't get pilot logs for AREX CEs when using the "alwaysIncludeProxy". This is because the PilotManager doesn't include a proxy when trying to fetch it but it isn't actually needed in this case (just token auth is fine).
The easiest fix we've found for this is just to remove the check which I added when I wrote the alwaysIncludeProxy patch...

Regards,
Simon

BEGINRELEASENOTES
*Resources
FIX: Fix AREX CE pilot logs in alwaysIncludeProxy case
ENDRELEASENOTES
