### PR TITLE
[8.0] fix: do not reset files for not yet submitted jobs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
               src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py|
               tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
           )$
+        language_version: python3.11
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1

--- a/src/DIRAC/TransformationSystem/Client/WorkflowTasks.py
+++ b/src/DIRAC/TransformationSystem/Client/WorkflowTasks.py
@@ -679,10 +679,6 @@ class WorkflowTasks(TaskBase):
         taskNameIDs = res["Value"]["TaskNameIDs"]
 
         updateDict = {}
-        for jobName in noTasks:
-            for lfn, oldStatus in taskFiles[jobName].items():
-                if oldStatus != TransformationFilesStatus.UNUSED:
-                    updateDict[lfn] = TransformationFilesStatus.UNUSED
 
         res = self.jobMonitoringClient.getJobsStatus(list(taskNameIDs.values()))
         if not res["OK"]:


### PR DESCRIPTION
The removed operation was reseting files to Unused for tasks that were created but job not yet submitted. As a result new jobs were created for the same files multiple files.  

A fix was needed in the pre-commit configuration for the flynt part as by default it uses python3.14 version not compatible with 3.11. I think this should be harmless

BEGINRELEASENOTES

*Transformation
FIX: WorkflowTasks - do not reset files for not yet submitted jobs

ENDRELEASENOTES
