### PR TITLE
Ensure all requests calls have a timeout

### DIFF
--- a/.github/workflows/make_release.py
+++ b/.github/workflows/make_release.py
@@ -29,6 +29,7 @@ def make_release(version, commit_hash, release_notes=""):
             "prerelease": Version(version).is_prerelease,
         },
         headers=headers,
+        timeout=30,
     )
     r.raise_for_status()
     release_data = r.json()
@@ -41,6 +42,7 @@ def make_release(version, commit_hash, release_notes=""):
             "draft": False,
         },
         headers=headers,
+        timeout=30,
     )
     r.raise_for_status()
     release_data = r.json()

--- a/src/DIRAC/Core/Security/IAMService.py
+++ b/src/DIRAC/Core/Security/IAMService.py
@@ -65,7 +65,7 @@ class IAMService:
         totalResults = 1000  # total number of users
         itemsPerPage = 10
         while startIndex <= totalResults:
-            resp = requests.get(url, headers=headers, params={"startIndex": startIndex})
+            resp = requests.get(url, headers=headers, params={"startIndex": startIndex}, timeout=30)
             resp.raise_for_status()
             data = resp.json()
             # These 2 should never change while looping

--- a/src/DIRAC/Core/Security/VOMSService.py
+++ b/src/DIRAC/Core/Security/VOMSService.py
@@ -80,8 +80,9 @@ class VOMSService:
                         cert=getProxyLocation(),
                         verify=getCAsLocation(),
                         params={"startIndex": str(startIndex), "pageSize": "100"},
+                        timeout=30,
                     )
-                except requests.ConnectionError as exc:
+                except (requests.ConnectionError, requests.Timeout) as exc:
                     error = f"{url}:{repr(exc)}"
                     urlDone = True
                     continue

--- a/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
+++ b/src/DIRAC/DataManagementSystem/Client/FTS3Job.py
@@ -69,7 +69,7 @@ def get_scitag(vo: str, activity: Optional[str] = None) -> int:
     @cached(_scitag_json_cache, lock=_scitag_json_lock)
     def get_remote_json():
         gLogger.verbose("Fetching https://scitags.org/api.json from the network")
-        response = requests.get("https://scitags.org/api.json")
+        response = requests.get("https://scitags.org/api.json", timeout=30)
         response.raise_for_status()
         return response.json()
 

--- a/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -354,7 +354,7 @@ class SystemAdministratorHandler(RequestHandler):
         )
         self.log.info("Downloading DIRACOS2 installer from", installer_url)
         with tempfile.NamedTemporaryFile(suffix=".sh", mode="wb") as installer:
-            with requests.get(installer_url, stream=True) as r:
+            with requests.get(installer_url, timeout=30, stream=True) as r:
                 if not r.ok:
                     return S_ERROR(f"Failed to download {installer_url}")
                 for chunk in r.iter_content(chunk_size=1024**2):

