### PR TITLE
[8.0] SiteDirector - fix pilot option CVMFS_locations string value

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/SiteDirector.py
@@ -1035,7 +1035,7 @@ class SiteDirector(AgentModule):
         # Preinstalled environment or list of CVMFS locations defined ?
         preinstalledEnv = opsHelper.getValue("Pilot/PreinstalledEnv", "")
         preinstalledEnvPrefix = opsHelper.getValue("Pilot/PreinstalledEnvPrefix", "")
-        CVMFS_locations = opsHelper.getValue("Pilot/CVMFS_locations", "")
+        CVMFS_locations = ",".join(opsHelper.getValue("Pilot/CVMFS_locations", []))
         if preinstalledEnv:
             pilotOptions.append(f"--preinstalledEnv={preinstalledEnv}")
         elif preinstalledEnvPrefix:


### PR DESCRIPTION
  When several CVMFS_locations defined in the Pilot CS, the option is defined as a comma separated list but with spaces. Those spaces must be removed otherwise the pilot options are screwed.

BEGINRELEASENOTES

*WorkloadManagementSubsystem
FIX: SiteDirector - fix pilot option CVMFS_locations string value

ENDRELEASENOTES
