### PR TITLE
fix: sql parameterisation regressions

### DIFF
--- a/src/DIRAC/AccountingSystem/DB/AccountingDB.py
+++ b/src/DIRAC/AccountingSystem/DB/AccountingDB.py
@@ -416,6 +416,7 @@ class AccountingDB(DB):
             req += ",".join(allKeyTables)
             if sqlCond:
                 req += f",{mainTable} WHERE "
+                req += f"{keyTable}.id = {mainTable}.`{keyName}` AND "
                 req += " AND ".join(sqlCond)
             retVal = self._query(req, args=condArgs, conn=connObj)
             if not retVal["OK"]:
@@ -688,24 +689,30 @@ class AccountingDB(DB):
         sqlFields.extend(self.dbCatalog[typeName]["values"])
         sqlUpData = ["entriesInBucket=entriesInBucket+VALUES(entriesInBucket)"]
         sqlUpData.extend([f"{x}={x}+VALUES({x})" for x in self.dbCatalog[typeName]["values"]])
+        valueGroups = []
         sqlValues = []
         for bucketInfo in buckets:
             bStartTime = bucketInfo[0]
             bProportion = bucketInfo[1]
             bLength = bucketInfo[2]
-            sqlValues = [bStartTime, bLength, valuesList[-1] * bProportion]
+            rowValues = [bStartTime, bLength, valuesList[-1] * bProportion]
             for keyPos in range(len(self.dbCatalog[typeName]["keys"])):
-                sqlValues.append(keyValues[keyPos])
+                rowValues.append(keyValues[keyPos])
             for valPos in range(len(self.dbCatalog[typeName]["values"])):
-                sqlValues.append(valuesList[valPos] * bProportion)
+                rowValues.append(valuesList[valPos] * bProportion)
+            valueGroups.append("(" + ",".join(["%s"] * len(rowValues)) + ")")
+            sqlValues.extend(rowValues)
+
+        if not valueGroups:
+            return S_OK()
 
         req = "INSERT INTO "
         req += self._getTableName("bucket", typeName)
         req += " ("
         req += ",".join(sqlFields)
-        req += ") VALUES ("
-        req += ",".join(["%s"] * len(sqlValues))
-        req += ") ON DUPLICATE KEY UPDATE "
+        req += ") VALUES "
+        req += ",".join(valueGroups)
+        req += " ON DUPLICATE KEY UPDATE "
         req += ",".join(sqlUpData)
 
         for _i in range(max(1, self.__deadLockRetries)):
@@ -985,7 +992,7 @@ class AccountingDB(DB):
             sqlGroupList.append(field)
         req += " GROUP BY "
         req += ",".join(sqlGroupList)
