### PR TITLE
Check MD5 & SHA1 usage

### DIFF
--- a/src/DIRAC/AccountingSystem/private/MainReporter.py
+++ b/src/DIRAC/AccountingSystem/private/MainReporter.py
@@ -39,7 +39,7 @@ class MainReporter:
         for key in ("startTime", "endTime"):
             epoch = requestToHash[key]
             requestToHash[key] = epoch - epoch % granularity
-        md5Hash = hashlib.md5()
+        md5Hash = hashlib.md5(usedforsecurity=False)
         md5Hash.update(repr(requestToHash).encode())
         return md5Hash.hexdigest()
 

--- a/src/DIRAC/Core/DISET/MessageClient.py
+++ b/src/DIRAC/Core/DISET/MessageClient.py
@@ -31,7 +31,7 @@ class MessageClient(BaseClient):
         hashStr = ":".join(
             (str(datetime.datetime.utcnow()), str(random.random()), Network.getFQDN(), gLogger.getName())
         )
-        hexHash = md5(hashStr.encode()).hexdigest()
+        hexHash = md5(hashStr.encode(), usedforsecurity=False).hexdigest()
         return hexHash
 
     def setUniqueName(self, uniqueName):

--- a/src/DIRAC/Core/DISET/private/FileHelper.py
+++ b/src/DIRAC/Core/DISET/private/FileHelper.py
@@ -20,7 +20,7 @@ class FileHelper:
     def __init__(self, oTransport=None, checkSum=True):
         self.oTransport = oTransport
         self.__checkMD5 = checkSum
-        self.__oMD5 = hashlib.md5()
+        self.__oMD5 = hashlib.md5(usedforsecurity=False)
         self.bFinishedTransmission = False
         self.bReceivedEOF = False
         self.direction = False
@@ -149,7 +149,7 @@ class FileHelper:
     def networkToDataSink(self, dataSink, maxFileSize=0):
         if "write" not in dir(dataSink):
             return S_ERROR(f"{str(dataSink)} data sink object does not have a write method")
-        self.__oMD5 = hashlib.md5()
+        self.__oMD5 = hashlib.md5(usedforsecurity=False)
         self.bReceivedEOF = False
         self.bErrorInMD5 = False
         receivedBytes = 0
@@ -212,7 +212,7 @@ class FileHelper:
         return S_OK()
 
     def FDToNetwork(self, iFD):
-        self.__oMD5 = hashlib.md5()
+        self.__oMD5 = hashlib.md5(usedforsecurity=False)
         iPacketSize = self.packetSize
         self.__fileBytes = 0
         sentBytes = 0
@@ -244,7 +244,7 @@ class FileHelper:
     def DataSourceToNetwork(self, dataSource):
         if "read" not in dir(dataSource):
             return S_ERROR(f"{str(dataSource)} data source object does not have a read method")
-        self.__oMD5 = hashlib.md5()
+        self.__oMD5 = hashlib.md5(usedforsecurity=False)
         iPacketSize = self.packetSize
         self.__fileBytes = 0
         sentBytes = 0

--- a/src/DIRAC/Core/DISET/private/Transports/BaseTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/BaseTransport.py
@@ -53,7 +53,7 @@ class BaseTransport:
         self.remoteAddress = False
         self.appData = ""
         self.startedKeepAlives = set()
-        self.keepAliveId = md5((str(stServerAddress) + str(bServerMode)).encode()).hexdigest()
+        self.keepAliveId = md5((str(stServerAddress) + str(bServerMode)).encode(), usedforsecurity=False).hexdigest()
         self.receivedMessages = []
         self.sentKeepAlives = 0
         self.waitingForKeepAlivePong = False

--- a/src/DIRAC/Core/Security/m2crypto/X509Chain.py
+++ b/src/DIRAC/Core/Security/m2crypto/X509Chain.py
@@ -144,7 +144,7 @@ class X509Chain:
         # This is the position of the first proxy in the chain
         self.__firstProxyStep = 0
 
-        # Cache for sha1 hash of the object
+        # Cache for sha256 hash of the object
         # This is just used as a unique identifier for
         # indexing in the ProxyCache
         self.__hash = False
@@ -1004,25 +1004,25 @@ class X509Chain:
 
     @needCertList
     def hash(self):
-        """Get a hash of the chain
+        """Get a hash of the chain (32 byte hex-string is returned)
         In practice, this is only used to index the chain in a DictCache
 
         :returns: S_OK(string hash)
         """
         if self.__hash:
             return S_OK(self.__hash)
-        sha1 = hashlib.sha1()
+        sha = hashlib.sha256()
         for cert in self._certList:
-            sha1.update(str(cert.getSubjectNameObject()["Value"]).encode())
-        sha1.update(str(self.getRemainingSecs()["Value"] / 3600).encode())
-        sha1.update(self.getDIRACGroup()["Value"].encode())
+            sha.update(str(cert.getSubjectNameObject()["Value"]).encode())
+        sha.update(str(self.getRemainingSecs()["Value"] / 3600).encode())
+        sha.update(self.getDIRACGroup()["Value"].encode())
         if self.isVOMS():
-            sha1.update(b"VOMS")
+            sha.update(b"VOMS")
             from DIRAC.Core.Security.VOMS import VOMS
 
             result = VOMS().getVOMSAttributes(self)
             if result["OK"]:
                 for attribute in result["Value"]:
-                    sha1.update(attribute.encode())
-        self.__hash = sha1.hexdigest()
-        return S_OK(self.__hash)
+                    sha.update(attribute.encode())
+        self.__hash = sha.hexdigest()
+        return S_OK(self.__hash[:32])

--- a/src/DIRAC/Core/Utilities/File.py
+++ b/src/DIRAC/Core/Utilities/File.py
@@ -69,7 +69,7 @@ def makeGuid(fileName=None):
 
     :param string fileName: name of file
     """
