### PR TITLE
feat: add UseDiracXBackendOnly CS option to SandboxStore

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/WorkloadManagementSystem/ConfigTemplate.cfg
@@ -126,6 +126,8 @@ Services
     BasePath = /opt/dirac/storage/sandboxes
     # If true, uploads the sandbox via diracx on an S3 storage
     UseDiracXBackend = False
+    # If true, all sandbox operations use diracx exclusively and local purging is disabled
+    UseDiracXBackendOnly = False
     Authorization
     {
       Default = authenticated
@@ -144,6 +146,10 @@ Services
     MaxThreads = 200
     MaxSandboxSizeMiB = 10
     BasePath = /opt/dirac/storage/sandboxes
+    # If true, uploads the sandbox via diracx on an S3 storage
+    UseDiracXBackend = False
+    # If true, all sandbox operations use diracx exclusively and local purging is disabled
+    UseDiracXBackendOnly = False
     Authorization
     {
       Default = authenticated

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -46,7 +46,10 @@ class SandboxStoreHandlerMixin:
     def initializeRequest(self):
         self.__localSEName = self.getCSOption("LocalSE", "SandboxSE")
         self._useDiracXBackend = self.getCSOption("UseDiracXBackend", False)
+        self._useDiracXBackendOnly = self.getCSOption("UseDiracXBackendOnly", False)
         self._maxUploadBytes = self.getCSOption("MaxSandboxSizeMiB", 10) * 1048576
+        if self._useDiracXBackendOnly:
+            return
         # Execute the purge once every 1000 calls
         SandboxStoreHandler.__purgeCount += 1
         if SandboxStoreHandler.__purgeCount > 1000:
@@ -97,7 +100,7 @@ class SandboxStoreHandlerMixin:
         vo = credDict.get("VO", Registry.getVOForGroup(credDict["group"]))
 
         disabledVOs = gConfig.getValue("/DiracX/DisabledVOs", [])
-        if self._useDiracXBackend and vo not in disabledVOs:
+        if self._useDiracXBackendOnly or (self._useDiracXBackend and vo not in disabledVOs):
             gLogger.info("Forwarding to DiracX")
             with tempfile.TemporaryFile(mode="w+b") as tar_fh:
                 result = fileHelper.networkToDataSink(tar_fh, maxFileSize=self._maxUploadBytes)


### PR DESCRIPTION
BEGINRELEASENOTES

*WorkloadManagement
NEW: add `UseDiracXBackendOnly` CS option to SandboxStore to make DiracX the exclusive sandbox backend and disable local purging

ENDRELEASENOTES