### PR TITLE
fix: prevent any local-UTC offset being introduced in plots

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
+++ b/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
@@ -73,7 +73,12 @@ def convert_to_datetime(dstring):
             # Use utcfromtimestamp for UTC time
             results = datetime.datetime.utcfromtimestamp(int(results))
         elif isinstance(results, datetime.datetime):
-            results = results.astimezone(datetime.timezone.utc)  # Ensure in UTC
+            if results.tzinfo is not None:
+                # non-naive datetime: convert to UTC
+                results = results.astimezone(datetime.timezone.utc)
+            else:
+                # DIRAC naive datetimes are UTC everywhere: add tzinfo
+                results = results.replace(tzinfo=datetime.timezone.utc)
         else:
             raise ValueError("Unknown datetime type!")
     except Exception:


### PR DESCRIPTION
`.astimezone()` interprets any `datetime` with `tzinfo=None` to be a local datetime. This means UTC naive datetime objects have local-UTC offsets introduced.

BEGINRELEASENOTES

*GraphUtilities
FIX: prevent any local-UTC offset being introduced in plots


ENDRELEASENOTES
