### PR TITLE
fix (Tornado): return on retry on another service

### DIFF
--- a/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
+++ b/src/DIRAC/Core/Tornado/Client/private/TornadoBaseClient.py
@@ -599,7 +599,7 @@ class TornadoBaseClient:
             if url not in self.__bannedUrls:
                 self.__bannedUrls += [url]
             if retry < self.__nbOfUrls - 1:
-                self._request(retry=retry + 1, outputFile=outputFile, **kwargs)
+                return self._request(retry=retry + 1, outputFile=outputFile, **kwargs)
 
             errStr = f"{str(e)}: {rawText}"
             return S_ERROR(errStr)


### PR DESCRIPTION
This bug screwed us bad. When you have multiple tornado service (which was apparently never tested anymore), and one has an error, it tries the other, but still considers the original error. With the ReqProxy mechanism, that effectively means you double all your failover requests that went through the Proxy....

BEGINRELEASENOTES

*Tornado
FIX: return when retrying another Tornado service

ENDRELEASENOTES
