### PR TITLE
[8.0] IdP clients per user group 

### DIFF
--- a/docs/source/AdministratorGuide/HowTo/pilotsWithTokens.rst
+++ b/docs/source/AdministratorGuide/HowTo/pilotsWithTokens.rst
@@ -28,9 +28,24 @@ Setting up an ``IdProvider``
           {
             client_id = <client_id>
             client_secret = <client_secret>
+            dirac_pilot
+            {
+              client_id = <client_id_for_dirac_VO>
+              client_secret = <client_secret_for_dirac_VO>
+            }
+            biomed_pilot
+            {
+              client_id = <client_id_for_biomed_VO>
+              client_secret = <client_secret_for_biomed_VO>
+            }
           }
         }
       }
+
+  In the case you use the same IdProvider for several VOs, you can specify different
+  OAuth2 client credentials per DIRAC user group representing the VO as in the example above.
+  For groups without this specific setting the general IdProvider client credentials
+  will be used.
 
 - Then in your global configuration, add the following section to set up an ``IdProvider`` interface:
 

--- a/src/DIRAC/FrameworkSystem/Utilities/TokenManagementUtilities.py
+++ b/src/DIRAC/FrameworkSystem/Utilities/TokenManagementUtilities.py
@@ -23,7 +23,7 @@ def getIdProviderClient(userGroup: str, idProviderClientName: str = None):
         return S_ERROR(f"The {userGroup} group belongs to the VO that is not tied to any Identity Provider.")
 
     # Prepare the client instance of the appropriate IdP
-    return IdProviderFactory().getIdProvider(idProviderClientName)
+    return IdProviderFactory().getIdProvider(idProviderClientName, groupClient=userGroup)
 
 
 def getCachedKey(

--- a/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
+++ b/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
@@ -70,6 +70,13 @@ class IdProviderFactory:
                 return result
             pDict = result["Value"]
 
+            # Check if the client has a special configuration for the requested group
+            if groupClient := kwargs.get("groupClient", None):
+                # Look for special client parameters for this user group
+                result = gConfig.getOptionsDict(f"/Resources/IdProviders/{name}/{groupClient}")
+                if result["OK"]:
+                    pDict.update(result["Value"])
+
         pDict.update(kwargs)
         pDict["ProviderName"] = name
 


### PR DESCRIPTION
  This PR adds the possibility to define IdP client credentials per user group to allow using the same IdProvider for several VOs without the need to define separate IdProvider per VO. If no setting is added for a group, generic client credentials will be taken. So, existing IdP configurations will be still valid. Example IdP configuration:

      Resources
      {
        IdProviders
        {
          <IdProvider name>
          {
            client_id = <client_id>
            client_secret = <client_secret>
            dirac_pilot
            {
              client_id = <client_id_for_dirac_VO>
              client_secret = <client_secret_for_dirac_VO>
            }
            biomed_pilot
            {
              client_id = <client_id_for_biomed_VO>
              client_secret = <client_secret_for_biomed_VO>
            }
          }
        }
      }


BEGINRELEASENOTES

*Framework
NEW: Possibility to define several OAuth2 clients for a given IdP for different DIRAC groups

ENDRELEASENOTES
