### PR TITLE
[9.0] Subprocess: use psutil for killing processes

### DIFF
--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -320,8 +320,6 @@ class Subprocess:
         if pid == 0:
             os.close(readFD)
             self.__executePythonFunction(function, writeFD, *stArgs, **stKeyArgs)
-            # FIXME: the close it is done at __executePythonFunction, do we need it here?
-            os.close(writeFD)
         else:
             os.close(writeFD)
             readSeq = self.__selectFD([readFD])
@@ -330,14 +328,13 @@ class Subprocess:
             try:
                 if len(readSeq) == 0:
                     self.log.debug("Timeout limit reached for pythonCall", function.__name__)
-                    self.__terminateProcess(psutil.Process(pid))
-
-                    # HACK to avoid python bug
-                    # self.wait()
-                    retries = 10000
-                    while os.waitpid(pid, 0) == -1 and retries > 0:
-                        time.sleep(0.001)
-                        retries -= 1
+                    gone, alive = self.__terminateProcess(psutil.Process(pid))
+                    if alive:
+                        for p in alive:
+                            try:
+                                p.kill()
+                            except psutil.NoSuchProcess:
+                                continue
 
                     return S_ERROR('%d seconds timeout for "%s" call' % (self.timeout, function.__name__))
                 elif readSeq[0] == readFD:

--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -162,7 +162,6 @@ class Subprocess:
 
         self.child = None
         self.childPID = 0
-        self.childKilled = False
         self.callback = None
         self.bufferList = []
         self.cmdSeq = []
@@ -251,20 +250,25 @@ class Subprocess:
             return ([], [])
         return psutil.wait_procs([process], timeout=60)
 
-    def __poll(self, pid):
-        """return pid status"""
+    def __poll(self, process):
+        """Non-blocking check of whether process `pid` is still alive.
+        Returns:
+        - (0, 0) if process is still running  (like os.waitpid(pid, os.WNOHANG))
+        - (pid, exitcode) if process has terminated
+        - None if process info cannot be retrieved
+        """
         try:
-            p = psutil.Process(pid)
-            exitcode = p.wait(timeout=0)
-            return (pid, exitcode)  # exited
+            exitcode = process.wait(timeout=0)
+            return (process.pid, exitcode)  # exited
         except psutil.TimeoutExpired:
             return (0, 0)  # still running
         except psutil.NoSuchProcess:
             return None
 
     def killChild(self, recursive=True):
-        """Kills a process tree (including children) with signal SIGTERM.
-        if that fails, escalate to SIGKILL"""
+        """Kills a process tree (including children) with signal SIGTERM. If that fails, escalate to SIGKILL
+        returns (gone, alive) tuple.
+        """
 
         self.log.info(f"Killing childPID {self.childPID}")
 
@@ -276,6 +280,7 @@ class Subprocess:
             return (gone, alive)
 
         if recursive:
+            # grandchildren
             children = child_process.children(recursive=True)
             self.log.info(f"Sending kill signal to {len(children)} children PIDs")
             for p in children:
@@ -292,12 +297,15 @@ class Subprocess:
         gone.extend(g)
         alive.extend(a)
 
+        # if there's something still alive, use SIGKILL
         if alive:
             for p in alive:
                 try:
                     p.kill()
                 except psutil.NoSuchProcess:
                     pass
+
+        return psutil.wait_procs(alive, timeout=60)
 
     def pythonCall(self, function, *stArgs, **stKeyArgs):
         """call python function :function: with :stArgs: and :stKeyArgs:"""
@@ -449,6 +457,7 @@ class Subprocess:
                 start_new_session=start_new_session,
             )
             self.childPID = self.child.pid
+            child_process = psutil.Process(self.childPID)
         except OSError as v:
             retDict = S_ERROR(repr(v))
             retDict["Value"] = (-1, "", str(v))
@@ -467,7 +476,7 @@ class Subprocess:
             self.bufferList = [["", 0], ["", 0]]
             initialTime = time.time()
 
-            exitStatus = self.__poll(self.child.pid)
+            exitStatus = self.__poll(child_process)
 
             while (0, 0) == exitStatus:  # This means that the process is still alive
                 retDict = self.__readFromCommand()
@@ -481,7 +490,7 @@ class Subprocess:
                         1, "Timeout (%d seconds) for '%s' call" % (self.timeout, cmdSeq)
                     )
                 time.sleep(0.01)
-                exitStatus = self.__poll(self.child.pid)
+                exitStatus = self.__poll(child_process)
 
             self.__readFromCommand()
 

