### PR TITLE
fix: increase hostname field length installedcompdb

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/InstalledComponentsDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/InstalledComponentsDB.py
@@ -90,7 +90,7 @@ class Host(componentsBase):
     __table_args__ = {"mysql_engine": "InnoDB", "mysql_charset": "utf8mb4"}
 
     hostID = Column("HostID", Integer, primary_key=True)
-    hostName = Column("HostName", String(32), nullable=False)
+    hostName = Column("HostName", String(64), nullable=False)
     cpu = Column("CPU", String(64), nullable=False)
     installationList = relationship("InstalledComponent", backref="installationHost")
 

--- a/src/DIRAC/FrameworkSystem/Utilities/MonitoringUtilities.py
+++ b/src/DIRAC/FrameworkSystem/Utilities/MonitoringUtilities.py
@@ -30,6 +30,7 @@ def monitorInstallation(componentType, system, component, module=None, cpu=None,
 
     if not hostname:
         hostname = socket.getfqdn()
+        hostname = hostname[0:64]
     instance = component[0:32]
 
     result = monitoringClient.installationExists(


### PR DESCRIPTION
Increased the InstalledComponentDB `HostName` field to a 64 string.

Make sure monitorInstallation uses 64 max lenght hostname.

closes #8384 
