### PR TITLE
[int] Update fixed time conversion window in GraphUtilities

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
+++ b/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
@@ -109,7 +109,11 @@ def convert_to_datetime(dstring):
 def to_timestamp(val):
     try:
         v = float(val)
-        if v > 1000000000 and v < 1900000000:
+        # Check if time is in a sensible window for unix time_t already
+        # if it is we can use it as-is, otherwise try to convert it
+        # 1000000000 = 2001-09-09
+        # 2540000000 = 2050-06-28
+        if v > 1000000000 and v < 2540000000:
             return v
     except Exception:
         pass


### PR DESCRIPTION
Hi,

This made it into one of my other pull requests, but should have been separated and include a comment about the magic numbers...

This is a time_t window that GraphUtil uses to decided the format of a date:  The original value only goes to 2030; while I suspect the plan is for this code to be replaced by DIRACX by then, it feels like a good idea to extend the window just-in-case.

Regards,
Simon

BEGINRELEASENOTES
*Core
FIX: Update fixed time conversion window in GraphUtilities
ENDRELEASENOTES
