### PR TITLE
[int] Fix asserts in ElasticSearchDB

### DIFF
--- a/tests/Integration/Core/Test_ElasticsearchDB.py
+++ b/tests/Integration/Core/Test_ElasticsearchDB.py
@@ -340,18 +340,14 @@ def test_Search():
     s = elasticSearchDB._Search(index_name)
     s = s.filter("bool", must=q)
     query = s.to_dict()
-    assert (
-        query
-        == {
-            "query": {
-                "bool": {
-                    "filter": [
-                        {"bool": {"must": [{"range": {"timestamp": {"gte": 1423497057518, "lte": 1423501337292}}}]}}
-                    ]
-                }
+    exp_query = {
+        "query": {
+            "bool": {
+                "filter": [{"bool": {"must": [{"range": {"timestamp": {"gte": 1423497057518, "lte": 1423501337292}}}]}}]
             }
-        },
-    )
+        }
+    }
+    assert query == exp_query
     result = s.execute()
     assert len(result.hits) == 0
 
@@ -359,18 +355,15 @@ def test_Search():
     s = elasticSearchDB._Search(index_name)
     s = s.filter("bool", must=q)
     query = s.to_dict()
-    assert (
-        query
-        == {
-            "query": {
-                "bool": {
-                    "filter": [
-                        {"bool": {"must": [{"range": {"timestamp": {"gte": 1423399451544, "lte": 1423631917911}}}]}}
-                    ]
-                }
+    exp_query = {
+        "query": {
+            "bool": {
+                "filter": [{"bool": {"must": [{"range": {"timestamp": {"gte": 1423399451544, "lte": 1423631917911}}}]}}]
             }
-        },
-    )
+        }
+    }
+    assert query == exp_query
+
     result = s.execute()
     assert len(result.hits) == 0
     tearDown(index_name)


### PR DESCRIPTION
Hi,

It seems that the way asserts are processed in the pytest AST is slightly unusual and black formatting (particularly wrapping things in brackets) can change the meaning, even if in native python the value would be unchanged: specifically `assert cond` apparently isn't the same as `assert (cond)`.

This fixes up a couple of assets in ElasticSearchDB that may not trigger even if the test should fail due to this unusual behaviour.

Regards,
Simon

BEGINRELEASENOTES
*Core
FIX: Fix asserts in ElasticSearchDB
ENDRELEASENOTES
