### PR TITLE
RSS: remove "nodes" tables, added developer docs

### DIFF
--- a/docs/source/AdministratorGuide/Systems/ResourceStatus/advanced_configuration.rst
+++ b/docs/source/AdministratorGuide/Systems/ResourceStatus/advanced_configuration.rst
@@ -62,6 +62,10 @@ we cannot define the following matchParams:
 
 .. warning :: This setting will match the cartesian product of name x statusType. We will match CERN-USER for WriteAccess and PIC-USER for ReadAccess as well. We will need two separate policies.
 
+.. seealso::
+
+   Code templates and examples for creating custom policies: :doc:`../../../DeveloperGuide/Systems/ResourceStatus/index`
+
 -------------
 PolicyActions
 -------------

--- a/docs/source/AdministratorGuide/Systems/ResourceStatus/install.rst
+++ b/docs/source/AdministratorGuide/Systems/ResourceStatus/install.rst
@@ -75,7 +75,6 @@ Let's do it one by one to make it easier::
 
     $ dirac-rss-sync --element Site -o LogLevel=VERBOSE
     $ dirac-rss-sync --element Resource -o LogLevel=VERBOSE
-    $ dirac-rss-sync --element Node -o LogLevel=VERBOSE
 
 ---------------------------------------
 Initialize Statuses for StorageElements

--- a/docs/source/AdministratorGuide/Systems/ResourceStatus/introduction.rst
+++ b/docs/source/AdministratorGuide/Systems/ResourceStatus/introduction.rst
@@ -172,6 +172,10 @@ tuple ( ElementName, StatusType ) has not changed.
 
 .. note :: There are no Foreign Keys on the ResourceStatusDB tables.
 
+.. seealso::
+
+   Complete database schema with all field descriptions: :doc:`../../../DeveloperGuide/Systems/ResourceStatus/index`
+
 ------------
 Synchronizer
 ------------

--- a/docs/source/AdministratorGuide/Systems/ResourceStatus/introduction.rst
+++ b/docs/source/AdministratorGuide/Systems/ResourceStatus/introduction.rst
@@ -42,12 +42,11 @@ Element
 
 An *Element* in the RSS world represents a Grid Element as described on the `RFC5`_. It can be any of the following:
 
-* Node
 * Resource
 * Site
 
 Elements are the information unit used on RSS. Everything is an Element, and all are treated equally, simplifying the design
-and reducing the complexity of the system. If all are treated equally, the reader may be wondering why three flavors instead
+and reducing the complexity of the system. If all are treated equally, the reader may be wondering why two flavors instead
 of just an Element type. The answer for that question is simply to keep them separated. On the RSS they are treated equally,
 but in Real they have very different significance. Marking as unusable a Site or a CE on the RSS requires the same single and
 unique operation. However, the consequences of marking as unusable a Site instead of one if its CEs by mistake are not negligible.
@@ -82,27 +81,6 @@ Resources Element, we have the following Element Types:
 * ComputingElement
 * StorageElement
 * ...
-
-And if we take a look to the ComputingElement Resources, we can see the pattern happening again.
-
-::
-
-    .../Computing/some.htcondor.ce
-                         /CEType = HTCondorCE
-                         /Host = some.htcondor.ce
-                         /Queues
-                                 /condor-long
-                                           /Communities = VO1, VO2
-                                           /Domains = Grid1, Grid2
-                                           /MaxCPUTime =
-                                           /SI00 =
-                                           /MaxWaitingJobs =
-                                           /MaxTotalJobs =
-                                           /OutputURL =
-                                 ...
-                         ...
-
-Each CE Resource has any number of Nodes, in this case of the ElementType Queue.
 
 The list of ElementTypes per Element may vary depending on the CS/Resources section !
 
@@ -176,10 +154,10 @@ Resources() Helper
 Database schema
 ---------------
 
-The database used for the basic operations is *ResourceStatusDB* and consists on three sets of identical tables,
-one for *Site*, another for *Resource* and the last one for *Node* Elements ( as explained on `Element`_ ).
+The database used for the basic operations is *ResourceStatusDB* and consists on two sets of identical tables,
+one for *Site* and another for *Resource* Elements ( as explained on `Element`_ ).
 
-On each set there is a main table, called <element>Status ( replace <element> with Site, Resource or Node ), which
+On each set there is a main table, called <element>Status ( replace <element> with Site or Resource ), which
 contains all status information regarding that Elements family. The Status tables are enough to start running the RSS.
 However, if we need to keep track of the History of our Elements, the next two tables come into scene: <element>Log
 and <element>History.

--- a/docs/source/AdministratorGuide/Systems/ResourceStatus/monitoring.rst
+++ b/docs/source/AdministratorGuide/Systems/ResourceStatus/monitoring.rst
@@ -217,6 +217,10 @@ dictionary and returns it to the PEP.
 Info Getter
 ===========
 
+.. seealso::
+
+   For detailed implementation examples, database schemas, and code templates for extending the policy system, see :doc:`../../../DeveloperGuide/Systems/ResourceStatus/index`.
+
 Info getter is the piece of code that decides which policies and actions match. It reads from the CS ( /Operation/ResourceStatus/Policies ) and
 gets a dictionary per policy defined there. The matching algorithm works as follows:
 

--- a/docs/source/AdministratorGuide/Systems/ResourceStatus/monitoring.rst
+++ b/docs/source/AdministratorGuide/Systems/ResourceStatus/monitoring.rst
@@ -25,7 +25,7 @@ it as Active.
 Element Inspector Agents
 ------------------------
 
-There is one InspectorAgent per family of elements: Site, Resource and Node. They run frequently
+There is one InspectorAgent per family of elements: Site and Resource. They run frequently
 and get from the DB the elements that have not been checked recently. With other words, they
 take elements following:
 

--- a/docs/source/AdministratorGuide/Systems/ResourceStatus/usage.rst
+++ b/docs/source/AdministratorGuide/Systems/ResourceStatus/usage.rst
@@ -37,7 +37,7 @@ This is a quick reference of the basic usage of RSS from the python interactive 
 There are two main components that can be used to extract information :
 
 * the client : ResourceStatusSystem
-* the helper : SiteStatus, ResourceStatus, NodeStatus
+* the helper : SiteStatus, ResourceStatus
 
 The second is a simplification of the client with an internal cache. Unless you
 want to access not-only status information, please use the second. Nevertheless,

