### PR TITLE
fix(DISET): prevent services from getting permanently stuck in throttle mode

### DIFF
--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -200,7 +200,6 @@ class ServiceReactor:
                                   services at the same time
         """
         sel = self.__getListeningSelector(svcName)
-        throttleExpires = None
         while self.__alive:
             clientTransport = None
             try:
@@ -224,16 +223,13 @@ class ServiceReactor:
                 gLogger.warn(f"Client connected from banned ip {clientIP}")
                 clientTransport.close()
                 continue
-            # Handle throttling
-            if self.__services[svcName].wantsThrottle and throttleExpires is None:
-                throttleExpires = time.time() + THROTTLE_SERVICE_SLEEP_SECONDS
-            if throttleExpires:
-                if time.time() > throttleExpires:
-                    throttleExpires = None
-                else:
-                    gLogger.warn("Rejecting client due to throttling", str(clientTransport.getRemoteAddress()))
-                    clientTransport.close()
-                    continue
+            # Handle throttling: reject all connections while overloaded
+            # to prevent queue growth when threads are stuck
+            if self.__services[svcName].wantsThrottle:
+                gLogger.warn("Rejecting client due to throttling", str(clientTransport.getRemoteAddress()))
+                clientTransport.close()
+                time.sleep(THROTTLE_SERVICE_SLEEP_SECONDS)
+                continue
             # Handle connection
             self.__stats.connectionStablished()
             self.__services[svcName].handleConnection(clientTransport)

--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -31,9 +31,6 @@ from DIRAC.Core.DISET.private.Protocols import gProtocolDict
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.ConfigurationSystem.Client import PathFinder
 
-#: Interval between periodic throttle warning messages (seconds)
-THROTTLE_LOG_INTERVAL_SECONDS = 30
-
 
 class ServiceReactor:
     __transportExtraKeywords = {
@@ -199,8 +196,6 @@ class ServiceReactor:
                                   services at the same time
         """
         sel = self.__getListeningSelector(svcName)
-        throttleStartedAt = None
-        lastThrottleLog = 0
         while self.__alive:
             clientTransport = None
             try:
@@ -225,33 +220,17 @@ class ServiceReactor:
                 clientTransport.close()
                 continue
             # Handle throttling: reject all connections while overloaded
-            # to prevent queue growth when threads are stuck
-            if self.__services[svcName].wantsThrottle:
-                now = time.time()
-                if throttleStartedAt is None:
-                    throttleStartedAt = now
-                    diag = self.__services[svcName].throttleDiagnostics()
-                    gLogger.warn(
-                        f"Service {svcName} entering throttle mode",
-                        f"queue={diag['queue']}/{diag['maxQueue']}, " f"threads={diag['threads']}/{diag['maxThreads']}",
-                    )
-                    lastThrottleLog = now
-                elif now - lastThrottleLog >= THROTTLE_LOG_INTERVAL_SECONDS:
-                    duration = now - throttleStartedAt
-                    diag = self.__services[svcName].throttleDiagnostics()
-                    gLogger.warn(
-                        f"Service {svcName} still throttling",
-                        f"duration={duration:.0f}s, queue={diag['queue']}/{diag['maxQueue']}, "
-                        f"threads={diag['threads']}/{diag['maxThreads']}",
-                    )
-                    lastThrottleLog = now
+            # to prevent queue growth when threads are stuck.
+            # wantsThrottle also handles state tracking and diagnostic logging.
+            svc = self.__services[svcName]
+            if svc.wantsThrottle:
                 # Check if throttle has exceeded the maximum allowed duration
-                maxThrottleDuration = self.__services[svcName].getConfig().getMaxThrottleDuration()
-                if maxThrottleDuration > 0 and (now - throttleStartedAt) > maxThrottleDuration:
-                    diag = self.__services[svcName].throttleDiagnostics()
+                maxThrottleDuration = svc.getConfig().getMaxThrottleDuration()
+                if maxThrottleDuration > 0 and svc.throttleDuration > maxThrottleDuration:
+                    diag = svc.throttleDiagnostics()
                     gLogger.fatal(
                         f"Service {svcName} stuck in throttle, initiating process restart",
-                        f"duration={now - throttleStartedAt:.0f}s (limit: {maxThrottleDuration}s), "
+                        f"duration={svc.throttleDuration:.0f}s (limit: {maxThrottleDuration}s), "
                         f"queue={diag['queue']}/{diag['maxQueue']}, "
                         f"threads={diag['threads']}/{diag['maxThreads']}",
                     )
