### PR TITLE
[8.0] Use python3.11 for flynt pre-commit module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
               src/DIRAC/WorkloadManagementSystem/Utilities/PilotWrapper.py|
               tests/Integration/WorkloadManagementSystem/Test_GenerateAndExecutePilotWrapper.py
           )$
+        language_version: python3.11
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1


### PR DESCRIPTION
Use python3.11 for flynt pre-commit module

BEGINRELEASENOTES

*Core
FIX: Use python3.11 for flynt pre-commit module

ENDRELEASENOTES
