### PR TITLE
[int] Replace sqlalchemy imports to remove deprecations

### DIFF
--- a/src/DIRAC/Core/Base/SQLAlchemyDB.py
+++ b/src/DIRAC/Core/Base/SQLAlchemyDB.py
@@ -6,8 +6,7 @@
 
 import datetime
 from urllib import parse as urlparse
-from sqlalchemy import create_engine, desc, exc
-from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy import create_engine, desc, exc, inspect
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.query import Query
 
@@ -61,7 +60,7 @@ class SQLAlchemyDB(DIRACDB):
             echo=self.log.getLevel() == "DEBUG",
         )
         self.sessionMaker_o = sessionmaker(bind=self.engine)
-        self.inspector = Inspector.from_engine(self.engine)
+        self.inspector = inspect(self.engine)
 
     def _createTablesIfNotThere(self, tablesList):
         """

--- a/src/DIRAC/FrameworkSystem/DB/AuthDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/AuthDB.py
@@ -5,9 +5,8 @@ import time
 import pprint
 
 from sqlalchemy import Column, Integer, Text, String
-from sqlalchemy.orm import scoped_session
+from sqlalchemy.orm import declarative_base, scoped_session
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
-from sqlalchemy.ext.declarative import declarative_base
 
 from authlib.jose import KeySet, JsonWebKey
 from authlib.common.security import generate_token

--- a/src/DIRAC/FrameworkSystem/DB/InstalledComponentsDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/InstalledComponentsDB.py
@@ -5,10 +5,8 @@ Classes and functions for easier management of the InstalledComponents database
 import re
 from urllib import parse as urlparse
 
-from sqlalchemy import Column, DateTime, Integer, MetaData, String, create_engine
-from sqlalchemy.engine.reflection import Inspector
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, scoped_session, sessionmaker
+from sqlalchemy import Column, DateTime, Integer, MetaData, String, create_engine, inspect
+from sqlalchemy.orm import declarative_base, relationship, scoped_session, sessionmaker
 from sqlalchemy.schema import ForeignKey
 from sqlalchemy.sql.expression import null
 
@@ -369,7 +367,7 @@ class InstalledComponentsDB:
             echo_pool=True,
         )
         self.session = scoped_session(sessionmaker(bind=self.engine))
-        self.inspector = Inspector.from_engine(self.engine)
+        self.inspector = inspect(self.engine)
 
     def __initializeDB(self):
         """

--- a/src/DIRAC/FrameworkSystem/DB/TokenDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/TokenDB.py
@@ -6,9 +6,8 @@ import time
 import pprint
 
 from sqlalchemy import Column, Integer, Text, String
-from sqlalchemy.orm import scoped_session
+from sqlalchemy.orm import declarative_base, scoped_session
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.ext.declarative import declarative_base
 
 from authlib.integrations.sqla_oauth2 import OAuth2TokenMixin
 

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -17,9 +17,8 @@ TABLESLIST = TABLESLIST + [list of new table names]
 """
 
 import datetime
-from sqlalchemy.orm import class_mapper
+from sqlalchemy.orm import class_mapper, declarative_base
 from sqlalchemy.orm.query import Query
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, String, DateTime, exc, Integer, Float
 
 from DIRAC import S_OK, S_ERROR

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -17,9 +17,8 @@ TABLESLISTWITHID = TABLESLISTWITHID + [list of new table names]
 """
 
 import datetime
-from sqlalchemy.orm import class_mapper
+from sqlalchemy.orm import class_mapper, declarative_base
 from sqlalchemy.orm.query import Query
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, String, DateTime, exc, BigInteger
 
 from DIRAC import S_OK, S_ERROR, gConfig


### PR DESCRIPTION
Hi,

While running the integration tests locally, I noticed a number of warnings from various tests that Inspector and declarative_base from sqlalchemy were deprecated. Inspector has changed a tiny bit and declarative_base has simply moved, so this is the patch to update them.

Regards,
Simon

BEGINRELEASENOTES
*All
FIX: Replace sqlalchemy imports to remove deprecations
ENDRELEASENOTES