--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -1,7 +1,7 @@
 """
 DIRAC Wrapper to execute python and system commands with a wrapper, that might
 set a timeout.
-3 FUNCTIONS are provided:
+3 functions are provided:
 
      - shellCall( iTimeOut, cmdSeq, callbackFunction = None, env = None ):
        it uses subprocess.Popen class with "shell = True".
@@ -26,6 +26,7 @@ set a timeout.
        should be used to wrap third party python functions
 
 """
+
 import os
 import selectors
 import signal
@@ -193,7 +194,7 @@ class Subprocess:
                     f"First and last data in buffer: \n{dataString[:100]} \n....\n {dataString[-100:]} ",
                 )
                 retDict = S_ERROR(
-                    "Reached maximum allowed length (%d bytes) " "for called function return value" % self.bufferLimit
+                    "Reached maximum allowed length (%d bytes) for called function return value" % self.bufferLimit
                 )
                 retDict["Value"] = dataString
                 return retDict
@@ -241,60 +242,62 @@ class Subprocess:
         events = sel.select(timeout=timeout or self.timeout or None)
         return [key.fileobj for key, event in events if event & selectors.EVENT_READ]
 
-    def __killPid(self, pid, sig=9):
-        """send signal :sig: to process :pid:
-
-        :param int pid: process id
-        :param int sig: signal to send, default 9 (SIGKILL)
-        """
+    def __terminateProcess(self, process):
+        """Tries to terminate a process with SIGTERM. Returns a (gone, alive) tuple"""
+        self.log.verbose(f"Sending SIGTERM signal to PID {process.pid}")
         try:
-            os.kill(pid, sig)
-        except Exception as x:
-            if str(x) != "[Errno 3] No such process":
-                self.log.exception("Exception while killing timed out process")
-                raise x
+            process.terminate()
+        except psutil.NoSuchProcess:
+            return ([], [])
+        return psutil.wait_procs([process], timeout=60)
 
     def __poll(self, pid):
-        """wait for :pid:"""
+        """return pid status"""
         try:
-            return os.waitpid(pid, os.WNOHANG)
-        except os.error:
-            if self.childKilled:
-                return False
+            p = psutil.Process(pid)
+            exitcode = p.wait(timeout=0)
+            return (pid, exitcode)  # exited
+        except psutil.TimeoutExpired:
+            return (0, 0)  # still running
+        except psutil.NoSuchProcess:
             return None
 
     def killChild(self, recursive=True):
-        """kill child process
+        """Kills a process tree (including children) with signal SIGTERM.
+        if that fails, escalate to SIGKILL"""
 
-        :param boolean recursive: flag to kill all descendants
-        """
-        pgid = os.getpgid(self.childPID)
-        if pgid != os.getpgrp():
-            try:
-                # Child is in its own group: kill the group
-                os.killpg(pgid, signal.SIGTERM)
-            except OSError:
-                # Process is already dead
-                pass
-        else:
-            # No separate group: walk the tree
-            parent = psutil.Process(self.childPID)
-            procs = parent.children(recursive=recursive)
-            procs.append(parent)
-            for p in procs:
+        self.log.info(f"Killing childPID {self.childPID}")
+
+        gone, alive = [], []
+        try:
+            child_process = psutil.Process(self.childPID)
+        except psutil.NoSuchProcess:
+            self.log.warn(f"Child PID {self.childPID} no longer exists")
+            return (gone, alive)
+
+        if recursive:
+            children = child_process.children(recursive=True)
+            self.log.info(f"Sending kill signal to {len(children)} children PIDs")
+            for p in children:
                 try:
                     p.terminate()
                 except psutil.NoSuchProcess:
-                    pass
-            _gone, alive = psutil.wait_procs(procs, timeout=10)
-            # Escalate any survivors
+                    continue
+            g, a = psutil.wait_procs(children, timeout=60)
+            gone.extend(g)
+            alive.extend(a)
+
+        # now killing the child_process
+        g, a = self.__terminateProcess(child_process)
+        gone.extend(g)
+        alive.extend(a)
+
+        if alive:
             for p in alive:
                 try:
                     p.kill()
                 except psutil.NoSuchProcess:
                     pass
-
-        self.childKilled = True
 
     def pythonCall(self, function, *stArgs, **stKeyArgs):
         """call python function :function: with :stArgs: and :stKeyArgs:"""
@@ -319,7 +322,7 @@ class Subprocess:
             try:
                 if len(readSeq) == 0:
                     self.log.debug("Timeout limit reached for pythonCall", function.__name__)
-                    self.__killPid(pid)
+                    self.__terminateProcess(psutil.Process(pid))
 
                     # HACK to avoid python bug
                     # self.wait()
