### PR TITLE
[9.0] Use resolved socket address for SSL connections in M2SSLTransport

### DIFF
--- a/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
@@ -116,13 +116,12 @@ class SSLTransport(BaseTransport):
         # The following piece of code was inspired by the python socket documentation
         # as well as the implementation of M2Crypto.httpslib.HTTPSConnection
 
-        # We ignore the returned sockaddr because SSL.Connection.connect needs
-        # a host name.
+        # Get all available addresses (IPv6 and IPv4) and try them in order
         try:
             addrInfoList = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
         except OSError as e:
             return S_ERROR(f"DNS lookup failed {e!r}")
-        for family, _socketType, _proto, _canonname, _socketAddress in addrInfoList:
+        for family, _socketType, _proto, _canonname, socketAddress in addrInfoList:
             try:
                 self.oSocket = SSL.Connection(self.__ctx, family=family)
 
@@ -138,7 +137,10 @@ class SSLTransport(BaseTransport):
                 # set SNI server name since we know it at this point
                 self.oSocket.set_tlsext_host_name(host)
 
-                self.oSocket.connect((host, port))
+                # tell the connection which host we are connecting to so we can
+                # use the address we obtained from DNS
+                self.oSocket.set1_host(host)
+                self.oSocket.connect(socketAddress)
 
                 # Once the connection is established, we can use the timeout
                 # asked for RPC

--- a/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
@@ -110,7 +110,7 @@ class SSLTransport(BaseTransport):
         if self.serverMode():
             raise RuntimeError("SSLTransport is in server mode.")
 
-        error = None
+        errors = []
         host, port = self.stServerAddress
 
         # The following piece of code was inspired by the python socket documentation
@@ -151,12 +151,12 @@ class SSLTransport(BaseTransport):
             # They should be propagated upwards and caught by the BaseClient
             # not to enter the retry loop
             except OSError as e:
-                error = f"{e}:{repr(e)}"
+                errors.append(f"{socketAddress} {e}:{repr(e)}")
 
                 if self.oSocket is not None:
                     self.close()
 
-        return S_ERROR(error)
+        return S_ERROR("; ".join(errors))
 
     def initAsServer(self):
         """Prepare this server socket for use."""


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
NEW: Report errors for every failed attempt in M2SSLTransport initAsClient
FIX: Use resolved socket address for SSL connections in M2SSLTransport

ENDRELEASENOTES
