### PR TITLE
[9.0] fix: disable cleanup on failed FTS transfers

### DIFF
--- a/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
+++ b/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
@@ -661,6 +661,7 @@ class FTS3Job(JSerializable):
         job = fts3.new_job(
             transfers=transfers,
             overwrite=True,
+            disable_cleanup=True,
             source_spacetoken=source_spacetoken,
             bring_online=bring_online,
             copy_pin_lifetime=copy_pin_lifetime,
@@ -804,6 +805,7 @@ class FTS3Job(JSerializable):
         job = fts3.new_job(
             transfers=transfers,
             overwrite=True,
+            disable_cleanup=True,
             source_spacetoken=target_spacetoken,
             bring_online=bring_online,
             copy_pin_lifetime=copy_pin_lifetime,


### PR DESCRIPTION
Closes https://github.com/DIRACGrid/DIRAC/issues/8465

BEGINRELEASENOTES

*DMS
CHANGE: FTS3 jobs don't call delete when TPC fails

ENDRELEASENOTES