-    myMd5 = hashlib.md5()
+    myMd5 = hashlib.md5(usedforsecurity=False)
     if fileName:
         try:
             with open(fileName, "rb") as fd:
@@ -106,7 +106,7 @@ def generateGuid(checksum, checksumtype):
             return guid
 
     # Failed to use the check sum, generate a new guid
-    myMd5 = hashlib.md5()
+    myMd5 = hashlib.md5(usedforsecurity=False)
     myMd5.update(str(random.getrandbits(128)).encode())
     md5HexString = myMd5.hexdigest()
     guid = "{}-{}-{}-{}-{}".format(
@@ -213,7 +213,7 @@ def getMD5ForFiles(fileList):
     :type fileList: python:list
     """
     fileList.sort()
-    hashMD5 = hashlib.md5()
+    hashMD5 = hashlib.md5(usedforsecurity=False)
     for filePath in fileList:
         if os.path.isdir(filePath):
             continue

--- a/src/DIRAC/Core/Utilities/Graphs/Palette.py
+++ b/src/DIRAC/Core/Utilities/Graphs/Palette.py
@@ -83,7 +83,7 @@ class Palette:
             return self.generateColor(label)
 
     def generateColor(self, label):
-        myMD5 = hashlib.md5()
+        myMD5 = hashlib.md5(usedforsecurity=False)
         myMD5.update(label.encode())
         hexstring = myMD5.hexdigest()
         color = "#" + hexstring[:6]

--- a/src/DIRAC/Core/Utilities/LockRing.py
+++ b/src/DIRAC/Core/Utilities/LockRing.py
@@ -15,10 +15,10 @@ class LockRing(metaclass=DIRACSingleton):
 
     def __genName(self, container):
         # TODO: Shouldn't this be a UUID?
-        name = md5(str(time.time() + random.random()).encode()).hexdigest()
+        name = md5(str(time.time() + random.random()).encode(), usedforsecurity=False).hexdigest()
         retries = 10
         while name in container and retries:
-            name = md5(str(time.time() + random.random()).encode()).hexdigest()
+            name = md5(str(time.time() + random.random()).encode(), usedforsecurity=False).hexdigest()
             retries -= 1
         return name
 

--- a/src/DIRAC/Core/Utilities/ThreadScheduler.py
+++ b/src/DIRAC/Core/Utilities/ThreadScheduler.py
@@ -32,7 +32,7 @@ class ThreadScheduler:
             return S_ERROR(f"{str(taskFunc)} is not callable")
         period = max(period, self.__minPeriod)
         elapsedTime = min(elapsedTime, period - 1)
-        md = hashlib.md5()
+        md = hashlib.md5(usedforsecurity=False)
         task = {
             "period": period,
             "func": taskFunc,

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
@@ -321,7 +321,7 @@ class DatasetManager:
         idLfnDict = result["Value"]
         lfnIDList = list(idLfnDict)
         lfnList = sorted(idLfnDict.values())
-        myMd5 = hashlib.md5()
+        myMd5 = hashlib.md5(usedforsecurity=False)
         myMd5.update(str(lfnList).encode())
         datasetHash = myMd5.hexdigest().upper()
         numberOfFiles = len(lfnList)

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_removal_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_create_removal_request.py
@@ -59,8 +59,8 @@ def main():
     for lfnList in breakListIntoChunks(lfns, 100):
         oRequest = Request()
         requestName = "{}_{}".format(
-            md5(repr(time.time()).encode()).hexdigest()[:16],
-            md5(repr(time.time()).encode()).hexdigest()[:16],
+            md5(repr(time.time()).encode(), usedforsecurity=False).hexdigest()[:16],
+            md5(repr(time.time()).encode(), usedforsecurity=False).hexdigest()[:16],
         )
         oRequest.RequestName = requestName
 

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_move_replica_request.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_move_replica_request.py
@@ -81,8 +81,8 @@ def main():
 
         request = Request()
         request.RequestName = "{}_{}".format(
-            md5(repr(time.time()).encode()).hexdigest()[:16],
-            md5(repr(time.time()).encode()).hexdigest()[:16],
+            md5(repr(time.time()).encode(), usedforsecurity=False).hexdigest()[:16],
+            md5(repr(time.time()).encode(), usedforsecurity=False).hexdigest()[:16],
         )
 
         moveReplica = Operation()

--- a/src/DIRAC/MonitoringSystem/private/MainReporter.py
+++ b/src/DIRAC/MonitoringSystem/private/MainReporter.py
@@ -71,7 +71,7 @@ class MainReporter:
         for key in ("startTime", "endTime"):
             epoch = requestToHash[key]
             requestToHash[key] = epoch - epoch % granularity
-        md5Hash = hashlib.md5()
+        md5Hash = hashlib.md5(usedforsecurity=False)
         md5Hash.update(repr(requestToHash).encode())
         return md5Hash.hexdigest()
 

--- a/src/DIRAC/RequestManagementSystem/Service/ReqProxyHandler.py
+++ b/src/DIRAC/RequestManagementSystem/Service/ReqProxyHandler.py
@@ -143,7 +143,7 @@ class ReqProxyHandler(RequestHandler):
         :param str requestJSON:  request serialized to JSON format
         """
         try:
-            requestFile = os.path.join(self.cacheDir(), md5(requestJSON.encode()).hexdigest())
+            requestFile = os.path.join(self.cacheDir(), md5(requestJSON.encode(), usedforsecurity=False).hexdigest())
             with open(requestFile, "w+") as request:
                 request.write(requestJSON)
             return S_OK(requestFile)

--- a/src/DIRAC/Resources/MessageQueue/Simple/StompInterface.py
+++ b/src/DIRAC/Resources/MessageQueue/Simple/StompInterface.py
@@ -100,7 +100,7 @@ def getSubscriptionID(broker: tuple[str, int], dest: str) -> str:
 
     """
     host, port = broker
-    return hashlib.md5((f"{host}_{port}_{dest}").encode()).hexdigest()
+    return hashlib.md5((f"{host}_{port}_{dest}").encode(), usedforsecurity=False).hexdigest()
 
 
 class StompConsumer:

--- a/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationCleaningAgent.py
@@ -723,7 +723,8 @@ class TransformationCleaningAgent(AgentModule):
 
         for index, lfnList in enumerate(breakListIntoChunks(lfns, 300)):
             oRequest = Request()
-            requestName = f"TCA_{transID}_{index}_{md5(repr(time.time()).encode()).hexdigest()[:5]}"
+            reqHash = md5(repr(time.time()).encode(), usedforsecurity=False).hexdigest()[:5]
+            requestName = f"TCA_{transID}_{index}_{reqHash}"
             oRequest.RequestName = requestName
             oOperation = Operation()
             oOperation.Type = "RemoveFile"

--- a/src/DIRAC/WorkloadManagementSystem/Client/SandboxStoreClient.py
+++ b/src/DIRAC/WorkloadManagementSystem/Client/SandboxStoreClient.py
@@ -144,7 +144,7 @@ class SandboxStoreClient:
                 result["SandboxFileName"] = tmpFilePath
                 return result
 
-        oMD5 = hashlib.md5()
+        oMD5 = hashlib.md5(usedforsecurity=False)
         with open(tmpFilePath, "rb") as fd:
             bData = fd.read(10240)
             while bData:

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -184,7 +184,7 @@ class SandboxStoreHandlerMixin:
         if fileHelper:
             hdHash = fileHelper.getHash()
         else:
-            oMD5 = hashlib.md5()
+            oMD5 = hashlib.md5(usedforsecurity=False)
             with open(hdPath, "rb") as fd:
                 bData = fd.read(10240)
                 while bData:

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/QueueUtilities.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/QueueUtilities.py
@@ -135,7 +135,7 @@ def setAdditionalParams(ceDict, queueDict):
 
 def generateQueueHash(queueDict):
     """Generate a hash of the queue description"""
-    myMD5 = hashlib.md5()
+    myMD5 = hashlib.md5(usedforsecurity=False)
     myMD5.update(str(queueDict).encode())
     hexstring = myMD5.hexdigest()
     return hexstring

--- a/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
+++ b/src/DIRAC/WorkloadManagementSystem/Utilities/RemoteRunner.py
@@ -274,7 +274,7 @@ class RemoteRunner:
             for line in f:
                 checkSum, remoteOutput = list(filter(None, line.strip("\n").split(" ")))
 
-                hash = hashlib.md5()
+                hash = hashlib.md5(usedforsecurity=False)
                 localOutput = os.path.join(workingDirectory, remoteOutput)
                 if not os.path.exists(localOutput):
                     return S_ERROR(f"{localOutput} was expected but not found")


### PR DESCRIPTION
Hi,

I've looked through all of the usage of MD5 & SHA1 in the codebase... The majority of these are just protection for accidental corruption and caching (where the input parameters aren't user controlled). I've marked these as usedforsecurity=False. (This flag doesn't do anything on non-FIPS systems, but is picked up by security scanners as a hint).

There is one place in the proxy cache where I swapped md5 out for truncated sha256: This doesn't make an enormous amount of difference and is more an "abundance of caution" style change.

Regards,
Simon

BEGINRELEASENOTES
*All
FIX: Mark md5/sha1 usage as not used for security where appropriate.
*Core
FIX: Use truncated sha256 for proxy hash (caching) rather than md5.
ENDRELEASENOTES
