### PR TITLE
feat (DFC Client): speedup getReplicas by sorting LFNs

### DIFF
--- a/src/DIRAC/Resources/Catalog/FileCatalogClient.py
+++ b/src/DIRAC/Resources/Catalog/FileCatalogClient.py
@@ -141,7 +141,9 @@ class FileCatalogClient(FileCatalogClientBase):
         successful = {}
         failed = {}
 
-        for chunk in breakListIntoChunks(lfns, GET_REPLICAS_CHUNK_SIZE):
+        # We want to sort the lfns because of the way the server groups the db queries by
+        # directory. So if we sort them, the grouping is more efficient.
+        for chunk in breakListIntoChunks(sorted(lfns), GET_REPLICAS_CHUNK_SIZE):
             rpcClient = self._getRPC(timeout=timeout)
             result = rpcClient.getReplicas(chunk, allStatus)
 

--- a/src/DIRAC/Resources/Catalog/Utilities.py
+++ b/src/DIRAC/Resources/Catalog/Utilities.py
@@ -1,5 +1,5 @@
-""" DIRAC FileCatalog client utilities
-"""
+"""DIRAC FileCatalog client utilities"""
+
 import os
 import errno
 import functools
@@ -16,7 +16,7 @@ def checkArgumentFormat(path, generateMap=False):
         """Check and process format of the arguments to FileCatalog methods"""
         if isinstance(path, str):
             urls = {path: True}
-        elif isinstance(path, list):
+        elif isinstance(path, (list, set)):
             urls = {}
             for url in path:
                 urls[url] = True

--- a/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
@@ -500,19 +500,18 @@ class TransformationAgent(AgentModule, TransformationAgentsUtilities):
             startTime = time.time()
             self._logInfo(f"Getting replicas for {len(newLFNs)} files from catalog", method=method, transID=transID)
             newReplicas = {}
-            for chunk in breakListIntoChunks(newLFNs, 10000):
-                res = self._getDataReplicasDM(transID, chunk, clients, forJobs=forJobs)
-                if res["OK"]:
-                    reps = {lfn: ses for lfn, ses in res["Value"].items() if ses}
-                    newReplicas.update(reps)
-                    self.__updateCache(transID, reps)
-                else:
-                    self._logWarn(
-                        f"Failed to get replicas for {len(chunk)} files",
-                        res["Message"],
-                        method=method,
-                        transID=transID,
-                    )
+            res = self._getDataReplicasDM(transID, newLFNs, clients, forJobs=forJobs)
+            if res["OK"]:
+                newReplicas = {lfn: ses for lfn, ses in res["Value"].items() if ses}
+
+                self.__updateCache(transID, newReplicas)
+            else:
+                self._logWarn(
+                    f"Failed to get replicas for {len(newLFNs)} files",
+                    res["Message"],
+                    method=method,
+                    transID=transID,
+                )
 
             self._logInfo(
                 f"Obtained {len(newReplicas)} replicas from catalog in {time.time() - startTime:.1f} seconds",


### PR DESCRIPTION
```bash
# Before
Replica results for 1 000 000 files obtained in 135.01 seconds

# After
Replica results for 1 000 000 files obtained in 56.16 seconds

````

Just for fun, this is the effect

That's the 95 percentile for `getReplicas`
<img width="1847" height="411" alt="image" src="https://github.com/user-attachments/assets/6f678b98-2f10-4a39-a380-b7f343bf80d5" />





BEGINRELEASENOTES

*Resources

CHANGE: improve getReplicas performances by sorting LFNs

*Transformation

CHANGE: TransformationAgent does not bulk calls to dm.getReplicas

ENDRELEASENOTES
