### PR TITLE
fix: Update profiler test to make it more reliable

### DIFF
--- a/src/DIRAC/Core/Utilities/test/Test_Profiler.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Profiler.py
@@ -76,8 +76,10 @@ def test_base():
     assert resWC["Value"] >= 0
     assert resWC["Value"] >= res["Value"]
 
+    mainProcess.kill()
+    mainProcess.wait()
 
-@pytest.mark.flaky(reruns=10)
+
 def test_cpuUsage():
     mainProcess = Popen(
         [
@@ -147,6 +149,7 @@ def test_cpuUsage():
     assert resTC["Value"] >= res["Value"]
 
     # After this the main process will no-longer exist
+    mainProcess.kill()
     mainProcess.wait()
 
     res = p.cpuUsageUser()

--- a/src/DIRAC/tests/Utilities/ProcessesCreator_withChildren.py
+++ b/src/DIRAC/tests/Utilities/ProcessesCreator_withChildren.py
@@ -26,3 +26,8 @@ if __name__ == "__main__":
         p.daemon = False
         p.start()
         p.join()
+
+    # On fast machines, this can finish too quickly
+    # Just sleep (we've accumulated usage now)
+    # and the test can interrupt this with a kill
+    time.sleep(60)


### PR DESCRIPTION
Hi,

I've found the CPU profiler test to be particularly flaky: The fake workload frequently finishes before the test causing "process not found" exceptions. This patch makes the payload wait before exiting so that things are synchronised and the test is no-longer flaky on any speed of machine.

Regards,
Simon

BEGINRELEASENOTES
*Core
FIX: Update profiler test to make it more reliable
ENDRELEASENOTES
