### PR TITLE
fix: use PEP8 compliant pyparsing method name

### DIFF
--- a/src/DIRAC/Resources/Catalog/FCConditionParser.py
+++ b/src/DIRAC/Resources/Catalog/FCConditionParser.py
@@ -191,7 +191,7 @@ class FCConditionParser:
         """
 
         # Whenever we parse text matching the __pluginOperand grammar, create a PluginOperand object
-        self.__pluginOperand.setParseAction(lambda tokens: self.PluginOperand(tokens))
+        self.__pluginOperand.set_parse_action(lambda tokens: self.PluginOperand(tokens))
 
         self.opHelper = Operations(vo=vo)
 


### PR DESCRIPTION
## Summary
- Replace deprecated `setParseAction` with `set_parse_action` in `FCConditionParser`
- The snake_case method names were introduced in pyparsing 3.0.0 (August 2021)
- Deprecation warnings for the legacy camelCase names started in pyparsing 3.3.0