--- a/docs/source/DeveloperGuide/Systems/ResourceStatus/index.rst
+++ b/docs/source/DeveloperGuide/Systems/ResourceStatus/index.rst
@@ -1,0 +1,556 @@
+.. _developer_resource_status:
+
+============================
+Architecture Reference Guide
+============================
+
+.. contents::
+   :depth: 2
+   :local:
+
+This document provides technical details for developers working with the ResourceStatusSystem (RSS) internals.
+
+
+Database Schemas
+================
+
+ResourceStatusDB
+----------------
+
+The ResourceStatusDB contains two sets of tables (Site and Resource), each with three table types.
+
+Status Tables
+~~~~~~~~~~~~~
+
+Current state of all elements. **Primary key:** (Name, StatusType, VO)
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 20 45
+
+   * - Field
+     - Type
+     - Default
+     - Description
+   * - Name
+     - VARCHAR(64)
+     -
+     - Element name (e.g., site name, SE name)
+   * - StatusType
+     - VARCHAR(128)
+     - 'all'
+     - Status type (all, ReadAccess, WriteAccess, etc.)
+   * - VO
+     - VARCHAR(64)
+     - 'all'
+     - Virtual Organization
+   * - Status
+     - VARCHAR(8)
+     -
+     - Current status (Active, Degraded, Probing, Banned, Unknown, Error)
+   * - Reason
+     - VARCHAR(512)
+     - 'Unspecified'
+     - Reason for current status
+   * - DateEffective
+     - DATETIME
+     -
+     - When status became effective
+   * - TokenExpiration
+     - DATETIME
+     - 9999-12-31 23:59:59
+     - When lock expires
+   * - ElementType
+     - VARCHAR(32)
+     -
+     - Type (CE, SE, etc.)
+   * - LastCheckTime
+     - DATETIME
+     - 1000-01-01 00:00:00
+     - Last policy check
+   * - TokenOwner
+     - VARCHAR(16)
+     - 'rs_svc'
+     - Who owns the lock
+
+**Tables:** SiteStatus, ResourceStatus
+
+Log Tables
+~~~~~~~~~~
+
+All status changes with auto-increment ID. **Primary key:** ID
+
+Same fields as Status tables plus:
+
+* **ID** (BIGINT, AUTO_INCREMENT) - Unique identifier
+
+**Tables:** SiteLog, ResourceLog
+
+History Tables
+~~~~~~~~~~~~~~
+
+Archived logs with duplicates removed. Same schema as Log tables.
+
+**Tables:** SiteHistory, ResourceHistory
+
+ResourceManagementDB
+--------------------
+
+Cache tables for metrics used by policies.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Table
+     - Purpose
+   * - AccountingCache
+     - Accounting plots and metrics
+   * - DowntimeCache
+     - Scheduled downtimes from GOCDB (DowntimeID, StartDate, EndDate, Severity)
+   * - GGUSTicketsCache
+     - GGUS support tickets (Tickets JSON, OpenTickets count)
+   * - JobCache
+     - Job efficiency metrics per site (Efficiency, MaskStatus)
+   * - PilotCache
+     - Pilot efficiency per CE (Site, CE, Efficiency, Status)
+   * - PolicyResult
+     - Policy evaluation results (Element, Name, PolicyName, Status, Reason)
+   * - SpaceTokenOccupancyCache
+     - Storage space usage (Endpoint, Token, Free, Guaranteed)
+   * - TransferCache
+     - Transfer quality metrics (SourceName, DestinationName, Metric, Value)
+
+Key Methods
+~~~~~~~~~~~
+
+insert()
+   Insert new records
+
+select()
+   Query records with flexible conditions
+
+delete()
+   Remove records
+
+addOrModify()
+   Insert if not exists, update if exists (by primary key)
+
+addIfNotThere()
+   Insert only if record doesn't exist
+
+Policy System
+=============
+
+Three-Tier Architecture
+-----------------------
+
+.. code-block:: text
+
+   Inspector Agent
+        ↓
+   PEP (Policy Enforcement Point) ← Entry point
+        ↓
+   PDP (Policy Decision Point) ← Discovers & runs policies
+        ↓
+   Policies → Commands → Metrics
+        ↓
+   StateMachine ← Combines results
+        ↓
+   Actions ← Execute changes
+
+State Machine
+-------------
+
+Valid states ordered by priority (lowest number = highest priority):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - State
+     - Level
+     - Description
+   * - Unknown
+     - 5
+     - No information available
+   * - Active
+     - 4
+     - Fully operational
+   * - Degraded
+     - 3
+     - Operational but suboptimal
+   * - Probing
+     - 2
+     - Under testing (transition from Banned)
+   * - Banned
+     - 1
+     - Not usable
+   * - Error
+     - 0
+     - Error state
+
+**Transition Rule:** Transitions from Banned to Active/Degraded/Unknown must go through Probing first.
+
+**Location:** ``PolicySystem/StateMachine.py:28-44``
+
+Policy Implementation
+---------------------
+
+Policies inherit from ``PolicyBase`` and implement ``evaluate()``.
+
+**Example:** Job Efficiency Policy
+
+.. code-block:: python
+
+   # Location: Policy/JobEfficiencyPolicy.py
+   class JobEfficiencyPolicy(PolicyBase):
+       def evaluate(self):
+           # Execute command to get job stats
+           jobStats = self.command.doCommand()
+           efficiency = jobStats['Done'] / jobStats['Total']
+
+           # Apply thresholds
+           if efficiency > 0.9:
+               return {'Status': 'Active', 'Reason': f'Efficiency: {efficiency:.2%}'}
+           elif efficiency > 0.7:
+               return {'Status': 'Degraded', 'Reason': f'Low efficiency: {efficiency:.2%}'}
+           return {'Status': 'Banned', 'Reason': f'Very low efficiency: {efficiency:.2%}'}
+
+Command Implementation
+----------------------
+
+Commands inherit from ``Command`` and implement ``doCommand()``.
+
+**Example:** Downtime Command
+
+.. code-block:: python
+
+   # Location: Command/DowntimeCommand.py
+   class DowntimeCommand(Command):
+       def doCommand(self):
+           # Query GOCDB API
+           gocdb = GOCDB()
+           downtimes = gocdb.getDowntimes(elementName=self.args['name'])
+
+           # Store in cache
+           for dt in downtimes:
+               self.clients['ResourceManagementClient'].addOrModifyDowntimeCache(
+                   name=dt['Name'], downtimeID=dt['ID'],
+                   startDate=dt['StartDate'], endDate=dt['EndDate'],
+                   severity=dt['Severity']
+               )
+
+           return S_OK(downtimes)
+
+Client Architecture
+===================
+
+ResourceStatus Client
+---------------------
+
+High-level API with caching (Singleton pattern).
+
+**Location:** ``Client/ResourceStatus.py``
+
+getElementStatus(elementName, elementType, statusType=None, vO=None)
+   Get status for Storage/Computing Elements, FTS, Catalogs
+
+   .. code-block:: python
+
+      from DIRAC.ResourceStatusSystem.Client.ResourceStatus import ResourceStatus
+      rs = ResourceStatus()
+
+      # Get all status types for a SE
+      rs.getElementStatus('CERN-USER', 'StorageElement')
+      # Returns: {'CERN-USER': {'ReadAccess': 'Active', 'WriteAccess': 'Active', ...}}
+
+      # Get specific status type
+      rs.getElementStatus('CERN-USER', 'StorageElement', 'ReadAccess')
+      # Returns: {'CERN-USER': {'ReadAccess': 'Active'}}
+
+      # Get multiple SEs
+      rs.getElementStatus(['CERN-USER', 'PIC-USER'], 'StorageElement', 'ReadAccess')
+
+setElementStatus(elementName, elementType, statusType, status, reason=None, tokenOwner=None)
+   Set element status (acquires 1-day token)
+
+   .. code-block:: python
+
+      rs.setElementStatus('CERN-USER', 'StorageElement', 'ReadAccess',
+                         'Banned', reason='Maintenance')
+
+**Caching:** Internal RSSCache with configurable lifetime, refreshed automatically on cache miss.
+
+SiteStatus Client
+-----------------
+
+Simplified interface for site operations (Singleton pattern).
+
+**Location:** ``Client/SiteStatus.py``
+
+getSiteStatuses(siteNames=None)
+   Get status for one or more sites
+
+isUsableSite(siteName, statusType='all')
+   Returns True if site is Active or Degraded
+
+getUsableSites(statusType='all')
+   Returns list of all usable sites
+
+setSiteStatus(siteName, status, reason=None)
+   Set site status manually
+
+Agent Implementation
+====================
+
+Inspector Agents
+----------------
+
+Check elements periodically based on their status.
+
+**Check Frequency:**
+
+Active/Degraded
+   Every 20 minutes
+
+Probing/Banned/Unknown
+   Every 20 minutes
+
+Error
+   Every 5 minutes
+
+**Implementation Pattern:**
+
+.. code-block:: python
+
+   # Location: Agent/SiteInspectorAgent.py, Agent/ElementInspectorAgent.py
+   def execute(self):
+       # Get elements needing check (LastCheckTime + lifetime < now)
+       elements = self._getElementsToBeChecked()
+
+       # Process in parallel (15 threads)
+       with ThreadPoolExecutor(max_workers=15) as executor:
+           for element in elements:
+               executor.submit(self._execute, element)
+
+   def _execute(self, element):
+       pep = PEP(clients=self.clients)
+       pep.enforce({
+           'element': 'Site',  # or 'Resource'
+           'name': element['Name'],
+           'statusType': element['StatusType'],
+           'status': element['Status'],
+           'elementType': element['ElementType']
+       })
+
+**Skip Condition:** Elements with ``TokenOwner != 'rs_svc'`` are skipped (manual override active).
+
+All Agents
+----------
+
+SiteInspectorAgent
+   Evaluates policies for Site elements (PollingTime: 300s, maxThreads: 15)
+
+ElementInspectorAgent
+   Evaluates policies for Resource elements (PollingTime: 300s, elementType: Resource)
+
+CacheFeederAgent
+   Populates cache tables with metrics (PollingTime: 900s, commands: Downtime, GOCDBSync, FreeDiskSpace, Pilot)
+
+TokenAgent
+   Manages token expiration, notifies owners 12h before expiry (PollingTime: 3600s)
+
+EmailAgent
+   Sends aggregated status change notifications (PollingTime: 1800s)
+
+SummarizeLogsAgent
+   Archives logs to history tables (PollingTime: 300s, keeps 36 months)
+
+RucioRSSAgent
+   Synchronizes with Rucio RSE status (PollingTime: 120s)
+
+Status Flow
+===========
+
+Complete flow from element check to database update:
+
+.. code-block:: text
+
+   1. Inspector Agent
+         ↓ Query elements where LastCheckTime + lifetime < now
+   2. Get Current Status from DB
+         ↓ (Name, StatusType, Status, TokenOwner, etc.)
+   3. PEP.enforce(decisionParams)
+         ↓ Skip if TokenOwner != 'rs_svc'
+   4. PDP.setup(decisionParams)
+         ↓ Discover applicable policies from CS
+   5. PDP.takeDecision()
+         ↓ Run each policy via PolicyCaller
+   6. Policy.evaluate()
+         ↓ Execute Command to gather metrics
+   7. Command.doCommand()
+         ↓ Fetch from cache or external API
+   8. StateMachine.orderPolicyResults()
+         ↓ Sort by severity (Banned > Active)
+   9. PDP discovers applicable actions
+         ↓ LogStatusAction, EmailAction, etc.
+  10. PEP validates element unchanged
+         ↓ Check DB to prevent race conditions
+  11. Execute Actions
+         ↓
+  12. LogStatusAction
+         ↓ Update Status table (current state)
+         ↓ Insert Log table (history)
+         ↓ Set TokenOwner='rs_svc', LastCheckTime=now
+  13. EmailAction (optional)
+         ↓ Insert into ResourceStatusCache
+         ↓ EmailAgent aggregates and sends later
+
+Extension Points
+================
+
+Adding Custom Policies
+----------------------
+
+**1. Create policy file:**
+
+``MyExtension/ResourceStatusSystem/Policy/MyCustomPolicy.py``
+
+.. code-block:: python
+
+   from DIRAC.ResourceStatusSystem.Policy.PolicyBase import PolicyBase
+
+   class MyCustomPolicy(PolicyBase):
+       def evaluate(self):
+           # Execute command to get metrics
+           result = self.command.doCommand()
+
+           # Apply custom logic
+           if result['metric'] > threshold:
+               return {'Status': 'Active', 'Reason': 'All good'}
+           return {'Status': 'Degraded', 'Reason': 'Metric below threshold'}
+
+**2. Configure in CS:**
+
+.. code-block:: cfg
+
+   Operations/Defaults/ResourceStatus/Policies
+   {
+     Site
+     {
+       all
+       {
+         policyName = MyCustomPolicy
+       }
+     }
+   }
+
+Adding Custom Commands
+----------------------
+
+**1. Create command file:**
+
+``MyExtension/ResourceStatusSystem/Command/MyCustomCommand.py``
+
+.. code-block:: python
+
+   from DIRAC.ResourceStatusSystem.Command.Command import Command
+
+   class MyCustomCommand(Command):
+       def doCommand(self):
+           # Fetch data from external source
+           data = self.fetchFromAPI()
+
+           # Store in cache (optional)
+           self.clients['ResourceManagementClient'].addOrModifyCustomCache(data)
+
+           return S_OK(data)
+
+**2. Use in policy:**
+
+Policies automatically discover and execute commands based on naming convention.
+
+Adding Custom Actions
+---------------------
+
+**1. Create action file:**
+
+``MyExtension/ResourceStatusSystem/PolicySystem/Actions/MyCustomAction.py``
+
+.. code-block:: python
+
+   from DIRAC.ResourceStatusSystem.PolicySystem.Actions.BaseAction import BaseAction
+
+   class MyCustomAction(BaseAction):
+       def run(self):
+           element = self.decisionParams['name']
+           newStatus = self.policyCombinedResult['Status']
+
+           # Execute custom action (e.g., call external API)
+           self.notifyExternalSystem(element, newStatus)
+
+           return S_OK()
+
+**2. Configure in CS:**
+
+.. code-block:: cfg
+
+   Operations/Defaults/ResourceStatus/PolicyActions += MyCustomAction
+
+Quick Reference
+===============
+
+Key Classes
+-----------
+
+PEP
+   Policy Enforcement Point - ``PolicySystem/PEP.py:73-160``
+
+PDP
+   Policy Decision Point - ``PolicySystem/PDP.py``
+
+RSSMachine
+   State machine - ``PolicySystem/StateMachine.py:28-44``
+
+ResourceStatus
+   High-level API (Singleton) - ``Client/ResourceStatus.py:42-98``
+
+SiteStatus
+   Site-specific API (Singleton) - ``Client/SiteStatus.py``
+
+ResourceStatusDB
+   Status database access - ``DB/ResourceStatusDB.py``
+
+ResourceManagementDB
+   Cache database access - ``DB/ResourceManagementDB.py``
+
+Valid States (Priority Order)
+------------------------------
+
+1. Unknown (Level 5)
+2. Active (Level 4)
+3. Degraded (Level 3)
+4. Probing (Level 2)
+5. Banned (Level 1)
+6. Error (Level 0)
+
+Lower level numbers indicate higher priority when combining policy results.
+
+Configuration Paths
+-------------------
+
+Policies
+   ``/Operations/Defaults/ResourceStatus/Policies/<Element>/<StatusType>/policyName``
+
+Actions
+   ``/Operations/Defaults/ResourceStatus/PolicyActions``
+
+Status Types
+   ``/Operations/Defaults/ResourceStatus/Config/StatusTypes``
+
+Services
+   ``/Systems/ResourceStatus/Services/``
+
+Agents
+   ``/Systems/ResourceStatus/Agents/``