@@ -261,10 +240,6 @@ class ServiceReactor:
                 gLogger.warn("Rejecting client due to throttling", str(clientTransport.getRemoteAddress()))
                 clientTransport.close()
                 continue
-            if throttleStartedAt is not None:
-                duration = time.time() - throttleStartedAt
-                gLogger.info(f"Service {svcName} throttle cleared", f"duration={duration:.1f}s")
-                throttleStartedAt = None
             # Handle connection
             self.__stats.connectionStablished()
             self.__services[svcName].handleConnection(clientTransport)

--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -244,16 +244,31 @@ class ServiceReactor:
                     duration = now - throttleStartedAt
                     diag = self.__services[svcName].throttleDiagnostics()
                     gLogger.warn(
-                        f"Service {svcName} still throttling after {duration:.0f}s",
-                        f"queue={diag['queue']}/{diag['maxQueue']}, " f"threads={diag['threads']}/{diag['maxThreads']}",
+                        f"Service {svcName} still throttling",
+                        f"duration={duration:.0f}s, queue={diag['queue']}/{diag['maxQueue']}, "
+                        f"threads={diag['threads']}/{diag['maxThreads']}",
                     )
                     lastThrottleLog = now
+                # Check if throttle has exceeded the maximum allowed duration
+                maxThrottleDuration = self.__services[svcName].getConfig().getMaxThrottleDuration()
+                if maxThrottleDuration > 0 and (now - throttleStartedAt) > maxThrottleDuration:
+                    diag = self.__services[svcName].throttleDiagnostics()
+                    gLogger.fatal(
+                        f"Service {svcName} stuck in throttle, initiating process restart",
+                        f"duration={now - throttleStartedAt:.0f}s (limit: {maxThrottleDuration}s), "
+                        f"queue={diag['queue']}/{diag['maxQueue']}, "
+                        f"threads={diag['threads']}/{diag['maxThreads']}",
+                    )
+                    clientTransport.close()
+                    self.__alive = False
+                    return
+                gLogger.warn("Rejecting client due to throttling", str(clientTransport.getRemoteAddress()))
                 clientTransport.close()
                 time.sleep(THROTTLE_SERVICE_SLEEP_SECONDS)
                 continue
             if throttleStartedAt is not None:
                 duration = time.time() - throttleStartedAt
-                gLogger.info(f"Service {svcName} throttle cleared after {duration:.1f}s")
+                gLogger.info(f"Service {svcName} throttle cleared", f"duration={duration:.1f}s")
                 throttleStartedAt = None
             # Handle connection
             self.__stats.connectionStablished()

--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -31,10 +31,6 @@ from DIRAC.Core.DISET.private.Protocols import gProtocolDict
 from DIRAC.ConfigurationSystem.Client.Helpers import Registry
 from DIRAC.ConfigurationSystem.Client import PathFinder
 
-#: Time during which the service does not accept new requests and handles those in the queue, if the backlog is too large
-#: This sleep is repeated for as long as Service.wantsThrottle is truthy
-THROTTLE_SERVICE_SLEEP_SECONDS = 0.25
-
 #: Interval between periodic throttle warning messages (seconds)
 THROTTLE_LOG_INTERVAL_SECONDS = 30
 
@@ -264,7 +260,6 @@ class ServiceReactor:
                     return
                 gLogger.warn("Rejecting client due to throttling", str(clientTransport.getRemoteAddress()))
                 clientTransport.close()
-                time.sleep(THROTTLE_SERVICE_SLEEP_SECONDS)
                 continue
             if throttleStartedAt is not None:
                 duration = time.time() - throttleStartedAt

--- a/src/DIRAC/Core/DISET/ServiceReactor.py
+++ b/src/DIRAC/Core/DISET/ServiceReactor.py
@@ -35,6 +35,9 @@ from DIRAC.ConfigurationSystem.Client import PathFinder
 #: This sleep is repeated for as long as Service.wantsThrottle is truthy
 THROTTLE_SERVICE_SLEEP_SECONDS = 0.25
 
