### PR TITLE
[9.0] fix(wms): download input data in the job directory

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Client/DownloadInputData.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/DownloadInputData.py
@@ -243,12 +243,13 @@ class DownloadInputData:
             return S_ERROR(msg)
 
     def __getDownloadDir(self, incrementCounter=True):
+        jobIDPath = str(self.configuration.get("JobIDPath", os.getcwd()))
         if self.inputDataDirectory == "PerFile":
             if incrementCounter:
                 self.counter += 1
-            return tempfile.mkdtemp(prefix=f"InputData_{self.counter}", dir=os.getcwd())
+            return tempfile.mkdtemp(prefix=f"InputData_{self.counter}", dir=jobIDPath)
         elif self.inputDataDirectory == "CWD":
-            return os.getcwd()
+            return jobIDPath
         else:
             return self.inputDataDirectory
 

--- a/src/DIRAC/WorkloadManagementSystem/Client/test/Test_Client_DownloadInputData.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/test/Test_Client_DownloadInputData.py
@@ -1,6 +1,8 @@
 """Test for WMS clients."""
 # pylint: disable=protected-access, missing-docstring, invalid-name
 
+from pathlib import Path
+import shutil
 import pytest
 
 from unittest.mock import MagicMock
@@ -280,3 +282,30 @@ def test_DLI_execute_NoLocal(mocker, dli, mockSE):
     assert res["Value"]["Failed"]
     assert "/a/lfn/1.txt" in res["Value"]["Failed"], res
     assert res["Value"]["Failed"][0] == "/a/lfn/1.txt", res
+
+
+def test_DLI_execute_jobIDPath(mocker, dli, mockSE):
+    """Specify a jobIDPath. Output should be in the jobIDPath directory."""
+    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
+
+    # Create the jobIDPath directory
+    jobIDPath = Path().cwd() / "job" / "12345"
+    jobIDPath.mkdir(parents=True, exist_ok=True)
+
+    dli.configuration["JobIDPath"] = str(jobIDPath)
+
+    mocker.patch("DIRAC.WorkloadManagementSystem.Client.DownloadInputData.gConfig.getValue", return_value=2)
+    mockObjectSE = mockSE.return_value
+    mockObjectSE.getFileMetadata.return_value = S_OK(
+        {"Successful": {"/a/lfn/1.txt": {"Cached": 1, "Accessible": 0}}, "Failed": {}}
+    )
+    dli._downloadFromSE = MagicMock(side_effect=[S_ERROR("Failed to down"), S_OK({"path": jobIDPath / "1.txt"})])
+    dli._isCache = MagicMock(return_value=True)
+    res = dli.execute(dataToResolve=["/a/lfn/1.txt"])
+
+    assert res["OK"]
+    assert not res["Value"]["Failed"]
+    assert "/a/lfn/1.txt" in res["Value"]["Successful"], res
+
+    # Check that the output path is in the jobIDPath directory
+    assert res["Value"]["Successful"]["/a/lfn/1.txt"]["path"] == jobIDPath / "1.txt", res


### PR DESCRIPTION
Bug introduced in https://github.com/DIRACGrid/DIRAC/pull/7587
Downloaded input data does not land in the directory where the job will run.

The fix was tested by @arrabito and @natthan-pigoux and works fine.

BEGINRELEASENOTES
*WorkloadManagement
FIX: Download input data in the job directory
ENDRELEASENOTES
