### PR TITLE
fix: rootPath for server installation can be a random string, followed by a timestamp

### DIFF
--- a/src/DIRAC/__init__.py
+++ b/src/DIRAC/__init__.py
@@ -139,7 +139,7 @@ def _computeRootPath(rootPath):
     if versionsPath.parent.name != "versions":
         return str(rootPath)
     # VERSION-INSTALL_TIME
-    pattern1 = re.compile(r"v(\d+\.\d+\.\d+[^\-]*)\-(\d+)")
+    pattern1 = re.compile(r"(v\d+\.\d+\.\d+[^\-]*|[^-]+)-(\d+)")
     # $(uname -s)-$(uname -m)
     pattern2 = re.compile(r"([^\-]+)-([^\-]+)")
     if pattern1.fullmatch(versionsPath.name) and pattern2.fullmatch(rootPath.name):


### PR DESCRIPTION
BEGINRELEASENOTES

*Core
FIX: rootPath for server installation can be a random string, followed by a timestamp

ENDRELEASENOTES
