### PR TITLE
feat: add global OpenSearch index prefix support (#8489)

### DIFF
--- a/docs/source/AdministratorGuide/ExternalsSupport/index.rst
+++ b/docs/source/AdministratorGuide/ExternalsSupport/index.rst
@@ -55,6 +55,7 @@ You can run your OpenSearch cluster without authentication, or using User name a
   - ``ca_certs`` (default:``None``)
   - ``client_key`` (default:``None``)
   - ``client_cert`` (default:``None``)
+  - ``IndexPrefix`` (default:``''``). Prefix prepended to all DIRAC-created OpenSearch indexes. The prefix will be lower case only.
 
 
 to the location::

--- a/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
+++ b/docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
@@ -50,13 +50,14 @@ For example::
      {
        User = test
        Password = password
+       IndexPrefix = mydirac-
      }
    }
 
 
-The following option can be set in `Systems/Monitoring/Databases/MonitoringDB`:
+The following global option can be set in `Systems/NoSQLDatabases`:
 
-   *IndexPrefix*:  Prefix used to prepend to indexes created in the ES instance.
+   *IndexPrefix*: Prefix prepended to all indexes created in the OpenSearch instance.
 
 For each monitoring types managed, the Period (how often a new index is created)
 can be defined with::

--- a/src/DIRAC/ConfigurationSystem/Client/Utilities.py
+++ b/src/DIRAC/ConfigurationSystem/Client/Utilities.py
@@ -532,6 +532,9 @@ def getElasticDBParameters(fullname):
         if ca_certs:
             parameters["ca_certs"] = ca_certs
 
+    # Global index prefix for all OpenSearch databases
+    parameters["IndexPrefix"] = gConfig.getValue("/Systems/NoSQLDatabases/IndexPrefix", "")
+
     # Check optional parameters: Host, Port, SSL
     result = gConfig.getOption(cs_path + "/Host")
     if not result["OK"]:

--- a/src/DIRAC/Core/Base/ElasticDB.py
+++ b/src/DIRAC/Core/Base/ElasticDB.py
@@ -34,6 +34,7 @@ class ElasticDB(DIRACDB, ElasticSearchDB):
         self.__ca_certs = dbParameters.get("ca_certs", None)
         self.__client_key = dbParameters.get("client_key", None)
         self.__client_cert = dbParameters.get("client_cert", None)
