### PR TITLE
[9.0] test: skip backward-compatibility assertions for APIs dropped in v9.1

### DIFF
--- a/tests/Integration/ResourceStatusSystem/Test_Publisher.py
+++ b/tests/Integration/ResourceStatusSystem/Test_Publisher.py
@@ -15,7 +15,7 @@ publisher = PublisherClient()
 gLogger.setLevel("DEBUG")
 
 
-def test_Get():
+def test_Get(serverIsOlderThan):
     res = publisher.getSites()
     assert res["OK"] is True, res["Message"]
 
@@ -31,8 +31,10 @@ def test_Get():
     res = publisher.getElementPolicies("Site", None, None)
     assert res["OK"] is True, res["Message"]
 
-    res = publisher.getNodeStatuses()
-    assert res["OK"] is True, res["Message"]
+    # Nodes (queues) were dropped from the RSS, and getNodeStatuses with them, in v9.1
+    if serverIsOlderThan(publisher, "9.1"):
+        res = publisher.getNodeStatuses()
+        assert res["OK"] is True, res["Message"]
 
     res = publisher.getTree("", "")
     assert res["OK"] is True, res["Message"]

--- a/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
+++ b/tests/Integration/ResourceStatusSystem/Test_ResourceManagement.py
@@ -28,10 +28,12 @@ def fixtureResourceManagementClient():
     yield ResourceManagementClient()
 
 
-def test_AccountingCache(rmClient):
+def test_AccountingCache(rmClient, serverIsOlderThan):
     """
     DowntimeCache table
     """
+    if not serverIsOlderThan(rmClient, "9.1"):
+        pytest.skip("The AccountingCache table was dropped from ResourceManagementDB in v9.1")
 
     res = rmClient.deleteAccountingCache("TestName12345")  # just making sure it's not there (yet)
     assert res["OK"] is True, res["Message"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 import DIRAC
 
@@ -56,3 +57,27 @@ def _check_environment():
             "bypass this check pass --no-check-dirac-environment to pytest.",
             returncode=42,
         )
+
+
+@pytest.fixture(name="serverIsOlderThan")
+def fixtureServerIsOlderThan():
+    """Return a callable telling whether the server behind a client predates a given version.
+
+    These integration tests are also run by the "Backward Compatibility" CI job, which points
+    the tests of a release branch at a server installed from a more recent branch. Use this to
+    guard the assertions covering an API that a later release is known to have dropped::
+
+        def test_something(someClient, serverIsOlderThan):
+            if serverIsOlderThan(someClient, "9.1"):
+                assert someClient.methodDroppedIn91()["OK"]
+
+    :param client: any :class:`~DIRAC.Core.Base.Client.Client` talking to the service of interest
+    :param str version: the version to compare the server against
+    """
+
+    def _serverIsOlderThan(client, version):
+        res = client.ping()
+        assert res["OK"], res["Message"]
+        return Version(res["Value"]["version"]) < Version(version)
+
+    return _serverIsOlderThan


### PR DESCRIPTION
The "Backward Compatibility" CI job runs this branch's tests against a server
installed from a more recent branch. Two v9.0 tests exercise APIs that v9.1
deliberately removed (#8473 dropped ResourceManagement.AccountingCache, #8446
dropped nodes/queues from the RSS along with Publisher.getNodeStatuses), so they
cannot pass against a 9.1 server.

No need for release notes.