### PR TITLE
[8.0] fix: the architecture script can be set in the options

### DIFF
--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/Pilots3.rst
@@ -50,8 +50,8 @@ Other options that can be set also in the Operations part of the CS include:
 | *CVMFS_locations*                  | CVMFS locations to use for finding pilot   | CVMFS_locations = /cvmfs/lhcb.cern.ch/,/cvmfs/lhcbdev.cern.ch           |
 |                                    | files, DIRAC installations, CAs, CRLS      |                                                                         |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
-| *workDir*                          | Local directory of the master CS where the | workDir = /tmp/pilotSyncDir                                             |
-|                                    | files will be downloaded before the upload | There is no default (so /opt/dirac/runit/Configuration/Server)          |
+| *ArchitectureScript*               | The script to be used for                  | ArchitectureScript = dirac-apptainer-exec dirac-platform                |
+|                                    | discovering the local architecture.        | Default: dirac-platform                                                 |
 +------------------------------------+--------------------------------------------+-------------------------------------------------------------------------+
 
 

--- a/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
+++ b/docs/source/AdministratorGuide/Systems/WorkloadManagement/Pilots/index.rst
@@ -88,7 +88,6 @@ Inside this section, you should define the following options, and give them a me
    Installation = mycfg.cfg # For an optional configuration file, used by the installation script.
    PreInstalledEnv = /cvmfs/some/where/specific/bashrc # A specific rc file to source for setting up DIRAC
    PreInstalledEnvPrefix = /cvmfs/some/where/ # Location where DIRAC installations can be found. The Pilot will then try and find the following: /cvmfs/some/where/{Version/}{platform}/diracosrc
-   CVMFS_locations = /cvmfs/some/ # Comma-separated list of locations where DIRAC installations, CAs and CRLs can be found. The Pilot will then try and find the following: /cvmfs/some/{releaseProject}dirac/{Version/}{platform}/diracosrc and /cvmfs/some/etc/grid-security/certificates. Those same locations will also be used by the Pilot Wrapper to try and find the pilot files in /cvmfs/some/{releaseProject}dirac/pilot/.
    # For the Matcher
    CheckVersion = False # True by default, if false any version would be accepted at matching level (this is a check done by the WorkloadManagementSystem/Matcher service).
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1027,6 +1027,11 @@ class SiteDirector(AgentModule):
         else:
             self.log.info("DIRAC project will be installed by pilots")
 
+        # Architecture script to use
+        architectureScript = opsHelper.getValue("Pilot/ArchitectureScript", "")
+        if architectureScript:
+            pilotOptions.append(f"--architectureScript={architectureScript}")
+
         # Preinstalled environment or list of CVMFS locations defined ?
         preinstalledEnv = opsHelper.getValue("Pilot/PreinstalledEnv", "")
         preinstalledEnvPrefix = opsHelper.getValue("Pilot/PreinstalledEnvPrefix", "")


### PR DESCRIPTION

BEGINRELEASENOTES

*Subsystem
FIX: SiteDirector: the architecture script can be set in the options

ENDRELEASENOTES
