### PR TITLE
feat: remove PilotManager dependency from HTCondorCE

### DIFF
--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -66,7 +66,6 @@ from DIRAC.FrameworkSystem.private.authorization.utils.Tokens import writeToToke
 from DIRAC.Resources.Computing.BatchSystems.Condor import HOLD_REASON_SUBCODE, parseCondorStatus, subTemplate
 from DIRAC.Resources.Computing.ComputingElement import ComputingElement
 from DIRAC.WorkloadManagementSystem.Client import PilotStatus
-from DIRAC.WorkloadManagementSystem.Client.PilotManagerClient import PilotManagerClient
 
 MANDATORY_PARAMETERS = ["Queue"]
 DEFAULT_WORKINGDIRECTORY = "/opt/dirac/pro/runit/WorkloadManagement/SiteDirectorHT"
@@ -386,33 +385,10 @@ class HTCondorCEComputingElement(ComputingElement):
 
     #############################################################################
     def getCEStatus(self):
-        """Method to return information on running and pending jobs.
-
-        Warning: information currently returned depends on the PilotManager and not HTCondor.
-        Results might be wrong if pilots or jobs are submitted manually via the CE.
-        """
-        result = S_OK()
-        result["SubmittedJobs"] = 0
-        result["RunningJobs"] = 0
-        result["WaitingJobs"] = 0
-
-        # getWaitingPilots
-        condDict = {"DestinationSite": self.ceName, "Status": PilotStatus.PILOT_WAITING_STATES}
-        res = PilotManagerClient().countPilots(condDict)
-        if res["OK"]:
-            result["WaitingJobs"] = int(res["Value"])
-        else:
-            self.log.warn(f"Failure getting pilot count for {self.ceName}: {res['Message']} ")
-
-        # getRunningPilots
-        condDict = {"DestinationSite": self.ceName, "Status": PilotStatus.RUNNING}
-        res = PilotManagerClient().countPilots(condDict)
-        if res["OK"]:
-            result["RunningJobs"] = int(res["Value"])
-        else:
-            self.log.warn(f"Failure getting pilot count for {self.ceName}: {res['Message']} ")
-
-        return result
+        """Method to return information on running and pending jobs."""
+        return S_ERROR(
+            "getCEStatus() not supported for HTCondorCEComputingElement: HTCondor does not expose this information"
+        )
 
     def getJobStatus(self, jobIDList):
         """Get the status information for the given list of jobs"""

--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 import DIRAC
-from DIRAC import S_ERROR, S_OK, gConfig
+from DIRAC import S_ERROR, S_OK
 from DIRAC.AccountingSystem.Client.DataStoreClient import gDataStoreClient
 from DIRAC.AccountingSystem.Client.Types.Pilot import Pilot as PilotAccounting
 from DIRAC.AccountingSystem.Client.Types.PilotSubmission import (


### PR DESCRIPTION
The following change was not accepted in https://github.com/DIRACGrid/DIRAC/pull/5406, but I still think it makes sense because:
- we have the following relationship: `WMS` agents/services use `Resources/Computing` (`Resources/Computing` should work as a standalone, so without having to interact with a `WMS` service).
- there is no reliable way to get the CE status from HTCondor itself
- the caller (Site Director) now tries to get the CE status from the CE itself, and if it does not work, tries from the `PilotAgentsDB`, so we duplicate the operation: https://github.com/DIRACGrid/DIRAC/blob/889337e6ae72e833bbb5d5394767c6281f8b8d76/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py#L369-L408
- if we would try to call `Resources/Computing` from `diracx`, we would have troubles because `HTCondorComputingElement` relies on a DIRAC service.

Any reason to keep this dependency?

BEGINRELEASENOTES
*Resources
CHANGE: remove dependency from HTCondorComputingElement to PilotManager
ENDRELEASENOTES
