### PR TITLE
feat: return full URL in ping. Useful when using loadbalancer

### DIFF
--- a/src/DIRAC/Core/DISET/RequestHandler.py
+++ b/src/DIRAC/Core/DISET/RequestHandler.py
@@ -504,6 +504,7 @@ class RequestHandler:
         # Load average
         dInfo["load"] = " ".join([str(lx) for lx in os.getloadavg()])
         dInfo["name"] = self.serviceInfoDict["serviceName"]
+        dInfo["URL"] = self.serviceInfoDict["URL"]
         stTimes = os.times()
         dInfo["cpu times"] = {
             "user time": stTimes[0],

--- a/src/DIRAC/Core/Tornado/Server/TornadoService.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoService.py
@@ -201,6 +201,7 @@ class TornadoService(BaseRequestHandler):  # pylint: disable=abstract-method
         except Exception:  # pylint: disable=broad-except
             pass
         dInfo["name"] = self._serviceInfoDict["serviceName"]
+        dInfo["URL"] = self._serviceInfoDict["URL"]
         stTimes = os.times()
         dInfo["cpu times"] = {
             "user time": stTimes[0],


### PR DESCRIPTION

BEGINRELEASENOTES

*Core

NEW: return full URL when pinging a service. This is useful to know which host answers behind a load balancer

ENDRELEASENOTES
