### PR TITLE
docs: freeze sphinx until

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -74,7 +74,8 @@ dependencies:
   - typer-cli
   # docs
   - pygments >=1.5
-  - sphinx
+  # Until https://github.com/sphinx-doc/sphinx/issues/14548 is fixed
+  - sphinx <9.0.0
   - graphviz
   # RTD Sphinx theme
   - sphinx_rtd_theme


### PR DESCRIPTION
Our issue comes from https://github.com/sphinx-doc/sphinx/issues/14548 
It seems to be actively looked at, so let's see if they get a release out quickly enough. 
Otherwise we just pin the version


