### PR TITLE
[int] Tidy up https use in runjoblocal

### DIFF
--- a/src/DIRAC/TransformationSystem/scripts/dirac_production_runjoblocal.py
+++ b/src/DIRAC/TransformationSystem/scripts/dirac_production_runjoblocal.py
@@ -8,7 +8,6 @@ from importlib import import_module
 import os
 import shutil
 import subprocess
-import ssl
 
 from xml.etree import ElementTree as et
 
@@ -59,17 +58,15 @@ def __downloadPilotScripts():
     Downloads the scripts necessary to configure the pilot
     """
 
-    context = ssl._create_unverified_context()
     for fileName in [
         "dirac-pilot.py",
         "pilotCommands.py",
         "pilotTools",
     ]:
         remoteFile = urlopen(
-            os.path.join("https://raw.githubusercontent.com/DIRACGrid/Pilot/master/Pilot/", fileName),
+            f"https://raw.githubusercontent.com/DIRACGrid/Pilot/master/Pilot/{fileName}",
             timeout=10,
-            context=context,
-        )
+        )  # nosec: B310
         with open(fileName, "wb") as localFile:
             localFile.write(remoteFile.read())
 


### PR DESCRIPTION
Another quick fix-up part #8547. The cert for github should be in the system store, f-string is simpler for just adding a filename onto the end of a static string: No need to import the full urjoin just for that. B310 exception as URL has https:// hardcoded so there is no unexpected protocol risk.

Regards,
Simon

BEGINRELEASENOTES
*TransformationSystem
FIX: Tidy up https use in runjoblocal
ENDRELEASENOTES
