### PR TITLE
fix: add shebang to run_detached script

### DIFF
--- a/src/DIRAC/Resources/Computing/BatchSystems/Host.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Host.py
@@ -71,8 +71,7 @@ class Host(object):
             os.unlink(runFileName)
         runFile = open(runFileName, "w")
         runFile.write(
-            """
-#!/bin/bash
+            """#!/bin/bash
 ( exec </dev/null
 #  echo $2
   exec > $2

--- a/src/DIRAC/Resources/Computing/BatchSystems/Host.py
+++ b/src/DIRAC/Resources/Computing/BatchSystems/Host.py
@@ -72,6 +72,7 @@ class Host(object):
         runFile = open(runFileName, "w")
         runFile.write(
             """
+#!/bin/bash
 ( exec </dev/null
 #  echo $2
   exec > $2


### PR DESCRIPTION
Add shebang to `run_detached.sh` script to run subprocess without `shell=True` which results as a bandit security issue. 

closes #8715 