### PR TITLE
[8.0] fix: job agent fix endless loop finalize

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -706,7 +706,13 @@ class JobAgent(AgentModule):
         # Here we iterate over a copy of the keys because we are modifying the dictionary within the loop
         for jobID in list(self.jobs.keys()):
             taskID = self.jobs[jobID].get("TaskID")
-            if taskID is None or taskID not in self.computingElement.taskResults:
+            if taskID is None:
+                # This generally means that there was an error before the submission
+                # and the TaskID was not set and will never be.
+                self.log.info("No taskID found for job", jobID)
+                del self.jobs[jobID]
+                continue
+            if taskID not in self.computingElement.taskResults:
                 continue
 
             result = self.computingElement.taskResults[taskID]

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobAgent.py
@@ -754,3 +754,27 @@ def test_submitAndCheck2Jobs(mocker):
 
     # From here, taskResults should be empty
     assert len(jobAgent.computingElement.taskResults) == 0
+
+
+def test_failureBeforeSubmission(mocker):
+    """Test that a failure before job submission is handled correctly.
+
+    We want to make sure that there is no endless loop in the finalize method.
+    """
+    # Mock the JobAgent
+    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobAgent.AgentModule.__init__")
+
+    jobAgent = JobAgent("JobAgent", "Test")
+    jobAgent.log = gLogger.getSubLogger("JobAgent")
+
+    # Here we simulate a failure before the job submission: no TaskID
+    jobID = "123"
+    jobAgent.jobs[jobID] = {}
+    jobAgent.jobs[jobID]["JobReport"] = JobReport(jobID)
+
+    # Make sure that the job is removed from jobAgent.jobs
+    result = jobAgent._checkSubmittedJobs()
+    assert result["OK"]
+    assert result["Value"] == ([], [])
+
+    assert jobAgent.jobs == {}


### PR DESCRIPTION
Closes #7912 

BEGINRELEASENOTES
*WorkloadManagement
FIX: JobAgent endlessly looping in checkSubmittedJobs
ENDRELEASENOTES
