### PR TITLE
[int] Add missing pilotID column back in web pilot lookup

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -508,7 +508,7 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)"
         args = []
         if isinstance(pilotID, list):
             placeholders = ",".join(["%s"] * len(pilotID))
-            cmd = f"SELECT JobID FROM JobToPilotMapping WHERE pilotID IN ({placeholders})"
+            cmd = f"SELECT pilotID,JobID FROM JobToPilotMapping WHERE pilotID IN ({placeholders})"
             args = [str(int(x)) for x in pilotID]
         else:
             cmd = f"{cmd} WHERE pilotID = %s"


### PR DESCRIPTION
Hi,

One of my security patches added a bug in the web interface (causes PilotMonitor to fail to list pilots)... Here is the fix; I intend to backport it (9.0 & 8) once it's approved here.

Regards,
Simon


BEGINRELEASENOTES
*WorkloadManagement
FIX: Add missing pilotID column back in web pilot lookup
ENDRELEASENOTES
