### PR TITLE
fix: don't recreate MonitoringReporter on every DISET call

### DIFF
--- a/src/DIRAC/Core/DISET/private/Service.py
+++ b/src/DIRAC/Core/DISET/private/Service.py
@@ -560,9 +560,6 @@ class Service:
                         retStatus = "OK"
                     else:
                         retStatus = "ERROR"
-                from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
-
-                self.activityMonitoringReporter = MonitoringReporter(monitoringType="ServiceMonitoring")
                 self.activityMonitoringReporter.addRecord(
                     {
                         "timestamp": int(TimeUtilities.toEpochMilliSeconds()),
@@ -592,9 +589,6 @@ class Service:
         handlerObj = result["Value"]
         response = handlerObj._rh_executeMessageCallback(msgObj)
         if self.activityMonitoring and response["OK"]:
-            from DIRAC.MonitoringSystem.Client.MonitoringReporter import MonitoringReporter
-
-            self.activityMonitoringReporter = MonitoringReporter(monitoringType="ServiceMonitoring")
             self.activityMonitoringReporter.addRecord(
                 {
                     "timestamp": int(TimeUtilities.toEpochMilliSeconds()),


### PR DESCRIPTION
The per-request and per-message paths in Service were replacing `self.activityMonitoringReporter` with a fresh `MonitoringReporter` before each `addRecord`, discarding the buffer built by the periodic `__reportActivity` task and dropping nearly all records before `__activityMonitoringReporting` could commit them. Reuse the instance created in `initialize()`.

BEGINRELEASENOTES

*Core
FIX: Most activity sent via MonitoringReporter was lost.

ENDRELEASENOTES
