### PR TITLE
[int] Tidy up CS auth

### DIFF
--- a/src/DIRAC/ConfigurationSystem/ConfigTemplate.cfg
+++ b/src/DIRAC/ConfigurationSystem/ConfigTemplate.cfg
@@ -14,7 +14,9 @@ Services
     {
       # Default authorization
       Default = authenticated
-      #Define who can commit new configuration
+      # Define who can register other services
+      publishSlaveServer = TrustedHost
+      # Define who can commit new configuration
       commitNewData = CSAdministrator
       # Define who can roll back the configuration to a previous version
       rollbackToVersion = CSAdministrator
@@ -35,7 +37,9 @@ Services
     {
       # Default authorization
       Default = authenticated
-      #Define who can commit new configuration
+      # Define who can register other services
+      publishSlaveServer = TrustedHost
+      # Define who can commit new configuration
       commitNewData = CSAdministrator
       # Define who can roll back the configuration to a previous version
       rollbackToVersion = CSAdministrator

--- a/src/DIRAC/ConfigurationSystem/Service/ConfigurationHandler.py
+++ b/src/DIRAC/ConfigurationSystem/Service/ConfigurationHandler.py
@@ -52,6 +52,7 @@ class ConfigurationHandler(RequestHandler):
         return S_OK(retDict)
 
     types_publishSlaveServer = [str]
+    auth_publishSlaveServer = ["TrustedHost"]
 
     @classmethod
     def export_publishSlaveServer(cls, sURL):

--- a/src/DIRAC/ConfigurationSystem/Service/TornadoConfigurationHandler.py
+++ b/src/DIRAC/ConfigurationSystem/Service/TornadoConfigurationHandler.py
@@ -57,6 +57,8 @@ class TornadoConfigurationHandler(TornadoService):
             retDict["data"] = b64encode(self.ServiceInterface.getCompressedConfigurationData()).decode()
         return S_OK(retDict)
 
+    auth_publishSlaveServer = ["TrustedHost"]
+
     def export_publishSlaveServer(self, sURL):
         """
         Used by worker server to register as a worker server.


### PR DESCRIPTION
I think the publishSlaveServer is only used by other services to register themselves, so should ideally be restricted to TrustedHost. I've added it to the ConfigTemplate and as an auth constant so that it wouldn't require admins to do a manual config update. If you're happy with this we might want to consider a backport.

Regards,
Simon

BEGINRELEASENOTES
*Configuration
FIX: Tidy up CS auth
ENDRELEASENOTES
