### PR TITLE
[8.0] feat: integrate `WholeNode` option in `Slurm` plugin

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
@@ -40,6 +40,7 @@ class SLURM(object):
         executable = kwargs["Executable"]
         account = kwargs.get("Account", "")
         numberOfProcessors = kwargs.get("NumberOfProcessors", 1)
+        wholeNode = kwargs.get("WholeNode", False)
         # numberOfNodes is treated as a string as it can contain values such as "2-4"
         # where 2 would represent the minimum number of nodes to allocate, and 4 the maximum
         numberOfNodes = kwargs.get("NumberOfNodes", "1")
@@ -72,7 +73,10 @@ class SLURM(object):
             # One pilot (task) per node, allocating a certain number of processors
             cmd += "--ntasks-per-node=1 "
             cmd += "--nodes=%s " % numberOfNodes
-            cmd += "--cpus-per-task=%d " % numberOfProcessors
+            if wholeNode:
+                cmd += "--exclusive "
+            else:
+                cmd += "--cpus-per-task=%d " % numberOfProcessors
             if numberOfGPUs:
                 cmd += "--gpus-per-task=%d " % int(numberOfGPUs)
             # Additional options

--- a/src/DIRAC/Resources/Computing/BatchSystems/test/Test_SLURM.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/test/Test_SLURM.py
@@ -199,3 +199,49 @@ def test_getJobOutputFiles(numberOfNodes, outputContent, expectedContent):
 
     os.remove(outputFile)
     os.remove(errorFile)
+
+
+def test_submitJob_cmd_generation(mocker):
+    """Test submitJob() command string generation for various kwargs"""
+    slurm = SLURM()
+    # Mock subprocess.Popen to capture the command
+    popen_mock = mocker.patch("subprocess.Popen")
+    process_mock = popen_mock.return_value
+    process_mock.communicate.return_value = ("Submitted batch job 1234\n", "")
+    process_mock.returncode = 0
+
+    # Minimal kwargs
+    kwargs = {
+        "Executable": "/bin/echo",
+        "OutputDir": "/tmp",
+        "ErrorDir": "/tmp",
+        "Queue": "testq",
+        "SubmitOptions": "",
+        "JobStamps": ["stamp1"],
+        "NJobs": 1,
+    }
+    # Test default (WholeNode False)
+    slurm.submitJob(**kwargs)
+    cmd = popen_mock.call_args[0][0]
+    assert "--cpus-per-task=1" in cmd
+    assert "--exclusive" not in cmd
+
+    # Test WholeNode True disables --cpus-per-task and adds --exclusive
+    kwargs["WholeNode"] = True
+    slurm.submitJob(**kwargs)
+    cmd = popen_mock.call_args[0][0]
+    assert "--exclusive" in cmd
+    assert "--cpus-per-task" not in cmd
+
+    # Test NumberOfProcessors
+    kwargs["WholeNode"] = False
+    kwargs["NumberOfProcessors"] = 8
+    slurm.submitJob(**kwargs)
+    cmd = popen_mock.call_args[0][0]
+    assert "--cpus-per-task=8" in cmd
+
+    # Test NumberOfGPUs
+    kwargs["NumberOfGPUs"] = 2
+    slurm.submitJob(**kwargs)
+    cmd = popen_mock.call_args[0][0]
+    assert "--gpus-per-task=2" in cmd


### PR DESCRIPTION
We interact with a queue having a variable number of cores per node, and the `SLURM` plugin is not flexible enough to deal with such a use case.

BEGINRELEASENOTES
*Resources
CHANGE: SLURM plugin now supports the WholeNode options
ENDRELEASENOTES
