### PR TITLE
[9.0] fix (REA): just ignore a shifter if we cannot get a matching proxy

### DIFF
--- a/src/DIRAC/RequestManagementSystem/private/RequestTask.py
+++ b/src/DIRAC/RequestManagementSystem/private/RequestTask.py
@@ -106,7 +106,8 @@ class RequestTask:
                     userDN, userGroup, requiredTimeLeft=1200, cacheTime=4 * 43200
                 )
             if not getProxy["OK"]:
-                return S_ERROR(f"unable to setup shifter proxy for {shifter}: {getProxy['Message']}")
+                self.log.error("unable to setup shifter proxy", f"{shifter}: {getProxy['Message']}")
+                continue
             chain = getProxy["chain"]
             fileName = getProxy["Value"]
             self.log.debug(f"got {shifter}: {userName} {userGroup}")


### PR DESCRIPTION
When starting to execute a request, we download all the shifter proxies (sigh). If one of the shifter proxy was expired, the request executing was failed, even if that proxy is totally useless. Change that behavior to just ignore it

BEGINRELEASENOTES

*RMS
CHANGE: just ignore a shifter if we cannot get a matching proxy


ENDRELEASENOTES
