### PR TITLE
fix: wrong default type for metadata container

### DIFF
--- a/src/DIRAC/DataManagementSystem/Client/ConsistencyInspector.py
+++ b/src/DIRAC/DataManagementSystem/Client/ConsistencyInspector.py
@@ -727,7 +727,7 @@ class ConsistencyInspector:
 
     def _getCatalogMetadata(self, lfns):
         """Obtain the file metadata from the catalog while checking they exist"""
-        allMetadata = []
+        allMetadata = {}
         missingCatalogFiles = []
         zeroSizeFiles = []
 


### PR DESCRIPTION

BEGINRELEASENOTES

*DMS

FIX: correct default type for catalog metadata in ConsistencyInspector


ENDRELEASENOTES
