### PR TITLE
[9.0] Printing DiracX ForwardDISET requests

### DIFF
--- a/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
+++ b/src/DIRAC/RequestManagementSystem/Client/ReqClient.py
@@ -634,8 +634,10 @@ def printOperation(indexOperation, verbose=True, onlyFailed=False):
             output = ""
             prettyPrint(decode, offset=10)
             prStr += "\n      Arguments:\n" + output.strip("\n")
-        else:
+        elif isinstance(decode, list):
             prStr += f"\n      Service: {decode[0][0]}"
+        else:
+            prStr += f"\n      Command: {decode['dCls']}.{decode['dMeth']}(*{decode['args']!r})"
     gLogger.always(
         "  [%s] Operation Type='%s' ID=%s Order=%s Status='%s'%s%s"
         % (


### PR DESCRIPTION
Fixes this crash:

```
$ lb-dirac dirac-rms-request --Job 1086302975
Request name='jobAgent_1086302975' ID=53840381 Status='Waiting' Job=1086302975 Created 2025-04-10 15:54:31, Updated 2025-04-14 10:58:57, NotBefore 2025-04-14 10:58:59 Owner: 'lbpilot', Group: lhcb_pilot
Traceback (most recent call last):
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v12.0.0a17-1744604904/Linux-x86_64/bin/dirac-rms-request", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v12.0.0a17-1744604904/Linux-x86_64/lib/python3.11/site-packages/DIRAC/Core/Base/Script.py", line 74, in __call__
    return entrypointFunc._func()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v12.0.0a17-1744604904/Linux-x86_64/lib/python3.11/site-packages/DIRAC/RequestManagementSystem/scripts/dirac_rms_request.py", line 287, in main
    printRequest(request, status=dbStatus, full=full, verbose=verbose, terse=terse)
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v12.0.0a17-1744604904/Linux-x86_64/lib/python3.11/site-packages/DIRAC/RequestManagementSystem/Client/ReqClient.py", line 613, in printRequest
    printOperation(indexOperation, verbose, onlyFailed=terse)
  File "/cvmfs/lhcb.cern.ch/lhcbdirac/versions/v12.0.0a17-1744604904/Linux-x86_64/lib/python3.11/site-packages/DIRAC/RequestManagementSystem/Client/ReqClient.py", line 638, in printOperation
    prStr += f"\n      Service: {decode[0][0]}"
                                 ~~~~~~^^^
KeyError: 0
```


BEGINRELEASENOTES

*RequestManagement
FIX: Printing DiracX ForwardDISET requests

ENDRELEASENOTES
