### PR TITLE
fix(IdProviderFactory): make client_id and client_secret optional with `.get()`

### DIFF
--- a/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
+++ b/src/DIRAC/Resources/IdProvider/IdProviderFactory.py
@@ -75,8 +75,10 @@ class IdProviderFactory:
 
             if client_name_prefix:
                 client_name_prefix = client_name_prefix + "_"
-            pDict["client_id"] = pDict[f"{client_name_prefix}client_id"]
-            pDict["client_secret"] = pDict[f"{client_name_prefix}client_secret"]
+            if f"{client_name_prefix}client_id" in pDict:
+                pDict["client_id"] = pDict[f"{client_name_prefix}client_id"]
+            if f"{client_name_prefix}client_secret" in pDict:
+                pDict["client_secret"] = pDict[f"{client_name_prefix}client_secret"]
 
         pDict.update(kwargs)
         pDict["ProviderName"] = name

--- a/src/DIRAC/Resources/IdProvider/tests/Test_IdProviderFactory.py
+++ b/src/DIRAC/Resources/IdProvider/tests/Test_IdProviderFactory.py
@@ -63,6 +63,12 @@ Resources
       client_secret = IdP_client_secret
       scope = openid+profile+offline_access+eduperson_entitlement
     }
+    SomeIdP3.partial
+    {
+      ProviderType = OAuth2
+      issuer = https://and-another-idp.url/
+      scope = openid+profile+offline_access+eduperson_entitlement
+    }
   }
 }
 """
@@ -77,6 +83,7 @@ idps = IdProviderFactory()
         ("SomeIdP1.2", {"OK": True}, "https://idp.url/", "IdP_client_id2", "IdP_client_secret"),
         ("SomeIdP2", {"OK": True}, "https://another-idp.url/", "IdP_client_id1", "IdP_client_secret"),
         ("SomeIdP3", {"OK": True}, "https://and-another-idp.url/", "IdP_client_id3", "IdP_client_secret"),
+        ("SomeIdP3.partial", {"OK": True}, "https://and-another-idp.url/", None, None),
         # Try to get an unknown DIRAC client
         ("DIRACUnknown", {"OK": False, "Message": "DIRACUnknown does not exist"}, None, None, None),
     ],


### PR DESCRIPTION
Vladimir and I sometimes play with the Computing Elements and need to get tokens from the `TokenManager`. It was working until that commit: https://github.com/DIRACGrid/DIRAC/commit/bedcfb0b7c8e7a3875181c163edd61ff7547b172

Now we get the following error:

```python
>           pDict["client_id"] = pDict[f"{client_name_prefix}client_id"]
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           KeyError: 'client_id'
```

Why? Because the `TokenManagerClient` is obviously not expected to store the `client_id` and `client_secret` but might need all the public info to cache the tokens (name, scope, issuer, ...). Therefore, it's calling `IdProviderFactory.getIdProvider()`, which know try to extract the secret fields.

Here I added a simple unit test to avoid regression and make these `client_id` and `client_secret` optional.


BEGINRELEASENOTES
*Resources
FIX: make client_id and secret optional to avoid KeyError exceptions.
ENDRELEASENOTES
