### PR TITLE
[9.0] Apply PreferredURLPatterns to Configuration refresh server list

### DIFF
--- a/src/DIRAC/ConfigurationSystem/private/RefresherBase.py
+++ b/src/DIRAC/ConfigurationSystem/private/RefresherBase.py
@@ -1,7 +1,7 @@
 import time
 
 from DIRAC.ConfigurationSystem.Client.ConfigurationData import gConfigurationData
-from DIRAC.ConfigurationSystem.Client.PathFinder import getGatewayURLs
+from DIRAC.ConfigurationSystem.Client.PathFinder import getGatewayURLs, groupURLsByPriority
 from DIRAC.Core.Utilities import List
 from DIRAC.Core.Utilities.EventDispatcher import gEventDispatcher
 from DIRAC.Core.Utilities.ReturnValues import S_ERROR, S_OK
@@ -138,7 +138,9 @@ class RefresherBase:
         if not initialServerList:
             return S_OK()
 
-        randomServerList = List.randomize(initialServerList)
+        randomServerList = []
+        for urlGroup in groupURLsByPriority(initialServerList):
+            randomServerList.extend(List.randomize(urlGroup))
         gLogger.debug(f"Randomized server list is {', '.join(randomServerList)}")
 
         for sServer in randomServerList:


### PR DESCRIPTION
The RefresherBase now respects the PreferredURLPatterns option when randomizing server lists, ensuring preferred servers are tried first while maintaining randomization within each priority group.



BEGINRELEASENOTES

*Configuration
CHANGE: Apply PreferredURLPatterns to Configuration refresh server list

ENDRELEASENOTES
