### PR TITLE
Fix standardLogging tests failing in CI when handlers are removed

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/test/Test_LocalConfiguration.py
+++ b/src/DIRAC/ConfigurationSystem/Client/test/Test_LocalConfiguration.py
@@ -1,10 +1,9 @@
-""" Unit tests for PathFinder only for functions that I added
-"""
-from unittest import mock
+"""Unit tests for PathFinder only for functions that I added"""
+
 import pytest
 import random
 
-from DIRAC import S_OK, S_ERROR
+from DIRAC import S_OK
 import DIRAC.ConfigurationSystem.Client.LocalConfiguration
 
 
@@ -88,6 +87,9 @@ def localCFG(monkeypatch):
     localCFG = DIRAC.ConfigurationSystem.Client.LocalConfiguration.LocalConfiguration()
     # It's local test, do not contact Configuration Server
     localCFG.disableCS()
+    # These tests reset the logging while testing the script init
+    # This would cause an empty logger to persist post-test, so we mock away the __initLogger
+    monkeypatch.setattr(localCFG, "_LocalConfiguration__initLogger", lambda *a, **kw: None)
     return localCFG
 
 

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/BaseFormatter.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/Formatter/BaseFormatter.py
@@ -65,7 +65,7 @@ class BaseFormatter(logging.Formatter):
 
         fmt += "%(message)s%(spacer)s%(varmessage)s"
 
-        self._style._fmt = fmt  # pylint: disable=no-member
+        self._style = logging.PercentStyle(fmt)
         return super().format(record)
 
     def formatTime(self, record, datefmt=None):

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/TestLogUtilities.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/TestLogUtilities.py
@@ -6,6 +6,7 @@ from io import StringIO
 
 from DIRAC.FrameworkSystem.private.standardLogging.LoggingRoot import LoggingRoot
 from DIRAC.FrameworkSystem.private.standardLogging.Logging import Logging
+from DIRAC.FrameworkSystem.private.standardLogging.Formatter.BaseFormatter import BaseFormatter
 
 
 gLogger = LoggingRoot()
@@ -31,6 +32,7 @@ def captureBackend():
     for i, handler in enumerate(diracLogger.handlers):
         if hasattr(handler, "stream"):
             handler.stream = bufferDirac
+            handler.setFormatter(BaseFormatter())
             if i > 0:
                 # Move to index 0 so it survives del handlers[1:]
                 diracLogger.handlers.remove(handler)
@@ -38,6 +40,7 @@ def captureBackend():
             return bufferDirac
     # No StreamHandler found, create one at index 0
     handler = logging.StreamHandler(bufferDirac)
+    handler.setFormatter(BaseFormatter())
     diracLogger.handlers.insert(0, handler)
     return bufferDirac
 

--- a/src/DIRAC/FrameworkSystem/private/standardLogging/test/TestLogUtilities.py
+++ b/src/DIRAC/FrameworkSystem/private/standardLogging/test/TestLogUtilities.py
@@ -25,8 +25,20 @@ def captureBackend():
     Modify the output to capture logs of LoggingRoot
     """
     bufferDirac = StringIO()
-    if logging.getLogger("dirac").handlers:
-        logging.getLogger("dirac").handlers[0].stream = bufferDirac
+    diracLogger = logging.getLogger("dirac")
+    # Find an existing StreamHandler, redirect its stream, and ensure it's at index 0
+    # so it survives the `del handlers[1:]` in gLoggerReset
+    for i, handler in enumerate(diracLogger.handlers):
+        if hasattr(handler, "stream"):
+            handler.stream = bufferDirac
+            if i > 0:
+                # Move to index 0 so it survives del handlers[1:]
+                diracLogger.handlers.remove(handler)
+                diracLogger.handlers.insert(0, handler)
+            return bufferDirac
+    # No StreamHandler found, create one at index 0
+    handler = logging.StreamHandler(bufferDirac)
+    diracLogger.handlers.insert(0, handler)
     return bufferDirac
 
 


### PR DESCRIPTION
The captureBackend() function assumed there was always a StreamHandler with a .stream attribute on the 'dirac' logger. When running the full test suite in CI, other tests would remove or replace these handlers, causing capturedBackend.getvalue() to return empty strings.

Modified captureBackend() to:
1. Search for an existing StreamHandler and redirect its stream
2. If no StreamHandler exists, create a new one with the StringIO buffer


