### PR TITLE
fix: use cachedmethod instead of cached for methods

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -11,7 +11,7 @@
 import textwrap
 from threading import Lock
 
-from cachetools import TTLCache, cached
+from cachetools import TTLCache, cachedmethod
 
 from DIRAC import S_ERROR, S_OK, gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
@@ -24,6 +24,10 @@ from DIRAC.FrameworkSystem.Client.NotificationClient import NotificationClient
 from DIRAC.Resources.ProxyProvider.ProxyProviderFactory import ProxyProviderFactory
 
 DEFAULT_MAIL_FROM = "proxymanager@diracgrid.org"
+
+# Module-level cache for getProxyStrength method (shared across ProxyDB instances)
+_get_proxy_strength_cache = TTLCache(maxsize=1000, ttl=600)
+_get_proxy_strength_lock = Lock()
 
 
 class ProxyDB(DB):
@@ -398,7 +402,7 @@ class ProxyDB(DB):
             return S_ERROR(", ".join(errMsgs))
         return result
 
-    @cached(TTLCache(maxsize=1000, ttl=600), lock=Lock())
+    @cachedmethod(lambda self: _get_proxy_strength_cache, lock=lambda self: _get_proxy_strength_lock)
     def getProxyStrength(self, userDN, userGroup=None, vomsAttr=None):
         """Load the proxy in cache corresponding to the criteria, and check its strength
 

--- a/src/DIRAC/TransformationSystem/Client/Utilities.py
+++ b/src/DIRAC/TransformationSystem/Client/Utilities.py
@@ -9,7 +9,7 @@ Utilities for Transformation system
 import ast
 import random
 
-from cachetools import LRUCache, cached
+from cachetools import LRUCache, cachedmethod
 from cachetools.keys import hashkey
 from DIRAC import S_OK, S_ERROR, gLogger
 
@@ -23,6 +23,9 @@ from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 from DIRAC.Resources.Catalog.FileCatalog import FileCatalog
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
+
+# Module-level cache for isSameSEInList method (shared across PluginUtilities instances)
+_is_same_se_in_list_cache = LRUCache(maxsize=1024)
 
 
 class PluginUtilities:
@@ -402,8 +405,8 @@ class PluginUtilities:
 
         return StorageElement(se1).isSameSE(StorageElement(se2))
 
-    @cached(
-        LRUCache(maxsize=1024),
+    @cachedmethod(
+        lambda self: _is_same_se_in_list_cache,
         key=lambda _, a, b: hashkey(a, *sorted(b)),
     )
     def isSameSEInList(self, se1, seList):


### PR DESCRIPTION
`cached` prevents garbage collection

```python
import functools
import objgraph   # pip install objgraph
import gc


class Foo:
    # This cache is held somewhere in global memory, and prevents Foo objects from being reaped
    @functools.cache
    def func(self, key):
        return key + key

for i in range(10):
    Foo().func(i)


gc.collect()
print(f"Foo: {objgraph.by_type('Foo')}")  # 10 objects

```

BEGINRELEASENOTES

*Framework
FIX: use cachedmethod instead of cached in ProxyDB

*TS
FIX: use cachedmethod instead of cached in Utilities

ENDRELEASENOTES
