### PR TITLE
fix: Use existing DB connection for a few more places in FileManager

### DIFF
--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManager.py
@@ -298,7 +298,7 @@ class FileManager(FileManagerBase):
         if insertTuples:
             fields = "FileID,GUID,Checksum,ChecksumType,CreationDate,ModificationDate,Mode"
             req = f"INSERT INTO FC_FileInfo ({fields}) VALUES {','.join(insertTuples)}"
-            res = self.db._update(req)
+            res = self.db._update(req, conn=connection)
             if not res["OK"]:
                 self._deleteFiles(toDelete, connection=connection)
                 for lfn in list(lfns):
@@ -841,7 +841,7 @@ class FileManager(FileManagerBase):
 
         fields = "FileID,GUID,CreationDate,ModificationDate,Mode"
         req = f"INSERT INTO FC_FileInfo ({fields}) VALUES {','.join(insertTuples)}"
-        result = self.db._update(req)
+        result = self.db._update(req, conn=connection)
         if not result["OK"]:
             return result
 


### PR DESCRIPTION
Hi,

There are a few db._update calls in FileManager that don't use the existing database connection, but probably should. There is a suspicion that the FileInfo one might be behind our occasional "corrupt file" issue where very occasionally an entry is only created in the File table but not FileInfo, but this is too rare for us to directly test.

Regards,
Simon

BEGINRELEASENOTES
*DataManagement
FIX: Use existing connection for all updates in FileManager
ENDRELEASENOTES
