### PR TITLE
[int] Check hardcoded /tmp locations

### DIFF
--- a/src/DIRAC/Core/Security/Locations.py
+++ b/src/DIRAC/Core/Security/Locations.py
@@ -22,8 +22,8 @@ def getProxyLocation():
                 return proxyPath
     # /tmp/x509up_u<uid>
     proxyName = "x509up_u%d" % os.getuid()
-    if os.path.isfile(f"/tmp/{proxyName}"):
-        return f"/tmp/{proxyName}"
+    if os.path.isfile(f"/tmp/{proxyName}"):  # nosec: B108
+        return f"/tmp/{proxyName}"  # nosec: B108
 
 
 def getCAsLocation():
@@ -190,7 +190,7 @@ def getDefaultProxyLocation():
 
     # /tmp/x509up_u<uid>
     proxyName = "x509up_u%d" % os.getuid()
-    return f"/tmp/{proxyName}"
+    return f"/tmp/{proxyName}"  # nosec: B108
 
 
 def getVomsesLocation():

--- a/src/DIRAC/DataManagementSystem/scripts/dirac_dms_protocol_matrix.py
+++ b/src/DIRAC/DataManagementSystem/scripts/dirac_dms_protocol_matrix.py
@@ -41,7 +41,9 @@ You can have the following combinations::
   Using sources: IN2P3-User
   Using target: IN2P3-User
 """
+import os
 import csv
+import tempfile
 from collections import defaultdict
 
 from DIRAC.Core.Base.Script import Script
@@ -49,9 +51,10 @@ from DIRAC.Core.Base.Script import Script
 
 @Script()
 def main():
+    outputFile = os.path.join(tempfile.gettempdir(), "protocol-matrix.csv")
     Script.registerSwitch("", "FromSE=", "SE1[,SE2,...]")
     Script.registerSwitch("", "TargetSE=", "SE1[,SE2,...]")
-    Script.registerSwitch("", "OutputFile=", "CSV output file (default /tmp/protocol-matrix.csv)")
+    Script.registerSwitch("", "OutputFile=", f"CSV output file (default {outputFile})")
     Script.registerSwitch("", "Bidirection", "If FromSE or TargetSE are specified, make a square matrix ")
     Script.registerSwitch("", "FTS", "Display the protocols sent to FTS")
     Script.registerSwitch("", "TPC", "Display the protocols tried for interactive TPC")
@@ -69,7 +72,6 @@ def main():
     fromSE = []
     targetSE = []
     excludeSE = []
-    outputFile = "/tmp/protocol-matrix.csv"
     bidirection = False
     ftsTab = False
     tpcTab = False

--- a/src/DIRAC/FrameworkSystem/private/authorization/utils/Tokens.py
+++ b/src/DIRAC/FrameworkSystem/private/authorization/utils/Tokens.py
@@ -33,7 +33,7 @@ def getTokenFileLocation(fileName=None):
     elif os.environ.get("XDG_RUNTIME_DIR"):
         return f"{os.environ['XDG_RUNTIME_DIR']}/bt_u{os.getuid()}"
     else:
-        return f"/tmp/bt_u{os.getuid()}"
+        return f"/tmp/bt_u{os.getuid()}"  # nosec: B108
 
 
 def getLocalTokenDict(location=None):

--- a/src/DIRAC/Resources/Computing/SingularityComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SingularityComputingElement.py
@@ -32,7 +32,7 @@ from DIRAC.WorkloadManagementSystem.Utilities.Utils import createJobWrapper
 # Default container to use if it isn't specified in the CE options
 CONTAINER_DEFROOT = "/cvmfs/cernvm-prod.cern.ch/cvm4"
 CONTAINER_WORKDIR = "DIRAC_containers"
-CONTAINER_INNERDIR = "/tmp"
+CONTAINER_INNERDIR = "/tmp"  # nosec: B108
 
 
 # What is executed inside the container (2 options given)
@@ -218,7 +218,7 @@ class SingularityComputingElement(ComputingElement):
             pythonPath="python",
             log=log,
             logLevel=logLevel,
-            extraOptions="" if self.__installDIRACInContainer else "/tmp/pilot.cfg",
+            extraOptions="" if self.__installDIRACInContainer else "/tmp/pilot.cfg",  # nosec: B108
         )
         if not result["OK"]:
             return result
@@ -284,8 +284,8 @@ class SingularityComputingElement(ComputingElement):
             payloadEnv = {k: v for k, v in os.environ.items() if ENV_VAR_WHITELIST.match(k)}
 
         payloadEnv["PATH"] = str(Path(sys.executable).parent)
-        payloadEnv["TMP"] = "/tmp"
-        payloadEnv["TMPDIR"] = "/tmp"
+        payloadEnv["TMP"] = "/tmp"  # nosec: B108
+        payloadEnv["TMPDIR"] = "/tmp"  # nosec: B108
         payloadEnv["X509_USER_PROXY"] = os.path.join(self.__innerdir, "proxy")
         payloadEnv["DIRACSYSCONFIG"] = os.path.join(self.__innerdir, "pilot.cfg")
 
@@ -349,7 +349,8 @@ class SingularityComputingElement(ComputingElement):
         outerCmd.extend(["--contain"])  # use minimal /dev and empty other directories (e.g. /tmp and $HOME)
         outerCmd.extend(["--ipc"])  # run container in a new IPC namespace
         outerCmd.extend(["--workdir", baseDir])  # working directory to be used for /tmp, /var/tmp and $HOME
-        outerCmd.extend(["--home", "/tmp"])  # Avoid using small tmpfs for default $HOME and use scratch /tmp instead
+        # Avoid using small tmpfs for default $HOME and use scratch /tmp instead
+        outerCmd.extend(["--home", "/tmp"])  # nosec: B108
         outerCmd.append("--userns")
         if withCVMFS:
             outerCmd.extend(["--bind", "/cvmfs"])


### PR DESCRIPTION
Hi,

This is another part of #8547: I've looked through the places where /tmp is hardcoded. In most places it's either a grid standard (proxy/token location fallback after checking proper env var) or in a container (where it should be hardcoded because we set-up the paths). There was only one instance where I changed it to use the proper lookup function.

Regards,
Simon

BEGINRELEASENOTES
*All
FIX: Check hardcoded /tmp usage.
ENDRELEASENOTES
