### PR TITLE
[9.0] fix: JobWrapper does not manage to send job parameters

### DIFF
--- a/src/DIRAC/Resources/Computing/ComputingElement.py
+++ b/src/DIRAC/Resources/Computing/ComputingElement.py
@@ -52,7 +52,7 @@ from DIRAC.WorkloadManagementSystem.Utilities.JobParameters import (
     getNumberOfProcessors,
 )
 
-INTEGER_PARAMETERS = ["CPUTime", "NumberOfProcessors", "NumberOfPayloadProcessors", "MaxRAM"]
+INTEGER_PARAMETERS = ["CPUTime", "CPUNormalizationFactor", "NumberOfProcessors", "NumberOfPayloadProcessors", "MaxRAM"]
 FLOAT_PARAMETERS = ["WaitingToRunningRatio"]
 LIST_PARAMETERS = ["Tag", "RequiredTag"]
 WAITING_TO_RUNNING_RATIO = 0.5
@@ -450,7 +450,7 @@ def getCEConfigDict(section: str) -> dict:
     ceOptions = result["Value"]
     for key in ceOptions:
         if key in INTEGER_PARAMETERS:
-            ceOptions[key] = int(ceOptions[key])
+            ceOptions[key] = int(float(ceOptions[key]))
         if key in FLOAT_PARAMETERS:
             ceOptions[key] = float(ceOptions[key])
         if key in LIST_PARAMETERS:

--- a/src/DIRAC/WorkloadManagementSystem/Client/JobReport.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/JobReport.py
@@ -115,16 +115,20 @@ class JobReport:
 
     def commit(self):
         """Send all the accumulated information"""
+        messages = []
 
-        success = True
         result = self.sendStoredStatusInfo()
-        success &= result["OK"]
+        if not result["OK"]:
+            messages.append(result["Message"])
         result = self.sendStoredJobParameters()
-        success &= result["OK"]
+        if not result["OK"]:
+            messages.append(result["Message"])
 
-        if success:
-            return S_OK()
-        return S_ERROR("Information upload to JobStateUpdate service failed")
+        if messages:
+            gLogger.warn("Some information could not be uploaded to JobStateUpdate service:", "; ".join(messages))
+            return S_ERROR("Information upload to JobStateUpdate service failed")
+
+        return S_OK()
 
     def dump(self):
         """Print out the contents of the internal cached information"""

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -546,7 +546,7 @@ class JobWrapper:
             self.__report(status=JobStatus.FAILED, minorStatus=JobMinorStatus.APP_THREAD_FAILED, sendFlag=True)
             applicationErrorStatus = "None reported"
             if payloadStatus:
-                applicationErrorStatus = payloadStatus
+                applicationErrorStatus = str(payloadStatus)
             self.__setJobParam("ApplicationError", applicationErrorStatus, sendFlag=True)
 
         # This might happen if process() and postProcess() are called on different machines
@@ -1544,7 +1544,7 @@ class JobWrapper:
     #############################################################################
     def __setJobParam(self, name, value, sendFlag=False):
         """Wraps around setJobParameter of JobReport client"""
-        jobParam = self.jobReport.setJobParameter(str(name), str(value), sendFlag)
+        jobParam = self.jobReport.setJobParameter(str(name), value, sendFlag)
         if not jobParam["OK"]:
             self.log.warn("Failed setting job parameter", jobParam["Message"])
         if self.jobID:

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -565,7 +565,7 @@ def test_postProcess_executor_failed_status_defined(setup_job_wrapper, mocker, m
     assert result["OK"]
     assert report_args[-1]["status"] == JobStatus.COMPLETING
     assert report_args[-1]["minorStatus"] == JobMinorStatus.APP_ERRORS
-    assert set_param_args[-3][0][1] == 126
+    assert set_param_args[-3][0][1] == "126"
 
 
 def test_postProcess_subprocess_not_complete(setup_job_wrapper, mocker, mock_report_and_set_param):


### PR DESCRIPTION
While trying to debug the issue we have with job parameters, I noticed we didn't have any way (or at least any obvious way) to change the log level of the job wrapper (`INFO` by default from what I can see).

BEGINRELEASENOTES
*WorkloadManagement
NEW: ability to adjust job wrapper log level
ENDRELEASENOTES
