### PR TITLE
fix: pass job id to cwl job wrapper template

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Utilities/Utils.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/Utils.py
@@ -1,5 +1,5 @@
-""" Utilities for WMS
-"""
+"""Utilities for WMS"""
+
 import os
 from pathlib import Path
 from glob import glob
@@ -161,7 +161,7 @@ pixi install --manifest-path {protoPath}
 # Get json
 dirac-wms-job-get-input {jobID} -D {rootLocation}
 # Run JobWrapper
-pixi run --manifest-path {protoPath} python {directJobWrapperFile} {directJobWrapperJsonFile}
+pixi run --manifest-path {protoPath} python {directJobWrapperFile} {directJobWrapperJsonFile} {jobID}
 """
     return S_OK((jobWrapperFile, jobWrapperJsonFile, jobExeFile, jobFileContents))
 


### PR DESCRIPTION
A simple fix to pass the Job ID to the dirac-cwl job wrapper.

This is notably needed for https://github.com/DIRACGrid/dirac-cwl/issues/83.

closes #8447.

BEGINRELEASENOTES

*WorkloadManagementSystem
FIX: pass the job ID to the dirac-cwl job wrapper

ENDRELEASENOTES