-        return self._query(req, conn=connObj)
+        return self._query(req, args=args, conn=connObj)
 
     def __deleteForCompactBuckets(self, typeName, timeLimit, bucketLength, connObj=False):
         """
@@ -1081,6 +1088,7 @@ class AccountingDB(DB):
         req += " FROM "
         req += self._getTableName("bucket", typeName)
         req += " WHERE startTime < %s AND bucketLength = %s"
+        req += f" LIMIT {int(querySize)}"
         return self._query(req, args=(timeLimit, bucketLength), conn=connObj)
 
     def __deleteIndividualForCompactBuckets(self, typeName, bucketsData, connObj=False):
@@ -1300,4 +1308,7 @@ class AccountingDB(DB):
 
 
 def _bucketizeDataField(dataField, bucketLength):
-    return f"{dataField} - ( {dataField} % {int(bucketLength)} )"
+    # '%%' is a literal MySQL modulo operator, doubled because every query that
+    # embeds this expression is executed with bound args, i.e. through the
+    # driver's "cmd % args" formatting which collapses '%%' back to '%'.
+    return f"{dataField} - ( {dataField} %% {int(bucketLength)} )"

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DatasetManager/DatasetManager.py
@@ -529,13 +529,15 @@ class DatasetManager:
         req += parameterString
         req += " FROM FC_MetaDatasets"
         dsName = os.path.basename(datasetName)
+        args = []
         if "*" in dsName:
-            dName = dsName.replace("_", "\\_").replace("*", "%")
+            args.append(dsName.replace("_", "\\_").replace("*", "%"))
             req += " WHERE DatasetName LIKE %s"
         elif dsName:
+            args.append(dsName)
             req += " WHERE DatasetName=%s"
 
-        result = self.db._query(req, args=(dsName,))
+        result = self.db._query(req, args=args)
         if not result["OK"]:
             return result
 
@@ -697,7 +699,7 @@ class DatasetManager:
             dsName,
             dirID,
         )
-        result = self.db._query(req, args)
+        result = self.db._query(req, args=args)
         if not result["OK"]:
             return result
 
@@ -836,15 +838,16 @@ class DatasetManager:
         if not result["OK"]:
             return result
         fileIDList = result["FileIDList"]
-        req = "INSERT INTO FC_MetaDatasetFiles (DatasetID,FileID) VALUES "
-        args = []
-        for fileID in fileIDList:
-            req += "(%s,%s)"
-            args.append(datasetID)
-            args.append(fileID)
-        result = self.db._update(req, args=args)
-        if not result["OK"]:
-            return result
+        if fileIDList:
+            req = "INSERT INTO FC_MetaDatasetFiles (DatasetID,FileID) VALUES "
+            req += ",".join(["(%s,%s)"] * len(fileIDList))
+            args = []
+            for fileID in fileIDList:
+                args.append(datasetID)
+                args.append(fileID)
+            result = self.db._update(req, args=args)
+            if not result["OK"]:
+                return result
 
         result = self.setDatasetStatus(datasetName, "Frozen")
         return result

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/DirectoryManager/DirectoryTreeBase.py
@@ -342,7 +342,7 @@ class DirectoryTreeBase:
             return S_ERROR(f"Invalid parameter name: {pname}")
         req = "UPDATE FC_DirectoryInfo "
         req += f"SET {pname}=%s, ModificationDate=UTC_TIMESTAMP() "
-        req += f"WHERE DirID IN {dirIDString}"
+        req += f"WHERE DirID IN ({dirIDString})"
         result = self.db._update(req, args=(pvalue,))
         return result
 

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManager.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManager.py
@@ -88,7 +88,7 @@ class FileManager(FileManagerBase):
                 dirID = directoryIDs[dirPath]
                 whereStr = "( DirID=%s AND FileName IN ("
                 whereStr += ",".join(["%s"] * len(fileNames))
-                whereStr += ")"
+                whereStr += ") )"
                 args.append(dirID)
                 args.extend(fileNames)
                 wheres.append(whereStr)
@@ -543,8 +543,10 @@ class FileManager(FileManagerBase):
         queryTuples = []
         for fileID, seID in replicaTuples:
             queryTuples.append((fileID, seID))
+        if not queryTuples:
+            return S_OK({})
         req = "SELECT RepID,FileID,SEID FROM FC_Replicas WHERE (FileID,SEID) IN ("
-        req += ",".join(["%s,%s"] * len(queryTuples))
+        req += ",".join(["(%s,%s)"] * len(queryTuples))
         req += ")"
         # Flatten queryTuples into args
         args = tuple(f for t in queryTuples for f in t)
@@ -829,7 +831,7 @@ class FileManager(FileManagerBase):
         req = "SELECT FileID,SEID,RepID,Status FROM FC_Replicas WHERE FileID IN ("
         req += ",".join(["%s"] * len(fileIDs))
         req += ")"
-        args = fileIDs
+        args = list(fileIDs)
         if not allStatus:
             statusIDs = []
             for status in self.db.visibleReplicaStatus:

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerBase.py
@@ -51,7 +51,7 @@ class FileManagerBase:
             return res
         resultDict["Files w/o Replicas"] = res["Value"][0][0]
 
-        req = "SELECT COUNT(RepID) FROM FC_Replicas WHERE FileID NOT IN (SELECT FileID FROM FC_Files "
+        req = "SELECT COUNT(RepID) FROM FC_Replicas WHERE FileID NOT IN (SELECT FileID FROM FC_Files)"
         res = self.db._query(req, conn=connection)
         if not res["OK"]:
             return res
@@ -459,7 +459,7 @@ class FileManagerBase:
         req = "SELECT FileID, AncestorID, AncestorDepth FROM FC_FileAncestors WHERE FileID IN ("
         req += ",".join(["%s"] * len(fileIDs))
         req += ")"
-        args = fileIDs
+        args = list(fileIDs)
         if depths:
             req += " AND AncestorDepth IN ("
             req += ",".join(["%s"] * len(depths))
@@ -480,7 +480,7 @@ class FileManagerBase:
         req = "SELECT AncestorID, FileID, AncestorDepth FROM FC_FileAncestors WHERE AncestorID IN ("
         req += ",".join(["%s"] * len(fileIDs))
         req += ")"
-        args = fileIDs
+        args = list(fileIDs)
         if depths:
             req += " AND AncestorDepth IN ("
             req += ",".join(["%s"] * len(depths))

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerFlat.py
@@ -46,7 +46,7 @@ class FileManagerFlat(FileManagerBase):
                 return S_ERROR(f"Invalid field name: {field}")
         req = "SELECT FileName,"
         req += ",".join(metadata)
-        req += " WHERE DirID=%s"
+        req += " FROM FC_Files WHERE DirID=%s"
         args = [dirID]
         if not allStatus:
             statusIDs = []

--- a/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/ProxyDB.py
@@ -828,7 +828,7 @@ class ProxyDB(DB):
           parameters are a filter to the db
         """
         fields = ("Action", "IssuerDN", "IssuerGroup", "TargetDN", "TargetGroup", "Timestamp")