--- a/docs/source/DeveloperGuide/Systems/index.rst
+++ b/docs/source/DeveloperGuide/Systems/index.rst
@@ -13,4 +13,5 @@ Here the reader can find technical documentation for developing DIRAC systems
    Transformation/index
    Monitoring/index
    RequestManagement/index
+   ResourceStatus/index
    WorkloadManagement/index

--- a/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/ElementInspectorAgent.py
@@ -1,6 +1,6 @@
-""" ElementInspectorAgent
+"""ElementInspectorAgent
 
-  This agent inspect Resources (or maybe Nodes), and evaluates policies that apply.
+  This agent inspect Resources and evaluates policies that apply.
 
 
 The following options can be set for the ElementInspectorAgent.
@@ -11,6 +11,7 @@ The following options can be set for the ElementInspectorAgent.
   :dedent: 2
   :caption: ElementInspectorAgent options
 """
+
 import datetime
 import concurrent.futures
 
@@ -42,7 +43,7 @@ class ElementInspectorAgent(AgentModule):
 
         AgentModule.__init__(self, *args, **kwargs)
 
-        # ElementType, to be defined among Resource or Node
+        # ElementType, to be defined among Resource
         self.elementType = "Resource"
         self.rsClient = None
         self.clients = {}

--- a/src/DIRAC/ResourceStatusSystem/Agent/SummarizeLogsAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/SummarizeLogsAgent.py
@@ -1,9 +1,8 @@
-""" SummarizeLogsAgent module
+"""SummarizeLogsAgent module
 
-  This agents scans all the log tables (SiteLog, ResourceLog and NodeLog) on the
+  This agents scans all the log tables (SiteLog and ResourceLog) on the
   ResourceStatusDB and summarizes them. The results are stored on the History
-  tables (SiteHistory, ResourceHistory and NodeHistory) and the Log tables
-  cleared.
+  tables (SiteHistory and ResourceHistory) and the Log tables cleared.
 
   In order to summarize the logs, all entries with no changes on the Status or
   TokenOwner column for a given (Name, StatusType) tuple are discarded.
@@ -18,6 +17,7 @@
   :dedent: 2
   :caption: SummarizeLogsAgent options
 """
