### PR TITLE
fix: Add missing indices to PilotAgentsDB and JobDB

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.sql
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.sql
@@ -65,7 +65,8 @@ CREATE TABLE `Jobs` (
   KEY `MinorStatus` (`MinorStatus`),
   KEY `ApplicationStatus` (`ApplicationStatus`),
   KEY `StatusSite` (`Status`,`Site`),
-  KEY `LastUpdateTime` (`LastUpdateTime`)
+  KEY `LastUpdateTime` (`LastUpdateTime`),
+  KEY `JobName` (`JobName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ------------------------------------------------------------------------------

--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.sql
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.sql
@@ -45,7 +45,8 @@ CREATE TABLE `PilotAgents` (
   PRIMARY KEY (`PilotID`),
   KEY `PilotJobReference` (`PilotJobReference`),
   KEY `Status` (`Status`),
-  KEY `Statuskey` (`GridSite`,`DestinationSite`,`Status`)
+  KEY `Statuskey` (`GridSite`,`DestinationSite`,`Status`),
+  KEY `idx_dest_queue_status` (`DestinationSite`,`Queue`,`Status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 


### PR DESCRIPTION
Two hot-path queries are doing full table scans due to missing indices:

1. **PilotAgentsDB** — `SiteDirector.countPilots()` filters on `(DestinationSite, Queue, Status)` every scheduling cycle. The existing `Statuskey` index is `(GridSite, DestinationSite, Status)` which doesn't cover `Queue` and has the wrong leading column for this query. A composite `idx_dest_queue_status` index is added.

2. **JobDB** — `WorkflowTasks.updateTransformationReservedTasks()` calls `getJobs({"JobName": jobNames})`, which does `SELECT JobID FROM Jobs WHERE JobName IN (...)`. `JobName` had no index at all, causing a full table scan. Also hit by `dstat.py` and the REST API. A `JobName` index is added.

Both are pure schema changes to the `.sql` definition files. For existing deployments the schema change only takes effect on newly created tables (`__initializeDB` skips tables that already exist). Production DBs need a one-off `ALTER TABLE` to add the indices.

BEGINRELEASENOTES
*WorkloadManagement
FIX: Add composite (DestinationSite, Queue, Status) index to PilotAgents table for SiteDirector.countPilots()
FIX: Add JobName index to Jobs table for TransformationSystem and monitoring lookups

*Deployment
CHANGE: USE JobDB; ALTER TABLE `Jobs` ADD INDEX `JobName` (`JobName`), ALGORITHM=INPLACE, LOCK=NONE;
CHANGE: USE PilotAgentsDB; ALTER Table `PilotAgents` ADD INDEX `idx_dest_queue_status` (`DestinationSite`,`Queue`,`Status`), ALGORITHM=INPLACE, LOCK=NONE;

ENDRELEASENOTES