### PR TITLE
fix: remove MySQL ping reconnect

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -401,7 +401,7 @@ class ConnectionPool:
 
     def __ping(self, conn):
         try:
-            conn.ping(True)
+            conn.ping()
             return True
         except Exception:
             return False


### PR DESCRIPTION
- [ ] backport to v8


With the DIRACOS2 version https://github.com/DIRACGrid/DIRACOS2/releases/tag/2.59 the MySQL libraries were bumped to version 9.0.5. Such version flags the following:

```
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
```

which then spams all DIRAC component's logs. 

Seems like simply removing the flag in `conn.ping` solves it. For reference: https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlconnection-ping.html


BEGINRELEASENOTES

*Core
FIX: remove MySQL ping reconnect

ENDRELEASENOTES
