### PR TITLE
[8.0] fix: accounting for other formats (AREX CE)

### DIFF
--- a/src/DIRAC/Resources/Computing/AREXComputingElement.py
+++ b/src/DIRAC/Resources/Computing/AREXComputingElement.py
@@ -1,4 +1,4 @@
-""" AREX Computing Element (ARC REST interface)
+"""AREX Computing Element (ARC REST interface)
 
 Allows interacting with ARC AREX services via a REST interface.
 
@@ -655,7 +655,23 @@ class AREXComputingElement(ARCComputingElement):
         ceData = response.json()
 
         # Look only in the relevant section out of the headache
-        queueInfo = ceData["Domains"]["AdminDomain"]["Services"]["ComputingService"]["ComputingShare"]
+        # This "safe_get" function allows to go down the dictionary
+        # even if some elements are lists instead of dictionaries
+        # and returns None if any element is not found
+        # FIXME: this is a temporary measure to be removed after https://github.com/DIRACGrid/DIRAC/issues/8354
+        def safe_get(d, *keys):
+            for k in keys:
+                if isinstance(d, list):
+                    d = d[0]  # assume first element
+                d = d.get(k) if isinstance(d, dict) else None
+                if d is None:
+                    break
+            return d
+
+        queueInfo = safe_get(ceData, "Domains", "AdminDomain", "Services", "ComputingService", "ComputingShare")
+        if queueInfo is None:
+            self.log.error("Failed to extract queue info")
+
         if not isinstance(queueInfo, list):
             queueInfo = [queueInfo]
 


### PR DESCRIPTION
We have see that for few CEs (e.g. `brug.nikhel.nl`) the AREX CE gives back a slightly different format. The fix below makes assumptions. 

BEGINRELEASENOTES

*Resources
FIX: AREX CE: fix for understanding slightly different formats

ENDRELEASENOTES
