### PR TITLE
[9.0] Fix dirac-jobexec for generic WF parameters

### DIFF
--- a/src/DIRAC/WorkloadManagementSystem/scripts/dirac_jobexec.py
+++ b/src/DIRAC/WorkloadManagementSystem/scripts/dirac_jobexec.py
@@ -40,8 +40,6 @@ def main():
             sys.exit(1)
         workflow = fromXMLFile(jobfile)
         gLogger.debug(workflow)
-        code = workflow.createCode()
-        gLogger.debug(code)
         jobID = 0
         if "JOBID" in os.environ:
             jobID = os.environ["JOBID"]

--- a/tests/System/test_wf_job.py
+++ b/tests/System/test_wf_job.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Test the possibility to use general workflow parameters as variables
+# in the job description
+
+import subprocess
+import shlex
+import sys
+from pathlib import Path
+from DIRAC.Interfaces.API.Job import Job
+
+job = Job()
+
+job.setExecutable("/bin/ls")
+job.setExecutable("/bin/echo", arguments="@{InputData}")
+
+file = Path("jobDescription.xml")
+file.write_text(job.workflow.toXML())
+
+status = subprocess.call(shlex.split("dirac-jobexec jobDescription.xml -p InputData='{input_file_1,input_file_2}'"))
+if status:
+    sys.exit(status)
+
+file = Path("Script2_echo.log")
+content = file.read_text()
+if not "input_file_1;input_file_2" in content:
+    print("Test failed !")
+    sys.exit(-1)
+
+print("Test successful !")

--- a/tests/System/wms_scripts.sh
+++ b/tests/System/wms_scripts.sh
@@ -13,6 +13,7 @@ declare -a commands=(
 'dirac-wms-get-wn-parameters --Site=LCG.CERN.cern --Name=ce503.cern.ch --Queue=condor'
 'dirac-admin-site-info LCG.CERN.cern'
 'dirac-wms-select-jobs --Status=Running'
+'test_wf_job.py'
 )
 
 echo " "


### PR DESCRIPTION
  This PR is the port of #8602 to rel-v9r0

BEGINRELEASENOTES

*WorkloadManagement
FIX: dirac-jobexec - do not bootstrap the workflow before setting command line parameters

ENDRELEASENOTES
