### PR TITLE
[int] Check pickle usage

### DIFF
--- a/src/DIRAC/Interfaces/Utilities/DConfigCache.py
+++ b/src/DIRAC/Interfaces/Utilities/DConfigCache.py
@@ -2,7 +2,7 @@
 import os
 import re
 import time
-import pickle
+import pickle  # nosec: B403
 import tempfile
 
 from DIRAC import gLogger
@@ -69,7 +69,8 @@ class ConfigCache:
         else:
             try:
                 with open(self.configCacheName, "rb") as fh:
-                    gConfigurationData.mergedCFG = pickle.load(fh)
+                    # Pickle files are cached locally, so should be safe
+                    gConfigurationData.mergedCFG = pickle.load(fh)  # nosec: B301
                     reset_all_caches()
             except:
                 gLogger.error("Cache corrupt or unreadable")

--- a/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
+++ b/src/DIRAC/TransformationSystem/Agent/TransformationAgent.py
@@ -14,7 +14,7 @@ from importlib import import_module
 import time
 import os
 import datetime
-import pickle
+import pickle  # nosec: B403
 import concurrent.futures
 from pathlib import Path
 
@@ -672,7 +672,8 @@ class TransformationAgent(AgentModule, TransformationAgentsUtilities):
                 self.replicaCache[transID] = {}
             else:
                 with open(fileName, "rb") as cacheFile:
-                    self.replicaCache[transID] = pickle.load(cacheFile)
+                    # Pickle files are only written locally, so should be safe
+                    self.replicaCache[transID] = pickle.load(cacheFile)  # nosec: B301
                 self._logInfo(
                     "Successfully loaded replica cache from file %s (%d files)"
                     % (fileName, self.__filesInCache(transID)),


### PR DESCRIPTION
Part of #8547: Check usage of pickle for any security issues. All files are written locally and re-read as a cache, which is a safe way to use the module.

Regards,
Simon

BEGINRELEASENOTES
*All
FIX: Check pickle usage
ENDRELEASENOTES
