### PR TITLE
[9.0] SiteDirector: siteNames, ceTypes, ces and tags are None by default

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1,4 +1,4 @@
-"""  The Site Director is an agent performing pilot job submission to particular sites/Computing Elements.
+"""The Site Director is an agent performing pilot job submission to particular sites/Computing Elements.
 
 .. literalinclude:: ../ConfigTemplate.cfg
   :start-after: ##BEGIN SiteDirector
@@ -7,6 +7,7 @@
   :caption: SiteDirector options
 
 """
+
 import datetime
 import os
 from collections import defaultdict
@@ -147,10 +148,10 @@ class SiteDirector(AgentModule):
             self.sendSubmissionAccounting = True
 
         # Get the site description dictionary
-        siteNames = self.am_getOption("Site", [])
-        ceTypes = self.am_getOption("CETypes", [])
-        ces = self.am_getOption("CEs", [])
-        tags = self.am_getOption("Tags", [])
+        siteNames = self.am_getOption("Site")
+        ceTypes = self.am_getOption("CETypes")
+        ces = self.am_getOption("CEs")
+        tags = self.am_getOption("Tags")
 
         # Display options used
         self.log.always("VO:", self.vo)

--- a/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -263,14 +263,10 @@ Agents
     # the DN of the certificate proxy used to submit pilots. If not found here, what is in Operations/Pilot section of the CS will be used
     PilotDN =
 
-    # List of sites that will be treated by this SiteDirector (No value can refer to any Site defined in the CS)
-    Site =
-    # List of CEs that will be treated by this SiteDirector (No value can refer to any CE defined in the CS)
-    CEs =
-    # List of CE types that will be treated by this SiteDirector (No value can refer to any type of CE defined in the CS)
-    CETypes =
-    # List of Tags that are required to be present in the CE/Queue definition
-    Tags =
+    # Site = # List of CEs that will be treated by this SiteDirector (No value can refer to any CE defined in the CS)
+    # CEs =  # List of CE types that will be treated by this SiteDirector (No value can refer to any type of CE defined in the CS)
+    # CETypes = # List of Tags that are required to be present in the CE/Queue definition
+    # Tags =
 
     # How many cycles to skip if queue is not working
     FailedQueueCycleFactor = 10


### PR DESCRIPTION

BEGINRELEASENOTES

*WMS
FIX: SiteDirector: siteNames, ceTypes, ces and tags are None by default

ENDRELEASENOTES


Should fix this error: 

```python
{'OK': False,
 'Errno': 0,
 'Message': 'Empty cartesian product',
 'CallStack': ['  File "/opt/dirac/diracos/bin/dirac-agent", line 7, in <module>\n    sys.exit(main())\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/Core/Base/Script.py", line 74, in __call__\n    return entrypointFunc._func()\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/Core/scripts/dirac_agent.py", line 38, in main\n    agentReactor.go()\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/Core/Base/AgentReactor.py", line 143, in go\n    timeToNext = self.__scheduler.executeNextTask()\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/Core/Utilities/ThreadScheduler.py", line 127, in executeNextTask\n    self.__executeTask(taskId)\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/Core/Utilities/ThreadScheduler.py", line 180, in __executeTask\n    task["func"](*task["args"])\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/Core/Base/AgentModule.py", line 357, in am_go\n    cycleResult = self.__executeModuleCycle()\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/Core/Base/AgentModule.py", line 418, in __executeModuleCycle\n    result = self.am_secureCall(self.beginExecution, name="beginExecution")\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/Core/Base/AgentModule.py", line 314, in am_secureCall\n    result = functor(*args)\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 171, in beginExecution\n    if not (result := self._buildQueueDict(siteNames, ces, ceTypes, tags))["OK"]:\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py", line 212, in _buildQueueDict\n    result = self.siteClient.getUsableSites(siteNames)\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/ResourceStatusSystem/Client/SiteStatus.py", line 144, in getUsableSites\n    siteStatusDictRes = self.getSiteStatuses(siteNames)\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/ResourceStatusSystem/Client/SiteStatus.py", line 99, in getSiteStatuses\n    return self.__getRSSSiteStatus(siteNames)\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/ResourceStatusSystem/Client/SiteStatus.py", line 117, in __getRSSSiteStatus\n    cacheMatch = self.rssCache.match(siteName, "", "", "all")  # sites have VO="all".\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/ResourceStatusSystem/Utilities/RSSCacheNoThread.py", line 245, in match\n    return self._match(elementNames, elementType, statusTypes, vO)\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/ResourceStatusSystem/Utilities/RSSCacheNoThread.py", line 276, in _match\n    matchKeys = self.__match(validCache, elementNames, elementType, statusTypes, vO)\n',
  '  File "/opt/dirac/DIRAC/src/DIRAC/ResourceStatusSystem/Utilities/RSSCacheNoThread.py", line 405, in __match\n    return S_ERROR("Empty cartesian product")\n']}
```

that happens when the "Site" option is not set.