+
 from datetime import datetime, timedelta
 
 from DIRAC import S_OK
@@ -52,8 +52,8 @@ class SummarizeLogsAgent(AgentModule):
     def execute(self):
         """execute (main method)
 
-        The execute method runs over the three families of tables (Site, Resource and
-        Node) performing identical operations. First, selects all logs for a given
+        The execute method runs over the two families of tables (Site and Resource)
+        performing identical operations. First, selects all logs for a given
         family (and keeps track of which one is the last row ID). It summarizes the
         logs and finally, deletes the logs from the database.
 
@@ -63,7 +63,7 @@ class SummarizeLogsAgent(AgentModule):
         """
 
         # loop over the tables
-        for element in ("Site", "Resource", "Node"):
+        for element in ("Site", "Resource"):
             self.log.info(f"Summarizing {element}")
 
             # get all logs to be summarized
@@ -97,7 +97,7 @@ class SummarizeLogsAgent(AgentModule):
     def _summarizeLogs(self, element):
         """given an element, selects all logs in table <element>Log.
 
-        :param str element: name of the table family (either Site, Resource or Node)
+        :param str element: name of the table family (either Site or Resource)
         :return: S_OK(lastID, listOfLogs) / S_ERROR
         """
 
@@ -143,7 +143,7 @@ class SummarizeLogsAgent(AgentModule):
         the <element>History table. If it is, it is not inserted.
 
 
-        :param str element: name of the table family (either Site, Resource or Node)
+        :param str element: name of the table family (either Site, Resource)
         :param tuple key: tuple with the name of the element and the statusType
         :param list logs: list of dictionaries containing the logs
         :return: S_OK(lastID, listOfLogs) / S_ERROR
@@ -204,7 +204,7 @@ class SummarizeLogsAgent(AgentModule):
         """Given an element and a dictionary with all the arguments, this method
         inserts a new entry on the <element>History table
 
-        :param str element: name of the table family (either Site, Resource or Node)
+        :param str element: name of the table family (either Site, Resource)
         :param dict elementDict: dictionary returned from the DB to be inserted on the History table
 
         :return: S_OK / S_ERROR
@@ -240,7 +240,7 @@ class SummarizeLogsAgent(AgentModule):
     def _removeOldHistoryEntries(self, element, months):
         """Delete entries older than period
 
-        :param str element: name of the table family (either Site, Resource or Node)
+        :param str element: name of the table family (either Site, Resource)
         :param int months: number of months
 
         :return: S_OK / S_ERROR

--- a/src/DIRAC/ResourceStatusSystem/Agent/TokenAgent.py
+++ b/src/DIRAC/ResourceStatusSystem/Agent/TokenAgent.py
@@ -1,4 +1,4 @@
-""" TokenAgent
+"""TokenAgent
 
   This agent inspect all elements, and resets their tokens if necessary.
 
