### PR TITLE
fix: dirac-apptainer-exec: do not use minimal install

### DIFF
--- a/src/DIRAC/Core/scripts/dirac_apptainer_exec.py
+++ b/src/DIRAC/Core/scripts/dirac_apptainer_exec.py
@@ -71,7 +71,6 @@ def main():
 
     # Now let's construct the apptainer command
     cmd = ["apptainer", "exec"]
-    cmd.extend(["--contain"])  # use minimal /dev and empty other directories (e.g. /tmp and $HOME)
     cmd.extend(["--ipc"])  # run container in a new IPC namespace
     cmd.extend(["--pid"])  # run container in a new PID namespace
     cmd.extend(["--bind", f"{os.getcwd()}"])  # bind current directory for dirac_container.sh


### PR DESCRIPTION
background for this change is this error:

```
Apptainer command failed with exit code 4
Command output: (4, "Found 4 errors\n    > Command exited with 255: apptainer --silent exec --bind /cvmfs --bind /export/data1/condor/execute/dir_37976/DIRAC_XLi9ygpilot --userns --bind /etc/proxy /cvmfs/cernvm-prod.cern.ch/cvm3 pwd\n    > Working directory inside apptainer (.) doesn't match outside (/export/data1/condor/execute/dir_37976/DIRAC_XLi9ygpilot)\n    > Command exited with 255: apptainer --debug exec --bind /cvmfs --bind /export/data1/condor/execute/dir_37976/DIRAC_XLi9ygpilot --userns --bind /etc/proxy /cvmfs/cernvm-prod.cern.ch/cvm3 pwd\n    > Command exited with 2: lb-run --container apptainer -c best --siteroot=/cvmfs/lhcb.cern.ch/lib DaVinci/v45r5 gaudirun.py --help\n", '')
```