### PR TITLE
Fix req compat

### DIFF
--- a/src/DIRAC/RequestManagementSystem/Agent/RequestOperations/ForwardDISET.py
+++ b/src/DIRAC/RequestManagementSystem/Agent/RequestOperations/ForwardDISET.py
@@ -1,17 +1,5 @@
-""" :mod: ForwardDISET
-
-    ==================
-
-    .. module: ForwardDISET
-
-    :synopsis: DISET forwarding operation handler
-
-    .. moduleauthor:: Krzysztof.Ciba@NOSPAMgmail.com
-
-    DISET forwarding operation handler
-"""
-
 import importlib
+from collections.abc import Sequence
 
 # imports
 from DIRAC import S_ERROR, S_OK, gConfig
@@ -65,7 +53,7 @@ class ForwardDISET(OperationHandlerBase):
             return S_ERROR(str(error))
 
         # This is the DISET rpcStub
-        if isinstance(stub, tuple):
+        if isinstance(stub, Sequence):
             # Ensure the forwarded request is done on behalf of the request owner
             res = getDNForUsername(self.request.Owner)
             if not res["OK"]:

--- a/src/DIRAC/RequestManagementSystem/private/RequestValidator.py
+++ b/src/DIRAC/RequestManagementSystem/private/RequestValidator.py
@@ -1,49 +1,49 @@
-""" :mod: RequestValidator
+""":mod: RequestValidator
 
-    ======================
+======================
 
-    .. module: RequestValidator
+.. module: RequestValidator
 
-    :synopsis: request validator
+:synopsis: request validator
 
-    .. moduleauthor:: Krzysztof.Ciba@NOSPAMgmail.com
+.. moduleauthor:: Krzysztof.Ciba@NOSPAMgmail.com
 
-    A general and simple request validator checking for required attributes and logic.
-    It checks if required attributes are set/unset but not for their values.
+A general and simple request validator checking for required attributes and logic.
+It checks if required attributes are set/unset but not for their values.
 
-    RequestValidator class implements the DIRACSingleton pattern, no global object is
-    required to keep a single instance.
+RequestValidator class implements the DIRACSingleton pattern, no global object is
+required to keep a single instance.
 
-    If you need to extend this one with your own specific checks consider:
+If you need to extend this one with your own specific checks consider:
 
-      * for adding Operation or Files required attributes use :any:`addReqAttrsCheck` function::
+  * for adding Operation or Files required attributes use :any:`addReqAttrsCheck` function::
 
-          RequestValidator().addReqAttrsCheck( "FooOperation", operationAttrs = [ "Bar", "Buzz"], filesAttrs = [ "LFN" ] )
+      RequestValidator().addReqAttrsCheck( "FooOperation", operationAttrs = [ "Bar", "Buzz"], filesAttrs = [ "LFN" ] )
 
-      * for adding generic check define a new callable object ( function or functor ) which takes only one argument,
-        say for functor::
+  * for adding generic check define a new callable object ( function or functor ) which takes only one argument,
+    say for functor::
 
-          class MyValidator( RequestValidator ):
+      class MyValidator( RequestValidator ):
 
-            @staticmethod
-            def hasFoo( request ):
-              if not request.Foo:
-                return S_ERROR("Foo not set")
-              return S_OK()
+        @staticmethod
+        def hasFoo( request ):
+          if not request.Foo:
+            return S_ERROR("Foo not set")
+          return S_OK()
 
-      * or function::
+  * or function::
 
-          def hasBar( request ):
-            if not request.Bar:
-              return S_ERROR("Bar not set")
-            return S_OK()
+      def hasBar( request ):
+        if not request.Bar:
+          return S_ERROR("Bar not set")
+        return S_OK()
 
-    and add this one to the validators set by calling `RequestValidator().addValidator`, i.e.::
+and add this one to the validators set by calling `RequestValidator().addValidator`, i.e.::
 
-      RequestValidator().addValidator( MyValidator.hasFoo )
-      RequestValidator().addValidator( hasFoo )
+  RequestValidator().addValidator( MyValidator.hasFoo )
+  RequestValidator().addValidator( hasFoo )
 
-    Notice that all validators should always return S_ERROR/S_OK, no exceptions from that whatsoever!
+Notice that all validators should always return S_ERROR/S_OK, no exceptions from that whatsoever!
 """
 
 import inspect

--- a/src/DIRAC/RequestManagementSystem/private/RequestValidator.py
+++ b/src/DIRAC/RequestManagementSystem/private/RequestValidator.py
@@ -53,6 +53,7 @@ from DIRAC import S_OK, S_ERROR, gConfig, gLogger
 from DIRAC.Core.Security.Properties import FULL_DELEGATION, LIMITED_DELEGATION
 from DIRAC.Core.Utilities.DIRACSingleton import DIRACSingleton
 from DIRAC.ConfigurationSystem.Client import PathFinder
+from DIRAC.ConfigurationSystem.Client.Helpers.Registry import getUsernameForDN
 
 
 class RequestValidator(metaclass=DIRACSingleton):
@@ -268,28 +269,21 @@ class RequestValidator(metaclass=DIRACSingleton):
 
         :returns: True if everything is fine, False otherwise
         """
