### PR TITLE
[9.0] feat (OS): the weekly index uses also the year as a prefix

### DIFF
--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -621,7 +621,7 @@ class ElasticSearchDB:
         if period.lower() == "day":
             suffix = todayUTC.strftime("%Y-%m-%d")
         elif period.lower() == "week":
-            suffix = todayUTC.isocalendar()[1]
+            suffix = f"{todayUTC.strftime('%Y')}-{todayUTC.isocalendar()[1]}"
         elif period.lower() == "month":
             suffix = todayUTC.strftime("%Y-%m")
         elif period.lower() == "year":


### PR DESCRIPTION
If you use a weekly index and have a retention greater than a year, you end up reusing the same index name. Fix this by adding the year in the index suffix

BEGINRELEASENOTES

*Core

CHANGE: the weekly index for OpenSearch uses also the year as a prefix


ENDRELEASENOTES
