### PR TITLE
[8.0] fix: escape db password when passing to sqlalchemy

### DIFF
--- a/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
+++ b/src/DIRAC/DataManagementSystem/DB/FTS3DB.py
@@ -7,6 +7,7 @@
 
 import datetime
 import errno
+from urllib.parse import quote_plus
 
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import SQLAlchemyError
@@ -184,7 +185,7 @@ class FTS3DB:
         self.dbHost = dbParameters["Host"]
         self.dbPort = dbParameters["Port"]
         self.dbUser = dbParameters["User"]
-        self.dbPass = dbParameters["Password"]
+        self.dbPass = quote_plus(dbParameters["Password"])
         self.dbName = dbParameters["DBName"]
 
     def __init__(self, pool_size=15, url=None, parentLogger=None):

--- a/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
+++ b/src/DIRAC/RequestManagementSystem/DB/RequestDB.py
@@ -19,6 +19,7 @@
 """
 import errno
 import random
+from urllib.parse import quote_plus
 
 import datetime
 
@@ -199,7 +200,7 @@ class RequestDB:
         dbParameters = result["Value"]
         self.dbHost = dbParameters["Host"]
         self.dbPort = dbParameters["Port"]
-        self.dbUser = dbParameters["User"]
+        self.dbUser = quote_plus(dbParameters["User"])
         self.dbPass = dbParameters["Password"]
         self.dbName = dbParameters["DBName"]
 


### PR DESCRIPTION
backport of https://github.com/DIRACGrid/DIRAC/pull/8120