### PR TITLE
[9.0] fix: replace DIRACJOBID with JOBID

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -349,7 +349,7 @@ class JobWrapper:
 
     def __prepareEnvironment(self):
         """Prepare the environment to be used by the payload."""
-        os.environ["DIRACJOBID"] = str(self.jobID)
+        os.environ["JOBID"] = str(self.jobID)
 
         diracSite = DIRAC.siteName()
         os.environ["DIRACSITE"] = diracSite


### PR DESCRIPTION
The `JOBID` env variable  is useful to get access to the `job ID` within  the Dirac workflow (`ModuleBase`).
`DIRACJOBID` env variable does not seem to be used anymore.

BEGINRELEASENOTES
*WorkloadManagement
FIX: replace DIRACJOBID with JOBID in JobWrapper environment
ENDRELEASENOTES
