### PR TITLE
[int] Check permission on DConfigCache files

### DIFF
--- a/src/DIRAC/Interfaces/Utilities/DConfigCache.py
+++ b/src/DIRAC/Interfaces/Utilities/DConfigCache.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import re
+import stat
 import time
 import pickle  # nosec: B403
 import tempfile
@@ -85,6 +86,14 @@ class ConfigCache:
         else:
             try:
                 with open(self.configCacheName, "rb") as fh:
+                    # Check file permissions of cache file post-open to avoid check race conditions
+                    info = os.fstat(fh.fileno())
+                    if info.st_uid != os.getuid():
+                        gLogger.error(f"Cache file {self.configCacheName} not owned by current user! Ignoring...")
+                        return
+                    if stat.S_IMODE(info.st_mode) & (stat.S_IWGRP | stat.S_IWOTH):
+                        gLogger.error(f"Cache file {self.configCacheName} is writeable by group/others! Ignoring...")
+                        return
                     # Pickle files are cached locally, so should be safe
                     gConfigurationData.mergedCFG = pickle.load(fh)  # nosec: B301
                     reset_all_caches()


### PR DESCRIPTION
This adds a check of the DConfigCache files before they're loaded.

BEGINRELEASENOTES
*Interfaces
FIX: Check permission on DConfigCache files
ENDRELEASENOTES