-
         credUserName = remoteCredentials["username"]
         credGroup = remoteCredentials["group"]
         credProperties = remoteCredentials["properties"]
-        ownershipCheck = None
 
-        # FIXME: code for backward compatibility with requests created by 8.0 clients
-        # The below can be clearly simplified, leaving the extended checks for clarity
-        if hasattr(request, "OwnerDN") and not hasattr(
-            request, "Owner"
-        ):  # Requests created by v8.0 client for v8.0 servers
-            ownershipCheck = request.OwnerDN
-        if not hasattr(request, "OwnerDN") and hasattr(
-            request, "Owner"
-        ):  # Requests created by v9 client for v9 servers
-            ownershipCheck = request.Owner
-        if hasattr(request, "OwnerDN") and hasattr(request, "Owner"):  # Requests created by v8.0 client for v9 servers
-            ownershipCheck = request.Owner
-        # ##
+        # In case we have an old style request with only a DN and no Owner,
+        # get the Owner from the DN.
+        if getattr(request, "OwnerDN", None) and not getattr(request, "Owner", None):
+            res = getUsernameForDN(request.OwnerDN)
+            if not res["OK"]:
+                gLogger.error("Cannot Validate request", res)
+                return False
+            request.Owner = res["Value"]
 
         # If the owner or the group was not set, we use the one of the credentials
-        if not ownershipCheck or not request.OwnerGroup:
+        if not request.Owner or not request.OwnerGroup:
             request.Owner = credUserName
             request.OwnerGroup = credGroup
             return True


### PR DESCRIPTION
`v8.0` requests have OwnerDN and OwnerGroup
`v9.0` requests have Owner and OwnerGroup

There was a compatibility layer that allowed processing v8 request on a v9 server. Unfortunately that did not work well with server certificates (used in the `ReqProxy` for example).

To illustrate it, I created a `Request` and dumped it to a json file using `v8`.
I can then load it, and validate it with a `v9` server, and you see the `Owner` and `OwnerGroup` are wrong

```python
import json
from DIRAC import initialize

initialize()

from DIRAC.RequestManagementSystem.private.RequestValidator import RequestValidator
from DIRAC.RequestManagementSystem.Client.Request import Request

from DIRAC.Core.Base.Client import Client

validator = RequestValidator()

v8_req_json = '{"RequestName": null, "OwnerDN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bond/CN=705305/CN=James Bond", "OwnerGroup": "lhcb_user", "Status": "Waiting", "Error": null, "DIRACSetup": null, "SourceComponent": null, "JobID": 0, "CreationTime": "2025-04-11 14:59:34", "SubmitTime": "2025-04-11 14:59:34", "LastUpdate": "2025-04-11 14:59:34", "NotBefore": "2025-04-11 14:59:34", "Operations": []}'

loaded_dict = json.loads(v8_req_json)

print(
    f"{loaded_dict.get('Owner')=} {loaded_dict.get('OwnerGroup')=} {loaded_dict.get('OwnerDN')=}"
)
req = Request(v8_req_json)

print(f"{req.Owner=} {req.OwnerGroup=} {req.OwnerDN=}")


host_credentials = Client(url="Configuration/Server").whoami()["Value"]
validator.setAndCheckRequestOwner(req, host_credentials)

print(f"{req.Owner=} {req.OwnerGroup=} {req.OwnerDN=}")
```

```
loaded_dict.get('Owner')=None loaded_dict.get('OwnerGroup')='lhcb_user' loaded_dict.get('OwnerDN')='/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bond/CN=705305/CN=James Bond'
req.Owner=None req.OwnerGroup='lhcb_user' req.OwnerDN='/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bond/CN=705305/CN=James Bond'
req.Owner='secret.cern.ch' req.OwnerGroup='hosts' req.OwnerDN='/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bond/CN=705305/CN=James Bond'
```

The problem is that once the DB is screwed up, you have lost the group information for good, so you can only guess it.

There might still be a problem when the REA tries executing old requests, but since I don't have any of it anymore in the system, I can't check...

The only relevant commit is 543ffced5c7bdbf9e601423f4d92dcd95dafdcab
The other one is auto format...

BEGINRELEASENOTES

*RMS
FIX: RequestValidator sets correct Owner for v8 requests

ENDRELEASENOTES