+#: Interval between periodic throttle warning messages (seconds)
+THROTTLE_LOG_INTERVAL_SECONDS = 30
+
 
 class ServiceReactor:
     __transportExtraKeywords = {
@@ -200,6 +203,8 @@ class ServiceReactor:
                                   services at the same time
         """
         sel = self.__getListeningSelector(svcName)
+        throttleStartedAt = None
+        lastThrottleLog = 0
         while self.__alive:
             clientTransport = None
             try:
@@ -226,10 +231,30 @@ class ServiceReactor:
             # Handle throttling: reject all connections while overloaded
             # to prevent queue growth when threads are stuck
             if self.__services[svcName].wantsThrottle:
-                gLogger.warn("Rejecting client due to throttling", str(clientTransport.getRemoteAddress()))
+                now = time.time()
+                if throttleStartedAt is None:
+                    throttleStartedAt = now
+                    diag = self.__services[svcName].throttleDiagnostics()
+                    gLogger.warn(
+                        f"Service {svcName} entering throttle mode",
+                        f"queue={diag['queue']}/{diag['maxQueue']}, " f"threads={diag['threads']}/{diag['maxThreads']}",
+                    )
+                    lastThrottleLog = now
+                elif now - lastThrottleLog >= THROTTLE_LOG_INTERVAL_SECONDS:
+                    duration = now - throttleStartedAt
+                    diag = self.__services[svcName].throttleDiagnostics()
+                    gLogger.warn(
+                        f"Service {svcName} still throttling after {duration:.0f}s",
+                        f"queue={diag['queue']}/{diag['maxQueue']}, " f"threads={diag['threads']}/{diag['maxThreads']}",
+                    )
+                    lastThrottleLog = now
                 clientTransport.close()
                 time.sleep(THROTTLE_SERVICE_SLEEP_SECONDS)
                 continue
+            if throttleStartedAt is not None:
+                duration = time.time() - throttleStartedAt
+                gLogger.info(f"Service {svcName} throttle cleared after {duration:.1f}s")
+                throttleStartedAt = None
             # Handle connection
             self.__stats.connectionStablished()
             self.__services[svcName].handleConnection(clientTransport)

--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -286,6 +286,15 @@ class Service:
         nQueued = self._threadPool._work_queue.qsize()
         return nQueued > self._cfg.getMaxWaitingPetitions()
 
+    def throttleDiagnostics(self):
+        """Return a dict of diagnostics useful for throttle logging"""
+        return {
+            "queue": self._threadPool._work_queue.qsize(),
+            "maxQueue": self._cfg.getMaxWaitingPetitions(),
+            "threads": len(self._threadPool._threads),
+            "maxThreads": self._cfg.getMaxThreads(),
+        }
+
     # Threaded process function
     def _processInThread(self, clientTransport):
         """

--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -32,6 +32,10 @@ from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 from DIRAC.FrameworkSystem.Client.SecurityLogClient import SecurityLogClient
 
 
+#: Interval between periodic throttle warning messages (seconds)
+THROTTLE_LOG_INTERVAL_SECONDS = 30
+
+
 class Service:
     SVC_VALID_ACTIONS = {"RPC": "export", "FileTransfer": "transfer", "Message": "msg", "Connection": "Message"}
     SVC_SECLOG_CLIENT = SecurityLogClient()
@@ -62,6 +66,8 @@ class Service:
         self._transportPool = getGlobalTransportPool()
         self.__cloneId = 0
         self.__maxFD = 0
+        self._throttleStartedAt = None
+        self._lastThrottleLog = 0
         self.activityMonitoring = False
         # Check if monitoring is enabled
         if "Monitoring" in Operations().getMonitoringBackends(monitoringType="ServiceMonitoring"):
@@ -282,9 +288,47 @@ class Service:
 
     @property
     def wantsThrottle(self):
-        """Boolean property for if the service wants requests to stop being accepted"""
+        """Boolean property for if the service wants requests to stop being accepted.
+
+        Also maintains throttle duration tracking: records when throttling
+        started and logs state transitions and periodic diagnostics.
+        Returns True if the service should reject incoming connections.
+        """
         nQueued = self._threadPool._work_queue.qsize()
-        return nQueued > self._cfg.getMaxWaitingPetitions()
+        shouldThrottle = nQueued > self._cfg.getMaxWaitingPetitions()
+
+        now = time.time()
+        if shouldThrottle:
+            if self._throttleStartedAt is None:
+                self._throttleStartedAt = now
+                self._lastThrottleLog = now
+                diag = self.throttleDiagnostics()
+                gLogger.warn(
+                    f"Service {self._name} entering throttle mode",
+                    f"queue={diag['queue']}/{diag['maxQueue']}, " f"threads={diag['threads']}/{diag['maxThreads']}",
+                )
+            elif now - self._lastThrottleLog >= THROTTLE_LOG_INTERVAL_SECONDS:
+                duration = now - self._throttleStartedAt
+                diag = self.throttleDiagnostics()
+                gLogger.warn(
+                    f"Service {self._name} still throttling",
+                    f"duration={duration:.0f}s, queue={diag['queue']}/{diag['maxQueue']}, "
+                    f"threads={diag['threads']}/{diag['maxThreads']}",
+                )
+                self._lastThrottleLog = now
+        elif self._throttleStartedAt is not None:
+            duration = now - self._throttleStartedAt
+            gLogger.info(f"Service {self._name} throttle cleared", f"duration={duration:.1f}s")
+            self._throttleStartedAt = None
+
+        return shouldThrottle
+
+    @property
+    def throttleDuration(self):
+        """Seconds the service has been continuously throttling, or 0 if not throttling."""
+        if self._throttleStartedAt is None:
+            return 0
+        return time.time() - self._throttleStartedAt
 
     def throttleDiagnostics(self):
         """Return a dict of diagnostics useful for throttle logging"""

--- a/src/DIRAC/Core/DISET/private/ServiceConfiguration.py
+++ b/src/DIRAC/Core/DISET/private/ServiceConfiguration.py
@@ -121,6 +121,18 @@ class ServiceConfiguration:
         self.setURL(serviceURL)
         return serviceURL
 
+    def getMaxThrottleDuration(self):
+        """Maximum seconds a service can remain in throttle mode before triggering a restart.
+
+        Set to 0 to disable auto-restart (default).
+        When the throttle duration exceeds this value, the service process exits
+        to allow the process supervisor (e.g. runsv) to restart it cleanly.
+        """
+        try:
+            return int(self.getOption("MaxThrottleDuration"))
+        except Exception:
+            return 0
+
     def getContextLifeTime(self):
         optionValue = self.getOption("ContextLifeTime")
         try:


### PR DESCRIPTION
Production DISET services can enter throttle mode and never recover, requiring manual restarts. This PR addresses the root cause and adds safety mechanisms:

- **Fix throttle logic**: The previous mechanism accepted one connection every 0.25s even while overloaded. When threads were stuck (blocked DB queries, deadlocks, etc.), each accepted connection grew the queue further, making recovery impossible. Now **all** connections are rejected while `wantsThrottle` is True, and the unnecessary 0.25s sleep between rejections is removed — `sel.select(timeout=10)` already rate-limits when no connections arrive.
- **Add diagnostic logging**: Throttle state tracking (start time, periodic diagnostics) is maintained as Service instance state, persisting across `__acceptIncomingConnection` re-entries. Logs WARN on entry with queue/thread stats, periodic WARN every 30s, and INFO on clear with duration.
- **Add configurable auto-restart**: New `MaxThrottleDuration` CS option (default: 0 = disabled). When enabled, the service process exits after the specified seconds of continuous throttling, allowing the process supervisor (runsv) to restart it cleanly. Duration tracking is reliable since it lives on the Service instance rather than as a local variable that resets on select timeouts.

## Operational Impact

### Behavioral change
Previously, a throttled service would still accept 1 connection every 0.25s (~4 req/s). Now it rejects all connections while throttled. This means:
- Clients will see rejections sooner during genuine overload, rather than queueing behind stuck threads
- Transient load spikes will still recover naturally (throttle clears once queue drains)
- **Net positive**: prevents the self-reinforcing stuck state that required manual restarts

### New logging
- WARN on throttle entry with `queue=X/Y, threads=X/Y` diagnostics
- WARN every 30s while throttling persists with updated stats
- INFO when throttle clears with total duration
- Existing per-rejection WARN is preserved for monitoring
- State persists across `__acceptIncomingConnection` re-entries (no duplicate "entering" logs)

### Auto-restart
- **Disabled by default** (`MaxThrottleDuration = 0`)
- Opt-in per service via CS: `Systems/<System>/Services/<Service>/MaxThrottleDuration = 600`
- When enabled and throttle exceeds the limit, emits a FATAL log and exits
- Requires a process supervisor (runsv, systemd, etc.) to restart the service
- Duration accumulates correctly even when connections arrive slowly (state on Service instance, not local variable)

### Recommended deployment
1. Deploy with auto-restart disabled (default) to validate the throttle fix
2. Monitor logs for throttle duration patterns
3. Enable `MaxThrottleDuration` for services known to get stuck (suggested starting value: 600s)

## Test plan
- [ ] Hotfix into a service which throttles frequently and validate behavior

BEGINRELEASENOTES
*Core
FIX: prevent DISET services from getting permanently stuck in throttle mode by rejecting all connections while overloaded instead of accepting one every 0.25s
NEW: add throttle duration tracking with diagnostic logging (queue/thread stats on entry, periodic warnings, clear notification)
NEW: add configurable MaxThrottleDuration CS option to auto-restart services stuck in throttle mode (default: disabled)
ENDRELEASENOTES