@@ -400,7 +403,7 @@ class Subprocess:
         if len(dataString) + baseLength > self.bufferLimit:
             self.log.error("Maximum output buffer length reached")
             retDict = S_ERROR(
-                "Reached maximum allowed length (%d bytes) for called " "function return value" % self.bufferLimit
+                "Reached maximum allowed length (%d bytes) for called function return value" % self.bufferLimit
             )
             retDict["Value"] = dataString
             return retDict
@@ -466,7 +469,7 @@ class Subprocess:
 
             exitStatus = self.__poll(self.child.pid)
 
-            while (0, 0) == exitStatus or exitStatus is None:
+            while (0, 0) == exitStatus:  # This means that the process is still alive
                 retDict = self.__readFromCommand()
                 if not retDict["OK"]:
                     return retDict
@@ -485,7 +488,7 @@ class Subprocess:
             if exitStatus:
                 exitStatus = exitStatus[1]
 
-            if exitStatus >= 256:
+            if exitStatus and exitStatus >= 256:
                 exitStatus = int(exitStatus / 256)
             return S_OK((exitStatus, self.bufferList[0][0], self.bufferList[1][0]))
         finally:

--- a/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Subprocess.py
@@ -3,23 +3,25 @@
 # Date: 2012/12/11 18:04:25
 ########################################################################
 
-""" :mod: SubprocessTests
-    =======================
+""":mod: SubprocessTests
+=======================
 
-    .. module: SubprocessTests
-    :synopsis: unittest for Subprocess module
-    .. moduleauthor:: Krzysztof.Ciba@NOSPAMgmail.com
+.. module: SubprocessTests
+:synopsis: unittest for Subprocess module
+.. moduleauthor:: Krzysztof.Ciba@NOSPAMgmail.com
 
-    unittest for Subprocess module
+unittest for Subprocess module
 """
-import time
+
 import platform
+import time
 from os.path import dirname, join
 from subprocess import Popen
 
+import psutil
 import pytest
 
-from DIRAC.Core.Utilities.Subprocess import systemCall, shellCall, pythonCall, getChildrenPIDs, Subprocess
+from DIRAC.Core.Utilities.Subprocess import Subprocess, getChildrenPIDs, pythonCall, shellCall, systemCall
 
 # Mark this entire module as slow
 pytestmark = pytest.mark.slow
@@ -72,3 +74,51 @@ def test_decodingCommandOutput():
     retVal = sp.systemCall(r"""python -c 'import os; os.fdopen(2, "wb").write(b"\xdf")'""", shell=True)
     assert retVal["OK"]
     assert retVal["Value"] == (0, "", "\ufffd")
+
+
+@pytest.fixture
+def subprocess_instance():
+    """Provides a Subprocess instance for testing."""
+    subp = Subprocess()
+    return subp
+
+
+@pytest.fixture
+def dummy_child():
+    """Spawn a dummy process tree: parent -> child."""
+    # Start a shell that sleeps, with a subprocess child
+    parent = Popen(["bash", "-c", "sleep 10 & wait"])
+    time.sleep(0.2)  # give it a moment to start
+    yield parent
+    # Ensure cleanup
+    try:
+        parent.terminate()
+        parent.wait(timeout=1)
+    except Exception:
+        pass
+
+
+def test_kill_child_process_tree(subprocess_instance, dummy_child):
+    """Test that killChild kills both parent and its children."""
+    subprocess_instance.childPID = dummy_child.pid
+    parent_proc = psutil.Process(subprocess_instance.childPID)
+
+    # Sanity check: parent should exist
+    assert parent_proc.is_running()
+
+    # It should have at least one sleeping child
+    children = parent_proc.children(recursive=True)
+    assert children, "Expected dummy process to have at least one child"
+
+    # Kill the tree
+    gone, alive = subprocess_instance.killChild(recursive=True)
+
+    # Verify the parent and children are terminated
+    for p in gone:
+        assert not p.is_running(), f"Process {p.pid} still alive"
+    for p in alive:
+        assert not p.is_running(), f"Process {p.pid} still alive"
+
+    # Verify parent is gone
+    with pytest.raises(psutil.NoSuchProcess):
+        psutil.Process(subprocess_instance.childPID)

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -17,7 +17,6 @@ import errno
 import getpass
 import math
 import os
-import signal
 import socket
 import time
 from pathlib import Path
@@ -31,28 +30,6 @@ from DIRAC.Core.Utilities.Profiler import Profiler
 from DIRAC.Resources.Computing.BatchSystems.TimeLeft.TimeLeft import TimeLeft
 from DIRAC.WorkloadManagementSystem.Client import JobMinorStatus
 from DIRAC.WorkloadManagementSystem.Client.JobStateUpdateClient import JobStateUpdateClient
-
-
-def kill_proc_tree(pid, sig=signal.SIGTERM, includeParent=True):
-    """Kill a process tree (including grandchildren) with signal
-    "sig" and return a (gone, still_alive) tuple.
-    called as soon as a child terminates.
-
-    Taken from https://psutil.readthedocs.io/en/latest/index.html#kill-process-tree
-    """
-    assert pid != os.getpid(), "won't kill myself"
-    parent = psutil.Process(pid)
-    children = parent.children(recursive=True)
-    if includeParent:
-        children.append(parent)
-    for p in children:
-        try:
-            p.send_signal(sig)
-        except psutil.NoSuchProcess:
-            pass
-    _gone, alive = psutil.wait_procs(children, timeout=10)
-    for p in alive:
-        p.kill()
 
 
 class Watchdog:

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/Watchdog.py
@@ -1,16 +1,17 @@
-"""  The Watchdog class is used by the Job Wrapper to resolve and monitor
-     the system resource consumption.  The Watchdog can determine if
-     a running job is stalled and indicate this to the Job Wrapper.
-     Furthermore, the Watchdog will identify when the Job CPU limit has been
-     exceeded and fail jobs meaningfully.
+"""The Watchdog class is used by the Job Wrapper to resolve and monitor
+the system resource consumption.  The Watchdog can determine if
+a running job is stalled and indicate this to the Job Wrapper.
+Furthermore, the Watchdog will identify when the Job CPU limit has been
+exceeded and fail jobs meaningfully.
 
-     Information is returned to the WMS via the heart-beat mechanism.  This
-     also interprets control signals from the WMS e.g. to kill a running
-     job.
+Information is returned to the WMS via the heart-beat mechanism.  This
+also interprets control signals from the WMS e.g. to kill a running
+job.
 
-     - Still to implement:
-          - CPU normalization for correct comparison with job limit
+- Still to implement:
+     - CPU normalization for correct comparison with job limit
 """
