### PR TITLE
fix (DMSHelpers): keep the per-VO singleton through copies and pickles

### DIFF
--- a/src/DIRAC/DataManagementSystem/Utilities/DMSHelpers.py
+++ b/src/DIRAC/DataManagementSystem/Utilities/DMSHelpers.py
@@ -115,8 +115,23 @@ class DMSHelpers:
         if inst is None:
             inst = super().__new__(cls)
             inst.__csVersion = None
+            inst._vo = vo
             cls._instances[vo] = inst
         return inst
+
+    # A per-VO singleton must stay one through copies and pickles. Returning
+    # (or, on unpickle, looking up) the shared instance also keeps the method
+    # caches and their locks from being duplicated or serialised: deepcopying
+    # or pickling an object that holds a DMSHelpers (e.g. an RMS Request)
+    # would otherwise fail with "cannot pickle '_thread.lock' object".
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
+
+    def __reduce__(self):
+        return (self.__class__, (self._vo,))
 
     def __init__(self, vo=False):
         # We're a per-VO singleton (see __new__); skip re-init unless the CS

--- a/src/DIRAC/DataManagementSystem/Utilities/test/Test_DMSHelpers.py
+++ b/src/DIRAC/DataManagementSystem/Utilities/test/Test_DMSHelpers.py
@@ -1,0 +1,39 @@
+"""DMSHelpers is a per-VO singleton holding method caches guarded by locks.
+
+Copies and pickles must resolve back to the shared instance: duplicating it
+would fork the caches, and serialising it is impossible anyway (locks). The
+regression pinned here: deepcopying an object that embeds a DMSHelpers —
+e.g. an RMS Request — raised "cannot pickle '_thread.lock' object".
+"""
+
+import copy
+import pickle
+
+from DIRAC.DataManagementSystem.Utilities.DMSHelpers import DMSHelpers
+
+
+def test_copy_and_deepcopy_preserve_the_singleton():
+    helper = DMSHelpers()
+    assert copy.copy(helper) is helper
+    assert copy.deepcopy(helper) is helper
+
+
+def test_pickle_roundtrip_resolves_to_the_singleton():
+    helper = DMSHelpers()
+    assert pickle.loads(pickle.dumps(helper)) is helper
+
+
+def test_objects_embedding_a_helper_can_be_deepcopied():
+    request_like = {"payload": [1, 2], "dmsHelper": DMSHelpers()}
+    clone = copy.deepcopy(request_like)
+    assert clone["dmsHelper"] is request_like["dmsHelper"]
+    assert clone["payload"] == [1, 2] and clone["payload"] is not request_like["payload"]
+
+
+def test_request_deepcopy_regression():
+    # The in-the-wild breakage: Request.__init__ stores a DMSHelpers
+    from DIRAC.RequestManagementSystem.Client.Request import Request
+
+    request = Request()
+    clone = copy.deepcopy(request)
+    assert clone.dmsHelper is request.dmsHelper


### PR DESCRIPTION
Since v9.1.16, `copy.deepcopy()` or `pickle.dumps()` of any `Request` object raises:

```
TypeError: cannot pickle '_thread.lock' object
```

Minimal reproduction on v9.1.16:

```python
import copy
from DIRAC.RequestManagementSystem.Client.Request import Request

copy.deepcopy(Request())  # TypeError: cannot pickle '_thread.lock' object
```

Works fine on v9.1.15.

**Cause:** b11d7d9 (*feat(DMSHelper): cache some methods*) added per-instance `cachetools` caches guarded by real `threading.Lock`s in `DMSHelpers.__init__`. `Request.__init__` stores a `DMSHelpers` on every instance (`self.dmsHelper = DMSHelpers()`), so the locks are now reachable from every `Request`'s object graph, and `deepcopy`/`pickle` fail via `__reduce_ex__`. The same applies to anything else holding a `DMSHelpers` instance.

This is how we found it: LHCbDIRAC's CI installs the latest DIRAC integration tag, and every pipeline started after the v9.1.16 tag now fails `Test_Modules_LHCbScript`, which deepcopies a `workflow_commons` fixture containing a `Request` (nothing LHCbDIRAC-side changed between the green v9.1.15 run and the red v9.1.16 run: https://gitlab.cern.ch/roneil/LHCbDIRAC/-/jobs/81172151).

**Fix:** since 4c4260f `DMSHelpers` is a per-VO singleton, so copies should never duplicate it in the first place — `__copy__`/`__deepcopy__` return the shared instance, and `__reduce__` pickles as "look up the per-VO singleton again on load" (the `vo` key is now kept on the instance). Besides restoring copyability, this stops a copy from silently forking a singleton's caches and CS-derived state.

Tests cover copy/deepcopy/pickle identity plus the in-the-wild regression (deepcopy of an object embedding a helper, and of a real `Request`).

BEGINRELEASENOTES

*DataManagement
FIX: DMSHelpers instances stay per-VO singletons through copy, deepcopy and pickle, restoring deepcopy/pickle of objects that embed one (e.g. RMS Request)

ENDRELEASENOTES