### PR TITLE
[integration] Unpin mysqlclient in the development environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -48,7 +48,7 @@ dependencies:
   - voms
   - python-gfal2
   # Workaround for https://github.com/DIRACGrid/DIRAC/issues/6978
-  - mysqlclient >=2.0.3,<2.1
+  - mysqlclient >=2.2.0
   - diraccfg
   - ldap3
   - importlib_resources


### PR DESCRIPTION
The `<2.1` constraint dated from mysqlclient 2.1 removing the module-level `MySQLdb.escape_string`, which DIRAC stopped using in v9.1.13 (see #6978 and #8645). `setup.cfg` was never constrained, so this was the last place still forcing the old version.

No need for release notes