+
 import datetime
 import errno
 import getpass
@@ -212,7 +213,7 @@ class Watchdog:
             if self.littleTimeLeftCount == 0 and self.__timeLeft() == -1:
                 self.checkError = JobMinorStatus.JOB_EXCEEDED_CPU
                 self.log.error(self.checkError, self.timeLeft)
-                self.__killRunningThread()
+                self.spObject.killChild()
                 return S_OK()
 
             self.littleTimeLeftCount -= 1
@@ -321,7 +322,7 @@ class Watchdog:
 
                     self.log.info("=================END=================")
 
-            self.__killRunningThread()
+            self.spObject.killChild()
             return S_OK()
 
         recentStdOut = "None"
@@ -408,7 +409,7 @@ class Watchdog:
             if "Kill" in signalDict:
                 self.log.info("Received Kill signal, stopping job via control signal")
                 self.checkError = JobMinorStatus.RECEIVED_KILL_SIGNAL
-                self.__killRunningThread()
+                self.spObject.killChild()
             else:
                 self.log.info("The following control signal was sent but not understood by the watchdog:")
                 self.log.info(signalDict)
@@ -861,13 +862,6 @@ class Watchdog:
             result["Value"] = 0.0
 
         return result
-
-    #############################################################################
-    def __killRunningThread(self):
-        """Will kill the running thread process and any child processes."""
-        self.log.info("Sending kill signal to application PID", self.spObject.getChildPID())
-        self.spObject.killChild()
-        return S_OK("Thread killed")
 
     #############################################################################
     def __sendSignOfLife(self, jobID, heartBeatDict, staticParamDict):

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -1,5 +1,5 @@
-""" Test class for JobWrapper
-"""
+"""Test class for JobWrapper"""
+
 import os
 import shutil
 import tempfile
@@ -314,8 +314,7 @@ def test_processKilledSubprocess(mocker):
         result = jw.process("sleep 20", {})
 
     assert result["OK"]
-    assert result["Value"]["payloadStatus"] == 15  # SIGTERM
-    assert not result["Value"]["payloadOutput"]
+    assert result["Value"]["payloadStatus"] is None
     assert not result["Value"]["payloadExecutorError"]
     assert result["Value"]["watchdogError"] == "Job is stalled!"  # Error message from the watchdog
 


### PR DESCRIPTION
This is a rewrite of few functions in subprocess that need **very** careful evaluation. 

For reasons not understood (at least not by me) the logic of killing a pid and its sub-processes is not completing (not always, at least). I blame the very old logic used there, but of course I might be wrong. In any case this is a rewriting using `psutil`.

I had to change one test in Test_JobWrapper. I have not fully understood why, but I do not see how the previous code could work. cc @aldbr 

BEGINRELEASENOTES

CHANGE: Subprocess: use psutil for killing processes

ENDRELEASENOTES
