### PR TITLE
[9.0] Reuse DB objects when killing/deleting jobs

### DIFF
--- a/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -20,6 +20,7 @@ from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Utilities.DErrno import cmpError
 from DIRAC.Core.Utilities.List import breakListIntoChunks
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.Core.Utilities.Proxy import executeWithUserProxy
 from DIRAC.Core.Utilities.ReturnValues import returnSingleResult
 from DIRAC.RequestManagementSystem.Client.File import File
@@ -32,7 +33,6 @@ from DIRAC.Resources.Catalog.FileCatalogClient import FileCatalogClient
 from DIRAC.Resources.Storage.StorageElement import StorageElement
 from DIRAC.TransformationSystem.Client import TransformationStatus
 from DIRAC.TransformationSystem.Client.TransformationClient import TransformationClient
-from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
 from DIRAC.WorkloadManagementSystem.Service.JobPolicy import (
     RIGHT_DELETE,
     RIGHT_KILL,
@@ -65,8 +65,11 @@ class TransformationCleaningAgent(AgentModule):
         self.reqClient = None
         # # file catalog client
         self.metadataClient = None
-        # # JobDB
+        # # databases
         self.jobDB = None
+        self.pilotAgentsDB = None
+        self.taskQueueDB = None
+        self.storageManagementDB = None
 
         # # transformations types
         self.transformationTypes = None
@@ -125,8 +128,26 @@ class TransformationCleaningAgent(AgentModule):
         self.reqClient = ReqClient()
         # # file catalog client
         self.metadataClient = FileCatalogClient()
-        # # job DB
-        self.jobDB = JobDB()
+        # # databases
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
+        if not result["OK"]:
+            return result
+        self.jobDB = result["Value"]()
+
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.PilotAgentsDB", "PilotAgentsDB")
+        if not result["OK"]:
+            return result
+        self.pilotAgentsDB = result["Value"]()
+
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.TaskQueueDB", "TaskQueueDB")
+        if not result["OK"]:
+            return result
+        self.taskQueueDB = result["Value"]()
+
+        result = ObjectLoader().loadObject("StorageManagementSystem.DB.StorageManagementDB", "StorageManagementDB")
+        if not result["OK"]:
+            return result
+        self.storageManagementDB = result["Value"]()
 
         return S_OK()
 
@@ -615,11 +636,17 @@ class TransformationCleaningAgent(AgentModule):
         :param self: self reference
         :param list trasnJobIDs: job IDs
         """
+        db_kwargs = dict(
+            jobdb=self.jobDB,
+            taskqueuedb=self.taskQueueDB,
+            pilotagentsdb=self.pilotAgentsDB,
+            storagemanagementdb=self.storageManagementDB,
+        )
         # Prevent 0 job IDs
         jobIDs = [int(j) for j in transJobIDs if int(j)]
         allRemove = True
         for jobList in breakListIntoChunks(jobIDs, 1000):
-            res = kill_delete_jobs(RIGHT_KILL, jobList, force=True)
+            res = kill_delete_jobs(RIGHT_KILL, jobList, force=True, **db_kwargs)
             if res["OK"]:
                 self.log.info(f"Successfully killed {len(jobList)} jobs from WMS")
             elif ("InvalidJobIDs" in res) and ("NonauthorizedJobIDs" not in res) and ("FailedJobIDs" not in res):
@@ -631,7 +658,7 @@ class TransformationCleaningAgent(AgentModule):
                 self.log.error("Failed to kill jobs", f"(n={len(res['FailedJobIDs'])})")
                 allRemove = False
 
-            res = kill_delete_jobs(RIGHT_DELETE, jobList, force=True)
+            res = kill_delete_jobs(RIGHT_DELETE, jobList, force=True, **db_kwargs)
             if res["OK"]:
                 self.log.info("Successfully deleted jobs from WMS", f"(n={len(jobList)})")
             elif ("InvalidJobIDs" in res) and ("NonauthorizedJobIDs" not in res) and ("FailedJobIDs" not in res):

--- a/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/StalledJobAgent.py
@@ -17,11 +17,9 @@ from DIRAC.ConfigurationSystem.Client.Helpers import cfgPath
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Utilities import DErrno
 from DIRAC.Core.Utilities.ClassAd.ClassAdLight import ClassAd
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.Core.Utilities.TimeUtilities import fromString, second, toEpoch
 from DIRAC.WorkloadManagementSystem.Client import JobMinorStatus, JobStatus
-from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
-from DIRAC.WorkloadManagementSystem.DB.JobLoggingDB import JobLoggingDB
-from DIRAC.WorkloadManagementSystem.DB.PilotAgentsDB import PilotAgentsDB
 from DIRAC.WorkloadManagementSystem.Service.JobPolicy import RIGHT_KILL
 from DIRAC.WorkloadManagementSystem.DB.StatusUtils import kill_delete_jobs
 from DIRAC.WorkloadManagementSystem.Utilities.JobParameters import getJobParameters
@@ -40,6 +38,9 @@ class StalledJobAgent(AgentModule):
 
         self.jobDB = None
         self.logDB = None
+        self.taskQueueDB = None
+        self.pilotAgentsDB = None
+        self.storageManagementDB = None
         self.matchedTime = 7200
         self.rescheduledTime = 600
         self.submittingTime = 300
@@ -51,8 +52,30 @@ class StalledJobAgent(AgentModule):
     #############################################################################
     def initialize(self):
         """Sets default parameters."""
-        self.jobDB = JobDB()
-        self.logDB = JobLoggingDB()
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
+        if not result["OK"]:
+            return result
+        self.jobDB = result["Value"]()
+
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobLoggingDB", "JobLoggingDB")
+        if not result["OK"]:
+            return result
+        self.logDB = result["Value"]()
+
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.TaskQueueDB", "TaskQueueDB")
+        if not result["OK"]:
+            return result
+        self.taskQueueDB = result["Value"]()
+
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.PilotAgentsDB", "PilotAgentsDB")
+        if not result["OK"]:
+            return result
+        self.pilotAgentsDB = result["Value"]()
+
+        result = ObjectLoader().loadObject("StorageManagementSystem.DB.StorageManagementDB", "StorageManagementDB")
+        if not result["OK"]:
+            return result
+        self.storageManagementDB = result["Value"]()
 
         # getting parameters
 
@@ -235,7 +258,16 @@ class StalledJobAgent(AgentModule):
         # Set the jobs Failed, send them a kill signal in case they are not really dead
         # and send accounting info
         if setFailed:
-            res = kill_delete_jobs(RIGHT_KILL, [jobID], nonauthJobList=[], force=True)
+            res = kill_delete_jobs(
+                RIGHT_KILL,
+                [jobID],
+                nonauthJobList=[],
+                force=True,
+                jobdb=self.jobDB,
+                taskqueuedb=self.taskQueueDB,
+                pilotagentsdb=self.pilotAgentsDB,
+                storagemanagementdb=self.storageManagementDB,
+            )
             if not res["OK"]:
                 self.log.error("Failed to kill job", jobID)
 
@@ -262,7 +294,7 @@ class StalledJobAgent(AgentModule):
             # There is no pilot reference, hence its status is unknown
             return S_OK("NoPilot")
 
-        result = PilotAgentsDB().getPilotInfo(pilotReference)
+        result = self.pilotAgentsDB.getPilotInfo(pilotReference)
         if not result["OK"]:
             if DErrno.cmpError(result, DErrno.EWMSNOPILOT):
                 self.log.warn("No pilot found", f"for job {jobID}: {result['Message']}")

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_StalledJobAgent.py
@@ -23,10 +23,31 @@ def sja(mocker):
         side_effect=lambda x, y=None: y,
         create=True,
     )
-    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobDB")
-    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.JobLoggingDB")
+
+    # Mock ObjectLoader to return mock DB instances
+    mockJobDB = MagicMock()
+    mockJobDB.log = gLogger
+    mockJobLoggingDB = MagicMock()
+    mockTaskQueueDB = MagicMock()
+    mockPilotAgentsDB = MagicMock()
+    mockStorageManagementDB = MagicMock()
+
+    def mock_load_object(module_path, class_name):
+        mocks = {
+            "JobDB": mockJobDB,
+            "JobLoggingDB": mockJobLoggingDB,
+            "TaskQueueDB": mockTaskQueueDB,
+            "PilotAgentsDB": mockPilotAgentsDB,
+            "StorageManagementDB": mockStorageManagementDB,
+        }
+        return {"OK": True, "Value": lambda: mocks[class_name]}
+
+    mocker.patch(
+        "DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.ObjectLoader.loadObject",
+        side_effect=mock_load_object,
+    )
+
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.rescheduleJobs", return_value=MagicMock())
-    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.PilotAgentsDB", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.getJobParameters", return_value=MagicMock())
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.StalledJobAgent.kill_delete_jobs", return_value=MagicMock())
 
@@ -34,7 +55,6 @@ def sja(mocker):
     stalledJobAgent._AgentModule__configDefaults = mockAM
     stalledJobAgent.log = gLogger
     stalledJobAgent.initialize()
-    stalledJobAgent.jobDB.log = gLogger
     stalledJobAgent.log.setLevel("DEBUG")
     stalledJobAgent.stalledTime = 120
 

--- a/src/DIRAC/WorkloadManagementSystem/DB/StatusUtils.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/StatusUtils.py
@@ -1,43 +1,40 @@
 from DIRAC import S_ERROR, S_OK, gLogger
-from DIRAC.StorageManagementSystem.DB.StorageManagementDB import StorageManagementDB
 from DIRAC.WorkloadManagementSystem.Client import JobStatus
-from DIRAC.WorkloadManagementSystem.DB.JobDB import JobDB
-from DIRAC.WorkloadManagementSystem.DB.PilotAgentsDB import PilotAgentsDB
-from DIRAC.WorkloadManagementSystem.DB.TaskQueueDB import TaskQueueDB
+from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 from DIRAC.WorkloadManagementSystem.Service.JobPolicy import RIGHT_DELETE, RIGHT_KILL
 from DIRAC.WorkloadManagementSystem.Utilities.jobAdministration import _filterJobStateTransition
 
 
-def _deleteJob(jobID, force=False):
+def _deleteJob(jobID, force=False, *, jobdb, taskqueuedb, pilotagentsdb):
     """Set the job status to "Deleted"
     and remove the pilot that ran and its logging info if the pilot is finished.
 
     :param int jobID: job ID
     :return: S_OK()/S_ERROR()
     """
-    if not (result := JobDB().setJobStatus(jobID, JobStatus.DELETED, "Checking accounting", force=force))["OK"]:
+    if not (result := jobdb.setJobStatus(jobID, JobStatus.DELETED, "Checking accounting", force=force))["OK"]:
         gLogger.warn("Failed to set job Deleted status", result["Message"])
         return result
 
-    if not (result := TaskQueueDB().deleteJob(jobID))["OK"]:
+    if not (result := taskqueuedb.deleteJob(jobID))["OK"]:
         gLogger.warn("Failed to delete job from the TaskQueue")
 
     # if it was the last job for the pilot
-    result = PilotAgentsDB().getPilotsForJobID(jobID)
+    result = pilotagentsdb.getPilotsForJobID(jobID)
     if not result["OK"]:
         gLogger.error("Failed to get Pilots for JobID", result["Message"])
         return result
     for pilot in result["Value"]:
-        res = PilotAgentsDB().getJobsForPilot(pilot)
+        res = pilotagentsdb.getJobsForPilot(pilot)
         if not res["OK"]:
             gLogger.error("Failed to get jobs for pilot", res["Message"])
             return res
         if not res["Value"]:  # if list of jobs for pilot is empty, delete pilot
-            result = PilotAgentsDB().getPilotInfo(pilotID=pilot)
+            result = pilotagentsdb.getPilotInfo(pilotID=pilot)
             if not result["OK"]:
                 gLogger.error("Failed to get pilot info", result["Message"])
                 return result
-            ret = PilotAgentsDB().deletePilot(result["Value"]["PilotJobReference"])
+            ret = pilotagentsdb.deletePilot(result["Value"]["PilotJobReference"])
             if not ret["OK"]:
                 gLogger.error("Failed to delete pilot from PilotAgentsDB", ret["Message"])
                 return ret
@@ -45,7 +42,7 @@ def _deleteJob(jobID, force=False):
     return S_OK()
 
 
-def _killJob(jobID, sendKillCommand=True, force=False):
+def _killJob(jobID, sendKillCommand=True, force=False, *, jobdb, taskqueuedb):
     """Kill one job
 
     :param int jobID: job ID
@@ -54,32 +51,63 @@ def _killJob(jobID, sendKillCommand=True, force=False):
     :return: S_OK()/S_ERROR()
     """
     if sendKillCommand:
-        if not (result := JobDB().setJobCommand(jobID, "Kill"))["OK"]:
+        if not (result := jobdb.setJobCommand(jobID, "Kill"))["OK"]:
             gLogger.warn("Failed to set job Kill command", result["Message"])
             return result
 
     gLogger.info("Job marked for termination", jobID)
-    if not (result := JobDB().setJobStatus(jobID, JobStatus.KILLED, "Marked for termination", force=force))["OK"]:
+    if not (result := jobdb.setJobStatus(jobID, JobStatus.KILLED, "Marked for termination", force=force))["OK"]:
         gLogger.warn("Failed to set job Killed status", result["Message"])
-    if not (result := TaskQueueDB().deleteJob(jobID))["OK"]:
+    if not (result := taskqueuedb.deleteJob(jobID))["OK"]:
         gLogger.warn("Failed to delete job from the TaskQueue", result["Message"])
 
     return S_OK()
 
 
-def kill_delete_jobs(right, validJobList, nonauthJobList=[], force=False):
+def kill_delete_jobs(
+    right,
+    validJobList,
+    nonauthJobList=[],
+    force=False,
+    *,
+    jobdb=None,
+    taskqueuedb=None,
+    pilotagentsdb=None,
+    storagemanagementdb=None,
+):
     """Kill (== set the status to "KILLED") or delete (== set the status to "DELETED") jobs as necessary
 
     :param str right: RIGHT_KILL or RIGHT_DELETE
 
     :return: S_OK()/S_ERROR()
     """
+    if jobdb is None:
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.JobDB", "JobDB")
+        if not result["OK"]:
+            return result
+        jobdb = result["Value"]()
+    if taskqueuedb is None:
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.TaskQueueDB", "TaskQueueDB")
+        if not result["OK"]:
+            return result
+        taskqueuedb = result["Value"]()
+    if pilotagentsdb is None:
+        result = ObjectLoader().loadObject("WorkloadManagementSystem.DB.PilotAgentsDB", "PilotAgentsDB")
+        if not result["OK"]:
+            return result
+        pilotagentsdb = result["Value"]()
+    if storagemanagementdb is None:
+        result = ObjectLoader().loadObject("StorageManagementSystem.DB.StorageManagementDB", "StorageManagementDB")
+        if not result["OK"]:
+            return result
+        storagemanagementdb = result["Value"]()
+
     badIDs = []
 
     killJobList = []
     deleteJobList = []
     if validJobList:
-        result = JobDB().getJobsAttributes(validJobList, ["Status"])
+        result = jobdb.getJobsAttributes(validJobList, ["Status"])
         if not result["OK"]:
             return result
         jobStates = result["Value"]
@@ -92,12 +120,12 @@ def kill_delete_jobs(right, validJobList, nonauthJobList=[], force=False):
             deleteJobList.extend(_filterJobStateTransition(jobStates, JobStatus.DELETED))
 
         for jobID in killJobList:
-            result = _killJob(jobID, force=force)
+            result = _killJob(jobID, force=force, jobdb=jobdb, taskqueuedb=taskqueuedb)
             if not result["OK"]:
                 badIDs.append(jobID)
 
         for jobID in deleteJobList:
-            result = _deleteJob(jobID, force=force)
+            result = _deleteJob(jobID, force=force, jobdb=jobdb, taskqueuedb=taskqueuedb, pilotagentsdb=pilotagentsdb)
             if not result["OK"]:
                 badIDs.append(jobID)
 
@@ -105,9 +133,8 @@ def kill_delete_jobs(right, validJobList, nonauthJobList=[], force=False):
         stagingJobList = [jobID for jobID, sDict in jobStates.items() if sDict["Status"] == JobStatus.STAGING]
 
         if stagingJobList:
-            stagerDB = StorageManagementDB()
             gLogger.info("Going to send killing signal to stager as well!")
-            result = stagerDB.killTasksBySourceTaskID(stagingJobList)
+            result = storagemanagementdb.killTasksBySourceTaskID(stagingJobList)
             if not result["OK"]:
                 gLogger.warn("Failed to kill some Stager tasks", result["Message"])
 

--- a/src/DIRAC/WorkloadManagementSystem/DB/tests/Test_StatusUtils.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/tests/Test_StatusUtils.py
@@ -19,10 +19,25 @@ from DIRAC.WorkloadManagementSystem.DB.StatusUtils import kill_delete_jobs
     ],
 )
 def test___kill_delete_jobs(mocker, jobIDs_list, right):
-    mocker.patch("DIRAC.WorkloadManagementSystem.DB.StatusUtils.JobDB", MagicMock())
-    mocker.patch("DIRAC.WorkloadManagementSystem.DB.StatusUtils.TaskQueueDB", MagicMock())
-    mocker.patch("DIRAC.WorkloadManagementSystem.DB.StatusUtils.PilotAgentsDB", MagicMock())
-    mocker.patch("DIRAC.WorkloadManagementSystem.DB.StatusUtils.StorageManagementDB", MagicMock())
+    # Mock ObjectLoader to return mock DB instances
+    mockJobDB = MagicMock()
+    mockTaskQueueDB = MagicMock()
+    mockPilotAgentsDB = MagicMock()
+    mockStorageManagementDB = MagicMock()
+
+    def mock_load_object(module_path, class_name):
+        mocks = {
+            "JobDB": mockJobDB,
+            "TaskQueueDB": mockTaskQueueDB,
+            "PilotAgentsDB": mockPilotAgentsDB,
+            "StorageManagementDB": mockStorageManagementDB,
+        }
+        return {"OK": True, "Value": lambda: mocks[class_name]}
+
+    mocker.patch(
+        "DIRAC.WorkloadManagementSystem.DB.StatusUtils.ObjectLoader.loadObject",
+        side_effect=mock_load_object,
+    )
 
     res = kill_delete_jobs(right, jobIDs_list)
     assert res["OK"]

--- a/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/JobManagerHandler.py
@@ -65,6 +65,11 @@ class JobManagerHandlerMixin:
                 return result
             cls.pilotAgentsDB = result["Value"](parentLogger=cls.log)
 
+            result = ObjectLoader().loadObject("StorageManagementSystem.DB.StorageManagementDB", "StorageManagementDB")
+            if not result["OK"]:
+                return result
+            cls.storageManagementDB = result["Value"](parentLogger=cls.log)
+
         except RuntimeError as excp:
             return S_ERROR(f"Can't connect to DB: {excp!r}")
 
@@ -449,7 +454,16 @@ class JobManagerHandlerMixin:
             jobList, RIGHT_DELETE
         )
 
-        result = kill_delete_jobs(RIGHT_DELETE, validJobList, nonauthJobList, force=force)
+        result = kill_delete_jobs(
+            RIGHT_DELETE,
+            validJobList,
+            nonauthJobList,
+            force=force,
+            jobdb=self.jobDB,
+            taskqueuedb=self.taskQueueDB,
+            pilotagentsdb=self.pilotAgentsDB,
+            storagemanagementdb=self.storageManagementDB,
+        )
 
         result["requireProxyUpload"] = len(ownerJobList) > 0 and self.__checkIfProxyUploadIsRequired()
 
@@ -478,7 +492,16 @@ class JobManagerHandlerMixin:
             jobList, RIGHT_KILL
         )
 
-        result = kill_delete_jobs(RIGHT_KILL, validJobList, nonauthJobList, force=force)
+        result = kill_delete_jobs(
+            RIGHT_KILL,
+            validJobList,
+            nonauthJobList,
+            force=force,
+            jobdb=self.jobDB,
+            taskqueuedb=self.taskQueueDB,
+            pilotagentsdb=self.pilotAgentsDB,
+            storagemanagementdb=self.storageManagementDB,
+        )
 
         result["requireProxyUpload"] = len(ownerJobList) > 0 and self.__checkIfProxyUploadIsRequired()
 


### PR DESCRIPTION
Replace direct DB imports with ObjectLoader pattern across WorkloadManagementSystem and TransformationSystem components. Pass DB instances explicitly to kill_delete_jobs utility function to enable connection reuse.

Changes:
- TransformationCleaningAgent: load JobDB, PilotAgentsDB, TaskQueueDB, StorageManagementDB via ObjectLoader
- StalledJobAgent: load JobDB, JobLoggingDB, TaskQueueDB, PilotAgentsDB, StorageManagementDB via ObjectLoader
- StatusUtils: accept DB instances as keyword arguments in kill_delete_jobs and helper functions
- JobManagerHandler: load StorageManagementDB via ObjectLoader and pass to kill_delete_jobs


BEGINRELEASENOTES

*WorkloadManagement
FIX: Use ObjectLoader for DB instantiation in WMS components
FIX: Reuse DB objects when killing/deleting jobs

ENDRELEASENOTES
