### PR TITLE
[8.0] fix: AREXCE not detecting pilots in an accepted/staged states

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -667,7 +667,7 @@ class AREXComputingElement(ARCComputingElement):
         for qi in queueInfo:
             if qi["ID"].endswith(magic):
                 result["RunningJobs"] = int(qi["RunningJobs"])
-                result["WaitingJobs"] = int(qi["WaitingJobs"])
+                result["WaitingJobs"] = int(qi["WaitingJobs"]) + int(qi["StagingJobs"]) + int(qi["PreLRMSWaitingJobs"])
                 break  # Pick the first (should be only ...) matching queue + VO
         else:
             return S_ERROR(f"Could not find the queue {self.queue} associated to VO {vo}")


### PR DESCRIPTION
If the CE does not manage to pick up pilots from the session directory, then they are not detected as waiting by `AREX.getCEStatus`, and the Site Director just tries to submit pilots endlessly thinking there is no waiting pilot.

BEGINRELEASENOTES
*WorkloadManagement
FIX: AREXCE not detecting pilots in an accepted/staged states
ENDRELEASENOTES
