### PR TITLE
fix: include LICENSE file in dirac-common sdist and wheel

### DIFF
--- a/dirac-common/pyproject.toml
+++ b/dirac-common/pyproject.toml
@@ -49,6 +49,9 @@ include = [
     "/tests",
 ]
 
+[tool.hatch.build.targets.sdist.force-include]
+"../LICENSE" = "LICENSE"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/DIRACCommon"]
 


### PR DESCRIPTION
## Summary
- The `dirac-common` sub-package was missing the LICENSE file in published sdists and wheels because hatchling only auto-discovers license files in the package's own directory, not the monorepo root
- Added `[tool.hatch.build.targets.sdist.force-include]` to `dirac-common/pyproject.toml` to pull the root `LICENSE` into the sdist
- The wheel (built from the sdist) then auto-discovers the LICENSE and places it in `.dist-info/licenses/`