### PR TITLE
fix (dirac.cfg): Change default InputDataModule path in dirac.cfg

### DIFF
--- a/dirac.cfg
+++ b/dirac.cfg
@@ -1131,7 +1131,7 @@ Operations
         Remote = xroot, root
       }
       # Module used for InputData resolution if not specified in the JDL
-      InputDataModule = DIRAC.Core.Utilities.InputDataResolution
+      InputDataModule = DIRAC.WorkloadManagementSystem.Client.InputDataResolution
     }
     Logging
     {


### PR DESCRIPTION

BEGINRELEASENOTES

*DIRAC
FIX: Fix default InputDataModule path in dirac.cfg


ENDRELEASENOTES
