### PR TITLE
Fix documentation example typo

### DIFF
--- a/src/DIRAC/Core/Utilities/Proxy.py
+++ b/src/DIRAC/Core/Utilities/Proxy.py
@@ -22,7 +22,7 @@ Utilities to execute one or more functions with a given proxy.
      print foo, os.environ.get('X509_USER_PROXY')
      return S_OK()
 
-  executeWithUserProxy(testFcn)(foo='baz', proxyUserName='atsareg', proxyUserGroup='biomed_user')
+  executeWithUserProxy(undecoratedFunction)(foo='baz', proxyUserName='atsareg', proxyUserGroup='biomed_user')
 
 
 :class:`UserProxy` context manager example::


### PR DESCRIPTION
While learning my way around DIRAC, I noticed a minor typo in the documentation example.

BEGINRELEASENOTES

FIX: Minor documentation typo

ENDRELEASENOTES
