### PR TITLE
fix: add further details when time left cannot be obtained

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/TimeLeft/TimeLeft.py
@@ -75,7 +75,9 @@ class TimeLeft:
 
         resourceDict = self.batchPlugin.getResourceUsage()
         if not resourceDict["OK"]:
-            self.log.warn(f"Could not determine timeleft for batch system at site {DIRAC.siteName()}")
+            self.log.warn(
+                f"Could not determine timeleft for batch system at site {DIRAC.siteName()}: {resourceDict['Message']}"
+            )
             return resourceDict
 
         resources = resourceDict["Value"]


### PR DESCRIPTION
We sometimes have issues that would be much easier to debug if we could get the error message coming from the `<batch system>ResourceUsage` module.

BEGINRELEASENOTES
*Resources
FIX: add further details when time left cannot be obtained
ENDRELEASENOTES
