### PR TITLE
[int] Remove discoverInterfaces

### DIFF
--- a/src/DIRAC/Core/Utilities/Network.py
+++ b/src/DIRAC/Core/Utilities/Network.py
@@ -6,17 +6,7 @@ import socket
 import os
 from urllib import parse
 
-import psutil
-
 from DIRAC.Core.Utilities.ReturnValues import S_OK, S_ERROR
-
-
-def discoverInterfaces():
-    interfaces = {k: {a.family: a.address for a in v} for k, v in psutil.net_if_addrs().items()}
-    return {
-        k: {"ip": v.get(socket.AF_INET, "0.0.0.0"), "mac": v.get(psutil.AF_LINK, "00:00:00:00:00:00")}
-        for k, v in interfaces.items()
-    }
 
 
 def getFQDN():

--- a/src/DIRAC/Core/Utilities/test/Test_Network.py
+++ b/src/DIRAC/Core/Utilities/test/Test_Network.py
@@ -2,17 +2,7 @@
 """
 import pytest
 
-from DIRAC.Core.Utilities.Network import discoverInterfaces, getFQDN, getIPsForHostName, checkHostsMatch
-
-
-def test_discoverInterfaces():
-    interfaces = discoverInterfaces()
-    assert len(interfaces) >= 1
-    assert "lo" in interfaces or "lo0" in interfaces
-    assert interfaces.get("lo", interfaces.get("lo0"))["ip"].startswith("127")
-    for interfaceInfo in interfaces.values():
-        assert "ip" in interfaceInfo
-        assert "mac" in interfaceInfo
+from DIRAC.Core.Utilities.Network import getFQDN, getIPsForHostName, checkHostsMatch
 
 
 def test_getFQDN():


### PR DESCRIPTION
Hi,

(Part of #8547).
This function triggers a false positive in bandit (due to the "0.0.0.0" string looking like hardcoded use all interfaces). I could just mark it with a nosec, but I noticed it's not actually used, any complaints for just removing it?
(I could mark it as deprecated and add the nosec instead if you'd like a more cautious approach, just let me know).

Regards,
Simon

BEGINRELEASENOTES
*Core
CHANGE: Remove unused discoverInterfaces function
ENDRELEASENOTES
