### PR TITLE
[9.0] fix: disable watchdog wallclock check for remote executions

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -338,6 +338,9 @@ class JobWrapper:
             submissionPolicy = self.ceArgs.get("SubmissionPolicy", gConfig.getValue("/LocalSite/SubmissionPolicy", ""))
             if submissionPolicy == "Application":
                 configOptions += "-o /LocalSite/RemoteExecution=True "
+                # Disable the watchdog CPU wallclock check because the application is running
+                # on a remote worker node, so values are not relevant
+                (self.jobIDPath / "DISABLE_WATCHDOG_CPU_WALLCLOCK_CHECK").touch()
 
         command = executable
         if jobArguments:


### PR DESCRIPTION
For some reason, payloads executed through the `PushJobAgent` are quickly killed by the `Watchdog`s because the CPU consumption is way below the wallclock time, which is expected as the real work is done on a remote worker node.

I don't really understand why we didn't have such issues in `v8.0` but the following patch should solve the problem, I am going to test it.
 
BEGINRELEASENOTES
*WorkloadManagement
FIX: disable watchdgo wallclock check for remote executions
ENDRELEASENOTES
