### PR TITLE
[9.0] fix(wms): Watchdog does not kill payload properly and runs endlessly

### DIFF
--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -268,18 +268,33 @@ class Subprocess:
 
         :param boolean recursive: flag to kill all descendants
         """
-
-        parent = psutil.Process(self.childPID)
-        children = parent.children(recursive=recursive)
-        children.append(parent)
-        for p in children:
+        pgid = os.getpgid(self.childPID)
+        if pgid != os.getpgrp():
             try:
-                p.send_signal(signal.SIGTERM)
-            except psutil.NoSuchProcess:
+                # Child is in its own group: kill the group
+                os.killpg(pgid, signal.SIGTERM)
+            except OSError:
+                # Process is already dead
                 pass
-        _gone, alive = psutil.wait_procs(children, timeout=10)
-        for p in alive:
-            p.kill()
+        else:
+            # No separate group: walk the tree
+            parent = psutil.Process(self.childPID)
+            procs = parent.children(recursive=recursive)
+            procs.append(parent)
+            for p in procs:
+                try:
+                    p.terminate()
+                except psutil.NoSuchProcess:
+                    pass
+            _gone, alive = psutil.wait_procs(procs, timeout=10)
+            # Escalate any survivors
+            for p in alive:
+                try:
+                    p.kill()
+                except psutil.NoSuchProcess:
+                    pass
+
+        self.childKilled = True
 
     def pythonCall(self, function, *stArgs, **stKeyArgs):
         """call python function :function: with :stArgs: and :stKeyArgs:"""
@@ -405,7 +420,9 @@ class Subprocess:
             self.killChild()
             return self.__generateSystemCommandError(1, f"{retDict['Message']} for '{self.cmdSeq}' call")
 
-    def systemCall(self, cmdSeq, callbackFunction=None, shell=False, env=None, preexec_fn=None):
+    def systemCall(
+        self, cmdSeq, callbackFunction=None, shell=False, env=None, preexec_fn=None, start_new_session=False
+    ):
         """system call (no shell) - execute :cmdSeq:"""
 
         if shell:
@@ -426,6 +443,7 @@ class Subprocess:
                 env=env,
                 universal_newlines=True,
                 preexec_fn=preexec_fn,
+                start_new_session=start_new_session,
             )
             self.childPID = self.child.pid
         except OSError as v:

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -1584,7 +1584,9 @@ class ExecutionThread(threading.Thread):
         start = time.time()
         initialStat = os.times()
         log.verbose("Cmd called", self.cmd)
-        output = self.spObject.systemCall(self.cmd, env=self.exeEnv, callbackFunction=self.sendOutput, shell=True)
+        output = self.spObject.systemCall(
+            self.cmd, env=self.exeEnv, callbackFunction=self.sendOutput, shell=True, start_new_session=True
+        )
         log.verbose(f"Output of system call within execution thread: {output}")
         self.executionResults["Thread"] = output
         timing = time.time() - start

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -297,6 +297,30 @@ def test_processFailedSubprocess(mocker):
 
 
 @pytest.mark.slow
+def test_processKilledSubprocess(mocker):
+    """Test the process method of the JobWrapper class: the job is stalled and is killed by the Watchdog."""
+    jw = JobWrapper()
+    jw.jobArgs = {"CPUTime": 100, "Memory": 1}
+
+    mocker.patch.object(jw, "_JobWrapper__report")
+    mocker.patch.object(jw, "_JobWrapper__setJobParam")
+
+    mock_progress_call = mocker.patch("DIRAC.WorkloadManagementSystem.JobWrapper.Watchdog.Watchdog._checkProgress")
+    mock_progress_call.return_value = S_ERROR("Job is stalled!")
+
+    with tempfile.NamedTemporaryFile(delete=True) as std_out, tempfile.NamedTemporaryFile(delete=True) as std_err:
+        jw.outputFile = std_out.name
+        jw.errorFile = std_err.name
+        result = jw.process("sleep 20", {})
+
+    assert result["OK"]
+    assert result["Value"]["payloadStatus"] == 15  # SIGTERM
+    assert not result["Value"]["payloadOutput"]
+    assert not result["Value"]["payloadExecutorError"]
+    assert result["Value"]["watchdogError"] == "Job is stalled!"  # Error message from the watchdog
+
+
+@pytest.mark.slow
 def test_processQuickExecutionNoWatchdog(mocker):
     """Test the process method of the JobWrapper class: the payload is too fast to start the watchdog."""
     jw = JobWrapper()


### PR DESCRIPTION
**Problem**

1. The `PushJobAgent` submits `max` `JobWrapper`s to a `PoolComputingElement`.
2. Each `JobWrapper` executes its payload but the `Watchdog` quickly identifies it as `Stalled` and tries to kill it (this is another issue I haven't resolved yet)
3. Yet, the `PushJobAgent` remains stuck with the initial `max` jobs, hanging forever.

```bash
WorkloadManagement/PushJobAgent INFO: No available slots : 500 running jobs
``` 

`py-spy` indicates that the `JobWrapper` processes are stuck in the following loop: https://github.com/DIRACGrid/DIRAC/blob/db98c795809603f58c2eaf4037865aa657777a6b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py#L473-L476

```bash
$ py-spy dump --pid 2056307

Thread 2056307 (idle): "MainThread"
    process (DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py:476)
    execute (DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py:607)
    executePayload (DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapperUtilities.py:206)
    execute (Wrapper_1096327640:74)
    <module> (Wrapper_1096327640:103)
...
Thread 2056320 (idle): "Thread-6"
    systemCall (DIRAC/Core/Utilities/Subprocess.py:462)
    run (DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py:1587)
    _bootstrap_inner (threading.py:1045)
    _bootstrap (threading.py:1002)
```  

From what I understand, `Subprocess.killChild()` logic fails to close the `stdout/stderr` pipes, so the `ExecutionThread` never returns and the `JobWrapper` spins forever.

**Potential Solution**

From Python 3.8, `Popen` has a new parameter `start_new_session=True` that places the shell and all its descendants into their own UNIX process-group. It allows us to kill every member of the group atomically at once, and thus every process holding the pipes.

So I added the parameter to `Subprocess`. If the processes are running in their own UNIX process-group, then we kill the group, else we rely on the good old logic.


I added a unit test to reproduce the issue: it hangs forever without the changes.

**Note**

Pilot-Jobs are likely impacted by this issue.

BEGINRELEASENOTES
*WorkloadManagement
FIX: Watchdog does not kill payload properly and runs endlessly
ENDRELEASENOTES
