### PR TITLE
[int] Check use of exec

### DIFF
--- a/src/DIRAC/Core/Workflow/Module.py
+++ b/src/DIRAC/Core/Workflow/Module.py
@@ -84,7 +84,10 @@ class ModuleDefinition(AttributeCollection):
             # Python 3.14+: exec() doesn't populate the calling scope when used inside a function
             # without explicit locals dict, so we need to capture the locals
             local_vars = {}
-            exec(self.getBody(), globals(), local_vars)
+            body = self.getBody()
+            global_vars = globals()
+            # This runs in the context of the workflow runtime, so executing code is expected!
+            exec(body, global_vars, local_vars)  # nosec: B102
             if self.getType() in local_vars:
                 self.main_class_obj = local_vars[self.getType()]  # save class object
             else:


### PR DESCRIPTION
Another part of #8547. There is only one exec which runs in the workflow context.

I've had to juggle the parameters slightly: There is peculiarity of bandit where it gets confused by function calls in parameters of functions that are marked with nosec, it generates warnings for each one: Splitting them into their own variables simplifies the AST (and maybe makes it a tiny bit more readable for the humans too?).

BEGINRELEASENOTES
*Core
FIX: Check use of exec
ENDRELEASENOTES
