### PR TITLE
[int] Remove asserts from non-test code

### DIFF
--- a/consistency_check/consistency.py
+++ b/consistency_check/consistency.py
@@ -27,7 +27,8 @@ def load_se_dump(se_dump_path):
     se_dump = pd.read_csv(se_dump_path, names=["pfn", "se_cks"], delimiter="|", index_col="pfn")
     se_dump["se_cks"] = se_dump["se_cks"].str.lower().str.pad(8, fillchar="0")
     se_dump["version"] = "se_dump"
-    assert not se_dump.index.duplicated().any(), f"Duplicated entries in SE dump {se_dump[se_dump.index.duplicated()]}"
+    if se_dump.index.duplicated().any():
+        raise AssertionError(f"Duplicated entries in SE dump {se_dump[se_dump.index.duplicated()]}")
 
     return se_dump
 

--- a/src/DIRAC/ConfigurationSystem/Client/CSShellCLI.py
+++ b/src/DIRAC/ConfigurationSystem/Client/CSShellCLI.py
@@ -105,8 +105,10 @@ class CSShellCLI(CLI):
         Go one directory deeper in the CS"""
         # Check if invariant holds
         if self.connected:
-            assert self.root == "/" or not self.root.endswith("/")
-            assert self.root.startswith("/")
+            if (self.root != "/") and self.root.endswith("/"):
+                raise AssertionError("Unexpected trailing / on path")
+            if not self.root.startswith("/"):
+                raise AssertionError("Root path doesn't start with /")
             secs = self.modificator.getSections(self.root)
             if line == "..":
                 self.root = os.path.dirname(self.root)

--- a/src/DIRAC/Core/LCG/GOCDBClient.py
+++ b/src/DIRAC/Core/LCG/GOCDBClient.py
@@ -169,7 +169,8 @@ class GOCDBClient:
 
           :attr:`entity` : a string. Actual name of the entity.
         """
-        assert isinstance(granularity, str) and isinstance(entity, str)
+        if (not isinstance(granularity, str)) or (not isinstance(entity, str)):
+            raise AssertionError("Granularity or entity are not expected types")
         try:
             serviceXML = self._getServiceEndpointCurlDownload(granularity, entity)
             return S_OK(self._serviceEndpointXMLParsing(serviceXML))

--- a/src/DIRAC/Core/Utilities/Graphs/PieGraph.py
+++ b/src/DIRAC/Core/Utilities/Graphs/PieGraph.py
@@ -44,8 +44,8 @@ class PieGraph(PlotBase):
         labels = [l[0] for l in labels]
         if explode is None:
             explode = [0] * len(x)
-        assert len(x) == len(labels)
-        assert len(x) == len(explode)
+        if (len(x) != len(labels)) or (len(x) != len(explode)):
+            raise AssertionError("'labels' or 'explode' length doesn't make x-values length!")
         plot_axis_labels = self.prefs.get("plot_axis_labels", True)
 
         center = 0, 0

--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -173,9 +173,7 @@ def _checkFields(inFields, inValues):
     if inFields is None and inValues is None:
         return S_OK()
 
-    try:
-        assert len(inFields) == len(inValues)
-    except AssertionError:
+    if len(inFields) != len(inValues):
         return S_ERROR(DErrno.EMYSQL, "Mismatch between inFields and inValues.")
 
     return S_OK()

--- a/src/DIRAC/Resources/MessageQueue/Simple/StompInterface.py
+++ b/src/DIRAC/Resources/MessageQueue/Simple/StompInterface.py
@@ -53,7 +53,8 @@ def _resolve_brokers(alias: str, port: int, ipv4Only: bool = False, ipv6Only: bo
     :param ipv6Only: Only return IPv6
     :return: A list of tuples (resolved ip, port)
     """
-    assert not (ipv4Only and ipv6Only)
+    if ipv4Only and ipv6Only:
+        raise AssertionError("ipv4Only & ipv6Only are mutually exclusive")
 
     brokers = list()
 

--- a/src/DIRAC/Resources/Storage/FileStorage.py
+++ b/src/DIRAC/Resources/Storage/FileStorage.py
@@ -113,7 +113,8 @@ def set_xattr_adler32(path, checksum):
         + value_field  # 64 bytes
     )  # Total: 96 bytes
 
-    assert len(xrd_cks_data) == 96, f"Structure size mismatch: {len(xrd_cks_data)}"
+    if len(xrd_cks_data) != 96:
+        raise AssertionError(f"Structure size mismatch: {len(xrd_cks_data)}")
 
     # Set the extended attribute
     # XRootD uses "XrdCks.adler32" which becomes "user.XrdCks.adler32" on Linux


### PR DESCRIPTION
Hi,

Part of #8547. This removes all assert usage in non-test code paths as this can misbehave in certain circumstances (as I understand it certain types of packaging that pre-build the byte code can remove asserts as an optimisation). In most cases I've switched it to an AssertionError which will give exactly the same behaviour but won't get optimised out.

Regards,
Simon

BEGINRELEASENOTES
*All
FIX: Remove asserts from non-test code.
ENDRELEASENOTES
