### PR TITLE
[9.0] fix: cache the proxy strength (not changing that often...)

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -9,6 +9,9 @@
     * ProxyDB_Log -- table with logs.
 """
 import textwrap
+from threading import Lock
+
+from cachetools import TTLCache, cached
 
 from DIRAC import S_ERROR, S_OK, gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
@@ -395,6 +398,7 @@ class ProxyDB(DB):
             return S_ERROR(", ".join(errMsgs))
         return result
 
+    @cached(TTLCache(maxsize=1000, ttl=600), lock=Lock())
     def getProxyStrength(self, userDN, userGroup=None, vomsAttr=None):
         """Load the proxy in cache corresponding to the criteria, and check its strength
 


### PR DESCRIPTION
Given that anyway 90%+ of the calls would be for the same proxy over and over


BEGINRELEASENOTES

*Framework
FIX: Caching the proxy strength to avoid a DB call

ENDRELEASENOTES
