### PR TITLE
[9.0] fix(CS): rename LegacyClientEnabled to FutureClientEnabled

### DIFF
--- a/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
+++ b/src/DIRAC/ConfigurationSystem/Client/PathFinder.py
@@ -248,7 +248,7 @@ def useLegacyAdapter(system, service=None) -> bool:
     :return: bool -- True if DiracX should be used
     """
     system, service = divideFullName(system, service)
-    value = gConfigurationData.extractOptionFromCFG(f"/DiracX/LegacyClientEnabled/{system}/{service}")
+    value = gConfigurationData.extractOptionFromCFG(f"/DiracX/FutureClientEnabled/{system}/{service}")
     return (value or "no").lower() in ("y", "yes", "true", "1")
 
 

--- a/tests/Jenkins/dirac-cfg-setup-diracx.py
+++ b/tests/Jenkins/dirac-cfg-setup-diracx.py
@@ -74,16 +74,16 @@ def main(url: str, disabled_vos: list[str], legacy_adapted_services: list[str]):
     returnValueOrRaise(csAPI.mergeCFGUnderSection("/DiracX/", csSyncCFG))
 
     # Add service with legacy adaptors.
-    legacy = {"LegacyClientEnabled": {}}
+    legacy = {"FutureClientEnabled": {}}
     for service in legacy_adapted_services:
         print(f"Adding legacy adaptor for service {service}")
         # Service name such as:  system/name
         system, name = service.split("/")
 
-        if not system in legacy["LegacyClientEnabled"]:
-            legacy["LegacyClientEnabled"][system] = {}
+        if not system in legacy["FutureClientEnabled"]:
+            legacy["FutureClientEnabled"][system] = {}
 
-        legacy["LegacyClientEnabled"][system][name] = "yes"
+        legacy["FutureClientEnabled"][system][name] = "yes"
 
     legacyCFG = CFG().loadFromDict(legacy)
     returnValueOrRaise(csAPI.mergeCFGUnderSection("/DiracX/", legacyCFG))


### PR DESCRIPTION
#### PR Description
Verbatim backport of https://github.com/DIRACGrid/DIRAC/pull/8772 to `rel-v9r0`.

BEGINRELEASENOTES

*ConfigurationSystem
CHANGE: rename LegacyClientEnabled to FutureClientEnabled

ENDRELEASENOTES