@@ -10,6 +10,7 @@ The following options can be set for the TokenAgent.
   :dedent: 2
   :caption: TokenAgent options
 """
+
 from datetime import datetime, timedelta
 
 from DIRAC import S_OK, S_ERROR
@@ -62,7 +63,7 @@ class TokenAgent(AgentModule):
         # Initialized here, as it is needed empty at the beginning of the execution
         self.tokenDict = {}
 
-        elements = ("Site", "Resource", "Node")
+        elements = ("Site", "Resource")
 
         for element in elements:
             self.log.info(f"Processing {element}")
@@ -182,7 +183,7 @@ class TokenAgent(AgentModule):
 
             resNotify = self._notify(tokenOwner, expired, expiring)
             if not resNotify["OK"]:
-                self.log.error("Failed to notify token owner", resNotify["Message"])
+                self.log.error("Failed to notify token owner", f"{resNotify['Message']}")
 
         if (adminExpired or adminExpiring) and self.adminMail:
             return self._notify(self.adminMail, adminExpired, adminExpiring)

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceManagementClient.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceManagementClient.py
@@ -1,7 +1,8 @@
-""" ResourceManagementClient
+"""ResourceManagementClient
 
-  Client to interact with the ResourceManagement service and from it with the DB.
+Client to interact with the ResourceManagement service and from it with the DB.
 """
+
 from DIRAC.Core.Base.Client import Client, createClient
 
 
@@ -187,7 +188,7 @@ class ResourceManagementClient(Client):
 
         :param downtimeID: unique id for the downtime
         :type downtimeID: string, list
-        :param element: valid element in the topology (Site, Resource, Node)
+        :param element: valid element in the topology (Site, Resource)
         :type element: string, list
         :param name: name of the element(s) where the downtime applies
         :type name: string, list
@@ -261,7 +262,7 @@ class ResourceManagementClient(Client):
 
         :param downtimeID: unique id for the downtime
         :type downtimeID: string, list
-        :param element: valid element in the topology ( Site, Resource, Node )
+        :param element: valid element in the topology (Site, Resource)
         :type element: string, list
         :param name: name of the element where the downtime applies
         :type name: string, list
@@ -330,7 +331,7 @@ class ResourceManagementClient(Client):
         the database, decides whether to insert or update the table.
 
         :param str downtimeID: unique id for the downtime
-        :param str element: valid element in the topology ( Site, Resource, Node )
+        :param str element: valid element in the topology (Site, Resource)
         :param str name: name of the element where the downtime applies
         :param datetime startDate: starting time for the downtime
         :param datetime endDate: ending time for the downtime

--- a/src/DIRAC/ResourceStatusSystem/Client/ResourceStatusClient.py
+++ b/src/DIRAC/ResourceStatusSystem/Client/ResourceStatusClient.py
@@ -1,6 +1,6 @@
-""" ResourceStatusClient
+"""ResourceStatusClient
 
-  Client to interact with the ResourceStatus service and from it with the DB.
+Client to interact with the ResourceStatus service and from it with the DB.
 """
 
 # pylint: disable=unused-argument
@@ -92,8 +92,7 @@ class ResourceStatusClient(Client):
 
     :Parameters:
       **element** - `string`
-        it has to be a valid element ( ValidElement ), any of the defaults: `Site` \
-        | `Resource` | `Node`
+        it has to be a valid element ( ValidElement ), any of the defaults: `Site` | `Resource`
       **tableType** - `string`
         it has to be a valid tableType [ 'Status', 'Log', 'History' ]
       **name** - `string`
@@ -167,8 +166,7 @@ class ResourceStatusClient(Client):
 
     :Parameters:
       **element** - `string`
-        it has to be a valid element ( ValidElement ), any of the defaults: `Site` \
-        | `Resource` | `Node`
+        it has to be a valid element ( ValidElement ), any of the defaults: `Site` | `Resource`
       **tableType** - `string`
         it has to be a valid tableType [ 'Status', 'Log', 'History' ]
       **name** - `[, string, list]`
@@ -247,8 +245,7 @@ class ResourceStatusClient(Client):
 
     :Parameters:
       **element** - `string`
-        it has to be a valid element ( ValidElement ), any of the defaults: `Site` \
-        | `Resource` | `Node`
+        it has to be a valid element ( ValidElement ), any of the defaults: `Site` | `Resource`
       **tableType** - `string`
         it has to be a valid tableType [ 'Status', 'Log', 'History' ]
       **name** - `[, string, list]`
@@ -326,8 +323,7 @@ class ResourceStatusClient(Client):
 
     :Parameters:
       **element** - `string`
-        it has to be a valid element ( ValidElement ), any of the defaults: `Site` \
-        | `Resource` | `Node`
+        it has to be a valid element ( ValidElement ), any of the defaults: `Site` | `Resource`
       **tableType** - `string`
         it has to be a valid tableType [ 'Status', 'Log', 'History' ]
       **name** - `string`
@@ -400,8 +396,7 @@ class ResourceStatusClient(Client):
 
     :Parameters:
       **element** - `string`
-        it has to be a valid element ( ValidElement ), any of the defaults: `Site` \
-        | `Resource` | `Node`
+        it has to be a valid element ( ValidElement ), any of the defaults: `Site` | `Resource`
       **tableType** - `string`
         it has to be a valid tableType [ 'Status', 'Log', 'History' ]
       **name** - `string`
@@ -475,8 +470,7 @@ class ResourceStatusClient(Client):
 
     :Parameters:
       **element** - `string`
-        it has to be a valid element ( ValidElement ), any of the defaults: `Site` \
-        | `Resource` | `Node`
+        it has to be a valid element ( ValidElement ), any of the defaults: `Site` | `Resource`
       **tableType** - `string`
         it has to be a valid tableType [ 'Status', 'Log', 'History' ]
       **name** - `string`
@@ -541,23 +535,22 @@ class ResourceStatusClient(Client):
 
     def _extermineStatusElement(self, element, name, keepLogs=True):
         """
-    Deletes from <element>Status,
-                 <element>History
-                 <element>Log
-     all rows with `elementName`. It removes all the entries, logs, etc..
-    Use with common sense !
+        Deletes from <element>Status,
+                     <element>History
+                     <element>Log
+         all rows with `elementName`. It removes all the entries, logs, etc..
+        Use with common sense !
 
-    :Parameters:
-      **element** - `string`
-        it has to be a valid element ( ValidElements ), any of the defaults: \
-          `Site` | `Resource` | `Node`
-      **name** - `[, string, list]`
-        name of the individual of class element
-      **keepLogs** - `bool`
-        if active, logs are kept in the database
+        :Parameters:
+          **element** - `string`
+            it has to be a valid element ( ValidElements ), any of the defaults: `Site` | `Resource`
+          **name** - `[, string, list]`
+            name of the individual of class element
+          **keepLogs** - `bool`
+            if active, logs are kept in the database
 
