### PR TITLE
fix(tests): Replace removed egg syntax for installing client in CI

### DIFF
--- a/docs/source/AdministratorGuide/HowTo/SystemAdministratorInterface.rst
+++ b/docs/source/AdministratorGuide/HowTo/SystemAdministratorInterface.rst
@@ -256,8 +256,8 @@ A version can be:
 
 * a PEP440 valid version of DIRAC.
 * a PEP440 valid version of a DIRAC extension.
-* "integration" or "devel" or "master" or "main" would all be interpreted as git+https://github.com/DIRACGrid/DIRAC.git@integration#egg=DIRAC[server]
-* a git tag/branch like git+https://github.com/fstagni/DIRAC.git@test_branch#egg=DIRAC[server]
+* "integration" or "devel" or "master" or "main" would all be interpreted as ``DIRAC[server] @ git+https://github.com/DIRACGrid/DIRAC.git@integration``
+* a dependency link pointing to a git tag/branch like ``DIRAC[server] @ git+https://github.com/fstagni/DIRAC.git@test_branch``
 
 Usage::
 
@@ -267,4 +267,4 @@ For example::
 
     update 9.0.18
     update integration
-    update git+https://github.com/fstagni/DIRAC.git@test_branch#egg=DIRAC[server]
+    update 'DIRAC[server] @ git+https://github.com/fstagni/DIRAC.git@test_branch'

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -278,12 +278,38 @@ def prepare_environment(
 
     typer.secho("Running docker compose to create containers", fg=c.GREEN)
     with _gen_docker_compose(modules, diracx_src_dir=diracx_src_dir) as docker_compose_fn:
-        subprocess.run(
-            [*DOCKER_COMPOSE_CMD, "-f", docker_compose_fn, "up", "-d", "dirac-server", "dirac-client", "dirac-pilot"]
-            + extra_services,
-            check=True,
-            env=docker_compose_env,
-        )
+        try:
+            subprocess.run(
+                [
+                    *DOCKER_COMPOSE_CMD,
+                    "-f",
+                    docker_compose_fn,
+                    "up",
+                    "-d",
+                    "dirac-server",
+                    "dirac-client",
+                    "dirac-pilot",
+                ]
+                + extra_services,
+                check=True,
+                env=docker_compose_env,
+            )
+        except subprocess.CalledProcessError:
+            typer.secho(
+                "docker compose up failed, dumping container logs for diagnosis",
+                fg=c.RED,
+            )
+            subprocess.run(
+                [*DOCKER_COMPOSE_CMD, "-f", docker_compose_fn, "ps", "-a"],
+                check=False,
+                env=docker_compose_env,
+            )
+            subprocess.run(
+                [*DOCKER_COMPOSE_CMD, "-f", docker_compose_fn, "logs", "--no-color"],
+                check=False,
+                env=docker_compose_env,
+            )
+            raise
 
     typer.secho("Creating users in server client and pilot containers", fg=c.GREEN)
     for container_name in ["server", "client", "pilot"]:

--- a/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -259,8 +259,8 @@ class SystemAdministratorHandler(RequestHandler):
         A version can be:
         - a PEP440 valid version of DIRAC.
         - a PEP440 valid version of a DIRAC extension.
-        - "integration" or "devel" or "master" or "main" would all be interpreted as git+https://github.com/DIRACGrid/DIRAC.git@integration#egg=DIRAC[server]
-        - a git tag/branch like git+https://github.com/fstagni/DIRAC.git@test_branch#egg=DIRAC[server]
+        - "integration" or "devel" or "master" or "main" would all be interpreted as "DIRAC[server] @ git+https://github.com/DIRACGrid/DIRAC.git@integration"
+        - a git tag/branch like "DIRAC[server] @ git+https://github.com/fstagni/DIRAC.git@test_branch"
         """
         # Validate and normalise the requested version
         primaryExtension = None
@@ -273,7 +273,7 @@ class SystemAdministratorHandler(RequestHandler):
         # Special cases (e.g. installing the integration/main branch)
         if version.lower() in ["integration", "devel", "master", "main"]:
             released_version = False
-            version = "git+https://github.com/DIRACGrid/DIRAC.git@integration#egg=DIRAC[server]"
+            version = "DIRAC[server] @ git+https://github.com/DIRACGrid/DIRAC.git@integration"
 
         if released_version:
             try:
@@ -340,8 +340,15 @@ class SystemAdministratorHandler(RequestHandler):
         else:
             # from here on we assume a version like git+https://github.com/DIRACGrid/DIRAC.git@integration#egg=DIRAC[server]
             # is specified, for the primaryExtension
-            if not version.startswith("git+"):
-                version = f"git+{version}"
+            if "#egg=" in version:
+                if not version.startswith("git+"):
+                    version = f"git+{version}"
+
+                # pip removed support for egg= syntax, convert to current syntax but warn
+                url, _, spec = version.rpartition("#egg=")
+                version = f"{spec} @ {url}"
+                self.log.warn("The #egg= syntax has been removed from pip, using:", version)
+
             cmd += [version]
 
         cmd += [f"{e}[server]" for e in otherExtensions]

--- a/tests/Jenkins/utilities.sh
+++ b/tests/Jenkins/utilities.sh
@@ -297,8 +297,9 @@ installDIRAC() {
 
   if [[ -n "${INSTALLATION_BRANCH}" ]]; then
     # Use this for (e.g.) running backward-compatibility tests
-    echo "pip-installing DIRAC from git+https://github.com/DIRACGrid/DIRAC.git@${INSTALLATION_BRANCH}#egg=DIRAC[client]"
-    pip install "git+https://github.com/DIRACGrid/DIRAC.git@${INSTALLATION_BRANCH}#egg=DIRAC[client]"
+    dirac_spec="DIRAC[client] @ git+https://github.com/DIRACGrid/DIRAC.git@${INSTALLATION_BRANCH}"
+    echo "pip-installing DIRAC from $dirac_spec"
+    pip install "$dirac_spec"
   else
     for module_path in "${ALTERNATIVE_MODULES[@]}"; do
       # Special handling for DIRAC with DIRACCommon subdirectory


### PR DESCRIPTION
Trying to fix the integration tests that fails due to unsupported dependency format for pip.



BEGINRELEASENOTES
ENDRELEASENOTES
