### PR TITLE
feat: Add args parameter to allow for mysql parameterized queries

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -726,7 +726,7 @@ class MySQL:
         return S_OK()
 
     @captureOptimizerTraces
-    def _query(self, cmd, *, conn=None, debug=True):
+    def _query(self, cmd, *, args=None, conn=None, debug=True):
         """
         execute MySQL query command
 
@@ -749,7 +749,7 @@ class MySQL:
 
         try:
             cursor = connection.cursor()
-            if cursor.execute(cmd):
+            if cursor.execute(cmd, args=args):
                 res = cursor.fetchall()
             else:
                 res = ()


### PR DESCRIPTION
This patch allows passing the args parameter when doing generic SQL queries so they can be parameterized. This makes it consistent with _update.

BEGINRELEASENOTES
*Core
CHANGE: Allow args parameter in MySQL _query calls
ENDRELEASENOTES
