### PR TITLE
fix: Site Director stops trying to leverage banned CEs

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -229,12 +229,8 @@ class SiteDirector(AgentModule):
             site = self.queueDict[queueName]["Site"]
             ce = self.queueDict[queueName]["CEName"]
 
-            # Check the status of the Site
-            if site in siteMaskList:
-                continue
-
-            # Check the status of the CE (only for RSS=Active)
-            if ce not in ceMaskList:
+            # Check the status of the Site and CE
+            if site in siteMaskList and ce in ceMaskList:
                 continue
 
             self.log.warn("Queue not considered because not usable:", queueName)

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_SiteDirector.py
@@ -169,10 +169,16 @@ def sd(mocker, config):
         gConfig.getSections("Resources/Sites/LCG")["Value"] + gConfig.getSections("Resources/Sites/DIRAC")["Value"]
     )
     mocker.patch(
-        "DIRAC.WorkloadManagementSystem.Agent.SiteDirector.SiteStatus.getUsableSites", return_values=usableSites
+        "DIRAC.WorkloadManagementSystem.Agent.SiteDirector.SiteStatus.getUsableSites", return_value=S_OK(usableSites)
     )
+
+    # Mock getElementStatus to return a properly formatted dictionary
+    def mock_getElementStatus(ceNamesList, *args, **kwargs):
+        return S_OK({ceName: {"all": "Active"} for ceName in ceNamesList})
+
     mocker.patch(
-        "DIRAC.WorkloadManagementSystem.Agent.SiteDirector.ResourceStatus.getElementStatus", return_values=usableSites
+        "DIRAC.WorkloadManagementSystem.Agent.SiteDirector.ResourceStatus.getElementStatus",
+        side_effect=mock_getElementStatus,
     )
     mocker.patch(
         "DIRAC.WorkloadManagementSystem.Agent.SiteDirector.gProxyManager.downloadProxy", side_effect=mockPMProxyReply


### PR DESCRIPTION
Site Directors are currently trying to use banned CEs.


BEGINRELEASENOTES
*WorkloadManagement
FIX: Site Director stops trying to leverage banned CEs
ENDRELEASENOTES
