### PR TITLE
fix (Core): use utcfromtimestamp everywhere in Graph instead of fromtimestamp

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/GraphData.py
+++ b/src/DIRAC/Core/Utilities/Graphs/GraphData.py
@@ -411,7 +411,7 @@ class PlotData:
                 self.num_keys.append(next)
                 next += 1
         elif self.key_type == "time":
-            self.num_keys = [date2num(datetime.datetime.fromtimestamp(to_timestamp(key))) for key in self.keys]
+            self.num_keys = [date2num(datetime.datetime.utcfromtimestamp(to_timestamp(key))) for key in self.keys]
         elif self.key_type == "numeric":
             self.num_keys = [float(key) for key in self.keys]
 


### PR DESCRIPTION
This results in empty plots

BEGINRELEASENOTES

*Core
FIX: consistent use of utcfromtimestamp in the Graph

ENDRELEASENOTES
