### PR TITLE
fix: SLURM getCEStatus last empty line

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/SLURM.py
@@ -300,7 +300,7 @@ srun -l -k %(wrapper)s
 
         waitingJobs = 0
         runningJobs = 0
-        lines = output.split("\n")
+        lines = output.strip().split("\n")
         for line in lines[1:]:
             _jid, status = line.split()
             if status in ["PENDING", "SUSPENDED", "CONFIGURING"]:


### PR DESCRIPTION
There is generally an empty line at the end of the output causing exception when trying to get the "CE" status through SLURM.

BEGINRELEASENOTES
*Resources
FIX: SLURM getCEStatus last empty line
ENDRELEASENOTES
