### PR TITLE
[8.0] fix authserver authlib update

### DIFF
--- a/src/DIRAC/FrameworkSystem/private/authorization/AuthServer.py
+++ b/src/DIRAC/FrameworkSystem/private/authorization/AuthServer.py
@@ -333,13 +333,13 @@ class AuthServer(_AuthorizationServer):
         """Parse request. Rewrite authlib method."""
         return self.create_oauth2_request(request, JsonRequest, True)
 
-    def validate_requested_scope(self, scope, state=None):
+    def validate_requested_scope(self, scope):
         """See :func:`authlib.oauth2.rfc6749.authorization_server.validate_requested_scope`"""
         # We also consider parametric scope containing ":" charter
         extended_scope = list_to_scope(
             [re.sub(r":.*$", ":", s) for s in scope_to_list((scope or "").replace("+", " "))]
         )
-        super().validate_requested_scope(extended_scope, state)
+        super().validate_requested_scope(extended_scope)
 
     def handle_response(self, status_code=None, payload=None, headers=None, newSession=None, delSession=None):
         """Handle response


### PR DESCRIPTION
In `authlib 1.6.0`, `state` was removed from `validate_requested_scope`: https://docs.authlib.org/en/latest/changelog.html#version-1-6-0

It breaks the CI: https://github.com/DIRACGrid/DIRAC/actions/runs/15297419987/job/43029731811?pr=8208
 
BEGINRELEASENOTES
*Framework
FIX: adapt AuthServer to latest version of authlib
ENDRELEASENOTES
