### PR TITLE
fix (RMS): REA iterate over a copy of the requests

### DIFF
--- a/src/DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py
+++ b/src/DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py
@@ -192,7 +192,7 @@ class RequestExecutingAgent(AgentModule):
         :param self: self reference
         """
         self.log.info("putAllRequests: will put back requests", f"{len(self.__requestCache)}")
-        for requestID in self.__requestCache.keys():
+        for requestID in list(self.__requestCache.keys()):
             reset = self.putRequest(requestID)
             if not reset["OK"]:
                 self.log.error("Failed to put request", reset["Message"])


### PR DESCRIPTION
We have had this stack trace the other day in the REA logs:

```python
2026-05-28T15:09:04,088784Z RequestManagement/RequestExecutingAgent ERROR: Failed to execute finalize for Agent: RequestManagement/RequestExecutingAgent
Traceback (most recent call last):
  File "DIRAC/Core/Base/AgentReactor.py", line 129, in __finalize
    self.__agentModules[agentName]["instanceObj"].finalize()
  File "DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py", line 433, in finalize
    self.putAllRequests()
  File "DIRAC/RequestManagementSystem/Agent/RequestExecutingAgent.py", line 195, in putAllRequests
    for requestID in self.__requestCache.keys():
RuntimeError: dictionary changed size during iteration
```


BEGINRELEASENOTES

*RMS

FIX:REA iterate over a copy of the keys

ENDRELEASENOTES
