### PR TITLE
feat (WMS): define setJobStatus in the Client to allow keyword arguments

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/JobStateUpdateClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobStateUpdateClient.py
@@ -28,3 +28,6 @@ class JobStateUpdateClient(Client):
 
         else:
             self.serverURL = url
+
+    def setJobStatus(self, jobID, status="", minorStatus="", source="Unknown", datetime_=None, force=False, **kwargs):
+        return self._getRPC(**kwargs).setJobStatus(jobID, status, minorStatus, source, datetime_, force)


### PR DESCRIPTION
It makes @VladimirRomanovsky 's life easier, so mine too

BEGINRELEASENOTES

*WMS

NEW: define setJobStatus in the Client to allow keyword arguments


ENDRELEASENOTES
