### PR TITLE
[integration] fix (DMS): do not fail when registering a file without a checksum

### DIFF
--- a/src/DIRAC/Core/Utilities/MySQL.py
+++ b/src/DIRAC/Core/Utilities/MySQL.py
@@ -1847,7 +1847,10 @@ class MySQL:
     def executeStoredProcedureWithCursor(self, packageName, parameters, *, conn=None):
         """Execute a stored procedure "packageName" with the givens parameters.
 
-        NOTE: parameters should be pre-validated if user supplied.
+        The parameters are bound by the driver, so ``None`` is passed as ``NULL`` and strings
+        are escaped. NOTE: a few procedures take a SQL fragment as an argument and interpolate
+        it into a dynamic statement themselves, so such arguments must still be pre-validated
+        if user supplied.
         """
         if not self._checkIdentifier(packageName)["OK"]:
             return S_ERROR(f"Invalid stored procedure name: {packageName}")
@@ -1862,12 +1865,9 @@ class MySQL:
 
         cursor = connection.cursor()
         try:
-            #       execStr = "call %s(%s);" % ( packageName, ",".join( map( str, parameters ) ) )
-            execStr = "call {}({});".format(
-                packageName,
-                ",".join(['"%s"' % param if isinstance(param, str) else str(param) for param in parameters]),
-            )
-            cursor.execute(execStr)
+            parameters = tuple(parameters)
+            execStr = f"call {packageName}({','.join(['%s'] * len(parameters))});"
+            cursor.execute(execStr, args=parameters)
             rows = cursor.fetchall()
             retDict = S_OK(rows)
         except Exception as x:

--- a/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
+++ b/src/DIRAC/DataManagementSystem/DB/FileCatalogComponents/FileManager/FileManagerPs.py
@@ -222,9 +222,25 @@ class FileManagerPs(FileManagerBase):
         for lfn in wantedLfns:
             dirID, size, s_uid, s_gid, statusID, fileName, guid, checksum, checksumtype, mode = allFileValues[lfn]
             utcNow = DiracTime.utcnow().replace(microsecond=0)
+            # A missing checksum has to be NULL and not the string "None", to stay consistent with
+            # ps_insert_file below and with the FC_FileInfo inserts made by FileManager
+            checksumValue = "NULL" if checksum is None else f"'{checksum}'"
             fileValuesStrings.append(
-                "(%s, %s, %s, %s, %s, '%s', '%s', '%s', '%s', '%s', '%s', %s)"
-                % (dirID, size, s_uid, s_gid, statusID, fileName, guid, checksum, checksumtype, utcNow, utcNow, mode)
+                "(%s, %s, %s, %s, %s, '%s', '%s', %s, '%s', '%s', '%s', %s)"
+                % (
+                    dirID,
+                    size,
+                    s_uid,
+                    s_gid,
+                    statusID,
+                    fileName,
+                    guid,
+                    checksumValue,
+                    checksumtype,
+                    utcNow,
+                    utcNow,
+                    mode,
+                )
             )
             fileDescStrings.append(f"(DirID = {dirID} AND FileName = '{fileName}')")
 

--- a/tests/Integration/DataManagementSystem/Test_DataManager.py
+++ b/tests/Integration/DataManagementSystem/Test_DataManager.py
@@ -173,13 +173,13 @@ def test_putAndRegisterRemoveReplica(dm, tempFile):
     assertResult(removeRes, lfn)
 
 
-def test_registerFile(dm, tempFile):
+@pytest.mark.parametrize("checkSum", [None, "fakeCks"])
+def test_registerFile(dm, tempFile, checkSum):
     lfn = os.path.join(DESTINATION_PATH, f"registerFile/testFile.{time.time()}")
     physicalFile = f"srm://host:port/srm/managerv2?SFN=/sa/path{lfn}"
     fileSize = 10000
     storageElementName = "SE-1"
     fileGuid = makeGuid()
-    checkSum = "fakeCks"
     fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid, checkSum)
     registerRes = dm.registerFile(fileTuple)
     removeFileRes = dm.removeFile(lfn)
@@ -188,7 +188,8 @@ def test_registerFile(dm, tempFile):
     assertResult(removeFileRes, lfn)
 
 
-def test_registerReplica(dm, tempFile):
+@pytest.mark.parametrize("checkSum", [None, "fakeCks"])
+def test_registerReplica(dm, tempFile, checkSum):
     print(
         "\n\n#########################################################"
         "################\n\n\t\t\tRegister replica test\n"
@@ -198,7 +199,6 @@ def test_registerReplica(dm, tempFile):
     fileSize = 10000
     storageElementName = "SE-1"
     fileGuid = makeGuid()
-    checkSum = "fakeCks"
     fileTuple = (lfn, physicalFile, fileSize, storageElementName, fileGuid, checkSum)
     registerRes = dm.registerFile(fileTuple)
     seName = "SE-1"


### PR DESCRIPTION
Needed for #8751 

BEGINRELEASENOTES

*DataMangement
FIX: FIX: registering a file without a checksum no longer fails with `"Unknown column 'None' in 'field list'"`

ENDRELEASENOTES
