### PR TITLE
fix: update logAction call sites missed in e4a032d6f3

### DIFF
--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -833,7 +833,7 @@ class ProxyDB(DB):
         except KeyError:
             return S_ERROR("Can't escape from death")
         cmd = "INSERT INTO `ProxyDB_Log` ( Action, IssuerDN, IssuerGroup, TargetDN, TargetGroup, Timestamp ) VALUES "
-        cmd += f"( {sAction}, {sIssuerDN}, 'IssuerGroup' {sTargetDN}, 'TargetGroup', UTC_TIMESTAMP() )"
+        cmd += f"( {sAction}, {sIssuerDN}, 'IssuerGroup', {sTargetDN}, 'TargetGroup', UTC_TIMESTAMP() )"
         retVal = self._update(cmd)
         if not retVal["OK"]:
             self.log.error("Can't add a proxy action log: ", retVal["Message"])

--- a/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/ProxyManagerHandler.py
@@ -178,7 +178,7 @@ class ProxyManagerHandlerMixin:
             return result
         forceLimited = result["Value"]
 
-        self.__proxyDB.logAction("download proxy", credDict["DN"], credDict["group"], userDN, userGroup)
+        self.__proxyDB.logAction("download proxy", credDict["DN"], userDN)
         return self.__getProxy(userDN, userGroup, requestPem, requiredLifetime, forceLimited)
 
     def __getProxy(self, userDN, userGroup, requestPem, requiredLifetime, forceLimited):
@@ -226,7 +226,7 @@ class ProxyManagerHandlerMixin:
             return result
         forceLimited = result["Value"]
 
-        self.__proxyDB.logAction("download voms proxy", credDict["DN"], credDict["group"], userDN, userGroup)
+        self.__proxyDB.logAction("download voms proxy", credDict["DN"], userDN)
         return self.__getVOMSProxy(userDN, userGroup, requestPem, requiredLifetime, vomsAttribute, forceLimited)
 
     def __getVOMSProxy(self, userDN, userGroup, requestPem, requiredLifetime, vomsAttribute, forceLimited):


### PR DESCRIPTION
e4a032d6f3 removed the `issuerGroup` and `targetGroup` parameters from `ProxyDB.logAction()`. Two call sites in `ProxyManagerHandler` were not updated:

- Line 181 (`export_getProxy`)
- Line 229 (`export_getVOMSProxy`)

This results in `TypeError: ProxyDB.logAction() takes 4 positional arguments but 6 were given` when downloading proxies.

Also fixes a missing comma in the `logAction` SQL INSERT statement.