### PR TITLE
[int] Fix SQL escaping in TaskQueueDB priority calculation

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/TaskQueueDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/TaskQueueDB.py
@@ -1243,7 +1243,7 @@ WHERE j.JobId = %s AND t.TQId = j.TQId"
             # If group has JobSharing just set prio for that entry, user is irrelevant
             return self.__setPrioritiesForEntity(user, userGroup, share, connObj=connObj)
 
-        selSQL = f"SELECT Owner, COUNT(Owner) FROM `tq_TaskQueues` WHERE OwnerGroup='{userGroup}' GROUP BY Owner"
+        selSQL = f"SELECT Owner, COUNT(Owner) FROM `tq_TaskQueues` WHERE OwnerGroup={userGroup} GROUP BY Owner"
         result = self._query(selSQL, conn=connObj)
         if not result["OK"]:
             return result
@@ -1275,7 +1275,7 @@ WHERE j.JobId = %s AND t.TQId = j.TQId"
         Set the priority for a user/userGroup combo given a splitted share
         """
         self.log.info("Setting priorities", f"to {user}@{userGroup} TQs")
-        tqCond = [f"t.OwnerGroup='{userGroup}'"]
+        tqCond = [f"t.OwnerGroup={userGroup}"]
         allowBgTQs = gConfig.getValue(f"/Registry/Groups/{userGroup}/AllowBackgroundTQs", False)
         if Properties.JOB_SHARING not in Registry.getPropertiesForGroup(userGroup):
             res = self._escapeString(user)

--- a/tests/Integration/WorkloadManagementSystem/Test_TaskQueueDB.py
+++ b/tests/Integration/WorkloadManagementSystem/Test_TaskQueueDB.py
@@ -1359,7 +1359,7 @@ def test_TQ(tq_cleanup):
         "Jobs": 1,
         "OwnerGroup": "myGroup",
         "CPUTime": 86400,
-        "Priority": 1.0,
+        "Priority": 1000.0,
     }
     result = tqDB.findOrphanJobs()
     assert result["OK"]


### PR DESCRIPTION
Here is the patch from #8650 as a PR as requested...

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Fix SQL escaping in TaskQueueDB priority calculation
ENDRELEASENOTES
