### PR TITLE
[9.0]SE:  Only check protocols if no occupancy plugins are defined

### DIFF
--- a/src/DIRAC/Resources/Storage/StorageElement.py
+++ b/src/DIRAC/Resources/Storage/StorageElement.py
@@ -438,10 +438,6 @@ class StorageElementItem:
 
             kwargs["occupancyLFN"] = occupancyLFN
 
-        filteredPlugins = self.__filterPlugins("getOccupancy")
-        if not filteredPlugins:
-            return S_ERROR(errno.EPROTONOSUPPORT, "No storage plugins to query the occupancy")
-
         # Call occupancy plugin if requested
         occupancyPlugin = self.options.get("OccupancyPlugin")
         if occupancyPlugin:
@@ -458,6 +454,10 @@ class StorageElementItem:
                 return self.checkOccupancy(occupancyDict, unit)
             except Exception as e:
                 return S_ERROR(f"Occupancy plugin failed: {str(e)}")
+
+        filteredPlugins = self.__filterPlugins("getOccupancy")
+        if not filteredPlugins:
+            return S_ERROR(errno.EPROTONOSUPPORT, "No storage plugins to query the occupancy")
 
         # Try all of the storages one by one
         for storage in filteredPlugins:


### PR DESCRIPTION
In case a SE only has a local protocol defined, the code crash. 

BEGINRELEASENOTES

*Resources
FIX:  SE: check the protocol only after checking the plugins when checking the occupancy

ENDRELEASENOTES
