### PR TITLE
fix: Return structured errors from GFAL2 storage operations

### DIFF
--- a/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
+++ b/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py
@@ -230,8 +230,10 @@ class GFAL2_StorageBase(StorageBase):
         for url in urls:
             try:
                 successful[url] = self.__singleExists(url)
+            except gfal2.GError as e:
+                failed[url] = {"error": repr(e), "errno": e.code}
             except Exception as e:
-                failed[url] = repr(e)
+                failed[url] = {"error": repr(e), "errno": None}
 
         resDict = {"Failed": failed, "Successful": successful}
         return resDict
@@ -636,9 +638,10 @@ class GFAL2_StorageBase(StorageBase):
         for url in urls:
             try:
                 successful[url] = self._getSingleFileMetadata(url)
-
+            except gfal2.GError as e:
+                failed[url] = {"error": repr(e), "errno": e.code}
             except Exception as e:
-                failed[url] = repr(e)
+                failed[url] = {"error": repr(e), "errno": None}
 
         return {"Failed": failed, "Successful": successful}
 


### PR DESCRIPTION
## Summary
- Return error dictionaries with errno codes from `exists()` and `getFileMetadata()` in `GFAL2_StorageBase`
- Captures `gfal2.GError` separately to extract the `e.code` (errno)
- Allows consumers to distinguish between different error types (e.g., `ENOENT` vs `EACCES`)

See: https://gitlab.cern.ch/lhcb-dirac/LHCbDIRAC/-/merge_requests/1870

## Motivation
When a storage element returns HTTP 401 (Permission Denied / Authentication Error), `dirac-dms-check-fc2se` incorrectly reports files as "missing at SEs". This is because all files in `metadata["Failed"]` are treated as "not existing" regardless of the actual error type.

By returning structured error information with errno codes, downstream code can properly handle permission denied errors separately from file-not-found errors, avoiding false positives.

## Changes
The error format changes from:
```python
failed[url] = repr(e)  # string
```
to:
```python
failed[url] = {"error": repr(e), "errno": e.code}  # dict with errno
```

## Backward Compatibility
Downstream code should handle both the old string format and new dict format during the transition period:
```python
if isinstance(err_info, dict):
    err_code = err_info.get("errno")
else:
    err_code = None  # Legacy string format
```