### PR TITLE
Fix sandbox and run local

### DIFF
--- a/src/DIRAC/Interfaces/API/Dirac.py
+++ b/src/DIRAC/Interfaces/API/Dirac.py
@@ -422,6 +422,14 @@ class Dirac(API):
                 sandbox = [isFile.strip() for isFile in sandbox.split(",")]
             for isFile in sandbox:
                 self.log.debug(f"Resolving Input Sandbox {isFile}")
+                # If the sandbox is already in the sandbox store, download it
+                if isFile.startswith("SB:"):
+                    result = SandboxStoreClient(useCertificates=self.useCertificates).downloadSandbox(
+                        isFile, destinationDir=os.getcwd()
+                    )
+                    if not result["OK"]:
+                        return S_ERROR(f"Cannot download Input sandbox {isFile}: {result['Message']}")
+                    continue
                 if isFile.lower().startswith("lfn:"):  # isFile is an LFN
                     isFile = isFile[4:]
                 # Attempt to copy into job working directory, unless it is already there

--- a/src/DIRAC/Interfaces/API/Job.py
+++ b/src/DIRAC/Interfaces/API/Job.py
@@ -1105,6 +1105,7 @@ class Job(API):
                 uniqueInputSandbox = uniqueElements(finalInputSandbox.split(";"))
                 paramsDict["InputSandbox"]["value"] = ";".join(uniqueInputSandbox)
                 self.log.verbose(f"Final unique Input Sandbox {';'.join(uniqueInputSandbox)}")
+                paramsDict["InputSandbox"]["type"] = "JDL"
             else:
                 paramsDict["InputSandbox"] = {}
                 paramsDict["InputSandbox"]["value"] = extraFiles

--- a/src/DIRAC/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -34,7 +34,7 @@ def ZstdCompatibleTarFile(tarFileName: os.PathLike, *, mode: Literal["r"] = "r")
     # Read magic bytes to determine compression format
     if magic.startswith(b"\x28\xb5\x2f\xfd"):  # zstd magic number
         dctx = zstandard.ZstdDecompressor()
-        with dctx.stream_reader(f) as decompressor:
+        with open(tarFileName, "rb") as f, dctx.stream_reader(f) as decompressor:
             with tarfile.open(fileobj=decompressor, mode=f"{mode}|") as tf:
                 yield tf
     else:


### PR DESCRIPTION

BEGINRELEASENOTES

*WorkloadManagement
FIX: Use of closed file in ZstdCompatibleTarFile when downloading sandboxes
NEW: add sandbox download functionality in Dirac runLocal API

ENDRELEASENOTES