-        lowerFields = (x.lower() for x in fields)
+        lowerFields = [x.lower() for x in fields]
         req = "SELECT "
         # Timestamp is an SQL keyword so we have to be careful with backtick quoting
         req += ",".join([f"`{x}`" for x in fields])
@@ -850,7 +850,7 @@ class ProxyDB(DB):
             for field in selDict:
                 if field.lower() not in lowerFields:
                     return S_ERROR(f"Unknown field: {field}")
-                qr.append(" OR ".join([f"`{field}`=%s"] * len(selDict[field])))
+                qr.append("(" + " OR ".join([f"`{field}`=%s"] * len(selDict[field])) + ")")
                 qrArgs.extend(selDict[field])
             whereStr = " WHERE "
             whereStr += " AND ".join(qr)

--- a/src/DIRAC/FrameworkSystem/DB/UserProfileDB.py
+++ b/src/DIRAC/FrameworkSystem/DB/UserProfileDB.py
@@ -258,8 +258,6 @@ class UserProfileDB(DB):
         # when we retrieve the user profile we have to take into account the user.
         req = "SELECT data FROM up_ProfilesData "
         req += f"WHERE {sqlCond}"
-        print(req)
-        print(args)
         result = self._query(req, args=args)
         if not result["OK"]:
             return result

--- a/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
+++ b/src/DIRAC/StorageManagementSystem/DB/StorageManagementDB.py
@@ -352,7 +352,7 @@ class StorageManagementDB(DB):
         req += ",".join(["%s"] * len(toUpdate))
         req += ") AND Status != %s"
         args = [newStageStatus] + toUpdate + [newStageStatus]
-        res = self._update(req, conn=connection)
+        res = self._update(req, args=args, conn=connection)
         if not res["OK"]:
             return res
 

--- a/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
+++ b/src/DIRAC/WorkloadManagementSystem/DB/JobDB.py
@@ -208,7 +208,7 @@ class JobDB(DB):
                 attrList = attrList.replace(" ", "").split(",")
             for attrName in attrList:
                 if attrName.lower() not in [x.lower() for x in self.jobAttributeNames]:
-                    return S_ERROR(f"Unknown job attribute: {attrName}")
+                    raise SErrorException(f"Unknown job attribute: {attrName}")
         else:
             attrList = self.jobAttributeNames
         attrList.sort()
@@ -855,7 +855,9 @@ class JobDB(DB):
         values = []
 
         for lfn in inputData:
-            values.append((jobID, lfn))
+            if not lfn:
+                continue
+            values.append((jobID, lfn.strip()))
 
         if values:
             cmd = "INSERT INTO InputData (JobID,LFN) VALUES (%s, %s)"


### PR DESCRIPTION
BEGINRELEASENOTES

*DataManagementSystem
FIX: correct parameterised replica/file queries in FileManager (unbalanced IN parentheses, scalar list bound against the (FileID,SEID) row constructor, and argument-list aliasing that corrupted getReplicas)
FIX: repair getFileCounters and the file ancestor/descendent queries in FileManagerBase
FIX: restore the missing FROM clause in FileManagerFlat directory file listing
FIX: correct DatasetManager queries (keyword args to _query, comma-separated multi-row insert, and wildcard LIKE matching)
FIX: restore the IN-list parentheses when setting directory parameters in DirectoryTreeBase

*FrameworkSystem
FIX: correct getLogsContent field validation and OR-condition grouping in ProxyDB
FIX: remove stray debug prints from UserProfileDB.retrieveVarById

*StorageManagementSystem
FIX: pass the query arguments when updating stage request status in StorageManagementDB

*WorkloadManagementSystem
FIX: report unknown job attributes as an error (instead of a masked S_OK) and skip empty input-data LFNs in JobDB

*Accounting
FIX: correct AccountingDB bucket writing (multi-bucket records were silently dropped), rebucketing, key-value listing and bucket-compaction paging

ENDRELEASENOTES