--- a/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/SlackAction.py
+++ b/src/DIRAC/ResourceStatusSystem/PolicySystem/Actions/SlackAction.py
@@ -115,6 +115,8 @@ class SlackAction(BaseAction):
         """
 
         payload = {"text": message}
-        response = requests.post(self.url, data=json.dumps(payload), headers={"Content-Type": "application/json"})
+        response = requests.post(
+            self.url, data=json.dumps(payload), headers={"Content-Type": "application/json"}, timeout=30
+        )
         response.raise_for_status()
         return S_OK()

--- a/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
+++ b/src/DIRAC/Resources/IdProvider/OAuth2IdProvider.py
@@ -577,6 +577,7 @@ class OAuth2IdProvider(OAuth2Session):
                 self.get_metadata("device_authorization_endpoint"),
                 data=dict(client_id=self.client_id, scope=list_to_scope(scope_to_list(self.scope) + groupScopes)),
                 verify=self.verify,
+                timeout=30,
             )
             r.raise_for_status()
             deviceResponse = r.json()
@@ -616,6 +617,7 @@ class OAuth2IdProvider(OAuth2Session):
                 self.get_metadata("token_endpoint"),
                 data=dict(client_id=self.client_id, grant_type=DEVICE_CODE_GRANT_TYPE, device_code=deviceCode),
                 verify=self.verify,
+                timeout=30,
             )
             token = r.json()
             if not token:

--- a/src/DIRAC/Resources/Storage/S3Storage.py
+++ b/src/DIRAC/Resources/Storage/S3Storage.py
@@ -187,7 +187,7 @@ class S3Storage(StorageBase):
     #           failed[key] = res['Message']
     #           continue
     #         presignedURL = res['Value']
-    #         response = requests.get(presignedURL)
+    #         response = requests.get(presignedURL, timeout=30)
     #         if response.status_code == 200:
     #           successful[key] = True
     #         elif response.status_code == 404:  # not found
@@ -268,7 +268,7 @@ class S3Storage(StorageBase):
         # and perform it with requests
         for url, presignedURL in presignedURLs.items():
             try:
-                response = requests.get(presignedURL)
+                response = requests.get(presignedURL, timeout=30)
                 if response.status_code == 200:
                     successful[url] = True
                 elif response.status_code == 404:  # not found
@@ -373,7 +373,7 @@ class S3Storage(StorageBase):
 
                 # Stream download to save memory
                 # https://requests.readthedocs.io/en/latest/user/advanced/#body-content-workflow
-                with requests.get(presignedURL, stream=True) as r:
+                with requests.get(presignedURL, timeout=30, stream=True) as r:
                     r.raise_for_status()
                     with open(dest_file, "wb") as f:
                         for chunk in r.iter_content():
@@ -489,7 +489,7 @@ class S3Storage(StorageBase):
                 with open(src_file, "rb") as src_fd:
                     # files = {'file': (dest_key, src_fd)}
                     files = {"file": src_fd}
-                    response = requests.post(presignedURL, data=presignedFields, files=files)
+                    response = requests.post(presignedURL, data=presignedFields, files=files, timeout=30)
 
                     if not response.ok:
                         raise Exception(response.reason)
@@ -567,7 +567,7 @@ class S3Storage(StorageBase):
 
         for url, presignedURL in presignedURLs.items():
             try:
-                response = requests.head(presignedURL)
+                response = requests.head(presignedURL, timeout=30)
                 if not response.ok:
                     raise Exception(response.reason)
 
@@ -652,7 +652,7 @@ class S3Storage(StorageBase):
 
         for url, presignedURL in presignedURLs.items():
             try:
-                response = requests.delete(presignedURL)
+                response = requests.delete(presignedURL, timeout=30)
                 if not response.ok:
                     raise Exception(response.reason)
 

--- a/src/DIRAC/WorkloadManagementSystem/Agent/PilotSyncAgent.py
+++ b/src/DIRAC/WorkloadManagementSystem/Agent/PilotSyncAgent.py
@@ -109,7 +109,9 @@ class PilotSyncAgent(AgentModule):
             self.log.info("Attempting to upload", f"to {server}")
             if server.startswith("https://"):
                 for tf in allFiles:
-                    res = requests.put(server, data=tf, verify=self.casLocation, cert=self.certAndKeyLocation)
+                    res = requests.put(
+                        server, data=tf, verify=self.casLocation, cert=self.certAndKeyLocation, timeout=30
+                    )
                     if res.status_code not in (200, 202):
                         self.log.error("Could not upload", f"to {server}: status {res.status_code}")
             else:  # Assumes this is a DIRAC SE

--- a/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/SandboxStoreHandler.py
@@ -374,7 +374,7 @@ class SandboxStoreHandlerMixin:
         if filePath.startswith("/S3"):
             with TheImpersonator(credDict, source="SandboxStore") as client:
                 res = client.jobs.get_sandbox_file(pfn=filePath)
-                r = requests.get(res.url)
+                r = requests.get(res.url, timeout=30)
                 r.raise_for_status()
                 sbData = r.content
                 if fileHelper:


### PR DESCRIPTION
Hi,

This patch just adds a timeout parameter with a 30 second default to all requests calls that don't currently have one (outside of tests)...

Regards,
Simon

BEGINRELEASENOTES
*All
FIX: Ensure all requests calls have a timeout
ENDRELEASENOTES