+        self.__globalIndexPrefix = dbParameters.get("IndexPrefix", "")
 
         super().__init__(
             host=self._dbHost,
@@ -41,6 +42,7 @@ class ElasticDB(DIRACDB, ElasticSearchDB):
             user=self.__user,
             password=self.__dbPassword,
             indexPrefix=indexPrefix,
+            globalIndexPrefix=self.__globalIndexPrefix,
             useSSL=self.__useSSL,
             useCRT=self.__useCRT,
             ca_certs=self.__ca_certs,

--- a/src/DIRAC/Core/Utilities/ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/ElasticSearchDB.py
@@ -103,6 +103,7 @@ class ElasticSearchDB:
         user=None,
         password=None,
         indexPrefix="",
+        globalIndexPrefix="",
         useSSL=True,
         useCRT=False,
         ca_certs=None,
@@ -117,6 +118,7 @@ class ElasticSearchDB:
         :param str user: user name to access the db
         :param str password: if the db is password protected we need to provide a password
         :param str indexPrefix: it is the indexPrefix used to get all indexes
+        :param str globalIndexPrefix: prefix prepended to all index names and patterns
         :param bool useSSL: We can disable using secure connection. By default we use secure connection.
         :param bool useCRT: Use certificates.
         :param str ca_certs: CA certificates bundle.
@@ -125,6 +127,7 @@ class ElasticSearchDB:
         """
 
         self._connected = False
+        self.globalIndexPrefix = globalIndexPrefix
         if user and password:
             sLog.debug("Specified username and password")
             password = urlparse.quote_plus(password)
@@ -191,6 +194,43 @@ class ElasticSearchDB:
         except ElasticConnectionError as e:
             sLog.error(repr(e))
 
+    @property
+    def globalIndexPrefix(self) -> str:
+        """Global prefix prepended to all index names and patterns."""
+        return self._globalIndexPrefix
+
+    @globalIndexPrefix.setter
+    def globalIndexPrefix(self, value: str):
+        self._globalIndexPrefix = (value or "").strip().lower()
+
+    def _withGlobalPrefix(self, indexName):
+        """Prepend the global index prefix to an index name or pattern."""
+        if not self._globalIndexPrefix:
+            return indexName
+
+        prefixedTokens = []
+        for token in indexName.split(","):
+            strippedToken = token.strip()
+            if not strippedToken:
+                prefixedTokens.append(strippedToken)
+                continue
+
+            excluded = strippedToken.startswith("-")
+            if excluded:
+                strippedToken = strippedToken[1:]
+
+            if strippedToken == "_all":
+                strippedToken = "*"
+
+            if not strippedToken.startswith(self._globalIndexPrefix):
+                strippedToken = f"{self._globalIndexPrefix}{strippedToken}"
+
+            if excluded:
+                strippedToken = f"-{strippedToken}"
+            prefixedTokens.append(strippedToken)
+
+        return ",".join(prefixedTokens)
+
     @ifConnected
     def addIndexTemplate(
         self, name: str, index_patterns: list, mapping: dict, priority: int = 1, settings: dict = None
@@ -204,6 +244,7 @@ class ElasticSearchDB:
         """
         if settings is None:
             settings = {"index": {"number_of_shards": 1, "number_of_replicas": 1}}
+        index_patterns = [self._withGlobalPrefix(pattern) for pattern in index_patterns]
         body = {
             "index_patterns": index_patterns,
             "priority": priority,
@@ -225,6 +266,7 @@ class ElasticSearchDB:
         :param dict query: It is the query in OpenSearch DSL language
 
         """
+        index = self._withGlobalPrefix(index)
         try:
             esDSLQueryResult = self.client.search(index=index, body=query)
             return S_OK(esDSLQueryResult)
@@ -247,6 +289,7 @@ class ElasticSearchDB:
         if not index or not query:
             return S_ERROR("Missing index or query")
 
+        index = self._withGlobalPrefix(index)
         try:
             if updateByQuery:
                 esDSLQueryResult = self.client.update_by_query(index=index, body=query)
@@ -263,6 +306,7 @@ class ElasticSearchDB:
         :param index: name of the index
         :param docID: document ID
         """
+        index = self._withGlobalPrefix(index)
         sLog.debug(f"Retrieving document {docID} in index {index}")
         try:
             return S_OK(self.client.get(index=index, id=docID)["_source"])
@@ -280,7 +324,7 @@ class ElasticSearchDB:
         :param docIDs: document IDs
         """
         sLog.debug(f"Retrieving documents {docIDs}")
-        docs = [{"_index": indexFunc(docID, vo), "_id": docID} for docID in docIDs]
+        docs = [{"_index": self._withGlobalPrefix(indexFunc(docID, vo)), "_id": docID} for docID in docIDs]
         try:
             response = self.client.mget(body={"docs": docs})
         except RequestError as re:
@@ -298,6 +342,7 @@ class ElasticSearchDB:
         :param body: The request definition requires either `script` or
             partial `doc`
         """
+        index = self._withGlobalPrefix(index)
         sLog.debug(f"Updating document {docID} in index {index}")
         try:
             self.client.update(index=index, id=docID, body=body)
@@ -317,6 +362,7 @@ class ElasticSearchDB:
         :param index: name of the index
         :param docID: document ID
         """
+        index = self._withGlobalPrefix(index)
         sLog.debug(f"Deleting document {docID} in index {index}")
         try:
             return S_OK(self.client.delete(index=index, id=docID))
@@ -333,6 +379,7 @@ class ElasticSearchDB:
         :param index: name of the index
         :param docID: document ID
         """
+        index = self._withGlobalPrefix(index)
         sLog.debug(f"Checking if document {docID} in index {index} exists")
         return self.client.exists(index=index, id=docID)
 
@@ -341,6 +388,7 @@ class ElasticSearchDB:
         """
         it returns the object which can be used for retreiving certain value from the DB
         """
+        indexname = self._withGlobalPrefix(indexname)
         return Search(using=self.client, index=indexname)
 
     def _Q(self, name_or_query="match", **params):
@@ -361,8 +409,7 @@ class ElasticSearchDB:
         """
         It returns the available indexes...
         """
-        if not indexName:
-            indexName = ""
+        indexName = self._withGlobalPrefix(indexName) if indexName else self.globalIndexPrefix
         sLog.debug(f"Getting indices alias of {indexName}")
         # we only return indexes which belong to a specific prefix for example 'lhcb-production' or 'dirac-production etc.
         return list(self.client.indices.get_alias(index=f"{indexName}*"))
@@ -376,6 +423,7 @@ class ElasticSearchDB:
         :return: S_OK or S_ERROR
         """
         result = []
+        indexName = self._withGlobalPrefix(indexName)
         try:
             sLog.debug("Getting mappings for ", indexName)
             result = self.client.indices.get_mapping(index=indexName)
@@ -407,6 +455,7 @@ class ElasticSearchDB:
         :param str indexName: the name of the index
         :returns: S_OK/S_ERROR if the request is successful
         """
+        indexName = self._withGlobalPrefix(indexName)
         sLog.debug(f"Checking existance of index {indexName}")
         try:
             return S_OK(self.client.indices.exists(index=indexName))
@@ -428,6 +477,7 @@ class ElasticSearchDB:
         else:
             sLog.warn("The period is not provided, so using non-periodic indexes names")
             fullIndex = indexPrefix
+        fullIndex = self._withGlobalPrefix(fullIndex)
 
         try:
             if not mapping:
@@ -444,6 +494,7 @@ class ElasticSearchDB:
         """
         :param str indexName: the name of the index to be deleted...
         """
+        indexName = self._withGlobalPrefix(indexName)
         sLog.info("Deleting index", indexName)
         try:
             retVal = self.client.indices.delete(index=indexName)
@@ -474,6 +525,7 @@ class ElasticSearchDB:
         if not indexName or not body:
             return S_ERROR("Missing index or body")
 
+        indexName = self._withGlobalPrefix(indexName)
         try:
             res = self.client.index(index=indexName, body=body, id=docID, params={"op_type": op_type})
         except (RequestError, TransportError) as e:
@@ -505,8 +557,9 @@ class ElasticSearchDB:
             indexName = self.generateFullIndexName(indexPrefix, period)
         else:
             indexName = indexPrefix
-        sLog.debug(f"Bulk indexing into {indexName} of {len(data)}")
+        sLog.debug(f"Bulk indexing into {self._withGlobalPrefix(indexName)} of {len(data)}")
 
+        # Keep existence/creation checks on the raw name path; methods apply global prefix internally.
         res = self.existingIndex(indexName)
         if not res["OK"]:
             return res
@@ -514,6 +567,9 @@ class ElasticSearchDB:
             retVal = self.createIndex(indexPrefix, mapping, period)
             if not retVal["OK"]:
                 return retVal
+
+        # Prefix exactly once for the direct bulk API call.
+        indexName = self._withGlobalPrefix(indexName)
 
         try:
             res = bulk(client=self.client, index=indexName, actions=generateDocs(data, withTimeStamp))
@@ -534,7 +590,6 @@ class ElasticSearchDB:
         :param dict orderBy: it is a dictionary in case we want to order the result {key:'desc'} or {key:'asc'}
         :returns: a list of unique value for a certain key from the dictionary.
         """
-
         query = self._Search(indexName)
 
         endDate = datetime.utcnow()
@@ -592,6 +647,7 @@ class ElasticSearchDB:
         :param str indexName: the name of the index
         :param str query: the JSON-formatted query for which we want to issue the delete
         """
+        indexName = self._withGlobalPrefix(indexName)
         try:
             self.client.delete_by_query(index=indexName, body=query)
         except Exception as inst:

--- a/src/DIRAC/Core/Utilities/test/Test_ElasticSearchDB.py
+++ b/src/DIRAC/Core/Utilities/test/Test_ElasticSearchDB.py
@@ -1,0 +1,205 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import DIRAC.Core.Utilities.ElasticSearchDB as elastic_module
+from DIRAC.Core.Utilities.ElasticSearchDB import ElasticSearchDB
+
+
+def _get_db(prefix="dirac-"):
+    db = ElasticSearchDB.__new__(ElasticSearchDB)
+    db._connected = True
+    db.client = MagicMock()
+    db.globalIndexPrefix = prefix
+    return db
+
+
+def _arg_or_kwarg(call, name):
+    return call.kwargs.get(name, call.args[0] if call.args else None)
+
+
+def test_global_prefix_normalization_and_token_handling():
+    db = _get_db()
+    db.globalIndexPrefix = "  LHCB- "
+    assert db.globalIndexPrefix == "lhcb-"
+
+    assert db._withGlobalPrefix("jobs,-logs,_all,lhcb-ready") == "lhcb-jobs,-lhcb-logs,lhcb-*,lhcb-ready"
+
+
+def test_query_and_document_operations_use_prefixed_index_names():
+    db = _get_db("prefix-")
+    db.client.search.return_value = {}
+    db.client.update_by_query.return_value = {}
+    db.client.index.return_value = {"result": "updated"}
+    db.client.get.return_value = {"_source": {"a": 1}}
+    db.client.delete.return_value = {"result": "deleted"}
+    db.client.exists.return_value = True
+
+    db.query("myindex", {"query": {"match_all": {}}})
+    assert db.client.search.call_args.kwargs["index"] == "prefix-myindex"
+
+    db.update("myindex", {"script": {}}, updateByQuery=True)
+    assert db.client.update_by_query.call_args.kwargs["index"] == "prefix-myindex"
+
+    db.update("myindex", {"a": 1}, updateByQuery=False, docID="42")
+    assert db.client.index.call_args.kwargs["index"] == "prefix-myindex"
+
+    db.getDoc("myindex", "1")
+    assert _arg_or_kwarg(db.client.get.call_args, "index") == "prefix-myindex"
+
+    db.updateDoc("myindex", "1", {"doc": {"a": 2}})
+    assert _arg_or_kwarg(db.client.update.call_args, "index") == "prefix-myindex"
+
+    db.deleteDoc("myindex", "1")
+    assert _arg_or_kwarg(db.client.delete.call_args, "index") == "prefix-myindex"
+
+    db.existsDoc("myindex", "1")
+    assert _arg_or_kwarg(db.client.exists.call_args, "index") == "prefix-myindex"
+
+    db.index("myindex", {"a": 1}, docID="5")
+    assert db.client.index.call_args.kwargs["index"] == "prefix-myindex"
+
+    db.deleteByQuery("myindex", {"query": {"match_all": {}}})
+    assert db.client.delete_by_query.call_args.kwargs["index"] == "prefix-myindex"
+
+
+def test_index_management_and_template_operations_use_prefixed_index_names():
+    db = _get_db("prefix-")
+    db.client.indices.put_index_template.return_value = {"acknowledged": True}
+    db.client.indices.get_alias.return_value = {"prefix-myindex": {}}
+    db.client.indices.get_mapping.return_value = {
+        "prefix-myindex": {"mappings": {"properties": {"a": {"type": "keyword"}}}}
+    }
+    db.client.indices.exists.return_value = True
+    db.client.indices.create.return_value = {"acknowledged": True}
+    db.client.indices.delete.return_value = {"acknowledged": True}
+
+    db.addIndexTemplate("my-template", ["myindex-*", "prefix-already-*"], mapping={})
+    body = db.client.indices.put_index_template.call_args.kwargs["body"]
+    assert body["index_patterns"] == ["prefix-myindex-*", "prefix-already-*"]
+
+    db.getIndexes("myindex")
+    assert _arg_or_kwarg(db.client.indices.get_alias.call_args, "index") == "prefix-myindex*"
+
+    db.getIndexes()
+    assert _arg_or_kwarg(db.client.indices.get_alias.call_args, "index") == "prefix-*"
+
+    db.getDocTypes("myindex")
+    assert _arg_or_kwarg(db.client.indices.get_mapping.call_args, "index") == "prefix-myindex"
+
+    db.existingIndex("myindex")
+    assert _arg_or_kwarg(db.client.indices.exists.call_args, "index") == "prefix-myindex"
+
+    db.createIndex("myindex", mapping={}, period=None)
+    assert db.client.indices.create.call_args.kwargs["index"] == "prefix-myindex"
+
+    db.deleteIndex("myindex")
+    assert _arg_or_kwarg(db.client.indices.delete.call_args, "index") == "prefix-myindex"
+
+
+def test_get_indexes_without_global_prefix_lists_all_indexes():
+    db = _get_db("")
+    db.client.indices.get_alias.return_value = {}
+
+    db.getIndexes()
+    assert _arg_or_kwarg(db.client.indices.get_alias.call_args, "index") == "*"
+
+
+def test_get_docs_and_search_builder_use_prefixed_index_names(monkeypatch):
+    db = _get_db("prefix-")
+    db.client.mget.return_value = {"docs": [{"_id": "7", "found": True, "_source": {"v": 1}}]}
+
+    db.getDocs(lambda _doc_id, _vo: "logs", ["7"], "lhcb")
+    mget_body = _arg_or_kwarg(db.client.mget.call_args, "body")
+    assert mget_body["docs"][0]["_index"] == "prefix-logs"
+
+    captured = {}
+
+    def _fake_search(*, using, index):
+        captured["using"] = using
+        captured["index"] = index
+        return "search-object"
+
+    monkeypatch.setattr(elastic_module, "Search", _fake_search)
+    assert db._Search("myindex") == "search-object"
+    assert captured["using"] is db.client
+    assert captured["index"] == "prefix-myindex"
+
+
+def test_get_unique_value_leaves_prefixing_to_search_builder():
+    db = _get_db("prefix-")
+    query = MagicMock()
+    query.filter.return_value = query
+    query.extra.return_value = query
+    query.execute.return_value = SimpleNamespace(
+        aggregations={"quantity": SimpleNamespace(buckets=[{"key": 1}, {"key": 2}])}
+    )
+    db._Search = MagicMock(return_value=query)
+
+    result = db.getUniqueValue("myindex", "quantity")
+
+    assert result["OK"]
+    assert result["Value"] == [1, 2]
+    db._Search.assert_called_once_with("myindex")
+
+
+def test_bulk_index_prefixes_once_but_keeps_internal_checks_unprefixed(monkeypatch):
+    db = _get_db("prefix-")
+    db.existingIndex = MagicMock(return_value={"OK": True, "Value": False})
+    db.createIndex = MagicMock(return_value={"OK": True, "Value": "created"})
+
+    seen = {}
+
+    def _fake_bulk(*, client, index, actions):
+        seen["client"] = client
+        seen["index"] = index
+        seen["actions"] = list(actions)
+        return (len(seen["actions"]), [])
+
+    monkeypatch.setattr(elastic_module, "bulk", _fake_bulk)
+    res = db.bulk_index("myindex", data=[{"a": 1}, {"a": 2}], mapping=None, period=None, withTimeStamp=False)
+
+    assert res["OK"]
+    assert res["Value"] == 2
+    db.existingIndex.assert_called_once_with("myindex")
+    db.createIndex.assert_called_once_with("myindex", {}, None)
+    assert seen["client"] is db.client
+    assert seen["index"] == "prefix-myindex"
+
+
+def test_create_index_with_period_uses_generated_name_and_global_prefix():
+    db = _get_db("prefix-")
+    db.client.indices.create.return_value = {"acknowledged": True}
+    db.generateFullIndexName = MagicMock(return_value="myindex-2026-04-25")
+
+    res = db.createIndex("myindex", mapping={"a": {"type": "keyword"}}, period="day")
+
+    assert res["OK"]
+    assert res["Value"] == "prefix-myindex-2026-04-25"
+    db.generateFullIndexName.assert_called_once_with("myindex", "day")
+    assert db.client.indices.create.call_args.kwargs["index"] == "prefix-myindex-2026-04-25"
+
+
+def test_bulk_index_with_period_uses_prefixed_generated_name_once(monkeypatch):
+    db = _get_db("prefix-")
+    db.generateFullIndexName = MagicMock(return_value="myindex-2026-04-25")
+    db.existingIndex = MagicMock(return_value={"OK": True, "Value": False})
+    db.createIndex = MagicMock(return_value={"OK": True, "Value": "created"})
+
+    seen = {}
+
+    def _fake_bulk(*, client, index, actions):
+        seen["client"] = client
+        seen["index"] = index
+        seen["actions"] = list(actions)
+        return (len(seen["actions"]), [])
+
+    monkeypatch.setattr(elastic_module, "bulk", _fake_bulk)
+    res = db.bulk_index("myindex", data=[{"a": 1}], mapping={}, period="day", withTimeStamp=False)
+
+    assert res["OK"]
+    assert res["Value"] == 1
+    db.generateFullIndexName.assert_called_once_with("myindex", "day")
+    db.existingIndex.assert_called_once_with("myindex-2026-04-25")
+    db.createIndex.assert_called_once_with("myindex", {}, "day")
+    assert seen["client"] is db.client
+    assert seen["index"] == "prefix-myindex-2026-04-25"

--- a/src/DIRAC/Core/scripts/install_full.cfg
+++ b/src/DIRAC/Core/scripts/install_full.cfg
@@ -142,5 +142,7 @@ LocalInstallation
     Password = <password>
     Host = <host>
     Port = <port>
+    # Optional global prefix prepended to all DIRAC-created OpenSearch indexes
+    # IndexPrefix = <prefix>
   }
 }

