### PR TITLE
[9.0] the PoolXMLSlice should be created in the same directory where the job runs

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/InputDataResolution.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/InputDataResolution.py
@@ -6,6 +6,8 @@
     result and in principle has all the necessary information to resolve input data
     for applications.
 """
+from pathlib import Path
+
 import DIRAC
 from DIRAC import S_ERROR, S_OK, gConfig, gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
@@ -76,7 +78,7 @@ class InputDataResolution:
         self.log.verbose(f"Catalog name will be: {catalogName}")
 
         resolvedData = tmpDict
-        appCatalog = PoolXMLSlice(catalogName)
+        appCatalog = PoolXMLSlice(catalogName, Path(self.arguments["Configuration"].get("JobIDPath", "")))
         return appCatalog.execute(resolvedData)
 
     def __resolveInputData(self):

--- a/src/DIRAC/WorkloadManagementSystem/Client/PoolXMLSlice.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/PoolXMLSlice.py
@@ -10,14 +10,14 @@ from DIRAC.Resources.Catalog.PoolXMLCatalog import PoolXMLCatalog
 
 
 class PoolXMLSlice:
-    def __init__(self, catalogName):
+    def __init__(self, catalogName, jobID_path: os.PathLike):
         """Standard constructor"""
         self.fileName = catalogName
+        self.jobID_path = jobID_path
         self.log = gLogger.getSubLogger(self.__class__.__name__)
 
     def execute(self, dataDict):
         """Given a dictionary of resolved input data, this will creates a POOL XML slice."""
-        poolXMLCatName = self.fileName
         try:
             poolXMLCat = PoolXMLCatalog()
             self.log.verbose("Creating POOL XML slice")
@@ -41,18 +41,19 @@ class PoolXMLSlice:
             xmlSlice = poolXMLCat.toXML()
             self.log.verbose("POOL XML Slice is: ")
             self.log.verbose(xmlSlice)
-            with open(poolXMLCatName, "w") as poolSlice:
+            with open(self.jobID_path / self.fileName, "w") as poolSlice:
                 poolSlice.write(xmlSlice)
-            self.log.info(f"POOL XML Catalogue slice written to {poolXMLCatName}")
+            self.log.info(f"POOL XML Catalogue slice written to {self.jobID_path / self.fileName}")
             try:
                 # Temporary solution to the problem of storing the SE in the Pool XML slice
-                with open(f"{poolXMLCatName}.temp", "w") as poolSlice_temp:
+                with open(self.jobID_path / (self.fileName + ".temp"), "w") as poolSlice_temp:
                     xmlSlice = poolXMLCat.toXML(True)
                     poolSlice_temp.write(xmlSlice)
-            except Exception as x:
-                self.log.warn(f"Attempted to write catalog also to {poolXMLCatName}.temp but this failed")
-        except Exception as x:
-            self.log.error(str(x))
+            except Exception:
+                self.log.warn(f"Attempted to write catalog also to {self.fileName}.temp but this failed")
+                self.log.exception()
+        except Exception:
+            self.log.exception()
             return S_ERROR("Exception during construction of POOL XML slice")
 
         return S_OK("POOL XML Slice created")

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -765,6 +765,7 @@ class JobWrapper:
 
         configDict = {
             "JobID": self.jobID,
+            "JobIDPath": self.jobIDPath,
             "LocalSEList": localSEList,
             "DiskSEList": self.diskSE,
             "TapeSEList": self.tapeSE,


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: the PoolXMLSlice should be created in the same directory where the job runs

ENDRELEASENOTES
