### PR TITLE
[int] Check all remaining subprocess-with-shell calls

### DIFF
--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -592,7 +592,7 @@ def shellCall(timeout, cmdSeq, callbackFunction=None, env=None, bufferLimit=5242
         result = shCall(timeout + 1)
     else:
         spObject = Subprocess(timeout, bufferLimit=bufferLimit)
-        result = spObject.systemCall(cmdSeq, callbackFunction=callbackFunction, env=env, shell=True)
+        result = spObject.systemCall(cmdSeq, callbackFunction=callbackFunction, env=env, shell=True)  #  nosec: B604
     return result
 
 

--- a/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
+++ b/src/DIRAC/FrameworkSystem/Service/SystemAdministratorHandler.py
@@ -599,7 +599,7 @@ class SystemAdministratorHandler(RequestHandler):
 
         # Disk occupancy
         summary = ""
-        _status, output = subprocess.getstatusoutput("df")
+        _status, output = subprocess.getstatusoutput("df")  # nosec: B605
         lines = output.split("\n")
         for i in range(len(lines)):
             if lines[i].startswith("/dev"):

--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/JobWrapper.py
@@ -1604,7 +1604,7 @@ class ExecutionThread(threading.Thread):
         log.verbose("Cmd called", self.cmd)
         output = self.spObject.systemCall(
             self.cmd, env=self.exeEnv, callbackFunction=self.sendOutput, shell=True, start_new_session=True
-        )
+        )  # nosec: B604
         log.verbose(f"Output of system call within execution thread: {output}")
         self.executionResults["Thread"] = output
         timing = time.time() - start


### PR DESCRIPTION
Hi,

Part of #8547: There are 4 remaining calls where a subprocess is run with a shell one way or another, these are either completely intentional or safe because the call is hardcoded (one of which is about to be removed anyway, but as the PR for that is still a draft, I'm marking it for completeness anyway).

Regards,
Simon

BEGINRELEASENOTES
ENDRELEASENOTES
