### PR TITLE
fix: getInputData bulk query with duplicate jobIDs

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -326,10 +326,11 @@ class JobDB(DB):
             result = []
         else:
             # jobID is actually a list of jobIDs
+            jobIDs = {str(x) for x in jobID}
             cmd += " WHERE JobID IN ("
-            cmd += ",".join(["%s"] * len(jobID))
+            cmd += ",".join(["%s"] * len(jobIDs))
             cmd += ")"
-            args.extend({str(x) for x in jobID})
+            args.extend(jobIDs)
             result = {int(i): [] for i in jobID}
         res = self._query(cmd, args=args)
         if not res["OK"]:

--- a/src/DIRAC/WorkloadManagementSystem/DB/tests/Test_JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/tests/Test_JobDB.py
@@ -36,3 +36,18 @@ def test_getInputData(jobDB: JobDB):
     # Assert
     assert res["OK"], res["Message"]
     assert res["Value"] == ["/vo/user/lfn1", "/vo/user/lfn2"]
+
+
+def test_getInputData_bulk_with_duplicates(jobDB: JobDB):
+    """Test getInputData with a list of jobIDs containing duplicates"""
+    # Arrange
+    jobDB._query = MagicMock(return_value=S_OK([(1234, "/vo/user/lfn1"), (5678, "LFN:/vo/user/lfn2")]))
+
+    # Act
+    res = jobDB.getInputData([1234, 1234, 5678])
+
+    # Assert
+    assert res["OK"], res["Message"]
+    assert res["Value"] == {1234: ["/vo/user/lfn1"], 5678: ["/vo/user/lfn2"]}
+    # The number of SQL placeholders must match the number of bound arguments
+    assert jobDB._query.call_args.args[0].count("%s") == len(jobDB._query.call_args.kwargs["args"])


### PR DESCRIPTION
BEGINRELEASENOTES

*WorkloadManagement
FIX: getInputData bulk query with duplicate jobIDs

ENDRELEASENOTES