### PR TITLE
fix: remove no-longer required setuptools from runtime dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,6 @@ install_requires =
     pytz
     requests
     rucio-clients >=34.4.2
-    setuptools
     sqlalchemy
     typing_extensions >=4.3.0
     Authlib >=1.0.0.a2


### PR DESCRIPTION

BEGINRELEASENOTES
*General
Remove setuptools from runtime dependencies, no longer required.
ENDRELEASENOTES


After removing the use of `pkg_resources`, setuptools should no longer be a runtime requirement.
