### PR TITLE
[9.0] feat: get the pilot output(s) from a job ID using PilotManager

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/WMSAdministratorHandler.py
@@ -150,37 +150,24 @@ class WMSAdministratorHandlerMixin:
         :param str jobID: job ID
         :return: S_OK(dict)/S_ERROR()
         """
-        pilotReference = ""
-        # Get the pilot grid reference first from the job parameters
+        result = self.pilotManager.getPilots(jobID)
 
-        credDict = self.getRemoteCredentials()
-        vo = credDict.get("VO", Registry.getVOForGroup(credDict["group"]))
-        res = self.elasticJobParametersDB.getJobParameters(int(jobID), vo=vo, paramList=["Pilot_Reference"])
-        if not res["OK"]:
-            return res
-        if res["Value"].get(int(jobID)):
-            pilotReference = res["Value"][int(jobID)]["Pilot_Reference"]
+        if not result["OK"]:
+            return result
+        pilotJobReferences = result["Value"].keys()
 
-        if not pilotReference:
-            res = self.jobDB.getJobParameter(int(jobID), "Pilot_Reference")
-            if not res["OK"]:
-                return res
-            pilotReference = res["Value"]
+        outputs = {"StdOut": "", "StdErr": ""}
+        for pilotRef in pilotJobReferences:
+            result = self.pilotManager.getPilotOutput(pilotRef)
+            if not result["OK"]:
+                stdout = f"Could not retrieve output: {result['Message']}"
+                error = f"Could not retrieve error: {result['Message']}"
+            else:
+                stdout, error = result["Value"]["StdOut"], result["Value"]["StdErr"]
+            outputs["StdOut"] += f"# PilotJobReference: {pilotRef}\n\n{stdout}\n"
+            outputs["StdErr"] += f"# PilotJobReference: {pilotRef}\n\n{error}\n"
 
-        if not pilotReference:
-            # Failed to get the pilot reference, try to look in the attic parameters
-            res = self.jobDB.getAtticJobParameters(int(jobID), ["Pilot_Reference"])
-            if res["OK"]:
-                c = -1
-                # Get the pilot reference for the last rescheduling cycle
-                for cycle in res["Value"]:
-                    if cycle > c:
-                        pilotReference = res["Value"][cycle]["Pilot_Reference"]
-                        c = cycle
-
-        if pilotReference:
-            return self.pilotManager.getPilotOutput(pilotReference)
-        return S_ERROR("No pilot job reference found")
+        return S_OK(outputs)
 
 
 class WMSAdministratorHandler(WMSAdministratorHandlerMixin, RequestHandler):


### PR DESCRIPTION
Why not?

<img width="490" height="382" alt="image" src="https://github.com/user-attachments/assets/e6776de9-48ea-4a31-b8be-bdc96a52d7a1" />

This PR does not fix anything and is just a proposal.
We currently have issues with the job parameters in `lhcbdiracx` preventing us to get the `Pilot_Reference` job parameters, and therefore we cannot get the pilot output from a job ID.
Using the `PilotManager` seems more reliable in this case.

Also, it allows getting the pilot logs of the previous pilots, if any (why not?).
It looks like there is 0 unit test around the `WMSAdministrator` so if there is no issue with this solution (and I probably lack some context here), I can give it a try in our LHCbDIRAC environment.

In the meantime, I will investigate the issue we have in `lhcbdiracx` and the job parameters of course.

Note: the `Pilot_Reference` is also used in the `StalledJobAgent`, but here from what I understand we really want to only get the current pilot job, so may be we can keep it this way for now.

BEGINRELEASENOTES
*WorkloadManagement
CHANGE: use PilotManager to get the pilot output(s) from a job ID in WMSAdministrator service
ENDRELEASENOTES
