### PR TITLE
[v9] fix: do not eagerly read Connection.serverPostConnectionCheck

### DIFF
--- a/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
+++ b/src/DIRAC/Core/DISET/private/Transports/M2SSLTransport.py
@@ -326,7 +326,11 @@ class SSLTransport(BaseTransport):
             self.oSocket.setup_ssl()
             self.oSocket.set_accept_state()
             self.oSocket.accept_ssl()
-            check = getattr(self.oSocket, "postConnectionCheck", self.oSocket.serverPostConnectionCheck)
+            check = getattr(
+                self.oSocket,
+                "postConnectionCheck",
+                getattr(self.oSocket, "serverPostConnectionCheck", None),
+            )
             if check is not None:
                 if not check(self.oSocket.get_peer_cert(), self.oSocket.addr[0]):
                     raise SSL.Checker.SSLVerificationError("post connection check failed")


### PR DESCRIPTION
Independent of the m2crypto version bump. m2crypto 0.46.0 removed the
`serverPostConnectionCheck` class attribute from `SSL.Connection`; DIRAC used it
as the default argument of a `getattr()` lookup, and Python evaluates that
default eagerly, so every server-side handshake raised `AttributeError`. The
current `<0.46` pin is the only reason this has not been hit in production.

Verified against `Test_SSLTransport.py`: 4 passed with m2crypto 0.45.1 (no-op)
and 4 passed with 0.50.0, where each M2 test previously hung for
`BaseTransport.iReadTimeout` (600s) and cancelled the job.

Refs DIRACGrid/DIRACOS2#192

BEGINRELEASENOTES

*Core
FIX: server-side DISET handshakes no longer raise AttributeError with m2crypto >=0.46

ENDRELEASENOTES