### PR TITLE
[int] Use a random cookie secret

### DIFF
--- a/src/DIRAC/Core/Tornado/Server/TornadoServer.py
+++ b/src/DIRAC/Core/Tornado/Server/TornadoServer.py
@@ -7,6 +7,7 @@ import time
 import os
 import asyncio
 import psutil
+import secrets
 
 import M2Crypto.SSL
 
@@ -216,7 +217,7 @@ class TornadoServer:
             sLog.debug(" - %s" % "\n - ".join([f"{k} = {ssl_options[k]}" for k in ssl_options]))
 
             # Default server configuration
-            settings = dict(compress_response=True, cookie_secret="secret")
+            settings = dict(compress_response=True, cookie_secret=secrets.token_hex(32))
 
             # Merge appllication settings
             settings.update(app["settings"])


### PR DESCRIPTION
Hi,

Part of #8547.
The default cookie secret for Tornado seems to be hardcoded to "secret". I suggest randomising this: As far as I can tell the cookies are only used as part of the DIRAC OAuth2 login flow, which I think was entirely superseded by DIRACX anyway. In the worst case, restarting the server would invalidate any sessions that are mid-redirect at the time. If really needed we could store a secret somewhere (e.g. dirac.cfg) and use that, but it seems excessive.

Regards,
Simon

BEGINRELEASENOTES
*Core
FIX: Use a random cookie secret
ENDRELEASENOTES
