### PR TITLE
feat: Depend on diracx-cli to make DiracX CS conversion simplier

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -75,6 +75,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Fail-fast for outdated pipelines
       run: .github/workflows/fail-fast.sh
     - uses: conda-incubator/setup-miniconda@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,9 @@ install_requires =
     cwltool
     diraccfg
     DIRACCommon
-    diracx-client >=v0.0.1a18
-    diracx-core >=v0.0.1a18
+    diracx-client >=v0.0.1
+    diracx-core >=v0.0.1
+    diracx-cli >=v0.0.1
     db12
     fts3
     gfal2-python


### PR DESCRIPTION

BEGINRELEASENOTES

*DiracX
NEW: Depend on released versions of DiracX
NEW: Depend on diracx-cli to ease management of DiracX CS conversion

ENDRELEASENOTES
