### PR TITLE
[int] Catch ValueError when formatting SQL statement logs

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -759,7 +759,7 @@ class MySQL:
 
         try:
             return safe % tuple(subs)
-        except TypeError:
+        except (TypeError, ValueError):
             return safe
 
     def _connect(self):


### PR DESCRIPTION
Hi,

This is my simpler fix to avoid needing mogrify in the mysql library: If there is an unescaped formatting character in the SQL statement, the logging will throw ValueError. By catching it here, it'll raise a proper ProgrammingError from the mysql library instead, which will hopefully make it clearer that something is wrong.

Regards,
Simon

BEGINRELEASENOTES
*Core
FIX: Catch ValueError when formatting SQL statement logs
ENDRELEASENOTES
