### PR TITLE
[8.0] fix: skip Tornado server supervision

### DIFF
--- a/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/ComponentSupervisionAgent.py
@@ -322,7 +322,7 @@ class ComponentSupervisionAgent(AgentModule):
 
     def checkService(self, serviceName, options):
         """Ping the service, restart if the ping does not respond."""
-        if serviceName == "Tornado":
+        if serviceName == "Tornado__Tornado":
             return S_OK()
         url = self._getURL(serviceName, options)
         self.log.info("Pinging service", url)

--- a/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
+++ b/src/DIRAC/FrameworkSystem/Agent/test/Test_ComponentSupervisionAgent.py
@@ -411,6 +411,12 @@ class TestComponentSupervisionAgent(unittest.TestCase):
         self.assertFalse(res["OK"])
         self.restartAgent.restartInstance.assert_called_once_with(int(pid), agentName, True)
 
+        client = MagicMock()
+        with patch("DIRAC.FrameworkSystem.Agent.ComponentSupervisionAgent.Client", new=client):
+            res = self.restartAgent.checkService("Tornado__Tornado", options)
+        self.assertTrue(res["OK"])
+        client.assert_not_called()
+
     def test_get_last_access_time(self):
         """Test for the getLastAccessTime function."""
         self.agent.os.path.getmtime = MagicMock()


### PR DESCRIPTION
Backport of #8688

BEGINRELEASENOTES

*Framework
FIX: skip the Tornado server in ComponentSupervisionAgent service checks

ENDRELEASENOTES