### PR TITLE
feat(resources): spool SSH+Condor job inputs/outputs

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
@@ -286,10 +286,12 @@ class Condor(object):
         output, error = sp.communicate()
         status = sp.returncode
 
-        if status != 0 or not output:
+        if status != 0:
             resultDict["Status"] = status
             resultDict["Message"] = error
             return resultDict
+        if not output:
+            output = "[]"
 
         jobsMetadata = json.loads(output)
 
@@ -304,10 +306,12 @@ class Condor(object):
         output, _ = sp.communicate()
         status = sp.returncode
 
-        if status != 0 or not output:
+        if status != 0:
             resultDict["Status"] = status
             resultDict["Message"] = error
             return resultDict
+        if not output:
+            output = "[]"
 
         jobsMetadata += json.loads(output)
 

--- a/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Condor.py
@@ -167,7 +167,7 @@ class Condor(object):
         jdlFile.flush()
 
         cmd = "%s; " % preamble if preamble else ""
-        cmd += "condor_submit %s" % jdlFile.name
+        cmd += "condor_submit -spool %s" % jdlFile.name
         sp = subprocess.Popen(
             cmd,
             shell=True,
@@ -399,6 +399,21 @@ class Condor(object):
         jobDict = {}
         for jobID in jobIDList:
             jobDict[jobID] = {}
+
+            cmd = "condor_transfer_data %s" % jobID
+            sp = subprocess.Popen(
+                shlex.split(cmd),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+            )
+            _, error = sp.communicate()
+            status = sp.returncode
+            if status != 0:
+                resultDict["Status"] = -1
+                resultDict["Message"] = error
+                return resultDict
+
             jobDict[jobID]["Output"] = "%s/%s.out" % (outputDir, jobID)
             jobDict[jobID]["Error"] = "%s/%s.err" % (errorDir, jobID)
 


### PR DESCRIPTION
- would reduce the space taken by the logs in the user space
- we need to clean the user space from time to time using the `SSHCE` anyway, but if the submission pace is too fast, it's better to only get the logs of interests and not all of them.

BEGINRELEASENOTES
*Resources
CHANGE: add spool option to SSHCE+Condor
ENDRELEASENOTES
