### PR TITLE
[8.0] Audience parameter for the Check-In IdP

### DIFF
--- a/src/DIRAC/Resources/IdProvider/CheckInIdProvider.py
+++ b/src/DIRAC/Resources/IdProvider/CheckInIdProvider.py
@@ -26,3 +26,16 @@ class CheckInIdProvider(OAuth2IdProvider):
 
             idPScope = f"eduperson_entitlement?value=urn:mace:egi.eu:group:{vo}:role={groupElements[1]}#aai.egi.eu"
         return scope_to_list(idPScope)
+
+    def fetchToken(self, **kwargs):
+        """Fetch token
+
+        :param kwargs:
+        :return: dict
+        """
+
+        if "audience" in kwargs:
+            kwargs["resource"] = kwargs["audience"]
+            kwargs.pop("audience")
+
+        return super().fetchToken(**kwargs)


### PR DESCRIPTION
  Check-In IdP requires passing audience as resource parameter to fetch a token unlike IAM which needs audience parameter. Passing both with the same value should be OK for both cases.


BEGINRELEASENOTES

*WorkloadManagement
FIX: TokenManager - pass audience parameter as resource to fetchToken() to satisfy Check-In

ENDRELEASENOTES