--- a/src/DIRAC/MonitoringSystem/DB/MonitoringDB.py
+++ b/src/DIRAC/MonitoringSystem/DB/MonitoringDB.py
@@ -3,9 +3,8 @@ Wrapper on top of ElasticDB. It is used to manage the DIRAC monitoring types.
 
 **Configuration Parameters**:
 
-The following option can be set in `Systems/Monitoring/Databases/MonitoringDB`
-
-* *IndexPrefix*:  Prefix used to prepend to indexes created in the OpenSearch instance.
+The global OpenSearch index prefix can be set in
+`Systems/NoSQLDatabases/IndexPrefix`.
 
 For each monitoring types managed, the Period (how often a new index is created)
 can be defined with::
@@ -31,8 +30,6 @@ import calendar
 import time
 
 from DIRAC import S_ERROR, S_OK
-from DIRAC.ConfigurationSystem.Client.Config import gConfig
-from DIRAC.ConfigurationSystem.Client.PathFinder import getDatabaseSection
 from DIRAC.Core.Base.ElasticDB import ElasticDB
 from DIRAC.Core.Utilities.Plotting.TypeLoader import TypeLoader
 
@@ -45,10 +42,8 @@ class MonitoringDB(ElasticDB):
         """Standard constructor"""
 
         try:
