### PR TITLE
[9.0] Resolve race condition in monitoring test cleanup

### DIFF
--- a/tests/Integration/Monitoring/Test_MonitoringSystem.py
+++ b/tests/Integration/Monitoring/Test_MonitoringSystem.py
@@ -35,6 +35,12 @@ def putAndDelete():
     with open(fj) as fp:
         data = json.load(fp)
 
+    # Capture the date when inserting data to ensure cleanup uses the same date
+    # even if midnight passes during test execution.
+    # IMPORTANT: Must use UTC to match the server-side index naming in ElasticSearchDB.generateFullIndexName()
+    # which explicitly uses datetime.utcnow() to avoid timezone issues.
+    insertion_date = datetime.utcnow().strftime("%Y-%m-%d")
+
     # put
     res = client.addRecords("wmshistory_index", "WMSHistory", data)
     assert res["OK"]
@@ -45,9 +51,8 @@ def putAndDelete():
 
     # from here on is teardown
 
-    # delete the index
-    today = datetime.today().strftime("%Y-%m-%d")
-    result = f"wmshistory_index-{today}"
+    # delete the index using the same date as when we inserted the data
+    result = f"wmshistory_index-{insertion_date}"
     client.deleteIndex(result)
 
 


### PR DESCRIPTION
Use consistent UTC timestamp for ElasticSearch index creation and deletion to prevent cleanup failures if test crosses midnight boundary. This matches the server-side behavior in ElasticSearchDB.generateFullIndexName().

Example:

* https://github.com/DIRACGrid/DIRAC/actions/runs/19806011380/job/56741402549
* https://github.com/DIRACGrid/DIRAC/actions/runs/19806011380

BEGINRELEASENOTES

ENDRELEASENOTES
