### PR TITLE
fix: Don't apply saferEval default length cap to workflow XML values

### DIFF
--- a/src/DIRAC/Core/Workflow/WorkflowReader.py
+++ b/src/DIRAC/Core/Workflow/WorkflowReader.py
@@ -8,6 +8,16 @@ from DIRAC.Core.Workflow.Step import *
 from DIRAC.Core.Workflow.Workflow import Workflow
 from DIRAC.Core.Utilities.SaferEval import saferEval
 
+# Non-string workflow parameters (lists, dicts, ...) are serialised to XML as the
+# repr() of their value and read back by evaluating that string. Legitimate values
+# (e.g. a listoutput or a BKProcessingPass dict) are KB-scale and routinely exceed
+# the saferEval default cap, so that default is too small here. We still bound the
+# size as defence-in-depth against pathological/malicious input: literal_eval blocks
+# code execution regardless of content, and this ceiling limits its object-allocation
+# blow-up. Legitimate workflow values never approach it, so hitting it means the input
+# is genuinely anomalous and should be rejected.
+MAX_PARAMETER_VALUE_LEN = 1024 * 1024  # 1 MiB
+
 
 class WorkflowXMLHandler(ContentHandler):
     def __init__(self, new_wf=None):
@@ -113,7 +123,7 @@ class WorkflowXMLHandler(ContentHandler):
             if self.stack[-1].isTypeString():
                 self.stack[-1].setValue(ch)
             else:
-                self.stack[-1].setValue(saferEval(ch))
+                self.stack[-1].setValue(saferEval(ch, max_len=MAX_PARAMETER_VALUE_LEN))
 
         # objects
         elif name == "Workflow":

--- a/src/DIRAC/Core/Workflow/test/Test_WorkflowReader.py
+++ b/src/DIRAC/Core/Workflow/test/Test_WorkflowReader.py
@@ -1,0 +1,28 @@
+"""Regression tests for WorkflowReader parsing of workflow XML.
+
+Non-string workflow parameters (e.g. a ``list`` or ``dict``) are serialised to
+XML as ``repr()`` of their value and read back by evaluating that string. Such
+values can legitimately exceed the ``saferEval`` default length cap, so the
+reader must not impose it.
+
+Regression: replacing ``eval`` with ``saferEval`` introduced a hard 2048-byte
+limit, so parsing a workflow with a large non-string parameter failed with
+``ValueError: Object string is too long (>2048 bytes)``.
+"""
+
+from DIRAC.Core.Workflow.Parameter import Parameter
+from DIRAC.Core.Workflow.Workflow import Workflow, fromXMLString
+
+
+def test_round_trip_large_list_parameter():
+    # A list value whose repr() comfortably exceeds the 2048-byte default cap.
+    big_list = [f"LFN:/lhcb/data/2026/RAW/file_{i:05d}.raw" for i in range(300)]
+    assert len(str(big_list)) > 2048
+
+    wf = Workflow()
+    wf.setName("BigParamWF")
+    wf.addParameter(Parameter("InputDataList", big_list, "list"))
+
+    parsed = fromXMLString(wf.toXML())
+
+    assert parsed.findParameter("InputDataList").getValue() == big_list


### PR DESCRIPTION
Commit bf6858d replaced eval() with saferEval() in WorkflowReader to avoid evaluating arbitrary code. saferEval enforces a 2048-byte cap, but non-string workflow parameters (lists/dicts serialised as repr()) are KB-scale and routinely exceed it, so parsing legitimate workflows failed with "Object string is too long (>2048 bytes)".

Pass a generous finite cap (1 MiB) at this call site instead of the 2048 default. literal_eval still prevents code execution regardless of content; the ceiling remains as defence-in-depth against pathological/malicious input, bounding literal_eval's object-allocation blow-up. Legitimate workflow values never approach it. SaferEval's default is left unchanged for its other callers.



BEGINRELEASENOTES

*Workflow
FIX: increased saferEval limit to 1 MiB for Workflow XML handling

ENDRELEASENOTES