-            section = getDatabaseSection("Monitoring/MonitoringDB")
-            indexPrefix = gConfig.getValue(f"{section}/IndexPrefix", "").lower()
             # Connecting to the ES cluster
-            super().__init__(fullName=name, indexPrefix=indexPrefix)
+            super().__init__(fullName=name)
         except RuntimeError as ex:
             self.log.error("Can't connect to MonitoringDB", repr(ex))
             raise ex


### PR DESCRIPTION
Fixes #8489 by introducing index prefixing as a global OpenSearch setting and removing MonitoringDB-local prefix handling.

What changed

- src/DIRAC/ConfigurationSystem/Client/Utilities.py
  - Read `/Systems/NoSQLDatabases/IndexPrefix` in `getElasticDBParameters`.
  - Normalize value (`strip().lower()`) and pass it as `IndexPrefix`.

- src/DIRAC/Core/Base/ElasticDB.py
  - Read global `IndexPrefix` from DB parameters.
  - Forward it to `ElasticSearchDB` as `globalIndexPrefix`.

- src/DIRAC/Core/Utilities/ElasticSearchDB.py
  - Added `globalIndexPrefix` constructor parameter and property setter.
  - Added `_withGlobalPrefix()` helper to prepend the global prefix to index names/patterns.
  - Applied prefixing across index/template/search/read/write/delete operations.
  - Refactored `bulk_index` flow to avoid apparent double-prepending.

- src/DIRAC/MonitoringSystem/DB/MonitoringDB.py
  - Removed MonitoringDB-specific `IndexPrefix` lookup from CS.
  - Rely on inherited global prefix mechanism via `ElasticDB`.

- docs/source/AdministratorGuide/ExternalsSupport/index.rst
  - Documented `IndexPrefix` under `Systems/NoSQLDatabases` and clarified it is lower-case.

- docs/source/AdministratorGuide/Systems/MonitoringSystem/index.rst
  - Updated docs to reference global `Systems/NoSQLDatabases/IndexPrefix`.

- src/DIRAC/Core/scripts/install_full.cfg
  - Added commented example for global `IndexPrefix` under `NoSQLDatabases`.

- src/DIRAC/Core/Utilities/test/Test_ElasticSearchDB.py
  - Added and updated unit tests to verify expected index names across ElasticSearchDB interactions when a global index prefix is configured.
