### PR TITLE
[int] Move watchdog flag cleanup to correct place

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
+++ b/src/DIRAC/WorkloadManagementSystem/JobWrapper/test/Test_JobWrapper.py
@@ -182,6 +182,8 @@ def test_preProcess_dirac_jobexec_with_args(setup_job_wrapper):
     )
     assert result["Value"]["env"]["DIRAC_PROCESSORS"] == "1"
     assert result["Value"]["env"]["DIRAC_WHOLENODE"] == "False"
+    if os.path.exists("DISABLE_WATCHDOG_CPU_WALLCLOCK_CHECK"):
+        os.remove("DISABLE_WATCHDOG_CPU_WALLCLOCK_CHECK")
 
 
 # -------------------------------------------------------------------------------------------------
@@ -639,8 +641,6 @@ def test_execute(mocker, executable, args, src, expectedResult):
 
     if os.path.exists("std.out"):
         os.remove("std.out")
-    if os.path.exists("DISABLE_WATCHDOG_CPU_WALLCLOCK_CHECK"):
-        os.remove("DISABLE_WATCHDOG_CPU_WALLCLOCK_CHECK")
 
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This test fixup that I added isn't in the right place: It works for the "runslow" tests because the slow test with the cleanup runs after the test that creates it. In "fast" mode, the file still gets left behind: This patch puts the cleanup in the test that actually creates the file (really it could still do with being a test fixture so that it runs whatever state the test finishes in, but that also feels like a lot of extra code for this one file that doesn’t seem to annoy anyone else :-)

BEGINRELEASENOTES
*WorkloadManagement
FIX: Move watchdog flag cleanup to correct place
ENDRELEASENOTES
