### PR TITLE
[v8] chore: require m2crypto >=0.50

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,15 +21,7 @@ dependencies:
   - fts3
   - gitpython >=2.1.0
   - invoke
-  # Upper pin: m2crypto 0.46.0 rewrote ssl_read() in src/SWIG/_ssl.i and inverted the
-  # handling of ssl_sleep_with_timeout()'s return value (and dropped the gettimeofday()
-  # that initialises the deadline). Any read() on a connection with a timeout set now
-  # busy-loops and returns with a stale SSLTimeoutError set, which surfaces as
-  # "SystemError: <built-in function ssl_read> returned a result with an exception set"
-  # and breaks all DIRAC DISET/dips connections. Still unfixed upstream as of 0.49.0.
-  ## Reported in
-  ## https://lists.sr.ht/~mcepl/m2crypto/%3C7b94d866-bdd2-4a29-9713-b6a6fd076ad7@cta-observatory.org%3E
-  - m2crypto >=0.43,<0.46
+  - m2crypto >=0.50
   - matplotlib
   - numpy
   - pexpect >=4.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     gfal2-python
     importlib_metadata >=4.4
     importlib_resources
-    M2Crypto >=0.36
+    M2Crypto >=0.50
     packaging
     pexpect
     prompt-toolkit >=3


### PR DESCRIPTION
Follows up on DIRACGrid/DIRACOS2#192.

BEGINRELEASENOTES

*Core
FIX: require m2crypto >=0.50, which restores the timed ssl_read() retries broken in 0.46.0

ENDRELEASENOTES