### PR TITLE
[int] Tidy up bandit warnings for edge cases

### DIFF
--- a/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
+++ b/src/DIRAC/Core/Utilities/Graphs/GraphUtilities.py
@@ -91,7 +91,7 @@ def convert_to_datetime(dstring):
                 results = datetime.datetime.utcfromtimestamp(timestamp)
                 break
             except Exception:
-                pass  # nosec B110
+                pass  # nosec
         if t is None:
             try:
                 dstring = dstring.split(".", 1)[0]

--- a/src/DIRAC/Core/Utilities/Subprocess.py
+++ b/src/DIRAC/Core/Utilities/Subprocess.py
@@ -403,7 +403,7 @@ class Subprocess:
                 self.log.error("Error reading", f"type(nB) ={type(nB)}")
                 self.log.error("Error reading", f"nB ={str(nB)}")
             except Exception:
-                pass  # nosec B110
+                pass  # nosec
             return S_ERROR(f"Can not read from output: {str(x)}")
         if len(dataString) + baseLength > self.bufferLimit:
             self.log.error("Maximum output buffer length reached")
@@ -464,7 +464,7 @@ class Subprocess:
                 self.child.stdout.close()
                 self.child.stderr.close()
             except Exception:
-                pass  # nosec B110
+                pass  # nosec
             retDict = S_ERROR(repr(x))
             retDict["Value"] = (-1, "", str(x))
             return retDict

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/DirectorySecurityManagerWithDelete.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/SecurityManager/DirectorySecurityManagerWithDelete.py
@@ -72,7 +72,7 @@ class DirectorySecurityManagerWithDelete(DirectorySecurityManager):
                 try:
                     paths.pop(path)
                 except Exception:
-                    pass  # nosec B110
+                    pass  # nosec
 
         # For all the paths that exist, check the write permission
         if paths:

--- a/src/DIRAC/Resources/Computing/SingularityComputingElement.py
+++ b/src/DIRAC/Resources/Computing/SingularityComputingElement.py
@@ -33,6 +33,8 @@ from DIRAC.WorkloadManagementSystem.Utilities.Utils import createJobWrapper
 CONTAINER_DEFROOT = "/cvmfs/cernvm-prod.cern.ch/cvm4"
 CONTAINER_WORKDIR = "DIRAC_containers"
 CONTAINER_INNERDIR = "/tmp"  # nosec: B108
+# /tmp dir to use in the container
+CONTAINER_TMPDIR = "/tmp"  # nosec: B108
 
 
 # What is executed inside the container (2 options given)
@@ -218,7 +220,7 @@ class SingularityComputingElement(ComputingElement):
             pythonPath="python",
             log=log,
             logLevel=logLevel,
-            extraOptions="" if self.__installDIRACInContainer else "/tmp/pilot.cfg",  # nosec: B108
+            extraOptions="" if self.__installDIRACInContainer else os.path.join(CONTAINER_TMPDIR, "pilot.cfg"),
         )
         if not result["OK"]:
             return result
@@ -284,8 +286,8 @@ class SingularityComputingElement(ComputingElement):
             payloadEnv = {k: v for k, v in os.environ.items() if ENV_VAR_WHITELIST.match(k)}
 
         payloadEnv["PATH"] = str(Path(sys.executable).parent)
-        payloadEnv["TMP"] = "/tmp"  # nosec: B108
-        payloadEnv["TMPDIR"] = "/tmp"  # nosec: B108
+        payloadEnv["TMP"] = CONTAINER_TMPDIR
+        payloadEnv["TMPDIR"] = CONTAINER_TMPDIR
         payloadEnv["X509_USER_PROXY"] = os.path.join(self.__innerdir, "proxy")
         payloadEnv["DIRACSYSCONFIG"] = os.path.join(self.__innerdir, "pilot.cfg")
 
@@ -350,7 +352,7 @@ class SingularityComputingElement(ComputingElement):
         outerCmd.extend(["--ipc"])  # run container in a new IPC namespace
         outerCmd.extend(["--workdir", baseDir])  # working directory to be used for /tmp, /var/tmp and $HOME
         # Avoid using small tmpfs for default $HOME and use scratch /tmp instead
-        outerCmd.extend(["--home", "/tmp"])  # nosec: B108
+        outerCmd.extend(["--home", CONTAINER_TMPDIR])
         outerCmd.append("--userns")
         if withCVMFS:
             outerCmd.extend(["--bind", "/cvmfs"])


### PR DESCRIPTION
Hi,

There are a few places where, while technically correct, the nosec exceptions cause warnings from the bandit test. There are certain patterns (particularly nested excepts) where the nosec gets applied to multiple nodes in the syntax tree and this will cause a warning that a specific case is applied to a node that doesn't need it (such as `WARNING nosec encountered (B110), but no failed test on file`, removing the nosec will cause a test failure to appear).

The simplest fix for this is to make these cases a "nosec" with no specific type, those can be applied to any node without a warning and generally it doesn't really matter if it gets applied to another node. It is also possible to resolve some of these by refactoring things so the nosec is on a line that only creates a single AST node.

Regards,
Simon

BEGINRELEASENOTES
*All
FIX: Tidy up bandit warnings for edge cases
ENDRELEASENOTES