-    :return: S_OK() || S_ERROR()
-    """
+        :return: S_OK() || S_ERROR()
+        """
         return self.__extermineStatusElement(element, name, keepLogs)
 
     def __extermineStatusElement(self, element, name, keepLogs):

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -1,20 +1,21 @@
-""" ResourceStatusDB:
-    This module provides definition of the DB tables, and methods to access them.
+"""ResourceStatusDB:
+This module provides definition of the DB tables, and methods to access them.
 
-    Written using sqlalchemy declarative_base
+Written using sqlalchemy declarative_base
 
 
-    For extending the ResourceStatusDB tables:
+For extending the ResourceStatusDB tables:
 
-    1) In the extended module, call:
+1) In the extended module, call:
 
-    from DIRAC.ResourceStatusSystem.DB.ResourceStatusDB import rmsBase, TABLESLIST, TABLESLISTWITHID
-    TABLESLIST = TABLESLIST + [list of new table names]
-    TABLESLISTWITHID = TABLESLISTWITHID + [list of new table names]
+from DIRAC.ResourceStatusSystem.DB.ResourceStatusDB import rmsBase, TABLESLIST, TABLESLISTWITHID
+TABLESLIST = TABLESLIST + [list of new table names]
+TABLESLISTWITHID = TABLESLISTWITHID + [list of new table names]
 
-    2) provide a declarative_base definition of the tables (new or extended) in the extension module
+2) provide a declarative_base definition of the tables (new or extended) in the extension module
 
 """
+
 import datetime
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm.query import Query
@@ -26,7 +27,7 @@ from DIRAC.Core.Base.SQLAlchemyDB import SQLAlchemyDB
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
 
 
-TABLESLIST = ["SiteStatus", "ResourceStatus", "NodeStatus"]
+TABLESLIST = ["SiteStatus", "ResourceStatus"]
 
 TABLESLISTWITHID = [
     "ResourceStatusCache",
@@ -34,8 +35,6 @@ TABLESLISTWITHID = [
     "SiteHistory",
     "ResourceLog",
     "ResourceHistory",
-    "NodeLog",
-    "NodeHistory",
 ]
 
 
@@ -238,12 +237,6 @@ class ResourceStatus(ElementStatusBase, rssBase):
     __tablename__ = "ResourceStatus"
 
 
-class NodeStatus(ElementStatusBase, rssBase):
-    """NodeStatus table"""
-
-    __tablename__ = "NodeStatus"
-
-
 # tables with schema defined in ElementStatusBaseWithID
 
 
@@ -269,18 +262,6 @@ class ResourceHistory(ElementStatusBaseWithID, rssBase):
     """ResourceHistory table"""
 
     __tablename__ = "ResourceHistory"
-
-
-class NodeLog(ElementStatusBaseWithID, rssBase):
-    """NodeLog table"""
-
-    __tablename__ = "NodeLog"
-
-
-class NodeHistory(ElementStatusBaseWithID, rssBase):
-    """NodeHistory table"""
-
-    __tablename__ = "NodeHistory"
 
 
 # Interaction with the DB

--- a/src/DIRAC/ResourceStatusSystem/Service/PublisherHandler.py
+++ b/src/DIRAC/ResourceStatusSystem/Service/PublisherHandler.py
@@ -4,6 +4,7 @@ PublisherHandler
 This service has been built to provide the RSS web views with all the information
 they need. NO OTHER COMPONENT THAN Web controllers should make use of it.
 """
+
 #  pylint: disable=no-self-use
 from datetime import datetime, timedelta
 
@@ -156,12 +157,6 @@ class PublisherHandlerMixin:
         return cls.rmClient.selectPolicyResult(
             element=element, name=name, statusType=statusType, meta={"columns": columns}
         )
-
-    types_getNodeStatuses = []
-
-    @classmethod
-    def export_getNodeStatuses(cls):
-        return cls.rsClient.selectStatusElement("Node", "Status")
 
     types_getTree = [str, str]
 

--- a/src/DIRAC/ResourceStatusSystem/Utilities/CSHelpers.py
+++ b/src/DIRAC/ResourceStatusSystem/Utilities/CSHelpers.py
@@ -4,7 +4,6 @@ modules.
 """
 
 from DIRAC import S_OK, gConfig, gLogger
-from DIRAC.ConfigurationSystem.Client.Helpers.Resources import getQueues
 from DIRAC.Core.Utilities.SiteSEMapping import getSEParameters
 from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
 
@@ -76,7 +75,7 @@ def getFileCatalogs():
 
 def getSiteElements(siteName):
     """
-    Gets all the computing and storage elements for a given site
+    Gets all the storage elements for a given site
     """
 
     res = DMSHelpers().getSiteSEMapping()
@@ -84,52 +83,4 @@ def getSiteElements(siteName):
         return res
     resources = res["Value"][1].get(siteName, [])
 
-    res = getQueues(siteName)
-    if not res["OK"]:
-        return res
-    resources = list(resources) + list(res["Value"].get(siteName, []))
-
-    return S_OK(resources)
-
-
-def getQueuesRSS():
-    """
-    Gets all queues from /Resources/Sites/<>/<>/CEs/<>/Queues
-    """
-    _basePath = "Resources/Sites"
-
-    queues = []
-
-    domainNames = gConfig.getSections(_basePath)
-    if not domainNames["OK"]:
-        return domainNames
-    domainNames = domainNames["Value"]
-
-    for domainName in domainNames:
-        domainSites = gConfig.getSections(f"{_basePath}/{domainName}")
-        if not domainSites["OK"]:
-            return domainSites
-        domainSites = domainSites["Value"]
-
-        for site in domainSites:
-            siteCEs = gConfig.getSections(f"{_basePath}/{domainName}/{site}/CEs")
-            if not siteCEs["OK"]:
-                # return siteCEs
-                gLogger.error(siteCEs["Message"])
-                continue
-            siteCEs = siteCEs["Value"]
-
-            for siteCE in siteCEs:
-                siteQueue = gConfig.getSections(f"{_basePath}/{domainName}/{site}/CEs/{siteCE}/Queues")
-                if not siteQueue["OK"]:
-                    # return siteQueue
-                    gLogger.error(siteQueue["Message"])
-                    continue
-                siteQueue = siteQueue["Value"]
-
-                queues.extend(siteQueue)
-
-    # Remove duplicated ( just in case )
-    queues = list(set(queues))
-
-    return S_OK(queues)
+    return S_OK(list(resources))

--- a/src/DIRAC/ResourceStatusSystem/Utilities/RssConfiguration.py
+++ b/src/DIRAC/ResourceStatusSystem/Utilities/RssConfiguration.py
@@ -4,6 +4,7 @@
 Module that collects utility functions.
 
 """
+
 from DIRAC import S_OK
 from DIRAC.Core.Utilities import List
 from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
