### PR TITLE
[8.0] call ping with no True argument

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -400,7 +400,7 @@ class ConnectionPool:
 
     def __ping(self, conn):
         try:
-            conn.ping(True)
+            conn.ping()
             return True
         except Exception:
             return False


### PR DESCRIPTION
  Avoid 

BEGINRELEASENOTES

*Core
FIX: MySQL - avoid massive warnings with newer versions of MySQL and MariaDB


ENDRELEASENOTES
