### PR TITLE
[9.0] dirac-apptainer-exec : cd in /mnt to find locally-mounted files (e.g. pilot.cfg)

### DIFF
--- a/src/DIRAC/Core/scripts/dirac_apptainer_exec.py
+++ b/src/DIRAC/Core/scripts/dirac_apptainer_exec.py
@@ -83,6 +83,7 @@ def main():
     cmd.extend(["--bind", f"{vomses_location}:/etc/grid-security/vomses"])  # X509_VOMSES
     cmd.extend(["--bind", "{0}:{0}:ro".format(etc_dir)])  # etc dir for dirac.cfg
     cmd.extend(["--bind", "{0}:{0}:ro".format(os.path.join(os.path.realpath(sys.base_prefix)))])  # code dir
+    cmd.extend(["--cwd", "/mnt"])  # set working directory to /mnt
 
     rootImage = user_image or gConfig.getValue("/Resources/Computing/Singularity/ContainerRoot") or CONTAINER_DEFROOT
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -580,7 +580,7 @@ class SiteDirector(AgentModule):
             pilotOptions = []
 
         pilotOptions = " ".join(pilotOptions)
-        self.log.verbose(f"pilotOptions: {pilotOptions}")
+        self.log.verbose(f"{pilotOptions=}")
 
         # if a global workingDirectory is defined for the CEType (like HTCondor)
         # use it (otherwise the __cleanup done by HTCondor will be in the wrong folder !)

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/test/Test_PilotWrapper.py
@@ -136,3 +136,19 @@ def test_scriptPilot3_4():
     assert 'os.environ["someName"]="someValue"' in res
     assert "lhcb-portal.cern.ch" in res
     assert """locations += ["file:/cvmfs/dirac.egi.eu/pilot"]""" in res
+
+
+def test_scriptPilot3_5():
+    """test script creation"""
+    res = pilotWrapperScript(
+        pilotFilesCompressedEncodedDict={"proxy": "thisIsSomeProxy"},
+        pilotOptions="-l LHCb --architectureScript=dirac-architecture --CVMFS_locations=/cvmfs/lhcb.cern.ch -e LHCb -N atlasce1.lnf.infn.it -Q condor -n LCG.Frascati.it --wnVO=lhcb --architectureScript=dirac-apptainer-exec dirac-architecture -o lbRunOnly",
+        envVariables={"someName": "someValue", "someMore": "oneMore"},
+        location="lhcb-portal.cern.ch",
+        CVMFS_locations=[],
+    )
+    assert 'os.environ["someName"]="someValue"' in res
+    assert "lhcb-portal.cern.ch" in res
+    assert """locations += ["file:/cvmfs/dirac.egi.eu/pilot"]""" in res
+    assert "dirac-architecture" in res
+    assert "dirac-apptainer-exec dirac-architecture" in res


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
FIX: dirac-apptainer-exec : cd in /mnt to find locally-mounted files (e.g. pilot.cfg)

ENDRELEASENOTES
