### PR TITLE
[int] Ensure PS decodes step body from JSON

### DIFF
--- a/src/DIRAC/ProductionSystem/Utilities/ProdTransManager.py
+++ b/src/DIRAC/ProductionSystem/Utilities/ProdTransManager.py
@@ -65,7 +65,7 @@ class ProdTransManager:
 
         stepDesc = prodStep[2]
         stepLongDesc = prodStep[3]
-        stepBody = prodStep[4]
+        stepBody = json.loads(prodStep[4])
         stepType = prodStep[5]
         stepPlugin = prodStep[6]
         stepAgentType = prodStep[7]


### PR DESCRIPTION
Hi,

This fixes a problem that was revealed by tidying up the SQL queries: Production step bodies were in JSON and were getting partially decoded by the database layer due to quoting issues. Now we need to decode them properly for it work!

Fixes #8773 .

Regards,
Simon

BEGINRELEASENOTES
*ProductionSystem
FIX: Ensure PS decodes step body from JSON
ENDRELEASENOTES
