### PR TITLE
[int] Remove other/group permissions in chmod

### DIFF
--- a/src/DIRAC/Core/scripts/dirac_apptainer_exec.py
+++ b/src/DIRAC/Core/scripts/dirac_apptainer_exec.py
@@ -67,7 +67,8 @@ def main():
             dirac_env_var, diracos_env_var, etc_dir, rc_script, command, include_proxy=include_proxy
         )
         fd.write(script)
-    os.chmod("dirac_container.sh", 0o755)
+    # Script may include credentials, make sure other users can't read it
+    os.chmod("dirac_container.sh", 0o700)
 
     # Now let's construct the apptainer command
     cmd = ["apptainer", "exec"]

--- a/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
+++ b/src/DIRAC/Resources/Computing/HTCondorCEComputingElement.py
@@ -313,7 +313,8 @@ class HTCondorCEComputingElement(ComputingElement):
 
         self.log.verbose("Executable file path:", executableFile)
         if not os.access(executableFile, 5):
-            os.chmod(executableFile, 0o755)
+            # Script may include bundled credentials, we don't want other users to read it
+            os.chmod(executableFile, 0o700)
 
         # The submitted pilots are going to have a common part of the stamp to construct a path to retrieve results
         # Then they also have an individual part to make them unique

--- a/src/DIRAC/Resources/Computing/SSHComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SSHComputingElement.py
@@ -320,7 +320,8 @@ class SSHComputingElement(ComputingElement):
             self.log.error("Failed generating control script")
             return result
         localScript = result["Value"]
-        os.chmod(localScript, 0o755)
+        # Mark script as executable, but only for current user
+        os.chmod(localScript, 0o700)
 
         self.log.verbose(f"Uploading {self.batchSystem.__class__.__name__} script to {self.host}")
         remoteScript = f"{self.sharedArea}/execute_batch"
@@ -459,7 +460,8 @@ class SSHComputingElement(ComputingElement):
         # Copy the executable
         self.log.verbose(f"Copying executable to {self.host}")
         submitFile = os.path.join(self.executableArea, os.path.basename(executableFile))
-        os.chmod(executableFile, 0o755)
+        # Job file may contain bundled credentials, so make sure other users can't read it
+        os.chmod(executableFile, 0o700)
 
         result = self._put(connection, executableFile, submitFile)
         if not result["OK"]:


### PR DESCRIPTION
Hi,

This simply changes a few places where we set permissions on files to not open the group or other user ones: Some of these files contain things like the bundle proxies, so we don't really want to risk exposing these (in most cases the upstream dir permissions will protect these anyway, this is a defence in depth measure).

I've tested HTCondorCE and dirac_apptainer_exec; I don't have a test set-up for SSHCE, but in general files are executed by the same user that's writing them.

Regards,
Simon


BEGINRELEASENOTES
*Core/Resources
FIX: Remove other/group permissions in chmod
ENDRELEASENOTES
