### PR TITLE
[v9r0] Backport: Add missing pilotID column back in web pilot lookup

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/PilotAgentsDB.py
@@ -508,7 +508,7 @@ AND SubmissionTime < DATE_SUB(UTC_TIMESTAMP(),INTERVAL %d DAY)"
         args = []
         if isinstance(pilotID, list):
             placeholders = ",".join(["%s"] * len(pilotID))
-            cmd = f"SELECT JobID FROM JobToPilotMapping WHERE pilotID IN ({placeholders})"
+            cmd = f"SELECT pilotID,JobID FROM JobToPilotMapping WHERE pilotID IN ({placeholders})"
             args = [str(int(x)) for x in pilotID]
         else:
             cmd = f"{cmd} WHERE pilotID = %s"


### PR DESCRIPTION
Here is the v9 backport of #8581.
I've also checked v8, but that one doesn't contain the bug.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Add missing pilotID column back in web pilot lookup
ENDRELEASENOTES
