### PR TITLE
[9.1] More SQL fixes

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -581,8 +581,8 @@ class MySQL:
             if e.args and e.args[0] in self.__CONNECTION_LOST_ERRNOS:
                 self.__connectionPool.discardCurrentThreadConn()
             if debug:
-                self.log.error(f"{methodName} ({self._safeCmd(cmd)}): {err}", "%d: %s" % (e.args[0], e.args[1]))
-            return S_ERROR(DErrno.EMYSQL, "%s: ( %d: %s )" % (err, e.args[0], e.args[1]))
+                self.log.error(f"{methodName} ({self._safeCmd(cmd)}): {err}", f"{e.args}")
+            return S_ERROR(DErrno.EMYSQL, f"{err}: ({e.args} )")
         except Exception as e:
             if debug:
                 self.log.error(f"{methodName} ({self._safeCmd(cmd)}): {err}", repr(e))

--- a/src/DIRAC/TransformationSystem/DB/TransformationDB.py
+++ b/src/DIRAC/TransformationSystem/DB/TransformationDB.py
@@ -384,7 +384,7 @@ class TransformationDB(DB):
     def getTransformationWithStatus(self, status, connection=False):
         """Gets a list of the transformations with the supplied status"""
         req = "SELECT TransformationID FROM Transformations WHERE Status = %s"
-        res = self._query(req, args=(status), conn=connection)
+        res = self._query(req, args=(status,), conn=connection)
         if not res["OK"]:
             return res
         transIDs = [tupleIn[0] for tupleIn in res["Value"]]


### PR DESCRIPTION
#onlyWorksForGridPP

The first one is just a tuple with a single element without the comma. My regex skills only found that one occurrence

The other one is because not all MySQL have 2 arguments. 
For example 

```python
x = ProgrammingError('not all arguments converted during bytes formatting')
```


BEGINRELEASENOTES
*TS
FIX: bad tupling in getTransformationWithStatus

* Core:
FIX: do not expect an error ID in all MySQL exception

ENDRELEASENOTES