@@ -106,7 +107,7 @@ def getValidElements():
     """
     Returns from the OperationsHelper: <_rssConfigPath>/GeneralConfig/ValidElements
     """
-    _DEFAULTS = ("Site", "Resource", "Node")
+    _DEFAULTS = ("Site", "Resource")
 
     #  result = Operations().getValue( '%s/GeneralConfig/ValidElements' % _rssConfigPath )
     #  if result is not None:

--- a/src/DIRAC/ResourceStatusSystem/Utilities/Synchronizer.py
+++ b/src/DIRAC/ResourceStatusSystem/Utilities/Synchronizer.py
@@ -1,12 +1,13 @@
-""" Synchronizer
+"""Synchronizer
 
-  Module that keeps the database synchronized with the CS
-  Module that updates the RSS database ( ResourceStatusDB ) with the information
-  in the Resources section. If there are additions in the CS, those are incorporated
-  to the DB. If there are deletions, entries in RSS tables for those elements are
-  deleted ( except the Logs table ).
+Module that keeps the database synchronized with the CS
+Module that updates the RSS database ( ResourceStatusDB ) with the information
+in the Resources section. If there are additions in the CS, those are incorporated
+to the DB. If there are deletions, entries in RSS tables for those elements are
+deleted ( except the Logs table ).
 
 """
+
 from DIRAC import gLogger, S_OK
 from DIRAC.Core.Security.ProxyInfo import getProxyInfo
 from DIRAC.Core.Utilities.ObjectLoader import ObjectLoader
@@ -53,8 +54,8 @@ class Synchronizer:
 
     def sync(self, _eventName, _params):
         """
-        Main synchronizer method. It synchronizes the three types of elements: Sites,
-        Resources and Nodes. Each _syncX method returns a dictionary with the additions
+        Main synchronizer method. It synchronizes the two types of elements: Sites
+        and Resources. Each _syncX method returns a dictionary with the additions
         and deletions.
 
         examples:
@@ -77,10 +78,6 @@ class Synchronizer:
         syncResources = self._syncResources()
         if not syncResources["OK"]:
             gLogger.error(syncResources["Message"])
-
-        syncNodes = self._syncNodes()
-        if not syncNodes["OK"]:
-            gLogger.error(syncNodes["Message"])
 
         return S_OK()
 
@@ -168,20 +165,6 @@ class Synchronizer:
         removingResources = self.__removeNonExistingResourcesFromRM()
         if not removingResources["OK"]:
             gLogger.error(removingResources["Message"])
-
-        return S_OK()
-
-    def _syncNodes(self):
-        """
-        Sync resources: compares CS with DB and does the necessary modifications.
-        ( Queues )
-        """
-        gLogger.info("-- Synchronizing Nodes --")
-
-        gLogger.verbose("-> Queues")
-        queues = self.__syncQueues()
-        if not queues["OK"]:
-            gLogger.error(queues["Message"])
 
         return S_OK()
 
