### PR TITLE
[Maintenance]  Move DiracTime to DiracCommon

### DIFF
--- a/dirac-common/src/DIRACCommon/Core/Utilities/TimeUtilities.py
+++ b/dirac-common/src/DIRACCommon/Core/Utilities/TimeUtilities.py
@@ -123,7 +123,7 @@ def toEpochMilliSeconds(dateTimeObject=None):
     Get milliseconds since epoch
     """
     if dateTimeObject is None:
-        dateTimeObject = datetime.datetime.utcnow()
+        dateTimeObject = DiracTime.utcnow()
     if dateTimeObject.resolution == datetime.timedelta(days=1):
         # Add time information corresponding to midnight UTC if it's a datetime.date
         dateTimeObject = datetime.datetime.combine(
@@ -144,7 +144,7 @@ def fromEpoch(epoch):
         epoch /= 1000**2
     elif epoch > 10**11:  # milliseconds
         epoch /= 1000
-    return datetime.datetime.utcfromtimestamp(epoch)
+    return DiracTime.utcfromtimestamp(epoch)
 
 
 def toString(myDate=None):
@@ -172,7 +172,7 @@ def toString(myDate=None):
             myDate.microseconds,
         )
     else:
-        return toString(datetime.datetime.utcnow())
+        return toString(DiracTime.utcnow())
 
 
 def fromString(myDate=None):

--- a/dirac-common/src/DIRACCommon/Core/Utilities/TimeUtilities.py
+++ b/dirac-common/src/DIRACCommon/Core/Utilities/TimeUtilities.py
@@ -23,6 +23,39 @@ import datetime
 import sys
 import time
 
+# TimeUtilities imports datetime as well
+# To avoid conflicts/surprises, import copies here used a _local
+from datetime import datetime as dt_local, timezone as tz_local
+
+
+class DiracTime:
+    """datetime tools for DIRAC:
+    There are a number of facilities in DIRAC which can't handle timezone aware
+    datetime objects: These don't serialise, don't fit in database schemas, etc.
+    As the python non-timezone aware helper functions are being deprecated we
+    provide our own equivalents here.
+    """
+
+    @staticmethod
+    def utcnow() -> dt_local:
+        """Returns a UTC datetime object for now *without* a timezone field."""
+        return dt_local.now(tz_local.utc).replace(tzinfo=None)
+
+    @staticmethod
+    def utcfromtimestamp(epoch: float) -> dt_local:
+        """Returns a UTC datetime object from the given epoch offset (also in UTC)."""
+        return dt_local.fromtimestamp(epoch, tz=tz_local.utc).replace(tzinfo=None)
+
+    @staticmethod
+    def timestamp_utc(dt: dt_local) -> int:
+        """Converts a datetime object to a UTC epoch offset int.
+        Naive timezones are assumed to be UTC.
+        """
+        if dt.tzinfo is None:
+            return int(dt.replace(tzinfo=tz_local.utc).timestamp())
+        return int(dt.timestamp())
+
+
 # Some useful constants for time operations
 microsecond = datetime.timedelta(microseconds=1)
 second = datetime.timedelta(seconds=1)

--- a/dirac-common/tests/Core/Utilities/test_DiracTimeUtilities.py
+++ b/dirac-common/tests/Core/Utilities/test_DiracTimeUtilities.py
@@ -5,7 +5,7 @@ import datetime
 
 import pytest
 
-from DIRAC.Core.Utilities.TimeUtilities import DiracTime
+from DIRACCommon.Core.Utilities.TimeUtilities import DiracTime
 
 
 # ---------------------------------------------------------------------------

--- a/src/DIRAC/Core/Utilities/TimeUtilities.py
+++ b/src/DIRAC/Core/Utilities/TimeUtilities.py
@@ -19,31 +19,3 @@ from DIRAC import gLogger
 
 
 timeThis = partial(timeThis, logger_info=gLogger.info)
-
-
-class DiracTime:
-    """datetime tools for DIRAC:
-    There are a number of facilities in DIRAC which can't handle timezone aware
-    datetime objects: These don't serialise, don't fit in database schemas, etc.
-    As the python non-timezone aware helper functions are being deprecated we
-    provide our own equivalents here.
-    """
-
-    @staticmethod
-    def utcnow() -> dt_local:
-        """Returns a UTC datetime object for now *without* a timezone field."""
-        return dt_local.now(tz_local.utc).replace(tzinfo=None)
-
-    @staticmethod
-    def utcfromtimestamp(epoch: float) -> dt_local:
-        """Returns a UTC datetime object from the given epoch offset (also in UTC)."""
-        return dt_local.fromtimestamp(epoch, tz=tz_local.utc).replace(tzinfo=None)
-
-    @staticmethod
-    def timestamp_utc(dt: dt_local) -> int:
-        """Converts a datetime object to a UTC epoch offset int.
-        Naive timezones are assumed to be UTC.
-        """
-        if dt.tzinfo is None:
-            return int(dt.replace(tzinfo=tz_local.utc).timestamp())
-        return int(dt.timestamp())


### PR DESCRIPTION

BEGINRELEASENOTES

*Core
CHANGE: Move DiracTime class to DiracCommon which would allow using its utcnow() in DiracCommon time utilities.

ENDRELEASENOTES
