### PR TITLE
[int] Tidy up a few files left by unit tests

### DIFF
--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_Backends.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/Test_Logging_Backends.py
@@ -2,6 +2,7 @@
 Test backend attachment
 """
 import pytest
+from pathlib import Path
 
 from DIRAC.FrameworkSystem.private.standardLogging.test.TestLogUtilities import gLogger, gLoggerReset, cleaningLog
 
@@ -146,3 +147,11 @@ def test_registerBackendgLogger(backends):
     for backend, params in backends.items():
         content = params["extractBackendContent"](params["backendOptions"])
         assert content == params["backendContent"]
+
+    # Clean up backend temp output files
+    for params in backends.values():
+        fName = params.get("backendOptions", {}).get("FileName", None)
+        if fName:
+            fPath = Path(fName)
+            if fPath.exists():
+                fPath.unlink()

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -639,6 +639,8 @@ def test_execute(mocker, executable, args, src, expectedResult):
 
     if os.path.exists("std.out"):
         os.remove("std.out")
+    if os.path.exists("DISABLE_WATCHDOG_CPU_WALLCLOCK_CHECK"):
+        os.remove("DISABLE_WATCHDOG_CPU_WALLCLOCK_CHECK")
 
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

When running the unit tests locally, I've found they leave a few files in the cwd (generally the top of the code tree where they show up as untracked files)... This patch tidies them up.

Regards,
Simon

BEGINRELEASENOTES
*Tests
FIX: Tidy up a few files left by unit tests
ENDRELEASENOTES