@@ -484,73 +467,6 @@ class Synchronizer:
 
             query = self.rStatus.addIfNotThereStatusElement(
                 "Resource",
-                "Status",
-                name=_name,
-                statusType=_statusType,
-                status=_status,
-                elementType=_elementType,
-                tokenOwner=self.tokenOwner,
-                reason=_reason,
-            )
-            if not query["OK"]:
-                return query
-
-        return S_OK()
-
-    def __syncQueues(self):
-        """
-        Sync Queues: compares CS with DB and does the necessary modifications.
-        """
-
-        queuesCS = CSHelpers.getQueuesRSS()
-        if not queuesCS["OK"]:
-            return queuesCS
-        queuesCS = queuesCS["Value"]
-
-        gLogger.verbose(f"{len(queuesCS)} Queues found in CS")
-
-        queuesDB = self.rStatus.selectStatusElement("Node", "Status", elementType="Queue", meta={"columns": ["Name"]})
-        if not queuesDB["OK"]:
-            return queuesDB
-        queuesDB = [queueDB[0] for queueDB in queuesDB["Value"]]
-
-        # ComputingElements that are in DB but not in CS
-        toBeDeleted = list(set(queuesDB).difference(set(queuesCS)))
-        gLogger.verbose(f"{len(toBeDeleted)} Queues to be deleted")
-
-        # Delete storage elements
-        for queueName in toBeDeleted:
-            deleteQuery = self.rStatus._extermineStatusElement("Node", queueName)
-
-            gLogger.verbose(f"... {queueName}")
-            if not deleteQuery["OK"]:
-                return deleteQuery
-
-        statusTypes = self.rssConfig.getConfigStatusType("Queue")
-        # statusTypes = RssConfiguration.getValidStatusTypes()[ 'Node' ]
-
-        result = self.rStatus.selectStatusElement(
-            "Node", "Status", elementType="Queue", meta={"columns": ["Name", "StatusType"]}
-        )
-        if not result["OK"]:
-            return result
-        queueTuple = [(x[0], x[1]) for x in result["Value"]]
-
-        # For each ( se, statusType ) tuple not present in the DB, add it.
-        queueStatusTuples = [(se, statusType) for se in queuesCS for statusType in statusTypes]
-        toBeAdded = list(set(queueStatusTuples).difference(set(queueTuple)))
-
-        gLogger.verbose(f"{len(toBeAdded)} Queue entries to be added")
-
-        for queueTuple in toBeAdded:
-            _name = queueTuple[0]
-            _statusType = queueTuple[1]
-            _status = self.defaultStatus
-            _reason = "Synchronized"
-            _elementType = "Queue"
-
-            query = self.rStatus.addIfNotThereStatusElement(
-                "Node",
                 "Status",
                 name=_name,
                 statusType=_statusType,

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_list_status.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_list_status.py
@@ -3,6 +3,7 @@
 Script that dumps the DB information for the elements into the standard output.
 If returns information concerning the StatusType and Status attributes.
 """
+
 from DIRAC import exit as DIRACExit
 from DIRAC import gLogger
 from DIRAC.Core.Base.Script import Script
@@ -19,7 +20,7 @@ def registerSwitches():
     """
 
     switches = (
-        ("element=", "Element family to be Synchronized ( Site, Resource or Node )"),
+        ("element=", "Element family to be Synchronized (Site, Resource)"),
         ("elementType=", "ElementType narrows the search; None if default"),
         ("name=", "ElementName; None if default"),
         ("tokenOwner=", "Owner of the token; None if default"),
@@ -58,7 +59,7 @@ def parseSwitches():
         gLogger.error("Please, check documentation below")
         Script.showHelp(exitCode=1)
 
-    if not switches["element"] in ("Site", "Resource", "Node"):
+    if not switches["element"] in ("Site", "Resource"):
         gLogger.error(f"Found {switches['element']} as element switch")
         gLogger.error("Please, check documentation below")
         Script.showHelp(exitCode=1)

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_query_db.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_query_db.py
@@ -3,6 +3,7 @@
 Script that dumps the DB information for the elements into the standard output.
 If returns information concerning the StatusType and Status attributes.
 """
+
 import datetime
 
 from DIRAC import S_OK
@@ -23,7 +24,7 @@ def registerSwitches():
     """
 
     switches = (
-        ("element=", "Element family to be Synchronized ( Site, Resource, Node )"),
+        ("element=", "Element family to be Synchronized (Site, Resource"),
         ("tableType=", "A valid table type (Status, Log, History)"),
         ("name=", "ElementName (comma separated list allowed); None if default"),
         (
@@ -54,7 +55,7 @@ def parseSwitches():
         error("Missing all mandatory 'query', 'element', 'tableType' arguments")
     elif args[0].lower() not in ("select", "add", "modify", "delete"):
         error("Incorrect 'query' argument")
-    elif args[1].lower() not in ("site", "resource", "component", "node"):
+    elif args[1].lower() not in ("site", "resource"):
         error("Incorrect 'element' argument")
     elif args[2].lower() not in ("status", "log", "history"):
         error("Incorrect 'tableType' argument")

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_status.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_status.py
@@ -4,6 +4,7 @@ Script that facilitates the modification of a element through the command line.
 However, the usage of this script will set the element token to the command
 issuer with a duration of 1 day.
 """
+
 from datetime import datetime, timedelta
 
 from DIRAC import S_OK, gLogger
@@ -22,7 +23,7 @@ def registerSwitches():
     """
 
     switches = (
-        ("element=", "Element family to be Synchronized ( Site, Resource or Node )"),
+        ("element=", "Element family to be Synchronized (Site, Resource)"),
         ("name=", "Name (or comma-separeted list of names) of the element where the change applies"),
         ("statusType=", "StatusType (or comma-separeted list of names), if none applies to all possible statusTypes"),
         ("status=", "Status to be changed"),
@@ -59,14 +60,14 @@ def parseSwitches():
             gLogger.error("Please, check documentation below")
             Script.showHelp(exitCode=1)
 
-    if not switches["element"] in ("Site", "Resource", "Node"):
+    if switches["element"] not in ("Site", "Resource"):
         gLogger.error(f"Found {switches['element']} as element switch")
         gLogger.error("Please, check documentation below")
         Script.showHelp(exitCode=1)
 
     statuses = StateMachine.RSSMachine(None).getStates()
 
-    if not switches["status"] in statuses:
+    if switches["status"] not in statuses:
         gLogger.error(f"Found {switches['element']} as element switch")
         gLogger.error("Please, check documentation below")
         Script.showHelp(exitCode=1)

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_token.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_set_token.py
@@ -7,6 +7,7 @@ If the releaseToken switch is used, no matter what was the previous token, it wi
 If not set, the token will be set to whatever username is defined on the proxy loaded while issuing
 this command. In the second case, the token lasts one day.
 """
+
 from datetime import datetime, timedelta
 
 # DIRAC
@@ -27,7 +28,7 @@ def registerSwitches():
     """
 
     switches = (
-        ("element=", "Element family to be Synchronized ( Site, Resource or Node )"),
+        ("element=", "Element family to be Synchronized (Site, Resource)"),
         ("name=", "Name, name of the element where the change applies"),
         ("statusType=", "StatusType, if none applies to all possible statusTypes"),
         ("reason=", "Reason to set the Status"),
@@ -67,7 +68,7 @@ def parseSwitches():
             gLogger.error("Please, check documentation above")
             Script.showHelp(exitCode=1)
 
-    if not switches["element"] in ("Site", "Resource", "Node"):
+    if switches["element"] not in ("Site", "Resource"):
         gLogger.error(f"Found {switches['element']} as element switch")
         gLogger.error("Please, check documentation above")
         Script.showHelp(exitCode=1)

--- a/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_sync.py
+++ b/src/DIRAC/ResourceStatusSystem/scripts/dirac_rss_sync.py
@@ -6,6 +6,7 @@ reason to `Synchronized`. However, it can copy over the status on the CS to
 the RSS. Important: If the StatusType is not defined on the CS, it will set
 it to Active !
 """
+
 from DIRAC import S_OK
 from DIRAC import exit as DIRACExit
 from DIRAC import gLogger
@@ -24,7 +25,7 @@ def registerSwitches():
     Script.registerSwitch(
         "", "init", "Initialize the element to the status in the CS ( applicable for StorageElements )"
     )
-    Script.registerSwitch("", "element=", "Element family to be Synchronized ( Site, Resource or Node ) or `all`")
+    Script.registerSwitch("", "element=", "Element family to be Synchronized ( Site or Resource ) or `all`")
     Script.registerSwitch("", "defaultStatus=", "Default element status if not given in the CS")
 
 
@@ -45,7 +46,7 @@ def parseSwitches():
     # Default values
     switches.setdefault("element", None)
     switches.setdefault("defaultStatus", "Active")
-    if not switches["element"] in ("all", "Site", "Resource", "Node", None):
+    if not switches["element"] in ("all", "Site", "Resource", None):
         gLogger.error(f"Found {switches['element']} as element switch")
         gLogger.error("Please, check documentation below")
         Script.showHelp(exitCode=1)
@@ -76,12 +77,6 @@ def synchronize():
     if switchDict["element"] in ("Resource", "all"):
         gLogger.info("Synchronizing Resource")
         res = synchronizer._syncResources()
-        if not res["OK"]:
-            return res
-
-    if switchDict["element"] in ("Node", "all"):
-        gLogger.info("Synchronizing Nodes")
-        res = synchronizer._syncNodes()
         if not res["OK"]:
             return res
 

--- a/tests/Integration/ResourceStatusSystem/Test_Publisher.py
+++ b/tests/Integration/ResourceStatusSystem/Test_Publisher.py
@@ -1,6 +1,6 @@
-""" This is a test of the PublisherHandler
+"""This is a test of the PublisherHandler
 
-    It supposes that the RSS DBs are present, and that the service is running
+It supposes that the RSS DBs are present, and that the service is running
 """
 # pylint: disable=wrong-import-position
 
@@ -29,9 +29,6 @@ def test_Get():
     assert res["OK"] is True, res["Message"]
 
     res = publisher.getElementPolicies("Site", None, None)
-    assert res["OK"] is True, res["Message"]
-
-    res = publisher.getNodeStatuses()
     assert res["OK"] is True, res["Message"]
 
     res = publisher.getTree("", "")


### PR DESCRIPTION
BEGINRELEASENOTES

*docs
NEW: added RSS technical documentation

*RSS
CHANGE: Removed nodes (queues) tables

*Deployment
CHANGE: USE ResourceStatusDB; DROP TABLE `NodeHistory`; DROP TABLE `NodeLog`; DROP TABLE `NodeStatus`;

ENDRELEASENOTES
