### PR TITLE
[9.0] Use DIRACX_CA_PATH to communicate to diracx and S3

### DIFF
--- a/src/DIRAC/FrameworkSystem/Utilities/diracx.py
+++ b/src/DIRAC/FrameworkSystem/Utilities/diracx.py
@@ -27,6 +27,8 @@ DEFAULT_TOKEN_CACHE_TTL = 5 * 60
 DEFAULT_TOKEN_CACHE_SIZE = 1024
 
 legacy_exchange_session = requests.Session()
+diracxUrl = gConfig.getValue("/DiracX/URL")
+legacy_exchange_session.verify = DiracxPreferences(url=diracxUrl).ca_path or True
 
 
 def get_token(

--- a/src/DIRAC/FrameworkSystem/Utilities/diracx.py
+++ b/src/DIRAC/FrameworkSystem/Utilities/diracx.py
@@ -1,4 +1,5 @@
 import requests
+import os
 
 from cachetools import TTLCache, LRUCache, cached
 from cachetools.keys import hashkey
@@ -27,8 +28,8 @@ DEFAULT_TOKEN_CACHE_TTL = 5 * 60
 DEFAULT_TOKEN_CACHE_SIZE = 1024
 
 legacy_exchange_session = requests.Session()
-diracxUrl = gConfig.getValue("/DiracX/URL")
-legacy_exchange_session.verify = DiracxPreferences(url=diracxUrl).ca_path or True
+# Get CA's location from DIRACX_CA_PATH if defined or from the standard location
+legacy_exchange_session.verify = os.environ.get("DIRACX_CA_PATH", True)
 
 
 def get_token(

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -372,7 +372,8 @@ class SandboxStoreHandlerMixin:
         if filePath.startswith("/S3"):
             with TheImpersonator(credDict, source="SandboxStore") as client:
                 res = client.jobs.get_sandbox_file(pfn=filePath)
-                r = requests.get(res.url)
+                verify = os.environ.get("DIRACX_CA_PATH", True)
+                r = requests.get(res.url, verify=verify)
                 r.raise_for_status()
                 sbData = r.content
                 if fileHelper:

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -126,7 +126,8 @@ class SandboxStoreHandlerMixin:
                     gLogger.debug("Uploading sandbox for", res.pfn)
                     files = {"file": ("file", tar_fh)}
 
-                    response = requests.post(res.url, data=res.fields, files=files, timeout=300)
+                    verify = os.environ.get("DIRACX_CA_PATH", True)
+                    response = requests.post(res.url, data=res.fields, files=files, timeout=300, verify=verify)
 
                     gLogger.debug("Sandbox uploaded", f"for {res.pfn} with status code {response.status_code}")
                     # TODO: Handle this error better


### PR DESCRIPTION
  With this fix DIRAC9 clients can communicate to diracx and S3 minIO storage with are set up with IGTF non-default certificates using the DIRACX_CA_PATH environment.

BEGINRELEASENOTES

*Framework
FIX: Use DIRACX_CA_PATH to communicate to diracx

*WorkloadManagement
FIX: Use DIRACX_CA_PATH to communicate to S3

ENDRELEASENOTES
