### PR TITLE
fix: Convert MemoryLimitMB to int before comparison in SingularityComputingElement

### DIFF
--- a/src/DIRAC/Resources/Computing/SingularityComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SingularityComputingElement.py
@@ -421,7 +421,7 @@ class SingularityComputingElement(ComputingElement):
         # if there's a max RAM available to the job, use that
         if self.maxRAM:
             self.ceParameters["MemoryLimitMB"] = min(
-                self.maxRAM, self.ceParameters.get("MemoryLimitMB", 1024 * 1024)
+                self.maxRAM, int(self.ceParameters.get("MemoryLimitMB", 1024 * 1024))
             )  # 1024 * 1024 is an arbitrary large number
         result = CG2Manager().systemCall(
             0, cmd, callbackFunction=self.sendOutput, env=self.__getEnv(), ceParameters=self.ceParameters

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/JobParameters.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/JobParameters.py
@@ -242,7 +242,7 @@ def getAvailableRAM(siteName=None, gridCE=None, queue=None):
         gLogger.info("Looking in", csPath)
         availableRAM = gConfig.getValue(csPath, None)
         if availableRAM:
-            return availableRAM
+            return int(availableRAM)
 
     # 3) checks if 'WholeNode' is one of the used tags
     # Tags of the CE
@@ -277,6 +277,6 @@ def getRAMForJob(jobID):
     # from /Resources/Computing/JobLimits/jobID/MaxRAM (set by PoolComputingElement)
     ram = gConfig.getValue(f"Resources/Computing/JobLimits/{jobID}/MaxRAM")
     if ram:
-        return ram
+        return int(ram)
 
     return getAvailableRAM()


### PR DESCRIPTION
BEGINRELEASENOTES
*Resources
FIX: SingularityComputingElement: convert MemoryLimitMB to int before comparison with maxRAM
ENDRELEASENOTES

The `MemoryLimitMB` parameter from configuration is a string, causing a `TypeError` when compared with the integer `maxRAM` in `min()`:

```
TypeError: '<' not supported between instances of 'str' and 'int'
```