### PR TITLE
Moved killPilot to diracAdmin itself

### DIFF
--- a/src/DIRAC/Interfaces/API/DiracAdmin.py
+++ b/src/DIRAC/Interfaces/API/DiracAdmin.py
@@ -19,6 +19,9 @@ from DIRAC.ResourceStatusSystem.Client.SiteStatus import SiteStatus
 from DIRAC.WorkloadManagementSystem.Client.JobManagerClient import JobManagerClient
 from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
 from DIRAC.WorkloadManagementSystem.Client.WMSAdministratorClient import WMSAdministratorClient
+from DIRAC.WorkloadManagementSystem.Service.WMSUtilities import (
+    killPilotsInQueues,
+)
 
 voName = ""
 ret = getProxyInfo(disableVOMS=True)
@@ -452,8 +455,28 @@ class DiracAdmin(API):
         if not isinstance(gridReference, (str, list)):
             return self._errorReport("Expected string or list of strings for pilot reference")
 
-        result = PilotManagerClient().killPilot(gridReference)
-        return result
+        # Make a list if it is not yet
+        if isinstance(gridReference, str):
+            gridReference = [gridReference]
+
+        # Regroup pilots per site
+        pilotRefDict = {}
+        for pilotReference in gridReference:
+            result = PilotManagerClient().getPilotInfo(pilotReference)
+            if not result["OK"] or not result["Value"]:
+                return S_ERROR(f"Failed to get info for pilot {pilotReference}")
+
+            pilotDict = result["Value"][pilotReference]
+            queue = "@@@".join(
+                [pilotDict["VO"], pilotDict["GridSite"], pilotDict["DestinationSite"], pilotDict["Queue"]]
+            )
+            gridType = pilotDict["GridType"]
+            pilotRefDict.setdefault(queue, {})
+            pilotRefDict[queue].setdefault("PilotList", [])
+            pilotRefDict[queue]["PilotList"].append(pilotReference)
+            pilotRefDict[queue]["GridType"] = gridType
+
+        return killPilotsInQueues(pilotRefDict)
 
     #############################################################################
     def getPilotLoggingInfo(self, gridReference):

--- a/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/PilotManagerHandler.py
@@ -13,7 +13,6 @@ from DIRAC.WorkloadManagementSystem.Client import PilotStatus
 from DIRAC.WorkloadManagementSystem.Service.WMSUtilities import (
     getPilotCE,
     getPilotRef,
-    killPilotsInQueues,
     setPilotCredentials,
 )
 
@@ -300,35 +299,6 @@ class PilotManagerHandler(RequestHandler):
             return S_ERROR(f"Failed to get pilot for Job {int(jobID)}: {result.get('Message', '')}")
 
         return cls.pilotAgentsDB.getPilotInfo(pilotID=result["Value"])
-
-    ##############################################################################
-    types_killPilot = [[str, list]]
-
-    @classmethod
-    def export_killPilot(cls, pilotRefList):
-        """Kill the specified pilots"""
-        # Make a list if it is not yet
-        if isinstance(pilotRefList, str):
-            pilotRefList = [pilotRefList]
-
-        # Regroup pilots per site
-        pilotRefDict = {}
-        for pilotReference in pilotRefList:
-            result = cls.pilotAgentsDB.getPilotInfo(pilotReference)
-            if not result["OK"] or not result["Value"]:
-                return S_ERROR(f"Failed to get info for pilot {pilotReference}")
-
-            pilotDict = result["Value"][pilotReference]
-            queue = "@@@".join(
-                [pilotDict["VO"], pilotDict["GridSite"], pilotDict["DestinationSite"], pilotDict["Queue"]]
-            )
-            gridType = pilotDict["GridType"]
-            pilotRefDict.setdefault(queue, {})
-            pilotRefDict[queue].setdefault("PilotList", [])
-            pilotRefDict[queue]["PilotList"].append(pilotReference)
-            pilotRefDict[queue]["GridType"] = gridType
-
-        return killPilotsInQueues(pilotRefDict)
 
     ##############################################################################
     types_setJobForPilot = [[str, int], str]


### PR DESCRIPTION
BEGINRELEASENOTES

*PilotManagerHandler
CHANGE: Moved killpilot to diracAdmin itself to avoid migrating it to DiracX while migrating PilotManagerHandler

This is useful later because in DiracX we can't use it for now: it needs a proxy to contact the CS + we would need to import `MySQLdb` in DiracX (see error below):

```
from DIRAC.Core.Utilities.MySQL import MySQL
  File "/opt/conda/lib/python3.11/site-packages/DIRAC/Core/Utilities/MySQL.py", line 155, in <module>
    import MySQLdb
ModuleNotFoundError: No module named 'MySQLdb'
```

This error occurred while importing `killPilotsInQueues` from DiracX via an import.

ENDRELEASENOTES
