### PR TITLE
feat: add 5 min cooldown before cloud node shutoff

### DIFF
--- a/src/DIRAC/Resources/Computing/cloudinit.template
+++ b/src/DIRAC/Resources/Computing/cloudinit.template
@@ -88,4 +88,6 @@ runcmd:
  - [ cp, /root/run_pilot.sh, /mnt/run_pilot.sh ]
  - [ cp, /root/startup.sh, /mnt/startup.sh ]
  - [ sudo, -u, dirac, /mnt/startup.sh ]
+ - [ wall, "Done: node will shutdown in 5 minutes" ]
+ - [ sleep, 5m ]
  - [ poweroff ]


### PR DESCRIPTION

BEGINRELEASENOTES
*Resources/Computing
CHANGE: Add 5 min cooldown before shutting down cloud node. Helps with debugging when jobs crash.

ENDRELEASENOTES
