### PR TITLE
fix: handle NoneType correctly inside __escapeString and _escapeValues

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -611,7 +611,9 @@ class MySQL:
             if not retDict["OK"]:
                 return retDict
             connection = retDict["Value"]
-
+        if myString is None:
+            # handle NoneType correctly
+            return S_OK("NULL")
         if isinstance(myString, bytes):
             myString = myString.decode()
         try:

--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -612,7 +612,6 @@ class MySQL:
                 return retDict
             connection = retDict["Value"]
         if myString is None:
-            # handle NoneType correctly
             return S_OK("NULL")
         if isinstance(myString, bytes):
             myString = myString.decode()
@@ -723,7 +722,9 @@ class MySQL:
             return S_OK(inEscapeValues)
 
         for value in inValues:
-            if isinstance(value, str):
+            if value is None:
+                inEscapeValues.append("NULL")
+            elif isinstance(value, str):
                 retDict = self.__escapeString(value, connection=connection)
                 if not retDict["OK"]:
                     return retDict


### PR DESCRIPTION
#8645 breaks a number of call sites to `__escapeString`, `_escapeValues` downstream in LHCb.

cc @chrisburr 

BEGINRELEASENOTES

*Core
FIX: handle NoneType correctly inside __escapeString, _escapeValues

ENDRELEASENOTES
