### PR TITLE
Fix LHCb collaboration link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ DIRAC is an interware, meaning a software framework for distributed computing.
 
 DIRAC provides a complete solution to one or more user community requiring access to distributed resources. DIRAC builds a layer between the users and the resources offering a common interface to a number of heterogeneous providers, integrating them in a seamless manner, providing interoperability, at the same time as an optimized, transparent and reliable usage of the resources.
 
-DIRAC has been started by the `LHCb collaboration <https://lhcb.web.cern.ch/lhcb/>`_ who still maintains it. It is now used by several communities (AKA VO=Virtual Organizations) for their distributed computing workflows.
+DIRAC has been started by the `LHCb collaboration <https://lhcb-outreach.web.cern.ch/collaboration/>`_ who still maintains it. It is now used by several communities (AKA VO=Virtual Organizations) for their distributed computing workflows.
 
-DIRAC is written in python 3.9.
+DIRAC is written in python 3.11.
 
 Status rel-v8r0 series (stable, recommended):
 


### PR DESCRIPTION
Hi, I watched a presentation by Alejandro Pérez from CERN about his work, and learned about DIRAC and CWL. I'm using this for my thesis, and checking papers, and docs.

The README.md has a link to the LHCb collaboration (”DIRAC has been started by the LHCb collaboration) that is currently pointing to this broken URL, https://lhcb.web.cern.ch/lhcb/.

I had a look and found these two URLs,

* https://lhcb.web.cern.ch/
* https://lhcb-outreach.web.cern.ch/collaboration/

The latter appears to be made for outreach and external public… so I thought it would be a better option for the README link? Let me know if that's the wrong link and I will change it, or feel free to edit the commit and modify it, or create a separate PR and close this one :) whichever works best for you.

Cheers