### PR TITLE
[8.0] Do not bootstrap the workflow before setting command line parameters

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_jobexec.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_jobexec.py
@@ -43,8 +43,6 @@ def main():
             sys.exit(1)
         workflow = fromXMLFile(jobfile)
         gLogger.debug(workflow)
-        code = workflow.createCode()
-        gLogger.debug(code)
         jobID = 0
         if "JOBID" in os.environ:
             jobID = os.environ["JOBID"]

--- a/tests/System/test_wf_job.py
+++ b/tests/System/test_wf_job.py
@@ -1,0 +1,29 @@
+#!/bin/env python
+# Test the possibility to use general workflow parameters as variables
+# in the job description
+
+import subprocess
+import shlex
+import sys
+from pathlib import Path
+from DIRAC.Interfaces.API.Job import Job
+
+job = Job()
+
+job.setExecutable("/bin/ls")
+job.setExecutable("/bin/echo", arguments="@{InputData}")
+
+file = Path("jobDescription.xml")
+file.write_text(job.workflow.toXML())
+
+status = subprocess.call(shlex.split("dirac-jobexec jobDescription.xml -p InputData='{input_file_1,input_file_2}'"))
+if status:
+    sys.exit(status)
+
+file = Path("Script2_echo.log")
+content = file.read_text()
+if not "input_file_1;input_file_2" in content:
+    print("Test failed !")
+    sys.exit(-1)
+
+print("Test successful !")

--- a/tests/System/test_wf_job.py
+++ b/tests/System/test_wf_job.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # Test the possibility to use general workflow parameters as variables
 # in the job description
 

--- a/tests/System/wms_scripts.sh
+++ b/tests/System/wms_scripts.sh
@@ -15,6 +15,7 @@ declare -a commands=(
 'dirac-wms-get-normalized-queue-length ce503.cern.ch/condor'
 'dirac-wms-get-queue-normalization ce503.cern.ch/condor'
 'dirac-wms-select-jobs --Status=Running'
+'test_wf_job.py'
 )
 
 echo " "


### PR DESCRIPTION
   The call to the createCode() of the workflow triggers resolving global workflow parameters before the command line parameters are set into the workflow. This results in loosing some global references in a form @{Reference}, in particular, @{InputData} reference if it is specified in the command line. This fixes the issue #8595


BEGINRELEASENOTES

*WorkloadManagement
FIX: dirac-jobexec - removed workflow code generation

ENDRELEASENOTES
