### PR TITLE
Speed up Client_RequestTasks test path gen

### DIFF
--- a/src/DIRAC/TransformationSystem/Client/test/Test_Client_RequestTasks.py
+++ b/src/DIRAC/TransformationSystem/Client/test/Test_Client_RequestTasks.py
@@ -15,9 +15,8 @@ from hypothesis.strategies import (
     lists,
     text,
     dictionaries,
-    from_regex,
 )
-from string import ascii_letters, digits
+from string import ascii_letters, ascii_lowercase, digits
 
 
 from DIRAC.Core.Utilities.JEncode import encode
@@ -32,7 +31,10 @@ def taskStrategy(draw):
     """Generate a strategy that returns a task dictionary"""
     transformationID = draw(integers(min_value=1))
     targetSE = ",".join(draw(lists(text(ascii_letters, min_size=5, max_size=10), min_size=1, max_size=3)))
-    inputData = draw(lists(from_regex("(/[a-z]+)+", fullmatch=True), min_size=1, max_size=10))
+    pathStrategy = lists(text(ascii_lowercase, min_size=1), min_size=1, max_size=10).map(
+        lambda segs: "/" + "/".join(segs)
+    )
+    inputData = draw(lists(pathStrategy, min_size=1, max_size=10))
 
     return {"TransformationID": transformationID, "TargetSE": targetSE, "InputData": inputData}
 
@@ -65,7 +67,7 @@ reqTasks = RequestTasks(
     ],
 )
 @mark.slow
-@settings(max_examples=50, deadline=500)
+@settings(max_examples=50)
 @given(
     owner=text(ascii_letters + "-_" + digits, min_size=1),
     taskDict=taskDictStrategy(),
@@ -148,7 +150,7 @@ def test_prepareSingleOperationsBody(transBody, owner, taskDict):
     ],
 )
 @mark.slow
-@settings(max_examples=50, deadline=500)
+@settings(max_examples=50)
 @given(
     owner=text(ascii_letters + "-_" + digits, min_size=1),
     taskDict=taskDictStrategy(),
@@ -226,7 +228,7 @@ def test_prepareMultiOperationsBody(transBody, owner, taskDict):
     ],
 )
 @mark.slow
-@settings(max_examples=50, deadline=500)
+@settings(max_examples=50)
 @given(
     owner=text(ascii_letters + "-_" + digits, min_size=1),
     taskDict=taskDictStrategy(),
@@ -298,7 +300,7 @@ def test_prepareProblematicMultiOperationsBody(transBody, owner, taskDict):
 
 
 @mark.slow
-@settings(max_examples=50, deadline=500)
+@settings(max_examples=50)
 @given(
     taskDict=taskDictStrategy(),
     pluginFactor=integers(),


### PR DESCRIPTION
Hi,

I've found the Client_RequestTasks test to be flaky on my machine: It sometimes overruns the 500ms deadline set on hypothesis. The cause of this is the regex based LFN generation taking a long time to generate valid results: Sometimes if it gets unlucky it doesn't manage to generate enough valid candidates in time. (The deadline is likely disabled in the CI, so it probably doesn't show up as an issue there).

I believe adjusting the strategy to joining random strings with "/" instead keeps approximately the same test parameter space, but runs in ~10 seconds instead the original ~93.

This still feels a bit suboptimal: The actual test runtime is 1 second, the other 9 seconds are spent generating the random input LFNs for inputData lists.

Regards,
Simon

BEGINRELEASENOTES
*RequestManagement
FIX: Speed up Client_RequestTasks test path gen
ENDRELEASENOTES
