### PR TITLE
fix: cast CPUTimeLeft as an int

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/JobAgent.py
@@ -428,7 +428,9 @@ class JobAgent(AgentModule):
         if not result["OK"]:
             return self._finish(result["Message"])
 
-        self._updateConfiguration("CPUTimeLeft", self.cpuWorkLeft)
+        # Store as int: consumers generally call gConfig.getValue(..., 0)
+        # with an int default, and a float-formatted value silently coerces to 0.
+        self._updateConfiguration("CPUTimeLeft", int(self.cpuWorkLeft))
         return S_OK()
 
     #############################################################################

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapperUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapperUtilities.py
@@ -20,7 +20,7 @@ class JobWrapperError(Exception):
 
     def __init__(self, value):
         self.value = value
-        super().__init__()
+        super().__init__(value)
 
     def __str__(self):
         return str(self.value)


### PR DESCRIPTION
BEGINRELEASENOTES
*WorkloadManagement
FIX: JobAgent cast CPUTimeLeft as an int
ENDRELEASENOTES

Most of the consumers are expecting an int (which makes sense actually).
Having that piece of code in the consumers:

```
cpuWorkLeft = gConfig.getValue("/LocalSite/CPUTimeLeft", 0)
```

Always results in `0`, the default value.

Context: https://github.com/DIRACGrid/DIRAC/issues/8416