### PR TITLE
fix: RSS supports setting 0 for a value

### DIFF
--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceManagementDB.py
@@ -426,7 +426,7 @@ class ResourceManagementDB(SQLAlchemyDB):
                     columnValue = DiracTime.utcnow().replace(microsecond=0)
                 if columnName == "DateEffective" and not columnValue:  # we always update DateEffective, if there
                     columnValue = DiracTime.utcnow().replace(microsecond=0)
-                if columnValue:
+                if columnValue is not None:
                     setattr(res, columnName.lower(), columnValue)
 
             session.commit()

--- a/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
+++ b/src/DIRAC/ResourceStatusSystem/DB/ResourceStatusDB.py
@@ -372,7 +372,7 @@ class ResourceStatusDB(SQLAlchemyDB):
                     columnValue = DiracTime.utcnow().replace(microsecond=0)
                 if changeDE and columnName == "DateEffective" and not columnValue:
                     columnValue = DiracTime.utcnow().replace(microsecond=0)
-                if columnValue:
+                if columnValue is not None:
                     if isinstance(columnValue, datetime.datetime):
                         columnValue = columnValue.replace(microsecond=0)
                     setattr(res, columnName.lower(), columnValue)

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
@@ -249,6 +249,13 @@ def test_SpaceTokenOccupancy(rmClient):
     # check if the result has changed
     assert res["Value"][0][3] == 100.0
 
+    res = rmClient.addOrModifySpaceTokenOccupancyCache("endpoint", "token", free=0.0)
+    assert res["OK"] is True, res["Message"]
+
+    res = rmClient.selectSpaceTokenOccupancyCache("endpoint", "token")
+    # check if the result has changed
+    assert res["Value"][0][3] == 0.0
+
     # TEST deleteSpaceTokenOccupancy
     # ...............................................................................
     res = rmClient.deleteSpaceTokenOccupancyCache("endpoint", "token")


### PR DESCRIPTION
We had this bug that a storage would not be banned if it actually hit 0 free space. This comes from a wrong evaluation 

BEGINRELEASENOTES

*RSS

FIX: fix RSS to be able to update falsy values 

ENDRELEASENOTES
