### PR TITLE
fix: cache SandboxMetadataDB instance instead of recreating per job

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobCleaningAgent.py
@@ -54,6 +54,7 @@ class JobCleaningAgent(AgentModule):
 
         # clients
         self.jobDB = None
+        self.sandboxDB = None
 
         self.maxJobsAtOnce = 500
         self.prodTypes = []
@@ -66,6 +67,7 @@ class JobCleaningAgent(AgentModule):
         """Sets defaults"""
 
         self.jobDB = JobDB()
+        self.sandboxDB = SandboxMetadataDB()
 
         agentTSTypes = self.am_getOption("ProductionTypes", [])
         if agentTSTypes:
@@ -156,7 +158,7 @@ class JobCleaningAgent(AgentModule):
         self.log.info("Unassigning sandboxes from soon to be deleted jobs", f"({len(jobList)})")
 
         entitiesList = [f"Job:{jobId}" for jobId in jobList]
-        if not (result := SandboxMetadataDB().unassignEntities(entitiesList))["OK"]:
+        if not (result := self.sandboxDB.unassignEntities(entitiesList))["OK"]:
             self.log.error("Cannot unassign jobs to sandboxes", result["Message"])
             return result
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobCleaningAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/test/Test_Agent_JobCleaningAgent.py
@@ -32,6 +32,9 @@ def jca(mocker):
     )
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.JobDB.selectJobs", side_effect=mockReply)
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.JobDB.__init__", side_effect=mockNone)
+    mocker.patch(
+        "DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.SandboxMetadataDB.__init__", side_effect=mockNone
+    )
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.ReqClient", return_value=mockNone)
 
     jca = JobCleaningAgent()
@@ -126,6 +129,7 @@ def test_deleteJobOversizedSandbox(mocker, inputs, params, expected):
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.AgentModule.__init__")
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.AgentModule.am_getOption", return_value=mockAM)
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.JobDB", return_value=mockNone)
+    mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.SandboxMetadataDB", return_value=mockNone)
     mocker.patch("DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.ReqClient", return_value=mockNone)
     mocker.patch(
         "DIRAC.WorkloadManagementSystem.Agent.JobCleaningAgent.getDNForUsername", return_value=S_OK(["/bih/boh/DN"])

--- a/src/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py
+++ b/src/DIRAC/WorkloadManagementSystem/Executor/JobSanity.py
@@ -15,6 +15,7 @@ class JobSanity(OptimizerExecutor):
     @classmethod
     def initializeOptimizer(cls):
         """Initialize specific parameters for JobSanityAgent."""
+        cls.sandboxDB = SandboxMetadataDB()
         return S_OK()
 
     def optimizeJob(self, jid, jobState):
@@ -57,7 +58,7 @@ class JobSanity(OptimizerExecutor):
             return S_OK(0)
         self.jobLog.info("Assigning sandboxes", f"({numSBsToAssign} on behalf of {ownerName}@{ownerGroup}@{vo})")
         eId = f"Job:{jobState.jid}"
-        result = SandboxMetadataDB().assignSandboxesToEntities({eId: sbsToAssign}, ownerName, ownerGroup)
+        result = self.sandboxDB.assignSandboxesToEntities({eId: sbsToAssign}, ownerName, ownerGroup)
         if not result["OK"]:
             self.jobLog.error("Could not assign sandboxes in the SandboxStore")
             return result


### PR DESCRIPTION
- Cache `SandboxMetadataDB` in `JobSanity.initializeOptimizer()` and `JobCleaningAgent.initialize()` instead of creating a new instance on every call
- Each instantiation was triggering a config lookup, connection pool ping, `SHOW TABLES` query, and table schema check unnecessarily

BEGINRELEASENOTES
*WorkloadManagement
FIX: cache SandboxMetadataDB instance in JobSanity and JobCleaningAgent to avoid unnecessary DB overhead per job
ENDRELEASENOTES