### PR TITLE
fix: killPilotsInQueues needs the VO information

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSUtilities.py
@@ -121,6 +121,7 @@ def killPilotsInQueues(pilotRefDict):
             return result
         ce = result["Value"]
 
+        pilotDict["VO"] = vo
         result = setPilotCredentials(ce, pilotDict)
         if not result["OK"]:
             return result


### PR DESCRIPTION
Forgot that piece of code in https://github.com/DIRACGrid/DIRAC/pull/8123 :man_facepalming: 

BEGINRELEASENOTES
*WorkloadManagement
FIX: add VO information to the pilotDict when killing pilots
ENDRELEASENOTES
