### PR TITLE
[int] Make OptimizationMind auth more strict

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/Service/OptimizationMindHandler.py
+++ b/src/DIRAC/WorkloadManagementSystem/Service/OptimizationMindHandler.py
@@ -42,7 +42,7 @@ class OptimizationMindHandler(ExecutorMindHandler):
 
     MSG_DEFINITIONS = {"OptimizeJobs": {"jids": (list, tuple)}}
 
-    auth_msg_OptimizeJobs = ["all"]
+    auth_msg_OptimizeJobs = ["TrustedHost"]
 
     def msg_OptimizeJobs(self, msgObj):
         jids = msgObj.jids


### PR DESCRIPTION
This is small patch to change OptimizationMind from all to TrustedHost as I think it's only ever contacted by other services/agents. If you're happy with this patch, I suggest we backport it too.

Regards,
Simon

BEGINRELEASENOTES
*WorkloadManagement
FIX: Make OptimizationMind auth more strict
ENDRELEASENOTES
