### PR TITLE
[v9.1] fix (MySQL escape): make a special case of RAND()

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -1508,7 +1508,12 @@ class MySQL:
                 # self.log.debug('buildCondition:', error)
                 raise Exception(error)
 
-            orderField = _quotedList(orderAttr.split(":")[:1])
+            # Do not escape the special RAND case
+            if orderAttr.split(":")[:1] == ["RAND()"]:
+                orderField = "RAND()"
+            else:
+                orderField = _quotedList(orderAttr.split(":")[:1])
+
             if not orderField:
                 error = "Invalid orderAttribute argument"
                 # self.log.debug('buildCondition:', error)


### PR DESCRIPTION
@sfayer maybe there's a better way ? 

BEGINRELEASENOTES
*WMS
FIX: MySQL does not escape RAND() as an order attribute

ENDRELEASENOTES
