### PR TITLE
[9.0] improve service throttling mechanism to reject clients instead of blocking

### DIFF
--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -200,6 +200,7 @@ class ServiceReactor:
                                   services at the same time
         """
         sel = self.__getListeningSelector(svcName)
+        throttleExpires = None
         while self.__alive:
             clientTransport = None
             try:
@@ -223,12 +224,19 @@ class ServiceReactor:
                 gLogger.warn(f"Client connected from banned ip {clientIP}")
                 clientTransport.close()
                 continue
+            # Handle throttling
+            if self.__services[svcName].wantsThrottle and throttleExpires is None:
+                throttleExpires = time.time() + THROTTLE_SERVICE_SLEEP_SECONDS
+            if throttleExpires:
+                if time.time() > throttleExpires:
+                    throttleExpires = None
+                else:
+                    gLogger.warn("Rejecting client due to throttling", str(clientTransport.getRemoteAddress()))
+                    clientTransport.close()
+                    continue
             # Handle connection
             self.__stats.connectionStablished()
             self.__services[svcName].handleConnection(clientTransport)
-            while self.__services[svcName].wantsThrottle:
-                gLogger.warn("Sleeping as service requested throttling", svcName)
-                time.sleep(THROTTLE_SERVICE_SLEEP_SECONDS)
             # Renew context?
             now = time.time()
             renewed = False


### PR DESCRIPTION
The theory is that the connections are still backing up even while the service is sleeping. If we instead close connections agressively during the throttle period hopefully we'll be able to recover from overload periods more effectively



BEGINRELEASENOTES

*Core
CHANGE: Agressively close connections when serivces are overloaded

For examples look into release.notes

ENDRELEASENOTES
