### PR TITLE
docs: Prevent documenting inherited Pydantic internals

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,7 +108,18 @@ extensions = [
 ]
 
 
+def skip_inherited_members(app, what, name, obj, skip, options):
+    removals_list = [
+        "model_json_schema",  # for pydantic.main.BaseModel.model_json_schema
+        "send_error",
+    ]  # for http.server.BaseHTTPRequestHandler.send_error
+    if name in removals_list:
+        return True
+    return skip
+
+
 def setup(app):
+    app.connect("autodoc-skip-member", skip_inherited_members)
     app.add_config_value(
         "recommonmark_config",
         {
@@ -300,7 +311,6 @@ latex_documents = [
 
 # packages that cannot be installed in RTD
 autodoc_mock_imports = DIRAC_DOC_MOCK_LIST
-
 
 # link with the python standard library docs
 intersphinx_mapping = {

--- a/src/DIRAC/Core/Tornado/Server/TornadoService.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoService.py
@@ -73,7 +73,7 @@ class TornadoService(BaseRequestHandler):  # pylint: disable=abstract-method
     :py:class:`BaseRequestHandler <DIRAC.Core.Tornado.Server.private.BaseRequestHandler.BaseRequestHandler>` for more details.
 
     In order to pass information around and keep some states, we use instance attributes.
-    These are initialized in the :py:meth:`.initialize` method.
+    These are initialized in the ``initialize`` methods.
 
     The handler only define the ``post`` verb. Please refer to :py:meth:`.post` for the details.
 


### PR DESCRIPTION
Because of

```
JobModel.py:docstring of pydantic.main.BaseModel.model_json_schema:8: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
```

seen e.g. in https://app.readthedocs.org/api/v2/build/29898195.txt (last PRs)
